### PR TITLE
KAN-45: Add changeset-based automated release workflow

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,38 @@
+# Changesets
+
+When creating a PR, add a changeset file to describe your changes.
+
+## Creating a Changeset
+
+Create a file `.changeset/<descriptive-name>.md`:
+
+```md
+---
+bump: patch
+---
+
+Brief description of changes for the changelog
+```
+
+## Bump Types
+
+- `patch` - Bug fixes, small changes (0.1.0 → 0.1.1)
+- `minor` - New features, backwards compatible (0.1.0 → 0.2.0)
+- `major` - Breaking changes (0.1.0 → 1.0.0)
+
+## Example
+
+`.changeset/add-vim-keybindings.md`:
+```md
+---
+bump: minor
+---
+
+Add vim-style keybindings for navigation
+```
+
+On merge to master, this will:
+1. Update CHANGELOG.md with the description
+2. Bump version according to the highest bump type
+3. Tag and publish to crates.io
+4. Delete processed changesets

--- a/.changeset/automated-release-workflow.md
+++ b/.changeset/automated-release-workflow.md
@@ -1,5 +1,5 @@
 ---
-bump: minor
+bump: patch
 ---
 
 Add automated release workflow with changeset-based version management

--- a/.changeset/automated-release-workflow.md
+++ b/.changeset/automated-release-workflow.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Add automated release workflow with changeset-based version management

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -13,7 +13,8 @@ jobs:
 
       - name: Check for changeset
         run: |
