### PR TITLE
fix: use git add . to capture all changes in bump-version.sh

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -81,5 +81,5 @@ echo "CHANGELOG.md updated"
 echo "Changesets processed and deleted"
 
 # Commit the version bump
-git add Cargo.toml crates/*/Cargo.toml
+git add .
 git commit -m "chore: bump version to $NEW_VERSION"


### PR DESCRIPTION
Catches Cargo.lock and any other files modified by cargo update