### PR TITLE
MVP-49/hitting-q-in-dialogue-quits-the-program

### DIFF
--- a/.changeset/mvp-49-hitting-q-in-dialogue-quits-the-program.md
+++ b/.changeset/mvp-49-hitting-q-in-dialogue-quits-the-program.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- fix: exclude AppModes with text input form the `q` to quit binding

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -225,7 +225,21 @@ impl App {
         use crossterm::event::KeyCode;
         let mut should_restart_events = false;
 
-        if matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q')) {
+        let is_input_mode = matches!(
+            self.mode,
+            AppMode::CreateBoard
+                | AppMode::CreateCard
+                | AppMode::CreateSprint
+                | AppMode::RenameBoard
+                | AppMode::ExportBoard
+                | AppMode::ExportAll
+                | AppMode::SetCardPoints
+                | AppMode::SetBranchPrefix
+                | AppMode::CreateColumn
+                | AppMode::RenameColumn
+        );
+
+        if matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q')) && !is_input_mode {
             self.quit();
             return false;
         }


### PR DESCRIPTION
Fixes quit binding interfering with text input dialogs:

- Check if current mode accepts text input before processing 'q' to quit
- Allow 'q' character to be typed in dialog inputs
- Preserve quit functionality in non-input modes

**What**: Disabled 'q' quit binding when in text input dialog modes

**Why**: Users couldn't type 'q' in dialog boxes (creating boards, cards, etc.) because the global quit binding would trigger and exit the application

**How**: Added `is_input_mode` check that identifies all dialog modes with text input, and only processes the quit binding when not in these modes

**Testing**: Manually verified 'q' can be typed in all input dialogs without quitting, and 'q' still quits when in normal mode