### PR TITLE
refactor: make scripts own their commits

### DIFF
--- a/.github/workflows/aggregate-changesets.yml
+++ b/.github/workflows/aggregate-changesets.yml
@@ -63,13 +63,12 @@ jobs:
         run: |
           nix develop --command bash scripts/bump-version.sh "${{ steps.aggregate.outputs.bump_type }}"
 
-      - name: Clean and commit
+      - name: Clean changesets and push
         if: success()
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: |
-          rm -rf .changeset/*.md
-          git add CHANGELOG.md Cargo.toml crates/*/Cargo.toml
-          git commit -m "chore: aggregate changesets and bump version [skip ci]" || echo "No changes to commit"
+          # Changesets already deleted by bump-version.sh
+          # Pull and push the commits made by the scripts
           git pull --rebase origin develop
           git push origin develop

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -79,3 +79,7 @@ rm -f .changeset/*.md
 echo "Version bumped to $NEW_VERSION"
 echo "CHANGELOG.md updated"
 echo "Changesets processed and deleted"
+
+# Commit the version bump
+git add Cargo.toml crates/*/Cargo.toml
+git commit -m "chore: bump version to $NEW_VERSION"

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -56,3 +56,7 @@ else
 fi
 
 echo "Updated $CHANGELOG with version $VERSION"
+
+# Commit the changelog update
+git add "$CHANGELOG"
+git commit -m "chore: update changelog for version $VERSION"


### PR DESCRIPTION
- update-changelog.sh now commits changelog changes
- bump-version.sh now commits version bump changes
- Removed redundant commit step from workflow
- Simplifies workflow orchestration and prevents git dirty state