### PR TITLE
MVP-7/add-column-definitions

### DIFF
--- a/.changeset/mvp-7-add-column-definitions.md
+++ b/.changeset/mvp-7-add-column-definitions.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+- feat: add kanban column navigation
+- feat: implement three task list view modes
+- feat: add column and view selection UI state
+- feat: add task list view support to Board domain
+- feat: add column management handlers
+- feat: add TaskListView domain enum

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -2,6 +2,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::task_list_view::TaskListView;
+
 pub type BoardId = Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -45,6 +47,8 @@ pub struct Board {
     pub next_sprint_number: u32,
     #[serde(default)]
     pub active_sprint_id: Option<Uuid>,
+    #[serde(default)]
+    pub task_list_view: TaskListView,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -82,6 +86,7 @@ impl Board {
             sprint_name_used_count: 0,
             next_sprint_number: 1,
             active_sprint_id: None,
+            task_list_view: TaskListView::default(),
             created_at: now,
             updated_at: now,
         }
@@ -146,6 +151,11 @@ impl Board {
         self.sprint_name_used_count += 1;
         self.updated_at = Utc::now();
         index
+    }
+
+    pub fn update_task_list_view(&mut self, view: TaskListView) {
+        self.task_list_view = view;
+        self.updated_at = Utc::now();
     }
 }
 

--- a/crates/kanban-domain/src/column.rs
+++ b/crates/kanban-domain/src/column.rs
@@ -40,4 +40,9 @@ impl Column {
         self.position = position;
         self.updated_at = Utc::now();
     }
+
+    pub fn update_name(&mut self, name: String) {
+        self.name = name;
+        self.updated_at = Utc::now();
+    }
 }

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -3,9 +3,11 @@ pub mod card;
 pub mod column;
 pub mod sprint;
 pub mod tag;
+pub mod task_list_view;
 
 pub use board::{Board, BoardId, SortField, SortOrder};
 pub use card::{Card, CardId, CardPriority, CardStatus};
 pub use column::{Column, ColumnId};
 pub use sprint::{Sprint, SprintId, SprintStatus};
 pub use tag::{Tag, TagId};
+pub use task_list_view::TaskListView;

