### PR TITLE
MVP-90/moving-cards-from-last-column-doesnt-uncomplete

### DIFF
--- a/.changeset/mvp-90-moving-cards-from-last-column-doesnt-uncomplete.md
+++ b/.changeset/mvp-90-moving-cards-from-last-column-doesnt-uncomplete.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- fix: moving cards from the last column should uncomplete said card
+

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -481,6 +481,7 @@ impl App {
                     if let Some(pos) = current_position {
                         if pos > 0 {
                             let target_column_id = board_columns[pos - 1].id;
+                            let is_moving_from_last = pos == board_columns.len() - 1;
 
                             let new_position = self
                                 .cards
@@ -490,7 +491,20 @@ impl App {
 
                             if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
                                 card.move_to_column(target_column_id, new_position);
-                                tracing::info!("Moved card '{}' to previous column", card.title);
+
+                                // If moving from last column and board has more than 1 column, unmark as complete
+                                if is_moving_from_last
+                                    && board_columns.len() > 1
+                                    && card.status == CardStatus::Done
+                                {
+                                    card.update_status(CardStatus::Todo);
+                                    tracing::info!(
+                                        "Moved card '{}' from last column (unmarked as complete)",
+                                        card.title
+                                    );
+                                } else {
+                                    tracing::info!("Moved card '{}' to previous column", card.title);
+                                }
                             }
 
                             if self.is_kanban_view() {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -503,7 +503,10 @@ impl App {
                                         card.title
                                     );
                                 } else {
-                                    tracing::info!("Moved card '{}' to previous column", card.title);
+                                    tracing::info!(
+                                        "Moved card '{}' to previous column",
+                                        card.title
+                                    );
                                 }
                             }
 


### PR DESCRIPTION
Fixes card completion status when moving cards from the last column:

- Add automatic status update to Todo when moving cards left from the last column
- Mirror the existing behavior for moving right (which marks as Done)
- Apply only to boards with more than 1 column

**What**: Added logic to automatically uncomplete cards when moved from the last column

**Why**: Cards were being marked as complete when moved to the last column, but remained complete when moved away, creating inconsistent state

**How**: Enhanced `handle_move_card_left` to detect when moving from the last column and update card status to Todo (similar to existing `handle_move_card_right` logic)

**Testing**: Manually tested moving cards between columns in multi-column boards, verified status updates correctly