### PR TITLE
fix: use GitHub Actions key=value format for output parsing

### DIFF
--- a/.github/workflows/aggregate-changesets.yml
+++ b/.github/workflows/aggregate-changesets.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Aggregate changesets
         id: aggregate
         run: |
-          bash scripts/aggregate-changesets.sh > /tmp/aggregate.json || exit 0
-          cat /tmp/aggregate.json >> $GITHUB_OUTPUT
+          bash scripts/aggregate-changesets.sh >> $GITHUB_OUTPUT || exit 0
 
       - uses: cachix/install-nix-action@v27
         if: success()

--- a/scripts/aggregate-changesets.sh
+++ b/scripts/aggregate-changesets.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # Aggregate all changesets in .changeset/ and determine the highest bump type
-# Outputs JSON with bump_type and changeset files
+# Outputs key=value format for GitHub Actions
 # Exit 0 if changesets found, exit 1 if none
 
 CHANGESET_DIR=".changeset"
 
 # Find all changeset files (excluding README.md)
-CHANGESETS=$(find "$CHANGESET_DIR" -maxdepth 1 -name "*.md" ! -name "README.md" 2>/dev/null || true)
+CHANGESETS=$(find "$CHANGESET_DIR" -maxdepth 1 -name "*.md" ! -name "README.md" 2>/dev/null | sort || true)
 
 if [ -z "$CHANGESETS" ]; then
   echo "No changesets found"
@@ -30,5 +30,6 @@ elif echo "$BUMP_TYPES" | grep -q "minor"; then
   HIGHEST_BUMP="minor"
 fi
 
-# Output as JSON
-echo "{\"bump_type\": \"$HIGHEST_BUMP\", \"files\": [$(echo "$CHANGESETS" | sed 's/^/"/; s/$/"/' | paste -sd ',' -)]}"
+# Output in GitHub Actions format
+echo "bump_type=$HIGHEST_BUMP"
+echo "files=$CHANGESETS"


### PR DESCRIPTION
- Changed aggregate-changesets.sh to output bump_type=X and files=list format
- Updated workflow to directly append script output to GITHUB_OUTPUT
- Fixes 'Invalid format' error from JSON parsing