### PR TITLE
KAN-141/scrolling-up-from-column-options-lands-the-cursor-on-the-first-sprint-in-the-list

### DIFF
--- a/.changeset/kan-141-scrolling-up-from-column-options-lands-the-cursor-on-the-first-sprint-in-the-list.md
+++ b/.changeset/kan-141-scrolling-up-from-column-options-lands-the-cursor-on-the-first-sprint-in-the-list.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- fix: navigate to last sprint when scrolling up from columns in board settings
+

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -285,7 +285,19 @@ impl App {
                     let current_idx = self.column_selection.get().unwrap_or(0);
                     if current_idx == 0 {
                         self.board_focus = BoardFocus::Sprints;
-                        self.sprint_selection.set(Some(0));
+                        let last_sprint_idx = self
+                            .board_selection
+                            .get()
+                            .and_then(|idx| self.boards.get(idx))
+                            .map(|board| {
+                                self.sprints
+                                    .iter()
+                                    .filter(|s| s.board_id == board.id)
+                                    .count()
+                                    .saturating_sub(1)
+                            })
+                            .unwrap_or(0);
+                        self.sprint_selection.set(Some(last_sprint_idx));
                     } else {
                         self.column_selection.prev();
                     }


### PR DESCRIPTION
Fixes board settings navigation:

- Navigate to last sprint when scrolling up from columns section

**What**: Fix cyclic navigation in board settings view to land on the last sprint when scrolling up from columns.

**Why**: When pressing up/k from the first column option, the cursor would jump to the first sprint instead of the last. This breaks the expected cyclic navigation pattern where moving up should land on the bottom of the previous section.

**How**: Changed `sprint_selection.set(Some(0))` to calculate and select the last sprint index for the active board in `detail_view_handlers.rs`.

**Testing**:
- Open board settings view
- Navigate to the Columns section (press `5` or scroll down)
- Press up/k from the first column → cursor now lands on the last sprint