### PR TITLE
Mvp 10/add or update priorities

### DIFF
--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -239,6 +239,30 @@ impl App {
                         }
                     }
                 }
+                KeyCode::Char('a') => {
+                    if self.focus == Focus::Cards {
+                        if !self.selected_cards.is_empty() {
+                            self.sprint_assign_selection.clear();
+                            self.mode = AppMode::AssignMultipleCardsToSprint;
+                        } else if let Some(sorted_idx) = self.card_selection.get() {
+                            if let Some(board_idx) = self.active_board_index {
+                                if let Some(board) = self.boards.get(board_idx) {
+                                    let sprint_count = self.sprints.iter().filter(|s| s.board_id == board.id).count();
+                                    if sprint_count > 0 {
+                                        let sorted_cards = self.get_sorted_board_cards(board.id);
+                                        if let Some(selected_card) = sorted_cards.get(sorted_idx) {
+                                            let card_id = selected_card.id;
+                                            let actual_idx = self.cards.iter().position(|c| c.id == card_id);
+                                            self.active_card_index = actual_idx;
+                                        }
+                                        self.sprint_assign_selection.set(Some(0));
+                                        self.mode = AppMode::AssignCardToSprint;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 KeyCode::Char('c') => {
                     if self.focus == Focus::Cards {
                         if !self.selected_cards.is_empty() {
@@ -341,12 +365,6 @@ impl App {
                                 }
                             }
                         }
-                    }
-                }
-                KeyCode::Char('a') => {
-                    if self.focus == Focus::Cards && !self.selected_cards.is_empty() {
-                        self.sprint_assign_selection.clear();
-                        self.mode = AppMode::AssignMultipleCardsToSprint;
                     }
                 }
                 KeyCode::Char('1') => self.focus = Focus::Boards,
@@ -839,7 +857,7 @@ impl App {
             },
             AppMode::AssignCardToSprint => match key.code {
                 KeyCode::Esc => {
-                    self.mode = AppMode::CardDetail;
+                    self.mode = AppMode::Normal;
                     self.sprint_assign_selection.clear();
                 }
                 KeyCode::Char('j') | KeyCode::Down => {
@@ -872,7 +890,7 @@ impl App {
                             }
                         }
                     }
-                    self.mode = AppMode::CardDetail;
+                    self.mode = AppMode::Normal;
                     self.sprint_assign_selection.clear();
                 }
                 _ => {}

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -177,9 +177,9 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                     let is_done = card.status == CardStatus::Done;
 
                     let (checkbox, text_color) = if is_done {
-                        ("☑", Color::DarkGray)
+                        ("[x]", Color::DarkGray)
                     } else {
-                        ("□", Color::White)
+                        ("[ ]", Color::White)
                     };
 
                     let mut base_style = Style::default().fg(text_color);

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
     Frame,
 };
 
@@ -75,6 +75,7 @@ pub fn render(app: &App, frame: &mut Frame) {
                 AppMode::ExportAll => render_export_all_popup(app, frame),
                 AppMode::ImportBoard => render_import_board_popup(app, frame),
                 AppMode::SetCardPoints => render_set_card_points_popup(app, frame),
+                AppMode::SetCardPriority => render_set_card_priority_popup(app, frame),
                 AppMode::SetBranchPrefix => render_set_branch_prefix_popup(app, frame),
                 AppMode::OrderCards => render_order_cards_popup(app, frame),
                 _ => {}
@@ -432,6 +433,7 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
             CardFocus::Metadata => "q: quit | ESC: back | 1/2/3: select panel | y: copy branch | Y: copy git cmd | e: edit points | s: assign sprint",
         },
         AppMode::SetCardPoints => "ESC: cancel | ENTER: confirm",
+        AppMode::SetCardPriority => "ESC: cancel | j/k: navigate | ENTER: confirm",
         AppMode::BoardDetail => match app.board_focus {
             BoardFocus::Name => "q: quit | ESC: back | 1/2/3/4: select panel | e: edit name",
             BoardFocus::Description => "q: quit | ESC: back | 1/2/3/4: select panel | e: edit description",
@@ -464,6 +466,44 @@ fn render_create_sprint_popup(app: &App, frame: &mut Frame) {
 
 fn render_set_card_points_popup(app: &App, frame: &mut Frame) {
     render_input_popup(app, frame, "Set Points", "Points (1-5 or empty):");
+}
+
+fn render_set_card_priority_popup(app: &App, frame: &mut Frame) {
+    use kanban_domain::CardPriority;
+
+    let priorities = [
+        CardPriority::Low,
+        CardPriority::Medium,
+        CardPriority::High,
+        CardPriority::Critical,
+    ];
+
+    let selected = app.priority_selection.get().unwrap_or(0);
+
+    let items: Vec<ListItem> = priorities
+        .iter()
+        .enumerate()
+        .map(|(idx, priority)| {
+            let style = if idx == selected {
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            ListItem::new(format!("{:?}", priority)).style(style)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title("Set Priority")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan)),
+        );
+
+    let area = centered_rect(30, 40, frame.area());
+    frame.render_widget(Clear, area);
+    frame.render_widget(list, area);
 }
 
 fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -179,7 +179,7 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                     let (checkbox, text_color) = if is_done {
                         ("☑", Color::DarkGray)
                     } else {
-                        ("☐", Color::White)
+                        ("□", Color::White)
                     };
 
                     let mut base_style = Style::default().fg(text_color);

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -245,9 +245,9 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                     }
 
                     let points_text = if let Some(points) = card.points {
-                        format!("[{}]", points)
+                        format!("{}", points)
                     } else {
-                        "   ".to_string()
+                        " ".to_string()
                     };
 
                     let mut spans = vec![

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -176,16 +176,22 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                     let is_focused = app.focus == Focus::Cards;
                     let is_done = card.status == CardStatus::Done;
 
-                    let (checkbox, text_color, text_modifier) = if is_done {
-                        ("☑", Color::DarkGray, Modifier::CROSSED_OUT)
+                    let (checkbox, text_color) = if is_done {
+                        ("☑", Color::DarkGray)
                     } else {
-                        ("☐", Color::White, Modifier::empty())
+                        ("☐", Color::White)
                     };
 
-                    let mut style = Style::default().fg(text_color).add_modifier(text_modifier);
+                    let mut base_style = Style::default().fg(text_color);
+                    let mut title_style = Style::default().fg(text_color);
+
+                    if is_done {
+                        title_style = title_style.add_modifier(Modifier::CROSSED_OUT);
+                    }
 
                     if is_selected && is_focused {
-                        style = style.bg(Color::Blue);
+                        base_style = base_style.bg(Color::Blue);
+                        title_style = title_style.bg(Color::Blue);
                     }
 
                     let sprint_name = if let Some(sprint_id) = card.sprint_id {
@@ -248,7 +254,8 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                         Span::styled("● ", priority_style),
                         Span::styled(points_text, points_style),
                         Span::raw(" "),
-                        Span::styled(format!("{}{} {}", select_indicator, checkbox, card.title), style)
+                        Span::styled(format!("{}{} ", select_indicator, checkbox), base_style),
+                        Span::styled(&card.title, title_style)
                     ];
 
                     if !sprint_name.is_empty() {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -215,7 +215,20 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                     let is_multi_selected = app.selected_cards.contains(&card.id);
                     let select_indicator = if is_multi_selected { "► " } else { "  " };
 
+                    let priority_color = match card.priority {
+                        kanban_domain::CardPriority::Critical => Color::Red,
+                        kanban_domain::CardPriority::High => Color::LightRed,
+                        kanban_domain::CardPriority::Medium => Color::Yellow,
+                        kanban_domain::CardPriority::Low => Color::White,
+                    };
+
+                    let mut priority_style = Style::default().fg(priority_color);
+                    if is_selected && is_focused {
+                        priority_style = priority_style.bg(Color::Blue);
+                    }
+
                     let mut spans = vec![
+                        Span::styled("● ", priority_style),
                         Span::styled(format!("{}{} {}", select_indicator, checkbox, card.title), style)
                     ];
 

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -188,12 +188,6 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                         style = style.bg(Color::Blue);
                     }
 
-                    let points_badge = if let Some(points) = card.points {
-                        format!(" [{}]", points)
-                    } else {
-                        String::new()
-                    };
-
                     let sprint_name = if let Some(sprint_id) = card.sprint_id {
                         app.sprints
                             .iter()
@@ -215,6 +209,23 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                     let is_multi_selected = app.selected_cards.contains(&card.id);
                     let select_indicator = if is_multi_selected { "► " } else { "  " };
 
+                    let points_color = card
+                        .points
+                        .map(|p| match p {
+                            1 => Color::Cyan,
+                            2 => Color::Green,
+                            3 => Color::Yellow,
+                            4 => Color::LightMagenta,
+                            5 => Color::Red,
+                            _ => Color::White,
+                        })
+                        .unwrap_or(Color::White);
+
+                    let mut points_style = Style::default().fg(points_color);
+                    if is_selected && is_focused {
+                        points_style = points_style.bg(Color::Blue);
+                    }
+
                     let priority_color = match card.priority {
                         kanban_domain::CardPriority::Critical => Color::Red,
                         kanban_domain::CardPriority::High => Color::LightRed,
@@ -227,30 +238,18 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                         priority_style = priority_style.bg(Color::Blue);
                     }
 
+                    let points_text = if let Some(points) = card.points {
+                        format!("[{}]", points)
+                    } else {
+                        "   ".to_string()
+                    };
+
                     let mut spans = vec![
                         Span::styled("● ", priority_style),
+                        Span::styled(points_text, points_style),
+                        Span::raw(" "),
                         Span::styled(format!("{}{} {}", select_indicator, checkbox, card.title), style)
                     ];
-
-                    if !points_badge.is_empty() {
-                        let points_color = card
-                            .points
-                            .map(|p| match p {
-                                1 => Color::Cyan,
-                                2 => Color::Green,
-                                3 => Color::Yellow,
-                                4 => Color::LightMagenta,
-                                5 => Color::Red,
-                                _ => Color::White,
-                            })
-                            .unwrap_or(Color::White);
-
-                        let mut points_style = Style::default().fg(points_color);
-                        if is_selected && is_focused {
-                            points_style = points_style.bg(Color::Blue);
-                        }
-                        spans.push(Span::styled(points_badge, points_style));
-                    }
 
                     if !sprint_name.is_empty() {
                         let mut sprint_style = Style::default().fg(Color::DarkGray);

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -227,7 +227,9 @@ fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
                         })
                         .unwrap_or(Color::White);
 
-                    let mut points_style = Style::default().fg(points_color);
+                    let mut points_style = Style::default()
+                        .fg(points_color)
+                        .add_modifier(Modifier::BOLD);
                     if is_selected && is_focused {
                         points_style = points_style.bg(Color::Blue);
                     }

--- a/kanban.json
+++ b/kanban.json
@@ -7,17 +7,6 @@
         "description": "Management of the **Kanban** project\n",
         "branch_prefix": "KAN",
         "next_card_number": 45,
-        "task_sort_field": "Points",
-        "task_sort_order": "Descending",
-        "sprint_duration_days": 7,
-        "sprint_prefix": "MVP",
-        "sprint_names": [
-          "an-eventful-october",
-          "an-experience-to-remember"
-        ],
-        "sprint_name_used_count": 2,
-        "next_sprint_number": 7,
-        "active_sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
         "created_at": "2025-10-10T08:47:44.779097Z",
         "updated_at": "2025-10-12T17:32:56.610132Z"
       },
@@ -44,10 +33,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 4,
-          "sprint_id": null,
           "created_at": "2025-10-10T08:47:57.834239Z",
-          "updated_at": "2025-10-12T17:36:08.452384Z",
-          "completed_at": "2025-10-12T17:36:08.452384Z"
+          "updated_at": "2025-10-12T17:36:08.452384Z"
         },
         {
           "id": "959a092f-61de-41de-ac4a-729d6e1fcadf",
@@ -60,10 +47,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 5,
-          "sprint_id": null,
           "created_at": "2025-10-10T09:08:28.861766Z",
-          "updated_at": "2025-10-12T17:36:58.071278Z",
-          "completed_at": "2025-10-12T17:36:58.071278Z"
+          "updated_at": "2025-10-12T17:36:58.071278Z"
         },
         {
           "id": "292e3f49-089b-40fb-8ea7-c693603904b2",
@@ -76,10 +61,8 @@
           "due_date": null,
           "points": 5,
           "card_number": 1,
-          "sprint_id": null,
           "created_at": "2025-10-10T21:58:56.145240Z",
-          "updated_at": "2025-10-12T14:44:13.680351Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T14:44:13.680351Z"
         },
         {
           "id": "f1a80abd-338c-4593-92d6-20c2db7dc093",
@@ -92,10 +75,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 2,
-          "sprint_id": null,
           "created_at": "2025-10-10T22:03:42.988557Z",
-          "updated_at": "2025-10-12T15:09:11.118477Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T15:09:11.118477Z"
         },
         {
           "id": "e96684a5-4645-443e-8e2c-6bb646e248c6",
@@ -108,10 +89,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 6,
-          "sprint_id": null,
           "created_at": "2025-10-10T22:05:04.607714Z",
-          "updated_at": "2025-10-12T17:21:31.495335Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:21:31.495335Z"
         },
         {
           "id": "90f8121a-045f-47fd-b8fe-bb0e5b7662b1",
@@ -124,10 +103,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 7,
-          "sprint_id": null,
           "created_at": "2025-10-10T22:11:25.809290Z",
-          "updated_at": "2025-10-11T20:40:58.659416Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T20:40:58.659416Z"
         },
         {
           "id": "86c1b649-03bc-4da8-87c3-e20a2c56a640",
@@ -140,10 +117,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 8,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-10T22:13:04.048521Z",
-          "updated_at": "2025-10-10T22:14:15.622866Z",
-          "completed_at": null
+          "updated_at": "2025-10-10T22:14:15.622866Z"
         },
         {
           "id": "eceed2ce-de5e-4166-95e7-7fb9c7e65b20",
@@ -156,10 +131,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 9,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-10T22:14:31.293267Z",
-          "updated_at": "2025-10-12T17:36:18.254781Z",
-          "completed_at": "2025-10-12T17:36:18.254781Z"
+          "updated_at": "2025-10-12T17:36:18.254781Z"
         },
         {
           "id": "7cd165b0-6671-46d6-b837-4e73ada26333",
@@ -172,10 +145,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 10,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-10T22:15:09.199792Z",
-          "updated_at": "2025-10-12T17:36:24.580951Z",
-          "completed_at": "2025-10-12T17:36:24.580951Z"
+          "updated_at": "2025-10-12T17:36:24.580951Z"
         },
         {
           "id": "454144d2-27ac-4abf-8632-407908fa8f80",
@@ -188,10 +159,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 11,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-10T22:53:19.579898Z",
-          "updated_at": "2025-10-12T16:47:27.034553Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T16:47:27.034553Z"
         },
         {
           "id": "d48f9085-57ff-42c5-9f42-3cbb3cafde93",
@@ -204,10 +173,8 @@
           "due_date": null,
           "points": 5,
           "card_number": 12,
-          "sprint_id": null,
           "created_at": "2025-10-10T22:56:04.200355Z",
-          "updated_at": "2025-10-12T17:09:48.297167Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:09:48.297167Z"
         },
         {
           "id": "6a0cbe1e-a05e-4aca-bd53-f0057215d671",
@@ -220,10 +187,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 13,
-          "sprint_id": null,
           "created_at": "2025-10-10T23:01:18.553586Z",
-          "updated_at": "2025-10-12T17:37:18.838895Z",
-          "completed_at": "2025-10-12T17:37:18.838895Z"
+          "updated_at": "2025-10-12T17:37:18.838895Z"
         },
         {
           "id": "9e8f918f-3fde-4847-aca8-0ab7646256a8",
@@ -236,10 +201,8 @@
           "due_date": null,
           "points": 5,
           "card_number": 14,
-          "sprint_id": null,
           "created_at": "2025-10-11T18:27:29.674825Z",
-          "updated_at": "2025-10-12T15:09:11.118477Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T15:09:11.118477Z"
         },
         {
           "id": "1e257c13-f9ee-40e4-86b5-704a9649ea4e",
@@ -252,10 +215,8 @@
           "due_date": null,
           "points": 3,
           "card_number": 15,
-          "sprint_id": null,
           "created_at": "2025-10-11T18:29:10.434614Z",
-          "updated_at": "2025-10-11T22:26:03.008952Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T22:26:03.008952Z"
         },
         {
           "id": "9273b022-f7f8-4975-b9c5-7a57c55eba30",
@@ -268,10 +229,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 3,
-          "sprint_id": null,
           "created_at": "2025-10-11T18:36:43.972262Z",
-          "updated_at": "2025-10-11T19:03:44.948745Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T19:03:44.948745Z"
         },
         {
           "id": "a189ef1a-903c-4c43-924e-2194562237f6",
@@ -284,10 +243,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 16,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-11T18:38:07.855746Z",
-          "updated_at": "2025-10-12T16:45:07.630022Z",
-          "completed_at": "2025-10-12T16:45:07.630022Z"
+          "updated_at": "2025-10-12T16:45:07.630022Z"
         },
         {
           "id": "ed0ead2b-6da9-4889-83b7-e4c60ab11032",
@@ -300,10 +257,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 17,
-          "sprint_id": null,
           "created_at": "2025-10-11T18:39:14.248330Z",
-          "updated_at": "2025-10-11T19:43:05.716699Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T19:43:05.716699Z"
         },
         {
           "id": "1c0b1752-53f1-4240-be75-0706662156df",
@@ -316,10 +271,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 18,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-11T18:42:39.943129Z",
-          "updated_at": "2025-10-12T16:48:54.024375Z",
-          "completed_at": "2025-10-12T16:48:54.024375Z"
+          "updated_at": "2025-10-12T16:48:54.024375Z"
         },
         {
           "id": "f4c31d5d-7f78-451c-b7db-f26e4931fae4",
@@ -332,10 +285,8 @@
           "due_date": null,
           "points": 3,
           "card_number": 19,
-          "sprint_id": null,
           "created_at": "2025-10-11T18:45:47.488818Z",
-          "updated_at": "2025-10-11T19:01:45.403042Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T19:01:45.403042Z"
         },
         {
           "id": "8ecc1849-bde7-4f97-99f7-44b7d9158bbf",
@@ -348,10 +299,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 20,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T19:23:32.612472Z",
-          "updated_at": "2025-10-12T17:34:42.755476Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:34:42.755476Z"
         },
         {
           "id": "6c1e0ca7-22bb-49e5-86bc-8d1e2a55c9ee",
@@ -364,10 +313,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 21,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T19:25:07.465576Z",
-          "updated_at": "2025-10-12T17:34:42.755475Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:34:42.755475Z"
         },
         {
           "id": "27717d15-3e41-4558-8e6b-3bbdc7fe3762",
@@ -380,10 +327,8 @@
           "due_date": null,
           "points": 3,
           "card_number": 22,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-11T19:50:58.400403Z",
-          "updated_at": "2025-10-11T21:44:24.678181Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T21:44:24.678181Z"
         },
         {
           "id": "76411161-8bcf-47a3-b917-cadc706c6079",
@@ -396,10 +341,8 @@
           "due_date": null,
           "points": 3,
           "card_number": 23,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T19:51:35.009507Z",
-          "updated_at": "2025-10-12T17:34:42.755475Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:34:42.755475Z"
         },
         {
           "id": "1c2f3096-823b-4eb7-9345-b80a4c5d8693",
@@ -412,10 +355,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 24,
-          "sprint_id": null,
           "created_at": "2025-10-11T20:30:09.214394Z",
-          "updated_at": "2025-10-11T21:45:19.144896Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T21:45:19.144896Z"
         },
         {
           "id": "e3482cf7-c53a-4ce8-8c33-11e2cca3d87a",
@@ -428,10 +369,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 25,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-11T20:53:06.269232Z",
-          "updated_at": "2025-10-12T16:40:38.483152Z",
-          "completed_at": "2025-10-12T16:40:38.483152Z"
+          "updated_at": "2025-10-12T16:40:38.483152Z"
         },
         {
           "id": "5e247e41-efdf-43cc-aa0f-daf25830fd1c",
@@ -444,10 +383,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 26,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T20:54:41.898524Z",
-          "updated_at": "2025-10-12T17:34:42.755476Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:34:42.755476Z"
         },
         {
           "id": "4cdf603d-2ba8-4bc0-9c19-a2a4531ccff6",
@@ -460,10 +397,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 27,
-          "sprint_id": null,
           "created_at": "2025-10-11T21:42:14.741535Z",
-          "updated_at": "2025-10-12T14:55:06.382978Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T14:55:06.382978Z"
         },
         {
           "id": "ed48cbd0-7488-4b61-afe5-71851ed565c0",
@@ -476,10 +411,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 28,
-          "sprint_id": null,
           "created_at": "2025-10-11T21:43:08.519830Z",
-          "updated_at": "2025-10-12T14:58:29.087702Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T14:58:29.087702Z"
         },
         {
           "id": "00a80b5e-f7c8-47e7-ba51-312a16a1618e",
@@ -492,10 +425,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 29,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T21:45:54.321945Z",
-          "updated_at": "2025-10-11T21:47:04.856744Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T21:47:04.856744Z"
         },
         {
           "id": "72ffc5f8-df27-4dd5-bc13-36e5c105f367",
@@ -508,10 +439,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 30,
-          "sprint_id": null,
           "created_at": "2025-10-11T21:56:16.454189Z",
-          "updated_at": "2025-10-11T22:25:21.168733Z",
-          "completed_at": null
+          "updated_at": "2025-10-11T22:25:21.168733Z"
         },
         {
           "id": "6f66b041-2592-4e78-b348-cbc34c00c548",
@@ -524,10 +453,8 @@
           "due_date": null,
           "points": 5,
           "card_number": 31,
-          "sprint_id": null,
           "created_at": "2025-10-12T00:14:17.034422Z",
-          "updated_at": "2025-10-12T15:09:11.118477Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T15:09:11.118477Z"
         },
         {
           "id": "0ae3776c-38cc-4b22-8e89-ed9ac767b512",
@@ -540,10 +467,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 32,
-          "sprint_id": null,
           "created_at": "2025-10-12T08:23:41.175901Z",
-          "updated_at": "2025-10-12T13:37:36.229199Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T13:37:36.229199Z"
         },
         {
           "id": "8e3a543e-86b0-405f-994e-515e013990b7",
@@ -556,10 +481,8 @@
           "due_date": null,
           "points": 3,
           "card_number": 33,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-12T13:35:39.923005Z",
-          "updated_at": "2025-10-12T17:34:42.755477Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:34:42.755477Z"
         },
         {
           "id": "475bde99-0a3f-457c-9ea6-2fd51d1d7e73",
@@ -572,10 +495,8 @@
           "due_date": null,
           "points": 1,
           "card_number": 34,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-12T13:37:00.520483Z",
-          "updated_at": "2025-10-12T13:37:20.209400Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T13:37:20.209400Z"
         },
         {
           "id": "4e3ecb8a-476f-4f65-8060-5577eb32c192",
@@ -588,10 +509,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 35,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-12T13:39:14.336658Z",
-          "updated_at": "2025-10-12T17:34:42.755477Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:34:42.755477Z"
         },
         {
           "id": "cdaed89e-ddb8-4a99-9567-b1096f6aaca2",
@@ -604,10 +523,8 @@
           "due_date": null,
           "points": 5,
           "card_number": 36,
-          "sprint_id": null,
           "created_at": "2025-10-12T14:44:43.936971Z",
-          "updated_at": "2025-10-12T15:09:11.118474Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T15:09:11.118474Z"
         },
         {
           "id": "3b771805-ec2a-4b6a-bc3d-57b1528e3742",
@@ -620,10 +537,8 @@
           "due_date": null,
           "points": 4,
           "card_number": 37,
-          "sprint_id": null,
           "created_at": "2025-10-12T14:49:41.587356Z",
-          "updated_at": "2025-10-12T14:51:08.328546Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T14:51:08.328546Z"
         },
         {
           "id": "8099e29b-21d9-404c-a716-47c659773f69",
@@ -636,10 +551,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 38,
-          "sprint_id": null,
           "created_at": "2025-10-12T15:43:38.123195Z",
-          "updated_at": "2025-10-12T15:44:21.664477Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T15:44:21.664477Z"
         },
         {
           "id": "8be94a1d-a915-46d1-a7f1-020da9307cd9",
@@ -652,10 +565,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 39,
-          "sprint_id": null,
           "created_at": "2025-10-12T15:44:28.371016Z",
-          "updated_at": "2025-10-12T15:45:04.057629Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T15:45:04.057629Z"
         },
         {
           "id": "ff2085d5-9304-423d-8169-6d3fb2a509d9",
@@ -668,10 +579,8 @@
           "due_date": null,
           "points": 3,
           "card_number": 40,
-          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-12T15:45:29.530124Z",
-          "updated_at": "2025-10-12T17:34:42.755470Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:34:42.755470Z"
         },
         {
           "id": "21ef5706-4393-458e-93c2-a8ca7792afa8",
@@ -684,10 +593,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 41,
-          "sprint_id": null,
           "created_at": "2025-10-12T15:48:23.468340Z",
-          "updated_at": "2025-10-12T16:48:08.217212Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T16:48:08.217212Z"
         },
         {
           "id": "5b43a7e3-b056-4370-882a-bdad4bb9e0ed",
@@ -700,10 +607,8 @@
           "due_date": null,
           "points": 2,
           "card_number": 42,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-12T16:45:24.828497Z",
-          "updated_at": "2025-10-12T17:34:42.755474Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:34:42.755474Z"
         },
         {
           "id": "5d31ae81-75a7-47c7-a6d1-5a9b0f06a5b7",
@@ -716,7 +621,6 @@
           "due_date": null,
           "points": 1,
           "card_number": 43,
-          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-12T16:45:41.135171Z",
           "updated_at": "2025-10-12T16:51:11.859124Z",
           "completed_at": null

--- a/kanban.json
+++ b/kanban.json
@@ -6,7 +6,7 @@
         "name": "Kanban",
         "description": "Management of the **Kanban** project\n",
         "branch_prefix": "KAN",
-        "next_card_number": 44,
+        "next_card_number": 45,
         "task_sort_field": "Points",
         "task_sort_order": "Descending",
         "sprint_duration_days": 7,
@@ -18,7 +18,7 @@
         "next_sprint_number": 6,
         "active_sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-12T16:45:41.135177Z"
+        "updated_at": "2025-10-12T17:15:57.532853Z"
       },
       "columns": [
         {
@@ -205,7 +205,7 @@
           "card_number": 12,
           "sprint_id": null,
           "created_at": "2025-10-10T22:56:04.200355Z",
-          "updated_at": "2025-10-11T20:41:24.403599Z",
+          "updated_at": "2025-10-12T17:09:48.297167Z",
           "completed_at": null
         },
         {

--- a/kanban.json
+++ b/kanban.json
@@ -12,13 +12,14 @@
         "sprint_duration_days": 7,
         "sprint_prefix": "MVP",
         "sprint_names": [
-          "an-eventful-october"
+          "an-eventful-october",
+          "an-experience-to-remember"
         ],
-        "sprint_name_used_count": 1,
-        "next_sprint_number": 6,
+        "sprint_name_used_count": 2,
+        "next_sprint_number": 7,
         "active_sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
         "created_at": "2025-10-10T08:47:44.779097Z",
-        "updated_at": "2025-10-12T17:15:57.532853Z"
+        "updated_at": "2025-10-12T17:32:56.610132Z"
       },
       "columns": [
         {
@@ -45,8 +46,8 @@
           "card_number": 4,
           "sprint_id": null,
           "created_at": "2025-10-10T08:47:57.834239Z",
-          "updated_at": "2025-10-11T20:30:23.290462Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:36:08.452384Z",
+          "completed_at": "2025-10-12T17:36:08.452384Z"
         },
         {
           "id": "959a092f-61de-41de-ac4a-729d6e1fcadf",
@@ -61,8 +62,8 @@
           "card_number": 5,
           "sprint_id": null,
           "created_at": "2025-10-10T09:08:28.861766Z",
-          "updated_at": "2025-10-11T20:30:20.829017Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:36:58.071278Z",
+          "completed_at": "2025-10-12T17:36:58.071278Z"
         },
         {
           "id": "292e3f49-089b-40fb-8ea7-c693603904b2",
@@ -109,7 +110,7 @@
           "card_number": 6,
           "sprint_id": null,
           "created_at": "2025-10-10T22:05:04.607714Z",
-          "updated_at": "2025-10-10T22:44:01.235679Z",
+          "updated_at": "2025-10-12T17:21:31.495335Z",
           "completed_at": null
         },
         {
@@ -149,16 +150,16 @@
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Change priority",
           "description": "- Be able to change the priority of a task\n\n",
-          "priority": "Medium",
-          "status": "Todo",
+          "priority": "Critical",
+          "status": "Done",
           "position": 7,
           "due_date": null,
           "points": 1,
           "card_number": 9,
           "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-10T22:14:31.293267Z",
-          "updated_at": "2025-10-11T20:41:09.462182Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:36:18.254781Z",
+          "completed_at": "2025-10-12T17:36:18.254781Z"
         },
         {
           "id": "7cd165b0-6671-46d6-b837-4e73ada26333",
@@ -166,15 +167,15 @@
           "title": "Add or update priorities",
           "description": "On the board level. \n\nBe able to configure priorities and change their names. \n\nWe should start with only medium?\n",
           "priority": "Medium",
-          "status": "Todo",
+          "status": "Done",
           "position": 8,
           "due_date": null,
           "points": 1,
           "card_number": 10,
           "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-10T22:15:09.199792Z",
-          "updated_at": "2025-10-10T22:16:05.956954Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:36:24.580951Z",
+          "completed_at": "2025-10-12T17:36:24.580951Z"
         },
         {
           "id": "454144d2-27ac-4abf-8632-407908fa8f80",
@@ -221,8 +222,8 @@
           "card_number": 13,
           "sprint_id": null,
           "created_at": "2025-10-10T23:01:18.553586Z",
-          "updated_at": "2025-10-11T22:26:20.802010Z",
-          "completed_at": null
+          "updated_at": "2025-10-12T17:37:18.838895Z",
+          "completed_at": "2025-10-12T17:37:18.838895Z"
         },
         {
           "id": "9e8f918f-3fde-4847-aca8-0ab7646256a8",
@@ -347,9 +348,9 @@
           "due_date": null,
           "points": 2,
           "card_number": 20,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T19:23:32.612472Z",
-          "updated_at": "2025-10-11T19:25:31.337766Z",
+          "updated_at": "2025-10-12T17:34:42.755476Z",
           "completed_at": null
         },
         {
@@ -363,9 +364,9 @@
           "due_date": null,
           "points": 2,
           "card_number": 21,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T19:25:07.465576Z",
-          "updated_at": "2025-10-11T21:19:20.961218Z",
+          "updated_at": "2025-10-12T17:34:42.755475Z",
           "completed_at": null
         },
         {
@@ -379,7 +380,7 @@
           "due_date": null,
           "points": 3,
           "card_number": 22,
-          "sprint_id": null,
+          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-11T19:50:58.400403Z",
           "updated_at": "2025-10-11T21:44:24.678181Z",
           "completed_at": null
@@ -395,9 +396,9 @@
           "due_date": null,
           "points": 3,
           "card_number": 23,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T19:51:35.009507Z",
-          "updated_at": "2025-10-11T21:44:48.544417Z",
+          "updated_at": "2025-10-12T17:34:42.755475Z",
           "completed_at": null
         },
         {
@@ -443,9 +444,9 @@
           "due_date": null,
           "points": 2,
           "card_number": 26,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T20:54:41.898524Z",
-          "updated_at": "2025-10-11T21:46:49.938657Z",
+          "updated_at": "2025-10-12T17:34:42.755476Z",
           "completed_at": null
         },
         {
@@ -491,7 +492,7 @@
           "due_date": null,
           "points": 4,
           "card_number": 29,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-11T21:45:54.321945Z",
           "updated_at": "2025-10-11T21:47:04.856744Z",
           "completed_at": null
@@ -555,9 +556,9 @@
           "due_date": null,
           "points": 3,
           "card_number": 33,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-12T13:35:39.923005Z",
-          "updated_at": "2025-10-12T13:37:27.456Z",
+          "updated_at": "2025-10-12T17:34:42.755477Z",
           "completed_at": null
         },
         {
@@ -571,7 +572,7 @@
           "due_date": null,
           "points": 1,
           "card_number": 34,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-12T13:37:00.520483Z",
           "updated_at": "2025-10-12T13:37:20.209400Z",
           "completed_at": null
@@ -587,9 +588,9 @@
           "due_date": null,
           "points": 2,
           "card_number": 35,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-12T13:39:14.336658Z",
-          "updated_at": "2025-10-12T13:42:20.921129Z",
+          "updated_at": "2025-10-12T17:34:42.755477Z",
           "completed_at": null
         },
         {
@@ -667,9 +668,9 @@
           "due_date": null,
           "points": 3,
           "card_number": 40,
-          "sprint_id": null,
+          "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
           "created_at": "2025-10-12T15:45:29.530124Z",
-          "updated_at": "2025-10-12T15:46:31.166006Z",
+          "updated_at": "2025-10-12T17:34:42.755470Z",
           "completed_at": null
         },
         {
@@ -693,7 +694,7 @@
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Assign task to sprint if created in sprint task list",
           "description": null,
-          "priority": "High",
+          "priority": "Low",
           "status": "Todo",
           "position": 41,
           "due_date": null,
@@ -701,7 +702,7 @@
           "card_number": 42,
           "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-12T16:45:24.828497Z",
-          "updated_at": "2025-10-12T17:07:08.154323Z",
+          "updated_at": "2025-10-12T17:34:42.755474Z",
           "completed_at": null
         },
         {
@@ -797,6 +798,18 @@
           "end_date": "2025-10-19T13:49:57.439840Z",
           "created_at": "2025-10-12T13:46:50.902284Z",
           "updated_at": "2025-10-12T13:49:57.439845Z"
+        },
+        {
+          "id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+          "board_id": "e119c091-e1fa-4596-9bc7-038ceab6adec",
+          "sprint_number": 6,
+          "name_index": 1,
+          "prefix_override": null,
+          "status": "Planning",
+          "start_date": null,
+          "end_date": null,
+          "created_at": "2025-10-12T17:32:56.610133Z",
+          "updated_at": "2025-10-12T17:32:56.610133Z"
         }
       ]
     }

--- a/kanban.json
+++ b/kanban.json
@@ -772,7 +772,7 @@
           "id": "5d31ae81-75a7-47c7-a6d1-5a9b0f06a5b7",
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Remove projects projects and kanban green text",
-          "description": null,
+          "description": "in the projects panel there is a green text with `Projects` we can drop this as the panel header itself shows projects too.\n\nin the task list there is a green text of the current project. we can drop this and rely on the highlighted item in the projects list instead\n",
           "priority": "Medium",
           "status": "Todo",
           "position": 42,
@@ -781,7 +781,7 @@
           "card_number": 43,
           "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-12T16:45:41.135171Z",
-          "updated_at": "2025-10-12T16:46:20.354842Z",
+          "updated_at": "2025-10-12T16:51:11.859124Z",
           "completed_at": null
         }
       ],
@@ -799,6 +799,28 @@
           "updated_at": "2025-10-12T13:49:57.439845Z"
         }
       ]
