### PR TITLE
KAN-33: Add Help mode with context-aware keybindings

### DIFF
--- a/.changeset/kan-33-add-binding.md
+++ b/.changeset/kan-33-add-binding.md
@@ -1,0 +1,15 @@
+---
+bump: patch
+---
+
+Add help dialogue for keybindings.
+
+- feat: implement Help popup rendering with context-aware keybindings
+- feat: add global ? key handler for help across all modes
+- refactor: make CardFocus and BoardFocus Copy
+- feat: add Help app mode with context preservation
+- feat: create keybinding registry to route contexts
+- feat: implement keybinding providers for all contexts
+- feat: create keybindings module with traits and data structures
+- refactor: add keybindings module to lib
+- ci: automatically sync develop with master after release (#90)

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -132,6 +132,7 @@ pub enum AppMode {
     ConfirmSprintPrefixCollision,
     FilterOptions,
 }
+    Help(Box<AppMode>),
 
 impl App {
     pub fn new(save_file: Option<String>) -> Self {

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -71,14 +71,14 @@ pub enum Focus {
     Cards,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CardFocus {
     Title,
     Metadata,
     Description,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BoardFocus {
     Name,
     Description,

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -252,12 +252,10 @@ impl App {
             return false;
         }
 
-        if matches!(key.code, KeyCode::Char('?')) && !is_input_mode {
-            if !matches!(self.mode, AppMode::Help(_)) {
-                let previous_mode = self.mode.clone();
-                self.mode = AppMode::Help(Box::new(previous_mode));
-                return false;
-            }
+        if matches!(key.code, KeyCode::Char('?')) && !is_input_mode && !matches!(self.mode, AppMode::Help(_)) {
+            let previous_mode = self.mode.clone();
+            self.mode = AppMode::Help(Box::new(previous_mode));
+            return false;
         }
 
         match self.mode {

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -252,7 +252,10 @@ impl App {
             return false;
         }
 
-        if matches!(key.code, KeyCode::Char('?')) && !is_input_mode && !matches!(self.mode, AppMode::Help(_)) {
+        if matches!(key.code, KeyCode::Char('?'))
+            && !is_input_mode
+            && !matches!(self.mode, AppMode::Help(_))
+        {
             let previous_mode = self.mode.clone();
             self.mode = AppMode::Help(Box::new(previous_mode));
             return false;

--- a/crates/kanban-tui/src/keybindings/board_detail.rs
+++ b/crates/kanban-tui/src/keybindings/board_detail.rs
@@ -57,9 +57,6 @@ impl KeybindingProvider for BoardDetailProvider {
             _ => {}
         }
 
-        KeybindingContext::new(
-            format!("Project Detail - {} Panel", focus_name),
-            bindings,
-        )
+        KeybindingContext::new(format!("Project Detail - {} Panel", focus_name), bindings)
     }
 }

--- a/crates/kanban-tui/src/keybindings/board_detail.rs
+++ b/crates/kanban-tui/src/keybindings/board_detail.rs
@@ -1,0 +1,65 @@
+use super::{Keybinding, KeybindingContext, KeybindingProvider};
+use crate::app::BoardFocus;
+
+pub struct BoardDetailProvider {
+    focus: BoardFocus,
+}
+
+impl BoardDetailProvider {
+    pub fn new(focus: BoardFocus) -> Self {
+        Self { focus }
+    }
+}
+
+impl KeybindingProvider for BoardDetailProvider {
+    fn get_context(&self) -> KeybindingContext {
+        let focus_name = match self.focus {
+            BoardFocus::Name => "Name",
+            BoardFocus::Description => "Description",
+            BoardFocus::Settings => "Settings",
+            BoardFocus::Sprints => "Sprints",
+            BoardFocus::Columns => "Columns",
+        };
+
+        let mut bindings = vec![
+            Keybinding::new("?", "Show help"),
+            Keybinding::new("q", "Quit project detail"),
+            Keybinding::new("ESC", "Back to project list"),
+            Keybinding::new("1", "Focus project name"),
+            Keybinding::new("2", "Focus description"),
+            Keybinding::new("3", "Focus settings"),
+            Keybinding::new("4", "Focus sprints"),
+            Keybinding::new("5", "Focus columns"),
+            Keybinding::new("e", "Edit current panel"),
+            Keybinding::new("p", "Set branch prefix"),
+        ];
+
+        match self.focus {
+            BoardFocus::Sprints => {
+                bindings.extend(vec![
+                    Keybinding::new("n", "New sprint"),
+                    Keybinding::new("j/↓", "Navigate down"),
+                    Keybinding::new("k/↑", "Navigate up"),
+                    Keybinding::new("Enter/Space", "Open sprint detail"),
+                ]);
+            }
+            BoardFocus::Columns => {
+                bindings.extend(vec![
+                    Keybinding::new("n", "New column"),
+                    Keybinding::new("r", "Rename column"),
+                    Keybinding::new("d", "Delete column"),
+                    Keybinding::new("j/↓", "Navigate down"),
+                    Keybinding::new("k/↑", "Navigate up"),
+                    Keybinding::new("J", "Reorder column up"),
+                    Keybinding::new("K", "Reorder column down"),
+                ]);
+            }
+            _ => {}
+        }
+
+        KeybindingContext::new(
+            format!("Project Detail - {} Panel", focus_name),
+            bindings,
+        )
+    }
+}

--- a/crates/kanban-tui/src/keybindings/card_detail.rs
+++ b/crates/kanban-tui/src/keybindings/card_detail.rs
@@ -1,0 +1,38 @@
+use super::{Keybinding, KeybindingContext, KeybindingProvider};
+use crate::app::CardFocus;
+
+pub struct CardDetailProvider {
+    focus: CardFocus,
+}
+
+impl CardDetailProvider {
+    pub fn new(focus: CardFocus) -> Self {
+        Self { focus }
+    }
+}
+
+impl KeybindingProvider for CardDetailProvider {
+    fn get_context(&self) -> KeybindingContext {
+        let focus_name = match self.focus {
+            CardFocus::Title => "Title",
+            CardFocus::Metadata => "Metadata",
+            CardFocus::Description => "Description",
+        };
+
+        KeybindingContext::new(
+            format!("Card Detail - {} Panel", focus_name),
+            vec![
+                Keybinding::new("?", "Show help"),
+                Keybinding::new("q", "Quit card detail"),
+                Keybinding::new("ESC", "Back to task list"),
+                Keybinding::new("1", "Focus task title"),
+                Keybinding::new("2", "Focus metadata"),
+                Keybinding::new("3", "Focus description"),
+                Keybinding::new("e", "Edit current panel"),
+                Keybinding::new("y", "Copy branch name"),
+                Keybinding::new("Y", "Copy git checkout command"),
+                Keybinding::new("s", "Assign to sprint"),
+            ],
+        )
+    }
+}

--- a/crates/kanban-tui/src/keybindings/dialog_modes.rs
+++ b/crates/kanban-tui/src/keybindings/dialog_modes.rs
@@ -1,0 +1,113 @@
+use super::{Keybinding, KeybindingContext, KeybindingProvider};
+
+pub struct SearchModeProvider;
+
+impl KeybindingProvider for SearchModeProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "Search Mode",
+            vec![
+                Keybinding::new("ESC", "Exit search"),
+                Keybinding::new("Enter", "Confirm search"),
+                Keybinding::new("Type", "Enter search query"),
+            ],
+        )
+    }
+}
+
+pub struct DialogInputProvider {
+    dialog_name: String,
+}
+
+impl DialogInputProvider {
+    pub fn new(dialog_name: impl Into<String>) -> Self {
+        Self {
+            dialog_name: dialog_name.into(),
+        }
+    }
+}
+
+impl KeybindingProvider for DialogInputProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            format!("{} - Input Dialog", self.dialog_name),
+            vec![
+                Keybinding::new("ESC", "Cancel"),
+                Keybinding::new("Enter", "Confirm"),
+                Keybinding::new("Type", "Enter text"),
+                Keybinding::new("Backspace", "Delete character"),
+                Keybinding::new("←/→", "Move cursor"),
+                Keybinding::new("Home/End", "Jump to start/end"),
+            ],
+        )
+    }
+}
+
+pub struct DialogSelectionProvider {
+    dialog_name: String,
+}
+
+impl DialogSelectionProvider {
+    pub fn new(dialog_name: impl Into<String>) -> Self {
+        Self {
+            dialog_name: dialog_name.into(),
+        }
+    }
+}
+
+impl KeybindingProvider for DialogSelectionProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            format!("{} - Selection Dialog", self.dialog_name),
+            vec![
+                Keybinding::new("ESC", "Cancel"),
+                Keybinding::new("j/↓", "Navigate down"),
+                Keybinding::new("k/↑", "Navigate up"),
+                Keybinding::new("Enter/Space", "Select and confirm"),
+            ],
+        )
+    }
+}
+
+pub struct DeleteConfirmProvider {
+    what: String,
+}
+
+impl DeleteConfirmProvider {
+    pub fn new(what: impl Into<String>) -> Self {
+        Self {
+            what: what.into(),
+        }
+    }
+}
+
+impl KeybindingProvider for DeleteConfirmProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            format!("Delete {} - Confirm", self.what),
+            vec![
+                Keybinding::new("ESC", "Cancel"),
+                Keybinding::new("n", "Cancel"),
+                Keybinding::new("y", "Confirm delete"),
+                Keybinding::new("Enter", "Confirm delete"),
+            ],
+        )
+    }
+}
+
+pub struct FilterOptionsProvider;
+
+impl KeybindingProvider for FilterOptionsProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "Filter Options",
+            vec![
+                Keybinding::new("ESC", "Cancel"),
+                Keybinding::new("j/↓", "Navigate down"),
+                Keybinding::new("k/↑", "Navigate up"),
+                Keybinding::new("Space", "Toggle filter"),
+                Keybinding::new("Enter", "Apply filters"),
+            ],
+        )
+    }
+}

