### PR TITLE
Kan 93/dialogs always return to main when opened

### DIFF
--- a/.changeset/kan-93-dialogs-always-return-to-main-when-opened.md
+++ b/.changeset/kan-93-dialogs-always-return-to-main-when-opened.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+Refactored dialog mode handling to use nested AppMode::Dialog(DialogMode) enum
+for type-safe dialog management. Dialogs now correctly display their parent
+view in the background instead of hardcoded destinations.
+
+- Added DialogMode enum with all 23 dialog variants
+- Simplified is_dialog_mode() to matches!(self.mode, AppMode::Dialog(_))
+- Added get_base_mode() to determine parent view from mode_stack
+- Two-phase rendering: base view first, then dialog overlay
+- Converted all push_mode(AppMode::X) calls to open_dialog(DialogMode::X)

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -691,9 +691,7 @@ impl App {
                 DialogMode::OrderCards => {
                     should_restart_events = self.handle_order_cards_popup(key.code);
                 }
-                DialogMode::AssignCardToSprint => {
-                    self.handle_assign_card_to_sprint_popup(key.code)
-                }
+                DialogMode::AssignCardToSprint => self.handle_assign_card_to_sprint_popup(key.code),
                 DialogMode::AssignMultipleCardsToSprint => {
                     self.handle_assign_multiple_cards_to_sprint_popup(key.code)
                 }
@@ -702,16 +700,12 @@ impl App {
                 DialogMode::DeleteColumnConfirm => {
                     self.handle_delete_column_confirm_popup(key.code)
                 }
-                DialogMode::SelectTaskListView => {
-                    self.handle_select_task_list_view_popup(key.code)
-                }
+                DialogMode::SelectTaskListView => self.handle_select_task_list_view_popup(key.code),
                 DialogMode::ConfirmSprintPrefixCollision => {
                     self.handle_confirm_sprint_prefix_collision_popup(key.code)
                 }
                 DialogMode::FilterOptions => self.handle_filter_options_popup(key.code),
-                DialogMode::ConflictResolution => {
-                    self.handle_conflict_resolution_popup(key.code)
-                }
+                DialogMode::ConflictResolution => self.handle_conflict_resolution_popup(key.code),
                 DialogMode::ExternalChangeDetected => {
                     self.handle_external_change_detected_popup(key.code)
                 }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -44,6 +44,7 @@ pub struct App {
     pub should_quit: bool,
     pub quit_with_pending: bool, // Force quit even if saves are pending (second 'q' press)
     pub mode: AppMode,
+    pub mode_stack: Vec<AppMode>,
     pub input: InputState,
     pub boards: Vec<Board>,
     pub board_selection: SelectionState,
@@ -133,13 +134,10 @@ pub enum BoardField {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AppMode {
-    Normal,
+pub enum DialogMode {
     CreateBoard,
     CreateCard,
-    CardDetail,
     RenameBoard,
-    BoardDetail,
     ExportBoard,
     ExportAll,
     ImportBoard,
@@ -147,7 +145,6 @@ pub enum AppMode {
     SetCardPriority,
     SetBranchPrefix,
     OrderCards,
-    SprintDetail,
     CreateSprint,
     AssignCardToSprint,
     AssignMultipleCardsToSprint,
@@ -155,15 +152,24 @@ pub enum AppMode {
     RenameColumn,
     DeleteColumnConfirm,
     SelectTaskListView,
-    Search,
     SetSprintPrefix,
     SetSprintCardPrefix,
     ConfirmSprintPrefixCollision,
     FilterOptions,
-    ArchivedCardsView,
     ConflictResolution,
     ExternalChangeDetected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppMode {
+    Normal,
+    CardDetail,
+    BoardDetail,
+    SprintDetail,
+    Search,
+    ArchivedCardsView,
     Help(Box<AppMode>),
+    Dialog(DialogMode),
 }
 
 impl App {
@@ -179,6 +185,7 @@ impl App {
             should_quit: false,
             quit_with_pending: false,
             mode: AppMode::Normal,
+            mode_stack: Vec::new(),
             input: InputState::new(),
             boards: Vec::new(),
             board_selection: SelectionState::new(),
@@ -271,6 +278,31 @@ impl App {
 
     pub fn quit(&mut self) {
         self.should_quit = true;
+    }
+
+    pub fn push_mode(&mut self, new_mode: AppMode) {
+        self.mode_stack.push(self.mode.clone());
+        self.mode = new_mode;
+    }
+
+    pub fn pop_mode(&mut self) {
+        self.mode = self.mode_stack.pop().unwrap_or(AppMode::Normal);
+    }
+
+    pub fn is_dialog_mode(&self) -> bool {
+        matches!(self.mode, AppMode::Dialog(_))
+    }
+
+    pub fn get_base_mode(&self) -> &AppMode {
+        if self.is_dialog_mode() {
+            self.mode_stack.last().unwrap_or(&AppMode::Normal)
+        } else {
+            &self.mode
+        }
+    }
+
+    pub fn open_dialog(&mut self, dialog: DialogMode) {
+        self.push_mode(AppMode::Dialog(dialog));
     }
 
     pub fn set_error(&mut self, message: String) {
@@ -410,19 +442,19 @@ impl App {
 
         let is_input_mode = matches!(
             self.mode,
-            AppMode::CreateBoard
-                | AppMode::CreateCard
-                | AppMode::CreateSprint
-                | AppMode::RenameBoard
-                | AppMode::ExportBoard
-                | AppMode::ExportAll
-                | AppMode::SetCardPoints
-                | AppMode::SetBranchPrefix
-                | AppMode::CreateColumn
-                | AppMode::RenameColumn
-                | AppMode::Search
-                | AppMode::SetSprintPrefix
-                | AppMode::SetSprintCardPrefix
+            AppMode::Search
+                | AppMode::Dialog(DialogMode::CreateBoard)
+                | AppMode::Dialog(DialogMode::CreateCard)
+                | AppMode::Dialog(DialogMode::CreateSprint)
+                | AppMode::Dialog(DialogMode::RenameBoard)
+                | AppMode::Dialog(DialogMode::ExportBoard)
+                | AppMode::Dialog(DialogMode::ExportAll)
+                | AppMode::Dialog(DialogMode::SetCardPoints)
+                | AppMode::Dialog(DialogMode::SetBranchPrefix)
+                | AppMode::Dialog(DialogMode::CreateColumn)
+                | AppMode::Dialog(DialogMode::RenameColumn)
+                | AppMode::Dialog(DialogMode::SetSprintPrefix)
+                | AppMode::Dialog(DialogMode::SetSprintCardPrefix)
         );
 
         if matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q')) && !is_input_mode {
@@ -627,17 +659,6 @@ impl App {
                     self.pending_key = None;
                 }
             },
-            AppMode::CreateBoard => self.handle_create_board_dialog(key.code),
-            AppMode::CreateCard => self.handle_create_card_dialog(key.code),
-            AppMode::CreateSprint => self.handle_create_sprint_dialog(key.code),
-            AppMode::RenameBoard => self.handle_rename_board_dialog(key.code),
-            AppMode::ExportBoard => self.handle_export_board_dialog(key.code),
-            AppMode::ExportAll => self.handle_export_all_dialog(key.code),
-            AppMode::ImportBoard => self.handle_import_board_popup(key.code),
-            AppMode::SetCardPoints => {
-                should_restart_events = self.handle_set_card_points_dialog(key.code);
-            }
-            AppMode::SetCardPriority => self.handle_set_card_priority_popup(key.code),
             AppMode::CardDetail => {
                 should_restart_events =
                     self.handle_card_detail_key(key.code, terminal, event_handler);
@@ -646,30 +667,55 @@ impl App {
                 should_restart_events =
                     self.handle_board_detail_key(key.code, terminal, event_handler);
             }
-            AppMode::SetBranchPrefix => self.handle_set_branch_prefix_dialog(key.code),
-            AppMode::SetSprintPrefix => self.handle_set_sprint_prefix_dialog(key.code),
-            AppMode::SetSprintCardPrefix => self.handle_set_sprint_card_prefix_dialog(key.code),
-            AppMode::OrderCards => {
-                should_restart_events = self.handle_order_cards_popup(key.code);
-            }
             AppMode::SprintDetail => self.handle_sprint_detail_key(key.code),
-            AppMode::AssignCardToSprint => self.handle_assign_card_to_sprint_popup(key.code),
-            AppMode::AssignMultipleCardsToSprint => {
-                self.handle_assign_multiple_cards_to_sprint_popup(key.code)
-            }
-            AppMode::CreateColumn => self.handle_create_column_dialog(key.code),
-            AppMode::RenameColumn => self.handle_rename_column_dialog(key.code),
-            AppMode::DeleteColumnConfirm => self.handle_delete_column_confirm_popup(key.code),
-            AppMode::SelectTaskListView => self.handle_select_task_list_view_popup(key.code),
             AppMode::Search => self.handle_search_mode(key.code),
-            AppMode::ConfirmSprintPrefixCollision => {
-                self.handle_confirm_sprint_prefix_collision_popup(key.code)
-            }
-            AppMode::FilterOptions => self.handle_filter_options_popup(key.code),
             AppMode::ArchivedCardsView => self.handle_archived_cards_view_mode(key.code),
-            AppMode::ConflictResolution => self.handle_conflict_resolution_popup(key.code),
-            AppMode::ExternalChangeDetected => self.handle_external_change_detected_popup(key.code),
             AppMode::Help(_) => self.handle_help_mode(key.code),
+            AppMode::Dialog(ref dialog) => match dialog {
+                DialogMode::CreateBoard => self.handle_create_board_dialog(key.code),
+                DialogMode::CreateCard => self.handle_create_card_dialog(key.code),
+                DialogMode::CreateSprint => self.handle_create_sprint_dialog(key.code),
+                DialogMode::RenameBoard => self.handle_rename_board_dialog(key.code),
+                DialogMode::ExportBoard => self.handle_export_board_dialog(key.code),
+                DialogMode::ExportAll => self.handle_export_all_dialog(key.code),
+                DialogMode::ImportBoard => self.handle_import_board_popup(key.code),
+                DialogMode::SetCardPoints => {
+                    should_restart_events = self.handle_set_card_points_dialog(key.code);
+                }
+                DialogMode::SetCardPriority => self.handle_set_card_priority_popup(key.code),
+                DialogMode::SetBranchPrefix => self.handle_set_branch_prefix_dialog(key.code),
+                DialogMode::SetSprintPrefix => self.handle_set_sprint_prefix_dialog(key.code),
+                DialogMode::SetSprintCardPrefix => {
+                    self.handle_set_sprint_card_prefix_dialog(key.code)
+                }
+                DialogMode::OrderCards => {
+                    should_restart_events = self.handle_order_cards_popup(key.code);
+                }
+                DialogMode::AssignCardToSprint => {
+                    self.handle_assign_card_to_sprint_popup(key.code)
+                }
+                DialogMode::AssignMultipleCardsToSprint => {
+                    self.handle_assign_multiple_cards_to_sprint_popup(key.code)
+                }
+                DialogMode::CreateColumn => self.handle_create_column_dialog(key.code),
+                DialogMode::RenameColumn => self.handle_rename_column_dialog(key.code),
+                DialogMode::DeleteColumnConfirm => {
+                    self.handle_delete_column_confirm_popup(key.code)
+                }
+                DialogMode::SelectTaskListView => {
+                    self.handle_select_task_list_view_popup(key.code)
+                }
+                DialogMode::ConfirmSprintPrefixCollision => {
+                    self.handle_confirm_sprint_prefix_collision_popup(key.code)
+                }
+                DialogMode::FilterOptions => self.handle_filter_options_popup(key.code),
+                DialogMode::ConflictResolution => {
+                    self.handle_conflict_resolution_popup(key.code)
+                }
+                DialogMode::ExternalChangeDetected => {
+                    self.handle_external_change_detected_popup(key.code)
+                }
+            },
         }
         should_restart_events
     }
@@ -1663,12 +1709,12 @@ impl App {
                             tracing::info!("External change detected, auto-reloading");
                             self.auto_reload_from_external_change().await;
                             tracing::info!("Auto-reloaded due to external file change");
-                        } else if self.mode != AppMode::ConflictResolution
-                            && self.mode != AppMode::ExternalChangeDetected
+                        } else if self.mode != AppMode::Dialog(DialogMode::ConflictResolution)
+                            && self.mode != AppMode::Dialog(DialogMode::ExternalChangeDetected)
                         {
                             // Local changes exist, prompt user
                             tracing::warn!("External file change detected with local changes");
-                            self.mode = AppMode::ExternalChangeDetected;
+                            self.open_dialog(DialogMode::ExternalChangeDetected);
                         }
                     }
                 }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1,11 +1,11 @@
-use crate::app::{App, AppMode, BoardFocus, Focus};
+use crate::app::{App, AppMode, BoardFocus, DialogMode, Focus};
 use crate::state::commands::{CreateBoard, CreateColumn, UpdateBoard};
 use kanban_domain::{BoardUpdate, TaskListView};
 
 impl App {
     pub fn handle_create_board_key(&mut self) {
         if self.focus == Focus::Boards {
-            self.mode = AppMode::CreateBoard;
+            self.open_dialog(DialogMode::CreateBoard);
             self.input.clear();
         }
     }
@@ -15,7 +15,7 @@ impl App {
             if let Some(board_idx) = self.board_selection.get() {
                 if let Some(board) = self.boards.get(board_idx) {
                     self.input.set(board.name.clone());
-                    self.mode = AppMode::RenameBoard;
+                    self.open_dialog(DialogMode::RenameBoard);
                 }
             }
         }
@@ -23,7 +23,7 @@ impl App {
 
     pub fn handle_edit_board_key(&mut self) {
         if self.focus == Focus::Boards && self.board_selection.get().is_some() {
-            self.mode = AppMode::BoardDetail;
+            self.push_mode(AppMode::BoardDetail);
             self.board_focus = BoardFocus::Name;
         }
     }
@@ -38,7 +38,7 @@ impl App {
                         chrono::Utc::now().format("%Y%m%d-%H%M%S")
                     );
                     self.input.set(filename);
-                    self.mode = AppMode::ExportBoard;
+                    self.open_dialog(DialogMode::ExportBoard);
                 }
             }
         }
@@ -51,7 +51,7 @@ impl App {
                 chrono::Utc::now().format("%Y%m%d-%H%M%S")
             );
             self.input.set(filename);
-            self.mode = AppMode::ExportAll;
+            self.open_dialog(DialogMode::ExportAll);
         }
     }
 
@@ -60,7 +60,7 @@ impl App {
             self.scan_import_files();
             if !self.import_files.is_empty() {
                 self.import_selection.set(Some(0));
-                self.mode = AppMode::ImportBoard;
+                self.open_dialog(DialogMode::ImportBoard);
             }
         }
     }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, AppMode, CardField, Focus};
+use crate::app::{App, AppMode, CardField, DialogMode, Focus};
 use crate::card_list::CardListId;
 use crate::events::EventHandler;
 use crate::state::commands::{
@@ -11,7 +11,7 @@ use std::io;
 impl App {
     pub fn handle_create_card_key(&mut self) {
         if self.focus == Focus::Cards && self.active_board_index.is_some() {
-            self.mode = AppMode::CreateCard;
+            self.open_dialog(DialogMode::CreateCard);
             self.input.clear();
         }
     }
@@ -57,7 +57,7 @@ impl App {
 
         if !self.selected_cards.is_empty() {
             self.sprint_assign_selection.clear();
-            self.mode = AppMode::AssignMultipleCardsToSprint;
+            self.open_dialog(DialogMode::AssignMultipleCardsToSprint);
         } else if self.get_selected_card_id().is_some() {
             if let Some(board_idx) = self.active_board_index {
                 if let Some(board) = self.boards.get(board_idx) {
@@ -74,7 +74,7 @@ impl App {
                         }
                         let selection_idx = self.get_current_sprint_selection_index();
                         self.sprint_assign_selection.set(Some(selection_idx));
-                        self.mode = AppMode::AssignCardToSprint;
+                        self.open_dialog(DialogMode::AssignCardToSprint);
                     }
                 }
             }
@@ -85,7 +85,7 @@ impl App {
         if self.focus == Focus::Cards && self.active_board_index.is_some() {
             let sort_idx = self.get_current_sort_field_selection_index();
             self.sort_field_selection.set(Some(sort_idx));
-            self.mode = AppMode::OrderCards;
+            self.open_dialog(DialogMode::OrderCards);
         }
     }
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1,4 +1,6 @@
-use crate::app::{App, AppMode, BoardField, BoardFocus, CardField, CardFocus, DialogMode, SprintTaskPanel};
+use crate::app::{
+    App, AppMode, BoardField, BoardFocus, CardField, CardFocus, DialogMode, SprintTaskPanel,
+};
 use crate::events::EventHandler;
 use crossterm::event::KeyCode;
 use kanban_domain::{BoardSettingsDto, CardMetadataDto};

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, AppMode, BoardField, BoardFocus, CardField, CardFocus, SprintTaskPanel};
+use crate::app::{App, AppMode, BoardField, BoardFocus, CardField, CardFocus, DialogMode, SprintTaskPanel};
 use crate::events::EventHandler;
 use crossterm::event::KeyCode;
 use kanban_domain::{BoardSettingsDto, CardMetadataDto};
@@ -15,7 +15,7 @@ impl App {
         let mut should_restart = false;
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.active_card_index = None;
                 self.card_focus = CardFocus::Title;
             }
@@ -89,7 +89,7 @@ impl App {
             },
             KeyCode::Char('d') => {
                 self.handle_archive_card();
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.active_card_index = None;
                 self.card_focus = CardFocus::Title;
                 self.refresh_view();
@@ -105,18 +105,18 @@ impl App {
                         if sprint_count > 0 {
                             let selection_idx = self.get_current_sprint_selection_index();
                             self.sprint_assign_selection.set(Some(selection_idx));
-                            self.mode = AppMode::AssignCardToSprint;
+                            self.open_dialog(DialogMode::AssignCardToSprint);
                         }
                     }
                 }
             }
             KeyCode::Char('p') => {
-                self.mode = AppMode::SetCardPoints;
+                self.open_dialog(DialogMode::SetCardPoints);
             }
             KeyCode::Char('P') => {
                 let priority_idx = self.get_current_priority_selection_index();
                 self.priority_selection.set(Some(priority_idx));
-                self.mode = AppMode::SetCardPriority;
+                self.open_dialog(DialogMode::SetCardPriority);
             }
             _ => {}
         }
@@ -132,7 +132,7 @@ impl App {
         let mut should_restart = false;
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.board_focus = BoardFocus::Name;
             }
             KeyCode::Char('1') => {
@@ -318,7 +318,7 @@ impl App {
                                     if let Some(sprint) = self.sprints.get(*actual_idx) {
                                         self.populate_sprint_task_lists(sprint.id);
                                     }
-                                    self.mode = AppMode::SprintDetail;
+                                    self.push_mode(AppMode::SprintDetail);
                                 }
                             }
                         }
@@ -332,7 +332,7 @@ impl App {
                             let current_prefix =
                                 board.sprint_prefix.clone().unwrap_or_else(String::new);
                             self.input.set(current_prefix);
-                            self.mode = AppMode::SetBranchPrefix;
+                            self.open_dialog(DialogMode::SetBranchPrefix);
                         }
                     }
                 }
