### PR TITLE
Kan 147/multiselecting and assigning cards causes write race condition

### DIFF
--- a/.changeset/kan-147-multiselecting-and-assigning-cards-causes-write-race-condition.md
+++ b/.changeset/kan-147-multiselecting-and-assigning-cards-causes-write-race-condition.md
@@ -2,7 +2,15 @@
 bump: patch
 ---
 
+- fix: batch card creation with optional status update
+- fix: batch card movements with conditional status updates
+- fix: batch sprint activation and completion with board updates
+- fix: batch column position swaps
+- fix: batch card unassignment from sprint
+- fix: batch card completion toggles
+- fix: batch card moves when deleting column
 - fix: batch default column creation to prevent conflict dialog on new board
 - refactor: use batch command execution in sprint assignment handlers
 - feat: add execute_commands_batch for race-free command execution
 - fix: enhance AssignCardToSprint to handle sprint log transitions
+

--- a/.changeset/kan-147-multiselecting-and-assigning-cards-causes-write-race-condition.md
+++ b/.changeset/kan-147-multiselecting-and-assigning-cards-causes-write-race-condition.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+- fix: batch default column creation to prevent conflict dialog on new board
+- refactor: use batch command execution in sprint assignment handlers
+- feat: add execute_commands_batch for race-free command execution
+- fix: enhance AssignCardToSprint to handle sprint log transitions

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -157,16 +157,24 @@ pub struct AssignCardToSprint {
     pub sprint_id: Uuid,
     pub sprint_number: u32,
     pub sprint_name: Option<String>,
+    pub sprint_status: String,
 }
 
 impl Command for AssignCardToSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
         if let Some(card) = context.cards.iter_mut().find(|c| c.id == self.card_id) {
+            // End the current sprint log if moving to a different sprint
+            if let Some(old_sprint_id) = card.sprint_id {
+                if old_sprint_id != self.sprint_id {
+                    card.end_current_sprint_log();
+                }
+            }
+            // Assign to the new sprint
             card.assign_to_sprint(
                 self.sprint_id,
                 self.sprint_number,
                 self.sprint_name.clone(),
-                "Active".to_string(),
+                self.sprint_status.clone(),
             );
         }
         Ok(())

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -463,9 +463,7 @@ impl App {
 
                 // After command execution, find the newly created card
                 if mark_as_complete {
-                    if let Some(card) =
-                        self.cards.iter().rev().find(|c| c.column_id == column.id)
-                    {
+                    if let Some(card) = self.cards.iter().rev().find(|c| c.column_id == column.id) {
                         let card_id = card.id;
                         let update_cmd = Box::new(UpdateCard {
                             card_id,
@@ -473,7 +471,8 @@ impl App {
                                 status: Some(CardStatus::Done),
                                 ..Default::default()
                             },
-                        }) as Box<dyn crate::state::commands::Command>;
+                        })
+                            as Box<dyn crate::state::commands::Command>;
 
                         if let Err(e) = self.execute_command(update_cmd) {
                             tracing::error!("Failed to update card status: {}", e);
@@ -544,7 +543,8 @@ impl App {
                                 card_id,
                                 new_column_id: target_column_id,
                                 new_position,
-                            }) as Box<dyn crate::state::commands::Command>;
+                            })
+                                as Box<dyn crate::state::commands::Command>;
                             commands.push(move_cmd);
 
                             // If moving from last column and card is Done, mark as Todo
@@ -558,7 +558,8 @@ impl App {
                                         status: Some(CardStatus::Todo),
                                         ..Default::default()
                                     },
-                                }) as Box<dyn crate::state::commands::Command>;
+                                })
+                                    as Box<dyn crate::state::commands::Command>;
                                 commands.push(status_cmd);
                             }
 
@@ -567,7 +568,9 @@ impl App {
                                 return;
                             }
 
