### PR TITLE
MVP-101/add-column-header-for-non-assigned-filter

### DIFF
--- a/.changeset/mvp-101-add-column-header-for-non-assigned-filter.md
+++ b/.changeset/mvp-101-add-column-header-for-non-assigned-filter.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+- refactor: extract tasks panel title builder
+- refactor: extract filter title suffix helper
+- feat: add unassigned cards header to filter view

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -227,6 +227,8 @@ fn render_tasks_flat(app: &App, frame: &mut Frame, area: Rect) {
                 }
             }
         }
+    } else if app.hide_assigned_cards {
+        title.push_str(" - Unassigned Cards");
     }
 
     let panel_config = PanelConfig::new(&title)
@@ -341,6 +343,8 @@ fn render_tasks_grouped_by_column(app: &App, frame: &mut Frame, area: Rect) {
                 }
             }
         }
+    } else if app.hide_assigned_cards {
+        title.push_str(" - Unassigned Cards");
     }
 
     let panel_config = PanelConfig::new(&title)
@@ -381,6 +385,8 @@ fn render_tasks_kanban_view(app: &App, frame: &mut Frame, area: Rect) {
                 } else {
                     None
                 }
+            } else if app.hide_assigned_cards {
+                Some(" - Unassigned Cards".to_string())
             } else {
                 None
             };

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -148,6 +148,22 @@ fn build_filter_title_suffix(app: &App) -> Option<String> {
     None
 }
 
+fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
+    let mut title = if app.focus == Focus::Cards {
+        "Tasks [2]".to_string()
+    } else {
+        "Tasks".to_string()
+    };
+
+    if with_filter_suffix {
+        if let Some(suffix) = build_filter_title_suffix(app) {
+            title.push_str(&suffix);
+        }
+    }
+
+    title
+}
+
 fn render_tasks_panel(app: &App, frame: &mut Frame, area: Rect) {
     let board_idx = app.active_board_index.or(app.board_selection.get());
 
@@ -228,15 +244,7 @@ fn render_tasks_flat(app: &App, frame: &mut Frame, area: Rect) {
         )));
     }
 
-    let mut title = if app.focus == Focus::Cards {
-        "Tasks [2]".to_string()
-    } else {
-        "Tasks".to_string()
-    };
-
-    if let Some(suffix) = build_filter_title_suffix(app) {
-        title.push_str(&suffix);
-    }
+    let title = build_tasks_panel_title(app, true);
 
     let panel_config = PanelConfig::new(&title)
         .with_focus_indicator(&title)
@@ -334,15 +342,7 @@ fn render_tasks_grouped_by_column(app: &App, frame: &mut Frame, area: Rect) {
         )));
     }
 
-    let mut title = if app.focus == Focus::Cards {
-        "Tasks [2]".to_string()
-    } else {
-        "Tasks".to_string()
-    };
-
-    if let Some(suffix) = build_filter_title_suffix(app) {
-        title.push_str(&suffix);
-    }
+    let title = build_tasks_panel_title(app, true);
 
     let panel_config = PanelConfig::new(&title)
         .with_focus_indicator(&title)


### PR DESCRIPTION
Add column header for unassigned cards filter view and refactor UI title logic.

## Changes

- Add "Unassigned Cards" column header when hide_assigned_cards filter is active
- Extract filter title suffix helper to eliminate code duplication
- Extract tasks panel title builder for better code organization

## What

Added visual indicator to show when the unassigned cards filter is active, similar to the existing sprint filter header. Refactored duplicated title-building logic into reusable helper functions.

## Why

Users need clear visual feedback when viewing filtered card lists. The unassigned cards filter previously had no header indication, making it unclear what filter was active. The duplicated title logic across three rendering functions made maintenance difficult.

## How

1. Modified `render_tasks_flat`, `render_tasks_grouped_by_column`, and `render_tasks_kanban_view` to display "Unassigned Cards" suffix when `hide_assigned_cards` is true
2. Extracted `build_filter_title_suffix()` helper to consolidate sprint/unassigned filter logic
3. Extracted `build_tasks_panel_title()` helper to standardize title construction

## Testing

- Built successfully with `cargo build`
- Passed clippy checks with `cargo clippy --all-targets --all-features`
- Manually tested unassigned filter displays correct header
- Verified sprint filter still works correctly