### PR TITLE
fix: prevent stdout pollution of GITHUB_OUTPUT in release workflow

### DIFF
--- a/.changeset/kan-117-workflows-and-releases.md
+++ b/.changeset/kan-117-workflows-and-releases.md
@@ -8,3 +8,4 @@ Update release flow
 - chore: update bump-version script to output new version
 - ci: enhance release workflow with version bump and changelog
 - ci: simplify aggregate-changesets workflow
+- fix: prevent stdout pollution of GITHUB_OUTPUT in release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,13 @@ jobs:
         if: steps.versions.outputs.should_release == 'true'
         id: bump
         run: |
-          bash scripts/aggregate-changesets.sh >> $GITHUB_OUTPUT || echo "bump_type=patch" >> $GITHUB_OUTPUT
+          bash scripts/aggregate-changesets.sh || echo "bump_type=patch" >> $GITHUB_OUTPUT
 
       - name: Bump version and update changelog
         if: steps.versions.outputs.should_release == 'true'
         id: new_version
         run: |
-          nix develop --command bash scripts/bump-version.sh "${{ steps.bump.outputs.bump_type }}" >> $GITHUB_OUTPUT
+          nix develop --command bash scripts/bump-version.sh "${{ steps.bump.outputs.bump_type }}"
 
       - name: Commit version bump
         if: steps.versions.outputs.should_release == 'true'

--- a/scripts/aggregate-changesets.sh
+++ b/scripts/aggregate-changesets.sh
@@ -31,4 +31,8 @@ elif echo "$BUMP_TYPES" | grep -q "minor"; then
 fi
 
 # Output in GitHub Actions format
-echo "bump_type=$HIGHEST_BUMP"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "bump_type=$HIGHEST_BUMP" >> "$GITHUB_OUTPUT"
+else
+  echo "bump_type=$HIGHEST_BUMP"
+fi


### PR DESCRIPTION
The bump-version and aggregate-changesets scripts were having their stdout appended to GITHUB_OUTPUT, mixing normal log output with key=value pairs. This caused GitHub Actions to fail with 'Invalid format' errors.

Changes:
- Update release.yml to not redirect stdout to GITHUB_OUTPUT
- Let scripts write to GITHUB_OUTPUT directly
- Update aggregate-changesets.sh to write to GITHUB_OUTPUT when available
- Maintain stdout output for local script testing