### PR TITLE
Kan 27/refactor hunt for abstractions

### DIFF
--- a/.changeset/refactor-ui-components.md
+++ b/.changeset/refactor-ui-components.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+Extract theme system and reusable UI components
+
+- Add theme module with semantic colors and style functions
+- Create composable components (ListItem, Panel, Popup, DetailView, CardListItem, SelectionList)
+- Refactor ui.rs using new components (1227→869 lines, 29% reduction)
+- Improve code reusability and maintainability through composition
+- CardListItem provides reusable task list rendering for board and sprint views

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,46 @@ Use semantic commit format:
 - `docs: update keyboard shortcuts in README`
 - `refactor: extract dialog rendering logic`
 
+**Commit Strategy:**
+
+Make **small, atomic commits** that contain one functionally related change:
+
+✅ **Good - Refactoring:**
+```
+refactor: add handlers module
+refactor: extract navigation handlers
+refactor: extract board handlers
+refactor: simplify handle_key_event to use handlers
+```
+
+✅ **Good - Features:**
+```
+feat: add sprint domain model
+feat: add sprint UI rendering
+feat: wire up sprint keyboard shortcuts
+```
+
+✅ **Good - Fixes:**
+```
+fix: validate card title before creation
+fix: handle empty board state in renderer
+fix: prevent duplicate card IDs on import
+```
+
+❌ **Bad:**
+```
+refactor: extract all handlers and simplify app.rs (giant commit)
+feat: add complete sprint feature with UI and tests (too large)
+fix: fix bugs (vague, multiple unrelated fixes)
+```
+
+**Guidelines:**
+- One logical change per commit
+- Each commit should compile and pass tests
+- Keep commits focused and reviewable
+- Group related file additions together
+- Separate creation from refactoring
+
 ### Changesets
 
 When submitting a PR, add a changeset file to describe your changes:

--- a/crates/kanban-tui/src/components/card_list_item.rs
+++ b/crates/kanban-tui/src/components/card_list_item.rs
@@ -1,0 +1,104 @@
+use crate::theme::*;
+use kanban_domain::{Board, Card, CardStatus, Sprint};
+use ratatui::{
+    style::{Modifier, Style},
+    text::{Line, Span},
+};
+
+pub struct CardListItemConfig<'a> {
+    pub card: &'a Card,
+    pub board: &'a Board,
+    pub sprints: &'a [Sprint],
+    pub is_selected: bool,
+    pub is_focused: bool,
+    pub is_multi_selected: bool,
+}
+
+pub fn render_card_list_item(config: CardListItemConfig) -> Line<'static> {
+    let is_done = config.card.status == CardStatus::Done;
+
+    let (checkbox, text_color) = if is_done {
+        ("[x]", DONE_TEXT)
+    } else {
+        ("[ ]", NORMAL_TEXT)
+    };
+
+    let mut base_style = Style::default().fg(text_color);
+    let mut title_style = Style::default().fg(text_color);
+
+    if is_done {
+        title_style = title_style.add_modifier(Modifier::CROSSED_OUT);
+    }
+
+    if config.is_selected && config.is_focused {
+        base_style = base_style.bg(SELECTED_BG);
+        title_style = title_style.bg(SELECTED_BG);
+    }
+
+    let sprint_name = if let Some(sprint_id) = config.card.sprint_id {
+        config
+            .sprints
+            .iter()
+            .find(|s| s.id == sprint_id)
+            .map(|s| {
+                format!(
+                    " ({})",
+                    s.formatted_name(
+                        config.board,
+                        config.board.sprint_prefix.as_deref().unwrap_or("sprint")
+                    )
+                )
+            })
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    let select_indicator = if config.is_multi_selected {
+        "► "
+    } else {
+        "  "
+    };
+
+    let mut points_style = if let Some(points) = config.card.points {
+        points_style(points)
+    } else {
+        normal_text()
+    };
+
+    if config.is_selected && config.is_focused {
+        points_style = points_style.bg(SELECTED_BG);
+    }
+
+    let mut priority_style_val = priority_style(config.card.priority);
+    if config.is_selected && config.is_focused {
+        priority_style_val = priority_style_val.bg(SELECTED_BG);
+    }
+
+    let points_text = config
+        .card
+        .points
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| " ".to_string());
+
+    let mut spans = vec![
+        Span::styled("● ", priority_style_val),
+        Span::styled(points_text, points_style),
+        Span::raw(" "),
+        Span::styled(
+            format!("{}{} ", select_indicator, checkbox),
+            base_style,
+        ),
+        Span::styled(config.card.title.clone(), title_style),
+    ];
+
+    if !sprint_name.is_empty() {
+        let mut sprint_style = label_text();
+        if config.is_selected && config.is_focused {
+            sprint_style = sprint_style.bg(SELECTED_BG);
+        }
+        spans.push(Span::styled(sprint_name, sprint_style));
+    }
+
+    Line::from(spans)
+}

--- a/crates/kanban-tui/src/components/detail_view.rs
+++ b/crates/kanban-tui/src/components/detail_view.rs
@@ -1,0 +1,81 @@
+use crate::theme::{focused_border, label_text, normal_text, unfocused_border};
+use ratatui::{
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Borders},
+};
+
+pub struct FieldSectionConfig<'a> {
+    pub title: &'a str,
+    pub focused_title: &'a str,
+    pub is_focused: bool,
+}
+
+impl<'a> FieldSectionConfig<'a> {
+    pub fn new(title: &'a str) -> Self {
+        Self {
+            title,
+            focused_title: title,
+            is_focused: false,
+        }
+    }
+
+    pub fn with_focus_indicator(mut self, focused_title: &'a str) -> Self {
+        self.focused_title = focused_title;
+        self
+    }
+
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.is_focused = focused;
+        self
+    }
+
+    pub fn border_style(&self) -> Style {
+        if self.is_focused {
+            focused_border()
+        } else {
+            unfocused_border()
+        }
+    }
+
+    pub fn title_text(&self) -> &str {
+        if self.is_focused {
+            self.focused_title
+        } else {
+            self.title
+        }
+    }
+
+    pub fn block(&'a self) -> Block<'a> {
+        Block::default()
+            .title(self.title_text())
+            .borders(Borders::ALL)
+            .border_style(self.border_style())
+    }
+}
+
+pub fn metadata_line<'a>(label: &'a str, value: impl Into<String>) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(format!("{}: ", label), label_text()),
+        Span::styled(value.into(), normal_text()),
+    ])
+}
+
+pub fn metadata_line_styled<'a>(label: &'a str, value: impl Into<String>, style: Style) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(format!("{}: ", label), label_text()),
+        Span::styled(value.into(), style),
+    ])
+}
+
+pub fn metadata_line_multi<'a>(parts: Vec<(&'a str, String, Style)>) -> Line<'a> {
+    let mut spans = Vec::new();
+    for (i, (label, value, style)) in parts.into_iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(Span::styled(format!("{}: ", label), label_text()));
+        spans.push(Span::styled(value, style));
+    }
+    Line::from(spans)
+}

--- a/crates/kanban-tui/src/components/list.rs
+++ b/crates/kanban-tui/src/components/list.rs
@@ -1,0 +1,101 @@
+use crate::theme::{active_item, normal_text, selected_item};
+use ratatui::{
+    style::{Modifier, Style},
+    text::{Line, Span},
+};
+
+pub struct ListItemConfig {
+    pub is_selected: bool,
+    pub is_focused: bool,
+    pub is_active: bool,
+    pub is_multi_selected: bool,
+}
+
+impl ListItemConfig {
+    pub fn new() -> Self {
+        Self {
+            is_selected: false,
+            is_focused: false,
+            is_active: false,
+            is_multi_selected: false,
+        }
+    }
+
+    pub fn selected(mut self, selected: bool) -> Self {
+        self.is_selected = selected;
+        self
+    }
+
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.is_focused = focused;
+        self
+    }
+
+    pub fn active(mut self, active: bool) -> Self {
+        self.is_active = active;
+        self
+    }
+
+    pub fn multi_selected(mut self, multi_selected: bool) -> Self {
+        self.is_multi_selected = multi_selected;
+        self
+    }
+
+    pub fn item_style(&self) -> Style {
+        let mut style = normal_text();
+
+        if self.is_active {
+            style = active_item();
+        }
+
+        if self.is_selected && self.is_focused {
+            style = style.bg(selected_item(true).bg.unwrap());
+        }
+
+        style
+    }
+
+    pub fn item_prefix(&self) -> &'static str {
+        if self.is_active {
+            "● "
+        } else if self.is_multi_selected {
+            "► "
+        } else {
+            "  "
+        }
+    }
+}
+
+impl Default for ListItemConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn styled_list_item(text: impl Into<String>, config: &ListItemConfig) -> Line<'static> {
+    let prefix = config.item_prefix();
+    let style = config.item_style();
+    Line::from(Span::styled(format!("{}{}", prefix, text.into()), style))
+}
+
+pub fn styled_task_item(
+    checkbox: impl Into<String>,
+    title: impl Into<String>,
+    is_done: bool,
+    config: &ListItemConfig,
+) -> Line<'static> {
+    let prefix = config.item_prefix();
+    let base_style = config.item_style();
+    let mut title_style = base_style;
+
+    if is_done {
+        title_style = title_style.add_modifier(Modifier::CROSSED_OUT);
+    }
+
+    Line::from(vec![
+        Span::styled(prefix.to_string(), base_style),
+        Span::styled(checkbox.into(), base_style),
+        Span::raw(" "),
+        Span::styled(title.into(), title_style),
+    ])
+}

--- a/crates/kanban-tui/src/components/mod.rs
+++ b/crates/kanban-tui/src/components/mod.rs
@@ -1,0 +1,13 @@
+pub mod card_list_item;
+pub mod detail_view;
+pub mod list;
+pub mod panel;
+pub mod popup;
+pub mod selection_list;
+
+pub use card_list_item::*;
+pub use detail_view::*;
+pub use list::*;
+pub use panel::*;
+pub use popup::*;
+pub use selection_list::*;

