### PR TITLE
KAN-109/choose-which-sprint-to-filter-by

### DIFF
--- a/.changeset/kan-109-choose-which-sprint-to-filter-by.md
+++ b/.changeset/kan-109-choose-which-sprint-to-filter-by.md
@@ -1,0 +1,17 @@
+---
+bump: patch
+---
+
+Adding a dialogue to chose card filters
+
+- feat: support filtering by multiple sprints simultaneously
+- feat: display all active filters in card list header
+- chore: cargo fmt
+- fix: simplify Space key handler to remove clippy single-match warning
+- refactor: merge unassigned sprints into sprints section with graphical separation
+- feat: apply filters immediately when toggled in dialog
+- feat: implement filter dialog item selection and cursor feedback
+- feat: add filter dialog UI rendering
+- feat: implement filter dialog handlers
+- feat: add filters module with FilterOptions AppMode
+

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -277,7 +277,7 @@ impl App {
                 KeyCode::Char('c') => self.handle_toggle_card_completion(),
                 KeyCode::Char('o') => self.handle_order_cards_key(),
                 KeyCode::Char('O') => self.handle_toggle_sort_order_key(),
-                KeyCode::Char('T') => self.handle_toggle_hide_assigned(),
+                KeyCode::Char('T') => self.handle_open_filter_dialog(),
                 KeyCode::Char('t') => self.handle_toggle_sprint_filter(),
                 KeyCode::Char('v') => self.handle_card_selection_toggle(),
                 KeyCode::Char('V') => self.handle_toggle_task_list_view(),
@@ -338,9 +338,7 @@ impl App {
             AppMode::ConfirmSprintPrefixCollision => {
                 self.handle_confirm_sprint_prefix_collision_popup(key.code)
             }
-            AppMode::FilterOptions => {
-                // placeholder handler
-            }
+            AppMode::FilterOptions => self.handle_filter_options_popup(key.code),
         }
         should_restart_events
     }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -5,6 +5,7 @@ use crate::{
     editor::edit_in_external_editor,
     events::{Event, EventHandler},
     export::{BoardExporter, BoardImporter},
+    filters::FilterDialogState,
     input::InputState,
     search::SearchState,
     selection::SelectionState,
@@ -61,6 +62,7 @@ pub struct App {
     pub view_strategy: Box<dyn ViewStrategy>,
     pub card_list_component: CardListComponent,
     pub search: SearchState,
+    pub filter_dialog_state: Option<FilterDialogState>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -128,6 +130,7 @@ pub enum AppMode {
     SetSprintPrefix,
     SetSprintCardPrefix,
     ConfirmSprintPrefixCollision,
+    FilterOptions,
 }
 
 impl App {
@@ -195,6 +198,7 @@ impl App {
                 CardListComponentConfig::new(),
             ),
             search: SearchState::new(),
+            filter_dialog_state: None,
         };
 
         if let Some(ref filename) = save_file {
@@ -333,6 +337,9 @@ impl App {
             AppMode::Search => self.handle_search_mode(key.code),
             AppMode::ConfirmSprintPrefixCollision => {
                 self.handle_confirm_sprint_prefix_collision_popup(key.code)
+            }
+            AppMode::FilterOptions => {
+                // placeholder handler
             }
         }
         should_restart_events

--- a/crates/kanban-tui/src/filters.rs
+++ b/crates/kanban-tui/src/filters.rs
@@ -5,6 +5,7 @@ pub enum FilterDialogSection {
     UnassignedSprints,
     Sprints,
     DateRange,
+    Tags,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -13,12 +14,14 @@ pub struct CardFilters {
     pub selected_sprint_ids: HashSet<uuid::Uuid>,
     pub date_from: Option<String>,
     pub date_to: Option<String>,
+    pub selected_tags: HashSet<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct FilterDialogState {
     pub current_section: FilterDialogSection,
-    pub section_selection: usize,
+    pub section_index: usize,
+    pub item_selection: usize,
     pub filters: CardFilters,
 }
 
@@ -26,8 +29,37 @@ impl FilterDialogState {
     pub fn new(filters: CardFilters) -> Self {
         Self {
             current_section: FilterDialogSection::UnassignedSprints,
-            section_selection: 0,
+            section_index: 0,
+            item_selection: 0,
             filters,
         }
+    }
+
+    pub fn next_section(&mut self) {
+        self.section_index = (self.section_index + 1) % 4;
+        self.item_selection = 0;
+        self.current_section = match self.section_index {
+            0 => FilterDialogSection::UnassignedSprints,
+            1 => FilterDialogSection::Sprints,
+            2 => FilterDialogSection::DateRange,
+            3 => FilterDialogSection::Tags,
+            _ => FilterDialogSection::UnassignedSprints,
+        };
+    }
+
+    pub fn prev_section(&mut self) {
+        self.section_index = if self.section_index == 0 {
+            3
+        } else {
+            self.section_index - 1
+        };
+        self.item_selection = 0;
+        self.current_section = match self.section_index {
+            0 => FilterDialogSection::UnassignedSprints,
+            1 => FilterDialogSection::Sprints,
+            2 => FilterDialogSection::DateRange,
+            3 => FilterDialogSection::Tags,
+            _ => FilterDialogSection::UnassignedSprints,
+        };
     }
 }

--- a/crates/kanban-tui/src/filters.rs
+++ b/crates/kanban-tui/src/filters.rs
@@ -1,0 +1,33 @@
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FilterDialogSection {
+    UnassignedSprints,
+    Sprints,
+    DateRange,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CardFilters {
+    pub show_unassigned_sprints: bool,
+    pub selected_sprint_ids: HashSet<uuid::Uuid>,
+    pub date_from: Option<String>,
+    pub date_to: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilterDialogState {
+    pub current_section: FilterDialogSection,
+    pub section_selection: usize,
+    pub filters: CardFilters,
+}
+
+impl FilterDialogState {
+    pub fn new(filters: CardFilters) -> Self {
+        Self {
+            current_section: FilterDialogSection::UnassignedSprints,
+            section_selection: 0,
+            filters,
+        }
+    }
+}

--- a/crates/kanban-tui/src/filters.rs
+++ b/crates/kanban-tui/src/filters.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FilterDialogSection {
-    UnassignedSprints,
     Sprints,
     DateRange,
     Tags,
@@ -28,7 +27,7 @@ pub struct FilterDialogState {
 impl FilterDialogState {
     pub fn new(filters: CardFilters) -> Self {
         Self {
-            current_section: FilterDialogSection::UnassignedSprints,
+            current_section: FilterDialogSection::Sprints,
             section_index: 0,
             item_selection: 0,
             filters,
@@ -36,30 +35,28 @@ impl FilterDialogState {
     }
 
     pub fn next_section(&mut self) {
-        self.section_index = (self.section_index + 1) % 4;
+        self.section_index = (self.section_index + 1) % 3;
         self.item_selection = 0;
         self.current_section = match self.section_index {
-            0 => FilterDialogSection::UnassignedSprints,
-            1 => FilterDialogSection::Sprints,
-            2 => FilterDialogSection::DateRange,
-            3 => FilterDialogSection::Tags,
-            _ => FilterDialogSection::UnassignedSprints,
+            0 => FilterDialogSection::Sprints,
+            1 => FilterDialogSection::DateRange,
+            2 => FilterDialogSection::Tags,
+            _ => FilterDialogSection::Sprints,
         };
     }
 
     pub fn prev_section(&mut self) {
         self.section_index = if self.section_index == 0 {
-            3
+            2
         } else {
             self.section_index - 1
         };
         self.item_selection = 0;
         self.current_section = match self.section_index {
-            0 => FilterDialogSection::UnassignedSprints,
-            1 => FilterDialogSection::Sprints,
-            2 => FilterDialogSection::DateRange,
-            3 => FilterDialogSection::Tags,
-            _ => FilterDialogSection::UnassignedSprints,
+            0 => FilterDialogSection::Sprints,
+            1 => FilterDialogSection::DateRange,
+            2 => FilterDialogSection::Tags,
+            _ => FilterDialogSection::Sprints,
         };
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -150,11 +150,12 @@ impl App {
             if let Some(board_idx) = self.active_board_index {
                 if let Some(board) = self.boards.get(board_idx) {
                     if let Some(active_sprint_id) = board.active_sprint_id {
-                        if self.active_sprint_filter == Some(active_sprint_id) {
-                            self.active_sprint_filter = None;
+                        if self.active_sprint_filters.contains(&active_sprint_id) {
+                            self.active_sprint_filters.remove(&active_sprint_id);
                             tracing::info!("Disabled sprint filter - showing all cards");
                         } else {
-                            self.active_sprint_filter = Some(active_sprint_id);
+                            self.active_sprint_filters.clear();
+                            self.active_sprint_filters.insert(active_sprint_id);
                             tracing::info!("Enabled sprint filter - showing active sprint only");
                         }
 

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -1,5 +1,5 @@
 use crate::app::{App, AppMode, Focus};
-use crate::filters::{CardFilters, FilterDialogState, FilterDialogSection};
+use crate::filters::{CardFilters, FilterDialogSection, FilterDialogState};
 use crossterm::event::KeyCode;
 
 impl App {
@@ -29,44 +29,40 @@ impl App {
                     self.filter_dialog_state = None;
                     self.mode = AppMode::Normal;
                 }
-                KeyCode::Char('j') | KeyCode::Down => {
-                    match dialog_state.current_section {
-                        FilterDialogSection::Sprints => {
-                            if let Some(board_idx) = self.active_board_index {
-                                if let Some(board) = self.boards.get(board_idx) {
-                                    let sprint_count = self
-                                        .sprints
-                                        .iter()
-                                        .filter(|s| s.board_id == board.id)
-                                        .count();
-                                    let total_items = 1 + sprint_count;
-                                    if dialog_state.item_selection < total_items.saturating_sub(1) {
-                                        dialog_state.item_selection += 1;
-                                    } else {
-                                        dialog_state.next_section();
-                                    }
+                KeyCode::Char('j') | KeyCode::Down => match dialog_state.current_section {
+                    FilterDialogSection::Sprints => {
+                        if let Some(board_idx) = self.active_board_index {
+                            if let Some(board) = self.boards.get(board_idx) {
+                                let sprint_count = self
+                                    .sprints
+                                    .iter()
+                                    .filter(|s| s.board_id == board.id)
+                                    .count();
+                                let total_items = 1 + sprint_count;
+                                if dialog_state.item_selection < total_items.saturating_sub(1) {
+                                    dialog_state.item_selection += 1;
+                                } else {
+                                    dialog_state.next_section();
                                 }
                             }
                         }
-                        _ => {
-                            dialog_state.next_section();
-                        }
                     }
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    match dialog_state.current_section {
-                        FilterDialogSection::Sprints => {
-                            if dialog_state.item_selection > 0 {
-                                dialog_state.item_selection -= 1;
-                            } else {
-                                dialog_state.prev_section();
-                            }
-                        }
-                        _ => {
+                    _ => {
+                        dialog_state.next_section();
+                    }
+                },
+                KeyCode::Char('k') | KeyCode::Up => match dialog_state.current_section {
+                    FilterDialogSection::Sprints => {
+                        if dialog_state.item_selection > 0 {
+                            dialog_state.item_selection -= 1;
+                        } else {
                             dialog_state.prev_section();
                         }
                     }
-                }
+                    _ => {
+                        dialog_state.prev_section();
+                    }
+                },
                 KeyCode::Char(' ') => {
                     if dialog_state.current_section == FilterDialogSection::Sprints {
                         if dialog_state.item_selection == 0 {
@@ -87,7 +83,11 @@ impl App {
 
                                 let sprint_idx = dialog_state.item_selection - 1;
                                 if let Some(sprint) = board_sprints.get(sprint_idx) {
-                                    if dialog_state.filters.selected_sprint_ids.contains(&sprint.id) {
+                                    if dialog_state
+                                        .filters
+                                        .selected_sprint_ids
+                                        .contains(&sprint.id)
+                                    {
                                         dialog_state.filters.selected_sprint_ids.remove(&sprint.id);
                                     } else {
                                         dialog_state.filters.selected_sprint_ids.insert(sprint.id);

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -1,0 +1,76 @@
+use crate::app::{App, AppMode, Focus};
+use crate::filters::{CardFilters, FilterDialogState, FilterDialogSection};
+use crossterm::event::KeyCode;
+
+impl App {
+    pub fn handle_open_filter_dialog(&mut self) {
+        if self.focus != Focus::Cards || self.active_board_index.is_none() {
+            return;
+        }
+
+        let filters = CardFilters {
+            show_unassigned_sprints: self.hide_assigned_cards,
+            selected_sprint_ids: self.active_sprint_filter.iter().cloned().collect(),
+            date_from: None,
+            date_to: None,
+        };
+
+        self.filter_dialog_state = Some(FilterDialogState::new(filters));
+        self.mode = AppMode::FilterOptions;
+    }
+
+    pub fn handle_filter_options_popup(&mut self, key_code: KeyCode) {
+        use crossterm::event::KeyCode;
+
+        if let Some(ref mut dialog_state) = self.filter_dialog_state {
+            match key_code {
+                KeyCode::Esc => {
+                    self.filter_dialog_state = None;
+                    self.mode = AppMode::Normal;
+                }
+                KeyCode::Char('j') | KeyCode::Down => {
+                    dialog_state.section_selection = (dialog_state.section_selection + 1) % 3;
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    dialog_state.section_selection = if dialog_state.section_selection == 0 {
+                        2
+                    } else {
+                        dialog_state.section_selection - 1
+                    };
+                }
+                KeyCode::Char(' ') => {
+                    match dialog_state.current_section {
+                        FilterDialogSection::UnassignedSprints => {
+                            dialog_state.filters.show_unassigned_sprints =
+                                !dialog_state.filters.show_unassigned_sprints;
+                        }
+                        _ => {}
+                    }
+                }
+                KeyCode::Enter => {
+                    self.apply_filters();
+                    self.filter_dialog_state = None;
+                    self.mode = AppMode::Normal;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn apply_filters(&mut self) {
+        if let Some(dialog_state) = &self.filter_dialog_state {
+            self.hide_assigned_cards = dialog_state.filters.show_unassigned_sprints;
+
+            if !dialog_state.filters.selected_sprint_ids.is_empty() {
+                if let Some(sprint_id) = dialog_state.filters.selected_sprint_ids.iter().next() {
+                    self.active_sprint_filter = Some(*sprint_id);
+                }
+            } else {
+                self.active_sprint_filter = None;
+            }
+
+            self.refresh_view();
+            tracing::info!("Applied filters");
+        }
+    }
+}

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -68,41 +68,38 @@ impl App {
                     }
                 }
                 KeyCode::Char(' ') => {
-                    match dialog_state.current_section {
-                        FilterDialogSection::Sprints => {
-                            if dialog_state.item_selection == 0 {
-                                dialog_state.filters.show_unassigned_sprints =
-                                    !dialog_state.filters.show_unassigned_sprints;
-                                tracing::info!(
-                                    "Toggled unassigned sprints filter: {}",
-                                    dialog_state.filters.show_unassigned_sprints
-                                );
-                                self.apply_filters();
-                            } else if let Some(board_idx) = self.active_board_index {
-                                if let Some(board) = self.boards.get(board_idx) {
-                                    let board_sprints: Vec<_> = self
-                                        .sprints
-                                        .iter()
-                                        .filter(|s| s.board_id == board.id)
-                                        .collect();
+                    if dialog_state.current_section == FilterDialogSection::Sprints {
+                        if dialog_state.item_selection == 0 {
+                            dialog_state.filters.show_unassigned_sprints =
+                                !dialog_state.filters.show_unassigned_sprints;
+                            tracing::info!(
+                                "Toggled unassigned sprints filter: {}",
+                                dialog_state.filters.show_unassigned_sprints
+                            );
+                            self.apply_filters();
+                        } else if let Some(board_idx) = self.active_board_index {
+                            if let Some(board) = self.boards.get(board_idx) {
+                                let board_sprints: Vec<_> = self
+                                    .sprints
+                                    .iter()
+                                    .filter(|s| s.board_id == board.id)
+                                    .collect();
 
-                                    let sprint_idx = dialog_state.item_selection - 1;
-                                    if let Some(sprint) = board_sprints.get(sprint_idx) {
-                                        if dialog_state.filters.selected_sprint_ids.contains(&sprint.id) {
-                                            dialog_state.filters.selected_sprint_ids.remove(&sprint.id);
-                                        } else {
-                                            dialog_state.filters.selected_sprint_ids.insert(sprint.id);
-                                        }
-                                        tracing::info!(
-                                            "Toggled sprint: {}",
-                                            sprint.formatted_name(board, "sprint")
-                                        );
-                                        self.apply_filters();
+                                let sprint_idx = dialog_state.item_selection - 1;
+                                if let Some(sprint) = board_sprints.get(sprint_idx) {
+                                    if dialog_state.filters.selected_sprint_ids.contains(&sprint.id) {
+                                        dialog_state.filters.selected_sprint_ids.remove(&sprint.id);
+                                    } else {
+                                        dialog_state.filters.selected_sprint_ids.insert(sprint.id);
                                     }
+                                    tracing::info!(
+                                        "Toggled sprint: {}",
+                                        sprint.formatted_name(board, "sprint")
+                                    );
+                                    self.apply_filters();
                                 }
                             }
                         }
-                        _ => {}
                     }
                 }
                 KeyCode::Enter => {

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -78,6 +78,7 @@ impl App {
                                 "Toggled unassigned sprints filter: {}",
                                 dialog_state.filters.show_unassigned_sprints
                             );
+                            self.apply_filters();
                         }
                         FilterDialogSection::Sprints => {
                             if let Some(board_idx) = self.active_board_index {
@@ -98,6 +99,7 @@ impl App {
                                             "Toggled sprint: {}",
                                             sprint.formatted_name(board, "sprint")
                                         );
+                                        self.apply_filters();
                                     }
                                 }
                             }

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -10,7 +10,7 @@ impl App {
 
         let filters = CardFilters {
             show_unassigned_sprints: self.hide_assigned_cards,
-            selected_sprint_ids: self.active_sprint_filter.iter().cloned().collect(),
+            selected_sprint_ids: self.active_sprint_filters.clone(),
             date_from: None,
             date_to: None,
             selected_tags: Default::default(),
@@ -115,17 +115,14 @@ impl App {
     fn apply_filters(&mut self) {
         if let Some(dialog_state) = &self.filter_dialog_state {
             self.hide_assigned_cards = dialog_state.filters.show_unassigned_sprints;
-
-            if !dialog_state.filters.selected_sprint_ids.is_empty() {
-                if let Some(sprint_id) = dialog_state.filters.selected_sprint_ids.iter().next() {
-                    self.active_sprint_filter = Some(*sprint_id);
-                }
-            } else {
-                self.active_sprint_filter = None;
-            }
+            self.active_sprint_filters = dialog_state.filters.selected_sprint_ids.clone();
 
             self.refresh_view();
-            tracing::info!("Applied filters");
+            tracing::info!(
+                "Applied filters: unassigned={}, sprints={}",
+                self.hide_assigned_cards,
+                self.active_sprint_filters.len()
+            );
         }
     }
 }

--- a/crates/kanban-tui/src/handlers/mod.rs
+++ b/crates/kanban-tui/src/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod card_handlers;
 pub mod column_handlers;
 pub mod detail_view_handlers;
 pub mod dialog_handlers;
+pub mod filter_handlers;
 pub mod navigation_handlers;
 pub mod popup_handlers;
 pub mod sprint_handlers;

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -55,7 +55,7 @@ impl App {
                         if let Some(board) = self.boards.get_mut(board_idx) {
                             if board.active_sprint_id == Some(sprint_id) {
                                 board.active_sprint_id = None;
-                                self.active_sprint_filter = None;
+                                self.active_sprint_filters.remove(&sprint_id);
                             }
                         }
                     }

--- a/crates/kanban-tui/src/lib.rs
+++ b/crates/kanban-tui/src/lib.rs
@@ -8,6 +8,7 @@ pub mod dialog;
 pub mod editor;
 pub mod events;
 pub mod export;
+pub mod filters;
 pub mod handlers;
 pub mod input;
 pub mod markdown_renderer;

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -784,6 +784,7 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
         AppMode::ConfirmSprintPrefixCollision => {
             "ESC: cancel | j/k: navigate | ENTER: confirm".to_string()
         }
+        AppMode::FilterOptions => "ESC: cancel | j/k: navigate | Space: toggle | ENTER: apply".to_string(),
     };
     let help = Paragraph::new(help_text)
         .style(label_text())

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1521,7 +1521,7 @@ fn render_select_task_list_view_popup(app: &App, frame: &mut Frame) {
 }
 
 fn render_filter_options_popup(app: &App, frame: &mut Frame) {
-    let area = centered_rect(70, 60, frame.area());
+    let area = centered_rect(70, 80, frame.area());
     frame.render_widget(Clear, area);
 
     let block = Block::default()
@@ -1537,24 +1537,28 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
         .margin(2)
         .constraints([
             Constraint::Length(3),
-            Constraint::Length(5),
-            Constraint::Length(4),
+            Constraint::Min(6),
+            Constraint::Length(3),
+            Constraint::Length(3),
         ])
         .split(inner);
 
     if let Some(ref dialog_state) = app.filter_dialog_state {
-        let mut lines = vec![];
+        let section_index = dialog_state.section_index;
 
+        let mut lines = vec![];
         lines.push(Line::from(Span::styled(
             "Unassigned Sprints",
-            if dialog_state.section_selection == 0 {
+            if section_index == 0 {
                 bold_highlight()
             } else {
                 normal_text()
             },
         )));
+
+        let cursor = if section_index == 0 { "> " } else { "  " };
         lines.push(Line::from(vec![
-            Span::raw("  "),
+            Span::raw(cursor),
             Span::styled(
                 if dialog_state.filters.show_unassigned_sprints {
                     "[✓] Show cards with unassigned sprints"
@@ -1568,7 +1572,7 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
         let section1 = Paragraph::new(lines).block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(if dialog_state.section_selection == 0 {
+                .border_style(if section_index == 0 {
                     focused_border()
                 } else {
                     Style::default()
@@ -1578,7 +1582,7 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
 
         let mut sprint_lines = vec![Line::from(Span::styled(
             "Sprints",
-            if dialog_state.section_selection == 1 {
+            if section_index == 1 {
                 bold_highlight()
             } else {
                 normal_text()
@@ -1599,10 +1603,16 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
                         label_text(),
                     )));
                 } else {
-                    for sprint in board_sprints {
+                    for (idx, sprint) in board_sprints.iter().enumerate() {
                         let is_selected = dialog_state.filters.selected_sprint_ids.contains(&sprint.id);
+                        let cursor = if section_index == 1 && dialog_state.item_selection == idx {
+                            "> "
+                        } else {
+                            "  "
+                        };
+
                         sprint_lines.push(Line::from(vec![
-                            Span::raw("  "),
+                            Span::raw(cursor),
                             Span::styled(
                                 if is_selected { "[✓]" } else { "[ ]" },
                                 normal_text(),
@@ -1621,7 +1631,7 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
         let section2 = Paragraph::new(sprint_lines).block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(if dialog_state.section_selection == 1 {
+                .border_style(if section_index == 1 {
                     focused_border()
                 } else {
                     Style::default()
@@ -1629,24 +1639,56 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
         );
         frame.render_widget(section2, chunks[1]);
 
-        let date_lines = vec![Line::from(Span::styled(
-            "Date Range (Future)",
-            if dialog_state.section_selection == 2 {
-                bold_highlight()
-            } else {
-                label_text()
-            },
-        ))];
+        let date_lines = vec![
+            Line::from(Span::styled(
+                "Date Range (Future)",
+                if section_index == 2 {
+                    bold_highlight()
+                } else {
+                    label_text()
+                },
+            )),
+            Line::from(Span::styled(
+                "  Filter by last updated or created date",
+                label_text(),
+            )),
+        ];
 
         let section3 = Paragraph::new(date_lines).block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(if dialog_state.section_selection == 2 {
+                .border_style(if section_index == 2 {
                     focused_border()
                 } else {
                     Style::default()
                 }),
         );
         frame.render_widget(section3, chunks[2]);
+
+        let tag_lines = vec![
+            Line::from(Span::styled(
+                "Tags (Future)",
+                if section_index == 3 {
+                    bold_highlight()
+                } else {
+                    label_text()
+                },
+            )),
+            Line::from(Span::styled(
+                "  Filter cards by tags",
+                label_text(),
+            )),
+        ];
+
+        let section4 = Paragraph::new(tag_lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(if section_index == 3 {
+                    focused_border()
+                } else {
+                    Style::default()
+                }),
+        );
+        frame.render_widget(section4, chunks[3]);
     }
 }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1521,7 +1521,7 @@ fn render_select_task_list_view_popup(app: &App, frame: &mut Frame) {
 }
 
 fn render_filter_options_popup(app: &App, frame: &mut Frame) {
-    let area = centered_rect(70, 80, frame.area());
+    let area = centered_rect(70, 75, frame.area());
     frame.render_widget(Clear, area);
 
     let block = Block::default()
@@ -1536,8 +1536,7 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(3),
-            Constraint::Min(6),
+            Constraint::Min(8),
             Constraint::Length(3),
             Constraint::Length(3),
         ])
@@ -1546,48 +1545,36 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
     if let Some(ref dialog_state) = app.filter_dialog_state {
         let section_index = dialog_state.section_index;
 
-        let mut lines = vec![];
-        lines.push(Line::from(Span::styled(
-            "Unassigned Sprints",
+        let mut sprint_lines = vec![Line::from(Span::styled(
+            "Sprints",
             if section_index == 0 {
                 bold_highlight()
             } else {
                 normal_text()
             },
-        )));
+        ))];
 
-        let cursor = if section_index == 0 { "> " } else { "  " };
-        lines.push(Line::from(vec![
-            Span::raw(cursor),
+        let unassigned_cursor = if section_index == 0 && dialog_state.item_selection == 0 {
+            "> "
+        } else {
+            "  "
+        };
+
+        sprint_lines.push(Line::from(vec![
+            Span::raw(unassigned_cursor),
             Span::styled(
                 if dialog_state.filters.show_unassigned_sprints {
-                    "[✓] Show cards with unassigned sprints"
+                    "[✓]"
                 } else {
-                    "[ ] Show cards with unassigned sprints"
+                    "[ ]"
                 },
                 normal_text(),
             ),
+            Span::raw(" "),
+            Span::styled("Show cards with unassigned sprints", normal_text()),
         ]));
 
-        let section1 = Paragraph::new(lines).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(if section_index == 0 {
-                    focused_border()
-                } else {
-                    Style::default()
-                }),
-        );
-        frame.render_widget(section1, chunks[0]);
-
-        let mut sprint_lines = vec![Line::from(Span::styled(
-            "Sprints",
-            if section_index == 1 {
-                bold_highlight()
-            } else {
-                normal_text()
-            },
-        ))];
+        sprint_lines.push(Line::from(Span::styled("─────────────────────────", label_text())));
 
         if let Some(board_idx) = app.active_board_index {
             if let Some(board) = app.boards.get(board_idx) {
@@ -1605,7 +1592,7 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
                 } else {
                     for (idx, sprint) in board_sprints.iter().enumerate() {
                         let is_selected = dialog_state.filters.selected_sprint_ids.contains(&sprint.id);
-                        let cursor = if section_index == 1 && dialog_state.item_selection == idx {
+                        let cursor = if section_index == 0 && dialog_state.item_selection == idx + 1 {
                             "> "
                         } else {
                             "  "
@@ -1628,21 +1615,21 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
             }
         }
 
-        let section2 = Paragraph::new(sprint_lines).block(
+        let section1 = Paragraph::new(sprint_lines).block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(if section_index == 1 {
+                .border_style(if section_index == 0 {
                     focused_border()
                 } else {
                     Style::default()
                 }),
         );
-        frame.render_widget(section2, chunks[1]);
+        frame.render_widget(section1, chunks[0]);
 
         let date_lines = vec![
             Line::from(Span::styled(
                 "Date Range (Future)",
-                if section_index == 2 {
+                if section_index == 1 {
                     bold_highlight()
                 } else {
                     label_text()
@@ -1654,21 +1641,21 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
             )),
         ];
 
-        let section3 = Paragraph::new(date_lines).block(
+        let section2 = Paragraph::new(date_lines).block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(if section_index == 2 {
+                .border_style(if section_index == 1 {
                     focused_border()
                 } else {
                     Style::default()
                 }),
         );
-        frame.render_widget(section3, chunks[2]);
+        frame.render_widget(section2, chunks[1]);
 
         let tag_lines = vec![
             Line::from(Span::styled(
                 "Tags (Future)",
-                if section_index == 3 {
+                if section_index == 2 {
                     bold_highlight()
                 } else {
                     label_text()
@@ -1680,15 +1667,15 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
             )),
         ];
 
-        let section4 = Paragraph::new(tag_lines).block(
+        let section3 = Paragraph::new(tag_lines).block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(if section_index == 3 {
+                .border_style(if section_index == 2 {
                     focused_border()
                 } else {
                     Style::default()
                 }),
         );
-        frame.render_widget(section4, chunks[3]);
+        frame.render_widget(section3, chunks[2]);
     }
 }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1574,7 +1574,10 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
             Span::styled("Show cards with unassigned sprints", normal_text()),
         ]));
 
-        sprint_lines.push(Line::from(Span::styled("─────────────────────────", label_text())));
+        sprint_lines.push(Line::from(Span::styled(
+            "─────────────────────────",
+            label_text(),
+        )));
 
         if let Some(board_idx) = app.active_board_index {
             if let Some(board) = app.boards.get(board_idx) {
@@ -1591,8 +1594,12 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
                     )));
                 } else {
                     for (idx, sprint) in board_sprints.iter().enumerate() {
-                        let is_selected = dialog_state.filters.selected_sprint_ids.contains(&sprint.id);
-                        let cursor = if section_index == 0 && dialog_state.item_selection == idx + 1 {
+                        let is_selected = dialog_state
+                            .filters
+                            .selected_sprint_ids
+                            .contains(&sprint.id);
+                        let cursor = if section_index == 0 && dialog_state.item_selection == idx + 1
+                        {
                             "> "
                         } else {
                             "  "
@@ -1600,15 +1607,9 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
 
                         sprint_lines.push(Line::from(vec![
                             Span::raw(cursor),
-                            Span::styled(
-                                if is_selected { "[✓]" } else { "[ ]" },
-                                normal_text(),
-                            ),
+                            Span::styled(if is_selected { "[✓]" } else { "[ ]" }, normal_text()),
                             Span::raw(" "),
-                            Span::styled(
-                                sprint.formatted_name(board, "sprint"),
-                                normal_text(),
-                            ),
+                            Span::styled(sprint.formatted_name(board, "sprint"), normal_text()),
                         ]));
                     }
                 }
@@ -1641,15 +1642,14 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
             )),
         ];
 
-        let section2 = Paragraph::new(date_lines).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(if section_index == 1 {
+        let section2 =
+            Paragraph::new(date_lines).block(Block::default().borders(Borders::ALL).border_style(
+                if section_index == 1 {
                     focused_border()
                 } else {
                     Style::default()
-                }),
-        );
+                },
+            ));
         frame.render_widget(section2, chunks[1]);
 
         let tag_lines = vec![
@@ -1661,21 +1661,17 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
                     label_text()
                 },
             )),
-            Line::from(Span::styled(
-                "  Filter cards by tags",
-                label_text(),
-            )),
+            Line::from(Span::styled("  Filter cards by tags", label_text())),
         ];
 
-        let section3 = Paragraph::new(tag_lines).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(if section_index == 2 {
+        let section3 =
+            Paragraph::new(tag_lines).block(Block::default().borders(Borders::ALL).border_style(
+                if section_index == 2 {
                     focused_border()
                 } else {
                     Style::default()
-                }),
-        );
+                },
+            ));
         frame.render_widget(section3, chunks[2]);
     }
 }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -135,19 +135,28 @@ fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
 }
 
 fn build_filter_title_suffix(app: &App) -> Option<String> {
+    let mut filters = vec![];
+
+    if app.hide_assigned_cards {
+        filters.push("Unassigned Cards".to_string());
+    }
+
     if let Some(sprint_id) = app.active_sprint_filter {
         if let Some(sprint) = app.sprints.iter().find(|s| s.id == sprint_id) {
             if let Some(board_idx) = app.active_board_index.or(app.board_selection.get()) {
                 if let Some(board) = app.boards.get(board_idx) {
                     let sprint_name = sprint.formatted_name(board, "sprint");
-                    return Some(format!(" - {}", sprint_name));
+                    filters.push(sprint_name);
                 }
             }
         }
-    } else if app.hide_assigned_cards {
-        return Some(" - Unassigned Cards".to_string());
     }
-    None
+
+    if filters.is_empty() {
+        None
+    } else {
+        Some(format!(" - {}", filters.join(" + ")))
+    }
 }
 
 fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -141,13 +141,17 @@ fn build_filter_title_suffix(app: &App) -> Option<String> {
         filters.push("Unassigned Cards".to_string());
     }
 
-    if let Some(sprint_id) = app.active_sprint_filter {
-        if let Some(sprint) = app.sprints.iter().find(|s| s.id == sprint_id) {
-            if let Some(board_idx) = app.active_board_index.or(app.board_selection.get()) {
-                if let Some(board) = app.boards.get(board_idx) {
-                    let sprint_name = sprint.formatted_name(board, "sprint");
-                    filters.push(sprint_name);
-                }
+    if !app.active_sprint_filters.is_empty() {
+        if let Some(board_idx) = app.active_board_index.or(app.board_selection.get()) {
+            if let Some(board) = app.boards.get(board_idx) {
+                let mut sprint_names: Vec<String> = app
+                    .sprints
+                    .iter()
+                    .filter(|s| app.active_sprint_filters.contains(&s.id))
+                    .map(|s| s.formatted_name(board, "sprint"))
+                    .collect();
+                sprint_names.sort();
+                filters.extend(sprint_names);
             }
         }
     }
@@ -240,7 +244,7 @@ fn render_tasks_flat(app: &App, frame: &mut Frame, area: Rect) {
                                 is_selected: task_list.get_selected_index() == Some(card_idx),
                                 is_focused: app.focus == Focus::Cards,
                                 is_multi_selected: app.selected_cards.contains(&card.id),
-                                show_sprint_name: app.active_sprint_filter.is_none(),
+                                show_sprint_name: app.active_sprint_filters.is_empty(),
                             });
                             lines.push(line);
                         }
@@ -333,7 +337,7 @@ fn render_tasks_grouped_by_column(app: &App, frame: &mut Frame, area: Rect) {
                                             is_multi_selected: app
                                                 .selected_cards
                                                 .contains(&card.id),
-                                            show_sprint_name: app.active_sprint_filter.is_none(),
+                                            show_sprint_name: app.active_sprint_filters.is_empty(),
                                         });
                                         lines.push(line);
                                     }
@@ -428,7 +432,7 @@ fn render_tasks_kanban_view(app: &App, frame: &mut Frame, area: Rect) {
                                 is_selected,
                                 is_focused: app.focus == Focus::Cards && is_focused_column,
                                 is_multi_selected: app.selected_cards.contains(&card.id),
-                                show_sprint_name: app.active_sprint_filter.is_none(),
+                                show_sprint_name: app.active_sprint_filters.is_empty(),
                             });
                             lines.push(line);
                         }

--- a/crates/kanban-tui/src/view_strategy.rs
+++ b/crates/kanban-tui/src/view_strategy.rs
@@ -10,7 +10,7 @@ pub struct ViewRefreshContext<'a> {
     pub all_cards: &'a [Card],
     pub all_columns: &'a [Column],
     pub all_sprints: &'a [Sprint],
-    pub active_sprint_filter: Option<Uuid>,
+    pub active_sprint_filters: std::collections::HashSet<Uuid>,
     pub hide_assigned_cards: bool,
     pub search_query: Option<&'a str>,
 }
@@ -90,8 +90,12 @@ impl ViewStrategy for FlatViewStrategy {
                         return false;
                     }
                 }
-                if let Some(sprint_id) = ctx.active_sprint_filter {
-                    if c.sprint_id != Some(sprint_id) {
+                if !ctx.active_sprint_filters.is_empty() {
+                    if let Some(sprint_id) = c.sprint_id {
+                        if !ctx.active_sprint_filters.contains(&sprint_id) {
+                            return false;
+                        }
+                    } else {
                         return false;
                     }
                 }
@@ -232,8 +236,12 @@ impl ViewStrategy for GroupedViewStrategy {
                         return false;
                     }
                 }
-                if let Some(sprint_id) = ctx.active_sprint_filter {
-                    if c.sprint_id != Some(sprint_id) {
+                if !ctx.active_sprint_filters.is_empty() {
+                    if let Some(sprint_id) = c.sprint_id {
+                        if !ctx.active_sprint_filters.contains(&sprint_id) {
+                            return false;
+                        }
+                    } else {
                         return false;
                     }
                 }
@@ -406,8 +414,12 @@ impl ViewStrategy for KanbanViewStrategy {
                         return false;
                     }
                 }
-                if let Some(sprint_id) = ctx.active_sprint_filter {
-                    if c.sprint_id != Some(sprint_id) {
+                if !ctx.active_sprint_filters.is_empty() {
+                    if let Some(sprint_id) = c.sprint_id {
+                        if !ctx.active_sprint_filters.contains(&sprint_id) {
+                            return false;
+                        }
+                    } else {
                         return false;
                     }
                 }


### PR DESCRIPTION
## What

Refactored sprint filtering system to support filtering by multiple sprints simultaneously. The filter dialog now allows users to select/deselect multiple sprints, and the card list updates in real-time to show only cards from selected sprints.

- Changed `active_sprint_filter: Option<Uuid>` to `active_sprint_filters: HashSet<Uuid>` in app state
- Updated all filtering logic across app.rs, view_strategy.rs, and handlers to work with multi-sprint sets
- Filter dialog displays all active filters in header with " + " separator
- Merged unassigned sprints into Sprints section with visual graphical separator
- Live filter updates when toggling options (no need to close dialog)

## Why

Previously, the filter dialog UI allowed multi-select of sprints but only the first selected sprint was actually used for filtering. This created a mismatch between what users could select and what actually filtered. The system needed architectural changes to support true multi-sprint filtering with proper feedback.

## How

- Modified FilterDialogState and filtering logic to work with HashSet instead of Option
- Updated ViewRefreshContext to accept HashSet of sprint IDs
- Refactored all three view strategy implementations (Flat, Grouped, Kanban) with consistent multi-sprint filtering
- Implemented build_filter_title_suffix() to iterate and display all selected sprints
- Added immediate apply_filters() calls on toggle for real-time feedback

## Testing

- Verified multiple sprints can be selected and cards filter correctly
- Tested that deselecting sprints updates card list in real-time
- Confirmed filter header displays all active sprints with proper formatting
- Validated sprint completion correctly removes sprint from active filters
- All code formatted with `cargo fmt` and checked with `cargo clippy`