### PR TITLE
KAN-113/dont-add-to-sprint-log-for-a-card-if-the-same-sprint-is-added

### DIFF
--- a/.changeset/kan-113-dont-add-to-sprint-log-for-a-card-if-the-same-sprint-is-added.md
+++ b/.changeset/kan-113-dont-add-to-sprint-log-for-a-card-if-the-same-sprint-is-added.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- fix: prevent duplicate sprint log entries when reassigning to same sprint


### PR DESCRIPTION
Prevent duplicate sprint log entries when reassigning to same sprint

**What**
Modified `Card::assign_to_sprint()` to check if the target sprint_id matches the current sprint_id before creating a new sprint log entry.

**Why**
When a user re-assigns a card to the same sprint it's already in, we should not create a duplicate entry in the sprint log. This maintains data integrity while respecting user behavior of potentially re-selecting the same sprint in the UI.

**How**
- Added a guard clause in `Card::assign_to_sprint()` that only creates a new sprint log entry if the sprint assignment actually changes
- Added unit test `test_assign_same_sprint_no_duplicate()` to verify the behavior

**Testing**
- All 14 unit tests in kanban-domain pass
- New test verifies that re-assigning to the same sprint doesn't create duplicate entries
- No clippy warnings
- Code follows CONTRIBUTING.md guidelines with semantic commits