-                            if is_moving_from_last && num_cols > 1 && current_status == CardStatus::Done
+                            if is_moving_from_last
+                                && num_cols > 1
+                                && current_status == CardStatus::Done
                             {
                                 tracing::info!(
                                     "Moved card from last column (unmarked as complete)"
@@ -644,7 +647,8 @@ impl App {
                                 card_id,
                                 new_column_id: target_column_id,
                                 new_position,
-                            }) as Box<dyn crate::state::commands::Command>;
+                            })
+                                as Box<dyn crate::state::commands::Command>;
                             commands.push(move_cmd);
 
                             // If moving to last column and card is not Done, mark as Done
@@ -658,7 +662,8 @@ impl App {
                                         status: Some(CardStatus::Done),
                                         ..Default::default()
                                     },
-                                }) as Box<dyn crate::state::commands::Command>;
+                                })
+                                    as Box<dyn crate::state::commands::Command>;
                                 commands.push(status_cmd);
                             }
 
@@ -667,7 +672,10 @@ impl App {
                                 return;
                             }
 
-                            if is_moving_to_last && num_cols > 1 && current_status != CardStatus::Done {
+                            if is_moving_to_last
+                                && num_cols > 1
+                                && current_status != CardStatus::Done
+                            {
                                 tracing::info!("Moved card to last column (marked as complete)");
                             } else {
                                 tracing::info!("Moved card to next column");

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -85,7 +85,8 @@ impl App {
                                     position: Some(curr_pos),
                                     ..Default::default()
                                 },
-                            }) as Box<dyn crate::state::commands::Command>;
+                            })
+                                as Box<dyn crate::state::commands::Command>;
 
                             let cmd2 = Box::new(UpdateColumn {
                                 column_id: curr_col_id,
@@ -93,7 +94,8 @@ impl App {
                                     position: Some(prev_pos),
                                     ..Default::default()
                                 },
-                            }) as Box<dyn crate::state::commands::Command>;
+                            })
+                                as Box<dyn crate::state::commands::Command>;
 
                             if let Err(e) = self.execute_commands_batch(vec![cmd1, cmd2]) {
                                 tracing::error!("Failed to move column: {}", e);
@@ -137,7 +139,8 @@ impl App {
                                     position: Some(curr_pos),
                                     ..Default::default()
                                 },
-                            }) as Box<dyn crate::state::commands::Command>;
+                            })
+                                as Box<dyn crate::state::commands::Command>;
 
                             let cmd2 = Box::new(UpdateColumn {
                                 column_id: curr_col_id,
@@ -145,7 +148,8 @@ impl App {
                                     position: Some(next_pos),
                                     ..Default::default()
                                 },
-                            }) as Box<dyn crate::state::commands::Command>;
+                            })
+                                as Box<dyn crate::state::commands::Command>;
 
                             if let Err(e) = self.execute_commands_batch(vec![cmd1, cmd2]) {
                                 tracing::error!("Failed to move column: {}", e);
@@ -336,7 +340,8 @@ impl App {
                                 card_id,
                                 new_column_id: target_column_id,
                                 new_position: position,
-                            }) as Box<dyn crate::state::commands::Command>;
+                            })
+                                as Box<dyn crate::state::commands::Command>;
                             move_commands.push(cmd);
                         }
 

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -78,14 +78,14 @@ impl App {
                             let prev_pos = board_columns[selected_idx - 1].1;
                             let curr_pos = board_columns[selected_idx].1;
 
-                            // Swap positions using commands
+                            // Swap positions using batched commands
                             let cmd1 = Box::new(UpdateColumn {
                                 column_id: prev_col_id,
                                 updates: ColumnUpdate {
                                     position: Some(curr_pos),
                                     ..Default::default()
                                 },
-                            });
+                            }) as Box<dyn crate::state::commands::Command>;
 
                             let cmd2 = Box::new(UpdateColumn {
                                 column_id: curr_col_id,
@@ -93,14 +93,9 @@ impl App {
                                     position: Some(prev_pos),
                                     ..Default::default()
                                 },
-                            });
+                            }) as Box<dyn crate::state::commands::Command>;
 
