### PR TITLE
MVP-35/make-j-k-work-for-changing-panels

### DIFF
--- a/.changeset/mvp-35-make-j-k-work-for-changing-panels.md
+++ b/.changeset/mvp-35-make-j-k-work-for-changing-panels.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Add vim-style j/k navigation for changing panels in detail views
+
+- Enable j/k keys to navigate between panels in CardDetail view (Title, Metadata, Description)
+- Enable j/k keys to navigate between panels in BoardDetail view (Name, Description, Settings, Sprints, Columns)
+- Wrap navigation at list boundaries: reaching the end of Sprints/Columns lists transitions to next panel
+- Both arrow keys and vim-style j/k keys work consistently across all views
+

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -173,93 +173,89 @@ impl App {
                     self.handle_move_column_up();
                 }
             }
-            KeyCode::Char('j') | KeyCode::Down => {
-                match self.board_focus {
-                    BoardFocus::Sprints => {
-                        if let Some(board_idx) = self.board_selection.get() {
-                            if let Some(board) = self.boards.get(board_idx) {
-                                let sprint_count = self
-                                    .sprints
-                                    .iter()
-                                    .filter(|s| s.board_id == board.id)
-                                    .count();
-                                let current_idx = self.sprint_selection.get().unwrap_or(0);
-                                if current_idx >= sprint_count - 1 && sprint_count > 0 {
-                                    self.board_focus = BoardFocus::Columns;
-                                    self.column_selection.set(Some(0));
-                                } else {
-                                    self.sprint_selection.next(sprint_count);
-                                }
+            KeyCode::Char('j') | KeyCode::Down => match self.board_focus {
+                BoardFocus::Sprints => {
+                    if let Some(board_idx) = self.board_selection.get() {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let sprint_count = self
+                                .sprints
+                                .iter()
+                                .filter(|s| s.board_id == board.id)
+                                .count();
+                            let current_idx = self.sprint_selection.get().unwrap_or(0);
+                            if current_idx >= sprint_count - 1 && sprint_count > 0 {
+                                self.board_focus = BoardFocus::Columns;
+                                self.column_selection.set(Some(0));
+                            } else {
+                                self.sprint_selection.next(sprint_count);
                             }
                         }
                     }
-                    BoardFocus::Columns => {
-                        if let Some(board_idx) = self.board_selection.get() {
-                            if let Some(board) = self.boards.get(board_idx) {
-                                let column_count = self
-                                    .columns
-                                    .iter()
-                                    .filter(|col| col.board_id == board.id)
-                                    .count();
-                                let current_idx = self.column_selection.get().unwrap_or(0);
-                                if current_idx >= column_count - 1 && column_count > 0 {
-                                    self.board_focus = BoardFocus::Name;
-                                    self.sprint_selection.set(Some(0));
-                                } else {
-                                    self.column_selection.next(column_count);
-                                }
+                }
+                BoardFocus::Columns => {
+                    if let Some(board_idx) = self.board_selection.get() {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let column_count = self
+                                .columns
+                                .iter()
+                                .filter(|col| col.board_id == board.id)
+                                .count();
+                            let current_idx = self.column_selection.get().unwrap_or(0);
+                            if current_idx >= column_count - 1 && column_count > 0 {
+                                self.board_focus = BoardFocus::Name;
+                                self.sprint_selection.set(Some(0));
+                            } else {
+                                self.column_selection.next(column_count);
                             }
                         }
                     }
-                    _ => {
-                        self.board_focus = match self.board_focus {
-                            BoardFocus::Name => BoardFocus::Description,
-                            BoardFocus::Description => BoardFocus::Settings,
-                            BoardFocus::Settings => BoardFocus::Sprints,
-                            BoardFocus::Sprints => BoardFocus::Columns,
-                            BoardFocus::Columns => BoardFocus::Name,
-                        };
-                        if self.board_focus == BoardFocus::Sprints {
-                            self.sprint_selection.set(Some(0));
-                        } else if self.board_focus == BoardFocus::Columns {
-                            self.column_selection.set(Some(0));
-                        }
+                }
+                _ => {
+                    self.board_focus = match self.board_focus {
+                        BoardFocus::Name => BoardFocus::Description,
+                        BoardFocus::Description => BoardFocus::Settings,
+                        BoardFocus::Settings => BoardFocus::Sprints,
+                        BoardFocus::Sprints => BoardFocus::Columns,
+                        BoardFocus::Columns => BoardFocus::Name,
+                    };
+                    if self.board_focus == BoardFocus::Sprints {
+                        self.sprint_selection.set(Some(0));
+                    } else if self.board_focus == BoardFocus::Columns {
+                        self.column_selection.set(Some(0));
                     }
                 }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                match self.board_focus {
-                    BoardFocus::Sprints => {
-                        let current_idx = self.sprint_selection.get().unwrap_or(0);
-                        if current_idx == 0 {
-                            self.board_focus = BoardFocus::Settings;
-                        } else {
-                            self.sprint_selection.prev();
-                        }
-                    }
-                    BoardFocus::Columns => {
-                        let current_idx = self.column_selection.get().unwrap_or(0);
-                        if current_idx == 0 {
-                            self.board_focus = BoardFocus::Sprints;
-                            self.sprint_selection.set(Some(0));
-                        } else {
-                            self.column_selection.prev();
-                        }
-                    }
-                    _ => {
-                        self.board_focus = match self.board_focus {
-                            BoardFocus::Name => BoardFocus::Columns,
-                            BoardFocus::Description => BoardFocus::Name,
-                            BoardFocus::Settings => BoardFocus::Description,
-                            BoardFocus::Sprints => BoardFocus::Settings,
-                            BoardFocus::Columns => BoardFocus::Sprints,
-                        };
-                        if self.board_focus == BoardFocus::Columns {
-                            self.column_selection.set(Some(0));
-                        }
+            },
+            KeyCode::Char('k') | KeyCode::Up => match self.board_focus {
+                BoardFocus::Sprints => {
+                    let current_idx = self.sprint_selection.get().unwrap_or(0);
+                    if current_idx == 0 {
+                        self.board_focus = BoardFocus::Settings;
+                    } else {
+                        self.sprint_selection.prev();
                     }
                 }
-            }
+                BoardFocus::Columns => {
+                    let current_idx = self.column_selection.get().unwrap_or(0);
+                    if current_idx == 0 {
+                        self.board_focus = BoardFocus::Sprints;
+                        self.sprint_selection.set(Some(0));
+                    } else {
+                        self.column_selection.prev();
+                    }
+                }
+                _ => {
+                    self.board_focus = match self.board_focus {
+                        BoardFocus::Name => BoardFocus::Columns,
+                        BoardFocus::Description => BoardFocus::Name,
+                        BoardFocus::Settings => BoardFocus::Description,
+                        BoardFocus::Sprints => BoardFocus::Settings,
+                        BoardFocus::Columns => BoardFocus::Sprints,
+                    };
+                    if self.board_focus == BoardFocus::Columns {
+                        self.column_selection.set(Some(0));
+                    }
+                }
+            },
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if self.board_focus == BoardFocus::Sprints {
                     if let Some(sprint_idx) = self.sprint_selection.get() {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -27,6 +27,20 @@ impl App {
             KeyCode::Char('3') => {
                 self.card_focus = CardFocus::Description;
             }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.card_focus = match self.card_focus {
+                    CardFocus::Title => CardFocus::Metadata,
+                    CardFocus::Metadata => CardFocus::Description,
+                    CardFocus::Description => CardFocus::Title,
+                };
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.card_focus = match self.card_focus {
+                    CardFocus::Title => CardFocus::Description,
+                    CardFocus::Description => CardFocus::Metadata,
+                    CardFocus::Metadata => CardFocus::Title,
+                };
+            }
             KeyCode::Char('y') => {
                 self.copy_branch_name();
             }
@@ -160,35 +174,59 @@ impl App {
                 }
             }
             KeyCode::Char('j') | KeyCode::Down => {
-                if self.board_focus == BoardFocus::Sprints {
-                    if let Some(board_idx) = self.board_selection.get() {
-                        if let Some(board) = self.boards.get(board_idx) {
-                            let sprint_count = self
-                                .sprints
-                                .iter()
-                                .filter(|s| s.board_id == board.id)
-                                .count();
-                            self.sprint_selection.next(sprint_count);
+                match self.board_focus {
+                    BoardFocus::Sprints => {
+                        if let Some(board_idx) = self.board_selection.get() {
+                            if let Some(board) = self.boards.get(board_idx) {
+                                let sprint_count = self
+                                    .sprints
+                                    .iter()
+                                    .filter(|s| s.board_id == board.id)
+                                    .count();
+                                self.sprint_selection.next(sprint_count);
+                            }
                         }
                     }
-                } else if self.board_focus == BoardFocus::Columns {
-                    if let Some(board_idx) = self.board_selection.get() {
-                        if let Some(board) = self.boards.get(board_idx) {
-                            let column_count = self
-                                .columns
-                                .iter()
-                                .filter(|col| col.board_id == board.id)
-                                .count();
-                            self.column_selection.next(column_count);
+                    BoardFocus::Columns => {
+                        if let Some(board_idx) = self.board_selection.get() {
+                            if let Some(board) = self.boards.get(board_idx) {
+                                let column_count = self
+                                    .columns
+                                    .iter()
+                                    .filter(|col| col.board_id == board.id)
+                                    .count();
+                                self.column_selection.next(column_count);
+                            }
                         }
+                    }
+                    _ => {
+                        self.board_focus = match self.board_focus {
+                            BoardFocus::Name => BoardFocus::Description,
+                            BoardFocus::Description => BoardFocus::Settings,
+                            BoardFocus::Settings => BoardFocus::Sprints,
+                            BoardFocus::Sprints => BoardFocus::Columns,
+                            BoardFocus::Columns => BoardFocus::Name,
+                        };
                     }
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                if self.board_focus == BoardFocus::Sprints {
-                    self.sprint_selection.prev();
-                } else if self.board_focus == BoardFocus::Columns {
-                    self.column_selection.prev();
+                match self.board_focus {
+                    BoardFocus::Sprints => {
+                        self.sprint_selection.prev();
+                    }
+                    BoardFocus::Columns => {
+                        self.column_selection.prev();
+                    }
+                    _ => {
+                        self.board_focus = match self.board_focus {
+                            BoardFocus::Name => BoardFocus::Columns,
+                            BoardFocus::Description => BoardFocus::Name,
+                            BoardFocus::Settings => BoardFocus::Description,
+                            BoardFocus::Sprints => BoardFocus::Settings,
+                            BoardFocus::Columns => BoardFocus::Sprints,
+                        };
+                    }
                 }
             }
             KeyCode::Enter | KeyCode::Char(' ') => {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -183,7 +183,13 @@ impl App {
                                     .iter()
                                     .filter(|s| s.board_id == board.id)
                                     .count();
-                                self.sprint_selection.next(sprint_count);
+                                let current_idx = self.sprint_selection.get().unwrap_or(0);
+                                if current_idx >= sprint_count - 1 && sprint_count > 0 {
+                                    self.board_focus = BoardFocus::Columns;
+                                    self.column_selection.set(Some(0));
+                                } else {
+                                    self.sprint_selection.next(sprint_count);
+                                }
                             }
                         }
                     }
@@ -195,7 +201,13 @@ impl App {
                                     .iter()
                                     .filter(|col| col.board_id == board.id)
                                     .count();
-                                self.column_selection.next(column_count);
+                                let current_idx = self.column_selection.get().unwrap_or(0);
+                                if current_idx >= column_count - 1 && column_count > 0 {
+                                    self.board_focus = BoardFocus::Name;
+                                    self.sprint_selection.set(Some(0));
+                                } else {
+                                    self.column_selection.next(column_count);
+                                }
                             }
                         }
                     }
@@ -207,16 +219,32 @@ impl App {
                             BoardFocus::Sprints => BoardFocus::Columns,
                             BoardFocus::Columns => BoardFocus::Name,
                         };
+                        if self.board_focus == BoardFocus::Sprints {
+                            self.sprint_selection.set(Some(0));
+                        } else if self.board_focus == BoardFocus::Columns {
+                            self.column_selection.set(Some(0));
+                        }
                     }
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 match self.board_focus {
                     BoardFocus::Sprints => {
-                        self.sprint_selection.prev();
+                        let current_idx = self.sprint_selection.get().unwrap_or(0);
+                        if current_idx == 0 {
+                            self.board_focus = BoardFocus::Settings;
+                        } else {
+                            self.sprint_selection.prev();
+                        }
                     }
                     BoardFocus::Columns => {
-                        self.column_selection.prev();
+                        let current_idx = self.column_selection.get().unwrap_or(0);
+                        if current_idx == 0 {
+                            self.board_focus = BoardFocus::Sprints;
+                            self.sprint_selection.set(Some(0));
+                        } else {
+                            self.column_selection.prev();
+                        }
                     }
                     _ => {
                         self.board_focus = match self.board_focus {
@@ -226,6 +254,9 @@ impl App {
                             BoardFocus::Sprints => BoardFocus::Settings,
                             BoardFocus::Columns => BoardFocus::Sprints,
                         };
+                        if self.board_focus == BoardFocus::Columns {
+                            self.column_selection.set(Some(0));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What

Add vim-style j/k navigation for switching between panels in CardDetail and BoardDetail views. Navigation seamlessly wraps between list items and panels.

## Why

Users familiar with vim keybindings expect j/k to work for vertical navigation in all contexts. Previously, j/k only worked in the main kanban view, making detail views feel inconsistent.

## How

- **CardDetail**: j/down cycles through Title → Metadata → Description panels; k/up cycles backward
- **BoardDetail**: j/down navigates Name → Description → Settings → Sprints → Columns → Name; k/up navigates in reverse
- When at the end of Sprints/Columns lists, j wraps to the next panel; when at the top, k wraps to the previous panel
- Both Arrow keys and vim-style j/k keys work consistently

## Testing

- Built and verified no compilation errors
- Tested manual navigation through all panels with j/k keys
- Verified list boundary wrapping to next/previous panels works correctly
- Both up/down arrows and j/k keys behave identically