### PR TITLE
Mvp 43/remove projects projects and kanban green text

### DIFF
--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -94,15 +94,7 @@ fn render_main(app: &App, frame: &mut Frame, area: Rect) {
 }
 
 fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
-    let mut lines = vec![
-        Line::from(Span::styled(
-            "Projects",
-            Style::default()
-                .fg(Color::Green)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::from(Span::raw("")),
-    ];
+    let mut lines = vec![];
 
     if app.boards.is_empty() {
         lines.push(Line::from(Span::styled(
@@ -161,24 +153,7 @@ fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
 fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
     let board_idx = app.active_board_index.or(app.board_selection.get());
 
-    let project_name = if let Some(idx) = board_idx {
-        app.boards
-            .get(idx)
-            .map(|b| b.name.as_str())
-            .unwrap_or("Unknown")
-    } else {
-        "No Project"
-    };
-
-    let mut lines = vec![
-        Line::from(Span::styled(
-            project_name.to_string(),
-            Style::default()
-                .fg(Color::Green)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::from(Span::raw("")),
-    ];
+    let mut lines = vec![];
 
     if let Some(idx) = board_idx {
         if let Some(board) = app.boards.get(idx) {

--- a/kanban.json
+++ b/kanban.json
@@ -740,7 +740,7 @@
           "id": "5d31ae81-75a7-47c7-a6d1-5a9b0f06a5b7",
           "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
           "title": "Remove projects projects and kanban green text",
-          "description": null,
+          "description": "in the projects panel there is a green text with `Projects` we can drop this as the panel header itself shows projects too.\n\nin the task list there is a green text of the current project. we can drop this and rely on the highlighted item in the projects list instead\n",
           "priority": "Medium",
           "status": "Todo",
           "position": 42,
@@ -749,7 +749,7 @@
           "card_number": 43,
           "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
           "created_at": "2025-10-12T16:45:41.135171Z",
-          "updated_at": "2025-10-12T16:46:20.354842Z",
+          "updated_at": "2025-10-12T16:51:11.859124Z",
           "completed_at": null
         }
       ],

--- a/kanban.json
+++ b/kanban.json
@@ -719,6 +719,38 @@
           "created_at": "2025-10-12T16:45:41.135171Z",
           "updated_at": "2025-10-12T16:51:11.859124Z",
           "completed_at": null
+        },
+        {
+          "id": "5b43a7e3-b056-4370-882a-bdad4bb9e0ed",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Assign task to sprint if created in sprint task list",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 41,
+          "due_date": null,
+          "points": 2,
+          "card_number": 42,
+          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+          "created_at": "2025-10-12T16:45:24.828497Z",
+          "updated_at": "2025-10-12T16:46:10.916807Z",
+          "completed_at": null
+        },
+        {
+          "id": "5d31ae81-75a7-47c7-a6d1-5a9b0f06a5b7",
+          "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+          "title": "Remove projects projects and kanban green text",
+          "description": null,
+          "priority": "Medium",
+          "status": "Todo",
+          "position": 42,
+          "due_date": null,
+          "points": 1,
+          "card_number": 43,
+          "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+          "created_at": "2025-10-12T16:45:41.135171Z",
+          "updated_at": "2025-10-12T16:46:20.354842Z",
+          "completed_at": null
         }
       ],
       "sprints": [

--- a/kanban.json
+++ b/kanban.json
@@ -767,28 +767,6 @@
           "updated_at": "2025-10-12T13:49:57.439845Z"
         }
       ]
-    },
-    {
-      "board": {
-        "id": "2bdd79a5-b26a-473c-b790-8b5117283b2f",
-        "name": "test",
-        "description": null,
-        "branch_prefix": null,
-        "next_card_number": 1,
-        "task_sort_field": "Default",
-        "task_sort_order": "Ascending",
-        "sprint_duration_days": null,
-        "sprint_prefix": null,
-        "sprint_names": [],
-        "sprint_name_used_count": 0,
-        "next_sprint_number": 1,
-        "active_sprint_id": null,
-        "created_at": "2025-10-12T16:50:35.469369Z",
-        "updated_at": "2025-10-12T16:50:35.469369Z"
-      },
-      "columns": [],
-      "cards": [],
-      "sprints": []
     }
   ]
 }


### PR DESCRIPTION
## Changes

### UI Cleanup
- Remove "Kanban Board" header from all views
- Remove "Projects" green text label from projects panel
- Remove project name green text label from tasks panel

### Bug Fixes
- Add `completed_at` timestamp to Card model
- Track completion time when status changes to Done
- Reset card selection when toggling sprint filter
- Fix card count to respect active sprint filter