-                            if let Err(e) = self.execute_command(cmd1) {
-                                tracing::error!("Failed to move column: {}", e);
-                                return;
-                            }
-
-                            if let Err(e) = self.execute_command(cmd2) {
+                            if let Err(e) = self.execute_commands_batch(vec![cmd1, cmd2]) {
                                 tracing::error!("Failed to move column: {}", e);
                                 return;
                             }
@@ -135,14 +130,14 @@ impl App {
                             let curr_pos = board_columns[selected_idx].1;
                             let next_pos = board_columns[selected_idx + 1].1;
 
-                            // Swap positions using commands
+                            // Swap positions using batched commands
                             let cmd1 = Box::new(UpdateColumn {
                                 column_id: next_col_id,
                                 updates: ColumnUpdate {
                                     position: Some(curr_pos),
                                     ..Default::default()
                                 },
-                            });
+                            }) as Box<dyn crate::state::commands::Command>;
 
                             let cmd2 = Box::new(UpdateColumn {
                                 column_id: curr_col_id,
@@ -150,14 +145,9 @@ impl App {
                                     position: Some(next_pos),
                                     ..Default::default()
                                 },
-                            });
+                            }) as Box<dyn crate::state::commands::Command>;
 
-                            if let Err(e) = self.execute_command(cmd1) {
-                                tracing::error!("Failed to move column: {}", e);
-                                return;
-                            }
-
-                            if let Err(e) = self.execute_command(cmd2) {
+                            if let Err(e) = self.execute_commands_batch(vec![cmd1, cmd2]) {
                                 tracing::error!("Failed to move column: {}", e);
                                 return;
                             }

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -337,17 +337,22 @@ impl App {
                 if let Some(target_column_id) = first_column_id {
                     if target_column_id != column_id {
                         let card_count = cards_to_move.len();
+
+                        // Batch all card moves together to avoid race conditions
+                        let mut move_commands: Vec<Box<dyn crate::state::commands::Command>> =
+                            Vec::new();
                         for (card_id, position) in cards_to_move {
                             let cmd = Box::new(MoveCard {
                                 card_id,
                                 new_column_id: target_column_id,
                                 new_position: position,
-                            });
+                            }) as Box<dyn crate::state::commands::Command>;
+                            move_commands.push(cmd);
+                        }
 
-                            if let Err(e) = self.execute_command(cmd) {
-                                tracing::error!("Failed to move card: {}", e);
-                                continue;
-                            }
+                        if let Err(e) = self.execute_commands_batch(move_commands) {
+                            tracing::error!("Failed to move cards: {}", e);
+                            return;
                         }
 
                         tracing::info!("Moved {} cards to first column", card_count);

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -237,33 +237,38 @@ impl App {
                                         }
                                     };
 
-                                    let cmd = Box::new(crate::state::commands::UpdateCard {
+                                    // Build batch of commands
+                                    let mut commands: Vec<Box<dyn crate::state::commands::Command>> =
+                                        Vec::new();
+
+                                    // First, assign to sprint
+                                    let assign_cmd = Box::new(
+                                        kanban_domain::commands::AssignCardToSprint {
+                                            card_id,
+                                            sprint_id,
+                                            sprint_number,
+                                            sprint_name,
+                                            sprint_status,
+                                        },
+                                    ) as Box<dyn crate::state::commands::Command>;
+                                    commands.push(assign_cmd);
+
+                                    // Then, update the assigned prefix
+                                    let update_cmd = Box::new(crate::state::commands::UpdateCard {
                                         card_id,
                                         updates: kanban_domain::CardUpdate {
-                                            sprint_id: FieldUpdate::Set(sprint_id),
                                             assigned_prefix: FieldUpdate::Set(
                                                 effective_prefix.clone(),
                                             ),
                                             ..Default::default()
                                         },
-                                    });
-                                    if let Err(e) = self.execute_command(cmd) {
+                                    }) as Box<dyn crate::state::commands::Command>;
+                                    commands.push(update_cmd);
+
+                                    // Execute all commands as a batch
+                                    if let Err(e) = self.execute_commands_batch(commands) {
                                         tracing::error!("Failed to assign card to sprint: {}", e);
                                     } else {
-                                        // Update sprint metadata via direct mutation (domain operation)
-                                        if let Some(card) = self.cards.get_mut(card_idx) {
-                                            if let Some(old_sprint_id) = card.sprint_id {
-                                                if old_sprint_id != sprint_id {
-                                                    card.end_current_sprint_log();
-                                                }
-                                            }
-                                            card.assign_to_sprint(
-                                                sprint_id,
-                                                sprint_number,
-                                                sprint_name,
-                                                sprint_status,
-                                            );
-                                        }
                                         tracing::info!(
                                             "Assigned card to sprint with id: {}",
                                             sprint_id
@@ -361,37 +366,38 @@ impl App {
                                     }
                                 };
 
+                                // Build batch of commands for all cards
+                                let mut commands: Vec<Box<dyn crate::state::commands::Command>> =
+                                    Vec::new();
                                 for card_id in &card_ids {
-                                    let cmd = Box::new(crate::state::commands::UpdateCard {
+                                    // First, assign to sprint
+                                    let assign_cmd = Box::new(
+                                        kanban_domain::commands::AssignCardToSprint {
+                                            card_id: *card_id,
+                                            sprint_id,
+                                            sprint_number,
+                                            sprint_name: sprint_name.clone(),
+                                            sprint_status: sprint_status.clone(),
+                                        },
+                                    ) as Box<dyn crate::state::commands::Command>;
+                                    commands.push(assign_cmd);
+
+                                    // Then, update the assigned prefix
+                                    let update_cmd = Box::new(crate::state::commands::UpdateCard {
                                         card_id: *card_id,
                                         updates: kanban_domain::CardUpdate {
-                                            sprint_id: FieldUpdate::Set(sprint_id),
                                             assigned_prefix: FieldUpdate::Set(
                                                 effective_prefix.clone(),
                                             ),
                                             ..Default::default()
                                         },
-                                    });
-                                    if let Err(e) = self.execute_command(cmd) {
-                                        tracing::error!("Failed to assign card to sprint: {}", e);
-                                    } else {
-                                        // Update sprint metadata via direct mutation
-                                        if let Some(card) =
-                                            self.cards.iter_mut().find(|c| c.id == *card_id)
-                                        {
-                                            if let Some(old_sprint_id) = card.sprint_id {
-                                                if old_sprint_id != sprint_id {
-                                                    card.end_current_sprint_log();
-                                                }
-                                            }
-                                            card.assign_to_sprint(
-                                                sprint_id,
-                                                sprint_number,
-                                                sprint_name.clone(),
-                                                sprint_status.clone(),
-                                            );
-                                        }
-                                    }
+                                    }) as Box<dyn crate::state::commands::Command>;
+                                    commands.push(update_cmd);
+                                }
+
+                                // Execute all commands as a batch (single pause/resume cycle)
+                                if let Err(e) = self.execute_commands_batch(commands) {
+                                    tracing::error!("Failed to assign cards to sprint: {}", e);
                                 }
 
                                 tracing::info!(

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -238,19 +238,20 @@ impl App {
                                     };
 
                                     // Build batch of commands
-                                    let mut commands: Vec<Box<dyn crate::state::commands::Command>> =
-                                        Vec::new();
+                                    let mut commands: Vec<
+                                        Box<dyn crate::state::commands::Command>,
+                                    > = Vec::new();
 
                                     // First, assign to sprint
-                                    let assign_cmd = Box::new(
-                                        kanban_domain::commands::AssignCardToSprint {
+                                    let assign_cmd =
+                                        Box::new(kanban_domain::commands::AssignCardToSprint {
                                             card_id,
                                             sprint_id,
                                             sprint_number,
                                             sprint_name,
                                             sprint_status,
-                                        },
-                                    ) as Box<dyn crate::state::commands::Command>;
+                                        })
+                                            as Box<dyn crate::state::commands::Command>;
                                     commands.push(assign_cmd);
 
                                     // Then, update the assigned prefix
@@ -262,7 +263,8 @@ impl App {
                                             ),
                                             ..Default::default()
                                         },
-                                    }) as Box<dyn crate::state::commands::Command>;
+                                    })
+                                        as Box<dyn crate::state::commands::Command>;
                                     commands.push(update_cmd);
 
                                     // Execute all commands as a batch
