### PR TITLE
KAN-132: Add migrations for archived_cards and branch_prefix compatibility

### DIFF
--- a/.changeset/kan-132-urgent-migrations.md
+++ b/.changeset/kan-132-urgent-migrations.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+- migration: add reconciliation of branch_prefix and sprint_prefix to migrate old boards
+- migration: add serde default to support migration to archived cards board
+

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -66,8 +66,10 @@ impl<'de> Deserialize<'de> for Board {
             pub id: BoardId,
             pub name: String,
             pub description: Option<String>,
-            #[serde(default, alias = "branch_prefix")]
+            #[serde(default)]
             pub sprint_prefix: Option<String>,
+            #[serde(default)]
+            pub branch_prefix: Option<String>,
             #[serde(default)]
             pub card_prefix: Option<String>,
             #[serde(default = "default_sort_field")]
@@ -97,11 +99,12 @@ impl<'de> Deserialize<'de> for Board {
         }
 
         let helper = BoardHelper::deserialize(deserializer)?;
+        let sprint_prefix = helper.sprint_prefix.or(helper.branch_prefix);
         let mut board = Board {
             id: helper.id,
             name: helper.name,
             description: helper.description,
-            sprint_prefix: helper.sprint_prefix,
+            sprint_prefix,
             card_prefix: helper.card_prefix,
             task_sort_field: helper.task_sort_field,
             task_sort_order: helper.task_sort_order,

--- a/crates/kanban-tui/src/export/models.rs
+++ b/crates/kanban-tui/src/export/models.rs
@@ -7,6 +7,7 @@ pub struct BoardExport {
     pub columns: Vec<Column>,
     pub cards: Vec<Card>,
     pub sprints: Vec<Sprint>,
+    #[serde(default)]
     pub archived_cards: Vec<ArchivedCard>,
 }
 


### PR DESCRIPTION
## Summary

This PR adds critical migrations to support loading boards created before the archived cards feature was introduced, and to handle the transition from `branch_prefix` to `sprint_prefix` field naming.

## Changes

### 1. Support missing `archived_cards` field
- Added `#[serde(default)]` attribute to `archived_cards` in `BoardExport`
- Old board JSON files without this field will now load successfully with an empty archived cards vector
- Fixes deserialization failures when loading legacy boards

### 2. Handle both `branch_prefix` and `sprint_prefix` fields
- Modified `BoardHelper` to accept both `branch_prefix` (deprecated) and `sprint_prefix` (current)
- Changed from serde alias to separate fields with reconciliation logic
- Allows boards with either field name or both to load correctly
- Prioritizes `sprint_prefix` over `branch_prefix` when both exist

## Impact

- ✅ Legacy boards without `archived_cards` field can now load
- ✅ Boards with deprecated `branch_prefix` field continue to work
- ✅ Mixed-state JSON files with both prefix fields are handled gracefully
- ✅ No manual intervention required from users