### PR TITLE
KAN-140/filter-out-completed-sprints-from-assign-list

### DIFF
--- a/.changeset/kan-140-filter-out-completed-sprints-from-assign-list.md
+++ b/.changeset/kan-140-filter-out-completed-sprints-from-assign-list.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- fix: filter out completed and cancelled sprints from assign list
+

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -134,12 +134,16 @@ impl SelectionDialog for SprintAssignDialog {
     }
 
     fn options_count(&self, app: &App) -> usize {
+        use kanban_domain::SprintStatus;
         if let Some(board_idx) = app.active_board_index {
             if let Some(board) = app.boards.get(board_idx) {
                 let sprint_count = app
                     .sprints
                     .iter()
                     .filter(|s| s.board_id == board.id)
+                    .filter(|s| {
+                        s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled
+                    })
                     .count();
                 sprint_count + 1 // +1 for None option
             } else {
@@ -183,10 +187,14 @@ impl SelectionDialog for SprintAssignDialog {
 
         if let Some(board_idx) = app.active_board_index {
             if let Some(board) = app.boards.get(board_idx) {
+                use kanban_domain::SprintStatus;
                 let board_sprints: Vec<_> = app
                     .sprints
                     .iter()
                     .filter(|s| s.board_id == board.id)
+                    .filter(|s| {
+                        s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled
+                    })
                     .collect();
 
                 let current_sprint_id = if let Some(card_idx) = app.active_card_index {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1127,6 +1127,9 @@ fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
                 .sprints
                 .iter()
                 .filter(|s| s.board_id == board.id)
+                .filter(|s| {
+                    s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled
+                })
                 .collect();
 
             for (idx, sprint_option) in std::iter::once(None)


### PR DESCRIPTION
Filters sprint assign list to show only actionable sprints:

- Filter out Completed and Cancelled sprints from single card assignment dialog
- Filter out Completed and Cancelled sprints from multiple cards assignment dialog

**What**: Hide completed and cancelled sprints from the sprint assignment dialogs.

**Why**: Users should only see sprints they can meaningfully assign cards to. Completed and cancelled sprints clutter the list and assigning cards to them doesn't make sense from a workflow perspective.

**How**: Added status filter (`!= Completed && != Cancelled`) to sprint queries in `SprintAssignDialog` (both `options_count()` and `render()`) and `render_assign_multiple_cards_popup()`.

**Testing**:
- Create sprints in Planning, Active, Completed, and Cancelled states
- Press `s` on a card to assign to sprint → only Planning and Active sprints appear
- Multi-select cards and assign to sprint → only Planning and Active sprints appear