### PR TITLE
KAN-118/unfilter-tasks-list-on-completed-sprint

### DIFF
--- a/.changeset/kan-118-unfilter-tasks-list-on-completed-sprint.md
+++ b/.changeset/kan-118-unfilter-tasks-list-on-completed-sprint.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Remove filtering of cards from completed sprints
+
+- fix: remove auto-hiding of completed sprint cards from app methods
+- fix: remove auto-hiding of completed sprint cards from view strategies

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -389,12 +389,6 @@ impl App {
 
     pub fn get_board_card_count(&self, board_id: uuid::Uuid) -> usize {
         let board_filter = BoardFilter::new(board_id, &self.columns);
-        let completed_sprint_ids: std::collections::HashSet<uuid::Uuid> = self
-            .sprints
-            .iter()
-            .filter(|s| s.status == kanban_domain::SprintStatus::Completed)
-            .map(|s| s.id)
-            .collect();
 
         let cards: Vec<_> = self
             .cards
@@ -402,11 +396,6 @@ impl App {
             .filter(|c| {
                 if !board_filter.matches(c) {
                     return false;
-                }
-                if let Some(sprint_id) = c.sprint_id {
-                    if completed_sprint_ids.contains(&sprint_id) {
-                        return false;
-                    }
                 }
                 true
             })
@@ -440,24 +429,12 @@ impl App {
         let board = self.boards.iter().find(|b| b.id == board_id).unwrap();
         let board_filter = BoardFilter::new(board_id, &self.columns);
 
-        let completed_sprint_ids: std::collections::HashSet<uuid::Uuid> = self
-            .sprints
-            .iter()
-            .filter(|s| s.status == kanban_domain::SprintStatus::Completed)
-            .map(|s| s.id)
-            .collect();
-
         let mut cards: Vec<&Card> = self
             .cards
             .iter()
             .filter(|c| {
                 if !board_filter.matches(c) {
                     return false;
-                }
-                if let Some(sprint_id) = c.sprint_id {
-                    if completed_sprint_ids.contains(&sprint_id) {
-                        return false;
-                    }
                 }
                 if !self.active_sprint_filters.is_empty() {
                     if let Some(sprint_id) = c.sprint_id {

--- a/crates/kanban-tui/src/view_strategy.rs
+++ b/crates/kanban-tui/src/view_strategy.rs
@@ -2,7 +2,7 @@ use crate::card_list::{CardList, CardListId};
 use crate::search::{CardSearcher, CompositeCardSearcher};
 use crate::services::filter::CardFilter;
 use crate::services::{get_sorter_for_field, BoardFilter, OrderedSorter};
-use kanban_domain::{Board, Card, Column, Sprint, SprintStatus};
+use kanban_domain::{Board, Card, Column, Sprint};
 use uuid::Uuid;
 
 pub struct ViewRefreshContext<'a> {
@@ -67,13 +67,6 @@ impl ViewStrategy for FlatViewStrategy {
     fn refresh_task_lists(&mut self, ctx: &ViewRefreshContext) {
         let board_filter = BoardFilter::new(ctx.board.id, ctx.all_columns);
 
-        let completed_sprint_ids: std::collections::HashSet<Uuid> = ctx
-            .all_sprints
-            .iter()
-            .filter(|s| s.status == SprintStatus::Completed)
-            .map(|s| s.id)
-            .collect();
-
         let search_filter = ctx
             .search_query
             .map(|q| CompositeCardSearcher::new(q.to_string()));
@@ -84,11 +77,6 @@ impl ViewStrategy for FlatViewStrategy {
             .filter(|c| {
                 if !board_filter.matches(c) {
                     return false;
-                }
-                if let Some(sprint_id) = c.sprint_id {
-                    if completed_sprint_ids.contains(&sprint_id) {
-                        return false;
-                    }
                 }
                 if !ctx.active_sprint_filters.is_empty() {
                     if let Some(sprint_id) = c.sprint_id {
@@ -213,13 +201,6 @@ impl ViewStrategy for GroupedViewStrategy {
 
         let board_filter = BoardFilter::new(ctx.board.id, ctx.all_columns);
 
-        let completed_sprint_ids: std::collections::HashSet<Uuid> = ctx
-            .all_sprints
-            .iter()
-            .filter(|s| s.status == SprintStatus::Completed)
-            .map(|s| s.id)
-            .collect();
-
         let search_filter = ctx
             .search_query
             .map(|q| CompositeCardSearcher::new(q.to_string()));
@@ -230,11 +211,6 @@ impl ViewStrategy for GroupedViewStrategy {
             .filter(|c| {
                 if !board_filter.matches(c) {
                     return false;
-                }
-                if let Some(sprint_id) = c.sprint_id {
-                    if completed_sprint_ids.contains(&sprint_id) {
-                        return false;
-                    }
                 }
                 if !ctx.active_sprint_filters.is_empty() {
                     if let Some(sprint_id) = c.sprint_id {
@@ -391,13 +367,6 @@ impl ViewStrategy for KanbanViewStrategy {
 
         let board_filter = BoardFilter::new(ctx.board.id, ctx.all_columns);
 
-        let completed_sprint_ids: std::collections::HashSet<Uuid> = ctx
-            .all_sprints
-            .iter()
-            .filter(|s| s.status == SprintStatus::Completed)
-            .map(|s| s.id)
-            .collect();
-
         let search_filter = ctx
             .search_query
             .map(|q| CompositeCardSearcher::new(q.to_string()));
@@ -408,11 +377,6 @@ impl ViewStrategy for KanbanViewStrategy {
             .filter(|c| {
                 if !board_filter.matches(c) {
                     return false;
-                }
-                if let Some(sprint_id) = c.sprint_id {
-                    if completed_sprint_ids.contains(&sprint_id) {
-                        return false;
-                    }
                 }
                 if !ctx.active_sprint_filters.is_empty() {
                     if let Some(sprint_id) = c.sprint_id {


### PR DESCRIPTION
## Summary

Allow cards from completed sprints to be displayed in card lists, while preserving per-sprint filtering functionality.

## Changes

- Remove auto-hiding of completed sprint cards from all view strategies (Flat, Grouped, Kanban)
- Remove completed sprint filtering from `get_board_card_count()` and `get_sorted_board_cards()` utility methods
- Preserve `active_sprint_filters` and `hide_assigned_cards` logic so sprint-specific filtering still works

## Why

Previously, cards in completed sprints were automatically hidden from all card lists. This prevented users from viewing or working with completed sprint cards even when using the sprint filter feature. The fix allows users to see completed sprint cards and work with them while keeping the per-sprint filtering capability intact.

## How

Removed the `completed_sprint_ids` collection and filtering logic that was checking if a card's sprint was in the completed sprints set. The active sprint filter and hide unassigned cards features remain functional.

## Testing

- ✅ Build passes (`cargo build`)
- ✅ All tests pass (`cargo test`)
- ✅ Clippy checks pass with no warnings
- ✅ Manually tested that cards from all sprints (including completed ones) are now visible in card lists
- ✅ Verified sprint filter selection (T key) still works to filter by specific sprints