### PR TITLE
KAN-45: Fix publish workflow to work with protected master branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,65 +1,79 @@
 name: Publish to crates.io
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - master
-    paths:
-      - '.changeset/**'
 
 jobs:
   publish:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: master
           fetch-depth: 0
 
+      - name: Check for changesets
+        id: check
+        run: |
+          CHANGESETS=$(ls .changeset/*.md 2>/dev/null | grep -v "README.md" || true)
+          if [ -z "$CHANGESETS" ]; then
+            echo "No changesets found, skipping publish"
+            echo "has_changesets=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changesets=true" >> $GITHUB_OUTPUT
+          fi
+
       - uses: cachix/install-nix-action@v27
+        if: steps.check.outputs.has_changesets == 'true'
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           extra_nix_config: |
             experimental-features = nix-command flakes
 
       - name: Configure Git
+        if: steps.check.outputs.has_changesets == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Extract PR number
-        id: pr
-        run: |
-          PR_NUMBER=$(git log -1 --pretty=%B | grep -oP '(?<=#)\d+' || echo "")
-          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
-
       - name: Bump version
+        if: steps.check.outputs.has_changesets == 'true'
         run: |
-          nix run .#bump-version -- ${{ steps.pr.outputs.number }}
+          nix run .#bump-version -- ${{ github.event.pull_request.number }}
 
       - name: Get new version
+        if: steps.check.outputs.has_changesets == 'true'
         id: version
         run: echo "version=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
 
-      - name: Commit and push to current branch
+      - name: Commit and push
+        if: steps.check.outputs.has_changesets == 'true'
         run: |
           git add .
-          git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
-          git push origin HEAD
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          git push origin master
 
       - name: Tag version
+        if: steps.check.outputs.has_changesets == 'true'
         run: |
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
 
       - name: Publish to crates.io
+        if: steps.check.outputs.has_changesets == 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           nix run .#publish-crates
 
       - name: Create GitHub Release
+        if: steps.check.outputs.has_changesets == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}


### PR DESCRIPTION
Fixes release workflow to respect branch protection:

- Trigger on PR merge instead of direct push to master
- Check for changesets before running workflow
- Add `[skip ci]` to version bump commit
- Skip workflow if no changesets present