### PR TITLE
ci: automatically sync develop with master after release

### DIFF
--- a/.changeset/kan-117-workflows-and-releases.md
+++ b/.changeset/kan-117-workflows-and-releases.md
@@ -2,10 +2,4 @@
 bump: patch
 ---
 
-Update release flow
-
-- chore: remove unnecessary backup logic from update-changelog script
-- chore: update bump-version script to output new version
-- ci: enhance release workflow with version bump and changelog
-- ci: simplify aggregate-changesets workflow
-- fix: prevent stdout pollution of GITHUB_OUTPUT in release workflow
+- ci: automatically sync develop with master after release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,13 @@ jobs:
         with:
           tag_name: v${{ steps.new_version.outputs.new_version }}
           generate_release_notes: true
+
+      - name: Sync develop with master
+        if: steps.versions.outputs.should_release == 'true'
+        env:
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+        run: |
+          git checkout develop
+          git pull origin develop
+          git merge origin/master --no-edit
+          git push origin develop


### PR DESCRIPTION
After publishing and creating a GitHub release, automatically merge master back into develop to keep both branches in sync. This prevents drift where master has the version bump and changelog but develop doesn't.

The merge uses --no-edit to create a clean merge commit with the default message. Runs after all release steps (publish, tag, GitHub release) complete.