@@ -345,7 +345,7 @@ impl App {
     pub fn handle_sprint_detail_key(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::BoardDetail;
+                self.pop_mode();
                 self.board_focus = BoardFocus::Sprints;
                 self.active_sprint_index = None;
             }
@@ -360,7 +360,7 @@ impl App {
                     if let Some(sprint) = self.sprints.get(sprint_idx) {
                         let current_prefix = sprint.prefix.clone().unwrap_or_else(String::new);
                         self.input.set(current_prefix);
-                        self.mode = AppMode::SetSprintPrefix;
+                        self.open_dialog(DialogMode::SetSprintPrefix);
                     }
                 }
             }
@@ -369,14 +369,14 @@ impl App {
                     if let Some(sprint) = self.sprints.get(sprint_idx) {
                         let current_prefix = sprint.card_prefix.clone().unwrap_or_else(String::new);
                         self.input.set(current_prefix);
-                        self.mode = AppMode::SetSprintCardPrefix;
+                        self.open_dialog(DialogMode::SetSprintCardPrefix);
                     }
                 }
             }
             KeyCode::Char('o') => {
                 let sort_idx = self.get_current_sort_field_selection_index();
                 self.sort_field_selection.set(Some(sort_idx));
-                self.mode = AppMode::OrderCards;
+                self.open_dialog(DialogMode::OrderCards);
             }
             KeyCode::Char('O') => {
                 if let Some(current_order) = self.current_sort_order {
@@ -427,7 +427,7 @@ impl App {
                             if let Some(card_idx) = self.cards.iter().position(|c| c.id == card_id)
                             {
                                 self.active_card_index = Some(card_idx);
-                                self.mode = AppMode::CardDetail;
+                                self.push_mode(AppMode::CardDetail);
                                 self.card_focus = CardFocus::Title;
                             }
                         }
@@ -435,7 +435,7 @@ impl App {
                             if let Some(card_idx) = self.cards.iter().position(|c| c.id == card_id)
                             {
                                 self.active_card_index = Some(card_idx);
-                                self.mode = AppMode::CardDetail;
+                                self.push_mode(AppMode::CardDetail);
                                 self.card_focus = CardFocus::Title;
                             }
                         }
@@ -467,7 +467,7 @@ impl App {
                                 self.active_card_index = Some(card_idx);
                                 let priority_idx = self.get_current_priority_selection_index();
                                 self.priority_selection.set(Some(priority_idx));
-                                self.mode = AppMode::SetCardPriority;
+                                self.open_dialog(DialogMode::SetCardPriority);
                             }
                         }
                         CardListAction::AssignSprint(card_id) => {
@@ -485,7 +485,7 @@ impl App {
                                             let selection_idx =
                                                 self.get_current_sprint_selection_index();
                                             self.sprint_assign_selection.set(Some(selection_idx));
-                                            self.mode = AppMode::AssignCardToSprint;
+                                            self.open_dialog(DialogMode::AssignCardToSprint);
                                         }
                                     }
                                 }