--- a/crates/kanban-domain/src/task_list_view.rs
+++ b/crates/kanban-domain/src/task_list_view.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TaskListView {
+    Flat,
+    GroupedByColumn,
+    ColumnView,
+}
+
+impl Default for TaskListView {
+    fn default() -> Self {
+        Self::Flat
+    }
+}

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -47,6 +47,9 @@ pub struct App {
     pub current_sort_order: Option<SortOrder>,
     pub selected_cards: std::collections::HashSet<uuid::Uuid>,
     pub priority_selection: SelectionState,
+    pub column_selection: SelectionState,
+    pub active_column_index: Option<usize>,
+    pub task_list_view_selection: SelectionState,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -68,6 +71,7 @@ pub enum BoardFocus {
     Description,
     Settings,
     Sprints,
+    Columns,
 }
 
 pub enum CardField {
@@ -108,6 +112,10 @@ pub enum AppMode {
     CreateSprint,
     AssignCardToSprint,
     AssignMultipleCardsToSprint,
+    CreateColumn,
+    RenameColumn,
+    DeleteColumnConfirm,
+    SelectTaskListView,
 }
 
 impl App {
@@ -142,6 +150,9 @@ impl App {
             current_sort_order: None,
             selected_cards: std::collections::HashSet::new(),
             priority_selection: SelectionState::new(),
+            column_selection: SelectionState::new(),
+            active_column_index: None,
+            task_list_view_selection: SelectionState::new(),
         };
 
         if let Some(ref filename) = save_file {
@@ -199,8 +210,20 @@ impl App {
                 KeyCode::Char('T') => self.handle_toggle_hide_assigned(),
                 KeyCode::Char('t') => self.handle_toggle_sprint_filter(),
                 KeyCode::Char('v') => self.handle_card_selection_toggle(),
-                KeyCode::Char('1') => self.handle_focus_switch(Focus::Boards),
-                KeyCode::Char('2') => self.handle_focus_switch(Focus::Cards),
+                KeyCode::Char('V') => self.handle_toggle_task_list_view(),
+                KeyCode::Char('H') => self.handle_move_card_left(),
+                KeyCode::Char('L') => self.handle_move_card_right(),
+                KeyCode::Char('h') => self.handle_kanban_column_left(),
+                KeyCode::Char('l') => self.handle_kanban_column_right(),
+                KeyCode::Char('1') => self.handle_column_or_focus_switch(0),
+                KeyCode::Char('2') => self.handle_column_or_focus_switch(1),
+                KeyCode::Char('3') => self.handle_column_or_focus_switch(2),
+                KeyCode::Char('4') => self.handle_column_or_focus_switch(3),
+                KeyCode::Char('5') => self.handle_column_or_focus_switch(4),
+                KeyCode::Char('6') => self.handle_column_or_focus_switch(5),
+                KeyCode::Char('7') => self.handle_column_or_focus_switch(6),
+                KeyCode::Char('8') => self.handle_column_or_focus_switch(7),
+                KeyCode::Char('9') => self.handle_column_or_focus_switch(8),
                 KeyCode::Esc => self.handle_escape_key(),
                 KeyCode::Char('j') | KeyCode::Down => self.handle_navigation_down(),
                 KeyCode::Char('k') | KeyCode::Up => self.handle_navigation_up(),
@@ -235,6 +258,10 @@ impl App {
             AppMode::AssignMultipleCardsToSprint => {
                 self.handle_assign_multiple_cards_to_sprint_popup(key.code)
             }
+            AppMode::CreateColumn => self.handle_create_column_dialog(key.code),
+            AppMode::RenameColumn => self.handle_rename_column_dialog(key.code),
+            AppMode::DeleteColumnConfirm => self.handle_delete_column_confirm_popup(key.code),
+            AppMode::SelectTaskListView => self.handle_select_task_list_view_popup(key.code),
         }
         should_restart_events
     }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -65,8 +65,23 @@ impl App {
 
     pub fn create_board(&mut self) {
         let board = kanban_domain::Board::new(self.input.as_str().to_string(), None);
+        let board_id = board.id;
         tracing::info!("Creating board: {} (id: {})", board.name, board.id);
+
         self.boards.push(board);
+
+        let default_columns = vec![
+            ("TODO", 0),
+            ("Doing", 1),
+            ("Complete", 2),
+        ];
+
+        for (name, position) in default_columns {
+            let column = kanban_domain::Column::new(board_id, name.to_string(), position);
+            tracing::info!("Creating default column: {} (position: {})", column.name, column.position);
+            self.columns.push(column);
+        }
+
         let new_index = self.boards.len() - 1;
         self.board_selection.set(Some(new_index));
     }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -201,13 +201,54 @@ impl App {
                             CardStatus::Done
                         };
 
+                        let last_column_id = if new_status == CardStatus::Done {
+                            let mut board_columns: Vec<_> = self
+                                .columns
+                                .iter()
+                                .filter(|col| col.board_id == board.id)
+                                .collect();
+                            board_columns.sort_by_key(|col| col.position);
+                            board_columns.last().map(|col| col.id)
+                        } else {
+                            None
+                        };
+
+                        let new_position = if let Some(target_column_id) = last_column_id {
+                            Some(self
+                                .cards
+                                .iter()
+                                .filter(|c| c.column_id == target_column_id)
+                                .count() as i32)
+                        } else {
+                            None
+                        };
+
                         if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                            let old_column_id = card.column_id;
                             card.update_status(new_status);
-                            tracing::info!(
-                                "Toggled card '{}' to status: {:?}",
-                                card.title,
-                                new_status
-                            );
+
+                            if let (Some(target_column_id), Some(position)) = (last_column_id, new_position) {
+                                if old_column_id != target_column_id {
+                                    card.move_to_column(target_column_id, position);
+                                    tracing::info!(
+                                        "Moved card '{}' to last column (status: {:?})",
+                                        card.title,
+                                        new_status
+                                    );
+                                } else {
+                                    tracing::info!(
+                                        "Toggled card '{}' to status: {:?}",
+                                        card.title,
+                                        new_status
+                                    );
+                                }
+                            } else {
+                                tracing::info!(
+                                    "Toggled card '{}' to status: {:?}",
+                                    card.title,
+                                    new_status
+                                );
+                            }
                         }
                     }
                 }
@@ -219,14 +260,50 @@ impl App {
         let card_ids: Vec<uuid::Uuid> = self.selected_cards.iter().copied().collect();
         let mut toggled_count = 0;
 
+        let last_column_id = if let Some(board_idx) = self.active_board_index {
+            if let Some(board) = self.boards.get(board_idx) {
+                let mut board_columns: Vec<_> = self
+                    .columns
+                    .iter()
+                    .filter(|col| col.board_id == board.id)
+                    .collect();
+                board_columns.sort_by_key(|col| col.position);
+                board_columns.last().map(|col| col.id)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         for card_id in card_ids {
+            let new_position = if let Some(target_column_id) = last_column_id {
+                Some(self
+                    .cards
+                    .iter()
+                    .filter(|c| c.column_id == target_column_id)
+                    .count() as i32)
+            } else {
+                None
+            };
+
             if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                let old_column_id = card.column_id;
                 let new_status = if card.status == CardStatus::Done {
                     CardStatus::Todo
                 } else {
                     CardStatus::Done
                 };
                 card.update_status(new_status);
+
+                if new_status == CardStatus::Done {
+                    if let (Some(target_column_id), Some(position)) = (last_column_id, new_position) {
+                        if old_column_id != target_column_id {
+                            card.move_to_column(target_column_id, position);
+                        }
+                    }
+                }
+
                 toggled_count += 1;
             }
         }
@@ -266,6 +343,120 @@ impl App {
                 let card_count = self.get_board_card_count(board_id);
                 let new_card_index = card_count.saturating_sub(1);
                 self.card_selection.set(Some(new_card_index));
+            }
+        }
+    }
+
+    pub fn handle_move_card_left(&mut self) {
+        if self.focus != Focus::Cards {
+            return;
+        }
+
+        if let Some(sorted_idx) = self.card_selection.get() {
+            if let Some(board_idx) = self.active_board_index {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let sorted_cards = self.get_sorted_board_cards(board.id);
+
+                    if let Some(card) = sorted_cards.get(sorted_idx) {
+                        let card_id = card.id;
+                        let current_column_id = card.column_id;
+
+                        let mut board_columns: Vec<_> = self
+                            .columns
+                            .iter()
+                            .filter(|col| col.board_id == board.id)
+                            .collect();
+                        board_columns.sort_by_key(|col| col.position);
+
+                        let current_position = board_columns
+                            .iter()
+                            .position(|col| col.id == current_column_id);
+
+                        if let Some(pos) = current_position {
+                            if pos > 0 {
+                                let target_column_id = board_columns[pos - 1].id;
+
+                                let new_position = self
+                                    .cards
+                                    .iter()
+                                    .filter(|c| c.column_id == target_column_id)
+                                    .count() as i32;
+
+                                if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                                    card.move_to_column(target_column_id, new_position);
+                                    tracing::info!(
+                                        "Moved card '{}' to previous column",
+                                        card.title
+                                    );
+                                }
+
+                                let sorted_cards = self.get_sorted_board_cards(board.id);
+                                if let Some(new_idx) = sorted_cards.iter().position(|c| c.id == card_id) {
+                                    self.card_selection.set(Some(new_idx));
+                                }
+                            } else {
+                                tracing::warn!("Card is already in the first column");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_move_card_right(&mut self) {
+        if self.focus != Focus::Cards {
+            return;
+        }
+
+        if let Some(sorted_idx) = self.card_selection.get() {
+            if let Some(board_idx) = self.active_board_index {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let sorted_cards = self.get_sorted_board_cards(board.id);
+
+                    if let Some(card) = sorted_cards.get(sorted_idx) {
+                        let card_id = card.id;
+                        let current_column_id = card.column_id;
+
+                        let mut board_columns: Vec<_> = self
+                            .columns
+                            .iter()
+                            .filter(|col| col.board_id == board.id)
+                            .collect();
+                        board_columns.sort_by_key(|col| col.position);
+
+                        let current_position = board_columns
+                            .iter()
+                            .position(|col| col.id == current_column_id);
+
+                        if let Some(pos) = current_position {
+                            if pos < board_columns.len() - 1 {
+                                let target_column_id = board_columns[pos + 1].id;
+
+                                let new_position = self
+                                    .cards
+                                    .iter()
+                                    .filter(|c| c.column_id == target_column_id)
+                                    .count() as i32;
+
+                                if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                                    card.move_to_column(target_column_id, new_position);
+                                    tracing::info!(
+                                        "Moved card '{}' to next column",
+                                        card.title
+                                    );
+                                }
+
+                                let sorted_cards = self.get_sorted_board_cards(board.id);
+                                if let Some(new_idx) = sorted_cards.iter().position(|c| c.id == card_id) {
+                                    self.card_selection.set(Some(new_idx));
+                                }
+                            } else {
+                                tracing::warn!("Card is already in the last column");
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -1,0 +1,347 @@
+use crate::app::{App, AppMode, BoardFocus};
+use crossterm::event::KeyCode;
+use kanban_domain::{Column, TaskListView};
+
+impl App {
+    pub fn handle_create_column_key(&mut self) {
+        if self.board_focus == BoardFocus::Columns {
+            if let Some(board_idx) = self.board_selection.get() {
+                if self.boards.get(board_idx).is_some() {
+                    self.mode = AppMode::CreateColumn;
+                    self.input.clear();
+                }
+            }
+        }
+    }
+
+    pub fn handle_rename_column_key(&mut self) {
+        if self.board_focus == BoardFocus::Columns && self.column_selection.get().is_some() {
+            if let Some(board_idx) = self.board_selection.get() {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let board_columns: Vec<_> = self
+                        .columns
+                        .iter()
+                        .filter(|col| col.board_id == board.id)
+                        .collect();
+
+                    if let Some(column_idx) = self.column_selection.get() {
+                        if let Some(column) = board_columns.get(column_idx) {
+                            self.input.set(column.name.clone());
+                            self.mode = AppMode::RenameColumn;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_delete_column_key(&mut self) {
+        if self.board_focus == BoardFocus::Columns && self.column_selection.get().is_some() {
+            if let Some(board_idx) = self.board_selection.get() {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let column_count = self.columns.iter().filter(|col| col.board_id == board.id).count();
+
+                    if column_count > 1 {
+                        self.mode = AppMode::DeleteColumnConfirm;
+                    } else {
+                        tracing::warn!("Cannot delete the last column");
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_move_column_up(&mut self) {
+        if self.board_focus == BoardFocus::Columns && self.column_selection.get().is_some() {
+            if let Some(board_idx) = self.board_selection.get() {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let mut board_columns: Vec<_> = self
+                        .columns
+                        .iter_mut()
+                        .filter(|col| col.board_id == board.id)
+                        .collect();
+
+                    board_columns.sort_by_key(|col| col.position);
+
+                    if let Some(selected_idx) = self.column_selection.get() {
+                        if selected_idx > 0 && selected_idx < board_columns.len() {
+                            let prev_pos = board_columns[selected_idx - 1].position;
+                            let curr_pos = board_columns[selected_idx].position;
+                            board_columns[selected_idx - 1].update_position(curr_pos);
+                            board_columns[selected_idx].update_position(prev_pos);
+                            self.column_selection.prev();
+                            tracing::info!("Moved column up");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_move_column_down(&mut self) {
+        if self.board_focus == BoardFocus::Columns && self.column_selection.get().is_some() {
+            if let Some(board_idx) = self.board_selection.get() {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let mut board_columns: Vec<_> = self
+                        .columns
+                        .iter_mut()
+                        .filter(|col| col.board_id == board.id)
+                        .collect();
+
+                    board_columns.sort_by_key(|col| col.position);
+
+                    if let Some(selected_idx) = self.column_selection.get() {
+                        if selected_idx < board_columns.len() - 1 {
+                            let curr_pos = board_columns[selected_idx].position;
+                            let next_pos = board_columns[selected_idx + 1].position;
+                            board_columns[selected_idx + 1].update_position(curr_pos);
+                            board_columns[selected_idx].update_position(next_pos);
+                            let column_count = board_columns.len();
+                            self.column_selection.next(column_count);
+                            tracing::info!("Moved column down");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_toggle_task_list_view(&mut self) {
+        if let Some(board_idx) = self.board_selection.get() {
+            if self.boards.get(board_idx).is_some() {
+                self.task_list_view_selection.set(Some(0));
+                self.mode = AppMode::SelectTaskListView;
+            }
+        }
+    }
+
+    pub fn create_column(&mut self) {
+        if let Some(board_idx) = self.board_selection.get() {
+            if let Some(board) = self.boards.get(board_idx) {
+                let column_name = self.input.as_str().trim().to_string();
+
+                if column_name.is_empty() {
+                    tracing::warn!("Column name cannot be empty");
+                    return;
+                }
+
+                let position = self
+                    .columns
+                    .iter()
+                    .filter(|col| col.board_id == board.id)
+                    .map(|col| col.position)
+                    .max()
+                    .unwrap_or(-1) + 1;
+
+                let column = Column::new(board.id, column_name.clone(), position);
+                tracing::info!("Creating column: {} (position: {})", column.name, column.position);
+                self.columns.push(column);
+
+                let board_column_count = self.columns.iter().filter(|col| col.board_id == board.id).count();
+                let new_column_index = board_column_count.saturating_sub(1);
+                self.column_selection.set(Some(new_column_index));
+            }
+        }
+    }
+
+    pub fn rename_column(&mut self) {
+        if let Some(board_idx) = self.board_selection.get() {
+            if let Some(board) = self.boards.get(board_idx) {
+                if let Some(column_idx) = self.column_selection.get() {
+                    let board_columns: Vec<_> = self
+                        .columns
+                        .iter_mut()
+                        .filter(|col| col.board_id == board.id)
+                        .collect();
+
+                    if let Some(column) = board_columns.get(column_idx) {
+                        let new_name = self.input.as_str().trim().to_string();
+
+                        if new_name.is_empty() {
+                            tracing::warn!("Column name cannot be empty");
+                            return;
+                        }
+
+                        let column_id = column.id;
+                        if let Some(col) = self.columns.iter_mut().find(|c| c.id == column_id) {
+                            col.update_name(new_name.clone());
+                            tracing::info!("Renamed column to: {}", new_name);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn delete_column(&mut self) {
+        if let Some(board_idx) = self.board_selection.get() {
+            if let Some(board) = self.boards.get(board_idx) {
+                if let Some(column_idx) = self.column_selection.get() {
+                    let board_columns: Vec<_> = self
+                        .columns
+                        .iter()
+                        .filter(|col| col.board_id == board.id)
+                        .collect();
+
+                    if board_columns.len() <= 1 {
+                        tracing::warn!("Cannot delete the last column");
+                        return;
+                    }
+
+                    if let Some(column_to_delete) = board_columns.get(column_idx) {
+                        let column_id = column_to_delete.id;
+                        let column_name = column_to_delete.name.clone();
+
+                        let first_column_id = board_columns.first().map(|c| c.id);
+
+                        if let Some(target_column_id) = first_column_id {
+                            if target_column_id != column_id {
+                                let cards_to_move: Vec<_> = self
+                                    .cards
+                                    .iter()
+                                    .filter(|card| card.column_id == column_id)
+                                    .map(|card| card.id)
+                                    .collect();
+
+                                let card_count = cards_to_move.len();
+                                for card_id in cards_to_move {
+                                    if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                                        card.move_to_column(target_column_id, card.position);
+                                    }
+                                }
+
+                                tracing::info!("Moved {} cards to first column", card_count);
+                            }
+                        }
+
+                        self.columns.retain(|col| col.id != column_id);
+                        tracing::info!("Deleted column: {}", column_name);
+
+                        let remaining_columns = self.columns.iter().filter(|col| col.board_id == board.id).count();
+                        if remaining_columns > 0 {
+                            if column_idx >= remaining_columns {
+                                self.column_selection.set(Some(remaining_columns - 1));
+                            } else {
+                                self.column_selection.set(Some(column_idx));
+                            }
+                        } else {
+                            self.column_selection.clear();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_create_column_dialog(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Columns;
+                self.input.clear();
+            }
+            KeyCode::Enter => {
+                self.create_column();
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Columns;
+                self.input.clear();
+            }
+            KeyCode::Char(c) => {
+                self.input.insert_char(c);
+            }
+            KeyCode::Backspace => {
+                self.input.backspace();
+            }
+            KeyCode::Left => {
+                self.input.move_left();
+            }
+            KeyCode::Right => {
+                self.input.move_right();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_rename_column_dialog(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Columns;
+                self.input.clear();
+            }
+            KeyCode::Enter => {
+                self.rename_column();
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Columns;
+                self.input.clear();
+            }
+            KeyCode::Char(c) => {
+                self.input.insert_char(c);
+            }
+            KeyCode::Backspace => {
+                self.input.backspace();
+            }
+            KeyCode::Left => {
+                self.input.move_left();
+            }
+            KeyCode::Right => {
+                self.input.move_right();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_delete_column_confirm_popup(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Columns;
+            }
+            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+                self.delete_column();
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Columns;
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') => {
+                self.mode = AppMode::BoardDetail;
+                self.board_focus = BoardFocus::Columns;
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_select_task_list_view_popup(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.mode = AppMode::Normal;
+                self.task_list_view_selection.clear();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.task_list_view_selection.next(3);
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.task_list_view_selection.prev();
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if let Some(view_idx) = self.task_list_view_selection.get() {
+                    let view = match view_idx {
+                        0 => TaskListView::Flat,
+                        1 => TaskListView::GroupedByColumn,
+                        2 => TaskListView::ColumnView,
+                        _ => TaskListView::Flat,
+                    };
+
+                    if let Some(board_idx) = self.active_board_index {
+                        if let Some(board) = self.boards.get_mut(board_idx) {
+                            board.update_task_list_view(view);
+                            tracing::info!("Updated task list view to: {:?}", view);
+                        }
+                    }
+                }
+                self.mode = AppMode::Normal;
+                self.task_list_view_selection.clear();
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -102,6 +102,9 @@ impl App {
             KeyCode::Char('4') => {
                 self.board_focus = BoardFocus::Sprints;
             }
+            KeyCode::Char('5') => {
+                self.board_focus = BoardFocus::Columns;
+            }
             KeyCode::Char('e') => match self.board_focus {
                 BoardFocus::Name => {
                     if let Err(e) = self.edit_board_field(terminal, event_handler, BoardField::Name)
@@ -127,9 +130,34 @@ impl App {
                     should_restart = true;
                 }
                 BoardFocus::Sprints => {}
+                BoardFocus::Columns => {}
             },
             KeyCode::Char('n') => {
-                self.handle_create_sprint_key();
+                if self.board_focus == BoardFocus::Sprints {
+                    self.handle_create_sprint_key();
+                } else if self.board_focus == BoardFocus::Columns {
+                    self.handle_create_column_key();
+                }
+            }
+            KeyCode::Char('r') => {
+                if self.board_focus == BoardFocus::Columns {
+                    self.handle_rename_column_key();
+                }
+            }
+            KeyCode::Char('d') => {
+                if self.board_focus == BoardFocus::Columns {
+                    self.handle_delete_column_key();
+                }
+            }
+            KeyCode::Char('J') => {
+                if self.board_focus == BoardFocus::Columns {
+                    self.handle_move_column_down();
+                }
+            }
+            KeyCode::Char('K') => {
+                if self.board_focus == BoardFocus::Columns {
+                    self.handle_move_column_up();
+                }
             }
             KeyCode::Char('j') | KeyCode::Down => {
                 if self.board_focus == BoardFocus::Sprints {
@@ -143,11 +171,24 @@ impl App {
                             self.sprint_selection.next(sprint_count);
                         }
                     }
+                } else if self.board_focus == BoardFocus::Columns {
+                    if let Some(board_idx) = self.board_selection.get() {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let column_count = self
+                                .columns
+                                .iter()
+                                .filter(|col| col.board_id == board.id)
+                                .count();
+                            self.column_selection.next(column_count);
+                        }
+                    }
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 if self.board_focus == BoardFocus::Sprints {
                     self.sprint_selection.prev();
+                } else if self.board_focus == BoardFocus::Columns {
+                    self.column_selection.prev();
                 }
             }
             KeyCode::Enter | KeyCode::Char(' ') => {

--- a/crates/kanban-tui/src/handlers/mod.rs
+++ b/crates/kanban-tui/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod board_handlers;
 pub mod card_handlers;
+pub mod column_handlers;
 pub mod detail_view_handlers;
 pub mod dialog_handlers;
 pub mod navigation_handlers;

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -1,4 +1,5 @@
 use crate::app::{App, AppMode, Focus};
+use kanban_domain::TaskListView;
 
 impl App {
     pub fn handle_focus_switch(&mut self, focus_target: Focus) {
@@ -22,8 +23,26 @@ impl App {
             Focus::Cards => {
                 if let Some(board_idx) = self.active_board_index {
                     if let Some(board) = self.boards.get(board_idx) {
-                        let card_count = self.get_board_card_count(board.id);
-                        self.card_selection.next(card_count);
+                        if self.is_kanban_view() {
+                            let focused_col_idx = self.column_selection.get().unwrap_or(0);
+                            let mut board_columns: Vec<_> = self
+                                .columns
+                                .iter()
+                                .filter(|col| col.board_id == board.id)
+                                .collect();
+                            board_columns.sort_by_key(|col| col.position);
+
+                            if let Some(focused_column) = board_columns.get(focused_col_idx) {
+                                let column_card_count = self.get_sorted_board_cards(board.id)
+                                    .iter()
+                                    .filter(|card| card.column_id == focused_column.id)
+                                    .count();
+                                self.card_selection.next(column_card_count);
+                            }
+                        } else {
+                            let card_count = self.get_board_card_count(board.id);
+                            self.card_selection.next(card_count);
+                        }
                     }
                 }
             }
@@ -86,6 +105,99 @@ impl App {
             self.active_board_index = None;
             self.card_selection.clear();
             self.focus = Focus::Boards;
+        }
+    }
+
+    fn is_kanban_view(&self) -> bool {
+        if let Some(board_idx) = self.active_board_index.or(self.board_selection.get()) {
+            if let Some(board) = self.boards.get(board_idx) {
+                return board.task_list_view == TaskListView::ColumnView;
+            }
+        }
+        false
+    }
+
+    pub fn handle_kanban_column_left(&mut self) {
+        if !self.is_kanban_view() || self.focus != Focus::Cards {
+            return;
+        }
+
+        if let Some(board_idx) = self.active_board_index {
+            if let Some(board) = self.boards.get(board_idx) {
+                let column_count = self
+                    .columns
+                    .iter()
+                    .filter(|col| col.board_id == board.id)
+                    .count();
+
+                if column_count == 0 {
+                    return;
+                }
+
+                if let Some(current_col_idx) = self.column_selection.get() {
+                    if current_col_idx > 0 {
+                        self.column_selection.set(Some(current_col_idx - 1));
+                        self.card_selection.set(Some(0));
+                        tracing::info!("Moved to column {}", current_col_idx - 1);
+                    }
+                } else {
+                    self.column_selection.set(Some(0));
+                    self.card_selection.set(Some(0));
+                }
+            }
+        }
+    }
+
+    pub fn handle_kanban_column_right(&mut self) {
+        if !self.is_kanban_view() || self.focus != Focus::Cards {
+            return;
+        }
+
+        if let Some(board_idx) = self.active_board_index {
+            if let Some(board) = self.boards.get(board_idx) {
+                let column_count = self
+                    .columns
+                    .iter()
+                    .filter(|col| col.board_id == board.id)
+                    .count();
+
+                if column_count == 0 {
+                    return;
+                }
+
+                let current_col_idx = self.column_selection.get().unwrap_or(0);
+                if current_col_idx < column_count - 1 {
+                    self.column_selection.set(Some(current_col_idx + 1));
+                    self.card_selection.set(Some(0));
+                    tracing::info!("Moved to column {}", current_col_idx + 1);
+                }
+            }
+        }
+    }
+
+    pub fn handle_column_or_focus_switch(&mut self, index: usize) {
+        if self.is_kanban_view() && self.focus == Focus::Cards {
+            if let Some(board_idx) = self.active_board_index {
+                if let Some(board) = self.boards.get(board_idx) {
+                    let column_count = self
+                        .columns
+                        .iter()
+                        .filter(|col| col.board_id == board.id)
+                        .count();
+
+                    if index < column_count {
+                        self.column_selection.set(Some(index));
+                        self.card_selection.set(Some(0));
+                        tracing::info!("Switched to column {}", index);
+                    }
+                }
+            }
+        } else {
+            match index {
+                0 => self.handle_focus_switch(Focus::Boards),
+                1 => self.handle_focus_switch(Focus::Cards),
+                _ => {}
+            }
         }
     }
 }


### PR DESCRIPTION
Adds column management and multiple task list view modes with kanban board support.

## Changes

- Add column management (create, rename, delete, reorder)
- Add three task list view modes: Flat, Grouped by Column, and Kanban
- Add kanban column navigation with h/l and 1-9 keys
- Add smart view defaults (grouped view for multi-column boards)
- Add full-width kanban view when board is activated

## What

Implements column definitions and multiple viewing modes for tasks, including a full kanban board view with column navigation.

## Why

Users need to organize tasks into columns and view them in different layouts. The kanban view provides a visual board experience similar to tools like Trello or Jira, while maintaining keyboard-driven efficiency.

## How

- **Domain Layer**: Added `TaskListView` enum and column update methods to Board
- **Handlers**: Created column_handlers module for CRUD operations and navigation_handlers for kanban column navigation
- **UI Layer**: Implemented three rendering functions (flat, grouped, kanban) with smart routing based on view mode
- **Navigation**: Added h/l for column switching, 1-9 for direct column jumps, scoped j/k within focused column

## Testing

Manually tested:
- Column creation, renaming, deletion, and reordering in Board Detail view
- View mode switching with V key
- Smart defaults (single column shows flat, multiple columns show grouped)
- Kanban view with column navigation (h/l, 1-9)
- Card navigation within focused columns (j/k)
- Projects panel hiding behavior in kanban view