### PR TITLE
KAN-94/when-opening-a-dialogue-put-selector-on-the-currently-selected-item

### DIFF
--- a/.changeset/kan-94-when-opening-a-dialogue-put-selector-on-the-currently-selected-item.md
+++ b/.changeset/kan-94-when-opening-a-dialogue-put-selector-on-the-currently-selected-item.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+- refactor: delegate dialog rendering to SelectionDialog components
+- refactor: use dialog selection state helpers in event handlers
+- refactor: export SelectionDialog component from components module
+- refactor: create SelectionDialog trait and implementations
+- refactor: add dialog selection state helpers to app
+- Implement CardListComponent for reusable card list interactions (#65)

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -866,6 +866,59 @@ impl App {
             }
         }
     }
+
+    pub fn get_current_priority_selection_index(&self) -> usize {
+        if let Some(card_idx) = self.active_card_index {
+            if let Some(card) = self.cards.get(card_idx) {
+                use kanban_domain::CardPriority;
+                return match card.priority {
+                    CardPriority::Low => 0,
+                    CardPriority::Medium => 1,
+                    CardPriority::High => 2,
+                    CardPriority::Critical => 3,
+                };
+            }
+        }
+        0
+    }
+
+    pub fn get_current_sprint_selection_index(&self) -> usize {
+        if let Some(card_idx) = self.active_card_index {
+            if let Some(card) = self.cards.get(card_idx) {
+                if let Some(card_sprint_id) = card.sprint_id {
+                    if let Some(board_idx) = self.active_board_index {
+                        if let Some(board) = self.boards.get(board_idx) {
+                            let board_sprints: Vec<_> = self
+                                .sprints
+                                .iter()
+                                .filter(|s| s.board_id == board.id)
+                                .collect();
+                            for (idx, sprint) in board_sprints.iter().enumerate() {
+                                if sprint.id == card_sprint_id {
+                                    return idx + 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        0
+    }
+
+    pub fn get_current_sort_field_selection_index(&self) -> usize {
+        if let Some(sort_field) = self.current_sort_field {
+            return match sort_field {
+                SortField::Points => 0,
+                SortField::Priority => 1,
+                SortField::CreatedAt => 2,
+                SortField::UpdatedAt => 3,
+                SortField::Status => 4,
+                SortField::Default => 5,
+            };
+        }
+        0
+    }
 }
 
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>, io::Error> {

--- a/crates/kanban-tui/src/components/mod.rs
+++ b/crates/kanban-tui/src/components/mod.rs
@@ -3,6 +3,7 @@ pub mod detail_view;
 pub mod list;
 pub mod panel;
 pub mod popup;
+pub mod selection_dialog;
 pub mod selection_list;
 
 pub use card_list_item::*;
@@ -10,4 +11,5 @@ pub use detail_view::*;
 pub use list::*;
 pub use panel::*;
 pub use popup::*;
+pub use selection_dialog::*;
 pub use selection_list::*;

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,0 +1,242 @@
+use crate::app::App;
+use ratatui::Frame;
+
+pub trait SelectionDialog {
+    fn title(&self) -> &str;
+    fn get_current_selection(&self, app: &App) -> usize;
+    fn options_count(&self, app: &App) -> usize;
+    fn render(&self, app: &App, frame: &mut Frame);
+}
+
+pub struct PriorityDialog;
+
+impl SelectionDialog for PriorityDialog {
+    fn title(&self) -> &str {
+        "Set Priority"
+    }
+
+    fn get_current_selection(&self, app: &App) -> usize {
+        app.get_current_priority_selection_index()
+    }
+
+    fn options_count(&self, _app: &App) -> usize {
+        4 // Low, Medium, High, Critical
+    }
+
+    fn render(&self, app: &App, frame: &mut Frame) {
+        use kanban_domain::CardPriority;
+        use crate::components::render_selection_popup_with_list_items;
+        use crate::theme::*;
+        use ratatui::widgets::ListItem;
+
+        let priorities = [
+            CardPriority::Low,
+            CardPriority::Medium,
+            CardPriority::High,
+            CardPriority::Critical,
+        ];
+
+        let selected = app.priority_selection.get();
+
+        let items: Vec<ListItem> = priorities
+            .iter()
+            .enumerate()
+            .map(|(idx, priority)| {
+                let style = if Some(idx) == selected {
+                    bold_highlight()
+                } else {
+                    normal_text()
+                };
+                ListItem::new(format!("{:?}", priority)).style(style)
+            })
+            .collect();
+
+        render_selection_popup_with_list_items(frame, "Set Priority", items, 30, 40);
+    }
+}
+
+pub struct SortFieldDialog;
+
+impl SelectionDialog for SortFieldDialog {
+    fn title(&self) -> &str {
+        "Order Tasks By"
+    }
+
+    fn get_current_selection(&self, app: &App) -> usize {
+        app.get_current_sort_field_selection_index()
+    }
+
+    fn options_count(&self, _app: &App) -> usize {
+        6 // Points, Priority, CreatedAt, UpdatedAt, Status, Default
+    }
+
+    fn render(&self, app: &App, frame: &mut Frame) {
+        use kanban_domain::{SortField, SortOrder};
+        use crate::components::render_selection_popup_with_lines;
+
+        let sort_fields = [
+            SortField::Points,
+            SortField::Priority,
+            SortField::CreatedAt,
+            SortField::UpdatedAt,
+            SortField::Status,
+            SortField::Default,
+        ];
+
+        let active_idx = sort_fields
+            .iter()
+            .position(|f| Some(*f) == app.current_sort_field);
+
+        render_selection_popup_with_lines(
+            frame,
+            "Order Tasks By",
+            Some("Select sort field:"),
+            sort_fields.iter().enumerate(),
+            |_idx, (_, field), _is_selected, is_active| {
+                let field_name = match field {
+                    SortField::Priority => "Priority",
+                    SortField::Points => "Points",
+                    SortField::CreatedAt => "Date Created",
+                    SortField::UpdatedAt => "Date Updated",
+                    SortField::Default => "Task Number",
+                    SortField::Status => "Status",
+                };
+
+                let order_indicator = if is_active {
+                    match app.current_sort_order {
+                        Some(SortOrder::Ascending) => Some(" (↑)".to_string()),
+                        Some(SortOrder::Descending) => Some(" (↓)".to_string()),
+                        None => None,
+                    }
+                } else {
+                    None
+                };
+
+                (field_name.to_string(), order_indicator)
+            },
+            app.sort_field_selection.get(),
+            active_idx,
+            60,
+            50,
+        );
+    }
+}
+
+pub struct SprintAssignDialog;
+
+impl SelectionDialog for SprintAssignDialog {
+    fn title(&self) -> &str {
+        "Assign to Sprint"
+    }
+
+    fn get_current_selection(&self, app: &App) -> usize {
+        app.get_current_sprint_selection_index()
+    }
+
+    fn options_count(&self, app: &App) -> usize {
+        if let Some(board_idx) = app.active_board_index {
+            if let Some(board) = app.boards.get(board_idx) {
+                let sprint_count = app
+                    .sprints
+                    .iter()
+                    .filter(|s| s.board_id == board.id)
+                    .count();
+                sprint_count + 1 // +1 for None option
+            } else {
+                1
+            }
+        } else {
+            1
+        }
+    }
+
+    fn render(&self, app: &App, frame: &mut Frame) {
+        use ratatui::{
+            layout::{Constraint, Direction, Layout},
+            style::{Color, Modifier, Style},
+            text::{Line, Span},
+            widgets::{Block, Borders, Clear, Paragraph},
+        };
+        use crate::components::centered_rect;
+
+        let area = centered_rect(60, 50, frame.area());
+        frame.render_widget(Clear, area);
+
+        let block = Block::default()
+            .title("Assign to Sprint")
+            .borders(Borders::ALL)
+            .style(Style::default().bg(Color::Black));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(2)
+            .constraints([Constraint::Length(1), Constraint::Min(0)])
+            .split(inner);
+
+        let label = Paragraph::new("Select sprint:").style(Style::default().fg(Color::Yellow));
+        frame.render_widget(label, chunks[0]);
+
+        let mut lines = vec![];
+
+        if let Some(board_idx) = app.active_board_index {
+            if let Some(board) = app.boards.get(board_idx) {
+                let board_sprints: Vec<_> = app
+                    .sprints
+                    .iter()
+                    .filter(|s| s.board_id == board.id)
+                    .collect();
+
+                let current_sprint_id = if let Some(card_idx) = app.active_card_index {
+                    app.cards.get(card_idx).and_then(|c| c.sprint_id)
+                } else {
+                    None
+                };
+
+                for (idx, sprint_option) in std::iter::once(None)
+                    .chain(board_sprints.iter().map(|s| Some(*s)))
+                    .enumerate()
+                {
+                    let is_selected = app.sprint_assign_selection.get() == Some(idx);
+                    let is_current = match (sprint_option, current_sprint_id) {
+                        (None, None) => true,
+                        (Some(s), Some(id)) => s.id == id,
+                        _ => false,
+                    };
+
+                    let style = if is_selected {
+                        Style::default().fg(Color::White).bg(Color::Blue)
+                    } else if is_current {
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+
+                    let prefix = if is_selected { "> " } else { "  " };
+                    let current_indicator = if is_current { " (current)" } else { "" };
+
+                    let sprint_name = if let Some(sprint) = sprint_option {
+                        sprint.formatted_name(
+                            board,
+                            board.sprint_prefix.as_deref().unwrap_or("sprint"),
+                        )
+                    } else {
+                        "(None)".to_string()
+                    };
+
+                    lines.push(Line::from(Span::styled(
+                        format!("{}{}{}", prefix, sprint_name, current_indicator),
+                        style,
+                    )));
+                }
+            }
+        }
+
+        let list = Paragraph::new(lines);
+        frame.render_widget(list, chunks[1]);
+    }
+}

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -24,9 +24,9 @@ impl SelectionDialog for PriorityDialog {
     }
 
     fn render(&self, app: &App, frame: &mut Frame) {
-        use kanban_domain::CardPriority;
         use crate::components::render_selection_popup_with_list_items;
         use crate::theme::*;
+        use kanban_domain::CardPriority;
         use ratatui::widgets::ListItem;
 
         let priorities = [
@@ -71,8 +71,8 @@ impl SelectionDialog for SortFieldDialog {
     }
 
     fn render(&self, app: &App, frame: &mut Frame) {
-        use kanban_domain::{SortField, SortOrder};
         use crate::components::render_selection_popup_with_lines;
+        use kanban_domain::{SortField, SortOrder};
 
         let sort_fields = [
             SortField::Points,
@@ -151,13 +151,13 @@ impl SelectionDialog for SprintAssignDialog {
     }
 
     fn render(&self, app: &App, frame: &mut Frame) {
+        use crate::components::centered_rect;
         use ratatui::{
             layout::{Constraint, Direction, Layout},
             style::{Color, Modifier, Style},
             text::{Line, Span},
             widgets::{Block, Borders, Clear, Paragraph},
         };
-        use crate::components::centered_rect;
 
         let area = centered_rect(60, 50, frame.area());
         frame.render_widget(Clear, area);

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -91,7 +91,8 @@ impl App {
                             let actual_idx = self.cards.iter().position(|c| c.id == card_id);
                             self.active_card_index = actual_idx;
                         }
-                        self.sprint_assign_selection.set(Some(0));
+                        let selection_idx = self.get_current_sprint_selection_index();
+                        self.sprint_assign_selection.set(Some(selection_idx));
                         self.mode = AppMode::AssignCardToSprint;
                     }
                 }
@@ -101,7 +102,8 @@ impl App {
 
     pub fn handle_order_cards_key(&mut self) {
         if self.focus == Focus::Cards && self.active_board_index.is_some() {
-            self.sort_field_selection.set(Some(0));
+            let sort_idx = self.get_current_sort_field_selection_index();
+            self.sort_field_selection.set(Some(sort_idx));
             self.mode = AppMode::OrderCards;
         }
     }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -411,7 +411,8 @@ impl App {
                                             .filter(|s| s.board_id == board.id)
                                             .count();
                                         if sprint_count > 0 {
-                                            let selection_idx = self.get_current_sprint_selection_index();
+                                            let selection_idx =
+                                                self.get_current_sprint_selection_index();
                                             self.sprint_assign_selection.set(Some(selection_idx));
                                             self.mode = AppMode::AssignCardToSprint;
                                         }
@@ -431,7 +432,8 @@ impl App {
                                             .filter(|s| s.board_id == board.id)
                                             .count();
                                         if sprint_count > 0 {
-                                            let selection_idx = self.get_current_sprint_selection_index();
+                                            let selection_idx =
+                                                self.get_current_sprint_selection_index();
                                             self.sprint_assign_selection.set(Some(selection_idx));
                                             self.mode = AppMode::AssignCardToSprint;
                                         }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -77,14 +77,16 @@ impl App {
                             .filter(|s| s.board_id == board.id)
                             .count();
                         if sprint_count > 0 {
-                            self.sprint_assign_selection.set(Some(0));
+                            let selection_idx = self.get_current_sprint_selection_index();
+                            self.sprint_assign_selection.set(Some(selection_idx));
                             self.mode = AppMode::AssignCardToSprint;
                         }
                     }
                 }
             }
             KeyCode::Char('p') => {
-                self.priority_selection.set(Some(0));
+                let priority_idx = self.get_current_priority_selection_index();
+                self.priority_selection.set(Some(priority_idx));
                 self.mode = AppMode::SetCardPriority;
             }
             _ => {}
@@ -311,7 +313,8 @@ impl App {
                 self.handle_complete_sprint_key();
             }
             KeyCode::Char('o') => {
-                self.sort_field_selection.set(Some(0));
+                let sort_idx = self.get_current_sort_field_selection_index();
+                self.sort_field_selection.set(Some(sort_idx));
                 self.mode = AppMode::OrderCards;
             }
             KeyCode::Char('O') => {
@@ -391,7 +394,8 @@ impl App {
                             if let Some(card_idx) = self.cards.iter().position(|c| c.id == card_id)
                             {
                                 self.active_card_index = Some(card_idx);
-                                self.priority_selection.set(Some(0));
+                                let priority_idx = self.get_current_priority_selection_index();
+                                self.priority_selection.set(Some(priority_idx));
                                 self.mode = AppMode::SetCardPriority;
                             }
                         }
@@ -407,7 +411,8 @@ impl App {
                                             .filter(|s| s.board_id == board.id)
                                             .count();
                                         if sprint_count > 0 {
-                                            self.sprint_assign_selection.set(Some(0));
+                                            let selection_idx = self.get_current_sprint_selection_index();
+                                            self.sprint_assign_selection.set(Some(selection_idx));
                                             self.mode = AppMode::AssignCardToSprint;
                                         }
                                     }
@@ -426,7 +431,8 @@ impl App {
                                             .filter(|s| s.board_id == board.id)
                                             .count();
                                         if sprint_count > 0 {
-                                            self.sprint_assign_selection.set(Some(0));
+                                            let selection_idx = self.get_current_sprint_selection_index();
+                                            self.sprint_assign_selection.set(Some(selection_idx));
                                             self.mode = AppMode::AssignCardToSprint;
                                         }
                                     }
@@ -434,7 +440,8 @@ impl App {
                             }
                         }
                         CardListAction::Sort => {
-                            self.sort_field_selection.set(Some(0));
+                            let sort_idx = self.get_current_sort_field_selection_index();
+                            self.sort_field_selection.set(Some(sort_idx));
                             self.mode = AppMode::OrderCards;
                         }
                         CardListAction::OrderCards => {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1187,13 +1187,13 @@ fn render_set_branch_prefix_popup(app: &App, frame: &mut Frame) {
 }
 
 fn render_order_cards_popup(app: &App, frame: &mut Frame) {
-    use crate::components::{SortFieldDialog, SelectionDialog};
+    use crate::components::{SelectionDialog, SortFieldDialog};
     let dialog = SortFieldDialog;
     dialog.render(app, frame);
 }
 
 fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
-    use crate::components::{SprintAssignDialog, SelectionDialog};
+    use crate::components::{SelectionDialog, SprintAssignDialog};
     let dialog = SprintAssignDialog;
     dialog.render(app, frame);
 }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -828,31 +828,9 @@ fn render_set_card_points_popup(app: &App, frame: &mut Frame) {
 }
 
 fn render_set_card_priority_popup(app: &App, frame: &mut Frame) {
-    use kanban_domain::CardPriority;
-
-    let priorities = [
-        CardPriority::Low,
-        CardPriority::Medium,
-        CardPriority::High,
-        CardPriority::Critical,
-    ];
-
-    let selected = app.priority_selection.get();
-
-    let items: Vec<ListItem> = priorities
-        .iter()
-        .enumerate()
-        .map(|(idx, priority)| {
-            let style = if Some(idx) == selected {
-                bold_highlight()
-            } else {
-                normal_text()
-            };
-            ListItem::new(format!("{:?}", priority)).style(style)
-        })
-        .collect();
-
-    render_selection_popup_with_list_items(frame, "Set Priority", items, 30, 40);
+    use crate::components::{PriorityDialog, SelectionDialog};
+    let dialog = PriorityDialog;
+    dialog.render(app, frame);
 }
 
 fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
@@ -1209,133 +1187,15 @@ fn render_set_branch_prefix_popup(app: &App, frame: &mut Frame) {
 }
 
 fn render_order_cards_popup(app: &App, frame: &mut Frame) {
-    use kanban_domain::{SortField, SortOrder};
-
-    let sort_fields = [
-        SortField::Points,
-        SortField::Priority,
-        SortField::CreatedAt,
-        SortField::UpdatedAt,
-        SortField::Status,
-        SortField::Default,
-    ];
-
-    let active_idx = sort_fields
-        .iter()
-        .position(|f| Some(*f) == app.current_sort_field);
-
-    render_selection_popup_with_lines(
-        frame,
-        "Order Tasks By",
-        Some("Select sort field:"),
-        sort_fields.iter().enumerate(),
-        |_idx, (_, field), _is_selected, is_active| {
-            let field_name = match field {
-                SortField::Priority => "Priority",
-                SortField::Points => "Points",
-                SortField::CreatedAt => "Date Created",
-                SortField::UpdatedAt => "Date Updated",
-                SortField::Default => "Task Number",
-                SortField::Status => "Status",
-            };
-
-            let order_indicator = if is_active {
-                match app.current_sort_order {
-                    Some(SortOrder::Ascending) => Some(" (↑)".to_string()),
-                    Some(SortOrder::Descending) => Some(" (↓)".to_string()),
-                    None => None,
-                }
-            } else {
-                None
-            };
-
-            (field_name.to_string(), order_indicator)
-        },
-        app.sort_field_selection.get(),
-        active_idx,
-        60,
-        50,
-    );
+    use crate::components::{SortFieldDialog, SelectionDialog};
+    let dialog = SortFieldDialog;
+    dialog.render(app, frame);
 }
 
 fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
-    let area = centered_rect(60, 50, frame.area());
-
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title("Assign to Sprint")
-        .borders(Borders::ALL)
-        .style(Style::default().bg(Color::Black));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(2)
-        .constraints([Constraint::Length(1), Constraint::Min(0)])
-        .split(inner);
-
-    let label = Paragraph::new("Select sprint:").style(Style::default().fg(Color::Yellow));
-    frame.render_widget(label, chunks[0]);
-
-    let mut lines = vec![];
-
-    if let Some(board_idx) = app.active_board_index {
-        if let Some(board) = app.boards.get(board_idx) {
-            let board_sprints: Vec<_> = app
-                .sprints
-                .iter()
-                .filter(|s| s.board_id == board.id)
-                .collect();
-
-            let current_sprint_id = if let Some(card_idx) = app.active_card_index {
-                app.cards.get(card_idx).and_then(|c| c.sprint_id)
-            } else {
-                None
-            };
-
-            for (idx, sprint_option) in std::iter::once(None)
-                .chain(board_sprints.iter().map(|s| Some(*s)))
-                .enumerate()
-            {
-                let is_selected = app.sprint_assign_selection.get() == Some(idx);
-                let is_current = match (sprint_option, current_sprint_id) {
-                    (None, None) => true,
-                    (Some(s), Some(id)) => s.id == id,
-                    _ => false,
-                };
-
-                let style = if is_selected {
-                    Style::default().fg(Color::White).bg(Color::Blue)
-                } else if is_current {
-                    Style::default()
-                        .fg(Color::Green)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(Color::White)
-                };
-
-                let prefix = if is_selected { "> " } else { "  " };
-                let current_indicator = if is_current { " (current)" } else { "" };
-
-                let sprint_name = if let Some(sprint) = sprint_option {
-                    sprint.formatted_name(board, board.sprint_prefix.as_deref().unwrap_or("sprint"))
-                } else {
-                    "(None)".to_string()
-                };
-
-                lines.push(Line::from(Span::styled(
-                    format!("{}{}{}", prefix, sprint_name, current_indicator),
-                    style,
-                )));
-            }
-        }
-    }
-
-    let list = Paragraph::new(lines);
-    frame.render_widget(list, chunks[1]);
+    use crate::components::{SprintAssignDialog, SelectionDialog};
+    let dialog = SprintAssignDialog;
+    dialog.render(app, frame);
 }
 
 fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {


### PR DESCRIPTION
Implement SelectionDialog component to position selector on currently selected item when opening dialogs.

## What

Position dialog selectors on the currently selected item instead of always defaulting to index 0:
- Priority dialog opens with selector on card's current priority
- Sort field dialog opens with selector on current sort field
- Sprint assignment dialog opens with selector on card's currently assigned sprint

## Why

Previously, all dialogs opened with the selector at the first position, requiring users to navigate to the currently selected item. This was a suboptimal UX and revealed an architectural issue: dialog initialization logic was scattered across multiple handler and UI files, violating the DRY and SOLID principles.

## How

Created a `SelectionDialog` trait abstraction in `components/selection_dialog.rs` that centralizes all dialog rendering and selection initialization logic. Each dialog type implements the trait:
- `PriorityDialog` - maps `CardPriority` to selection indices
- `SortFieldDialog` - maps `SortField` to selection indices  
- `SprintAssignDialog` - dynamically determines available sprints and highlights the current one

Event handlers now use helper methods (`get_current_priority_selection_index()`, etc.) to determine initial selection state, and UI rendering functions delegate to the trait implementations.

## Testing

- All 18 existing tests pass
- Project builds successfully with no warnings
- Manual testing of all three dialog types verifies selector appears on currently selected item

## Commits

Made 5 small, atomic commits following the project's commit strategy:
1. `refactor: add dialog selection state helpers to app`
2. `refactor: create SelectionDialog trait and implementations`
3. `refactor: export SelectionDialog component from components module`
4. `refactor: use dialog selection state helpers in event handlers`
5. `refactor: delegate dialog rendering to SelectionDialog components`