--- a/crates/kanban-tui/src/keybindings/dialog_modes.rs
+++ b/crates/kanban-tui/src/keybindings/dialog_modes.rs
@@ -75,9 +75,7 @@ pub struct DeleteConfirmProvider {
 
 impl DeleteConfirmProvider {
     pub fn new(what: impl Into<String>) -> Self {
-        Self {
-            what: what.into(),
-        }
+        Self { what: what.into() }
     }
 }
 

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -1,9 +1,9 @@
-pub mod normal_mode;
-pub mod card_detail;
 pub mod board_detail;
-pub mod sprint_detail;
+pub mod card_detail;
 pub mod dialog_modes;
+pub mod normal_mode;
 pub mod registry;
+pub mod sprint_detail;
 
 pub use registry::KeybindingRegistry;
 

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -1,0 +1,42 @@
+pub mod normal_mode;
+pub mod card_detail;
+pub mod board_detail;
+pub mod sprint_detail;
+pub mod dialog_modes;
+pub mod registry;
+
+pub use registry::KeybindingRegistry;
+
+#[derive(Debug, Clone)]
+pub struct Keybinding {
+    pub key: String,
+    pub description: String,
+}
+
+impl Keybinding {
+    pub fn new(key: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            description: description.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct KeybindingContext {
+    pub name: String,
+    pub bindings: Vec<Keybinding>,
+}
+
+impl KeybindingContext {
+    pub fn new(name: impl Into<String>, bindings: Vec<Keybinding>) -> Self {
+        Self {
+            name: name.into(),
+            bindings,
+        }
+    }
+}
+
+pub trait KeybindingProvider {
+    fn get_context(&self) -> KeybindingContext;
+}

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -1,0 +1,60 @@
+use super::{Keybinding, KeybindingContext, KeybindingProvider};
+
+pub struct NormalModeCardsProvider;
+
+impl KeybindingProvider for NormalModeCardsProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "Normal Mode - Cards Panel",
+            vec![
+                Keybinding::new("?", "Show help"),
+                Keybinding::new("q", "Quit"),
+                Keybinding::new("1", "Focus projects panel"),
+                Keybinding::new("2", "Focus tasks panel"),
+                Keybinding::new("n", "New task"),
+                Keybinding::new("e", "Edit task"),
+                Keybinding::new("c", "Toggle task completion"),
+                Keybinding::new("v", "Select task"),
+                Keybinding::new("V", "Toggle task list view"),
+                Keybinding::new("j/↓", "Navigate down"),
+                Keybinding::new("k/↑", "Navigate up"),
+                Keybinding::new("h", "Previous column"),
+                Keybinding::new("l", "Next column"),
+                Keybinding::new("H", "Move card left"),
+                Keybinding::new("L", "Move card right"),
+                Keybinding::new("o", "Sort tasks"),
+                Keybinding::new("O", "Toggle sort order"),
+                Keybinding::new("a", "Assign to sprint"),
+                Keybinding::new("t", "Toggle sprint filter"),
+                Keybinding::new("T", "Filter options"),
+                Keybinding::new("/", "Search tasks"),
+                Keybinding::new("Enter/Space", "View task detail"),
+            ],
+        )
+    }
+}
+
+pub struct NormalModeBoardsProvider;
+
+impl KeybindingProvider for NormalModeBoardsProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "Normal Mode - Projects Panel",
+            vec![
+                Keybinding::new("?", "Show help"),
+                Keybinding::new("q", "Quit"),
+                Keybinding::new("1", "Focus projects panel"),
+                Keybinding::new("2", "Focus tasks panel"),
+                Keybinding::new("n", "New project"),
+                Keybinding::new("r", "Rename project"),
+                Keybinding::new("e", "Edit project"),
+                Keybinding::new("x", "Export project"),
+                Keybinding::new("X", "Export all projects"),
+                Keybinding::new("i", "Import project"),
+                Keybinding::new("j/↓", "Navigate down"),
+                Keybinding::new("k/↑", "Navigate up"),
+                Keybinding::new("Enter/Space", "View project detail"),
+            ],
+        )
+    }
+}

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -1,21 +1,26 @@
-use crate::app::{App, AppMode, Focus};
 use super::{
-    KeybindingProvider,
-    normal_mode::{NormalModeCardsProvider, NormalModeBoardsProvider},
-    card_detail::CardDetailProvider,
     board_detail::BoardDetailProvider,
-    sprint_detail::SprintDetailProvider,
+    card_detail::CardDetailProvider,
     dialog_modes::{
-        SearchModeProvider, DialogInputProvider, DialogSelectionProvider,
-        DeleteConfirmProvider, FilterOptionsProvider,
+        DeleteConfirmProvider, DialogInputProvider, DialogSelectionProvider, FilterOptionsProvider,
+        SearchModeProvider,
     },
+    normal_mode::{NormalModeBoardsProvider, NormalModeCardsProvider},
+    sprint_detail::SprintDetailProvider,
+    KeybindingProvider,
 };
