### PR TITLE
KAN-45/publish-to-crates-io

### DIFF
--- a/.changeset/kan-45-complete.md
+++ b/.changeset/kan-45-complete.md
@@ -1,0 +1,17 @@
+---
+bump: patch
+---
+
+KAN-45: Automated release workflow with changeset-based versioning
+
+- Add GitHub Actions workflow for automated crates.io publishing
+- Implement changeset system for version management
+- Add changeset validation check for PRs to master
+- Create Nix-based bump-version and publish-crates scripts
+- Configure deploy key authentication for protected branch bypass
+- Update `CHANGELOG.md` generation with PR links
+- Add unified workspace versioning across all crates
+- Document changeset workflow in `README.md` and `CONTRIBUTING.md`
+- Add semantic commit message guidelines
+- Add PR title and description format guidelines
+- Cross-reference `CLAUDE.md`, `CONTRIBUTING.md`, and `README.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**See also:**
+- [CONTRIBUTING.md](CONTRIBUTING.md) - Development workflow, code style, testing, and PR guidelines
+- [README.md](README.md) - Project overview, features, installation, and usage
+
 ## Project Overview
 
 This is a **terminal-based kanban/project management tool** written in **Rust**, inspired by lazygit's interface design. It follows **SOLID principles** with a clean, modular architecture using Cargo workspaces.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,9 +194,25 @@ mod tests {
 - [ ] Update README.md if adding user-facing features
 - [ ] Update CLAUDE.md if changing architecture/conventions
 
+### PR Title
+
+Use format: `<branch-name>`
+
 ### PR Description
 
-Include:
+Include concise list of changes:
+
+**Example:**
+```
+Fixes task filtering behavior:
+
+- Add sprint filter toggle to task view
+- Update UI to show active sprint indicator
+- Fix filter persistence across sessions
+```
+
+And include concisely
+
 - **What**: Brief description of changes
 - **Why**: Motivation and context
 - **How**: Implementation approach

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,9 +204,28 @@ Include:
 
 ### Commit Messages
 
-- Use present tense: "Add feature" not "Added feature"
-- Be concise but descriptive
-- Reference issues: "Fix #123: Handle empty board state"
+Use semantic commit format:
+
+```
+<type>: <description>
+
+[optional body]
+```
+
+**Types:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `refactor`: Code refactoring
+- `test`: Adding/updating tests
+- `chore`: Maintenance tasks
+- `ci`: CI/CD changes
+
+**Examples:**
+- `feat: add sprint filtering to task view`
+- `fix: handle empty board state correctly`
+- `docs: update keyboard shortcuts in README`
+- `refactor: extract dialog rendering logic`
 
 ### Changesets
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,33 @@ Include:
 - Be concise but descriptive
 - Reference issues: "Fix #123: Handle empty board state"
 
+### Changesets
+
+When submitting a PR, add a changeset file to describe your changes:
+
+1. Create `.changeset/<descriptive-name>.md`:
+
+```md
+---
+bump: patch
+---
+
+Description of changes
+
+- List of changes
+```
+
+2. **Bump types**:
+   - `patch` - Bug fixes, small changes (0.1.0 → 0.1.1)
+   - `minor` - New features, backwards compatible (0.1.0 → 0.2.0)
+   - `major` - Breaking changes (0.1.0 → 1.0.0)
+
+3. On merge to master:
+   - Version automatically bumps based on changeset
+   - CHANGELOG.md updates with your description
+   - New version publishes to crates.io
+   - GitHub release created with tag
+
 ## Code Review Process
 
 1. Automated checks run on all PRs (format, clippy, tests)
@@ -233,3 +260,4 @@ Include:
 ## License
 
 By contributing, you agree that your contributions will be licensed under the Apache 2.0 License.
+


### PR DESCRIPTION
Enhances project documentation:

- Add changeset workflow documentation to README
- Update CONTRIBUTING.md with semantic commit format
- Add cross-references between CLAUDE.md, CONTRIBUTING.md, and README
- Clarify PR guidelines and commit message format