@@ -506,7 +506,7 @@ impl App {
                                             let selection_idx =
                                                 self.get_current_sprint_selection_index();
                                             self.sprint_assign_selection.set(Some(selection_idx));
-                                            self.mode = AppMode::AssignCardToSprint;
+                                            self.open_dialog(DialogMode::AssignCardToSprint);
                                         }
                                     }
                                 }
@@ -515,7 +515,7 @@ impl App {
                         CardListAction::Sort => {
                             let sort_idx = self.get_current_sort_field_selection_index();
                             self.sort_field_selection.set(Some(sort_idx));
-                            self.mode = AppMode::OrderCards;
+                            self.open_dialog(DialogMode::OrderCards);
                         }
                         CardListAction::OrderCards => {
                             if let Some(current_order) = self.current_sort_order {
@@ -675,7 +675,7 @@ impl App {
                             }
                         }
                         CardListAction::Create => {
-                            self.mode = AppMode::CreateCard;
+                            self.open_dialog(DialogMode::CreateCard);
                             self.input.clear();
                         }
                         CardListAction::ToggleMultiSelect(card_id) => {

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, AppMode, BoardFocus};
+use crate::app::{App, BoardFocus, DialogMode};
 use crate::dialog::{handle_dialog_input, DialogAction};
 use crossterm::event::KeyCode;
 use kanban_domain::{Card, FieldUpdate};
@@ -18,11 +18,11 @@ impl App {
         match handle_dialog_input(&mut self.input, key_code, false) {
             DialogAction::Confirm => {
                 self.create_board();
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::Cancel => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::None => {}
@@ -33,11 +33,11 @@ impl App {
         match handle_dialog_input(&mut self.input, key_code, false) {
             DialogAction::Confirm => {
                 self.create_card();
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::Cancel => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::None => {}
@@ -48,12 +48,12 @@ impl App {
         match handle_dialog_input(&mut self.input, key_code, true) {
             DialogAction::Confirm => {
                 self.create_sprint();
-                self.mode = AppMode::BoardDetail;
+                self.pop_mode();
                 self.board_focus = BoardFocus::Sprints;
                 self.input.clear();
             }
             DialogAction::Cancel => {
-                self.mode = AppMode::BoardDetail;
+                self.pop_mode();
                 self.board_focus = BoardFocus::Sprints;
                 self.input.clear();
             }
@@ -65,11 +65,11 @@ impl App {
         match handle_dialog_input(&mut self.input, key_code, false) {
             DialogAction::Confirm => {
                 self.rename_board();
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::Cancel => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::None => {}
@@ -82,11 +82,11 @@ impl App {
                 if let Err(e) = self.export_board_with_filename() {
                     tracing::error!("Failed to export board: {}", e);
                 }
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::Cancel => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::None => {}
@@ -99,11 +99,11 @@ impl App {
                 if let Err(e) = self.export_all_boards_with_filename() {
                     tracing::error!("Failed to export all boards: {}", e);
                 }
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::Cancel => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::None => {}
@@ -121,13 +121,13 @@ impl App {
                         Some(p)
                     } else {
                         tracing::error!("Points must be between 1-5");
-                        self.mode = AppMode::CardDetail;
+                        self.pop_mode();
                         self.input.clear();
                         return false;
                     }
                 } else {
                     tracing::error!("Invalid points value");
-                    self.mode = AppMode::CardDetail;
+                    self.pop_mode();
                     self.input.clear();
                     return false;
                 };
@@ -163,12 +163,12 @@ impl App {
                         }
                     }
                 }
-                self.mode = AppMode::CardDetail;
+                self.pop_mode();
                 self.input.clear();
                 false
             }
             DialogAction::Cancel => {
-                self.mode = AppMode::CardDetail;
+                self.pop_mode();
                 self.input.clear();
                 false
             }
@@ -177,20 +177,12 @@ impl App {
     }
 
     /// Generic handler for prefix dialogs that handles common validation and state management
-    fn handle_prefix_dialog_impl(
-        &mut self,
-        key_code: KeyCode,
-        context: PrefixDialogContext,
-        next_mode: AppMode,
-        next_focus: Option<BoardFocus>,
-    ) {
+    fn handle_prefix_dialog_impl(&mut self, key_code: KeyCode, context: PrefixDialogContext) {
         match handle_dialog_input(&mut self.input, key_code, true) {
             DialogAction::Confirm => {
-                // Extract prefix early to avoid borrow issues with self
                 let prefix_str = self.input.as_str().trim().to_string();
 
                 if prefix_str.is_empty() {
-                    // Clear the prefix
                     match context {
                         PrefixDialogContext::BoardSprint => {
                             if let Some(board_idx) = self.board_selection.get() {
@@ -253,7 +245,6 @@ impl App {
                         }
                     }
                 } else if Card::validate_branch_prefix(&prefix_str) {
-                    // Set the prefix
                     match context {
                         PrefixDialogContext::BoardSprint => {
                             if let Some(board_idx) = self.board_selection.get() {
@@ -269,7 +260,6 @@ impl App {
                                         tracing::error!("Failed to set sprint prefix: {}", e);
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
-                                        // Ensure counter is initialized for new prefix
                                         if let Some(board) = self.boards.get_mut(board_idx) {
                                             board.ensure_sprint_counter_initialized(
                                                 &prefix_str,
@@ -298,7 +288,6 @@ impl App {
                                     }
                                 }
                             }
-                            // Initialize counter for sprint-level prefix
                             let board_idx = self.active_board_index.or(self.board_selection.get());
                             if let Some(board_idx) = board_idx {
                                 if let Some(board) = self.boards.get_mut(board_idx) {
@@ -339,17 +328,11 @@ impl App {
                     tracing::error!("Invalid prefix: use alphanumeric, hyphens, underscores only");
                 }
 
-                self.mode = next_mode;
-                if let Some(focus) = next_focus {
-                    self.board_focus = focus;
-                }
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::Cancel => {
-                self.mode = next_mode;
-                if let Some(focus) = next_focus {
-                    self.board_focus = focus;
-                }
+                self.pop_mode();
                 self.input.clear();
             }
             DialogAction::None => {}
@@ -357,46 +340,32 @@ impl App {
     }
 
     pub fn handle_set_branch_prefix_dialog(&mut self, key_code: KeyCode) {
-        self.handle_prefix_dialog_impl(
-            key_code,
-            PrefixDialogContext::BoardSprint,
-            AppMode::BoardDetail,
-            Some(BoardFocus::Settings),
-        );
+        self.handle_prefix_dialog_impl(key_code, PrefixDialogContext::BoardSprint);
     }
 
     pub fn handle_set_sprint_prefix_dialog(&mut self, key_code: KeyCode) {
-        self.handle_prefix_dialog_impl(
-            key_code,
-            PrefixDialogContext::Sprint,
-            AppMode::SprintDetail,
-            None,
-        );
+        self.handle_prefix_dialog_impl(key_code, PrefixDialogContext::Sprint);
     }
 
     pub fn handle_set_sprint_card_prefix_dialog(&mut self, key_code: KeyCode) {
-        self.handle_prefix_dialog_impl(
-            key_code,
-            PrefixDialogContext::SprintCard,
-            AppMode::SprintDetail,
-            None,
-        );
+        self.handle_prefix_dialog_impl(key_code, PrefixDialogContext::SprintCard);
     }
 
     pub fn handle_confirm_sprint_prefix_collision_popup(&mut self, key_code: KeyCode) {
         use crossterm::event::KeyCode;
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::SprintDetail;
+                self.pop_mode();
             }
             KeyCode::Enter | KeyCode::Char('y') => {
                 // User confirmed they want to continue with the colliding prefix
                 // The actual prefix application should happen before this mode is entered
-                self.mode = AppMode::SprintDetail;
+                self.pop_mode();
             }
             KeyCode::Char('n') | KeyCode::Char('N') => {
                 // User declined, go back to prefix dialog
-                self.mode = AppMode::SetSprintPrefix;
+                self.pop_mode();
+                self.open_dialog(DialogMode::SetSprintPrefix);
             }
             _ => {}
         }
@@ -409,17 +378,17 @@ impl App {
                 // Keep our changes - force overwrite
                 // Store the action to be processed in the event loop
                 self.pending_key = Some('o');
-                self.mode = AppMode::Normal;
+                self.pop_mode();
             }
             KeyCode::Char('t') | KeyCode::Char('T') => {
                 // Take their changes - reload from disk
                 self.pending_key = Some('t');
-                self.mode = AppMode::Normal;
+                self.pop_mode();
             }
             KeyCode::Esc => {
-                // Retry later - just go back to normal mode
+                // Retry later - just go back to previous mode
                 self.state_manager.clear_conflict();
-                self.mode = AppMode::Normal;
+                self.pop_mode();
             }
             _ => {}
         }
@@ -431,15 +400,15 @@ impl App {
             KeyCode::Char('r') | KeyCode::Char('R') => {
                 // Reload from external file - discard local changes
                 self.pending_key = Some('r');
-                self.mode = AppMode::Normal;
+                self.pop_mode();
             }
             KeyCode::Char('k') | KeyCode::Char('K') => {
                 // Keep local changes - continue editing
-                self.mode = AppMode::Normal;
+                self.pop_mode();
             }
             KeyCode::Esc => {
                 // Dismiss dialog - continue with current state
-                self.mode = AppMode::Normal;
+                self.pop_mode();
             }
             _ => {}
         }

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, AppMode, Focus};
+use crate::app::{App, DialogMode, Focus};
 use crate::filters::{CardFilters, FilterDialogSection, FilterDialogState};
 use crossterm::event::KeyCode;
 
@@ -17,7 +17,7 @@ impl App {
         };
 
         self.filter_dialog_state = Some(FilterDialogState::new(filters));
-        self.mode = AppMode::FilterOptions;
+        self.open_dialog(DialogMode::FilterOptions);
     }
 
     pub fn handle_filter_options_popup(&mut self, key_code: KeyCode) {
@@ -27,7 +27,7 @@ impl App {
             match key_code {
                 KeyCode::Esc => {
                     self.filter_dialog_state = None;
-                    self.mode = AppMode::Normal;
+                    self.pop_mode();
                 }
                 KeyCode::Char('j') | KeyCode::Down => match dialog_state.current_section {
                     FilterDialogSection::Sprints => {
@@ -105,7 +105,7 @@ impl App {
                 KeyCode::Enter => {
                     self.apply_filters();
                     self.filter_dialog_state = None;
-                    self.mode = AppMode::Normal;
+                    self.pop_mode();
                 }
                 _ => {}
             }

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -454,7 +454,7 @@ impl App {
                     let card_id = selected_card.id;
                     let actual_idx = self.cards.iter().position(|c| c.id == card_id);
                     self.active_card_index = actual_idx;
-                    self.mode = AppMode::CardDetail;
+                    self.push_mode(AppMode::CardDetail);
                 }
             }
         }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, AppMode};
+use crate::app::App;
 use crossterm::event::KeyCode;
 use kanban_domain::{FieldUpdate, SortField, SortOrder};
 
@@ -6,7 +6,7 @@ impl App {
     pub fn handle_import_board_popup(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.import_selection.clear();
             }
             KeyCode::Char('j') | KeyCode::Down => {
@@ -23,7 +23,7 @@ impl App {
                         }
                     }
                 }
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.import_selection.clear();
             }
             _ => {}
@@ -33,7 +33,7 @@ impl App {
     pub fn handle_set_card_priority_popup(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::CardDetail;
+                self.pop_mode();
             }
             KeyCode::Char('j') | KeyCode::Down => {
                 self.priority_selection.next(4);
@@ -67,7 +67,7 @@ impl App {
                         }
                     }
                 }
-                self.mode = AppMode::CardDetail;
+                self.pop_mode();
             }
             _ => {}
         }
@@ -76,7 +76,7 @@ impl App {
     pub fn handle_order_cards_popup(&mut self, key_code: KeyCode) -> bool {
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.sort_field_selection.clear();
                 false
             }
@@ -132,19 +132,12 @@ impl App {
                         }
                     }
 
-                    // Return to the appropriate mode based on where we came from
                     let is_sprint_detail = self.active_sprint_index.is_some();
-                    let prev_mode = if is_sprint_detail {
-                        AppMode::SprintDetail
-                    } else {
-                        AppMode::Normal
-                    };
-                    self.mode = prev_mode;
+                    self.pop_mode();
                     self.sort_field_selection.clear();
 
                     tracing::info!("Sorting by {:?} ({:?})", field, order);
 
-                    // Apply sorting to the appropriate context
                     if is_sprint_detail {
                         self.apply_sort_to_sprint_lists(field, order);
                     } else {
@@ -160,7 +153,7 @@ impl App {
     pub fn handle_assign_card_to_sprint_popup(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.sprint_assign_selection.clear();
             }
             KeyCode::Char('j') | KeyCode::Down => {
@@ -281,7 +274,7 @@ impl App {
                         }
                     }
                 }
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.sprint_assign_selection.clear();
             }
             _ => {}
@@ -291,7 +284,7 @@ impl App {
     pub fn handle_assign_multiple_cards_to_sprint_popup(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.sprint_assign_selection.clear();
                 self.selected_cards.clear();
             }
@@ -407,7 +400,7 @@ impl App {
                         }
                     }
                 }
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.sprint_assign_selection.clear();
                 self.selected_cards.clear();
             }

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -1,11 +1,11 @@
-use crate::app::{App, AppMode, BoardFocus};
+use crate::app::{App, BoardFocus, DialogMode};
 use crate::state::commands::{ActivateSprint, CompleteSprint, CreateSprint, UpdateBoard};
 use kanban_domain::{BoardUpdate, FieldUpdate, SprintStatus};
 
 impl App {
     pub fn handle_create_sprint_key(&mut self) {
         if self.board_focus == BoardFocus::Sprints && self.board_selection.get().is_some() {
-            self.mode = AppMode::CreateSprint;
+            self.open_dialog(DialogMode::CreateSprint);
             self.input.clear();
         }
     }
@@ -118,7 +118,7 @@ impl App {
 
                 tracing::info!("Completed sprint: {}", sprint_name);
 
-                self.mode = AppMode::BoardDetail;
+                self.pop_mode();
                 self.board_focus = BoardFocus::Sprints;
                 self.active_sprint_index = None;
             }

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -10,7 +10,7 @@ use super::{
     sprint_detail::SprintDetailProvider,
     KeybindingProvider,
 };
-use crate::app::{App, AppMode, Focus};
+use crate::app::{App, AppMode, DialogMode, Focus};
 
 pub struct KeybindingRegistry;
 
@@ -39,45 +39,55 @@ impl KeybindingRegistry {
             AppMode::BoardDetail => Box::new(BoardDetailProvider::new(board_focus)),
             AppMode::SprintDetail => Box::new(SprintDetailProvider),
             AppMode::Search => Box::new(SearchModeProvider),
-            AppMode::CreateBoard => Box::new(DialogInputProvider::new("Create Project")),
-            AppMode::CreateCard => Box::new(DialogInputProvider::new("Create Task")),
-            AppMode::CreateSprint => Box::new(DialogInputProvider::new("Create Sprint")),
-            AppMode::RenameBoard => Box::new(DialogInputProvider::new("Rename Project")),
-            AppMode::RenameColumn => Box::new(DialogInputProvider::new("Rename Column")),
-            AppMode::CreateColumn => Box::new(DialogInputProvider::new("Create Column")),
-            AppMode::ExportBoard => Box::new(DialogInputProvider::new("Export Project")),
-            AppMode::ExportAll => Box::new(DialogInputProvider::new("Export All Projects")),
-            AppMode::SetCardPoints => Box::new(DialogInputProvider::new("Set Points")),
-            AppMode::SetBranchPrefix => Box::new(DialogInputProvider::new("Set Branch Prefix")),
-            AppMode::SetSprintPrefix => Box::new(DialogInputProvider::new("Set Sprint Prefix")),
-            AppMode::SetSprintCardPrefix => Box::new(DialogInputProvider::new("Set Card Prefix")),
-            AppMode::ImportBoard => Box::new(DialogSelectionProvider::new("Import Project")),
-            AppMode::SetCardPriority => Box::new(DialogSelectionProvider::new("Set Priority")),
-            AppMode::OrderCards => Box::new(DialogSelectionProvider::new("Sort Tasks")),
-            AppMode::AssignCardToSprint => {
-                Box::new(DialogSelectionProvider::new("Assign to Sprint"))
-            }
-            AppMode::AssignMultipleCardsToSprint => {
-                Box::new(DialogSelectionProvider::new("Assign Cards to Sprint"))
-            }
-            AppMode::SelectTaskListView => {
-                Box::new(DialogSelectionProvider::new("Select Task View"))
-            }
-            AppMode::DeleteColumnConfirm => Box::new(DeleteConfirmProvider::new("Column")),
-            AppMode::ConfirmSprintPrefixCollision => {
-                Box::new(DialogSelectionProvider::new("Confirm Action"))
-            }
-            AppMode::FilterOptions => Box::new(FilterOptionsProvider),
             AppMode::ArchivedCardsView => Box::new(ArchivedCardsViewProvider),
-            AppMode::ConflictResolution => {
-                Box::new(DialogSelectionProvider::new("Resolve Conflict"))
-            }
-            AppMode::ExternalChangeDetected => {
-                Box::new(DialogSelectionProvider::new("External Change"))
-            }
             AppMode::Help(previous_mode) => {
                 Self::get_provider_for_mode(previous_mode, focus, card_focus, board_focus)
             }
+            AppMode::Dialog(dialog) => match dialog {
+                DialogMode::CreateBoard => Box::new(DialogInputProvider::new("Create Project")),
+                DialogMode::CreateCard => Box::new(DialogInputProvider::new("Create Task")),
+                DialogMode::CreateSprint => Box::new(DialogInputProvider::new("Create Sprint")),
+                DialogMode::RenameBoard => Box::new(DialogInputProvider::new("Rename Project")),
+                DialogMode::RenameColumn => Box::new(DialogInputProvider::new("Rename Column")),
+                DialogMode::CreateColumn => Box::new(DialogInputProvider::new("Create Column")),
+                DialogMode::ExportBoard => Box::new(DialogInputProvider::new("Export Project")),
+                DialogMode::ExportAll => Box::new(DialogInputProvider::new("Export All Projects")),
+                DialogMode::SetCardPoints => Box::new(DialogInputProvider::new("Set Points")),
+                DialogMode::SetBranchPrefix => {
+                    Box::new(DialogInputProvider::new("Set Branch Prefix"))
+                }
+                DialogMode::SetSprintPrefix => {
+                    Box::new(DialogInputProvider::new("Set Sprint Prefix"))
+                }
+                DialogMode::SetSprintCardPrefix => {
+                    Box::new(DialogInputProvider::new("Set Card Prefix"))
+                }
+                DialogMode::ImportBoard => Box::new(DialogSelectionProvider::new("Import Project")),
+                DialogMode::SetCardPriority => {
+                    Box::new(DialogSelectionProvider::new("Set Priority"))
+                }
+                DialogMode::OrderCards => Box::new(DialogSelectionProvider::new("Sort Tasks")),
+                DialogMode::AssignCardToSprint => {
+                    Box::new(DialogSelectionProvider::new("Assign to Sprint"))
+                }
+                DialogMode::AssignMultipleCardsToSprint => {
+                    Box::new(DialogSelectionProvider::new("Assign Cards to Sprint"))
+                }
+                DialogMode::SelectTaskListView => {
+                    Box::new(DialogSelectionProvider::new("Select Task View"))
+                }
+                DialogMode::DeleteColumnConfirm => Box::new(DeleteConfirmProvider::new("Column")),
+                DialogMode::ConfirmSprintPrefixCollision => {
+                    Box::new(DialogSelectionProvider::new("Confirm Action"))
+                }
+                DialogMode::FilterOptions => Box::new(FilterOptionsProvider),
+                DialogMode::ConflictResolution => {
+                    Box::new(DialogSelectionProvider::new("Resolve Conflict"))
+                }
+                DialogMode::ExternalChangeDetected => {
+                    Box::new(DialogSelectionProvider::new("External Change"))
+                }
+            },
         }
     }
 }

--- a/kanban.json
+++ b/kanban.json
@@ -2,8 +2,8 @@
   "version": 2,
   "metadata": {
     "format_version": 2,
-    "instance_id": "4a82f506-441f-4c9b-b912-3b7a145fdfbf",
-    "saved_at": "2025-12-04T23:34:17.512631Z",
+    "instance_id": "07e8eca0-da17-4dd5-906e-36815f5a4d7b",
+    "saved_at": "2025-12-05T23:23:00.318700Z",
     "schema_version": "2.0.0"
   },
   "data": {
@@ -2571,7 +2571,7 @@
         "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
         "completed_at": null,
         "created_at": "2025-10-24T19:54:30.818495Z",
-        "description": "discrupting the context of the viewer\n\nwhen opening a dialog inside say the sprint details view\n\nThe ui switches to the main card list, upsetting the viewers (user) context and mind model\n\nmake it so that opening a dialog keeps the background ui where it is so that context remains the same\n\n---\n\nsomething else is wrong with the context.\n\nonce the context has been disrupted like this the user will be sent back to the undefined context when taking an action.\n\nthen having to `escape` or whatever out of that list\n\nexample\n\nopen sprint details on a completed sprint\n\nnavigate two cards down\n\n`escape` that card\n\nbe returned to the main card list / kanban view.\n\nwhen one should have been returned to the sprint details\n",
+        "description": "disrupting the context of the viewer\n\nwhen opening a dialog inside say the sprint details view\n\nThe ui switches to the main card list, upsetting the viewers (user) context and mind model\n\nmake it so that opening a dialog keeps the background ui where it is so that context remains the same\n\n---\n\nsomething else is wrong with the context.\n\nonce the context has been disrupted like this the user will be sent back to the undefined context when taking an action.\n\nthen having to `escape` or whatever out of that list\n\nexample\n\nopen sprint details on a completed sprint\n\nnavigate two cards down\n\n`escape` that card\n\nbe returned to the main card list / kanban view.\n\nwhen one should have been returned to the sprint details\n\n---\n\nOr when after opening the external editor on the card description and then saving and exit. We are returned to the card list and not the card details \n",
         "due_date": null,
         "id": "6a994d78-3e0f-4158-bfe8-f3c82e402a65",
         "points": 4,
@@ -2606,7 +2606,7 @@
         ],
         "status": "Todo",
         "title": "dialogs always return to main when opened ",
-        "updated_at": "2025-12-04T22:38:49.459947Z"
+        "updated_at": "2025-12-05T23:23:00.298432Z"
       },
       {
         "assigned_prefix": null,
@@ -4021,210 +4021,14 @@
         "description": null,
         "due_date": null,
         "id": "55adb5ff-9ddf-4ea7-82ee-d93af5d1f552",
-        "points": 1,
+        "points": 2,
         "position": 2,
         "priority": "High",
         "sprint_id": null,
         "sprint_logs": [],
         "status": "Todo",
         "title": "multiselecting and assigning cards causes write race condition",
-        "updated_at": "2025-12-04T23:32:42.632591Z"
-      },
-      {
-        "assigned_prefix": "sprint",
-        "card_number": 1,
-        "card_prefix": null,
-        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
-        "completed_at": null,
-        "created_at": "2025-12-04T23:33:17.292547Z",
-        "description": null,
-        "due_date": null,
-        "id": "91ad3594-62f9-4ec5-a424-de8105ab22eb",
-        "points": null,
-        "position": 0,
-        "priority": "Medium",
-        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-            "sprint_name": "test",
-            "sprint_number": 1,
-            "started_at": "2025-12-04T23:34:17.506119Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "t",
-        "updated_at": "2025-12-04T23:34:17.506120Z"
-      },
-      {
-        "assigned_prefix": "sprint",
-        "card_number": 2,
-        "card_prefix": null,
-        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
-        "completed_at": null,
-        "created_at": "2025-12-04T23:33:18.459242Z",
-        "description": null,
-        "due_date": null,
-        "id": "b0c42030-a6a7-403d-9264-10a1dda5d42f",
-        "points": null,
-        "position": 1,
-        "priority": "Medium",
-        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-            "sprint_name": "test",
-            "sprint_number": 1,
-            "started_at": "2025-12-04T23:34:17.506116Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "t",
-        "updated_at": "2025-12-04T23:34:17.506118Z"
-      },
-      {
-        "assigned_prefix": "sprint",
-        "card_number": 3,
-        "card_prefix": null,
-        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
-        "completed_at": null,
-        "created_at": "2025-12-04T23:33:53.646227Z",
-        "description": null,
-        "due_date": null,
-        "id": "f336cd3b-1525-46ea-a76c-db4f07d8da9a",
-        "points": null,
-        "position": 2,
-        "priority": "Medium",
-        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-            "sprint_name": "test",
-            "sprint_number": 1,
-            "started_at": "2025-12-04T23:34:17.506113Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "t",
-        "updated_at": "2025-12-04T23:34:17.506115Z"
-      },
-      {
-        "assigned_prefix": "sprint",
-        "card_number": 4,
-        "card_prefix": null,
-        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
-        "completed_at": null,
-        "created_at": "2025-12-04T23:33:54.610343Z",
-        "description": null,
-        "due_date": null,
-        "id": "29ec1419-bc44-48b5-aaa4-c31e5655640e",
-        "points": null,
-        "position": 3,
-        "priority": "Medium",
-        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-            "sprint_name": "test",
-            "sprint_number": 1,
-            "started_at": "2025-12-04T23:34:17.506121Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "t",
-        "updated_at": "2025-12-04T23:34:17.506122Z"
-      },
-      {
-        "assigned_prefix": "sprint",
-        "card_number": 5,
-        "card_prefix": null,
-        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
-        "completed_at": null,
-        "created_at": "2025-12-04T23:33:55.307233Z",
-        "description": null,
-        "due_date": null,
-        "id": "0994e72a-13fc-43e3-adfd-955345c9e774",
-        "points": null,
-        "position": 4,
-        "priority": "Medium",
-        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-            "sprint_name": "test",
-            "sprint_number": 1,
-            "started_at": "2025-12-04T23:34:17.506123Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "t",
-        "updated_at": "2025-12-04T23:34:17.506124Z"
-      },
-      {
-        "assigned_prefix": "sprint",
-        "card_number": 6,
-        "card_prefix": null,
-        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
-        "completed_at": null,
-        "created_at": "2025-12-04T23:33:55.914221Z",
-        "description": null,
-        "due_date": null,
-        "id": "d327df47-10af-41c5-80e7-fd88847edbc4",
-        "points": null,
-        "position": 5,
-        "priority": "Medium",
-        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-            "sprint_name": "test",
-            "sprint_number": 1,
-            "started_at": "2025-12-04T23:34:17.506101Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "t",
-        "updated_at": "2025-12-04T23:34:17.506107Z"
-      },
-      {
-        "assigned_prefix": "sprint",
-        "card_number": 7,
-        "card_prefix": null,
-        "column_id": "f7588a2d-bc37-4ece-a1a3-a3babcf1c069",
-        "completed_at": null,
-        "created_at": "2025-12-04T23:33:56.538723Z",
-        "description": null,
-        "due_date": null,
-        "id": "329c13c3-b162-4194-bcfb-aadb4bdba4d0",
-        "points": null,
-        "position": 6,
-        "priority": "Medium",
-        "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "be826dbc-cbb9-4b2b-bc5b-cf4c99c860da",
-            "sprint_name": "test",
-            "sprint_number": 1,
-            "started_at": "2025-12-04T23:34:17.506109Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "t",
-        "updated_at": "2025-12-04T23:34:17.506111Z"
+        "updated_at": "2025-12-05T23:21:19.593796Z"
       }
     ],
     "columns": [


### PR DESCRIPTION
Fixes dialog context preservation so dialogs show their parent view in background:

- Add `DialogMode` enum with 23 dialog variants for type-safe dialog management
- Add `mode_stack: Vec<AppMode>` to track navigation history
- Add `push_mode()`, `pop_mode()`, `open_dialog()` helper methods
- Refactor rendering to two-phase approach: base view first, then dialog overlay
- Convert all dialog transitions to use `open_dialog(DialogMode::X)` pattern

## What

Dialogs now correctly display their parent view in the background instead of always showing the main kanban view. Escaping from a dialog or detail view returns to the previous context.

## Why

Opening dialogs (e.g., assign to sprint, set priority) from detail views like SprintDetail or CardDetail would disrupt user context by switching the background to the main view. Similarly, escaping from nested views would return to Normal mode instead of the parent view.

## How

Introduced a mode stack architecture:
- `AppMode` now has distinct view modes (Normal, CardDetail, BoardDetail, SprintDetail, Search, ArchivedCardsView) and a `Dialog(DialogMode)` variant
- `mode_stack` preserves the navigation path
- `get_base_mode()` determines which view to render behind dialogs
- Rendering uses two phases: render base view from stack, then overlay dialog

## Testing

- Open SprintDetail → open assign to sprint dialog → verify SprintDetail visible in background
- Open CardDetail → set priority → verify CardDetail visible in background
- Navigate CardDetail → BoardDetail → SprintDetail → escape each level → verify correct return path
- Verify all 23 dialog types show correct parent view