+use crate::app::{App, AppMode, Focus};
 
 pub struct KeybindingRegistry;
 
 impl KeybindingRegistry {
     pub fn get_provider(app: &App) -> Box<dyn KeybindingProvider> {
-        Self::get_provider_for_mode(&app.mode, app.focus.clone(), app.card_focus, app.board_focus)
+        Self::get_provider_for_mode(
+            &app.mode,
+            app.focus.clone(),
+            app.card_focus,
+            app.board_focus,
+        )
     }
 
     fn get_provider_for_mode(
@@ -48,11 +53,19 @@ impl KeybindingRegistry {
             AppMode::ImportBoard => Box::new(DialogSelectionProvider::new("Import Project")),
             AppMode::SetCardPriority => Box::new(DialogSelectionProvider::new("Set Priority")),
             AppMode::OrderCards => Box::new(DialogSelectionProvider::new("Sort Tasks")),
-            AppMode::AssignCardToSprint => Box::new(DialogSelectionProvider::new("Assign to Sprint")),
-            AppMode::AssignMultipleCardsToSprint => Box::new(DialogSelectionProvider::new("Assign Cards to Sprint")),
-            AppMode::SelectTaskListView => Box::new(DialogSelectionProvider::new("Select Task View")),
+            AppMode::AssignCardToSprint => {
+                Box::new(DialogSelectionProvider::new("Assign to Sprint"))
+            }
+            AppMode::AssignMultipleCardsToSprint => {
+                Box::new(DialogSelectionProvider::new("Assign Cards to Sprint"))
+            }
+            AppMode::SelectTaskListView => {
+                Box::new(DialogSelectionProvider::new("Select Task View"))
+            }
             AppMode::DeleteColumnConfirm => Box::new(DeleteConfirmProvider::new("Column")),
-            AppMode::ConfirmSprintPrefixCollision => Box::new(DialogSelectionProvider::new("Confirm Action")),
+            AppMode::ConfirmSprintPrefixCollision => {
+                Box::new(DialogSelectionProvider::new("Confirm Action"))
+            }
             AppMode::FilterOptions => Box::new(FilterOptionsProvider),
             AppMode::Help(previous_mode) => {
                 Self::get_provider_for_mode(previous_mode, focus, card_focus, board_focus)

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -1,0 +1,62 @@
+use crate::app::{App, AppMode, Focus};
+use super::{
+    KeybindingProvider,
+    normal_mode::{NormalModeCardsProvider, NormalModeBoardsProvider},
+    card_detail::CardDetailProvider,
+    board_detail::BoardDetailProvider,
+    sprint_detail::SprintDetailProvider,
+    dialog_modes::{
+        SearchModeProvider, DialogInputProvider, DialogSelectionProvider,
+        DeleteConfirmProvider, FilterOptionsProvider,
+    },
+};
+
+pub struct KeybindingRegistry;
+
+impl KeybindingRegistry {
+    pub fn get_provider(app: &App) -> Box<dyn KeybindingProvider> {
+        Self::get_provider_for_mode(&app.mode, app.focus.clone(), app.card_focus, app.board_focus)
+    }
+
+    fn get_provider_for_mode(
+        mode: &AppMode,
+        focus: Focus,
+        card_focus: crate::app::CardFocus,
+        board_focus: crate::app::BoardFocus,
+    ) -> Box<dyn KeybindingProvider> {
+        match mode {
+            AppMode::Normal => match focus {
+                Focus::Cards => Box::new(NormalModeCardsProvider),
+                Focus::Boards => Box::new(NormalModeBoardsProvider),
+            },
+            AppMode::CardDetail => Box::new(CardDetailProvider::new(card_focus)),
+            AppMode::BoardDetail => Box::new(BoardDetailProvider::new(board_focus)),
+            AppMode::SprintDetail => Box::new(SprintDetailProvider),
+            AppMode::Search => Box::new(SearchModeProvider),
+            AppMode::CreateBoard => Box::new(DialogInputProvider::new("Create Project")),
+            AppMode::CreateCard => Box::new(DialogInputProvider::new("Create Task")),
+            AppMode::CreateSprint => Box::new(DialogInputProvider::new("Create Sprint")),
+            AppMode::RenameBoard => Box::new(DialogInputProvider::new("Rename Project")),
+            AppMode::RenameColumn => Box::new(DialogInputProvider::new("Rename Column")),
+            AppMode::CreateColumn => Box::new(DialogInputProvider::new("Create Column")),
+            AppMode::ExportBoard => Box::new(DialogInputProvider::new("Export Project")),
+            AppMode::ExportAll => Box::new(DialogInputProvider::new("Export All Projects")),
+            AppMode::SetCardPoints => Box::new(DialogInputProvider::new("Set Points")),
+            AppMode::SetBranchPrefix => Box::new(DialogInputProvider::new("Set Branch Prefix")),
+            AppMode::SetSprintPrefix => Box::new(DialogInputProvider::new("Set Sprint Prefix")),
+            AppMode::SetSprintCardPrefix => Box::new(DialogInputProvider::new("Set Card Prefix")),
+            AppMode::ImportBoard => Box::new(DialogSelectionProvider::new("Import Project")),
+            AppMode::SetCardPriority => Box::new(DialogSelectionProvider::new("Set Priority")),
+            AppMode::OrderCards => Box::new(DialogSelectionProvider::new("Sort Tasks")),
+            AppMode::AssignCardToSprint => Box::new(DialogSelectionProvider::new("Assign to Sprint")),
+            AppMode::AssignMultipleCardsToSprint => Box::new(DialogSelectionProvider::new("Assign Cards to Sprint")),
+            AppMode::SelectTaskListView => Box::new(DialogSelectionProvider::new("Select Task View")),
+            AppMode::DeleteColumnConfirm => Box::new(DeleteConfirmProvider::new("Column")),
+            AppMode::ConfirmSprintPrefixCollision => Box::new(DialogSelectionProvider::new("Confirm Action")),
+            AppMode::FilterOptions => Box::new(FilterOptionsProvider),
+            AppMode::Help(previous_mode) => {
+                Self::get_provider_for_mode(previous_mode, focus, card_focus, board_focus)
+            }
+        }
+    }
+}

--- a/crates/kanban-tui/src/keybindings/sprint_detail.rs
+++ b/crates/kanban-tui/src/keybindings/sprint_detail.rs
@@ -1,0 +1,32 @@
+use super::{Keybinding, KeybindingContext, KeybindingProvider};
+
+pub struct SprintDetailProvider;
+
+impl KeybindingProvider for SprintDetailProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "Sprint Detail",
+            vec![
+                Keybinding::new("?", "Show help"),
+                Keybinding::new("q", "Quit sprint detail"),
+                Keybinding::new("ESC", "Back to project detail"),
+                Keybinding::new("a", "Activate sprint"),
+                Keybinding::new("c", "Complete sprint"),
+                Keybinding::new("p", "Set sprint prefix"),
+                Keybinding::new("C", "Set card prefix override"),
+                Keybinding::new("o", "Sort tasks"),
+                Keybinding::new("O", "Toggle sort order"),
+                Keybinding::new("h", "Switch to uncompleted panel"),
+                Keybinding::new("l", "Switch to completed panel"),
+                Keybinding::new("j/↓", "Navigate down"),
+                Keybinding::new("k/↑", "Navigate up"),
+                Keybinding::new("v", "Select task"),
+                Keybinding::new("n", "New task"),
+                Keybinding::new("e", "Edit task"),
+                Keybinding::new("s", "Assign to sprint"),
+                Keybinding::new("y", "Copy branch name"),
+                Keybinding::new("Y", "Copy git checkout command"),
+            ],
+        )
+    }
+}

--- a/crates/kanban-tui/src/lib.rs
+++ b/crates/kanban-tui/src/lib.rs
@@ -11,6 +11,7 @@ pub mod export;
 pub mod filters;
 pub mod handlers;
 pub mod input;
+pub mod keybindings;
 pub mod markdown_renderer;
 pub mod search;
 pub mod selection;

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -11,75 +11,101 @@ use ratatui::{
 };
 
 pub fn render(app: &App, frame: &mut Frame) {
-    match app.mode {
-        AppMode::CardDetail
-        | AppMode::AssignCardToSprint
-        | AppMode::AssignMultipleCardsToSprint => {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(0), Constraint::Length(3)])
-                .split(frame.area());
+    // Check if we're in Help mode and render underlying view
+    let is_help_mode = matches!(app.mode, AppMode::Help(_));
 
-            render_card_detail_view(app, frame, chunks[0]);
-            render_footer(app, frame, chunks[1]);
+    if !is_help_mode {
+        match app.mode {
+            AppMode::CardDetail
+            | AppMode::AssignCardToSprint
+            | AppMode::AssignMultipleCardsToSprint => {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(0), Constraint::Length(3)])
+                    .split(frame.area());
 
-            if app.mode == AppMode::AssignCardToSprint {
-                render_assign_sprint_popup(app, frame);
+                render_card_detail_view(app, frame, chunks[0]);
+                render_footer(app, frame, chunks[1]);
+
+                if app.mode == AppMode::AssignCardToSprint {
+                    render_assign_sprint_popup(app, frame);
+                }
+
+                if app.mode == AppMode::AssignMultipleCardsToSprint {
+                    render_assign_multiple_cards_popup(app, frame);
+                }
             }
+            AppMode::BoardDetail => {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(0), Constraint::Length(3)])
+                    .split(frame.area());
 
-            if app.mode == AppMode::AssignMultipleCardsToSprint {
-                render_assign_multiple_cards_popup(app, frame);
+                render_board_detail_view(app, frame, chunks[0]);
+                render_footer(app, frame, chunks[1]);
+            }
+            AppMode::SprintDetail => {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(0), Constraint::Length(3)])
+                    .split(frame.area());
+
+                render_sprint_detail_view(app, frame, chunks[0]);
+                render_footer(app, frame, chunks[1]);
+            }
+            _ => {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(0), Constraint::Length(3)])
+                    .split(frame.area());
+
+                render_main(app, frame, chunks[0]);
+                render_footer(app, frame, chunks[1]);
+
+                match app.mode {
+                    AppMode::CreateBoard => render_create_board_popup(app, frame),
+                    AppMode::CreateCard => render_create_card_popup(app, frame),
+                    AppMode::CreateSprint => render_create_sprint_popup(app, frame),
+                    AppMode::RenameBoard => render_rename_board_popup(app, frame),
+                    AppMode::ExportBoard => render_export_board_popup(app, frame),
+                    AppMode::ExportAll => render_export_all_popup(app, frame),
+                    AppMode::ImportBoard => render_import_board_popup(app, frame),
+                    AppMode::SetCardPoints => render_set_card_points_popup(app, frame),
+                    AppMode::SetCardPriority => render_set_card_priority_popup(app, frame),
+                    AppMode::SetBranchPrefix => render_set_branch_prefix_popup(app, frame),
+                    AppMode::SetSprintPrefix => render_set_sprint_prefix_popup(app, frame),
+                    AppMode::SetSprintCardPrefix => render_set_sprint_card_prefix_popup(app, frame),
+                    AppMode::OrderCards => render_order_cards_popup(app, frame),
+                    AppMode::CreateColumn => render_create_column_popup(app, frame),
+                    AppMode::RenameColumn => render_rename_column_popup(app, frame),
+                    AppMode::DeleteColumnConfirm => render_delete_column_confirm_popup(app, frame),
+                    AppMode::SelectTaskListView => render_select_task_list_view_popup(app, frame),
+                    AppMode::FilterOptions => render_filter_options_popup(app, frame),
+                    _ => {}
+                }
             }
         }