--- a/crates/kanban-tui/src/components/panel.rs
+++ b/crates/kanban-tui/src/components/panel.rs
@@ -1,0 +1,65 @@
+use crate::theme::{focused_border, unfocused_border};
+use ratatui::{
+    layout::Rect,
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+pub struct PanelConfig<'a> {
+    pub title: &'a str,
+    pub focused_title: &'a str,
+    pub is_focused: bool,
+}
+
+impl<'a> PanelConfig<'a> {
+    pub fn new(title: &'a str) -> Self {
+        Self {
+            title,
+            focused_title: title,
+            is_focused: false,
+        }
+    }
+
+    pub fn with_focus_indicator(mut self, focused_title: &'a str) -> Self {
+        self.focused_title = focused_title;
+        self
+    }
+
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.is_focused = focused;
+        self
+    }
+
+    pub fn border_style(&self) -> ratatui::style::Style {
+        if self.is_focused {
+            focused_border()
+        } else {
+            unfocused_border()
+        }
+    }
+
+    pub fn title_text(&self) -> &str {
+        if self.is_focused {
+            self.focused_title
+        } else {
+            self.title
+        }
+    }
+
+    pub fn block(&'a self) -> Block<'a> {
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(self.border_style())
+            .title(self.title_text())
+    }
+}
+
+pub fn render_panel<'a>(
+    frame: &mut Frame,
+    area: Rect,
+    config: &PanelConfig<'a>,
+    content: Paragraph<'a>,
+) {
+    let widget = content.block(config.block());
+    frame.render_widget(widget, area);
+}

--- a/crates/kanban-tui/src/components/popup.rs
+++ b/crates/kanban-tui/src/components/popup.rs
@@ -1,0 +1,90 @@
+use crate::theme::{focused_border, popup_bg};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+pub fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}
+
+pub fn render_input_popup(
+    frame: &mut Frame,
+    title: &str,
+    label: &str,
+    input_text: &str,
+    cursor_pos: usize,
+) {
+    let area = centered_rect(60, 30, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .style(popup_bg());
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    let label_widget = Paragraph::new(label).style(crate::theme::highlight_text());
+    frame.render_widget(label_widget, chunks[0]);
+
+    let input = Paragraph::new(input_text)
+        .style(crate::theme::normal_text())
+        .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(input, chunks[1]);
+
+    let cursor_x = chunks[1].x + cursor_pos as u16 + 1;
+    let cursor_y = chunks[1].y + 1;
+    frame.set_cursor_position((cursor_x, cursor_y));
+}
+
+pub fn render_popup_with_block(
+    frame: &mut Frame,
+    title: &str,
+    width_percent: u16,
+    height_percent: u16,
+) -> Rect {
+    let area = centered_rect(width_percent, height_percent, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(focused_border())
+        .style(popup_bg());
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    inner
+}

--- a/crates/kanban-tui/src/components/selection_list.rs
+++ b/crates/kanban-tui/src/components/selection_list.rs
@@ -1,0 +1,87 @@
+use crate::components::{centered_rect, render_popup_with_block, ListItemConfig, styled_list_item};
+use crate::theme::*;
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    widgets::{List, ListItem, Paragraph},
+    Frame,
+};
+
+pub fn render_selection_popup_with_list_items(
+    frame: &mut Frame,
+    title: &str,
+    items: Vec<ListItem>,
+    width: u16,
+    height: u16,
+) {
+    let area = centered_rect(width, height, frame.area());
+    let list = List::new(items).block(
+        ratatui::widgets::Block::default()
+            .title(title)
+            .borders(ratatui::widgets::Borders::ALL)
+            .border_style(focused_border()),
+    );
+
+    frame.render_widget(ratatui::widgets::Clear, area);
+    frame.render_widget(list, area);
+}
+
+pub fn render_selection_popup_with_lines<'a, I, F>(
+    frame: &mut Frame,
+    title: &str,
+    label: Option<&str>,
+    items: I,
+    format_fn: F,
+    selected_idx: Option<usize>,
+    active_idx: Option<usize>,
+    width: u16,
+    height: u16,
+) where
+    I: IntoIterator,
+    I::Item: 'a,
+    F: Fn(usize, &I::Item, bool, bool) -> (String, Option<String>),
+{
+    let inner = render_popup_with_block(frame, title, width, height);
+
+    let chunks = if label.is_some() {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .margin(2)
+            .constraints([Constraint::Length(1), Constraint::Min(0)])
+            .split(inner)
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .margin(2)
+            .constraints([Constraint::Min(0)])
+            .split(inner)
+    };
+
+    if let Some(label_text) = label {
+        let label_widget = Paragraph::new(label_text).style(highlight_text());
+        frame.render_widget(label_widget, chunks[0]);
+    }
+
+    let list_chunk = if label.is_some() { chunks[1] } else { chunks[0] };
+
+    let mut lines = vec![];
+    for (idx, item) in items.into_iter().enumerate() {
+        let is_selected = selected_idx == Some(idx);
+        let is_active = active_idx == Some(idx);
+        let (text, suffix) = format_fn(idx, &item, is_selected, is_active);
+
+        let config = ListItemConfig::new()
+            .selected(is_selected)
+            .focused(true)
+            .active(is_active);
+
+        let mut line_text = text;
+        if let Some(suffix_text) = suffix {
+            line_text.push_str(&suffix_text);
+        }
+
+        lines.push(styled_list_item(line_text, &config));
+    }
+
+    let list = Paragraph::new(lines);
+    frame.render_widget(list, list_chunk);
+}

