### PR TITLE
fix: simplify aggregate-changesets output to only bump_type

### DIFF
--- a/scripts/aggregate-changesets.sh
+++ b/scripts/aggregate-changesets.sh
@@ -32,4 +32,3 @@ fi
 
 # Output in GitHub Actions format
 echo "bump_type=$HIGHEST_BUMP"
-echo "files=$CHANGESETS"


### PR DESCRIPTION
- Remove files output to avoid GitHub Actions multiline parsing issues
- Workflow already finds changesets via its own find command
- Only bump_type is needed for version bumping step