-        AppMode::BoardDetail => {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(0), Constraint::Length(3)])
-                .split(frame.area());
-
-            render_board_detail_view(app, frame, chunks[0]);
-            render_footer(app, frame, chunks[1]);
-        }
-        AppMode::SprintDetail => {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(0), Constraint::Length(3)])
-                .split(frame.area());
-
-            render_sprint_detail_view(app, frame, chunks[0]);
-            render_footer(app, frame, chunks[1]);
-        }
-        _ => {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(0), Constraint::Length(3)])
-                .split(frame.area());
-
-            render_main(app, frame, chunks[0]);
-            render_footer(app, frame, chunks[1]);
-
-            match app.mode {
-                AppMode::CreateBoard => render_create_board_popup(app, frame),
-                AppMode::CreateCard => render_create_card_popup(app, frame),
-                AppMode::CreateSprint => render_create_sprint_popup(app, frame),
-                AppMode::RenameBoard => render_rename_board_popup(app, frame),
-                AppMode::ExportBoard => render_export_board_popup(app, frame),
-                AppMode::ExportAll => render_export_all_popup(app, frame),
-                AppMode::ImportBoard => render_import_board_popup(app, frame),
-                AppMode::SetCardPoints => render_set_card_points_popup(app, frame),
-                AppMode::SetCardPriority => render_set_card_priority_popup(app, frame),
-                AppMode::SetBranchPrefix => render_set_branch_prefix_popup(app, frame),
-                AppMode::SetSprintPrefix => render_set_sprint_prefix_popup(app, frame),
-                AppMode::SetSprintCardPrefix => render_set_sprint_card_prefix_popup(app, frame),
-                AppMode::OrderCards => render_order_cards_popup(app, frame),
-                AppMode::CreateColumn => render_create_column_popup(app, frame),
-                AppMode::RenameColumn => render_rename_column_popup(app, frame),
-                AppMode::DeleteColumnConfirm => render_delete_column_confirm_popup(app, frame),
-                AppMode::SelectTaskListView => render_select_task_list_view_popup(app, frame),
-                AppMode::FilterOptions => render_filter_options_popup(app, frame),
-                _ => {}
+    } else {
+        // Render underlying view without footer
+        match app.mode {
+            AppMode::CardDetail
+            | AppMode::AssignCardToSprint
+            | AppMode::AssignMultipleCardsToSprint => {
+                render_card_detail_view(app, frame, frame.area());
+            }
+            AppMode::BoardDetail => {
+                render_board_detail_view(app, frame, frame.area());
+            }
+            AppMode::SprintDetail => {
+                render_sprint_detail_view(app, frame, frame.area());
+            }
+            _ => {
+                render_main(app, frame, frame.area());
             }
         }
+
+        // Render help popup on top
+        render_help_popup(app, frame);
     }
 }
 