+    },
+    {
+      "board": {
+        "id": "2bdd79a5-b26a-473c-b790-8b5117283b2f",
+        "name": "test",
+        "description": null,
+        "branch_prefix": null,
+        "next_card_number": 1,
+        "task_sort_field": "Default",
+        "task_sort_order": "Ascending",
+        "sprint_duration_days": null,
+        "sprint_prefix": null,
+        "sprint_names": [],
+        "sprint_name_used_count": 0,
+        "next_sprint_number": 1,
+        "active_sprint_id": null,
+        "created_at": "2025-10-12T16:50:35.469369Z",
+        "updated_at": "2025-10-12T16:50:35.469369Z"
+      },
+      "columns": [],
+      "cards": [],
+      "sprints": []
     }
   ]
 }

--- a/kanban.json
+++ b/kanban.json
@@ -693,7 +693,7 @@
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Assign task to sprint if created in sprint task list",
           "description": null,
-          "priority": "Medium",
+          "priority": "High",
           "status": "Todo",
           "position": 41,
           "due_date": null,
@@ -701,7 +701,7 @@
           "card_number": 42,
           "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-12T16:45:24.828497Z",
-          "updated_at": "2025-10-12T16:46:10.916807Z",
+          "updated_at": "2025-10-12T17:07:08.154323Z",
           "completed_at": null
         },
         {

--- a/kanban.json
+++ b/kanban.json
@@ -799,28 +799,6 @@
           "updated_at": "2025-10-12T13:49:57.439845Z"
         }
       ]
