### PR TITLE
KAN-55/scroll-in-cards-list

### DIFF
--- a/.changeset/kan-55-scroll-in-cards-list.md
+++ b/.changeset/kan-55-scroll-in-cards-list.md
@@ -1,0 +1,27 @@
+---
+bump: patch
+---
+
+- fix: ensure forward progress when viewport shrinks during down navigation
+- fix: correct viewport height calculation across all renderers
+- feat: add viewport calculation infrastructure to CardList
+- fix: allow scrolling down to show the final card
+- feat: update navigation to account for scroll indicator space
+- feat: add scroll indicators showing tasks above and below viewport
+- feat: use actual viewport_height instead of hardcoded value
+- feat: calculate and update viewport_height during rendering
+- feat: add viewport_height tracking to App
+- fix: eliminate selector jitter by moving selection with scroll
+- refactor: remove preemptive ensure_selected_visible calls
+- refactor: update CardListComponent navigate methods for viewport awareness
+- refactor: implement scroll-on-boundary logic in navigate methods
+- feat: wire up automatic scroll adjustment on navigation
+- feat: implement scroll-aware rendering for sprint detail panels
+- feat: implement scroll-aware rendering in all card list views
+- feat: expose scroll management in CardListComponent
+- feat: add scroll offset tracking to CardList
+- KAN-130/three-card-list-components-to-become-one (#94)
+- KAN-118/unfilter-tasks-list-on-completed-sprint (#93)
+- KAN-111/sprint-binding-help-is-wrong (#92)
+- KAN-33: Add Help mode with context-aware keybindings (#91)
+- ci: automatically sync develop with master after release (#90)

--- a/.changeset/kan-55-scroll-in-cards-list.md
+++ b/.changeset/kan-55-scroll-in-cards-list.md
@@ -20,8 +20,3 @@ bump: patch
 - feat: implement scroll-aware rendering in all card list views
 - feat: expose scroll management in CardListComponent
 - feat: add scroll offset tracking to CardList
-- KAN-130/three-card-list-components-to-become-one (#94)
-- KAN-118/unfilter-tasks-list-on-completed-sprint (#93)
-- KAN-111/sprint-binding-help-is-wrong (#92)
-- KAN-33: Add Help mode with context-aware keybindings (#91)
-- ci: automatically sync develop with master after release (#90)

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -61,6 +61,7 @@ pub struct App {
     pub card_list_component: CardListComponent,
     pub search: SearchState,
     pub filter_dialog_state: Option<FilterDialogState>,
+    pub viewport_height: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -198,6 +199,7 @@ impl App {
             ),
             search: SearchState::new(),
             filter_dialog_state: None,
+            viewport_height: 20,
         };
 
         if let Some(ref filename) = save_file {

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -12,6 +12,7 @@ pub struct CardList {
     pub id: CardListId,
     pub cards: Vec<Uuid>,
     pub selection: SelectionState,
+    pub scroll_offset: usize,
 }
 
 impl CardList {
@@ -20,6 +21,7 @@ impl CardList {
             id,
             cards: Vec::new(),
             selection: SelectionState::new(),
+            scroll_offset: 0,
         }
     }
 
@@ -105,6 +107,31 @@ impl CardList {
             }
         } else {
             self.selection.clear();
+        }
+    }
+
+    pub fn get_scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn set_scroll_offset(&mut self, offset: usize) {
+        self.scroll_offset = offset.min(self.cards.len().saturating_sub(1));
+    }
+
+    pub fn ensure_selected_visible(&mut self, viewport_height: usize) {
+        if viewport_height == 0 {
+            return;
+        }
+
+        if let Some(selected_idx) = self.selection.get() {
+            let scroll_start = self.scroll_offset;
+            let scroll_end = scroll_start + viewport_height;
+
+            if selected_idx < scroll_start {
+                self.scroll_offset = selected_idx;
+            } else if selected_idx >= scroll_end {
+                self.scroll_offset = selected_idx.saturating_sub(viewport_height - 1);
+            }
         }
     }
 }

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -75,6 +75,7 @@ impl CardList {
 
             if current_idx == self.scroll_offset && self.scroll_offset > 0 {
                 self.scroll_offset = self.scroll_offset.saturating_sub(1);
+                self.selection.prev();
             } else {
                 self.selection.prev();
             }
@@ -96,6 +97,7 @@ impl CardList {
 
             if current_idx == viewport_bottom && self.scroll_offset < max_scroll {
                 self.scroll_offset = self.scroll_offset.saturating_add(1);
+                self.selection.next(self.cards.len());
             } else {
                 self.selection.next(self.cards.len());
             }

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -64,21 +64,43 @@ impl CardList {
         }
     }
 
-    pub fn navigate_up(&mut self) -> bool {
+    pub fn navigate_up(&mut self, _viewport_height: usize) -> bool {
         if self.cards.is_empty() {
             return true;
         }
         let was_at_top = self.selection.get() == Some(0) || self.selection.get().is_none();
-        self.selection.prev();
+
+        if !was_at_top {
+            let current_idx = self.selection.get().unwrap_or(0);
+
+            if current_idx == self.scroll_offset && self.scroll_offset > 0 {
+                self.scroll_offset = self.scroll_offset.saturating_sub(1);
+            } else {
+                self.selection.prev();
+            }
+        }
+
         was_at_top
     }
 
-    pub fn navigate_down(&mut self) -> bool {
+    pub fn navigate_down(&mut self, viewport_height: usize) -> bool {
         if self.cards.is_empty() {
             return true;
         }
         let was_at_bottom = self.selection.get() == Some(self.cards.len() - 1);
-        self.selection.next(self.cards.len());
+
+        if !was_at_bottom {
+            let current_idx = self.selection.get().unwrap_or(0);
+            let viewport_bottom = self.scroll_offset + viewport_height.saturating_sub(1);
+            let max_scroll = self.cards.len().saturating_sub(viewport_height.max(1));
+
+            if current_idx == viewport_bottom && self.scroll_offset < max_scroll {
+                self.scroll_offset = self.scroll_offset.saturating_add(1);
+            } else {
+                self.selection.next(self.cards.len());
+            }
+        }
+
         was_at_bottom
     }
 

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -89,7 +89,11 @@ impl CardList {
 
         if !was_at_top {
             let current_idx = self.selection.get().unwrap_or(0);
-            let render_start = if self.scroll_offset == 1 { 0 } else { self.scroll_offset };
+            let render_start = if self.scroll_offset == 1 {
+                0
+            } else {
+                self.scroll_offset
+            };
             let first_visible_idx = render_start;
 
             if current_idx == first_visible_idx && self.scroll_offset > 0 {
@@ -98,7 +102,11 @@ impl CardList {
                 self.scroll_offset = self.scroll_offset.saturating_sub(1);
 
                 loop {
-                    let current_render_start = if self.scroll_offset == 1 { 0 } else { self.scroll_offset };
+                    let current_render_start = if self.scroll_offset == 1 {
+                        0
+                    } else {
+                        self.scroll_offset
+                    };
                     if target_selection >= current_render_start || self.scroll_offset == 0 {
                         break;
                     }
@@ -126,10 +134,12 @@ impl CardList {
             let current_idx = self.selection.get().unwrap_or(0);
 
             let info = self.calculate_viewport_info(viewport_height);
-            let render_start = if self.scroll_offset == 1 { 0 } else { self.scroll_offset };
-            let actual_cards_to_show = (render_start..total_cards)
-                .take(info.cards_to_show)
-                .count();
+            let render_start = if self.scroll_offset == 1 {
+                0
+            } else {
+                self.scroll_offset
+            };
+            let actual_cards_to_show = (render_start..total_cards).take(info.cards_to_show).count();
             let last_visible_idx = render_start + actual_cards_to_show.saturating_sub(1);
 
             if current_idx == last_visible_idx && current_idx < total_cards - 1 {
@@ -138,7 +148,11 @@ impl CardList {
                 self.scroll_offset = self.scroll_offset.saturating_add(1);
 
                 let mut new_info = self.calculate_viewport_info(viewport_height);
-                let mut new_render_start = if self.scroll_offset == 1 { 0 } else { self.scroll_offset };
+                let mut new_render_start = if self.scroll_offset == 1 {
+                    0
+                } else {
+                    self.scroll_offset
+                };
                 let mut new_actual_cards = (new_render_start..total_cards)
                     .take(new_info.cards_to_show)
                     .count();
@@ -148,7 +162,11 @@ impl CardList {
                 while target_selection > new_last_visible_idx && target_selection < total_cards {
                     self.scroll_offset = self.scroll_offset.saturating_add(1);
                     new_info = self.calculate_viewport_info(viewport_height);
-                    new_render_start = if self.scroll_offset == 1 { 0 } else { self.scroll_offset };
+                    new_render_start = if self.scroll_offset == 1 {
+                        0
+                    } else {
+                        self.scroll_offset
+                    };
                     new_actual_cards = (new_render_start..total_cards)
                         .take(new_info.cards_to_show)
                         .count();
@@ -249,7 +267,11 @@ impl CardList {
 
         let info = self.calculate_viewport_info(viewport_height);
 
-        let render_start = if self.scroll_offset == 1 { 0 } else { self.scroll_offset };
+        let render_start = if self.scroll_offset == 1 {
+            0
+        } else {
+            self.scroll_offset
+        };
 
         let visible_indices: Vec<usize> = (0..info.cards_to_show)
             .map(|i| render_start + i)
@@ -279,7 +301,11 @@ impl CardList {
 
         if let Some(selected_idx) = self.selection.get() {
             let info = self.calculate_viewport_info(viewport_height);
-            let render_start = if self.scroll_offset == 1 { 0 } else { self.scroll_offset };
+            let render_start = if self.scroll_offset == 1 {
+                0
+            } else {
+                self.scroll_offset
+            };
             let first_visible = render_start;
             let last_visible = render_start + info.cards_to_show.saturating_sub(1);
 

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -129,7 +129,8 @@ impl CardList {
                 let mut new_actual_cards = (self.scroll_offset..total_cards)
                     .take(new_info.cards_to_show)
                     .count();
-                let mut new_last_visible_idx = self.scroll_offset + new_actual_cards.saturating_sub(1);
+                let mut new_last_visible_idx =
+                    self.scroll_offset + new_actual_cards.saturating_sub(1);
 
                 while target_selection > new_last_visible_idx && target_selection < total_cards {
                     self.scroll_offset = self.scroll_offset.saturating_add(1);
@@ -265,7 +266,9 @@ impl CardList {
             let first_visible = self.scroll_offset;
             let last_visible = self.scroll_offset + info.cards_to_show.saturating_sub(1);
 
-            let clamped = selected_idx.max(first_visible).min(last_visible.min(self.cards.len() - 1));
+            let clamped = selected_idx
+                .max(first_visible)
+                .min(last_visible.min(self.cards.len() - 1));
             self.selection.set(Some(clamped));
         }
     }
@@ -348,7 +351,10 @@ mod tests {
         assert_eq!(last_visible, 13);
         assert_eq!(info.cards_below_count, 2);
 
-        assert!(info.show_below_indicator, "Should show indicator for cards 14 and 15");
+        assert!(
+            info.show_below_indicator,
+            "Should show indicator for cards 14 and 15"
+        );
     }
 
     #[test]
@@ -454,11 +460,18 @@ mod tests {
 
         let info = list.get_render_info(48);
         assert_eq!(info.cards_above_count, 46);
-        assert!(!info.show_below_indicator, "Last card should have no 'below' indicator");
+        assert!(
+            !info.show_below_indicator,
+            "Last card should have no 'below' indicator"
+        );
 
         list.navigate_down(48);
 
-        assert_eq!(list.get_selected_index(), Some(92), "Should stay at last card (92)");
+        assert_eq!(
+            list.get_selected_index(),
+            Some(92),
+            "Should stay at last card (92)"
+        );
     }
 
     #[test]
@@ -479,7 +492,11 @@ mod tests {
             }
         }
 
-        assert_eq!(list.get_selected_index(), Some(92), "Should reach the last card");
+        assert_eq!(
+            list.get_selected_index(),
+            Some(92),
+            "Should reach the last card"
+        );
     }
 
     #[test]
@@ -489,14 +506,20 @@ mod tests {
         list.selection.set(Some(92));
 
         let info_before = list.get_render_info(50);
-        assert!(info_before.show_above_indicator, "Should have 'above' indicator");
+        assert!(
+            info_before.show_above_indicator,
+            "Should have 'above' indicator"
+        );
 
         let has_below_before = info_before.show_below_indicator;
 
         list.navigate_down(50);
 
         let info_after = list.get_render_info(50);
-        assert!(info_after.show_above_indicator, "Should still have 'above' indicator");
+        assert!(
+            info_after.show_above_indicator,
+            "Should still have 'above' indicator"
+        );
 
         assert_eq!(
             list.get_selected_index(),
@@ -529,6 +552,9 @@ mod tests {
             "Should reach card 116 after {} iterations",
             iterations
         );
-        assert!(iterations < 120, "Should reach last card in reasonable iterations");
+        assert!(
+            iterations < 120,
+            "Should reach last card in reasonable iterations"
+        );
     }
 }

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -89,7 +89,6 @@ impl CardList {
 
         if !was_at_top {
             let current_idx = self.selection.get().unwrap_or(0);
-            let _info = self.calculate_viewport_info(viewport_height);
             let first_visible_idx = self.scroll_offset;
 
             if current_idx == first_visible_idx && self.scroll_offset > 0 {

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -92,8 +92,15 @@ impl CardList {
             let first_visible_idx = self.scroll_offset;
 
             if current_idx == first_visible_idx && self.scroll_offset > 0 {
+                let target_selection = current_idx.saturating_sub(1);
+
                 self.scroll_offset = self.scroll_offset.saturating_sub(1);
-                self.selection.prev();
+
+                while target_selection < self.scroll_offset && self.scroll_offset > 0 {
+                    self.scroll_offset = self.scroll_offset.saturating_sub(1);
+                }
+
+                self.selection.set(Some(target_selection));
             } else if current_idx > first_visible_idx {
                 self.selection.prev();
             }

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -113,8 +113,8 @@ impl CardList {
             // Last visible card index in absolute terms
             let last_visible_idx = self.scroll_offset + visible_cards.saturating_sub(1);
 
-            // If at last visible card and there are more cards to scroll to, scroll and move selection
-            if current_idx == last_visible_idx && self.scroll_offset + visible_cards < total_cards {
+            // If at last visible card and the last visible is not the actual last card, scroll and move selection
+            if current_idx == last_visible_idx && last_visible_idx < total_cards - 1 {
                 self.scroll_offset = self.scroll_offset.saturating_add(1);
 
                 // After scrolling, recalculate the new last visible position based on updated state

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -273,6 +273,34 @@ impl CardList {
     }
 }
 
+/// Helper function to render scroll indicators based on render info
+pub fn render_scroll_indicators(render_info: &CardListRenderInfo) -> Vec<ratatui::text::Line<'_>> {
+    use ratatui::style::{Color, Style};
+    use ratatui::text::{Line, Span};
+
+    let mut lines = Vec::new();
+
+    if render_info.show_above_indicator {
+        let count = render_info.cards_above_count;
+        let plural = if count == 1 { "" } else { "s" };
+        lines.push(Line::from(Span::styled(
+            format!("  {} Task{} above", count, plural),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    if render_info.show_below_indicator {
+        let count = render_info.cards_below_count;
+        let plural = if count == 1 { "" } else { "s" };
+        lines.push(Line::from(Span::styled(
+            format!("  {} Task{} below", count, plural),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    lines
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -8,6 +8,23 @@ pub enum CardListId {
     Column(Uuid),
 }
 
+#[derive(Debug, Clone)]
+struct ViewportInfo {
+    has_cards_above: bool,
+    has_cards_below: bool,
+    cards_to_show: usize,
+    total_cards: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct CardListRenderInfo {
+    pub visible_card_indices: Vec<usize>,
+    pub show_above_indicator: bool,
+    pub cards_above_count: usize,
+    pub show_below_indicator: bool,
+    pub cards_below_count: usize,
+}
+
 pub struct CardList {
     pub id: CardListId,
     pub cards: Vec<Uuid>,
@@ -72,22 +89,15 @@ impl CardList {
 
         if !was_at_top {
             let current_idx = self.selection.get().unwrap_or(0);
+            let _info = self.calculate_viewport_info(viewport_height);
+            let first_visible_idx = self.scroll_offset;
 
-            // Check if there's a "cards above" indicator
-            let has_cards_above = self.scroll_offset > 0;
-
-            // First visible card index (accounting for "cards above" indicator)
-            let first_visible_idx = self.scroll_offset + (if has_cards_above { 1 } else { 0 });
-
-            // If at first visible card and there are cards above, scroll up and move selection
             if current_idx == first_visible_idx && self.scroll_offset > 0 {
                 self.scroll_offset = self.scroll_offset.saturating_sub(1);
                 self.selection.prev();
             } else if current_idx > first_visible_idx {
-                // Can move selection without scrolling (we're past the first visible position)
                 self.selection.prev();
             }
-            // If at first visible and can't scroll more, stay in place (don't call prev)
         }
 
         self.clamp_selection_to_visible(viewport_height);
@@ -104,33 +114,24 @@ impl CardList {
         if !was_at_bottom {
             let current_idx = self.selection.get().unwrap_or(0);
 
-            // Calculate indicator space to determine actual visible cards
-            let has_cards_above = self.scroll_offset > 0;
-            let has_cards_below = self.scroll_offset + viewport_height < total_cards;
-            let num_indicators = (has_cards_above as usize) + (has_cards_below as usize);
-            let visible_cards = viewport_height.saturating_sub(num_indicators);
+            let info = self.calculate_viewport_info(viewport_height);
+            let actual_cards_to_show = (self.scroll_offset..total_cards)
+                .take(info.cards_to_show)
+                .count();
+            let last_visible_idx = self.scroll_offset + actual_cards_to_show.saturating_sub(1);
 
-            // Last visible card index in absolute terms
-            let last_visible_idx = self.scroll_offset + visible_cards.saturating_sub(1);
-
-            // If at last visible card and the last visible is not the actual last card, scroll and move selection
-            if current_idx == last_visible_idx && last_visible_idx < total_cards - 1 {
+            if current_idx == last_visible_idx && current_idx < total_cards - 1 {
                 self.scroll_offset = self.scroll_offset.saturating_add(1);
 
-                // After scrolling, recalculate the new last visible position based on updated state
-                let new_has_cards_above = self.scroll_offset > 0;
-                let new_has_cards_below = self.scroll_offset + viewport_height < total_cards;
-                let new_num_indicators = (new_has_cards_above as usize) + (new_has_cards_below as usize);
-                let new_visible_cards = viewport_height.saturating_sub(new_num_indicators);
-                let new_last_visible_idx = self.scroll_offset + new_visible_cards.saturating_sub(1);
-
-                // Move selection to the new last visible position
+                let new_info = self.calculate_viewport_info(viewport_height);
+                let new_actual_cards = (self.scroll_offset..total_cards)
+                    .take(new_info.cards_to_show)
+                    .count();
+                let new_last_visible_idx = self.scroll_offset + new_actual_cards.saturating_sub(1);
                 self.selection.set(Some(new_last_visible_idx.min(total_cards - 1)));
             } else if current_idx < last_visible_idx {
-                // Can move selection without scrolling
                 self.selection.next(total_cards);
             }
-            // If at last visible and can't scroll more, stay in place (don't call next)
         }
 
         self.clamp_selection_to_visible(viewport_height);
@@ -190,25 +191,331 @@ impl CardList {
         }
     }
 
+    fn calculate_viewport_info(&self, viewport_height: usize) -> ViewportInfo {
+        let total_cards = self.cards.len();
+        let has_cards_above = self.scroll_offset > 0;
+
+        let available_space = viewport_height.saturating_sub(has_cards_above as usize);
+        let has_cards_below = self.scroll_offset + available_space < total_cards;
+
+        let num_indicator_lines = (has_cards_above as usize) + (has_cards_below as usize);
+        let cards_to_show = viewport_height.saturating_sub(num_indicator_lines);
+
+        ViewportInfo {
+            has_cards_above,
+            has_cards_below,
+            cards_to_show,
+            total_cards,
+        }
+    }
+
+    pub fn get_render_info(&self, viewport_height: usize) -> CardListRenderInfo {
+        if self.cards.is_empty() {
+            return CardListRenderInfo {
+                visible_card_indices: Vec::new(),
+                show_above_indicator: false,
+                cards_above_count: 0,
+                show_below_indicator: false,
+                cards_below_count: 0,
+            };
+        }
+
+        let info = self.calculate_viewport_info(viewport_height);
+
+        let visible_indices: Vec<usize> = (0..info.cards_to_show)
+            .map(|i| self.scroll_offset + i)
+            .filter(|&idx| idx < self.cards.len())
+            .collect();
+
+        let cards_below_count = if visible_indices.is_empty() {
+            info.total_cards.saturating_sub(self.scroll_offset)
+        } else {
+            let last_visible_idx = *visible_indices.last().unwrap();
+            info.total_cards.saturating_sub(last_visible_idx + 1)
+        };
+
+        CardListRenderInfo {
+            visible_card_indices: visible_indices,
+            show_above_indicator: info.has_cards_above,
+            cards_above_count: self.scroll_offset,
+            show_below_indicator: info.has_cards_below,
+            cards_below_count,
+        }
+    }
+
     pub fn clamp_selection_to_visible(&mut self, viewport_height: usize) {
         if self.cards.is_empty() {
             return;
         }
 
         if let Some(selected_idx) = self.selection.get() {
-            // Calculate indicators for current scroll state
-            let has_cards_above = self.scroll_offset > 0;
-            let has_cards_below = self.scroll_offset + viewport_height < self.cards.len();
-            let num_indicators = (has_cards_above as usize) + (has_cards_below as usize);
-            let visible_cards = viewport_height.saturating_sub(num_indicators);
+            let info = self.calculate_viewport_info(viewport_height);
+            let first_visible = self.scroll_offset;
+            let last_visible = self.scroll_offset + info.cards_to_show.saturating_sub(1);
 
-            // First and last visible card positions
-            let first_visible = self.scroll_offset + (if has_cards_above { 1 } else { 0 });
-            let last_visible = self.scroll_offset + visible_cards.saturating_sub(1);
-
-            // Clamp selection to visible range
             let clamped = selected_idx.max(first_visible).min(last_visible.min(self.cards.len() - 1));
             self.selection.set(Some(clamped));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_list_with_cards(count: usize) -> CardList {
+        let cards = (0..count).map(|_| Uuid::new_v4()).collect();
+        CardList::with_cards(CardListId::All, cards)
+    }
+
+    #[test]
+    fn test_empty_list_render_info() {
+        let list = CardList::new(CardListId::All);
+        let info = list.get_render_info(10);
+
+        assert!(info.visible_card_indices.is_empty());
+        assert!(!info.show_above_indicator);
+        assert!(!info.show_below_indicator);
+        assert_eq!(info.cards_above_count, 0);
+        assert_eq!(info.cards_below_count, 0);
+    }
+
+    #[test]
+    fn test_single_card_no_scrolling() {
+        let list = create_list_with_cards(1);
+        let info = list.get_render_info(10);
+
+        assert_eq!(info.visible_card_indices, vec![0]);
+        assert!(!info.show_above_indicator);
+        assert!(!info.show_below_indicator);
+        assert_eq!(info.cards_below_count, 0);
+    }
+
+    #[test]
+    fn test_viewport_exactly_fits_cards() {
+        let list = create_list_with_cards(5);
+        let info = list.get_render_info(5);
+
+        assert_eq!(info.visible_card_indices, vec![0, 1, 2, 3, 4]);
+        assert!(!info.show_above_indicator);
+        assert!(!info.show_below_indicator);
+    }
+
+    #[test]
+    fn test_cards_below_indicator() {
+        let list = create_list_with_cards(10);
+        let info = list.get_render_info(5);
+
+        assert_eq!(info.visible_card_indices, vec![0, 1, 2, 3]);
+        assert!(!info.show_above_indicator);
+        assert!(info.show_below_indicator);
+        assert_eq!(info.cards_below_count, 6);
+    }
+
+    #[test]
+    fn test_cards_above_and_below_indicators() {
+        let mut list = create_list_with_cards(16);
+        list.scroll_offset = 6;
+
+        let info = list.get_render_info(10);
+
+        assert!(info.show_above_indicator);
+        assert_eq!(info.cards_above_count, 6);
+        assert!(info.show_below_indicator);
+        assert_eq!(info.cards_below_count, 2);
+    }
+
+    #[test]
+    fn test_bug_scenario_card_15_visibility() {
+        let mut list = create_list_with_cards(16);
+        list.scroll_offset = 6;
+
+        let info = list.get_render_info(10);
+
+        let last_visible = *info.visible_card_indices.last().unwrap();
+        assert_eq!(last_visible, 13);
+        assert_eq!(info.cards_below_count, 2);
+
+        assert!(info.show_below_indicator, "Should show indicator for cards 14 and 15");
+    }
+
+    #[test]
+    fn test_scroll_to_last_card_visible() {
+        let mut list = create_list_with_cards(16);
+        list.scroll_offset = 15;
+
+        let info = list.get_render_info(10);
+
+        assert_eq!(info.visible_card_indices, vec![15]);
+        assert!(info.show_above_indicator);
+        assert!(!info.show_below_indicator);
+        assert_eq!(info.cards_below_count, 0);
+    }
+
+    #[test]
+    fn test_viewport_height_accounting_for_indicators() {
+        let mut list = create_list_with_cards(20);
+        list.scroll_offset = 5;
+
+        let info = list.get_render_info(10);
+
+        assert!(info.show_above_indicator);
+        assert!(info.show_below_indicator);
+
+        let cards_shown = info.visible_card_indices.len();
+        assert_eq!(cards_shown, 8);
+    }
+
+    #[test]
+    fn test_navigate_down_from_middle() {
+        let mut list = create_list_with_cards(20);
+        list.selection.set(Some(5));
+
+        list.navigate_down(10);
+
+        assert_eq!(list.get_selected_index(), Some(6));
+        assert_eq!(list.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_navigate_down_triggers_scroll() {
+        let mut list = create_list_with_cards(20);
+        list.selection.set(Some(8));
+        list.scroll_offset = 0;
+
+        list.navigate_down(10);
+
+        assert_eq!(list.scroll_offset, 1);
+    }
+
+    #[test]
+    fn test_navigate_up_from_middle() {
+        let mut list = create_list_with_cards(20);
+        list.selection.set(Some(5));
+        list.scroll_offset = 0;
+
+        list.navigate_up(10);
+
+        assert_eq!(list.get_selected_index(), Some(4));
+    }
+
+    #[test]
+    fn test_navigate_up_triggers_scroll() {
+        let mut list = create_list_with_cards(20);
+        list.selection.set(Some(5));
+        list.scroll_offset = 5;
+
+        list.navigate_up(10);
+
+        assert_eq!(list.scroll_offset, 4);
+    }
+
+    #[test]
+    fn test_clamp_selection_with_above_indicator() {
+        let mut list = create_list_with_cards(20);
+        list.selection.set(Some(0));
+        list.scroll_offset = 5;
+
+        list.clamp_selection_to_visible(10);
+
+        assert!(list.get_selected_index().unwrap() >= 5);
+    }
+
+    #[test]
+    fn test_render_info_indices_are_valid() {
+        let mut list = create_list_with_cards(20);
+        list.scroll_offset = 8;
+
+        let info = list.get_render_info(7);
+
+        for idx in &info.visible_card_indices {
+            assert!(*idx < list.cards.len(), "Index {} out of bounds", idx);
+        }
+    }
+
+    #[test]
+    fn test_navigate_to_last_card_with_many_cards_above() {
+        let mut list = create_list_with_cards(93);
+        list.scroll_offset = 46;
+        list.selection.set(Some(92));
+
+        let info = list.get_render_info(48);
+        assert_eq!(info.cards_above_count, 46);
+        assert!(!info.show_below_indicator, "Last card should have no 'below' indicator");
+
+        list.navigate_down(48);
+
+        assert_eq!(list.get_selected_index(), Some(92), "Should stay at last card (92)");
+    }
+
+    #[test]
+    fn test_select_all_cards_from_start_to_end() {
+        let mut list = create_list_with_cards(93);
+        list.selection.set(Some(0));
+
+        for _ in 0..92 {
+            let before_idx = list.get_selected_index();
+            list.navigate_down(48);
+            let after_idx = list.get_selected_index();
+
+            if before_idx.is_some() && after_idx.is_some() {
+                assert!(
+                    after_idx.unwrap() >= before_idx.unwrap(),
+                    "Selection should move down or stay"
+                );
+            }
+        }
+
+        assert_eq!(list.get_selected_index(), Some(92), "Should reach the last card");
+    }
+
+    #[test]
+    fn test_indicator_space_changes_on_scroll_boundary() {
+        let mut list = create_list_with_cards(93);
+        list.scroll_offset = 45;
+        list.selection.set(Some(92));
+
+        let info_before = list.get_render_info(50);
+        assert!(info_before.show_above_indicator, "Should have 'above' indicator");
+
+        let has_below_before = info_before.show_below_indicator;
+
+        list.navigate_down(50);
+
+        let info_after = list.get_render_info(50);
+        assert!(info_after.show_above_indicator, "Should still have 'above' indicator");
+
+        assert_eq!(
+            list.get_selected_index(),
+            Some(92),
+            "Should stay at last card"
+        );
+
+        if has_below_before {
+            assert!(
+                !info_after.show_below_indicator,
+                "Below indicator should disappear at the end"
+            );
+        }
+    }
+
+    #[test]
+    fn test_scroll_through_all_117_cards() {
+        let mut list = create_list_with_cards(117);
+        list.selection.set(Some(0));
+
+        let mut iterations = 0;
+        while list.get_selected_index() != Some(116) && iterations < 200 {
+            list.navigate_down(48);
+            iterations += 1;
+        }
+
+        assert_eq!(
+            list.get_selected_index(),
+            Some(116),
+            "Should reach card 116 after {} iterations",
+            iterations
+        );
+        assert!(iterations < 120, "Should reach last card in reasonable iterations");
     }
 }

--- a/crates/kanban-tui/src/card_list_component.rs
+++ b/crates/kanban-tui/src/card_list_component.rs
@@ -149,6 +149,7 @@ pub struct CardListComponent {
     pub card_list: CardList,
     pub config: CardListComponentConfig,
     pub multi_selected: std::collections::HashSet<Uuid>,
+    pub viewport_height: usize,
 }
 
 impl CardListComponent {
@@ -157,6 +158,7 @@ impl CardListComponent {
             card_list: CardList::new(list_id),
             config,
             multi_selected: std::collections::HashSet::new(),
+            viewport_height: 20,
         }
     }
 
@@ -245,7 +247,7 @@ impl CardListComponent {
                     .config
                     .is_action_enabled(&CardListActionType::Navigation)
                 {
-                    self.navigate_down(1000);
+                    self.navigate_down(self.viewport_height);
                 }
                 None
             }
@@ -254,7 +256,7 @@ impl CardListComponent {
                     .config
                     .is_action_enabled(&CardListActionType::Navigation)
                 {
-                    self.navigate_up(1000);
+                    self.navigate_up(self.viewport_height);
                 }
                 None
             }

--- a/crates/kanban-tui/src/card_list_component.rs
+++ b/crates/kanban-tui/src/card_list_component.rs
@@ -222,6 +222,18 @@ impl CardListComponent {
         self.card_list.set_selected_index(index);
     }
 
+    pub fn get_scroll_offset(&self) -> usize {
+        self.card_list.get_scroll_offset()
+    }
+
+    pub fn set_scroll_offset(&mut self, offset: usize) {
+        self.card_list.set_scroll_offset(offset);
+    }
+
+    pub fn ensure_selected_visible(&mut self, viewport_height: usize) {
+        self.card_list.ensure_selected_visible(viewport_height);
+    }
+
     pub fn help_text(&self) -> String {
         self.config.help_text()
     }

--- a/crates/kanban-tui/src/card_list_component.rs
+++ b/crates/kanban-tui/src/card_list_component.rs
@@ -198,12 +198,12 @@ impl CardListComponent {
         }
     }
 
-    pub fn navigate_up(&mut self) -> bool {
-        self.card_list.navigate_up()
+    pub fn navigate_up(&mut self, viewport_height: usize) -> bool {
+        self.card_list.navigate_up(viewport_height)
     }
 
-    pub fn navigate_down(&mut self) -> bool {
-        self.card_list.navigate_down()
+    pub fn navigate_down(&mut self, viewport_height: usize) -> bool {
+        self.card_list.navigate_down(viewport_height)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -245,7 +245,7 @@ impl CardListComponent {
                     .config
                     .is_action_enabled(&CardListActionType::Navigation)
                 {
-                    self.navigate_down();
+                    self.navigate_down(1000);
                 }
                 None
             }
@@ -254,7 +254,7 @@ impl CardListComponent {
                     .config
                     .is_action_enabled(&CardListActionType::Navigation)
                 {
-                    self.navigate_up();
+                    self.navigate_up(1000);
                 }
                 None
             }

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -86,7 +86,7 @@ impl App {
                         if let Some(list) = self.view_strategy.get_active_task_list_mut() {
                             if !list.is_empty() {
                                 list.set_selected_index(Some(0));
-                                list.ensure_selected_visible(20);
+                                list.ensure_selected_visible(self.viewport_height);
                             }
                         }
                     }
@@ -159,7 +159,7 @@ impl App {
                     } else if list.get_selected_index().is_none() {
                         list.set_selected_index(Some(0));
                     }
-                    list.ensure_selected_visible(20);
+                    list.ensure_selected_visible(self.viewport_height);
                 }
                 tracing::info!("Switched to column {}", index);
             }

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -24,7 +24,7 @@ impl App {
             }
             Focus::Cards => {
                 let hit_bottom = if let Some(list) = self.view_strategy.get_active_task_list_mut() {
-                    list.navigate_down(20)
+                    list.navigate_down(self.viewport_height)
                 } else {
                     false
                 };
@@ -44,7 +44,7 @@ impl App {
             }
             Focus::Cards => {
                 let hit_top = if let Some(list) = self.view_strategy.get_active_task_list_mut() {
-                    list.navigate_up(20)
+                    list.navigate_up(self.viewport_height)
                 } else {
                     false
                 };

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -24,14 +24,10 @@ impl App {
             }
             Focus::Cards => {
                 let hit_bottom = if let Some(list) = self.view_strategy.get_active_task_list_mut() {
-                    list.navigate_down()
+                    list.navigate_down(20)
                 } else {
                     false
                 };
-
-                if let Some(list) = self.view_strategy.get_active_task_list_mut() {
-                    list.ensure_selected_visible(20);
-                }
 
                 if hit_bottom {
                     self.view_strategy.navigate_right(false);
@@ -48,14 +44,10 @@ impl App {
             }
             Focus::Cards => {
                 let hit_top = if let Some(list) = self.view_strategy.get_active_task_list_mut() {
-                    list.navigate_up()
+                    list.navigate_up(20)
                 } else {
                     false
                 };
-
-                if let Some(list) = self.view_strategy.get_active_task_list_mut() {
-                    list.ensure_selected_visible(20);
-                }
 
                 if hit_top {
                     self.view_strategy.navigate_left(true);

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -29,6 +29,10 @@ impl App {
                     false
                 };
 
+                if let Some(list) = self.view_strategy.get_active_task_list_mut() {
+                    list.ensure_selected_visible(20);
+                }
+
                 if hit_bottom {
                     self.view_strategy.navigate_right(false);
                 }
@@ -48,6 +52,10 @@ impl App {
                 } else {
                     false
                 };
+
+                if let Some(list) = self.view_strategy.get_active_task_list_mut() {
+                    list.ensure_selected_visible(20);
+                }
 
                 if hit_top {
                     self.view_strategy.navigate_left(true);
@@ -86,6 +94,7 @@ impl App {
                         if let Some(list) = self.view_strategy.get_active_task_list_mut() {
                             if !list.is_empty() {
                                 list.set_selected_index(Some(0));
+                                list.ensure_selected_visible(20);
                             }
                         }
                     }
@@ -158,6 +167,7 @@ impl App {
                     } else if list.get_selected_index().is_none() {
                         list.set_selected_index(Some(0));
                     }
+                    list.ensure_selected_visible(20);
                 }
                 tracing::info!("Switched to column {}", index);
             }

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -88,7 +88,27 @@ impl RenderStrategy for SinglePanelRenderer {
                                     let viewport_height = (area.height as usize).saturating_sub(4);
                                     let max_scroll = task_list.cards.len().saturating_sub(viewport_height.max(1));
                                     let scroll_offset = task_list.get_scroll_offset().min(max_scroll);
-                                    let visible_cards = task_list.cards.iter().skip(scroll_offset).take(viewport_height);
+                                    let total_cards = task_list.cards.len();
+
+                                    let has_cards_above = scroll_offset > 0;
+                                    let has_cards_below = scroll_offset + viewport_height < total_cards;
+
+                                    if has_cards_above {
+                                        let count = scroll_offset;
+                                        let plural = if count == 1 { "" } else { "s" };
+                                        lines.push(Line::from(Span::styled(
+                                            format!("  {} Task{} above", count, plural),
+                                            ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                                        )));
+                                    }
+
+                                    let cards_to_show = if has_cards_above || has_cards_below {
+                                        viewport_height.saturating_sub((if has_cards_above { 1usize } else { 0 }).saturating_add(if has_cards_below { 1usize } else { 0 }))
+                                    } else {
+                                        viewport_height
+                                    };
+
+                                    let visible_cards = task_list.cards.iter().skip(scroll_offset).take(cards_to_show);
 
                                     for (idx, card_id) in visible_cards.enumerate() {
                                         let global_idx = scroll_offset + idx;
@@ -119,6 +139,15 @@ impl RenderStrategy for SinglePanelRenderer {
                                             lines.push(line);
                                         }
                                     }
+
+                                    if has_cards_below {
+                                        let count = total_cards - (scroll_offset + cards_to_show);
+                                        let plural = if count == 1 { "" } else { "s" };
+                                        lines.push(Line::from(Span::styled(
+                                            format!("  {} Task{} below", count, plural),
+                                            ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                                        )));
+                                    }
                                 }
 
                                 if col_idx < task_lists.len() - 1 {
@@ -139,7 +168,27 @@ impl RenderStrategy for SinglePanelRenderer {
                         let viewport_height = area.height.saturating_sub(2) as usize;
                         let max_scroll = task_list.cards.len().saturating_sub(viewport_height.max(1));
                         let scroll_offset = task_list.get_scroll_offset().min(max_scroll);
-                        let visible_cards = task_list.cards.iter().skip(scroll_offset).take(viewport_height);
+                        let total_cards = task_list.cards.len();
+
+                        let has_cards_above = scroll_offset > 0;
+                        let has_cards_below = scroll_offset + viewport_height < total_cards;
+
+                        if has_cards_above {
+                            let count = scroll_offset;
+                            let plural = if count == 1 { "" } else { "s" };
+                            lines.push(Line::from(Span::styled(
+                                format!("  {} Task{} above", count, plural),
+                                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                            )));
+                        }
+
+                        let cards_to_show = if has_cards_above || has_cards_below {
+                            viewport_height.saturating_sub((if has_cards_above { 1usize } else { 0 }).saturating_add(if has_cards_below { 1usize } else { 0 }))
+                        } else {
+                            viewport_height
+                        };
+
+                        let visible_cards = task_list.cards.iter().skip(scroll_offset).take(cards_to_show);
 
                         for (idx, card_id) in visible_cards.enumerate() {
                             let global_idx = scroll_offset + idx;
@@ -155,6 +204,15 @@ impl RenderStrategy for SinglePanelRenderer {
                                 });
                                 lines.push(line);
                             }
+                        }
+
+                        if has_cards_below {
+                            let count = total_cards - (scroll_offset + cards_to_show);
+                            let plural = if count == 1 { "" } else { "s" };
+                            lines.push(Line::from(Span::styled(
+                                format!("  {} Task{} below", count, plural),
+                                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                            )));
                         }
                     }
                 }
@@ -233,7 +291,27 @@ impl RenderStrategy for MultiPanelRenderer {
                         let viewport_height = chunks[col_idx].height.saturating_sub(2) as usize;
                         let max_scroll = task_list.cards.len().saturating_sub(viewport_height.max(1));
                         let scroll_offset = task_list.get_scroll_offset().min(max_scroll);
-                        let visible_cards = task_list.cards.iter().skip(scroll_offset).take(viewport_height);
+                        let total_cards = task_list.cards.len();
+
+                        let has_cards_above = scroll_offset > 0;
+                        let has_cards_below = scroll_offset + viewport_height < total_cards;
+
+                        if has_cards_above {
+                            let count = scroll_offset;
+                            let plural = if count == 1 { "" } else { "s" };
+                            lines.push(Line::from(Span::styled(
+                                format!("  {} Task{} above", count, plural),
+                                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                            )));
+                        }
+
+                        let cards_to_show = if has_cards_above || has_cards_below {
+                            viewport_height.saturating_sub((if has_cards_above { 1usize } else { 0 }).saturating_add(if has_cards_below { 1usize } else { 0 }))
+                        } else {
+                            viewport_height
+                        };
+
+                        let visible_cards = task_list.cards.iter().skip(scroll_offset).take(cards_to_show);
 
                         for (idx, card_id) in visible_cards.enumerate() {
                             let global_idx = scroll_offset + idx;
@@ -256,6 +334,15 @@ impl RenderStrategy for MultiPanelRenderer {
                                 });
                                 lines.push(line);
                             }
+                        }
+
+                        if has_cards_below {
+                            let count = total_cards - (scroll_offset + cards_to_show);
+                            let plural = if count == 1 { "" } else { "s" };
+                            lines.push(Line::from(Span::styled(
+                                format!("  {} Task{} below", count, plural),
+                                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                            )));
                         }
                     }
 

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -93,33 +93,39 @@ impl RenderStrategy for SinglePanelRenderer {
                                         let plural = if count == 1 { "" } else { "s" };
                                         lines.push(Line::from(Span::styled(
                                             format!("  {} Task{} above", count, plural),
-                                            ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                                            ratatui::style::Style::default()
+                                                .fg(ratatui::style::Color::DarkGray),
                                         )));
                                     }
 
                                     for card_idx in &render_info.visible_card_indices {
                                         if let Some(card_id) = task_list.cards.get(*card_idx) {
-                                            if let Some(card) = app.cards.iter().find(|c| c.id == *card_id) {
+                                            if let Some(card) =
+                                                app.cards.iter().find(|c| c.id == *card_id)
+                                            {
                                                 let is_selected = if is_active_column {
-                                                    task_list.get_selected_index() == Some(*card_idx)
+                                                    task_list.get_selected_index()
+                                                        == Some(*card_idx)
                                                 } else {
                                                     false
                                                 };
 
-                                                let line = render_card_list_item(CardListItemConfig {
-                                                    card,
-                                                    board,
-                                                    sprints: &app.sprints,
-                                                    is_selected,
-                                                    is_focused: app.focus == crate::app::Focus::Cards
-                                                        && is_active_column,
-                                                    is_multi_selected: app
-                                                        .selected_cards
-                                                        .contains(&card.id),
-                                                    show_sprint_name: app
-                                                        .active_sprint_filters
-                                                        .is_empty(),
-                                                });
+                                                let line =
+                                                    render_card_list_item(CardListItemConfig {
+                                                        card,
+                                                        board,
+                                                        sprints: &app.sprints,
+                                                        is_selected,
+                                                        is_focused: app.focus
+                                                            == crate::app::Focus::Cards
+                                                            && is_active_column,
+                                                        is_multi_selected: app
+                                                            .selected_cards
+                                                            .contains(&card.id),
+                                                        show_sprint_name: app
+                                                            .active_sprint_filters
+                                                            .is_empty(),
+                                                    });
                                                 lines.push(line);
                                             }
                                         }
@@ -130,7 +136,8 @@ impl RenderStrategy for SinglePanelRenderer {
                                         let plural = if count == 1 { "" } else { "s" };
                                         lines.push(Line::from(Span::styled(
                                             format!("  {} Task{} below", count, plural),
-                                            ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                                            ratatui::style::Style::default()
+                                                .fg(ratatui::style::Color::DarkGray),
                                         )));
                                     }
                                 }
@@ -158,7 +165,8 @@ impl RenderStrategy for SinglePanelRenderer {
                             let plural = if count == 1 { "" } else { "s" };
                             lines.push(Line::from(Span::styled(
                                 format!("  {} Task{} above", count, plural),
-                                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                                ratatui::style::Style::default()
+                                    .fg(ratatui::style::Color::DarkGray),
                             )));
                         }
 
@@ -169,7 +177,8 @@ impl RenderStrategy for SinglePanelRenderer {
                                         card,
                                         board,
                                         sprints: &app.sprints,
-                                        is_selected: task_list.get_selected_index() == Some(*card_idx),
+                                        is_selected: task_list.get_selected_index()
+                                            == Some(*card_idx),
                                         is_focused: app.focus == crate::app::Focus::Cards,
                                         is_multi_selected: app.selected_cards.contains(&card.id),
                                         show_sprint_name: app.active_sprint_filters.is_empty(),
@@ -184,7 +193,8 @@ impl RenderStrategy for SinglePanelRenderer {
                             let plural = if count == 1 { "" } else { "s" };
                             lines.push(Line::from(Span::styled(
                                 format!("  {} Task{} below", count, plural),
-                                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                                ratatui::style::Style::default()
+                                    .fg(ratatui::style::Color::DarkGray),
                             )));
                         }
                     }
@@ -269,7 +279,8 @@ impl RenderStrategy for MultiPanelRenderer {
                             let plural = if count == 1 { "" } else { "s" };
                             lines.push(Line::from(Span::styled(
                                 format!("  {} Task{} above", count, plural),
-                                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                                ratatui::style::Style::default()
+                                    .fg(ratatui::style::Color::DarkGray),
                             )));
                         }
 
@@ -302,7 +313,8 @@ impl RenderStrategy for MultiPanelRenderer {
                             let plural = if count == 1 { "" } else { "s" };
                             lines.push(Line::from(Span::styled(
                                 format!("  {} Task{} below", count, plural),
-                                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                                ratatui::style::Style::default()
+                                    .fg(ratatui::style::Color::DarkGray),
                             )));
                         }
                     }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -11,7 +11,7 @@ use ratatui::{
     Frame,
 };
 
-pub fn render(app: &App, frame: &mut Frame) {
+pub fn render(app: &mut App, frame: &mut Frame) {
     // Check if we're in Help mode and render underlying view
     let is_help_mode = matches!(app.mode, AppMode::Help(_));
 
@@ -110,7 +110,7 @@ pub fn render(app: &App, frame: &mut Frame) {
     }
 }
 
-fn render_main(app: &App, frame: &mut Frame, area: Rect) {
+fn render_main(app: &mut App, frame: &mut Frame, area: Rect) {
     let is_kanban_view = if let Some(idx) = app.active_board_index {
         if let Some(board) = app.boards.get(idx) {
             board.task_list_view == kanban_domain::TaskListView::ColumnView
@@ -122,6 +122,7 @@ fn render_main(app: &App, frame: &mut Frame, area: Rect) {
     };
 
     if is_kanban_view {
+        app.viewport_height = area.height.saturating_sub(2) as usize;
         render_tasks_panel(app, frame, area);
     } else {
         let chunks = Layout::default()
@@ -129,6 +130,7 @@ fn render_main(app: &App, frame: &mut Frame, area: Rect) {
             .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
             .split(area);
 
+        app.viewport_height = chunks[1].height.saturating_sub(2) as usize;
         render_projects_panel(app, frame, chunks[0]);
         render_tasks_panel(app, frame, chunks[1]);
     }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -395,16 +395,11 @@ fn render_sprint_task_panel_with_selection(
     if task_list.is_empty() {
         lines.push(Line::from(Span::styled("  (no tasks)", label_text())));
     } else {
-        let viewport_height = area.height.saturating_sub(4) as usize;
-        let max_scroll = task_list.cards.len().saturating_sub(viewport_height.max(1));
-        let scroll_offset = task_list.get_scroll_offset().min(max_scroll);
-        let total_cards = task_list.cards.len();
+        let viewport_height = area.height.saturating_sub(2) as usize;
+        let render_info = task_list.get_render_info(viewport_height);
 
-        let has_cards_above = scroll_offset > 0;
-        let has_cards_below = scroll_offset + viewport_height < total_cards;
-
-        if has_cards_above {
-            let count = scroll_offset;
+        if render_info.show_above_indicator {
+            let count = render_info.cards_above_count;
             let plural = if count == 1 { "" } else { "s" };
             lines.push(Line::from(Span::styled(
                 format!("  {} Task{} above", count, plural),
@@ -412,33 +407,26 @@ fn render_sprint_task_panel_with_selection(
             )));
         }
 
-        let cards_to_show = if has_cards_above || has_cards_below {
-            viewport_height.saturating_sub((if has_cards_above { 1usize } else { 0 }).saturating_add(if has_cards_below { 1usize } else { 0 }))
-        } else {
-            viewport_height
-        };
-
-        let visible_cards = task_list.cards.iter().skip(scroll_offset).take(cards_to_show);
-
-        for (idx, card_id) in visible_cards.enumerate() {
-            let global_idx = scroll_offset + idx;
-            if let Some(card) = app.cards.iter().find(|c| c.id == *card_id) {
-                let is_selected = selected_idx == Some(global_idx) && is_focused;
-                let line = render_card_list_item(CardListItemConfig {
-                    card,
-                    board,
-                    sprints: &app.sprints,
-                    is_selected,
-                    is_focused,
-                    is_multi_selected: false,
-                    show_sprint_name: false,
-                });
-                lines.push(line);
+        for card_idx in &render_info.visible_card_indices {
+            if let Some(card_id) = task_list.cards.get(*card_idx) {
+                if let Some(card) = app.cards.iter().find(|c| c.id == *card_id) {
+                    let is_selected = selected_idx == Some(*card_idx) && is_focused;
+                    let line = render_card_list_item(CardListItemConfig {
+                        card,
+                        board,
+                        sprints: &app.sprints,
+                        is_selected,
+                        is_focused,
+                        is_multi_selected: false,
+                        show_sprint_name: false,
+                    });
+                    lines.push(line);
+                }
             }
         }
 
-        if has_cards_below {
-            let count = total_cards - (scroll_offset + cards_to_show);
+        if render_info.show_below_indicator {
+            let count = render_info.cards_below_count;
             let plural = if count == 1 { "" } else { "s" };
             lines.push(Line::from(Span::styled(
                 format!("  {} Task{} below", count, plural),


### PR DESCRIPTION
Fix card list scrolling to last card and viewport indicator handling:

- Centralize viewport calculations in CardList with ViewportInfo and CardListRenderInfo structs
- Standardize viewport height calculations across all renderers (area.height - 2)
- Fix circular dependency in has_cards_below detection
- Ensure selection always moves forward when navigating and viewport shrinks
- Prevent double-press requirement when "above" indicator appears on first scroll

**Testing:**
- All 18 existing unit tests pass
- Tested with 93, 117, and larger card lists
- Verified scrolling reaches the final card on first attempt
- Confirmed no double-press needed when indicators appear/disappear