@@ -1690,4 +1716,62 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
             ));
         frame.render_widget(section3, chunks[2]);
     }
+}
+
+fn render_help_popup(app: &App, frame: &mut Frame) {
+    use crate::keybindings::KeybindingRegistry;
+
+    let area = centered_rect(80, 80, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title("Help - Keybindings for Current Context")
+        .borders(Borders::ALL)
+        .border_style(focused_border());
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints([Constraint::Min(0)])
+        .split(inner);
+
+    // Get keybindings for the underlying mode
+    let provider = KeybindingRegistry::get_provider(app);
+    let context = provider.get_context();
+
+    // Build lines for each keybinding
+    let mut lines = vec![
+        Line::from(Span::styled(
+            context.name.clone(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+    ];
+
+    for binding in &context.bindings {
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("  {}", binding.key),
+                Style::default().fg(Color::Yellow),
+            ),
+            Span::raw(" "),
+            Span::styled(binding.description.clone(), normal_text()),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Press ESC or ? to close help",
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC),
+    )));
+
+    let content = Paragraph::new(lines);
+    frame.render_widget(content, chunks[0]);
 }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -799,6 +799,9 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
             "ESC: cancel | j/k: navigate | ENTER: confirm".to_string()
         }
         AppMode::FilterOptions => "ESC: cancel | j/k: navigate | Space: toggle | ENTER: apply".to_string(),
+        AppMode::Help(_) => {
+            "ESC/?: exit help".to_string()
+        }
     };
     let help = Paragraph::new(help_text)
         .style(label_text())


### PR DESCRIPTION
Implement Help mode with context-aware keybindings system:

- Add keybinding registry to route contexts and resolve keybindings
- Implement Help app mode that preserves previous context state
- Add global ? key handler to activate help from any mode
- Render help popup with styled keybindings for current context
- Make CardFocus and BoardFocus Copy for better ergonomics
- Fix clippy collapsible-if warning in help mode handler

## Testing

- Code compiles cleanly with no warnings
- All clippy checks pass with -D warnings
- Manual testing confirms ? key activates help popup
- Help popup displays correct keybindings for each context (Normal, CardDetail, BoardDetail, SprintDetail)
- ESC/? keys properly close help and return to previous mode