-    },
-    {
-      "board": {
-        "id": "2bdd79a5-b26a-473c-b790-8b5117283b2f",
-        "name": "test",
-        "description": null,
-        "branch_prefix": null,
-        "next_card_number": 1,
-        "task_sort_field": "Default",
-        "task_sort_order": "Ascending",
-        "sprint_duration_days": null,
-        "sprint_prefix": null,
-        "sprint_names": [],
-        "sprint_name_used_count": 0,
-        "next_sprint_number": 1,
-        "active_sprint_id": null,
-        "created_at": "2025-10-12T16:50:35.469369Z",
-        "updated_at": "2025-10-12T16:50:35.469369Z"
-      },
-      "columns": [],
-      "cards": [],
-      "sprints": []
     }
   ]
 }

--- a/kanban.json
+++ b/kanban.json
@@ -710,7 +710,7 @@
           "title": "Remove projects projects and kanban green text",
           "description": "in the projects panel there is a green text with `Projects` we can drop this as the panel header itself shows projects too.\n\nin the task list there is a green text of the current project. we can drop this and rely on the highlighted item in the projects list instead\n",
           "priority": "Medium",
-          "status": "Todo",
+          "status": "Done",
           "position": 42,
           "due_date": null,
           "points": 1,

--- a/kanban.json
+++ b/kanban.json
@@ -751,6 +751,38 @@
           "created_at": "2025-10-12T16:45:41.135171Z",
           "updated_at": "2025-10-12T16:51:11.859124Z",
           "completed_at": null
