### PR TITLE
MVP-108/keep-a-log-of-sprints-for-a-card

### DIFF
--- a/.changeset/mvp-108-keep-a-log-of-sprints-for-a-card.md
+++ b/.changeset/mvp-108-keep-a-log-of-sprints-for-a-card.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Implement log for sprints that a card has seen
+
+- chore: cargo fmt
+- feat: integrate sprint logging into card-to-sprint assignment
+- feat: add sprint logging to Card domain model
+- feat: add SprintLog struct for tracking sprint history
+- feat: add logging abstraction to kanban-core

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod error;
+pub mod logging;
 pub mod result;
 pub mod traits;
 
 pub use config::AppConfig;
 pub use error::KanbanError;
+pub use logging::{LogEntry, Loggable};
 pub use result::KanbanResult;
 pub use traits::Editable;

--- a/crates/kanban-core/src/logging.rs
+++ b/crates/kanban-core/src/logging.rs
@@ -1,0 +1,22 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogEntry {
+    pub timestamp: DateTime<Utc>,
+    pub message: String,
+}
+
+impl LogEntry {
+    pub fn new(message: String) -> Self {
+        Self {
+            timestamp: Utc::now(),
+            message,
+        }
+    }
+}
+
+pub trait Loggable {
+    fn add_log(&mut self, message: String);
+    fn get_logs(&self) -> &[LogEntry];
+}

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -357,7 +357,12 @@ mod tests {
         assert_eq!(card.get_sprint_history().len(), 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
-        card.assign_to_sprint(sprint_id_1, 1, Some("Sprint 1".to_string()), "Active".to_string());
+        card.assign_to_sprint(
+            sprint_id_1,
+            1,
+            Some("Sprint 1".to_string()),
+            "Active".to_string(),
+        );
 
         assert_eq!(card.get_sprint_history().len(), 1);
         assert_eq!(card.sprint_id, Some(sprint_id_1));
@@ -376,7 +381,12 @@ mod tests {
         let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
-        card.assign_to_sprint(sprint_id_1, 1, Some("Sprint 1".to_string()), "Active".to_string());
+        card.assign_to_sprint(
+            sprint_id_1,
+            1,
+            Some("Sprint 1".to_string()),
+            "Active".to_string(),
+        );
 
         card.end_current_sprint_log();
 
@@ -393,12 +403,22 @@ mod tests {
         let sprint_id_1 = uuid::Uuid::new_v4();
         let sprint_id_2 = uuid::Uuid::new_v4();
 
-        card.assign_to_sprint(sprint_id_1, 1, Some("Sprint 1".to_string()), "Active".to_string());
+        card.assign_to_sprint(
+            sprint_id_1,
+            1,
+            Some("Sprint 1".to_string()),
+            "Active".to_string(),
+        );
         assert_eq!(card.sprint_id, Some(sprint_id_1));
         assert_eq!(card.get_sprint_history().len(), 1);
 
         card.end_current_sprint_log();
-        card.assign_to_sprint(sprint_id_2, 2, Some("Sprint 2".to_string()), "Active".to_string());
+        card.assign_to_sprint(
+            sprint_id_2,
+            2,
+            Some("Sprint 2".to_string()),
+            "Active".to_string(),
+        );
 
         assert_eq!(card.sprint_id, Some(sprint_id_2));
         assert_eq!(card.get_sprint_history().len(), 2);

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -3,6 +3,7 @@ pub mod card;
 pub mod column;
 pub mod editable;
 pub mod sprint;
+pub mod sprint_log;
 pub mod tag;
 pub mod task_list_view;
 
@@ -11,5 +12,6 @@ pub use card::{Card, CardId, CardPriority, CardStatus};
 pub use column::{Column, ColumnId};
 pub use editable::{BoardSettingsDto, CardMetadataDto};
 pub use sprint::{Sprint, SprintId, SprintStatus};
+pub use sprint_log::SprintLog;
 pub use tag::{Tag, TagId};
 pub use task_list_view::TaskListView;

--- a/crates/kanban-domain/src/sprint_log.rs
+++ b/crates/kanban-domain/src/sprint_log.rs
@@ -1,0 +1,35 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SprintLog {
+    pub sprint_id: Uuid,
+    pub sprint_number: u32,
+    pub sprint_name: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    pub status: String,
+}
+
+impl SprintLog {
+    pub fn new(
+        sprint_id: Uuid,
+        sprint_number: u32,
+        sprint_name: Option<String>,
+        status: String,
+    ) -> Self {
+        Self {
+            sprint_id,
+            sprint_number,
+            sprint_name,
+            started_at: Utc::now(),
+            ended_at: None,
+            status,
+        }
+    }
+
+    pub fn end_sprint(&mut self) {
+        self.ended_at = Some(Utc::now());
+    }
+}

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -165,6 +165,7 @@ impl App {
                     if let Some(card_idx) = self.active_card_index {
                         if let Some(card) = self.cards.get_mut(card_idx) {
                             if selection_idx == 0 {
+                                card.end_current_sprint_log();
                                 card.sprint_id = None;
                                 tracing::info!("Unassigned card from sprint");
                             } else if let Some(board_idx) = self.active_board_index {
@@ -175,7 +176,17 @@ impl App {
                                         .filter(|s| s.board_id == board.id)
                                         .collect();
                                     if let Some(sprint) = board_sprints.get(selection_idx - 1) {
-                                        card.sprint_id = Some(sprint.id);
+                                        if let Some(old_sprint_id) = card.sprint_id {
+                                            if old_sprint_id != sprint.id {
+                                                card.end_current_sprint_log();
+                                            }
+                                        }
+                                        card.assign_to_sprint(
+                                            sprint.id,
+                                            sprint.sprint_number,
+                                            sprint.get_name(board).map(|s| s.to_string()),
+                                            format!("{:?}", sprint.status),
+                                        );
                                         tracing::info!(
                                             "Assigned card to sprint: {}",
                                             sprint.formatted_name(board, "sprint")
@@ -221,6 +232,7 @@ impl App {
                     for card_id in card_ids {
                         if let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) {
                             if selection_idx == 0 {
+                                card.end_current_sprint_log();
                                 card.sprint_id = None;
                             } else if let Some(board_idx) = self.active_board_index {
                                 if let Some(board) = self.boards.get(board_idx) {
@@ -230,7 +242,17 @@ impl App {
                                         .filter(|s| s.board_id == board.id)
                                         .collect();
                                     if let Some(sprint) = board_sprints.get(selection_idx - 1) {
-                                        card.sprint_id = Some(sprint.id);
+                                        if let Some(old_sprint_id) = card.sprint_id {
+                                            if old_sprint_id != sprint.id {
+                                                card.end_current_sprint_log();
+                                            }
+                                        }
+                                        card.assign_to_sprint(
+                                            sprint.id,
+                                            sprint.sprint_number,
+                                            sprint.get_name(board).map(|s| s.to_string()),
+                                            format!("{:?}", sprint.status),
+                                        );
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

Implements sprint logging for cards and creates a general-purpose logging abstraction for tracking entity property changes. Cards now maintain a complete audit trail of all sprints they've been assigned to.

## What

- Add logging abstraction in `kanban-core` with `LogEntry` and `Loggable` trait
- Create `SprintLog` struct to track sprint membership history
- Add sprint history tracking to `Card` domain model
- Integrate sprint logging into card-to-sprint assignment handlers

## Why

- Cards need to maintain historical records of which sprints they belonged to
- When a sprint ends and a new one begins, cards should preserve their sprint history
- Generic logging abstraction allows future tracking of other entity property changes
- Provides audit trail for sprint migrations

## How

1. Created logging abstraction in `kanban-core` with timestamped log entries
2. Implemented `SprintLog` struct capturing sprint metadata (id, number, name, status) and membership duration
3. Added `sprint_logs` field to `Card` with methods for assignment and history retrieval
4. Updated popup handlers to call `assign_to_sprint()` and `end_current_sprint_log()` methods
5. Proper handling of sprint transitions (unassign, reassign) with correct log closure

## Testing

- All existing tests pass (59 total)
- Added 3 new unit tests for sprint logging:
  - `test_sprint_logging()` - verifies basic assignment logging
  - `test_sprint_log_ending()` - ensures logs can be properly closed
  - `test_multiple_sprint_logs()` - confirms multiple sprints tracked correctly
- Manual testing with cargo build and cargo test successful
- Backward compatible with existing data (uses `#[serde(default)]`)

## Commits

- `feat: add logging abstraction to kanban-core`
- `feat: add SprintLog struct for tracking sprint history`
- `feat: add sprint logging to Card domain model`
- `feat: integrate sprint logging into card-to-sprint assignment`