-          if [ -z "$(ls -A .changeset/*.md 2>/dev/null)" ]; then
+          CHANGESETS=$(ls .changeset/*.md 2>/dev/null | grep -v "README.md" || true)
+          if [ -z "$CHANGESETS" ]; then
             echo "❌ No changeset found!"
             echo "Please add a changeset file to .changeset/ directory"
             echo ""
@@ -25,4 +26,14 @@ jobs:
             echo "Description of your changes"
             exit 1
           fi
-          echo "✅ Changeset found"
+
+          for changeset in $CHANGESETS; do
+            bump=$(grep -A1 "^---$" "$changeset" | grep "^bump:" | cut -d' ' -f2 | tr -d '\r\n')
+            if [[ ! "$bump" =~ ^(patch|minor|major)$ ]]; then
+              echo "❌ Invalid bump type in $changeset: '$bump'"
+              echo "Must be one of: patch, minor, major"
+              exit 1
+            fi
+          done
+
+          echo "✅ Changeset found and validated: $CHANGESETS"

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,28 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for changeset
+        run: |
+          if [ -z "$(ls -A .changeset/*.md 2>/dev/null)" ]; then
+            echo "❌ No changeset found!"
+            echo "Please add a changeset file to .changeset/ directory"
+            echo ""
+            echo "Example: .changeset/my-feature.md"
+            echo "---"
+            echo "bump: patch"
+            echo "---"
+            echo ""
+            echo "Description of your changes"
+            exit 1
+          fi
+          echo "✅ Changeset found"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,11 @@
 name: Publish to crates.io
 
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+  push:
+    branches:
+      - master
+    paths:
+      - '.changeset/**'
 
 jobs:
   publish:
@@ -34,9 +28,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Extract PR number
+        id: pr
+        run: |
+          PR_NUMBER=$(git log -1 --pretty=%B | grep -oP '(?<=#)\d+' || echo "")
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
       - name: Bump version
         run: |
-          nix run .#bump-version -- ${{ inputs.bump }}
+          nix run .#bump-version -- ${{ steps.pr.outputs.number }}
 
       - name: Get new version
         id: version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,14 +42,15 @@ jobs:
         id: version
         run: echo "version=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
 
-      - name: Create release branch and push
+      - name: Commit and push to current branch
         run: |
-          BRANCH="release/v${{ steps.version.outputs.version }}"
-          git checkout -b "$BRANCH"
           git add .
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
+          git push origin HEAD
+
+      - name: Tag version
+        run: |
           git tag "v${{ steps.version.outputs.version }}"
-          git push origin "$BRANCH"
           git push origin "v${{ steps.version.outputs.version }}"
 
       - name: Publish to crates.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-10-10
+
+- Initial release
+- Terminal-based kanban board interface
+- PostgreSQL database backend
+- Nix development environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 - Terminal-based kanban board interface
-- PostgreSQL database backend
 - Nix development environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,6 @@ This is a **terminal-based kanban/project management tool** written in **Rust**,
 **Tech Stack**:
 - Language: Rust (2021 edition)
 - TUI Framework: ratatui + crossterm
-- Database: PostgreSQL with Diesel ORM
 - Async Runtime: Tokio
 - Development Environment: Nix
 
@@ -29,7 +28,6 @@ This is a **terminal-based kanban/project management tool** written in **Rust**,
 crates/
 ├── kanban-core/        # Core traits, errors, and result types
 ├── kanban-domain/      # Domain models (Board, Card, Column, Tag)
-├── kanban-db/          # Database layer with Diesel
 ├── kanban-tui/         # Terminal UI with ratatui
 └── kanban-cli/         # CLI entry point
 ```
@@ -50,16 +48,7 @@ nix develop            # Enter development shell
 The shell provides:
 - Rust toolchain (stable, rust-analyzer, rust-src)
 - cargo-watch, cargo-edit, cargo-audit, cargo-tarpaulin
-- PostgreSQL 15, pgcli, diesel-cli
 - bacon (background compiler)
-
-### Database Management
-```bash
-pg-start               # Start PostgreSQL server
-pg-stop                # Stop PostgreSQL server
-```
-
-Database URL: `postgresql://kanban:kanban_dev@localhost:5432/kanban_dev`
 
 ## Common Commands
 
@@ -93,14 +82,6 @@ cargo test --package kanban-domain  # Test specific crate
 cargo tarpaulin        # Code coverage
 ```
 
-### Database
-```bash
-diesel setup           # Create database and run migrations
-diesel migration generate <name>  # Create new migration
-diesel migration run   # Apply migrations
-diesel migration revert  # Rollback migration
-```
-
 ## Crate Descriptions
 
 ### kanban-core
@@ -123,16 +104,6 @@ diesel migration revert  # Rollback migration
 - `Tag` - Categorization tags
 
 **Design Pattern**: Rich domain models with behavior, no infrastructure dependencies
-
-### kanban-db
-**Purpose**: Database persistence layer
-
-- `schema` - Diesel schema (generated)
-- `models` - Database models mapping domain ↔ tables
-- `repositories` - Repository implementations
-- `connection` - Database connection management
-
-**Design Pattern**: Repository pattern, DTO mapping
 
 ### kanban-tui
 **Purpose**: Terminal UI implementation
@@ -168,7 +139,6 @@ diesel migration revert  # Rollback migration
 ### Async Patterns
 - Use `async-trait` for async trait methods
 - Tokio runtime for async execution
-- Database operations are async with diesel-async
 
 ### Testing
 - Unit tests in same file as implementation
@@ -187,7 +157,6 @@ diesel migration revert  # Rollback migration
 ## Development Workflow
 
 1. **Domain First**: Define models in `kanban-domain`
-2. **Database Schema**: Create migrations with Diesel
 3. **Repository Layer**: Implement persistence in `kanban-db`
 4. **TUI Components**: Build UI in `kanban-tui`
 5. **Integration**: Wire up in `kanban-cli`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,6 @@ crates/
 **Dependency Flow** (respecting dependency inversion):
 ```
 kanban-cli → kanban-tui → kanban-domain → kanban-core
-          ↘ kanban-db  ↗
 ```
 
 ## Development Environment

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,9 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BUMP_TYPE="${1:-patch}"
+PR_NUMBER="${1:-}"
 
 CURRENT_VERSION=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)
+
+if [ -z "$(ls -A .changeset/*.md 2>/dev/null)" ]; then
+  echo "Error: No changesets found in .changeset/"
+  exit 1
+fi
+
+BUMP_TYPE="patch"
+CHANGELOG_ENTRIES=""
+
+for changeset in .changeset/*.md; do
+  [ -e "$changeset" ] || continue
+
+  bump=$(grep -A1 "^---$" "$changeset" | grep "^bump:" | cut -d' ' -f2 | tr -d '\r\n')
+  description=$(sed -n '/^---$/,/^---$/!p' "$changeset" | sed '/^---$/d' | sed '/^$/d')
+
+  if [ "$bump" = "major" ]; then
+    BUMP_TYPE="major"
+  elif [ "$bump" = "minor" ] && [ "$BUMP_TYPE" != "major" ]; then
+    BUMP_TYPE="minor"
+  fi
+
+  CHANGELOG_ENTRIES+="- $description\n"
+done
 
 IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
 
@@ -17,13 +40,29 @@ case "$BUMP_TYPE" in
   patch)
     NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
     ;;
-  *)
-    echo "Error: Invalid bump type '$BUMP_TYPE'. Use: major, minor, or patch"
-    exit 1
-    ;;
 esac
 
-echo "Bumping version: $CURRENT_VERSION → $NEW_VERSION"
+echo "Bumping version: $CURRENT_VERSION → $NEW_VERSION (type: $BUMP_TYPE)"
+
+DATE=$(date +%Y-%m-%d)
+PR_LINK=""
+if [ -n "$PR_NUMBER" ]; then
+  PR_LINK=" ([#$PR_NUMBER](https://github.com/fulsomenko/kanban/pull/$PR_NUMBER))"
+fi
+
+if [ ! -f CHANGELOG.md ]; then
+  echo "# Changelog" > CHANGELOG.md
+  echo "" >> CHANGELOG.md
+fi
+
+{
+  echo "## [$NEW_VERSION] - $DATE$PR_LINK"
+  echo ""
+  echo -e "$CHANGELOG_ENTRIES"
+  echo ""
+  cat CHANGELOG.md
+} > CHANGELOG.md.new
+mv CHANGELOG.md.new CHANGELOG.md
 
 sed -i.bak "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" Cargo.toml
 rm Cargo.toml.bak
@@ -35,4 +74,8 @@ done
 
 cargo update --workspace
 
+rm -f .changeset/*.md
+
 echo "Version bumped to $NEW_VERSION"
+echo "CHANGELOG.md updated"
+echo "Changesets processed and deleted"


### PR DESCRIPTION
Implements automated version management and publishing:

- Changeset system for tracking changes and bump types
- Required changeset validation on PRs to master
- Auto-detect version bump from changesets on merge
- Update CHANGELOG.md with PR links
- Publish to crates.io automatically
- Nix-based scripts for reproducible builds