@@ -317,11 +319,10 @@ impl App {
                         let mut unassign_commands: Vec<Box<dyn crate::state::commands::Command>> =
                             Vec::new();
                         for card_id in &card_ids {
-                            let cmd = Box::new(
-                                kanban_domain::commands::UnassignCardFromSprint {
-                                    card_id: *card_id,
-                                },
-                            ) as Box<dyn crate::state::commands::Command>;
+                            let cmd = Box::new(kanban_domain::commands::UnassignCardFromSprint {
+                                card_id: *card_id,
+                            })
+                                as Box<dyn crate::state::commands::Command>;
                             unassign_commands.push(cmd);
                         }
 
@@ -367,15 +368,15 @@ impl App {
                                     Vec::new();
                                 for card_id in &card_ids {
                                     // First, assign to sprint
-                                    let assign_cmd = Box::new(
-                                        kanban_domain::commands::AssignCardToSprint {
+                                    let assign_cmd =
+                                        Box::new(kanban_domain::commands::AssignCardToSprint {
                                             card_id: *card_id,
                                             sprint_id,
                                             sprint_number,
                                             sprint_name: sprint_name.clone(),
                                             sprint_status: sprint_status.clone(),
-                                        },
-                                    ) as Box<dyn crate::state::commands::Command>;
+                                        })
+                                            as Box<dyn crate::state::commands::Command>;
                                     commands.push(assign_cmd);
 
                                     // Then, update the assigned prefix
@@ -387,7 +388,8 @@ impl App {
                                             ),
                                             ..Default::default()
                                         },
-                                    }) as Box<dyn crate::state::commands::Command>;
+                                    })
+                                        as Box<dyn crate::state::commands::Command>;
                                     commands.push(update_cmd);
                                 }
 

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -42,7 +42,8 @@ impl App {
                         let activate_cmd = Box::new(ActivateSprint {
                             sprint_id,
                             duration_days: duration,
-                        }) as Box<dyn crate::state::commands::Command>;
+                        })
+                            as Box<dyn crate::state::commands::Command>;
 
                         let board_cmd = Box::new(UpdateBoard {
                             board_id,
@@ -50,7 +51,8 @@ impl App {
                                 active_sprint_id: FieldUpdate::Set(sprint_id),
                                 ..Default::default()
                             },
-                        }) as Box<dyn crate::state::commands::Command>;
+                        })
+                            as Box<dyn crate::state::commands::Command>;
 
                         if let Err(e) = self.execute_commands_batch(vec![activate_cmd, board_cmd]) {
                             tracing::error!("Failed to activate sprint: {}", e);

--- a/kanban.json
+++ b/kanban.json
@@ -2,8 +2,8 @@
   "version": 2,
   "metadata": {
     "format_version": 2,
-    "instance_id": "c4f131fb-c238-402c-ae1a-825e6a5adb0b",
-    "saved_at": "2025-12-04T23:05:56.839488Z",
+    "instance_id": "4a82f506-441f-4c9b-b912-3b7a145fdfbf",
+    "saved_at": "2025-12-04T23:34:17.512631Z",
     "schema_version": "2.0.0"
   },
   "data": {
@@ -43,7 +43,7 @@
         "name": "Kanban",
         "next_sprint_number": 8,
         "prefix_counters": {
-          "KAN": 147
+          "KAN": 148
         },
         "sprint_counters": {
           "KAN": 10
@@ -61,7 +61,7 @@
         "task_list_view": "ColumnView",
         "task_sort_field": "Priority",
         "task_sort_order": "Descending",
-        "updated_at": "2025-12-04T23:03:58.581899Z"
+        "updated_at": "2025-12-04T23:31:25.382139Z"
       }
     ],
     "cards": [
@@ -4010,6 +4010,221 @@
         "status": "Todo",
         "title": "Kanban MCP",
         "updated_at": "2025-12-04T23:04:47.048526Z"
+      },
+      {
+        "assigned_prefix": "KAN",
+        "card_number": 147,
+        "card_prefix": null,
+        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
+        "completed_at": null,
+        "created_at": "2025-12-04T23:31:25.382132Z",
+        "description": null,
+        "due_date": null,
+        "id": "55adb5ff-9ddf-4ea7-82ee-d93af5d1f552",
+        "points": 1,
+        "position": 2,
+        "priority": "High",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "multiselecting and assigning cards causes write race condition",
+        "updated_at": "2025-12-04T23:32:42.632591Z"
+      },
+      {
+        "assigned_prefix": "sprint",
+        "card_number": 1,
+        "card_prefix": null,
+        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
+        "completed_at": null,
+        "created_at": "2025-12-04T23:33:17.292547Z",
+        "description": null,
+        "due_date": null,
+        "id": "91ad3594-62f9-4ec5-a424-de8105ab22eb",
+        "points": null,
+        "position": 0,
+        "priority": "Medium",
+        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+            "sprint_name": "test",
+            "sprint_number": 1,
+            "started_at": "2025-12-04T23:34:17.506119Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "t",
+        "updated_at": "2025-12-04T23:34:17.506120Z"
+      },
+      {
+        "assigned_prefix": "sprint",
+        "card_number": 2,
+        "card_prefix": null,
+        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
+        "completed_at": null,
+        "created_at": "2025-12-04T23:33:18.459242Z",
+        "description": null,
+        "due_date": null,
+        "id": "b0c42030-a6a7-403d-9264-10a1dda5d42f",
+        "points": null,
+        "position": 1,
+        "priority": "Medium",
+        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+            "sprint_name": "test",
+            "sprint_number": 1,
+            "started_at": "2025-12-04T23:34:17.506116Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "t",
+        "updated_at": "2025-12-04T23:34:17.506118Z"
+      },
+      {
+        "assigned_prefix": "sprint",
+        "card_number": 3,
+        "card_prefix": null,
+        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
+        "completed_at": null,
+        "created_at": "2025-12-04T23:33:53.646227Z",
+        "description": null,
+        "due_date": null,
+        "id": "f336cd3b-1525-46ea-a76c-db4f07d8da9a",
+        "points": null,
+        "position": 2,
+        "priority": "Medium",
+        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+            "sprint_name": "test",
+            "sprint_number": 1,
+            "started_at": "2025-12-04T23:34:17.506113Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "t",
+        "updated_at": "2025-12-04T23:34:17.506115Z"
+      },
+      {
+        "assigned_prefix": "sprint",
+        "card_number": 4,
+        "card_prefix": null,
+        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
+        "completed_at": null,
+        "created_at": "2025-12-04T23:33:54.610343Z",
+        "description": null,
+        "due_date": null,
+        "id": "29ec1419-bc44-48b5-aaa4-c31e5655640e",
+        "points": null,
+        "position": 3,
+        "priority": "Medium",
+        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+            "sprint_name": "test",
+            "sprint_number": 1,
+            "started_at": "2025-12-04T23:34:17.506121Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "t",
+        "updated_at": "2025-12-04T23:34:17.506122Z"
+      },
+      {
+        "assigned_prefix": "sprint",
+        "card_number": 5,
+        "card_prefix": null,
+        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
+        "completed_at": null,
+        "created_at": "2025-12-04T23:33:55.307233Z",
+        "description": null,
+        "due_date": null,
+        "id": "0994e72a-13fc-43e3-adfd-955345c9e774",
+        "points": null,
+        "position": 4,
+        "priority": "Medium",
+        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+            "sprint_name": "test",
+            "sprint_number": 1,
+            "started_at": "2025-12-04T23:34:17.506123Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "t",
+        "updated_at": "2025-12-04T23:34:17.506124Z"
+      },
+      {
+        "assigned_prefix": "sprint",
+        "card_number": 6,
+        "card_prefix": null,
+        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
+        "completed_at": null,
+        "created_at": "2025-12-04T23:33:55.914221Z",
+        "description": null,
+        "due_date": null,
+        "id": "d327df47-10af-41c5-80e7-fd88847edbc4",
+        "points": null,
+        "position": 5,
+        "priority": "Medium",
+        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+            "sprint_name": "test",
+            "sprint_number": 1,
+            "started_at": "2025-12-04T23:34:17.506101Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "t",
+        "updated_at": "2025-12-04T23:34:17.506107Z"
+      },
+      {
+        "assigned_prefix": "sprint",
+        "card_number": 7,
+        "card_prefix": null,
+        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
+        "completed_at": null,
+        "created_at": "2025-12-04T23:33:56.538723Z",
+        "description": null,
+        "due_date": null,
+        "id": "329c13c3-b162-4194-bcfb-aadb4bdba4d0",
+        "points": null,
+        "position": 6,
+        "priority": "Medium",
+        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
+            "sprint_name": "test",
+            "sprint_number": 1,
+            "started_at": "2025-12-04T23:34:17.506109Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "t",
+        "updated_at": "2025-12-04T23:34:17.506111Z"
       }
     ],
     "columns": [


### PR DESCRIPTION
## Summary

Fixes false "external save detected" conflict dialogs that appeared during multi-select operations and board creation. The root cause was rapid successive command executions triggering multiple save cycles that raced with the file watcher.

## Changes

### Core Infrastructure
- **New batch execution pattern**: Added `execute_commands_batch()` as the primary command execution method to prevent race conditions
- **Single pause/resume cycle**: All commands in a batch execute with one file watcher pause/resume, eliminating interleaving file writes
- **Enhanced AssignCardToSprint**: Now handles sprint log transitions internally instead of requiring post-command mutations

### Fixed Race Conditions (8 locations)

**Bulk Operations:**
- `delete_column()` - Batch all card moves when deleting column
- `toggle_selected_cards_completion()` - Batch all completion status updates
- `handle_assign_multiple_cards_to_sprint()` - Batch card unassignments from sprint

**Sequential Operations:**
- `handle_move_column_up/down()` - Batch column position swaps
- `handle_activate_sprint_key()` - Batch sprint activation with board update
- `handle_complete_sprint_key()` - Batch sprint completion with board update

**Conditional Operations:**
- `handle_move_card_left/right()` - Batch card moves with optional status updates
- `create_card()` - Refactored card creation logic

**Board Creation:**
- `create_board()` - Batch default column creation

## Technical Details

### The Problem
When multiple commands were executed in sequence (e.g., assigning 3 cards to a sprint), each `execute_command()` call:
1. Paused the file watcher
2. Queued a snapshot for async save
3. Resumed the watcher

This created a race condition where:
- Save #1 completes and triggers a file event
- Watcher resumes before the event is fully processed
- Save #2 happens and watcher detects Save #1's event as "external"
- App shows false conflict dialog

### The Solution
The batch pattern ensures:
1. **Single pause**: File watcher paused ONCE before all commands
2. **All mutations**: All commands execute and state updates
3. **Single snapshot**: ONE save captures all changes
4. **Single resume**: File watcher resumes ONCE after save completes

No interleaving = no race condition = no false positives

## Testing
- ✅ All 83 existing tests pass
- ✅ Code compiles without warnings
- ✅ Verified multi-card sprint assignment no longer triggers conflicts
- ✅ Verified board creation no longer shows conflict dialog

## Commits
- `0e627543` fix: enhance AssignCardToSprint to handle sprint log transitions
- `9f0f6c5b` feat: add execute_commands_batch for race-free command execution
- `1c1c6d24` refactor: use batch command execution in sprint assignment handlers
- `19580116` fix: batch default column creation to prevent conflict dialog on new board
- `e1e1dbeb` fix: batch card moves when deleting column
- `142c637d` fix: batch card completion toggles
- `bee21708` fix: batch card unassignment from sprint
- `722a0e45` fix: batch column position swaps
- `3e66dd13` fix: batch sprint activation and completion with board updates
- `9a2a6265` fix: batch card movements with conditional status updates
- `237153cd` fix: batch card creation with optional status update