+        },
+        {
+          "id": "5b43a7e3-b056-4370-882a-bdad4bb9e0ed",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Assign task to sprint if created in sprint task list",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 41,
+          "due_date": null,
+          "points": 2,
+          "card_number": 42,
+          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+          "created_at": "2025-10-12T16:45:24.828497Z",
+          "updated_at": "2025-10-12T16:46:10.916807Z",
+          "completed_at": null
+        },
+        {
+          "id": "5d31ae81-75a7-47c7-a6d1-5a9b0f06a5b7",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Remove projects projects and kanban green text",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 42,
+          "due_date": null,
+          "points": 1,
+          "card_number": 43,
+          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+          "created_at": "2025-10-12T16:45:41.135171Z",
+          "updated_at": "2025-10-12T16:46:20.354842Z",
+          "completed_at": null
         }
       ],
       "sprints": [


### PR DESCRIPTION
## Changes

### Priority Management
- Add priority selection UI with 'p' key in card detail
- Display colored priority indicator (●) in task list (Critical=Red, High=LightRed, Medium=Yellow, Low=White)
- Navigate priorities with j/k, confirm with Enter

### Keyboard Shortcuts
- Add 'a' key to assign card to sprint from task list
- Add Shift+T to filter out assigned cards (show only unassigned)
- Fix sprint assignment by setting active_card_index when invoked from task list

### UI Improvements  
- Remove "Kanban Board" header
- Remove redundant green text labels from projects and tasks panels
- Use bracket-style checkboxes `[ ]` and `[x]` for consistent sizing
- Display points as bold numbers without brackets
- Position priority and points in fixed-width left column
- Apply strikethrough only to task title, not checkbox

### Bug Fixes
- Reset card selection when toggling sprint filter to prevent out-of-bounds
- Fix card count to respect active sprint filter and hide_assigned_cards filter