### PR TITLE
MVP-22/hitting-e-on-an-item-in-the-task-list-should-open-editor-with-that-tasks-description

### DIFF
--- a/.changeset/quick-edit.md
+++ b/.changeset/quick-edit.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Enable direct card description editing from task list
+
+- Add 'e' key binding to edit card description when focus is on Cards
+- Previously required entering CardDetail mode first (Enter then 'e')

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -183,7 +183,12 @@ impl App {
                     Focus::Cards => self.handle_create_card_key(),
                 },
                 KeyCode::Char('r') => self.handle_rename_board_key(),
-                KeyCode::Char('e') => self.handle_edit_board_key(),
+                KeyCode::Char('e') => match self.focus {
+                    Focus::Boards => self.handle_edit_board_key(),
+                    Focus::Cards => {
+                        should_restart_events = self.handle_edit_card_key(terminal, event_handler);
+                    }
+                },
                 KeyCode::Char('x') => self.handle_export_board_key(),
                 KeyCode::Char('X') => self.handle_export_all_key(),
                 KeyCode::Char('i') => self.handle_import_board_key(),


### PR DESCRIPTION
Enable direct card description editing from task list:

- Add `handle_edit_card_key()` handler in `card_handlers.rs`
- Update Normal mode 'e' key binding to match on focus (Boards vs Cards)
- Convert sorted card index to actual card index before editing

**What**: Pressing 'e' on a card in the task list now opens $EDITOR with its description

**Why**: Previously users had to press Enter first to enter CardDetail mode, then press 'e' to edit. This adds a quicker workflow.

**How**: Added focus-based dispatching in the Normal mode 'e' handler. When focus is on Cards, the new `handle_edit_card_key()` method converts the selected card index to the actual card and opens the editor.

**Testing**: Manually tested with `cargo run`, verified build passes with `cargo check` and `cargo clippy`