### PR TITLE
MVP-60/moving-cards-out-of-complete-column-doesnt-unmark-the-card-as-complete

### DIFF
--- a/.changeset/mvp-60-moving-cards-out-of-complete-column-doesnt-unmark-the-card-as-complete.md
+++ b/.changeset/mvp-60-moving-cards-out-of-complete-column-doesnt-unmark-the-card-as-complete.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+- Update CardListAction::MoveColumn handler to reflect card status changes
+- Fix handle_move_card_right to complete cards moved to last column
+- Fix handle_move_card_left to uncomplete cards moved from last column

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -489,20 +489,8 @@ impl App {
                                 .count() as i32;
 
                             if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
-                                let was_in_last_column = pos == board_columns.len() - 1;
-
                                 card.move_to_column(target_column_id, new_position);
-
-                                // If moved from last column and board has more than 1 column, mark as incomplete
-                                if was_in_last_column && board_columns.len() > 1 && card.status == CardStatus::Done {
-                                    card.update_status(CardStatus::Todo);
-                                    tracing::info!(
-                                        "Moved card '{}' from last column to previous column (marked as incomplete)",
-                                        card.title
-                                    );
-                                } else {
-                                    tracing::info!("Moved card '{}' to previous column", card.title);
-                                }
+                                tracing::info!("Moved card '{}' to previous column", card.title);
                             }
 
                             if self.is_kanban_view() {
@@ -551,6 +539,7 @@ impl App {
                     if let Some(pos) = current_position {
                         if pos < board_columns.len() - 1 {
                             let target_column_id = board_columns[pos + 1].id;
+                            let is_moving_to_last = pos + 1 == board_columns.len() - 1;
 
                             let new_position = self
                                 .cards
@@ -560,7 +549,17 @@ impl App {
 
                             if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
                                 card.move_to_column(target_column_id, new_position);
-                                tracing::info!("Moved card '{}' to next column", card.title);
+
+                                // If moving to last column and board has more than 1 column, mark as complete
+                                if is_moving_to_last && board_columns.len() > 1 && card.status != CardStatus::Done {
+                                    card.update_status(CardStatus::Done);
+                                    tracing::info!(
+                                        "Moved card '{}' to last column (marked as complete)",
+                                        card.title
+                                    );
+                                } else {
+                                    tracing::info!("Moved card '{}' to next column", card.title);
+                                }
                             }
 
                             if self.is_kanban_view() {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -551,7 +551,10 @@ impl App {
                                 card.move_to_column(target_column_id, new_position);
 
                                 // If moving to last column and board has more than 1 column, mark as complete
-                                if is_moving_to_last && board_columns.len() > 1 && card.status != CardStatus::Done {
+                                if is_moving_to_last
+                                    && board_columns.len() > 1
+                                    && card.status != CardStatus::Done
+                                {
                                     card.update_status(CardStatus::Done);
                                     tracing::info!(
                                         "Moved card '{}' to last column (marked as complete)",

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -489,8 +489,20 @@ impl App {
                                 .count() as i32;
 
                             if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
+                                let was_in_last_column = pos == board_columns.len() - 1;
+
                                 card.move_to_column(target_column_id, new_position);
-                                tracing::info!("Moved card '{}' to previous column", card.title);
+
+                                // If moved from last column and board has more than 1 column, mark as incomplete
+                                if was_in_last_column && board_columns.len() > 1 && card.status == CardStatus::Done {
+                                    card.update_status(CardStatus::Todo);
+                                    tracing::info!(
+                                        "Moved card '{}' from last column to previous column (marked as incomplete)",
+                                        card.title
+                                    );
+                                } else {
+                                    tracing::info!("Moved card '{}' to previous column", card.title);
+                                }
                             }
 
                             if self.is_kanban_view() {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -488,22 +488,38 @@ impl App {
                                                 };
 
                                                 if let Some(new_col) = columns.get(new_idx) {
-                                                    let was_in_last = current_idx == columns.len() - 1;
-                                                    let moving_to_last = new_idx == columns.len() - 1;
+                                                    let was_in_last =
+                                                        current_idx == columns.len() - 1;
+                                                    let moving_to_last =
+                                                        new_idx == columns.len() - 1;
 
                                                     card.column_id = new_col.id;
 
                                                     // Update status based on movement
-                                                    if !is_right && was_in_last && columns.len() > 1 && card.status == kanban_domain::CardStatus::Done {
+                                                    if !is_right
+                                                        && was_in_last
+                                                        && columns.len() > 1
+                                                        && card.status
+                                                            == kanban_domain::CardStatus::Done
+                                                    {
                                                         // Moving left from last column: uncomplete
-                                                        card.update_status(kanban_domain::CardStatus::Todo);
+                                                        card.update_status(
+                                                            kanban_domain::CardStatus::Todo,
+                                                        );
                                                         tracing::info!(
                                                             "Moved card {} left from last column (marked as incomplete)",
                                                             card.title
                                                         );
-                                                    } else if is_right && moving_to_last && columns.len() > 1 && card.status != kanban_domain::CardStatus::Done {
+                                                    } else if is_right
+                                                        && moving_to_last
+                                                        && columns.len() > 1
+                                                        && card.status
+                                                            != kanban_domain::CardStatus::Done
+                                                    {
                                                         // Moving right to last column: complete
-                                                        card.update_status(kanban_domain::CardStatus::Done);
+                                                        card.update_status(
+                                                            kanban_domain::CardStatus::Done,
+                                                        );
                                                         tracing::info!(
                                                             "Moved card {} to last column (marked as complete)",
                                                             card.title

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -471,11 +471,12 @@ impl App {
                                     if let Some(board_idx) = self.active_board_index {
                                         if let Some(board) = self.boards.get(board_idx) {
                                             let current_col = card.column_id;
-                                            let columns: Vec<_> = self
+                                            let mut columns: Vec<_> = self
                                                 .columns
                                                 .iter()
                                                 .filter(|c| c.board_id == board.id)
                                                 .collect();
+                                            columns.sort_by_key(|col| col.position);
 
                                             if let Some(current_idx) =
                                                 columns.iter().position(|c| c.id == current_col)
@@ -487,14 +488,35 @@ impl App {
                                                 };
 
                                                 if let Some(new_col) = columns.get(new_idx) {
+                                                    let was_in_last = current_idx == columns.len() - 1;
+                                                    let moving_to_last = new_idx == columns.len() - 1;
+
                                                     card.column_id = new_col.id;
-                                                    let direction =
-                                                        if is_right { "right" } else { "left" };
-                                                    tracing::info!(
-                                                        "Moved card {} to {}",
-                                                        card.title,
-                                                        direction
-                                                    );
+
+                                                    // Update status based on movement
+                                                    if !is_right && was_in_last && columns.len() > 1 && card.status == kanban_domain::CardStatus::Done {
+                                                        // Moving left from last column: uncomplete
+                                                        card.update_status(kanban_domain::CardStatus::Todo);
+                                                        tracing::info!(
+                                                            "Moved card {} left from last column (marked as incomplete)",
+                                                            card.title
+                                                        );
+                                                    } else if is_right && moving_to_last && columns.len() > 1 && card.status != kanban_domain::CardStatus::Done {
+                                                        // Moving right to last column: complete
+                                                        card.update_status(kanban_domain::CardStatus::Done);
+                                                        tracing::info!(
+                                                            "Moved card {} to last column (marked as complete)",
+                                                            card.title
+                                                        );
+                                                    } else {
+                                                        let direction =
+                                                            if is_right { "right" } else { "left" };
+                                                        tracing::info!(
+                                                            "Moved card {} to {}",
+                                                            card.title,
+                                                            direction
+                                                        );
+                                                    }
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## What

Fix bug where moving cards from the last column didn't automatically uncomplete them. Cards are now properly marked as incomplete when moved left from the last column, and marked as complete when moved right to the last column.

## Why

In kanban boards with more than one column, cards placed in the last column are automatically marked as complete. However, when users moved cards out of the last column using the H key (left) or q command, the completion status wasn't updated. This created an inconsistency where cards appeared incomplete but retained their "Done" status internally.

## How

- **`handle_move_card_left`**: When a card is moved left from the last column in a board with > 1 column, the card status is updated to `Todo` and `completed_at` is cleared
- **`handle_move_card_right`**: When a card is moved right to the last column in a board with > 1 column, the card status is updated to `Done` and `completed_at` is set
- **`CardListAction::MoveColumn` handler**: Applied the same status update logic to the detail/sprint view for consistent behavior across all movement interfaces

## Testing

- All existing tests pass
- Code compiles without errors or warnings
- Changes affect only card movement logic and status updates
- Logic mirrors existing behavior in `handle_toggle_card_completion` for consistency

## Changeset

- Bump: patch
- Files changed: 2 (card_handlers.rs, detail_view_handlers.rs)
- Commits: 3 atomic commits
