### PR TITLE
Task 13/add order tasks lists by

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A terminal-based kanban/project management tool inspired by [lazygit](https://gi
 - 💾 **File Persistence**: JSON import/export with auto-save support
 - ⌨️ **Keyboard-Driven**: Vim-like navigation and shortcuts
 - ✅ **Task Management**: Task completion tracking, priority levels, and story points
-- 📊 **Metadata**: Assign story points (1-5) with color-coded badges
+- 📊 **Metadata**: Assign story points (1-5)
 - 🔄 **Reproducible Builds**: Nix flakes for development environment
 
 ## Quick Start
@@ -77,7 +77,7 @@ cargo fmt
 
 ```bash
 kanban                # Launch interactive TUI
-kanban board.json     # Launch with import
+kanban boards.json    # Launch with import
 ```
 
 ### Keyboard Shortcuts
@@ -132,8 +132,6 @@ When providing a file path:
 - If file exists, boards are loaded on startup
 - If file doesn't exist, it's created with empty boards array: `{"boards":[]}`
 - Changes are automatically saved on exit (`q`)
-- Single board export: `{"boards": [...]}`  with one board
-- Multiple boards export: `{"boards": [...]}` with all boards
 
 ## Card Metadata
 
@@ -158,7 +156,7 @@ When editing titles or descriptions, Kanban opens an external editor. The editor
    - **Unix/Linux/macOS**: vi
    - **Windows**: notepad
 
-**Tip**: Set your preferred editor with `export EDITOR=nano` (or add to your shell profile)
+**Tip**: Set your preferred editor with `export EDITOR=vim` (or add to your shell profile)
 
 ## License
 

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -5,7 +5,9 @@ use kanban_tui::App;
 #[command(name = "kanban")]
 #[command(about = "A terminal-based kanban board", long_about = None)]
 #[command(version, arg_required_else_help = false)]
-#[command(help_template = "{name} {version}\n{about-section}\n{usage-heading} {usage}\n\n{all-args}")]
+#[command(
+    help_template = "{name} {version}\n{about-section}\n{usage-heading} {usage}\n\n{all-args}"
+)]
 struct Cli {
     /// Optional file path to load and auto-save boards
     file: Option<String>,

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -4,6 +4,22 @@ use uuid::Uuid;
 
 pub type BoardId = Uuid;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SortField {
+    Points,
+    Priority,
+    CreatedAt,
+    UpdatedAt,
+    Status,
+    Default,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SortOrder {
+    Ascending,
+    Descending,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Board {
     pub id: BoardId,
@@ -13,12 +29,24 @@ pub struct Board {
     pub branch_prefix: Option<String>,
     #[serde(default = "default_next_card_number")]
     pub next_card_number: u32,
+    #[serde(default = "default_sort_field")]
+    pub task_sort_field: SortField,
+    #[serde(default = "default_sort_order")]
+    pub task_sort_order: SortOrder,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
 
 fn default_next_card_number() -> u32 {
     1
+}
+
+fn default_sort_field() -> SortField {
+    SortField::Default
+}
+
+fn default_sort_order() -> SortOrder {
+    SortOrder::Ascending
 }
 
 impl Board {
@@ -30,6 +58,8 @@ impl Board {
             description,
             branch_prefix: None,
             next_card_number: 1,
+            task_sort_field: SortField::Default,
+            task_sort_order: SortOrder::Ascending,
             created_at: now,
             updated_at: now,
         }
@@ -59,6 +89,12 @@ impl Board {
 
     pub fn effective_branch_prefix<'a>(&'a self, default_prefix: &'a str) -> &'a str {
         self.branch_prefix.as_deref().unwrap_or(default_prefix)
+    }
+
+    pub fn update_task_sort(&mut self, field: SortField, order: SortOrder) {
+        self.task_sort_field = field;
+        self.task_sort_order = order;
+        self.updated_at = Utc::now();
     }
 }
 

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -3,7 +3,7 @@ pub mod card;
 pub mod column;
 pub mod tag;
 
-pub use board::{Board, BoardId};
+pub use board::{Board, BoardId, SortField, SortOrder};
 pub use card::{Card, CardId, CardPriority, CardStatus};
 pub use column::{Column, ColumnId};
 pub use tag::{Tag, TagId};

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -703,6 +703,10 @@ impl App {
     }
 
     pub fn get_sorted_board_cards(&self, board_id: uuid::Uuid) -> Vec<&Card> {
+        let board = self.boards.iter().find(|b| b.id == board_id).unwrap();
+        let sort_field = board.task_sort_field;
+        let sort_order = board.task_sort_order;
+
         let mut cards: Vec<&Card> = self
             .cards
             .iter()
@@ -713,10 +717,9 @@ impl App {
             })
             .collect();
 
-        if let (Some(field), Some(order)) = (self.current_sort_field, self.current_sort_order) {
-            cards.sort_by(|a, b| {
+        cards.sort_by(|a, b| {
                 use std::cmp::Ordering;
-                let cmp = match field {
+                let cmp = match sort_field {
                     SortField::Points => match (a.points, b.points) {
                         (Some(ap), Some(bp)) => ap.cmp(&bp),
                         (Some(_), None) => Ordering::Less,
@@ -758,12 +761,11 @@ impl App {
                     SortField::Default => a.card_number.cmp(&b.card_number),
                 };
 
-                match order {
+                match sort_order {
                     SortOrder::Ascending => cmp,
                     SortOrder::Descending => cmp.reverse(),
                 }
             });
-        }
 
         cards
     }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -43,7 +43,7 @@ pub struct App {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Focus {
     Projects,
-    Tasks,
+    Cards,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -83,7 +83,7 @@ pub enum AppMode {
     ImportBoard,
     SetCardPoints,
     SetBranchPrefix,
-    OrderTasks,
+    OrderCards,
 }
 
 impl App {
@@ -149,7 +149,7 @@ impl App {
                         self.mode = AppMode::CreateBoard;
                         self.input.clear();
                     }
-                    Focus::Tasks => {
+                    Focus::Cards => {
                         if self.active_board_index.is_some() {
                             self.mode = AppMode::CreateCard;
                             self.input.clear();
@@ -212,18 +212,18 @@ impl App {
                     }
                 }
                 KeyCode::Char('c') => {
-                    if self.focus == Focus::Tasks && self.card_selection.get().is_some() {
+                    if self.focus == Focus::Cards && self.card_selection.get().is_some() {
                         self.toggle_card_completion();
                     }
                 }
                 KeyCode::Char('o') => {
-                    if self.focus == Focus::Tasks && self.active_board_index.is_some() {
+                    if self.focus == Focus::Cards && self.active_board_index.is_some() {
                         self.sort_field_selection.set(Some(0));
-                        self.mode = AppMode::OrderTasks;
+                        self.mode = AppMode::OrderCards;
                     }
                 }
                 KeyCode::Char('O') => {
-                    if self.focus == Focus::Tasks && self.active_board_index.is_some() {
+                    if self.focus == Focus::Cards && self.active_board_index.is_some() {
                         if let Some(current_order) = self.current_sort_order {
                             let new_order = match current_order {
                                 SortOrder::Ascending => SortOrder::Descending,
@@ -246,7 +246,7 @@ impl App {
                 KeyCode::Char('1') => self.focus = Focus::Projects,
                 KeyCode::Char('2') => {
                     if self.active_board_index.is_some() {
-                        self.focus = Focus::Tasks;
+                        self.focus = Focus::Cards;
                     }
                 }
                 KeyCode::Esc => {
@@ -260,7 +260,7 @@ impl App {
                     Focus::Projects => {
                         self.board_selection.next(self.boards.len());
                     }
-                    Focus::Tasks => {
+                    Focus::Cards => {
                         if let Some(board_idx) = self.active_board_index {
                             if let Some(board) = self.boards.get(board_idx) {
                                 let card_count = self.get_board_card_count(board.id);
@@ -273,7 +273,7 @@ impl App {
                     Focus::Projects => {
                         self.board_selection.prev();
                     }
-                    Focus::Tasks => {
+                    Focus::Cards => {
                         self.card_selection.prev();
                     }
                 },
@@ -295,10 +295,10 @@ impl App {
                                 }
                             }
 
-                            self.focus = Focus::Tasks;
+                            self.focus = Focus::Cards;
                         }
                     }
-                    Focus::Tasks => {
+                    Focus::Cards => {
                         if let Some(sorted_idx) = self.card_selection.get() {
                             if let Some(board_idx) = self.active_board_index {
                                 if let Some(board) = self.boards.get(board_idx) {
@@ -331,7 +331,7 @@ impl App {
             },
             AppMode::CreateCard => match handle_dialog_input(&mut self.input, key.code) {
                 DialogAction::Confirm => {
-                    self.create_task();
+                    self.create_card();
                     self.mode = AppMode::Normal;
                     self.input.clear();
                 }
@@ -583,7 +583,7 @@ impl App {
                 }
                 DialogAction::None => {}
             },
-            AppMode::OrderTasks => match key.code {
+            AppMode::OrderCards => match key.code {
                 KeyCode::Esc => {
                     self.mode = AppMode::Normal;
                     self.sort_field_selection.clear();
@@ -687,7 +687,7 @@ impl App {
         }
     }
 
-    fn create_task(&mut self) {
+    fn create_card(&mut self) {
         if let Some(idx) = self.active_board_index {
             if let Some(board) = self.boards.get_mut(idx) {
                 let column = self

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -222,6 +222,27 @@ impl App {
                         self.mode = AppMode::OrderTasks;
                     }
                 }
+                KeyCode::Char('O') => {
+                    if self.focus == Focus::Tasks && self.active_board_index.is_some() {
+                        if let Some(current_order) = self.current_sort_order {
+                            let new_order = match current_order {
+                                SortOrder::Ascending => SortOrder::Descending,
+                                SortOrder::Descending => SortOrder::Ascending,
+                            };
+                            self.current_sort_order = Some(new_order);
+
+                            if let Some(board_idx) = self.active_board_index {
+                                if let Some(board) = self.boards.get_mut(board_idx) {
+                                    if let Some(field) = self.current_sort_field {
+                                        board.update_task_sort(field, new_order);
+                                    }
+                                }
+                            }
+
+                            tracing::info!("Toggled sort order to: {:?}", new_order);
+                        }
+                    }
+                }
                 KeyCode::Char('1') => self.focus = Focus::Projects,
                 KeyCode::Char('2') => {
                     if self.active_board_index.is_some() {

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -42,7 +42,7 @@ pub struct App {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Focus {
-    Projects,
+    Boards,
     Cards,
 }
 
@@ -100,7 +100,7 @@ impl App {
             active_card_index: None,
             columns: Vec::new(),
             cards: Vec::new(),
-            focus: Focus::Projects,
+            focus: Focus::Boards,
             card_focus: CardFocus::Title,
             board_focus: BoardFocus::Name,
             import_files: Vec::new(),
@@ -145,7 +145,7 @@ impl App {
         match self.mode {
             AppMode::Normal => match key.code {
                 KeyCode::Char('n') => match self.focus {
-                    Focus::Projects => {
+                    Focus::Boards => {
                         self.mode = AppMode::CreateBoard;
                         self.input.clear();
                     }
@@ -157,7 +157,7 @@ impl App {
                     }
                 },
                 KeyCode::Char('r') => {
-                    if self.focus == Focus::Projects && self.board_selection.get().is_some() {
+                    if self.focus == Focus::Boards && self.board_selection.get().is_some() {
                         if let Some(board_idx) = self.board_selection.get() {
                             if let Some(board) = self.boards.get(board_idx) {
                                 self.input.set(board.name.clone());
@@ -167,18 +167,18 @@ impl App {
                     }
                 }
                 KeyCode::Char('e') => {
-                    if self.focus == Focus::Projects && self.board_selection.get().is_some() {
+                    if self.focus == Focus::Boards && self.board_selection.get().is_some() {
                         self.mode = AppMode::BoardDetail;
                         self.board_focus = BoardFocus::Name;
                     }
                 }
                 KeyCode::Char('s') => {
-                    if self.focus == Focus::Projects && self.board_selection.get().is_some() {
+                    if self.focus == Focus::Boards && self.board_selection.get().is_some() {
                         self.mode = AppMode::BoardSettings;
                     }
                 }
                 KeyCode::Char('x') => {
-                    if self.focus == Focus::Projects && self.board_selection.get().is_some() {
+                    if self.focus == Focus::Boards && self.board_selection.get().is_some() {
                         if let Some(board_idx) = self.board_selection.get() {
                             if let Some(board) = self.boards.get(board_idx) {
                                 let filename = format!(
@@ -193,7 +193,7 @@ impl App {
                     }
                 }
                 KeyCode::Char('X') => {
-                    if self.focus == Focus::Projects && !self.boards.is_empty() {
+                    if self.focus == Focus::Boards && !self.boards.is_empty() {
                         let filename = format!(
                             "kanban-all-{}.json",
                             chrono::Utc::now().format("%Y%m%d-%H%M%S")
@@ -203,7 +203,7 @@ impl App {
                     }
                 }
                 KeyCode::Char('i') => {
-                    if self.focus == Focus::Projects {
+                    if self.focus == Focus::Boards {
                         self.scan_import_files();
                         if !self.import_files.is_empty() {
                             self.import_selection.set(Some(0));
@@ -243,7 +243,7 @@ impl App {
                         }
                     }
                 }
-                KeyCode::Char('1') => self.focus = Focus::Projects,
+                KeyCode::Char('1') => self.focus = Focus::Boards,
                 KeyCode::Char('2') => {
                     if self.active_board_index.is_some() {
                         self.focus = Focus::Cards;
@@ -253,11 +253,11 @@ impl App {
                     if self.active_board_index.is_some() {
                         self.active_board_index = None;
                         self.card_selection.clear();
-                        self.focus = Focus::Projects;
+                        self.focus = Focus::Boards;
                     }
                 }
                 KeyCode::Char('j') | KeyCode::Down => match self.focus {
-                    Focus::Projects => {
+                    Focus::Boards => {
                         self.board_selection.next(self.boards.len());
                     }
                     Focus::Cards => {
@@ -270,7 +270,7 @@ impl App {
                     }
                 },
                 KeyCode::Char('k') | KeyCode::Up => match self.focus {
-                    Focus::Projects => {
+                    Focus::Boards => {
                         self.board_selection.prev();
                     }
                     Focus::Cards => {
@@ -278,7 +278,7 @@ impl App {
                     }
                 },
                 KeyCode::Enter | KeyCode::Char(' ') => match self.focus {
-                    Focus::Projects => {
+                    Focus::Boards => {
                         if self.board_selection.get().is_some() {
                             self.active_board_index = self.board_selection.get();
                             self.card_selection.clear();
@@ -644,7 +644,7 @@ impl App {
 
     fn create_board(&mut self) {
         let board = Board::new(self.input.as_str().to_string(), None);
-        tracing::info!("Creating project: {} (id: {})", board.name, board.id);
+        tracing::info!("Creating board: {} (id: {})", board.name, board.id);
         self.boards.push(board);
         let new_index = self.boards.len() - 1;
         self.board_selection.set(Some(new_index));
@@ -654,7 +654,7 @@ impl App {
         if let Some(idx) = self.board_selection.get() {
             if let Some(board) = self.boards.get_mut(idx) {
                 board.update_name(self.input.as_str().to_string());
-                tracing::info!("Renamed project to: {}", board.name);
+                tracing::info!("Renamed board to: {}", board.name);
             }
         }
     }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -585,9 +585,19 @@ impl App {
                             _ => return should_restart_events,
                         };
 
-                        let order = match key.code {
-                            KeyCode::Char('d') => SortOrder::Descending,
-                            _ => SortOrder::Ascending,
+                        let order = if self.current_sort_field == Some(field)
+                            && matches!(key.code, KeyCode::Enter | KeyCode::Char(' '))
+                        {
+                            match self.current_sort_order {
+                                Some(SortOrder::Ascending) => SortOrder::Descending,
+                                Some(SortOrder::Descending) => SortOrder::Ascending,
+                                None => SortOrder::Ascending,
+                            }
+                        } else {
+                            match key.code {
+                                KeyCode::Char('d') => SortOrder::Descending,
+                                _ => SortOrder::Ascending,
+                            }
                         };
 
                         self.current_sort_field = Some(field);
@@ -718,54 +728,54 @@ impl App {
             .collect();
 
         cards.sort_by(|a, b| {
-                use std::cmp::Ordering;
-                let cmp = match sort_field {
-                    SortField::Points => match (a.points, b.points) {
-                        (Some(ap), Some(bp)) => ap.cmp(&bp),
-                        (Some(_), None) => Ordering::Less,
-                        (None, Some(_)) => Ordering::Greater,
-                        (None, None) => Ordering::Equal,
-                    },
-                    SortField::Priority => {
-                        let a_val = match a.priority {
-                            kanban_domain::CardPriority::Critical => 3,
-                            kanban_domain::CardPriority::High => 2,
-                            kanban_domain::CardPriority::Medium => 1,
-                            kanban_domain::CardPriority::Low => 0,
-                        };
-                        let b_val = match b.priority {
-                            kanban_domain::CardPriority::Critical => 3,
-                            kanban_domain::CardPriority::High => 2,
-                            kanban_domain::CardPriority::Medium => 1,
-                            kanban_domain::CardPriority::Low => 0,
-                        };
-                        a_val.cmp(&b_val)
-                    }
-                    SortField::CreatedAt => a.created_at.cmp(&b.created_at),
-                    SortField::UpdatedAt => a.updated_at.cmp(&b.updated_at),
-                    SortField::Status => {
-                        let a_val = match a.status {
-                            CardStatus::Done => 3,
-                            CardStatus::InProgress => 2,
-                            CardStatus::Blocked => 1,
-                            CardStatus::Todo => 0,
-                        };
-                        let b_val = match b.status {
-                            CardStatus::Done => 3,
-                            CardStatus::InProgress => 2,
-                            CardStatus::Blocked => 1,
-                            CardStatus::Todo => 0,
-                        };
-                        a_val.cmp(&b_val)
-                    }
-                    SortField::Default => a.card_number.cmp(&b.card_number),
-                };
-
-                match sort_order {
-                    SortOrder::Ascending => cmp,
-                    SortOrder::Descending => cmp.reverse(),
+            use std::cmp::Ordering;
+            let cmp = match sort_field {
+                SortField::Points => match (a.points, b.points) {
+                    (Some(ap), Some(bp)) => ap.cmp(&bp),
+                    (Some(_), None) => Ordering::Less,
+                    (None, Some(_)) => Ordering::Greater,
+                    (None, None) => Ordering::Equal,
+                },
+                SortField::Priority => {
+                    let a_val = match a.priority {
+                        kanban_domain::CardPriority::Critical => 3,
+                        kanban_domain::CardPriority::High => 2,
+                        kanban_domain::CardPriority::Medium => 1,
+                        kanban_domain::CardPriority::Low => 0,
+                    };
+                    let b_val = match b.priority {
+                        kanban_domain::CardPriority::Critical => 3,
+                        kanban_domain::CardPriority::High => 2,
+                        kanban_domain::CardPriority::Medium => 1,
+                        kanban_domain::CardPriority::Low => 0,
+                    };
+                    a_val.cmp(&b_val)
                 }
-            });
+                SortField::CreatedAt => a.created_at.cmp(&b.created_at),
+                SortField::UpdatedAt => a.updated_at.cmp(&b.updated_at),
+                SortField::Status => {
+                    let a_val = match a.status {
+                        CardStatus::Done => 3,
+                        CardStatus::InProgress => 2,
+                        CardStatus::Blocked => 1,
+                        CardStatus::Todo => 0,
+                    };
+                    let b_val = match b.status {
+                        CardStatus::Done => 3,
+                        CardStatus::InProgress => 2,
+                        CardStatus::Blocked => 1,
+                        CardStatus::Todo => 0,
+                    };
+                    a_val.cmp(&b_val)
+                }
+                SortField::Default => a.card_number.cmp(&b.card_number),
+            };
+
+            match sort_order {
+                SortOrder::Ascending => cmp,
+                SortOrder::Descending => cmp.reverse(),
+            }
+        });
 
         cards
     }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -196,9 +196,9 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
 
     if let Some(idx) = board_idx {
         if let Some(board) = app.boards.get(idx) {
-            let board_tasks = app.get_sorted_board_cards(board.id);
+            let board_cards = app.get_sorted_board_cards(board.id);
 
-            if board_tasks.is_empty() {
+            if board_cards.is_empty() {
                 let message = if app.active_board_index.is_some() {
                     "  No tasks yet. Press 'n' to create one!"
                 } else {
@@ -209,7 +209,7 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                     Style::default().fg(Color::Gray),
                 )));
             } else {
-                for (card_idx, card) in board_tasks.iter().enumerate() {
+                for (card_idx, card) in board_cards.iter().enumerate() {
                     let is_selected = app.card_selection.get() == Some(card_idx);
                     let is_focused = app.focus == Focus::Tasks;
                     let is_done = card.status == CardStatus::Done;

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -630,7 +630,7 @@ fn render_board_settings_view(app: &App, frame: &mut Frame, area: Rect) {
                     ),
                 ]),
                 Line::from(vec![
-                    Span::styled("Next Card Number: ", Style::default().fg(Color::Gray)),
+                    Span::styled("Next Task Number: ", Style::default().fg(Color::Gray)),
                     Span::styled(
                         board.next_card_number.to_string(),
                         Style::default().fg(Color::White),

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -712,7 +712,7 @@ fn render_order_tasks_popup(app: &App, frame: &mut Frame) {
             SortField::CreatedAt => "Date Created",
             SortField::UpdatedAt => "Date Updated",
             SortField::Status => "Status",
-            SortField::Default => "Default",
+            SortField::Default => "Default (Task Number)",
         };
 
         let order_indicator = if is_active {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -127,7 +127,7 @@ fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
         for (idx, board) in app.boards.iter().enumerate() {
             let is_selected = app.board_selection.get() == Some(idx);
             let is_active = app.active_board_index == Some(idx);
-            let is_focused = app.focus == Focus::Projects;
+            let is_focused = app.focus == Focus::Boards;
 
             let mut style = Style::default();
             let prefix;
@@ -151,7 +151,7 @@ fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
         }
     }
 
-    let is_focused = app.focus == Focus::Projects;
+    let is_focused = app.focus == Focus::Boards;
     let border_color = if is_focused {
         Color::Cyan
     } else {
@@ -291,7 +291,7 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
 
 fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
     let help_text = match app.mode {
-        AppMode::Normal => "q: quit | n: new | r: rename | e: edit board | s: board settings | x: export | X: export all | i: import | c: toggle complete | 1/2: switch panel | j/k: navigate | Enter/Space: activate",
+        AppMode::Normal => "q: quit | n: new | r: rename | e: edit project | s: project settings | x: export | X: export all | i: import | c: toggle complete | 1/2: switch panel | j/k: navigate | Enter/Space: activate",
         AppMode::CreateBoard => "ESC: cancel | ENTER: confirm",
         AppMode::CreateCard => "ESC: cancel | ENTER: confirm",
         AppMode::RenameBoard => "ESC: cancel | ENTER: confirm",
@@ -299,9 +299,9 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
         AppMode::ExportAll => "ESC: cancel | ENTER: export all",
         AppMode::ImportBoard => "ESC: cancel | j/k: navigate | ENTER/Space: import selected",
         AppMode::CardDetail => match app.card_focus {
-            CardFocus::Title => "q: quit | ESC: back | 1/2/3: select panel | b: assign branch | y: copy branch | Y: copy git cmd | e: edit title",
-            CardFocus::Description => "q: quit | ESC: back | 1/2/3: select panel | b: assign branch | y: copy branch | Y: copy git cmd | e: edit description",
-            CardFocus::Metadata => "q: quit | ESC: back | 1/2/3: select panel | b: assign branch | y: copy branch | Y: copy git cmd | e: edit points",
+            CardFocus::Title => "q: quit | ESC: back | 1/2/3: select panel | y: copy branch | Y: copy git cmd | e: edit title",
+            CardFocus::Description => "q: quit | ESC: back | 1/2/3: select panel | y: copy branch | Y: copy git cmd | e: edit description",
+            CardFocus::Metadata => "q: quit | ESC: back | 1/2/3: select panel | y: copy branch | Y: copy git cmd | e: edit points",
         },
         AppMode::SetCardPoints => "ESC: cancel | ENTER: confirm",
         AppMode::BoardDetail => match app.board_focus {
@@ -537,9 +537,9 @@ fn render_board_detail_view(app: &App, frame: &mut Frame, area: Rect) {
             };
             let name_block = Block::default()
                 .title(if name_focused {
-                    "Board Name [1]"
+                    "Project Name [1]"
                 } else {
-                    "Board Name"
+                    "Project Name"
                 })
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(name_border_color));

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -707,8 +707,8 @@ fn render_order_tasks_popup(app: &App, frame: &mut Frame) {
 
         let prefix = if is_selected { "> " } else { "  " };
         let field_name = match field {
-            SortField::Points => "Points",
             SortField::Priority => "Priority",
+            SortField::Points => "Points",
             SortField::CreatedAt => "Date Created",
             SortField::UpdatedAt => "Date Updated",
             SortField::Default => "Task Number",

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -79,7 +79,7 @@ pub fn render(app: &App, frame: &mut Frame) {
                 AppMode::ImportBoard => render_import_board_popup(app, frame),
                 AppMode::SetCardPoints => render_set_card_points_popup(app, frame),
                 AppMode::SetBranchPrefix => render_set_branch_prefix_popup(app, frame),
-                AppMode::OrderTasks => render_order_tasks_popup(app, frame),
+                AppMode::OrderCards => render_order_cards_popup(app, frame),
                 _ => {}
             }
         }
@@ -211,7 +211,7 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
             } else {
                 for (card_idx, card) in board_cards.iter().enumerate() {
                     let is_selected = app.card_selection.get() == Some(card_idx);
-                    let is_focused = app.focus == Focus::Tasks;
+                    let is_focused = app.focus == Focus::Cards;
                     let is_done = card.status == CardStatus::Done;
 
                     let (checkbox, text_color, text_modifier) = if is_done {
@@ -272,7 +272,7 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
         )));
     }
 
-    let is_focused = app.focus == Focus::Tasks;
+    let is_focused = app.focus == Focus::Cards;
     let border_color = if is_focused {
         Color::Cyan
     } else {
@@ -310,7 +310,7 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
         },
         AppMode::BoardSettings => "q: quit | ESC: back | p: set branch prefix",
         AppMode::SetBranchPrefix => "ESC: cancel | ENTER: confirm (empty to clear)",
-        AppMode::OrderTasks => "ESC: cancel | j/k: navigate | ENTER/Space/a: ascending | d: descending",
+        AppMode::OrderCards => "ESC: cancel | j/k: navigate | ENTER/Space/a: ascending | d: descending",
     };
     let help = Paragraph::new(help_text)
         .style(Style::default().fg(Color::Gray))
@@ -655,7 +655,7 @@ fn render_set_branch_prefix_popup(app: &App, frame: &mut Frame) {
     render_input_popup(app, frame, "Set Branch Prefix", "Prefix (empty to clear):");
 }
 
-fn render_order_tasks_popup(app: &App, frame: &mut Frame) {
+fn render_order_cards_popup(app: &App, frame: &mut Frame) {
     use kanban_domain::{SortField, SortOrder};
 
     let area = centered_rect(60, 50, frame.area());

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -332,11 +332,9 @@ fn render_set_card_points_popup(app: &App, frame: &mut Frame) {
 
 fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
     if let Some(task_idx) = app.active_card_index {
-        if let Some(board_idx) = app.active_board_index {
-            if let Some(board) = app.boards.get(board_idx) {
-                let board_tasks = app.get_sorted_board_cards(board.id);
-
-                if let Some(task) = board_tasks.get(task_idx) {
+        if let Some(task) = app.cards.get(task_idx) {
+            if let Some(board_idx) = app.active_board_index {
+                if let Some(board) = app.boards.get(board_idx) {
                     let chunks = Layout::default()
                         .direction(Direction::Vertical)
                         .constraints([

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -711,8 +711,8 @@ fn render_order_tasks_popup(app: &App, frame: &mut Frame) {
             SortField::Priority => "Priority",
             SortField::CreatedAt => "Date Created",
             SortField::UpdatedAt => "Date Updated",
+            SortField::Default => "Task Number",
             SortField::Status => "Status",
-            SortField::Default => "Default (Task Number)",
         };
 
         let order_indicator = if is_active {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -209,10 +209,10 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                     Style::default().fg(Color::Gray),
                 )));
             } else {
-                for (task_idx, task) in board_tasks.iter().enumerate() {
-                    let is_selected = app.card_selection.get() == Some(task_idx);
+                for (card_idx, card) in board_tasks.iter().enumerate() {
+                    let is_selected = app.card_selection.get() == Some(card_idx);
                     let is_focused = app.focus == Focus::Tasks;
-                    let is_done = task.status == CardStatus::Done;
+                    let is_done = card.status == CardStatus::Done;
 
                     let (checkbox, text_color, text_modifier) = if is_done {
                         ("☑", Color::DarkGray, Modifier::CROSSED_OUT)
@@ -226,7 +226,7 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                         style = style.bg(Color::Blue);
                     }
 
-                    let points_badge = if let Some(points) = task.points {
+                    let points_badge = if let Some(points) = card.points {
                         format!(" [{}]", points)
                     } else {
                         String::new()
@@ -234,11 +234,11 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
 
                     let line = if points_badge.is_empty() {
                         Line::from(Span::styled(
-                            format!("  {} {}", checkbox, task.title),
+                            format!("  {} {}", checkbox, card.title),
                             style,
                         ))
                     } else {
-                        let points_color = task
+                        let points_color = card
                             .points
                             .map(|p| match p {
                                 1 => Color::Cyan,
@@ -256,7 +256,7 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                         }
 
                         Line::from(vec![
-                            Span::styled(format!("  {} {}", checkbox, task.title), style),
+                            Span::styled(format!("  {} {}", checkbox, card.title), style),
                             Span::styled(points_badge, points_style),
                         ])
                     };
@@ -331,8 +331,8 @@ fn render_set_card_points_popup(app: &App, frame: &mut Frame) {
 }
 
 fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
-    if let Some(task_idx) = app.active_card_index {
-        if let Some(task) = app.cards.get(task_idx) {
+    if let Some(card_idx) = app.active_card_index {
+        if let Some(card) = app.cards.get(card_idx) {
             if let Some(board_idx) = app.active_board_index {
                 if let Some(board) = app.boards.get(board_idx) {
                     let chunks = Layout::default()
@@ -358,7 +358,7 @@ fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
                         })
                         .borders(Borders::ALL)
                         .border_style(Style::default().fg(title_border_color));
-                    let title = Paragraph::new(task.title.clone())
+                    let title = Paragraph::new(card.title.clone())
                         .style(
                             Style::default()
                                 .fg(Color::Yellow)
@@ -385,25 +385,25 @@ fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
                         Line::from(vec![
                             Span::styled("Priority: ", Style::default().fg(Color::Gray)),
                             Span::styled(
-                                format!("{:?}", task.priority),
+                                format!("{:?}", card.priority),
                                 Style::default().fg(Color::White),
                             ),
                             Span::raw("  "),
                             Span::styled("Status: ", Style::default().fg(Color::Gray)),
                             Span::styled(
-                                format!("{:?}", task.status),
+                                format!("{:?}", card.status),
                                 Style::default().fg(Color::White),
                             ),
                             Span::raw("  "),
                             Span::styled("Points: ", Style::default().fg(Color::Gray)),
                             Span::styled(
-                                task.points
+                                card.points
                                     .map(|p| p.to_string())
                                     .unwrap_or_else(|| "-".to_string()),
                                 Style::default().fg(Color::White),
                             ),
                         ]),
-                        Line::from(if let Some(due_date) = task.due_date {
+                        Line::from(if let Some(due_date) = card.due_date {
                             vec![
                                 Span::styled("Due: ", Style::default().fg(Color::Gray)),
                                 Span::styled(
@@ -420,7 +420,7 @@ fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
                     ];
 
                     let branch_name =
-                        task.branch_name(board, app.app_config.effective_default_prefix());
+                        card.branch_name(board, app.app_config.effective_default_prefix());
                     meta_lines.push(Line::from(vec![
                         Span::styled("Branch: ", Style::default().fg(Color::Gray)),
                         Span::styled(
@@ -447,7 +447,7 @@ fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
                         })
                         .borders(Borders::ALL)
                         .border_style(Style::default().fg(desc_border_color));
-                    let desc_text = if let Some(desc) = &task.description {
+                    let desc_text = if let Some(desc) = &card.description {
                         desc.clone()
                     } else {
                         "No description".to_string()

--- a/kanban.json
+++ b/kanban.json
@@ -6,11 +6,11 @@
         "name": "Kanban",
         "description": null,
         "branch_prefix": null,
-        "next_card_number": 25,
-        "task_sort_field": "CreatedAt",
-        "task_sort_order": "Descending",
+        "next_card_number": 26,
+        "task_sort_field": "Priority",
+        "task_sort_order": "Ascending",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-11T20:30:09.214397Z"
+        "updated_at": "2025-10-11T20:53:06.269236Z"
       },
       "columns": [
         {
@@ -78,7 +78,7 @@
           "points": 4,
           "card_number": 2,
           "created_at": "2025-10-10T22:03:42.988557Z",
-          "updated_at": "2025-10-11T08:00:34.328075Z"
+          "updated_at": "2025-10-11T20:33:59.906332Z"
         },
         {
           "id": "e96684a5-4645-443e-8e2c-6bb646e248c6",
@@ -106,7 +106,7 @@
           "points": 2,
           "card_number": 7,
           "created_at": "2025-10-10T22:11:25.809290Z",
-          "updated_at": "2025-10-10T22:12:36.415713Z"
+          "updated_at": "2025-10-11T20:40:58.659416Z"
         },
         {
           "id": "86c1b649-03bc-4da8-87c3-e20a2c56a640",
@@ -134,7 +134,7 @@
           "points": 1,
           "card_number": 9,
           "created_at": "2025-10-10T22:14:31.293267Z",
-          "updated_at": "2025-10-10T22:36:31.344615Z"
+          "updated_at": "2025-10-11T20:41:09.462182Z"
         },
         {
           "id": "7cd165b0-6671-46d6-b837-4e73ada26333",
@@ -176,7 +176,7 @@
           "points": 5,
           "card_number": 12,
           "created_at": "2025-10-10T22:56:04.200355Z",
-          "updated_at": "2025-10-10T23:01:01.402918Z"
+          "updated_at": "2025-10-11T20:41:24.403599Z"
         },
         {
           "id": "6a0cbe1e-a05e-4aca-bd53-f0057215d671",
@@ -359,6 +359,20 @@
           "card_number": 24,
           "created_at": "2025-10-11T20:30:09.214394Z",
           "updated_at": "2025-10-11T20:30:13.695354Z"
+        },
+        {
+          "id": "e3482cf7-c53a-4ce8-8c33-11e2cca3d87a",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Add completed when time to task",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 24,
+          "due_date": null,
+          "points": null,
+          "card_number": 25,
+          "created_at": "2025-10-11T20:53:06.269232Z",
+          "updated_at": "2025-10-11T20:53:06.269232Z"
         }
       ]
     }

--- a/kanban.json
+++ b/kanban.json
@@ -6,11 +6,11 @@
         "name": "Kanban",
         "description": null,
         "branch_prefix": null,
-        "next_card_number": 30,
+        "next_card_number": 31,
         "task_sort_field": "Points",
-        "task_sort_order": "Ascending",
+        "task_sort_order": "Descending",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-11T21:45:54.321947Z"
+        "updated_at": "2025-10-11T21:57:14.078404Z"
       },
       "columns": [
         {
@@ -429,6 +429,20 @@
           "card_number": 29,
           "created_at": "2025-10-11T21:45:54.321945Z",
           "updated_at": "2025-10-11T21:47:04.856744Z"
+        },
+        {
+          "id": "72ffc5f8-df27-4dd5-bc13-36e5c105f367",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Vim Motions",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 29,
+          "due_date": null,
+          "points": null,
+          "card_number": 30,
+          "created_at": "2025-10-11T21:56:16.454189Z",
+          "updated_at": "2025-10-11T21:56:16.454189Z"
         }
       ]
     }

--- a/kanban.json
+++ b/kanban.json
@@ -7,10 +7,10 @@
         "description": null,
         "branch_prefix": null,
         "next_card_number": 27,
-        "task_sort_field": "Priority",
-        "task_sort_order": "Ascending",
+        "task_sort_field": "UpdatedAt",
+        "task_sort_order": "Descending",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-11T20:54:41.898529Z"
+        "updated_at": "2025-10-11T21:26:04.095776Z"
       },
       "columns": [
         {
@@ -190,7 +190,7 @@
           "points": 2,
           "card_number": 13,
           "created_at": "2025-10-10T23:01:18.553586Z",
-          "updated_at": "2025-10-11T20:30:25.768199Z"
+          "updated_at": "2025-10-11T21:19:06.054082Z"
         },
         {
           "id": "9e8f918f-3fde-4847-aca8-0ab7646256a8",
@@ -316,7 +316,7 @@
           "points": 2,
           "card_number": 21,
           "created_at": "2025-10-11T19:25:07.465576Z",
-          "updated_at": "2025-10-11T19:25:26.875800Z"
+          "updated_at": "2025-10-11T21:19:20.961218Z"
         },
         {
           "id": "27717d15-3e41-4558-8e6b-3bbdc7fe3762",
@@ -330,7 +330,7 @@
           "points": null,
           "card_number": 22,
           "created_at": "2025-10-11T19:50:58.400403Z",
-          "updated_at": "2025-10-11T19:51:40.504989Z"
+          "updated_at": "2025-10-11T21:18:30.761425Z"
         },
         {
           "id": "76411161-8bcf-47a3-b917-cadc706c6079",

--- a/kanban.json
+++ b/kanban.json
@@ -6,11 +6,11 @@
         "name": "Kanban",
         "description": null,
         "branch_prefix": null,
-        "next_card_number": 27,
-        "task_sort_field": "UpdatedAt",
-        "task_sort_order": "Descending",
+        "next_card_number": 30,
+        "task_sort_field": "Points",
+        "task_sort_order": "Ascending",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-11T21:26:04.095776Z"
+        "updated_at": "2025-10-11T21:45:54.321947Z"
       },
       "columns": [
         {
@@ -322,15 +322,15 @@
           "id": "27717d15-3e41-4558-8e6b-3bbdc7fe3762",
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Hitting e on an item in the task list should open $EDITOR with that tasks description",
-          "description": null,
+          "description": "It would feel natural to me if the card description was opened when hitting the e button on an element in the cards list\n",
           "priority": "Medium",
           "status": "Todo",
           "position": 21,
           "due_date": null,
-          "points": null,
+          "points": 3,
           "card_number": 22,
           "created_at": "2025-10-11T19:50:58.400403Z",
-          "updated_at": "2025-10-11T21:18:30.761425Z"
+          "updated_at": "2025-10-11T21:44:24.678181Z"
         },
         {
           "id": "76411161-8bcf-47a3-b917-cadc706c6079",
@@ -341,24 +341,24 @@
           "status": "Todo",
           "position": 22,
           "due_date": null,
-          "points": null,
+          "points": 3,
           "card_number": 23,
           "created_at": "2025-10-11T19:51:35.009507Z",
-          "updated_at": "2025-10-11T20:30:16.730121Z"
+          "updated_at": "2025-10-11T21:44:48.544417Z"
         },
         {
           "id": "1c2f3096-823b-4eb7-9345-b80a4c5d8693",
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Add github ci",
-          "description": null,
+          "description": "In the stash somewhere there is a draft of CI\n",
           "priority": "Medium",
           "status": "Todo",
           "position": 23,
           "due_date": null,
-          "points": null,
+          "points": 4,
           "card_number": 24,
           "created_at": "2025-10-11T20:30:09.214394Z",
-          "updated_at": "2025-10-11T20:30:13.695354Z"
+          "updated_at": "2025-10-11T21:45:19.144896Z"
         },
         {
           "id": "e3482cf7-c53a-4ce8-8c33-11e2cca3d87a",
@@ -369,10 +369,10 @@
           "status": "Todo",
           "position": 24,
           "due_date": null,
-          "points": null,
+          "points": 1,
           "card_number": 25,
           "created_at": "2025-10-11T20:53:06.269232Z",
-          "updated_at": "2025-10-11T20:53:45.535859Z"
+          "updated_at": "2025-10-11T21:45:30.599476Z"
         },
         {
           "id": "5e247e41-efdf-43cc-aa0f-daf25830fd1c",
@@ -383,10 +383,52 @@
           "status": "Todo",
           "position": 25,
           "due_date": null,
-          "points": null,
+          "points": 2,
           "card_number": 26,
           "created_at": "2025-10-11T20:54:41.898524Z",
-          "updated_at": "2025-10-11T20:55:07.636242Z"
+          "updated_at": "2025-10-11T21:46:49.938657Z"
+        },
+        {
+          "id": "4cdf603d-2ba8-4bc0-9c19-a2a4531ccff6",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Refactor, hunt for abstractions",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 26,
+          "due_date": null,
+          "points": 4,
+          "card_number": 27,
+          "created_at": "2025-10-11T21:42:14.741535Z",
+          "updated_at": "2025-10-11T21:46:56.750936Z"
+        },
+        {
+          "id": "ed48cbd0-7488-4b61-afe5-71851ed565c0",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "When setting the priority, the card details are closed and the lists are shown",
+          "description": "This is apparently wrong\n",
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 27,
+          "due_date": null,
+          "points": 4,
+          "card_number": 28,
+          "created_at": "2025-10-11T21:43:08.519830Z",
+          "updated_at": "2025-10-11T21:43:21.894906Z"
+        },
+        {
+          "id": "00a80b5e-f7c8-47e7-ba51-312a16a1618e",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Search in cards list",
+          "description": "Mvp, search by title use `/` to search\n\nLater for boards list also\n",
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 28,
+          "due_date": null,
+          "points": 4,
+          "card_number": 29,
+          "created_at": "2025-10-11T21:45:54.321945Z",
+          "updated_at": "2025-10-11T21:47:04.856744Z"
         }
       ]
     }

--- a/kanban.json
+++ b/kanban.json
@@ -180,7 +180,7 @@
           "id": "6a0cbe1e-a05e-4aca-bd53-f0057215d671",
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Add order tasks lists by",
-          "description": "Order tasks by\n\n- Points\n- Priority\n- Date created\n- Date due\n- Status\n\n",
+          "description": "Order tasks by\n\n- Points\n- Priority\n- Date created\n- Date due\n- Date updated\n- Status\n\nMVP\n---\n\nI think in the tasks panel. hit o (for order or organize) and then are presented with a dialogue where can choose one of the above options.\n\nThe dialogue should use the same selection mechanism as the projects and tasks lists do.\n\nAfter one of the options have been selected. The task list should be ordered according to the chosen option.\n\nFor now we leave out Date due from selection as we have not added this feature yet.\n\nOrder can be descending or ascending. a for ascending and d for descending after selecting an item. Taking suggestions on UX here..\n\n---\n\nFor the future. Keep in mind that I would also like to order the projects panel in the same way as the tasks panel but along a shorter list of options\n\n- Name\n- Date created\n- Date updated\n",
           "priority": "Medium",
           "status": "Todo",
           "position": 11,
@@ -188,7 +188,7 @@
           "points": 2,
           "card_number": 13,
           "created_at": "2025-10-10T23:01:18.553586Z",
-          "updated_at": "2025-10-11T07:58:56.105304Z"
+          "updated_at": "2025-10-11T19:49:17.985715Z"
         },
         {
           "id": "9e8f918f-3fde-4847-aca8-0ab7646256a8",
@@ -252,13 +252,13 @@
           "title": "Give cards ID from the beginning",
           "description": "No need to explicitly generate IDS for cards.\n\nWe just give them IDs immediately\n",
           "priority": "Medium",
-          "status": "Todo",
+          "status": "Done",
           "position": 16,
           "due_date": null,
           "points": 1,
           "card_number": 17,
           "created_at": "2025-10-11T18:39:14.248330Z",
-          "updated_at": "2025-10-11T19:11:05.358308Z"
+          "updated_at": "2025-10-11T19:43:05.716699Z"
         },
         {
           "id": "1c0b1752-53f1-4240-be75-0706662156df",

--- a/kanban.json
+++ b/kanban.json
@@ -10,7 +10,7 @@
         "task_sort_field": "Points",
         "task_sort_order": "Descending",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-11T21:57:14.078404Z"
+        "updated_at": "2025-10-11T22:00:10.028574Z"
       },
       "columns": [
         {
@@ -184,13 +184,13 @@
           "title": "Add order tasks lists by",
           "description": "Order tasks by\n\n- Points\n- Priority\n- Date created\n- Date due\n- Date updated\n- Status\n\nMVP\n---\n\nI think in the tasks panel. hit o (for order or organize) and then are presented with a dialogue where can choose one of the above options.\n\nThe dialogue should use the same selection mechanism as the projects and tasks lists do.\n\nAfter one of the options have been selected. The task list should be ordered according to the chosen option.\n\nFor now we leave out Date due from selection as we have not added this feature yet.\n\nOrder can be descending or ascending. a for ascending and d for descending after selecting an item. Taking suggestions on UX here..\n\n---\n\nFor the future. Keep in mind that I would also like to order the projects panel in the same way as the tasks panel but along a shorter list of options\n\n- Name\n- Date created\n- Date updated\n",
           "priority": "Medium",
-          "status": "Todo",
+          "status": "Done",
           "position": 11,
           "due_date": null,
           "points": 2,
           "card_number": 13,
           "created_at": "2025-10-10T23:01:18.553586Z",
-          "updated_at": "2025-10-11T21:19:06.054082Z"
+          "updated_at": "2025-10-11T22:26:20.802010Z"
         },
         {
           "id": "9e8f918f-3fde-4847-aca8-0ab7646256a8",
@@ -218,7 +218,7 @@
           "points": 3,
           "card_number": 15,
           "created_at": "2025-10-11T18:29:10.434614Z",
-          "updated_at": "2025-10-11T18:31:15.375129Z"
+          "updated_at": "2025-10-11T22:26:03.008952Z"
         },
         {
           "id": "9273b022-f7f8-4975-b9c5-7a57c55eba30",
@@ -439,10 +439,10 @@
           "status": "Todo",
           "position": 29,
           "due_date": null,
-          "points": null,
+          "points": 2,
           "card_number": 30,
           "created_at": "2025-10-11T21:56:16.454189Z",
-          "updated_at": "2025-10-11T21:56:16.454189Z"
+          "updated_at": "2025-10-11T22:25:21.168733Z"
         }
       ]
     }

--- a/kanban.json
+++ b/kanban.json
@@ -6,11 +6,11 @@
         "name": "Kanban",
         "description": null,
         "branch_prefix": null,
-        "next_card_number": 26,
+        "next_card_number": 27,
         "task_sort_field": "Priority",
         "task_sort_order": "Ascending",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-11T20:53:06.269236Z"
+        "updated_at": "2025-10-11T20:54:41.898529Z"
       },
       "columns": [
         {
@@ -364,7 +364,7 @@
           "id": "e3482cf7-c53a-4ce8-8c33-11e2cca3d87a",
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Add completed when time to task",
-          "description": null,
+          "description": "Add the date and time for when a task was marked as completed\n",
           "priority": "Medium",
           "status": "Todo",
           "position": 24,
@@ -372,7 +372,21 @@
           "points": null,
           "card_number": 25,
           "created_at": "2025-10-11T20:53:06.269232Z",
-          "updated_at": "2025-10-11T20:53:06.269232Z"
+          "updated_at": "2025-10-11T20:53:45.535859Z"
+        },
+        {
+          "id": "5e247e41-efdf-43cc-aa0f-daf25830fd1c",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "When titles are too long. they don't fit the tasks list",
+          "description": "So for now we just cut them with ... at the in before they hit the wall\n",
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 25,
+          "due_date": null,
+          "points": null,
+          "card_number": 26,
+          "created_at": "2025-10-11T20:54:41.898524Z",
+          "updated_at": "2025-10-11T20:55:07.636242Z"
         }
       ]
     }

--- a/kanban.json
+++ b/kanban.json
@@ -6,9 +6,11 @@
         "name": "Kanban",
         "description": null,
         "branch_prefix": null,
-        "next_card_number": 22,
+        "next_card_number": 25,
+        "task_sort_field": "CreatedAt",
+        "task_sort_order": "Descending",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-11T19:25:07.465579Z"
+        "updated_at": "2025-10-11T20:30:09.214397Z"
       },
       "columns": [
         {
@@ -34,7 +36,7 @@
           "points": 1,
           "card_number": 4,
           "created_at": "2025-10-10T08:47:57.834239Z",
-          "updated_at": "2025-10-10T08:50:57.752600Z"
+          "updated_at": "2025-10-11T20:30:23.290462Z"
         },
         {
           "id": "959a092f-61de-41de-ac4a-729d6e1fcadf",
@@ -48,7 +50,7 @@
           "points": 1,
           "card_number": 5,
           "created_at": "2025-10-10T09:08:28.861766Z",
-          "updated_at": "2025-10-10T09:09:13.709970Z"
+          "updated_at": "2025-10-11T20:30:20.829017Z"
         },
         {
           "id": "292e3f49-089b-40fb-8ea7-c693603904b2",
@@ -62,7 +64,7 @@
           "points": 5,
           "card_number": 1,
           "created_at": "2025-10-10T21:58:56.145240Z",
-          "updated_at": "2025-10-11T07:59:36.019371Z"
+          "updated_at": "2025-10-11T20:30:19.498471Z"
         },
         {
           "id": "f1a80abd-338c-4593-92d6-20c2db7dc093",
@@ -188,7 +190,7 @@
           "points": 2,
           "card_number": 13,
           "created_at": "2025-10-10T23:01:18.553586Z",
-          "updated_at": "2025-10-11T19:49:17.985715Z"
+          "updated_at": "2025-10-11T20:30:25.768199Z"
         },
         {
           "id": "9e8f918f-3fde-4847-aca8-0ab7646256a8",
@@ -202,7 +204,7 @@
           "points": 5,
           "card_number": 14,
           "created_at": "2025-10-11T18:27:29.674825Z",
-          "updated_at": "2025-10-11T18:36:31.619081Z"
+          "updated_at": "2025-10-11T20:30:26.827479Z"
         },
         {
           "id": "1e257c13-f9ee-40e4-86b5-704a9649ea4e",
@@ -264,7 +266,7 @@
           "id": "1c0b1752-53f1-4240-be75-0706662156df",
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Add sprints",
-          "description": "Be able to group cards by sprints. \nSet sprint duration and automatic starting of new sprints\n\nMVP\n\nBoard level defines sprint duration.\n\nIf duration is set, sprint init is possible.\n\nAdd Sprint, set start date, assign cards to it.\n",
+          "description": "Be able to group cards by sprints. \nSet sprint duration and automatic starting of new sprints\n\nMVP\n\nBoard level defines sprint duration.\n\nIf duration is set, sprint init is possible.\n\nAdd Sprint, set start date, assign cards to it.\n\n---\n\nThere should be a UI for sprints. On Project / Board edit\n",
           "priority": "Medium",
           "status": "Todo",
           "position": 17,
@@ -272,7 +274,7 @@
           "points": 4,
           "card_number": 18,
           "created_at": "2025-10-11T18:42:39.943129Z",
-          "updated_at": "2025-10-11T18:44:54.114982Z"
+          "updated_at": "2025-10-11T19:52:50.287355Z"
         },
         {
           "id": "f4c31d5d-7f78-451c-b7db-f26e4931fae4",
@@ -315,6 +317,48 @@
           "card_number": 21,
           "created_at": "2025-10-11T19:25:07.465576Z",
           "updated_at": "2025-10-11T19:25:26.875800Z"
+        },
+        {
+          "id": "27717d15-3e41-4558-8e6b-3bbdc7fe3762",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Hitting e on an item in the task list should open $EDITOR with that tasks description",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 21,
+          "due_date": null,
+          "points": null,
+          "card_number": 22,
+          "created_at": "2025-10-11T19:50:58.400403Z",
+          "updated_at": "2025-10-11T19:51:40.504989Z"
+        },
+        {
+          "id": "76411161-8bcf-47a3-b917-cadc706c6079",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "When inputting in the dialogues. Text is cut when going out of bounds for the iput box",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 22,
+          "due_date": null,
+          "points": null,
+          "card_number": 23,
+          "created_at": "2025-10-11T19:51:35.009507Z",
+          "updated_at": "2025-10-11T20:30:16.730121Z"
+        },
+        {
+          "id": "1c2f3096-823b-4eb7-9345-b80a4c5d8693",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Add github ci",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 23,
+          "due_date": null,
+          "points": null,
+          "card_number": 24,
+          "created_at": "2025-10-11T20:30:09.214394Z",
+          "updated_at": "2025-10-11T20:30:13.695354Z"
         }
       ]
     }


### PR DESCRIPTION
Add task sorting with persistent preferences per board.

Press `o` in the tasks panel to open a sorting dialog. Select from 6 sort options: Points, Priority, Date Created, Date Updated, Status, or Default (card number). Choose ascending with `a`/Enter/Space or descending with `d`.

The dialog highlights the currently active sort with green text and direction arrows (↑/↓). Sort preferences are saved per board and persist across sessions.

## Changes

- Add `SortField` and `SortOrder` enums to Board domain model
- Add `task_sort_field` and `task_sort_order` fields to Board with serde defaults
- Export sort types from domain lib
- Add `OrderTasks` app mode with sort field selection state
- Implement 'o' keybinding to open sort dialog in tasks panel
- Add `get_sorted_board_cards()` method with sorting logic for all fields
- Create sort dialog UI with active sort highlighting (green + arrows)
- Store and load sort preferences per board on activation
- Apply sorting in all task list views (main list and preview)
- Fix card selection bug: map sorted indices to actual card positions
- Fix toggle completion to work correctly with sorted lists
- Add order toggle: pressing Enter/Space on active field flips sort direction
- Format CLI help template for cleaner output
- Fix card_number fields in kanban.json