### PR TITLE
KAN-24/add-github-ci

### DIFF
--- a/.changeset/kan-24-add-github-ci.md
+++ b/.changeset/kan-24-add-github-ci.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+- update CONTRIBUTING.md with branching and release workflow
+- check for changesets onm develop branch
+- add create-changeset.sh

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - develop
 
 jobs:
   check:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,52 @@ mod tests {
 }
 ```
 
+## Branching and Release Workflow
+
+### Branch Strategy
+
+**develop → master** release workflow:
+
+- **Feature branches** → merge to `develop`
+- **develop** → accumulates features for next release
+- **master** → production releases only
+
+### Development Workflow
+
+1. **Create feature branch** from `develop`:
+   ```bash
+   git checkout develop
+   git pull origin develop
+   git checkout -b MVP-123/my-feature
+   ```
+
+2. **Make changes** and commit regularly (atomic commits)
+
+3. **Create changeset** before submitting PR:
+   ```bash
+   # Auto-generate from commits (default: patch)
+   ./scripts/create-changeset.sh
+
+   # Or specify bump type and description
+   ./scripts/create-changeset.sh minor "Add sprint support"
+   ```
+
+4. **Submit PR to develop**:
+   - PR will check for changeset presence
+   - Changesets accumulate in `develop` (not consumed yet)
+
+5. **Periodic releases** from `develop` → `master`:
+   - All accumulated changesets consumed
+   - Single version bump (highest precedence wins: patch < minor < major)
+   - Automatic publish to crates.io
+   - GitHub release created
+
+### Release Cadence
+
+- Features merge to `develop` continuously
+- `develop` → `master` releases at the end of the sprint
+- One version bump per release, not per feature
+
 ## Pull Request Guidelines
 
 ### Before Submitting
@@ -190,7 +236,8 @@ mod tests {
 - [ ] Run `cargo fmt` to format code
 - [ ] Run `cargo clippy` and address all warnings
 - [ ] Run `cargo test` and ensure all tests pass
-- [ ] Test manually with `cargo run -- -f test.json`
+- [ ] Test manually with `cargo run`
+- [ ] Create changeset with `./scripts/create-changeset.sh`
 - [ ] Update README.md if adding user-facing features
 - [ ] Update CLAUDE.md if changing architecture/conventions
 
@@ -211,7 +258,7 @@ Fixes task filtering behavior:
 - Fix filter persistence across sessions
 ```
 
-And include concisely
+And include concisely:
 
 - **What**: Brief description of changes
 - **Why**: Motivation and context

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,10 @@
           extensions = ["rust-src" "rust-analyzer" "clippy" "rustfmt"];
         };
 
+        changeset = pkgs.writeShellScriptBin "changeset" ''
+          ${builtins.readFile ./scripts/create-changeset.sh}
+        '';
+
         bumpVersion = pkgs.writeShellScriptBin "bump-version" ''
           ${builtins.readFile ./scripts/bump-version.sh}
         '';

--- a/scripts/create-changeset.sh
+++ b/scripts/create-changeset.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH=$(git branch --show-current)
+
+if [ "$BRANCH" = "master" ] || [ "$BRANCH" = "main" ]; then
+  echo "Error: Cannot create changeset on master/main branch"
+  exit 1
+fi
+
+BUMP_TYPE="${1:-patch}"
+
+if [[ ! "$BUMP_TYPE" =~ ^(patch|minor|major)$ ]]; then
+  echo "Error: Invalid bump type '$BUMP_TYPE'"
+  echo "Usage: $0 [patch|minor|major]"
+  exit 1
+fi
+
+DESCRIPTION="${2:-}"
+
+if [ -z "$DESCRIPTION" ]; then
+  BASE_BRANCH="${BASE_BRANCH:-master}"
+  COMMITS=$(git log --oneline "$BASE_BRANCH"..HEAD --pretty=format:"- %s")
+
+  if [ -z "$COMMITS" ]; then
+    echo "Error: No commits found and no description provided"
+    echo "Usage: $0 [patch|minor|major] \"Description of changes\""
+    exit 1
+  fi
+
+  DESCRIPTION="$COMMITS"
+  echo "Auto-generated description from commits:"
+  echo "$DESCRIPTION"
+  echo ""
+fi
+
+SANITIZED_BRANCH=$(echo "$BRANCH" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+CHANGESET_FILE=".changeset/${SANITIZED_BRANCH}.md"
+
+mkdir -p .changeset
+
+cat > "$CHANGESET_FILE" <<EOF
+---
+bump: $BUMP_TYPE
+---
+
+$DESCRIPTION
+EOF
+
+echo "Created changeset: $CHANGESET_FILE"
+echo "Bump type: $BUMP_TYPE"
+echo "Description: $DESCRIPTION"


### PR DESCRIPTION
Add develop branch workflow and changeset tooling

- Add `create-changeset.sh` script to auto-generate changesets from commits
- Update changeset check workflow to validate PRs to both `develop` and `master`
- Document develop → master release workflow in CONTRIBUTING.md

**What**: Infrastructure for sprint-based releases with changeset accumulation  
**Why**: Enable feature accumulation in develop before releasing to master  
**How**: Script for changeset creation, CI check for both branches, updated docs  
**Testing**: Manually tested script, workflow will validate on PR