### PR TITLE
KAN-142/updating-fields-jumps-the-user-back-to-board-2

### DIFF
--- a/.changeset/kan-142-updating-fields-jumps-the-user-back-to-board-2.md
+++ b/.changeset/kan-142-updating-fields-jumps-the-user-back-to-board-2.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- fix: preserve navigation mode during auto-reload from external changes
+

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -1764,7 +1764,6 @@ impl App {
                             data.apply_to_app(self);
                             self.state_manager.mark_clean();
                             self.state_manager.clear_conflict();
-                            self.mode = AppMode::Normal;
                             self.refresh_view();
                             tracing::info!("Auto-reloaded state from external file change");
                         }


### PR DESCRIPTION
Fixes navigation reset when editing card fields:

- Remove unconditional mode reset in `auto_reload_from_external_change()`

**What**: Preserve navigation mode when auto-reloading from external file changes.

**Why**: Editing card fields (priority via `P`, external editor via `e`) or changes from other application instances would unexpectedly reset the user to the card list. The `auto_reload_from_external_change()` function was unconditionally setting `mode = AppMode::Normal`, losing the `CardDetail` state.

**How**: Removed the line `self.mode = AppMode::Normal;` from `auto_reload_from_external_change()` in `crates/kanban-tui/src/app.rs`. The mode represents UI navigation state which should be preserved independently of data reloads.

**Testing**:
- Open app and navigate to card details view
- Press `P` to change priority, confirm selection → stays in card details
- Press `e` to edit field with external editor, save → stays in card details
- Open two instances, make changes in one → the other reloads data but preserves view