--- a/crates/kanban-tui/src/export/exporter.rs
+++ b/crates/kanban-tui/src/export/exporter.rs
@@ -1,0 +1,113 @@
+use super::models::{AllBoardsExport, BoardExport};
+use kanban_domain::{Board, Card, Column, Sprint};
+use std::io;
+use uuid::Uuid;
+
+pub struct BoardExporter;
+
+impl BoardExporter {
+    pub fn export_board(
+        board: &Board,
+        all_columns: &[Column],
+        all_cards: &[Card],
+        all_sprints: &[Sprint],
+    ) -> BoardExport {
+        let board_columns: Vec<Column> = all_columns
+            .iter()
+            .filter(|col| col.board_id == board.id)
+            .cloned()
+            .collect();
+
+        let column_ids: Vec<Uuid> = board_columns.iter().map(|c| c.id).collect();
+
+        let board_cards: Vec<Card> = all_cards
+            .iter()
+            .filter(|card| column_ids.contains(&card.column_id))
+            .cloned()
+            .collect();
+
+        let board_sprints: Vec<Sprint> = all_sprints
+            .iter()
+            .filter(|s| s.board_id == board.id)
+            .cloned()
+            .collect();
+
+        BoardExport {
+            board: board.clone(),
+            columns: board_columns,
+            cards: board_cards,
+            sprints: board_sprints,
+        }
+    }
+
+    pub fn export_all_boards(
+        boards: &[Board],
+        columns: &[Column],
+        cards: &[Card],
+        sprints: &[Sprint],
+    ) -> AllBoardsExport {
+        let board_exports: Vec<BoardExport> = boards
+            .iter()
+            .map(|board| Self::export_board(board, columns, cards, sprints))
+            .collect();
+
+        AllBoardsExport {
+            boards: board_exports,
+        }
+    }
+
+    pub fn export_to_json(export: &AllBoardsExport) -> Result<String, io::Error> {
+        serde_json::to_string_pretty(export).map_err(io::Error::other)
+    }
+
+    pub fn export_to_file(export: &AllBoardsExport, filename: &str) -> io::Result<()> {
+        let json = Self::export_to_json(export)?;
+        std::fs::write(filename, json)?;
+        tracing::info!("Exported to: {}", filename);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_export_single_board() {
+        let board = Board::new("Test".to_string(), None);
+        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let columns = vec![column.clone()];
+
+        let mut board_mut = board.clone();
+        let card = Card::new(&mut board_mut, column.id, "Task".to_string(), 0);
+        let cards = vec![card];
+
+        let sprints = vec![];
+
+        let export = BoardExporter::export_board(&board, &columns, &cards, &sprints);
+
+        assert_eq!(export.board.name, "Test");
+        assert_eq!(export.columns.len(), 1);
+        assert_eq!(export.cards.len(), 1);
+    }
+
+    #[test]
+    fn test_export_all_boards() {
+        let board1 = Board::new("Board 1".to_string(), None);
+        let board2 = Board::new("Board 2".to_string(), None);
+        let boards = vec![board1.clone(), board2.clone()];
+
+        let column1 = Column::new(board1.id, "Todo".to_string(), 0);
+        let column2 = Column::new(board2.id, "Todo".to_string(), 0);
+        let columns = vec![column1.clone(), column2.clone()];
+
+        let cards = vec![];
+        let sprints = vec![];
+
+        let export = BoardExporter::export_all_boards(&boards, &columns, &cards, &sprints);
+
+        assert_eq!(export.boards.len(), 2);
+        assert_eq!(export.boards[0].board.name, "Board 1");
+        assert_eq!(export.boards[1].board.name, "Board 2");
+    }
+}

--- a/crates/kanban-tui/src/export/importer.rs
+++ b/crates/kanban-tui/src/export/importer.rs
@@ -1,0 +1,114 @@
+use super::models::AllBoardsExport;
+use kanban_domain::{Board, Card, Column, Sprint};
+use std::io;
+
+pub struct BoardImporter;
+
+impl BoardImporter {
+    pub fn import_from_json(json: &str) -> Result<AllBoardsExport, io::Error> {
+        serde_json::from_str(json).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Invalid JSON format. Expected {{\"boards\": [...]}} structure. Error: {}",
+                    err
+                ),
+            )
+        })
+    }
+
+    pub fn import_from_file(filename: &str) -> io::Result<AllBoardsExport> {
+        let content = std::fs::read_to_string(filename)?;
+        Self::import_from_json(&content)
+    }
+
+    pub fn extract_entities(import: AllBoardsExport) -> (Vec<Board>, Vec<Column>, Vec<Card>, Vec<Sprint>) {
+        let mut boards = Vec::new();
+        let mut columns = Vec::new();
+        let mut cards = Vec::new();
+        let mut sprints = Vec::new();
+
+        for board_data in import.boards {
+            boards.push(board_data.board);
+            columns.extend(board_data.columns);
+            cards.extend(board_data.cards);
+            sprints.extend(board_data.sprints);
+        }
+
+        (boards, columns, cards, sprints)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_import_from_json_valid() {
+        let json = r#"{
+            "boards": [
+                {
+                    "board": {
+                        "id": "550e8400-e29b-41d4-a716-446655440000",
+                        "name": "Test Board",
+                        "description": null,
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "updated_at": "2024-01-01T00:00:00Z",
+                        "next_card_number": 1,
+                        "branch_prefix": null,
+                        "task_sort_field": "Default",
+                        "task_sort_order": "Ascending",
+                        "active_sprint_id": null,
+                        "sprint_duration_days": null,
+                        "sprint_prefix": null,
+                        "sprint_names": [],
+                        "next_sprint_number": 1,
+                        "sprint_name_used_count": 0
+                    },
+                    "columns": [],
+                    "cards": [],
+                    "sprints": []
+                }
+            ]
+        }"#;
+
+        let result = BoardImporter::import_from_json(json);
+        assert!(result.is_ok());
+
+        let import = result.unwrap();
+        assert_eq!(import.boards.len(), 1);
+        assert_eq!(import.boards[0].board.name, "Test Board");
+    }
+
+    #[test]
+    fn test_import_from_json_invalid() {
+        let json = r#"{ "invalid": "format" }"#;
+        let result = BoardImporter::import_from_json(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_entities() {
+        let board = Board::new("Test".to_string(), None);
+        let column = Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        let card = Card::new(&mut board_mut, column.id, "Task".to_string(), 0);
+
+        let export = AllBoardsExport {
+            boards: vec![super::super::models::BoardExport {
+                board: board.clone(),
+                columns: vec![column.clone()],
+                cards: vec![card.clone()],
+                sprints: vec![],
+            }],
+        };
+
+        let (boards, columns, cards, sprints) = BoardImporter::extract_entities(export);
+
+        assert_eq!(boards.len(), 1);
+        assert_eq!(columns.len(), 1);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(sprints.len(), 0);
+    }
+}

--- a/crates/kanban-tui/src/export/mod.rs
+++ b/crates/kanban-tui/src/export/mod.rs
@@ -1,0 +1,7 @@
+pub mod exporter;
+pub mod importer;
+pub mod models;
+
+pub use exporter::*;
+pub use importer::*;
+pub use models::*;

--- a/crates/kanban-tui/src/export/models.rs
+++ b/crates/kanban-tui/src/export/models.rs
@@ -1,0 +1,15 @@
+use kanban_domain::{Board, Card, Column, Sprint};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct BoardExport {
+    pub board: Board,
+    pub columns: Vec<Column>,
+    pub cards: Vec<Card>,
+    pub sprints: Vec<Sprint>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct AllBoardsExport {
+    pub boards: Vec<BoardExport>,
+}

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1,0 +1,101 @@
+use crate::app::{App, AppMode, BoardFocus, Focus};
+use std::io;
+
+impl App {
+    pub fn handle_create_board_key(&mut self) {
+        if self.focus == Focus::Boards {
+            self.mode = AppMode::CreateBoard;
+            self.input.clear();
+        }
+    }
+
+    pub fn handle_rename_board_key(&mut self) {
+        if self.focus == Focus::Boards && self.board_selection.get().is_some() {
+            if let Some(board_idx) = self.board_selection.get() {
+                if let Some(board) = self.boards.get(board_idx) {
+                    self.input.set(board.name.clone());
+                    self.mode = AppMode::RenameBoard;
+                }
+            }
+        }
+    }
+
+    pub fn handle_edit_board_key(&mut self) {
+        if self.focus == Focus::Boards && self.board_selection.get().is_some() {
+            self.mode = AppMode::BoardDetail;
+            self.board_focus = BoardFocus::Name;
+        }
+    }
+
+    pub fn handle_export_board_key(&mut self) {
+        if self.focus == Focus::Boards && self.board_selection.get().is_some() {
+            if let Some(board_idx) = self.board_selection.get() {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let filename = format!(
+                        "{}-{}.json",
+                        board.name.replace(" ", "-").to_lowercase(),
+                        chrono::Utc::now().format("%Y%m%d-%H%M%S")
+                    );
+                    self.input.set(filename);
+                    self.mode = AppMode::ExportBoard;
+                }
+            }
+        }
+    }
+
+    pub fn handle_export_all_key(&mut self) {
+        if self.focus == Focus::Boards && !self.boards.is_empty() {
+            let filename = format!(
+                "kanban-all-{}.json",
+                chrono::Utc::now().format("%Y%m%d-%H%M%S")
+            );
+            self.input.set(filename);
+            self.mode = AppMode::ExportAll;
+        }
+    }
+
+    pub fn handle_import_board_key(&mut self) {
+        if self.focus == Focus::Boards {
+            self.scan_import_files();
+            if !self.import_files.is_empty() {
+                self.import_selection.set(Some(0));
+                self.mode = AppMode::ImportBoard;
+            }
+        }
+    }
+
+    pub fn create_board(&mut self) {
+        let board = kanban_domain::Board::new(self.input.as_str().to_string(), None);
+        tracing::info!("Creating board: {} (id: {})", board.name, board.id);
+        self.boards.push(board);
+        let new_index = self.boards.len() - 1;
+        self.board_selection.set(Some(new_index));
+    }
+
+    pub fn rename_board(&mut self) {
+        if let Some(idx) = self.board_selection.get() {
+            if let Some(board) = self.boards.get_mut(idx) {
+                board.update_name(self.input.as_str().to_string());
+                tracing::info!("Renamed board to: {}", board.name);
+            }
+        }
+    }
+
+    fn scan_import_files(&mut self) {
+        self.import_files.clear();
+        if let Ok(entries) = std::fs::read_dir(".") {
+            for entry in entries.flatten() {
+                if let Ok(metadata) = entry.metadata() {
+                    if metadata.is_file() {
+                        if let Some(filename) = entry.file_name().to_str() {
+                            if filename.ends_with(".json") {
+                                self.import_files.push(filename.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.import_files.sort();
+    }
+}

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1,5 +1,4 @@
 use crate::app::{App, AppMode, BoardFocus, Focus};
-use std::io;
 
 impl App {
     pub fn handle_create_board_key(&mut self) {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1,0 +1,241 @@
+use crate::app::{App, AppMode, Focus};
+use kanban_domain::{Card, CardStatus, Column, SortOrder};
+
+impl App {
+    pub fn handle_create_card_key(&mut self) {
+        if self.focus == Focus::Cards && self.active_board_index.is_some() {
+            self.mode = AppMode::CreateCard;
+            self.input.clear();
+        }
+    }
+
+    pub fn handle_toggle_card_completion(&mut self) {
+        if self.focus != Focus::Cards {
+            return;
+        }
+
+        if !self.selected_cards.is_empty() {
+            self.toggle_selected_cards_completion();
+        } else if self.card_selection.get().is_some() {
+            self.toggle_card_completion();
+        }
+    }
+
+    pub fn handle_card_selection_toggle(&mut self) {
+        if self.focus == Focus::Cards && self.card_selection.get().is_some() {
+            if let Some(board_idx) = self.active_board_index {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let card_id = {
+                        let sorted_cards = self.get_sorted_board_cards(board.id);
+                        if let Some(sorted_idx) = self.card_selection.get() {
+                            sorted_cards.get(sorted_idx).map(|c| c.id)
+                        } else {
+                            None
+                        }
+                    };
+
+                    if let Some(id) = card_id {
+                        if self.selected_cards.contains(&id) {
+                            self.selected_cards.remove(&id);
+                        } else {
+                            self.selected_cards.insert(id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_assign_to_sprint_key(&mut self) {
+        if self.focus != Focus::Cards {
+            return;
+        }
+
+        if !self.selected_cards.is_empty() {
+            self.sprint_assign_selection.clear();
+            self.mode = AppMode::AssignMultipleCardsToSprint;
+        } else if let Some(sorted_idx) = self.card_selection.get() {
+            if let Some(board_idx) = self.active_board_index {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let sprint_count = self
+                        .sprints
+                        .iter()
+                        .filter(|s| s.board_id == board.id)
+                        .count();
+                    if sprint_count > 0 {
+                        let sorted_cards = self.get_sorted_board_cards(board.id);
+                        if let Some(selected_card) = sorted_cards.get(sorted_idx) {
+                            let card_id = selected_card.id;
+                            let actual_idx = self.cards.iter().position(|c| c.id == card_id);
+                            self.active_card_index = actual_idx;
+                        }
+                        self.sprint_assign_selection.set(Some(0));
+                        self.mode = AppMode::AssignCardToSprint;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_order_cards_key(&mut self) {
+        if self.focus == Focus::Cards && self.active_board_index.is_some() {
+            self.sort_field_selection.set(Some(0));
+            self.mode = AppMode::OrderCards;
+        }
+    }
+
+    pub fn handle_toggle_sort_order_key(&mut self) {
+        if self.focus == Focus::Cards && self.active_board_index.is_some() {
+            if let Some(current_order) = self.current_sort_order {
+                let new_order = match current_order {
+                    SortOrder::Ascending => SortOrder::Descending,
+                    SortOrder::Descending => SortOrder::Ascending,
+                };
+                self.current_sort_order = Some(new_order);
+
+                if let Some(board_idx) = self.active_board_index {
+                    if let Some(board) = self.boards.get_mut(board_idx) {
+                        if let Some(field) = self.current_sort_field {
+                            board.update_task_sort(field, new_order);
+                        }
+                    }
+                }
+
+                tracing::info!("Toggled sort order to: {:?}", new_order);
+            }
+        }
+    }
+
+    pub fn handle_toggle_hide_assigned(&mut self) {
+        if self.focus == Focus::Cards && self.active_board_index.is_some() {
+            self.hide_assigned_cards = !self.hide_assigned_cards;
+            let status = if self.hide_assigned_cards {
+                "enabled"
+            } else {
+                "disabled"
+            };
+            tracing::info!("Hide assigned cards: {}", status);
+
+            if let Some(board_idx) = self.active_board_index {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let card_count = self.get_board_card_count(board.id);
+                    if card_count > 0 {
+                        self.card_selection.set(Some(0));
+                    } else {
+                        self.card_selection.clear();
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_toggle_sprint_filter(&mut self) {
+        if self.focus == Focus::Cards && self.active_board_index.is_some() {
+            if let Some(board_idx) = self.active_board_index {
+                if let Some(board) = self.boards.get(board_idx) {
+                    if let Some(active_sprint_id) = board.active_sprint_id {
+                        if self.active_sprint_filter == Some(active_sprint_id) {
+                            self.active_sprint_filter = None;
+                            tracing::info!("Disabled sprint filter - showing all cards");
+                        } else {
+                            self.active_sprint_filter = Some(active_sprint_id);
+                            tracing::info!("Enabled sprint filter - showing active sprint only");
+                        }
+
+                        let card_count = self.get_board_card_count(board.id);
+                        if card_count > 0 {
+                            self.card_selection.set(Some(0));
+                        } else {
+                            self.card_selection.clear();
+                        }
+                    } else {
+                        tracing::warn!("No active sprint set for filtering");
+                    }
+                }
+            }
+        }
+    }
+
+    fn toggle_card_completion(&mut self) {
+        if let Some(sorted_idx) = self.card_selection.get() {
+            if let Some(board_idx) = self.active_board_index {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let sorted_cards = self.get_sorted_board_cards(board.id);
+
+                    if let Some(card) = sorted_cards.get(sorted_idx) {
+                        let card_id = card.id;
+                        let new_status = if card.status == CardStatus::Done {
+                            CardStatus::Todo
+                        } else {
+                            CardStatus::Done
+                        };
+
+                        if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                            card.update_status(new_status);
+                            tracing::info!(
+                                "Toggled card '{}' to status: {:?}",
+                                card.title,
+                                new_status
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn toggle_selected_cards_completion(&mut self) {
+        let card_ids: Vec<uuid::Uuid> = self.selected_cards.iter().copied().collect();
+        let mut toggled_count = 0;
+
+        for card_id in card_ids {
+            if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                let new_status = if card.status == CardStatus::Done {
+                    CardStatus::Todo
+                } else {
+                    CardStatus::Done
+                };
+                card.update_status(new_status);
+                toggled_count += 1;
+            }
+        }
+
+        tracing::info!("Toggled {} cards completion status", toggled_count);
+        self.selected_cards.clear();
+    }
+
+    pub fn create_card(&mut self) {
+        if let Some(idx) = self.active_board_index {
+            if let Some(board) = self.boards.get_mut(idx) {
+                let column = self
+                    .columns
+                    .iter()
+                    .find(|col| col.board_id == board.id)
+                    .cloned();
+
+                let column = match column {
+                    Some(col) => col,
+                    None => {
+                        let new_column = Column::new(board.id, "Todo".to_string(), 0);
+                        self.columns.push(new_column.clone());
+                        new_column
+                    }
+                };
+
+                let position = self
+                    .cards
+                    .iter()
+                    .filter(|c| c.column_id == column.id)
+                    .count() as i32;
+                let card = Card::new(board, column.id, self.input.as_str().to_string(), position);
+                let board_id = board.id;
+                tracing::info!("Creating card: {} (id: {})", card.title, card.id);
+                self.cards.push(card);
+
+                let card_count = self.get_board_card_count(board_id);
+                let new_card_index = card_count.saturating_sub(1);
+                self.card_selection.set(Some(new_card_index));
+            }
+        }
+    }
+}

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1,0 +1,206 @@
+use crate::app::{App, AppMode, BoardField, BoardFocus, CardField, CardFocus};
+use crate::editor::edit_in_external_editor;
+use crate::events::EventHandler;
+use crossterm::event::KeyCode;
+use ratatui::{backend::CrosstermBackend, Terminal};
+use std::io;
+
+impl App {
+    pub fn handle_card_detail_key(
+        &mut self,
+        key_code: KeyCode,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
+        let mut should_restart = false;
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::Normal;
+                self.active_card_index = None;
+                self.card_focus = CardFocus::Title;
+            }
+            KeyCode::Char('1') => {
+                self.card_focus = CardFocus::Title;
+            }
+            KeyCode::Char('2') => {
+                self.card_focus = CardFocus::Metadata;
+            }
+            KeyCode::Char('3') => {
+                self.card_focus = CardFocus::Description;
+            }
+            KeyCode::Char('y') => {
+                self.copy_branch_name();
+            }
+            KeyCode::Char('Y') => {
+                self.copy_git_checkout_command();
+            }
+            KeyCode::Char('e') => match self.card_focus {
+                CardFocus::Title => {
+                    if let Err(e) = self.edit_card_field(terminal, event_handler, CardField::Title)
+                    {
+                        tracing::error!("Failed to edit title: {}", e);
+                    }
+                    should_restart = true;
+                }
+                CardFocus::Description => {
+                    if let Err(e) =
+                        self.edit_card_field(terminal, event_handler, CardField::Description)
+                    {
+                        tracing::error!("Failed to edit description: {}", e);
+                    }
+                    should_restart = true;
+                }
+                CardFocus::Metadata => {
+                    self.input.clear();
+                    self.mode = AppMode::SetCardPoints;
+                }
+            },
+            KeyCode::Char('s') => {
+                if let Some(board_idx) = self.active_board_index {
+                    if let Some(board) = self.boards.get(board_idx) {
+                        let sprint_count = self
+                            .sprints
+                            .iter()
+                            .filter(|s| s.board_id == board.id)
+                            .count();
+                        if sprint_count > 0 {
+                            self.sprint_assign_selection.set(Some(0));
+                            self.mode = AppMode::AssignCardToSprint;
+                        }
+                    }
+                }
+            }
+            KeyCode::Char('p') => {
+                self.priority_selection.set(Some(0));
+                self.mode = AppMode::SetCardPriority;
+            }
+            _ => {}
+        }
+        should_restart
+    }
+
+    pub fn handle_board_detail_key(
+        &mut self,
+        key_code: KeyCode,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
+        let mut should_restart = false;
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::Normal;
+                self.board_focus = BoardFocus::Name;
+            }
+            KeyCode::Char('1') => {
+                self.board_focus = BoardFocus::Name;
+            }
+            KeyCode::Char('2') => {
+                self.board_focus = BoardFocus::Description;
+            }
+            KeyCode::Char('3') => {
+                self.board_focus = BoardFocus::Settings;
+            }
+            KeyCode::Char('4') => {
+                self.board_focus = BoardFocus::Sprints;
+            }
+            KeyCode::Char('e') => match self.board_focus {
+                BoardFocus::Name => {
+                    if let Err(e) = self.edit_board_field(terminal, event_handler, BoardField::Name)
+                    {
+                        tracing::error!("Failed to edit board name: {}", e);
+                    }
+                    should_restart = true;
+                }
+                BoardFocus::Description => {
+                    if let Err(e) =
+                        self.edit_board_field(terminal, event_handler, BoardField::Description)
+                    {
+                        tracing::error!("Failed to edit board description: {}", e);
+                    }
+                    should_restart = true;
+                }
+                BoardFocus::Settings => {
+                    if let Err(e) =
+                        self.edit_board_field(terminal, event_handler, BoardField::Settings)
+                    {
+                        tracing::error!("Failed to edit board settings: {}", e);
+                    }
+                    should_restart = true;
+                }
+                BoardFocus::Sprints => {}
+            },
+            KeyCode::Char('n') => {
+                self.handle_create_sprint_key();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.board_focus == BoardFocus::Sprints {
+                    if let Some(board_idx) = self.board_selection.get() {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let sprint_count = self
+                                .sprints
+                                .iter()
+                                .filter(|s| s.board_id == board.id)
+                                .count();
+                            self.sprint_selection.next(sprint_count);
+                        }
+                    }
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.board_focus == BoardFocus::Sprints {
+                    self.sprint_selection.prev();
+                }
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if self.board_focus == BoardFocus::Sprints {
+                    if let Some(sprint_idx) = self.sprint_selection.get() {
+                        if let Some(board_idx) = self.board_selection.get() {
+                            if let Some(board) = self.boards.get(board_idx) {
+                                let board_sprints: Vec<_> = self
+                                    .sprints
+                                    .iter()
+                                    .enumerate()
+                                    .filter(|(_, s)| s.board_id == board.id)
+                                    .collect();
+                                if let Some((actual_idx, _)) = board_sprints.get(sprint_idx) {
+                                    self.active_sprint_index = Some(*actual_idx);
+                                    self.mode = AppMode::SprintDetail;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            KeyCode::Char('p') => {
+                if self.board_focus == BoardFocus::Settings {
+                    if let Some(board_idx) = self.board_selection.get() {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let current_prefix = board.branch_prefix.clone().unwrap_or_else(String::new);
+                            self.input.set(current_prefix);
+                            self.mode = AppMode::SetBranchPrefix;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        should_restart
+    }
+
+    pub fn handle_sprint_detail_key(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Sprints;
+                self.active_sprint_index = None;
+            }
+            KeyCode::Char('a') => {
+                self.handle_activate_sprint_key();
+            }
+            KeyCode::Char('c') => {
+                self.handle_complete_sprint_key();
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1,5 +1,4 @@
 use crate::app::{App, AppMode, BoardField, BoardFocus, CardField, CardFocus};
-use crate::editor::edit_in_external_editor;
 use crate::events::EventHandler;
 use crossterm::event::KeyCode;
 use ratatui::{backend::CrosstermBackend, Terminal};

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -1,0 +1,195 @@
+use crate::app::{App, AppMode, BoardFocus};
+use crate::dialog::{handle_dialog_input, DialogAction};
+use crossterm::event::KeyCode;
+use kanban_domain::Card;
+
+impl App {
+    pub fn handle_create_board_dialog(&mut self, key_code: KeyCode) {
+        match handle_dialog_input(&mut self.input, key_code, false) {
+            DialogAction::Confirm => {
+                self.create_board();
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::Cancel => {
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::None => {}
+        }
+    }
+
+    pub fn handle_create_card_dialog(&mut self, key_code: KeyCode) {
+        match handle_dialog_input(&mut self.input, key_code, false) {
+            DialogAction::Confirm => {
+                self.create_card();
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::Cancel => {
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::None => {}
+        }
+    }
+
+    pub fn handle_create_sprint_dialog(&mut self, key_code: KeyCode) {
+        match handle_dialog_input(&mut self.input, key_code, true) {
+            DialogAction::Confirm => {
+                self.create_sprint();
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Sprints;
+                self.input.clear();
+            }
+            DialogAction::Cancel => {
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Sprints;
+                self.input.clear();
+            }
+            DialogAction::None => {}
+        }
+    }
+
+    pub fn handle_rename_board_dialog(&mut self, key_code: KeyCode) {
+        match handle_dialog_input(&mut self.input, key_code, false) {
+            DialogAction::Confirm => {
+                self.rename_board();
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::Cancel => {
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::None => {}
+        }
+    }
+
+    pub fn handle_export_board_dialog(&mut self, key_code: KeyCode) {
+        match handle_dialog_input(&mut self.input, key_code, false) {
+            DialogAction::Confirm => {
+                if let Err(e) = self.export_board_with_filename() {
+                    tracing::error!("Failed to export board: {}", e);
+                }
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::Cancel => {
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::None => {}
+        }
+    }
+
+    pub fn handle_export_all_dialog(&mut self, key_code: KeyCode) {
+        match handle_dialog_input(&mut self.input, key_code, false) {
+            DialogAction::Confirm => {
+                if let Err(e) = self.export_all_boards_with_filename() {
+                    tracing::error!("Failed to export all boards: {}", e);
+                }
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::Cancel => {
+                self.mode = AppMode::Normal;
+                self.input.clear();
+            }
+            DialogAction::None => {}
+        }
+    }
+
+    pub fn handle_set_card_points_dialog(&mut self, key_code: KeyCode) -> bool {
+        match handle_dialog_input(&mut self.input, key_code, true) {
+            DialogAction::Confirm => {
+                let input_str = self.input.as_str().trim();
+                let points = if input_str.is_empty() {
+                    None
+                } else if let Ok(p) = input_str.parse::<u8>() {
+                    if (1..=5).contains(&p) {
+                        Some(p)
+                    } else {
+                        tracing::error!("Points must be between 1-5");
+                        self.mode = AppMode::CardDetail;
+                        self.input.clear();
+                        return false;
+                    }
+                } else {
+                    tracing::error!("Invalid points value");
+                    self.mode = AppMode::CardDetail;
+                    self.input.clear();
+                    return false;
+                };
+
+                if let Some(card_idx) = self.active_card_index {
+                    if let Some(board_idx) = self.active_board_index {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let board_cards: Vec<_> = self
+                                .cards
+                                .iter()
+                                .filter(|card| {
+                                    self.columns.iter().any(|col| {
+                                        col.id == card.column_id && col.board_id == board.id
+                                    })
+                                })
+                                .collect();
+
+                            if let Some(card) = board_cards.get(card_idx) {
+                                let card_id = card.id;
+                                if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id)
+                                {
+                                    card.set_points(points);
+                                    tracing::info!("Set points to: {:?}", points);
+                                }
+                            }
+                        }
+                    }
+                }
+                self.mode = AppMode::CardDetail;
+                self.input.clear();
+                false
+            }
+            DialogAction::Cancel => {
+                self.mode = AppMode::CardDetail;
+                self.input.clear();
+                false
+            }
+            DialogAction::None => false,
+        }
+    }
+
+    pub fn handle_set_branch_prefix_dialog(&mut self, key_code: KeyCode) {
+        match handle_dialog_input(&mut self.input, key_code, true) {
+            DialogAction::Confirm => {
+                let prefix_str = self.input.as_str().trim();
+                if prefix_str.is_empty() {
+                    if let Some(board_idx) = self.board_selection.get() {
+                        if let Some(board) = self.boards.get_mut(board_idx) {
+                            board.update_branch_prefix(None);
+                            tracing::info!("Cleared branch prefix");
+                        }
+                    }
+                } else if Card::validate_branch_prefix(prefix_str) {
+                    if let Some(board_idx) = self.board_selection.get() {
+                        if let Some(board) = self.boards.get_mut(board_idx) {
+                            board.update_branch_prefix(Some(prefix_str.to_string()));
+                            tracing::info!("Set branch prefix to: {}", prefix_str);
+                        }
+                    }
+                } else {
+                    tracing::error!("Invalid prefix: use alphanumeric, hyphens, underscores only");
+                }
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Settings;
+                self.input.clear();
+            }
+            DialogAction::Cancel => {
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Settings;
+                self.input.clear();
+            }
+            DialogAction::None => {}
+        }
+    }
+}

--- a/crates/kanban-tui/src/handlers/mod.rs
+++ b/crates/kanban-tui/src/handlers/mod.rs
@@ -1,0 +1,15 @@
+pub mod board_handlers;
+pub mod card_handlers;
+pub mod detail_view_handlers;
+pub mod dialog_handlers;
+pub mod navigation_handlers;
+pub mod popup_handlers;
+pub mod sprint_handlers;
+
+pub use board_handlers::*;
+pub use card_handlers::*;
+pub use detail_view_handlers::*;
+pub use dialog_handlers::*;
+pub use navigation_handlers::*;
+pub use popup_handlers::*;
+pub use sprint_handlers::*;

--- a/crates/kanban-tui/src/handlers/mod.rs
+++ b/crates/kanban-tui/src/handlers/mod.rs
@@ -6,10 +6,3 @@ pub mod navigation_handlers;
 pub mod popup_handlers;
 pub mod sprint_handlers;
 
-pub use board_handlers::*;
-pub use card_handlers::*;
-pub use detail_view_handlers::*;
-pub use dialog_handlers::*;
-pub use navigation_handlers::*;
-pub use popup_handlers::*;
-pub use sprint_handlers::*;

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -1,5 +1,4 @@
 use crate::app::{App, AppMode, Focus};
-use crossterm::event::KeyCode;
 
 impl App {
     pub fn handle_focus_switch(&mut self, focus_target: Focus) {

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -1,0 +1,92 @@
+use crate::app::{App, AppMode, Focus};
+use crossterm::event::KeyCode;
+
+impl App {
+    pub fn handle_focus_switch(&mut self, focus_target: Focus) {
+        match focus_target {
+            Focus::Boards => {
+                self.focus = Focus::Boards;
+            }
+            Focus::Cards => {
+                if self.active_board_index.is_some() {
+                    self.focus = Focus::Cards;
+                }
+            }
+        }
+    }
+
+    pub fn handle_navigation_down(&mut self) {
+        match self.focus {
+            Focus::Boards => {
+                self.board_selection.next(self.boards.len());
+            }
+            Focus::Cards => {
+                if let Some(board_idx) = self.active_board_index {
+                    if let Some(board) = self.boards.get(board_idx) {
+                        let card_count = self.get_board_card_count(board.id);
+                        self.card_selection.next(card_count);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_navigation_up(&mut self) {
+        match self.focus {
+            Focus::Boards => {
+                self.board_selection.prev();
+            }
+            Focus::Cards => {
+                self.card_selection.prev();
+            }
+        }
+    }
+
+    pub fn handle_selection_activate(&mut self) {
+        match self.focus {
+            Focus::Boards => {
+                if self.board_selection.get().is_some() {
+                    self.active_board_index = self.board_selection.get();
+                    self.card_selection.clear();
+
+                    if let Some(board_idx) = self.active_board_index {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            self.current_sort_field = Some(board.task_sort_field);
+                            self.current_sort_order = Some(board.task_sort_order);
+
+                            let card_count = self.get_board_card_count(board.id);
+                            if card_count > 0 {
+                                self.card_selection.set(Some(0));
+                            }
+                        }
+                    }
+
+                    self.focus = Focus::Cards;
+                }
+            }
+            Focus::Cards => {
+                if let Some(sorted_idx) = self.card_selection.get() {
+                    if let Some(board_idx) = self.active_board_index {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let sorted_cards = self.get_sorted_board_cards(board.id);
+                            if let Some(selected_card) = sorted_cards.get(sorted_idx) {
+                                let card_id = selected_card.id;
+                                let actual_idx = self.cards.iter().position(|c| c.id == card_id);
+                                self.active_card_index = actual_idx;
+                                self.mode = AppMode::CardDetail;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_escape_key(&mut self) {
+        if self.active_board_index.is_some() {
+            self.active_board_index = None;
+            self.card_selection.clear();
+            self.focus = Focus::Boards;
+        }
+    }
+}

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,0 +1,255 @@
+use crate::app::{App, AppMode};
+use crossterm::event::KeyCode;
+use kanban_domain::{SortField, SortOrder};
+
+impl App {
+    pub fn handle_import_board_popup(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::Normal;
+                self.import_selection.clear();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.import_selection.next(self.import_files.len());
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.import_selection.prev();
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if let Some(idx) = self.import_selection.get() {
+                    if let Some(filename) = self.import_files.get(idx).cloned() {
+                        if let Err(e) = self.import_board_from_file(&filename) {
+                            tracing::error!("Failed to import board: {}", e);
+                        }
+                    }
+                }
+                self.mode = AppMode::Normal;
+                self.import_selection.clear();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_set_card_priority_popup(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::CardDetail;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.priority_selection.next(4);
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.priority_selection.prev();
+            }
+            KeyCode::Enter => {
+                if let Some(priority_idx) = self.priority_selection.get() {
+                    if let Some(card_idx) = self.active_card_index {
+                        if let Some(card) = self.cards.get_mut(card_idx) {
+                            use kanban_domain::CardPriority;
+                            let priority = match priority_idx {
+                                0 => CardPriority::Low,
+                                1 => CardPriority::Medium,
+                                2 => CardPriority::High,
+                                3 => CardPriority::Critical,
+                                _ => CardPriority::Medium,
+                            };
+                            card.update_priority(priority);
+                        }
+                    }
+                }
+                self.mode = AppMode::CardDetail;
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_order_cards_popup(&mut self, key_code: KeyCode) -> bool {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::Normal;
+                self.sort_field_selection.clear();
+                false
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.sort_field_selection.next(6);
+                false
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.sort_field_selection.prev();
+                false
+            }
+            KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('a') | KeyCode::Char('d') => {
+                if let Some(field_idx) = self.sort_field_selection.get() {
+                    let field = match field_idx {
+                        0 => SortField::Points,
+                        1 => SortField::Priority,
+                        2 => SortField::CreatedAt,
+                        3 => SortField::UpdatedAt,
+                        4 => SortField::Status,
+                        5 => SortField::Default,
+                        _ => return false,
+                    };
+
+                    let order = if self.current_sort_field == Some(field)
+                        && matches!(key_code, KeyCode::Enter | KeyCode::Char(' '))
+                    {
+                        match self.current_sort_order {
+                            Some(SortOrder::Ascending) => SortOrder::Descending,
+                            Some(SortOrder::Descending) => SortOrder::Ascending,
+                            None => SortOrder::Ascending,
+                        }
+                    } else {
+                        match key_code {
+                            KeyCode::Char('d') => SortOrder::Descending,
+                            _ => SortOrder::Ascending,
+                        }
+                    };
+
+                    self.current_sort_field = Some(field);
+                    self.current_sort_order = Some(order);
+
+                    if let Some(board_idx) = self.active_board_index {
+                        if let Some(board) = self.boards.get_mut(board_idx) {
+                            board.update_task_sort(field, order);
+                        }
+                    }
+
+                    self.mode = AppMode::Normal;
+                    self.sort_field_selection.clear();
+
+                    tracing::info!("Sorting by {:?} ({:?})", field, order);
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
+    pub fn handle_assign_card_to_sprint_popup(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::Normal;
+                self.sprint_assign_selection.clear();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if let Some(board_idx) = self.active_board_index {
+                    if let Some(board) = self.boards.get(board_idx) {
+                        let sprint_count = self
+                            .sprints
+                            .iter()
+                            .filter(|s| s.board_id == board.id)
+                            .count();
+                        self.sprint_assign_selection.next(sprint_count + 1);
+                    }
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.sprint_assign_selection.prev();
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if let Some(selection_idx) = self.sprint_assign_selection.get() {
+                    if let Some(card_idx) = self.active_card_index {
+                        if let Some(card) = self.cards.get_mut(card_idx) {
+                            if selection_idx == 0 {
+                                card.sprint_id = None;
+                                tracing::info!("Unassigned card from sprint");
+                            } else if let Some(board_idx) = self.active_board_index {
+                                if let Some(board) = self.boards.get(board_idx) {
+                                    let board_sprints: Vec<_> = self
+                                        .sprints
+                                        .iter()
+                                        .filter(|s| s.board_id == board.id)
+                                        .collect();
+                                    if let Some(sprint) = board_sprints.get(selection_idx - 1) {
+                                        card.sprint_id = Some(sprint.id);
+                                        tracing::info!(
+                                            "Assigned card to sprint: {}",
+                                            sprint.formatted_name(board, "sprint")
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                self.mode = AppMode::Normal;
+                self.sprint_assign_selection.clear();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_assign_multiple_cards_to_sprint_popup(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::Normal;
+                self.sprint_assign_selection.clear();
+                self.selected_cards.clear();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if let Some(board_idx) = self.active_board_index {
+                    if let Some(board) = self.boards.get(board_idx) {
+                        let sprint_count = self
+                            .sprints
+                            .iter()
+                            .filter(|s| s.board_id == board.id)
+                            .count();
+                        self.sprint_assign_selection.next(sprint_count + 1);
+                    }
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.sprint_assign_selection.prev();
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if let Some(selection_idx) = self.sprint_assign_selection.get() {
+                    let card_ids: Vec<uuid::Uuid> = self.selected_cards.iter().copied().collect();
+                    for card_id in card_ids {
+                        if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                            if selection_idx == 0 {
+                                card.sprint_id = None;
+                            } else if let Some(board_idx) = self.active_board_index {
+                                if let Some(board) = self.boards.get(board_idx) {
+                                    let board_sprints: Vec<_> = self
+                                        .sprints
+                                        .iter()
+                                        .filter(|s| s.board_id == board.id)
+                                        .collect();
+                                    if let Some(sprint) = board_sprints.get(selection_idx - 1) {
+                                        card.sprint_id = Some(sprint.id);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(board_idx) = self.active_board_index {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let board_sprints: Vec<_> = self
+                                .sprints
+                                .iter()
+                                .filter(|s| s.board_id == board.id)
+                                .collect();
+                            if selection_idx == 0 {
+                                tracing::info!(
+                                    "Unassigned {} cards from sprint",
+                                    self.selected_cards.len()
+                                );
+                            } else if let Some(sprint) = board_sprints.get(selection_idx - 1) {
+                                tracing::info!(
+                                    "Assigned {} cards to sprint: {}",
+                                    self.selected_cards.len(),
+                                    sprint.formatted_name(board, "sprint")
+                                );
+                            }
+                        }
+                    }
+                }
+                self.mode = AppMode::Normal;
+                self.sprint_assign_selection.clear();
+                self.selected_cards.clear();
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -1,0 +1,112 @@
+use crate::app::{App, AppMode, BoardFocus};
+use kanban_domain::{Sprint, SprintStatus};
+
+impl App {
+    pub fn handle_create_sprint_key(&mut self) {
+        if self.board_focus == BoardFocus::Sprints && self.board_selection.get().is_some() {
+            self.mode = AppMode::CreateSprint;
+            self.input.clear();
+        }
+    }
+
+    pub fn handle_activate_sprint_key(&mut self) {
+        if let Some(sprint_idx) = self.active_sprint_index {
+            if let Some(sprint) = self.sprints.get_mut(sprint_idx) {
+                if sprint.status == SprintStatus::Planning {
+                    let board_idx = self.active_board_index.or(self.board_selection.get());
+                    if let Some(board_idx) = board_idx {
+                        if let Some(board) = self.boards.get_mut(board_idx) {
+                            let duration = board.sprint_duration_days.unwrap_or(14);
+                            let sprint_id = sprint.id;
+                            sprint.activate(duration);
+                            board.active_sprint_id = Some(sprint_id);
+                        }
+                        if let Some(board) = self.boards.get(board_idx) {
+                            tracing::info!("Activated sprint: {}", sprint.formatted_name(board, "sprint"));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_complete_sprint_key(&mut self) {
+        if let Some(sprint_idx) = self.active_sprint_index {
+            if let Some(sprint) = self.sprints.get_mut(sprint_idx) {
+                if sprint.status == SprintStatus::Active
+                    || sprint.status == SprintStatus::Planning
+                {
+                    let sprint_id = sprint.id;
+                    sprint.complete();
+                    let board_idx = self.active_board_index.or(self.board_selection.get());
+                    if let Some(board_idx) = board_idx {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            tracing::info!(
+                                "Completed sprint: {}",
+                                sprint.formatted_name(board, "sprint")
+                            );
+                        }
+                    }
+
+                    for card in self.cards.iter_mut() {
+                        if card.sprint_id == Some(sprint_id) {
+                            card.sprint_id = None;
+                        }
+                    }
+
+                    let board_idx = self.active_board_index.or(self.board_selection.get());
+                    if let Some(board_idx) = board_idx {
+                        if let Some(board) = self.boards.get_mut(board_idx) {
+                            if board.active_sprint_id == Some(sprint_id) {
+                                board.active_sprint_id = None;
+                                self.active_sprint_filter = None;
+                            }
+                        }
+                    }
+
+                    self.mode = AppMode::BoardDetail;
+                    self.board_focus = BoardFocus::Sprints;
+                    self.active_sprint_index = None;
+                }
+            }
+        }
+    }
+
+    pub fn create_sprint(&mut self) {
+        let board_idx = self.active_board_index.or(self.board_selection.get());
+        if let Some(board_idx) = board_idx {
+            let (sprint_number, name_index, board_id) = {
+                if let Some(board) = self.boards.get_mut(board_idx) {
+                    let sprint_number = board.allocate_sprint_number();
+                    let input_text = self.input.as_str().trim();
+                    let name_index = if input_text.is_empty() {
+                        board.consume_sprint_name()
+                    } else {
+                        Some(board.add_sprint_name_at_used_index(input_text.to_string()))
+                    };
+                    (sprint_number, name_index, board.id)
+                } else {
+                    return;
+                }
+            };
+
+            let sprint = Sprint::new(board_id, sprint_number, name_index, None);
+            if let Some(board) = self.boards.get(board_idx) {
+                tracing::info!(
+                    "Creating sprint: {} (id: {})",
+                    sprint.formatted_name(board, "sprint"),
+                    sprint.id
+                );
+            }
+            self.sprints.push(sprint);
+
+            let board_sprints: Vec<_> = self
+                .sprints
+                .iter()
+                .filter(|s| s.board_id == board_id)
+                .collect();
+            let new_index = board_sprints.len() - 1;
+            self.sprint_selection.set(Some(new_index));
+        }
+    }
+}

--- a/crates/kanban-tui/src/lib.rs
+++ b/crates/kanban-tui/src/lib.rs
@@ -3,9 +3,11 @@ pub mod clipboard;
 pub mod dialog;
 pub mod editor;
 pub mod events;
+pub mod export;
 pub mod handlers;
 pub mod input;
 pub mod selection;
+pub mod services;
 pub mod ui;
 
 pub use app::App;

--- a/crates/kanban-tui/src/lib.rs
+++ b/crates/kanban-tui/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod clipboard;
+pub mod components;
 pub mod dialog;
 pub mod editor;
 pub mod events;
@@ -8,6 +9,7 @@ pub mod handlers;
 pub mod input;
 pub mod selection;
 pub mod services;
+pub mod theme;
 pub mod ui;
 
 pub use app::App;

--- a/crates/kanban-tui/src/lib.rs
+++ b/crates/kanban-tui/src/lib.rs
@@ -3,6 +3,7 @@ pub mod clipboard;
 pub mod dialog;
 pub mod editor;
 pub mod events;
+pub mod handlers;
 pub mod input;
 pub mod selection;
 pub mod ui;

--- a/crates/kanban-tui/src/services/filter.rs
+++ b/crates/kanban-tui/src/services/filter.rs
@@ -1,0 +1,161 @@
+use kanban_domain::{Card, Column};
+use uuid::Uuid;
+
+pub trait CardFilter {
+    fn matches(&self, card: &Card) -> bool;
+}
+
+pub struct SprintFilter {
+    sprint_id: Option<Uuid>,
+}
+
+impl SprintFilter {
+    pub fn new(sprint_id: Option<Uuid>) -> Self {
+        Self { sprint_id }
+    }
+}
+
+impl CardFilter for SprintFilter {
+    fn matches(&self, card: &Card) -> bool {
+        match self.sprint_id {
+            Some(id) => card.sprint_id == Some(id),
+            None => true,
+        }
+    }
+}
+
+pub struct AssignmentFilter {
+    hide_assigned: bool,
+}
+
+impl AssignmentFilter {
+    pub fn new(hide_assigned: bool) -> Self {
+        Self { hide_assigned }
+    }
+}
+
+impl CardFilter for AssignmentFilter {
+    fn matches(&self, card: &Card) -> bool {
+        if self.hide_assigned {
+            card.sprint_id.is_none()
+        } else {
+            true
+        }
+    }
+}
+
+pub struct BoardFilter<'a> {
+    board_id: Uuid,
+    columns: &'a [Column],
+}
+
+impl<'a> BoardFilter<'a> {
+    pub fn new(board_id: Uuid, columns: &'a [Column]) -> Self {
+        Self { board_id, columns }
+    }
+}
+
+impl CardFilter for BoardFilter<'_> {
+    fn matches(&self, card: &Card) -> bool {
+        self.columns
+            .iter()
+            .any(|col| col.id == card.column_id && col.board_id == self.board_id)
+    }
+}
+
+pub struct CompositeFilter {
+    filters: Vec<Box<dyn CardFilter>>,
+}
+
+impl CompositeFilter {
+    pub fn new() -> Self {
+        Self {
+            filters: Vec::new(),
+        }
+    }
+
+    pub fn add_filter(mut self, filter: Box<dyn CardFilter>) -> Self {
+        self.filters.push(filter);
+        self
+    }
+}
+
+impl Default for CompositeFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CardFilter for CompositeFilter {
+    fn matches(&self, card: &Card) -> bool {
+        self.filters.iter().all(|f| f.matches(card))
+    }
+}
+
+pub fn filter_cards<'a>(cards: &'a [Card], filter: &dyn CardFilter) -> Vec<&'a Card> {
+    cards.iter().filter(|c| filter.matches(c)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::Board;
+
+    #[test]
+    fn test_sprint_filter() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        let mut card1 = kanban_domain::Card::new(&mut board_mut, column.id, "Card 1".to_string(), 0);
+        let sprint_id = Uuid::new_v4();
+        card1.sprint_id = Some(sprint_id);
+
+        let card2 = kanban_domain::Card::new(&mut board_mut, column.id, "Card 2".to_string(), 1);
+
+        let filter = SprintFilter::new(Some(sprint_id));
+        assert!(filter.matches(&card1));
+        assert!(!filter.matches(&card2));
+    }
+
+    #[test]
+    fn test_assignment_filter() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        let mut card1 = kanban_domain::Card::new(&mut board_mut, column.id, "Card 1".to_string(), 0);
+        card1.sprint_id = Some(Uuid::new_v4());
+
+        let card2 = kanban_domain::Card::new(&mut board_mut, column.id, "Card 2".to_string(), 1);
+
+        let filter = AssignmentFilter::new(true);
+        assert!(!filter.matches(&card1));
+        assert!(filter.matches(&card2));
+    }
+
+    #[test]
+    fn test_composite_filter() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        let sprint_id = Uuid::new_v4();
+
+        let mut card1 = kanban_domain::Card::new(&mut board_mut, column.id, "Card 1".to_string(), 0);
+        card1.sprint_id = Some(sprint_id);
+
+        let mut card2 = kanban_domain::Card::new(&mut board_mut, column.id, "Card 2".to_string(), 1);
+        card2.sprint_id = Some(sprint_id);
+
+        let card3 = kanban_domain::Card::new(&mut board_mut, column.id, "Card 3".to_string(), 2);
+
+        let filter = CompositeFilter::new()
+            .add_filter(Box::new(SprintFilter::new(Some(sprint_id))))
+            .add_filter(Box::new(AssignmentFilter::new(false)));
+
+        assert!(filter.matches(&card1));
+        assert!(filter.matches(&card2));
+        assert!(!filter.matches(&card3));
+    }
+}

--- a/crates/kanban-tui/src/services/mod.rs
+++ b/crates/kanban-tui/src/services/mod.rs
@@ -1,0 +1,7 @@
+pub mod filter;
+pub mod query;
+pub mod sort;
+
+pub use filter::*;
+pub use query::*;
+pub use sort::*;

--- a/crates/kanban-tui/src/services/query.rs
+++ b/crates/kanban-tui/src/services/query.rs
@@ -1,0 +1,126 @@
+use kanban_domain::{Board, Card, Column, Sprint};
+use uuid::Uuid;
+
+pub struct CardQuery<'a> {
+    cards: &'a [Card],
+    columns: &'a [Column],
+}
+
+impl<'a> CardQuery<'a> {
+    pub fn new(cards: &'a [Card], columns: &'a [Column]) -> Self {
+        Self { cards, columns }
+    }
+
+    pub fn get_board_cards(&self, board_id: Uuid) -> Vec<&'a Card> {
+        self.cards
+            .iter()
+            .filter(|card| {
+                self.columns
+                    .iter()
+                    .any(|col| col.id == card.column_id && col.board_id == board_id)
+            })
+            .collect()
+    }
+
+    pub fn get_board_card_count(&self, board_id: Uuid) -> usize {
+        self.get_board_cards(board_id).len()
+    }
+
+    pub fn find_by_id(&self, card_id: Uuid) -> Option<&'a Card> {
+        self.cards.iter().find(|c| c.id == card_id)
+    }
+}
+
+pub struct BoardQuery<'a> {
+    boards: &'a [Board],
+}
+
+impl<'a> BoardQuery<'a> {
+    pub fn new(boards: &'a [Board]) -> Self {
+        Self { boards }
+    }
+
+    pub fn find_by_id(&self, board_id: Uuid) -> Option<&'a Board> {
+        self.boards.iter().find(|b| b.id == board_id)
+    }
+
+    pub fn get_all(&self) -> &'a [Board] {
+        self.boards
+    }
+}
+
+pub struct SprintQuery<'a> {
+    sprints: &'a [Sprint],
+}
+
+impl<'a> SprintQuery<'a> {
+    pub fn new(sprints: &'a [Sprint]) -> Self {
+        Self { sprints }
+    }
+
+    pub fn get_board_sprints(&self, board_id: Uuid) -> Vec<&'a Sprint> {
+        self.sprints
+            .iter()
+            .filter(|s| s.board_id == board_id)
+            .collect()
+    }
+
+    pub fn find_by_id(&self, sprint_id: Uuid) -> Option<&'a Sprint> {
+        self.sprints.iter().find(|s| s.id == sprint_id)
+    }
+
+    pub fn find_active_for_board(&self, board: &Board) -> Option<&'a Sprint> {
+        board
+            .active_sprint_id
+            .and_then(|id| self.find_by_id(id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::Board;
+
+    #[test]
+    fn test_card_query_get_board_cards() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+        let columns = vec![column.clone()];
+
+        let mut board_mut = board.clone();
+        let card = kanban_domain::Card::new(&mut board_mut, column.id, "Task".to_string(), 0);
+        let cards = vec![card];
+
+        let query = CardQuery::new(&cards, &columns);
+        let result = query.get_board_cards(board.id);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].title, "Task");
+    }
+
+    #[test]
+    fn test_board_query_find_by_id() {
+        let board1 = Board::new("Board 1".to_string(), None);
+        let board2 = Board::new("Board 2".to_string(), None);
+        let boards = vec![board1.clone(), board2.clone()];
+
+        let query = BoardQuery::new(&boards);
+        let result = query.find_by_id(board1.id);
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "Board 1");
+    }
+
+    #[test]
+    fn test_sprint_query_get_board_sprints() {
+        let board = Board::new("Test".to_string(), None);
+        let sprint1 = kanban_domain::Sprint::new(board.id, 1, None, None);
+        let sprint2 = kanban_domain::Sprint::new(board.id, 2, None, None);
+        let sprints = vec![sprint1, sprint2];
+
+        let query = SprintQuery::new(&sprints);
+        let result = query.get_board_sprints(board.id);
+
+        assert_eq!(result.len(), 2);
+    }
+}

--- a/crates/kanban-tui/src/services/sort.rs
+++ b/crates/kanban-tui/src/services/sort.rs
@@ -1,0 +1,172 @@
+use kanban_domain::{Card, CardPriority, CardStatus, SortField, SortOrder};
+use std::cmp::Ordering;
+
+pub trait CardSorter {
+    fn compare(&self, a: &Card, b: &Card) -> Ordering;
+}
+
+pub struct PointsSorter;
+
+impl CardSorter for PointsSorter {
+    fn compare(&self, a: &Card, b: &Card) -> Ordering {
+        match (a.points, b.points) {
+            (Some(ap), Some(bp)) => ap.cmp(&bp),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        }
+    }
+}
+
+pub struct PrioritySorter;
+
+impl CardSorter for PrioritySorter {
+    fn compare(&self, a: &Card, b: &Card) -> Ordering {
+        priority_value(&a.priority).cmp(&priority_value(&b.priority))
+    }
+}
+
+pub struct CreatedAtSorter;
+
+impl CardSorter for CreatedAtSorter {
+    fn compare(&self, a: &Card, b: &Card) -> Ordering {
+        a.created_at.cmp(&b.created_at)
+    }
+}
+
+pub struct UpdatedAtSorter;
+
+impl CardSorter for UpdatedAtSorter {
+    fn compare(&self, a: &Card, b: &Card) -> Ordering {
+        a.updated_at.cmp(&b.updated_at)
+    }
+}
+
+pub struct StatusSorter;
+
+impl CardSorter for StatusSorter {
+    fn compare(&self, a: &Card, b: &Card) -> Ordering {
+        status_value(&a.status).cmp(&status_value(&b.status))
+    }
+}
+
+pub struct CardNumberSorter;
+
+impl CardSorter for CardNumberSorter {
+    fn compare(&self, a: &Card, b: &Card) -> Ordering {
+        a.card_number.cmp(&b.card_number)
+    }
+}
+
+pub struct OrderedSorter {
+    sorter: Box<dyn CardSorter>,
+    order: SortOrder,
+}
+
+impl OrderedSorter {
+    pub fn new(sorter: Box<dyn CardSorter>, order: SortOrder) -> Self {
+        Self { sorter, order }
+    }
+
+    pub fn sort(&self, cards: &mut [&Card]) {
+        cards.sort_by(|a, b| {
+            let cmp = self.sorter.compare(a, b);
+            match self.order {
+                SortOrder::Ascending => cmp,
+                SortOrder::Descending => cmp.reverse(),
+            }
+        });
+    }
+}
+
+pub fn get_sorter_for_field(field: SortField) -> Box<dyn CardSorter> {
+    match field {
+        SortField::Points => Box::new(PointsSorter),
+        SortField::Priority => Box::new(PrioritySorter),
+        SortField::CreatedAt => Box::new(CreatedAtSorter),
+        SortField::UpdatedAt => Box::new(UpdatedAtSorter),
+        SortField::Status => Box::new(StatusSorter),
+        SortField::Default => Box::new(CardNumberSorter),
+    }
+}
+
+fn priority_value(priority: &CardPriority) -> u8 {
+    match priority {
+        CardPriority::Critical => 3,
+        CardPriority::High => 2,
+        CardPriority::Medium => 1,
+        CardPriority::Low => 0,
+    }
+}
+
+fn status_value(status: &CardStatus) -> u8 {
+    match status {
+        CardStatus::Done => 3,
+        CardStatus::InProgress => 2,
+        CardStatus::Blocked => 1,
+        CardStatus::Todo => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::Board;
+
+    #[test]
+    fn test_priority_sorter() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        let mut card1 = kanban_domain::Card::new(&mut board_mut, column.id, "Low".to_string(), 0);
+        card1.update_priority(CardPriority::Low);
+
+        let mut card2 = kanban_domain::Card::new(&mut board_mut, column.id, "High".to_string(), 1);
+        card2.update_priority(CardPriority::High);
+
+        let sorter = PrioritySorter;
+        assert_eq!(sorter.compare(&card1, &card2), Ordering::Less);
+        assert_eq!(sorter.compare(&card2, &card1), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_ordered_sorter_ascending() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        let mut card1 = kanban_domain::Card::new(&mut board_mut, column.id, "High".to_string(), 0);
+        card1.update_priority(CardPriority::High);
+
+        let mut card2 = kanban_domain::Card::new(&mut board_mut, column.id, "Low".to_string(), 1);
+        card2.update_priority(CardPriority::Low);
+
+        let mut cards = vec![&card1, &card2];
+        let sorter = OrderedSorter::new(Box::new(PrioritySorter), SortOrder::Ascending);
+        sorter.sort(&mut cards);
+
+        assert_eq!(cards[0].title, "Low");
+        assert_eq!(cards[1].title, "High");
+    }
+
+    #[test]
+    fn test_ordered_sorter_descending() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        let mut card1 = kanban_domain::Card::new(&mut board_mut, column.id, "Low".to_string(), 0);
+        card1.update_priority(CardPriority::Low);
+
+        let mut card2 = kanban_domain::Card::new(&mut board_mut, column.id, "High".to_string(), 1);
+        card2.update_priority(CardPriority::High);
+
+        let mut cards = vec![&card1, &card2];
+        let sorter = OrderedSorter::new(Box::new(PrioritySorter), SortOrder::Descending);
+        sorter.sort(&mut cards);
+
+        assert_eq!(cards[0].title, "High");
+        assert_eq!(cards[1].title, "Low");
+    }
+}

--- a/crates/kanban-tui/src/theme/colors.rs
+++ b/crates/kanban-tui/src/theme/colors.rs
@@ -1,0 +1,30 @@
+use ratatui::style::Color;
+
+pub const FOCUSED_BORDER: Color = Color::Cyan;
+pub const UNFOCUSED_BORDER: Color = Color::White;
+pub const SELECTED_BG: Color = Color::Blue;
+
+pub const ACTIVE_ITEM: Color = Color::Green;
+pub const DONE_TEXT: Color = Color::DarkGray;
+pub const NORMAL_TEXT: Color = Color::White;
+pub const LABEL_TEXT: Color = Color::Gray;
+pub const HIGHLIGHT_TEXT: Color = Color::Yellow;
+
+pub const PRIORITY_CRITICAL: Color = Color::Red;
+pub const PRIORITY_HIGH: Color = Color::LightRed;
+pub const PRIORITY_MEDIUM: Color = Color::Yellow;
+pub const PRIORITY_LOW: Color = Color::White;
+
+pub const POINTS_1: Color = Color::Cyan;
+pub const POINTS_2: Color = Color::Green;
+pub const POINTS_3: Color = Color::Yellow;
+pub const POINTS_4: Color = Color::LightMagenta;
+pub const POINTS_5: Color = Color::Red;
+
+pub const STATUS_ACTIVE: Color = Color::Green;
+pub const STATUS_PLANNING: Color = Color::Yellow;
+pub const STATUS_COMPLETED: Color = Color::Gray;
+pub const STATUS_CANCELLED: Color = Color::Red;
+
+pub const POPUP_BG: Color = Color::Black;
+pub const ERROR_COLOR: Color = Color::Red;

--- a/crates/kanban-tui/src/theme/mod.rs
+++ b/crates/kanban-tui/src/theme/mod.rs
@@ -1,0 +1,5 @@
+pub mod colors;
+pub mod styles;
+
+pub use colors::*;
+pub use styles::*;

--- a/crates/kanban-tui/src/theme/styles.rs
+++ b/crates/kanban-tui/src/theme/styles.rs
@@ -1,0 +1,85 @@
+use super::colors::*;
+use kanban_domain::{CardPriority, SprintStatus};
+use ratatui::style::{Modifier, Style};
+
+pub fn focused_border() -> Style {
+    Style::default().fg(FOCUSED_BORDER)
+}
+
+pub fn unfocused_border() -> Style {
+    Style::default().fg(UNFOCUSED_BORDER)
+}
+
+pub fn selected_item(focused: bool) -> Style {
+    if focused {
+        Style::default().bg(SELECTED_BG)
+    } else {
+        Style::default()
+    }
+}
+
+pub fn active_item() -> Style {
+    Style::default()
+        .fg(ACTIVE_ITEM)
+        .add_modifier(Modifier::BOLD)
+}
+
+pub fn done_text() -> Style {
+    Style::default()
+        .fg(DONE_TEXT)
+        .add_modifier(Modifier::CROSSED_OUT)
+}
+
+pub fn normal_text() -> Style {
+    Style::default().fg(NORMAL_TEXT)
+}
+
+pub fn label_text() -> Style {
+    Style::default().fg(LABEL_TEXT)
+}
+
+pub fn highlight_text() -> Style {
+    Style::default().fg(HIGHLIGHT_TEXT)
+}
+
+pub fn bold_highlight() -> Style {
+    Style::default()
+        .fg(HIGHLIGHT_TEXT)
+        .add_modifier(Modifier::BOLD)
+}
+
+pub fn priority_style(priority: CardPriority) -> Style {
+    let color = match priority {
+        CardPriority::Critical => PRIORITY_CRITICAL,
+        CardPriority::High => PRIORITY_HIGH,
+        CardPriority::Medium => PRIORITY_MEDIUM,
+        CardPriority::Low => PRIORITY_LOW,
+    };
+    Style::default().fg(color)
+}
+
+pub fn points_style(points: u8) -> Style {
+    let color = match points {
+        1 => POINTS_1,
+        2 => POINTS_2,
+        3 => POINTS_3,
+        4 => POINTS_4,
+        5 => POINTS_5,
+        _ => NORMAL_TEXT,
+    };
+    Style::default().fg(color).add_modifier(Modifier::BOLD)
+}
+
+pub fn sprint_status_style(status: SprintStatus) -> Style {
+    let color = match status {
+        SprintStatus::Active => STATUS_ACTIVE,
+        SprintStatus::Planning => STATUS_PLANNING,
+        SprintStatus::Completed => STATUS_COMPLETED,
+        SprintStatus::Cancelled => STATUS_CANCELLED,
+    };
+    Style::default().fg(color)
+}
+
+pub fn popup_bg() -> Style {
+    Style::default().bg(POPUP_BG)
+}

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -122,7 +122,8 @@ fn test_import_valid_format() {
                 "points": null,
                 "created_at": "2025-01-01T00:00:00Z",
                 "updated_at": "2025-01-01T00:00:00Z"
-            }]
+            }],
+            "sprints": []
         }]
     }"#;
 


### PR DESCRIPTION
Refactor codebase architecture through modular extraction and composition:

- Extract event handlers into focused modules (navigation, board, card, sprint, dialog, popup, detail)
- Simplify main event loop using handler delegation pattern
- Add services layer for business logic (query, filter, sort)
- Extract export/import logic into dedicated module with models
- Create theme system with semantic colors and reusable style functions
- Build composable UI components (ListItem, Panel, Popup, DetailView, CardListItem, SelectionList)
- Refactor ui.rs to use components (1227→869 lines, 29% reduction)

**What**: Comprehensive refactoring following SOLID principles to improve code organization and reusability

**Why**: Reduce duplication, improve maintainability, and establish patterns for future feature development

**How**: Extracted handlers, services, and components into separate modules; used composition over duplication

**Testing**: All existing tests pass; manual testing with `cargo run`