### PR TITLE
MVP-29/search-in-cards-list

### DIFF
--- a/.changeset/mvp-29-search-in-cards-list.md
+++ b/.changeset/mvp-29-search-in-cards-list.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+- style: make search query text white for better visibility
+- feat: add vim-style search query display in footer
+- refactor: consolidate refresh_view and refresh_preview functions
+- Add Search mode help text to footer
+- Integrate search functionality into App
+- Add search query parameter to view strategies
+- Add search module to crate exports
+- Add search module with trait-based architecture
+

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -567,8 +567,9 @@ impl App {
     }
 
     pub fn refresh_view(&mut self) {
-        if let Some(board_idx) = self.active_board_index {
-            if let Some(board) = self.boards.get(board_idx) {
+        let board_idx = self.active_board_index.or(self.board_selection.get());
+        if let Some(idx) = board_idx {
+            if let Some(board) = self.boards.get(idx) {
                 let search_query = if self.search.is_active {
                     Some(self.search.query())
                 } else {
@@ -595,28 +596,6 @@ impl App {
         }
     }
 
-    pub fn refresh_preview(&mut self) {
-        if let Some(board_idx) = self.board_selection.get() {
-            if let Some(board) = self.boards.get(board_idx) {
-                let search_query = if self.search.is_active {
-                    Some(self.search.query())
-                } else {
-                    None
-                };
-                self.view_strategy.refresh_task_lists(
-                    board,
-                    &self.cards,
-                    &self.columns,
-                    &self.sprints,
-                    self.active_sprint_filter,
-                    self.hide_assigned_cards,
-                    search_query,
-                );
-            }
-        }
-        self.sync_card_list_component();
-    }
-
     pub fn switch_view_strategy(&mut self, task_list_view: kanban_domain::TaskListView) {
         let new_strategy: Box<dyn ViewStrategy> = match task_list_view {
             kanban_domain::TaskListView::Flat => Box::new(FlatViewStrategy::new()),
@@ -625,13 +604,7 @@ impl App {
         };
 
         self.view_strategy = new_strategy;
-
-        if self.active_board_index.is_some() {
-            self.refresh_view();
-        } else {
-            self.refresh_preview();
-        }
-        self.sync_card_list_component();
+        self.refresh_view();
     }
 
     pub fn export_board_with_filename(&self) -> io::Result<()> {

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -10,7 +10,10 @@ use crate::{
     selection::SelectionState,
     services::{filter::CardFilter, get_sorter_for_field, BoardFilter, OrderedSorter},
     ui,
-    view_strategy::{FlatViewStrategy, GroupedViewStrategy, KanbanViewStrategy, ViewStrategy},
+    view_strategy::{
+        FlatViewStrategy, GroupedViewStrategy, KanbanViewStrategy, ViewRefreshContext,
+        ViewStrategy,
+    },
 };
 use crossterm::{
     execute,
@@ -575,15 +578,16 @@ impl App {
                 } else {
                     None
                 };
-                self.view_strategy.refresh_task_lists(
+                let ctx = ViewRefreshContext {
                     board,
-                    &self.cards,
-                    &self.columns,
-                    &self.sprints,
-                    self.active_sprint_filter,
-                    self.hide_assigned_cards,
+                    all_cards: &self.cards,
+                    all_columns: &self.columns,
+                    all_sprints: &self.sprints,
+                    active_sprint_filter: self.active_sprint_filter,
+                    hide_assigned_cards: self.hide_assigned_cards,
                     search_query,
-                );
+                };
+                self.view_strategy.refresh_task_lists(&ctx);
             }
         }
         self.sync_card_list_component();

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -11,8 +11,7 @@ use crate::{
     services::{filter::CardFilter, get_sorter_for_field, BoardFilter, OrderedSorter},
     ui,
     view_strategy::{
-        FlatViewStrategy, GroupedViewStrategy, KanbanViewStrategy, ViewRefreshContext,
-        ViewStrategy,
+        FlatViewStrategy, GroupedViewStrategy, KanbanViewStrategy, ViewRefreshContext, ViewStrategy,
     },
 };
 use crossterm::{

--- a/crates/kanban-tui/src/lib.rs
+++ b/crates/kanban-tui/src/lib.rs
@@ -10,6 +10,7 @@ pub mod export;
 pub mod handlers;
 pub mod input;
 pub mod markdown_renderer;
+pub mod search;
 pub mod selection;
 pub mod services;
 pub mod theme;

--- a/crates/kanban-tui/src/search.rs
+++ b/crates/kanban-tui/src/search.rs
@@ -1,0 +1,153 @@
+use crate::input::InputState;
+use kanban_domain::{Board, Card, Sprint};
+
+pub struct SearchState {
+    pub input: InputState,
+    pub is_active: bool,
+}
+
+impl SearchState {
+    pub fn new() -> Self {
+        Self {
+            input: InputState::new(),
+            is_active: false,
+        }
+    }
+
+    pub fn activate(&mut self) {
+        self.is_active = true;
+        self.input.clear();
+    }
+
+    pub fn deactivate(&mut self) {
+        self.is_active = false;
+        self.input.clear();
+    }
+
+    pub fn query(&self) -> &str {
+        self.input.as_str()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.input.as_str().is_empty()
+    }
+}
+
+impl Default for SearchState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub trait CardSearcher {
+    fn matches(&self, card: &Card, board: &Board, sprints: &[Sprint]) -> bool;
+}
+
+pub struct CardTitleSearcher {
+    query: String,
+}
+
+impl CardTitleSearcher {
+    pub fn new(query: String) -> Self {
+        Self {
+            query: query.to_lowercase(),
+        }
+    }
+}
+
+impl CardSearcher for CardTitleSearcher {
+    fn matches(&self, card: &Card, _board: &Board, _sprints: &[Sprint]) -> bool {
+        if self.query.is_empty() {
+            return true;
+        }
+        card.title.to_lowercase().contains(&self.query)
+    }
+}
+
+pub struct CardBranchNameSearcher {
+    query: String,
+}
+
+impl CardBranchNameSearcher {
+    pub fn new(query: String) -> Self {
+        Self {
+            query: query.to_lowercase(),
+        }
+    }
+}
+
+impl CardBranchNameSearcher {
+    fn get_branch_name(&self, card: &Card, board: &Board, sprints: &[Sprint]) -> String {
+        let sprint_prefix = card
+            .sprint_id
+            .and_then(|sid| sprints.iter().find(|s| s.id == sid))
+            .and_then(|sprint| {
+                Some(format!(
+                    "{}-{}/",
+                    board.sprint_prefix.as_deref().unwrap_or("sprint"),
+                    sprint.sprint_number
+                ))
+            });
+
+        let card_number = card.card_number;
+        let title_slug = card
+            .title
+            .to_lowercase()
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '-' })
+            .collect::<String>()
+            .split('-')
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("-");
+
+        let branch_prefix = board
+            .branch_prefix
+            .as_deref()
+            .unwrap_or_else(|| board.effective_branch_prefix("feature"));
+
+        if let Some(prefix) = sprint_prefix {
+            format!(
+                "{}{}{}-{}",
+                prefix, branch_prefix, card_number, title_slug
+            )
+        } else {
+            format!("{}{}-{}", branch_prefix, card_number, title_slug)
+        }
+    }
+}
+
+impl CardSearcher for CardBranchNameSearcher {
+    fn matches(&self, card: &Card, board: &Board, sprints: &[Sprint]) -> bool {
+        if self.query.is_empty() {
+            return true;
+        }
+        let branch_name = self.get_branch_name(card, board, sprints);
+        branch_name.to_lowercase().contains(&self.query)
+    }
+}
+
+pub struct CompositeCardSearcher {
+    searchers: Vec<Box<dyn CardSearcher>>,
+}
+
+impl CompositeCardSearcher {
+    pub fn new(query: String) -> Self {
+        let searchers: Vec<Box<dyn CardSearcher>> = vec![
+            Box::new(CardTitleSearcher::new(query.clone())),
+            Box::new(CardBranchNameSearcher::new(query)),
+        ];
+        Self { searchers }
+    }
+}
+
+impl CardSearcher for CompositeCardSearcher {
+    fn matches(&self, card: &Card, board: &Board, sprints: &[Sprint]) -> bool {
+        if self.searchers.is_empty() {
+            return true;
+        }
+        self.searchers
+            .iter()
+            .any(|searcher| searcher.matches(card, board, sprints))
+    }
+}

--- a/crates/kanban-tui/src/search.rs
+++ b/crates/kanban-tui/src/search.rs
@@ -107,10 +107,7 @@ impl CardBranchNameSearcher {
             .unwrap_or_else(|| board.effective_branch_prefix("feature"));
 
         if let Some(prefix) = sprint_prefix {
-            format!(
-                "{}{}{}-{}",
-                prefix, branch_prefix, card_number, title_slug
-            )
+            format!("{}{}{}-{}", prefix, branch_prefix, card_number, title_slug)
         } else {
             format!("{}{}-{}", branch_prefix, card_number, title_slug)
         }

--- a/crates/kanban-tui/src/search.rs
+++ b/crates/kanban-tui/src/search.rs
@@ -81,12 +81,12 @@ impl CardBranchNameSearcher {
         let sprint_prefix = card
             .sprint_id
             .and_then(|sid| sprints.iter().find(|s| s.id == sid))
-            .and_then(|sprint| {
-                Some(format!(
+            .map(|sprint| {
+                format!(
                     "{}-{}/",
                     board.sprint_prefix.as_deref().unwrap_or("sprint"),
                     sprint.sprint_number
-                ))
+                )
             });
 
         let card_number = card.card_number;

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -798,6 +798,7 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
         AppMode::RenameColumn => "ESC: cancel | ENTER: confirm".to_string(),
         AppMode::DeleteColumnConfirm => "ESC: cancel | ENTER/y: delete | n: cancel".to_string(),
         AppMode::SelectTaskListView => "ESC: cancel | j/k: navigate | ENTER/Space: select".to_string(),
+        AppMode::Search => "ESC/ENTER: exit search | type to filter".to_string(),
     };
     let help = Paragraph::new(help_text)
         .style(label_text())

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -752,6 +752,28 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
             false
         };
 
+    if app.mode == AppMode::Search {
+        let search_text = format!("/{}", app.search.query());
+        let help_text = "ESC/ENTER: exit search";
+
+        let available_width = area.width.saturating_sub(4);
+        let help_len = help_text.len() as u16;
+        let search_len = search_text.len() as u16;
+
+        let padding = if available_width > search_len + help_len + 1 {
+            available_width.saturating_sub(search_len).saturating_sub(help_len)
+        } else {
+            1
+        };
+
+        let footer_text = format!("{}{:width$}{}", search_text, "", help_text, width = padding as usize);
+        let help = Paragraph::new(footer_text)
+            .style(label_text())
+            .block(Block::default().borders(Borders::ALL));
+        frame.render_widget(help, area);
+        return;
+    }
+
     let generated_help = app.card_list_component.help_text();
     let help_text: String = match app.mode {
         AppMode::Normal => {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -761,19 +761,23 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
         let search_len = search_text.len() as u16;
 
         let padding = if available_width > search_len + help_len + 1 {
-            available_width.saturating_sub(search_len).saturating_sub(help_len)
+            available_width
+                .saturating_sub(search_len)
+                .saturating_sub(help_len)
         } else {
             1
         };
 
         let footer_line = Line::from(vec![
             Span::styled(search_text, Style::default().fg(Color::White)),
-            Span::styled(format!("{:width$}", "", width = padding as usize), label_text()),
+            Span::styled(
+                format!("{:width$}", "", width = padding as usize),
+                label_text(),
+            ),
             Span::styled(help_text, label_text()),
         ]);
 
-        let help = Paragraph::new(footer_line)
-            .block(Block::default().borders(Borders::ALL));
+        let help = Paragraph::new(footer_line).block(Block::default().borders(Borders::ALL));
         frame.render_widget(help, area);
         return;
     }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -766,9 +766,13 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
             1
         };
 
-        let footer_text = format!("{}{:width$}{}", search_text, "", help_text, width = padding as usize);
-        let help = Paragraph::new(footer_text)
-            .style(label_text())
+        let footer_line = Line::from(vec![
+            Span::styled(search_text, Style::default().fg(Color::White)),
+            Span::styled(format!("{:width$}", "", width = padding as usize), label_text()),
+            Span::styled(help_text, label_text()),
+        ]);
+
+        let help = Paragraph::new(footer_line)
             .block(Block::default().borders(Borders::ALL));
         frame.render_widget(help, area);
         return;


### PR DESCRIPTION
Implement vim-style search functionality for card lists:

- Add modular search architecture using trait-based design (CardSearcher trait)
- Implement search by card title (case-insensitive)
- Implement search by branch name (case-insensitive)
- Add CompositeCardSearcher for OR-based multi-searcher logic
- Integrate search into all view strategies (Flat, GroupedByColumn, Kanban)
- Add vim-style footer display showing search query in real-time
- Consolidate duplicate refresh functions for cleaner code

**What**: Added search functionality accessible via `/` key that filters cards by title or branch name across all view modes.

**Why**: Users need a quick way to find specific cards in large projects without manually scrolling through long lists.

**How**: 
- Created extensible trait-based search system following SOLID principles
- Search filters are applied after sprint/status filtering but before sorting
- Search state is managed through SearchState with InputState for text handling
- Footer displays vim-style `/query` format with white text for visibility

**Testing**: Manually tested search in all three view modes (flat, grouped, kanban) with various queries including title matches, branch name matches, and empty queries.