### PR TITLE
Fix critical release workflow issues

### DIFF
--- a/.changeset/kan-00-release-testing.md
+++ b/.changeset/kan-00-release-testing.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+---
+
+Fix critical release workflow issues that prevented successful publishing to crates.io:
+
+- Fix Nix script path resolution in publish-crates (validate-release now called directly)
+- Use portable sed syntax compatible with both Linux and macOS
+- Preserve .changeset/README.md when cleaning up changesets
+- Correct changeset description parsing in update-changelog script
+- Add runtime dependencies (cargo, git, grep, sed, find) to Nix shell applications
+- Add concurrency control to aggregate workflow to prevent race conditions
+- Remove error suppression that was hiding failures
+- Extract repository URL from git remote instead of hardcoding

--- a/.github/workflows/aggregate-changesets.yml
+++ b/.github/workflows/aggregate-changesets.yml
@@ -7,6 +7,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: aggregate-changesets
+  cancel-in-progress: false
+
 jobs:
   aggregate:
     name: Aggregate Changesets
@@ -23,7 +27,7 @@ jobs:
       - name: Aggregate changesets
         id: aggregate
         run: |
-          bash scripts/aggregate-changesets.sh >> $GITHUB_OUTPUT || exit 0
+          bash scripts/aggregate-changesets.sh >> $GITHUB_OUTPUT
 
       - uses: cachix/install-nix-action@v27
         if: success()

--- a/flake.nix
+++ b/flake.nix
@@ -23,21 +23,29 @@
           extensions = ["rust-src" "rust-analyzer" "clippy" "rustfmt"];
         };
 
-        changeset = pkgs.writeShellScriptBin "changeset" ''
-          ${builtins.readFile ./scripts/create-changeset.sh}
-        '';
+        changeset = pkgs.writeShellApplication {
+          name = "changeset";
+          runtimeInputs = with pkgs; [coreutils];
+          text = builtins.readFile ./scripts/create-changeset.sh;
+        };
 
-        bumpVersion = pkgs.writeShellScriptBin "bump-version" ''
-          ${builtins.readFile ./scripts/bump-version.sh}
-        '';
+        bumpVersion = pkgs.writeShellApplication {
+          name = "bump-version";
+          runtimeInputs = with pkgs; [rustToolchain cargo coreutils gnugrep gnused git findutils];
+          text = builtins.readFile ./scripts/bump-version.sh;
+        };
 
-        publishCrates = pkgs.writeShellScriptBin "publish-crates" ''
-          ${builtins.readFile ./scripts/publish-crates.sh}
-        '';
+        publishCrates = pkgs.writeShellApplication {
+          name = "publish-crates";
+          runtimeInputs = [rustToolchain pkgs.cargo pkgs.coreutils validateRelease];
+          text = builtins.readFile ./scripts/publish-crates.sh;
+        };
 
-        validateRelease = pkgs.writeShellScriptBin "validate-release" ''
-          ${builtins.readFile ./scripts/validate-release.sh}
-        '';
+        validateRelease = pkgs.writeShellApplication {
+          name = "validate-release";
+          runtimeInputs = with pkgs; [rustToolchain cargo coreutils gnugrep gnused];
+          text = builtins.readFile ./scripts/validate-release.sh;
+        };
       in {
         devShells.default = import ./shell.nix {
           inherit pkgs rustToolchain;

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -64,12 +64,12 @@ fi
 } > CHANGELOG.md.new
 mv CHANGELOG.md.new CHANGELOG.md
 
-sed -i.bak "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" Cargo.toml
-rm Cargo.toml.bak
+sed "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" Cargo.toml > Cargo.toml.tmp
+mv Cargo.toml.tmp Cargo.toml
 
 for crate in crates/*/Cargo.toml; do
-  sed -i.bak "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" "$crate"
-  rm "$crate.bak"
+  sed "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" "$crate" > "$crate.tmp"
+  mv "$crate.tmp" "$crate"
 done
 
 cargo update --workspace

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -74,7 +74,7 @@ done
 
 cargo update --workspace
 
-rm -f .changeset/*.md
+find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" -delete
 
 echo "Version bumped to $NEW_VERSION"
 echo "CHANGELOG.md updated"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -47,7 +47,8 @@ echo "Bumping version: $CURRENT_VERSION → $NEW_VERSION (type: $BUMP_TYPE)"
 DATE=$(date +%Y-%m-%d)
 PR_LINK=""
 if [ -n "$PR_NUMBER" ]; then
-  PR_LINK=" ([#$PR_NUMBER](https://github.com/fulsomenko/kanban/pull/$PR_NUMBER))"
+  REPO_URL=$(git remote get-url origin | sed 's/\.git$//' | sed 's|git@github.com:|https://github.com/|')
+  PR_LINK=" ([#$PR_NUMBER]($REPO_URL/pull/$PR_NUMBER))"
 fi
 
 if [ ! -f CHANGELOG.md ]; then

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -8,13 +8,11 @@ CRATES=(
   "crates/kanban-cli"
 )
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 echo "🚀 Publishing crates to crates.io..."
 echo ""
 
 echo "Running pre-publish validation..."
-bash "$SCRIPT_DIR/validate-release.sh"
+validate-release
 echo ""
 
 echo "Publishing crates in dependency order..."

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -30,7 +30,7 @@ fi
 ENTRIES=""
 for changeset in $CHANGESETS; do
   # Extract description (everything after the second ---)
-  description=$(tail -n +3 "$changeset" | sed '/^$/d')
+  description=$(sed -n '/^---$/,/^---$/!p' "$changeset" | sed '/^---$/d' | sed '/^$/d')
   if [ -n "$description" ]; then
     ENTRIES="$ENTRIES$description
 "


### PR DESCRIPTION
## Summary

Fixes multiple critical issues in the release automation that would prevent successful publishing to crates.io.

## Changes

- Fix Nix script path resolution in publish-crates script
- Replace BSD-specific `sed -i.bak` with portable syntax for Linux/macOS compatibility
- Preserve `.changeset/README.md` when cleaning up changesets
- Correct changeset description parsing in update-changelog script
- Add runtime dependencies (cargo, git, etc.) to Nix shell applications
- Add concurrency control to prevent race conditions in aggregate workflow
- Remove error suppression (`|| exit 0`) that was hiding failures
- Extract repository URL from git remote instead of hardcoding

## Testing

Manually tested Nix package builds and script execution. All scripts now have proper dependencies available in PATH when run via `nix run .#<package>`.

## Impact

These fixes resolve all identified blockers for the next crates.io release:
- ✅ Scripts work on both macOS and Linux (GitHub Actions)
- ✅ Nix packages have all required tools available
- ✅ Changeset cleanup preserves README
- ✅ Workflow errors properly propagate instead of being hidden
- ✅ No hardcoded repository URLs