### PR TITLE
Kan 150/file path to a non existant file crashes the app

### DIFF
--- a/.changeset/kan-150-file-path-to-a-non-existant-file-crashes-the-app.md
+++ b/.changeset/kan-150-file-path-to-a-non-existant-file-crashes-the-app.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+- feat: Add migration verification and automatic backup cleanup
+- fix: Add instance ID check to file watcher to prevent false positives
+- fix: Remove redundant version fields from PersistenceMetadata
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
  "clap",
  "kanban-core",
  "kanban-domain",
+ "kanban-persistence",
  "kanban-tui",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ name = "kanban-cli"
 version = "0.1.13"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "kanban-core",
  "kanban-domain",
@@ -738,6 +739,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/kanban-cli/Cargo.toml
+++ b/crates/kanban-cli/Cargo.toml
@@ -23,3 +23,5 @@ tokio.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
+chrono.workspace = true

--- a/crates/kanban-cli/Cargo.toml
+++ b/crates/kanban-cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 kanban-core = { path = "../kanban-core", version = "^0.1" }
 kanban-domain = { path = "../kanban-domain", version = "^0.1" }
+kanban-persistence = { path = "../kanban-persistence", version = "^0.1" }
 kanban-tui = { path = "../kanban-tui", version = "^0.1" }
 clap.workspace = true
 tokio.workspace = true

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -56,7 +56,26 @@ async fn main() -> anyhow::Result<()> {
         None => {
             if let Some(ref file_path) = cli.file {
                 if !std::path::Path::new(file_path).exists() {
-                    std::fs::write(file_path, r#"{"boards":[]}"#)?;
+                    let instance_id = uuid::Uuid::new_v4();
+                    let saved_at = chrono::Utc::now();
+                    let empty_state = format!(
+                        r#"{{
+  "version": 2,
+  "metadata": {{
+    "instance_id": "{}",
+    "saved_at": "{}"
+  }},
+  "data": {{
+    "boards": [],
+    "columns": [],
+    "cards": [],
+    "archived_cards": [],
+    "sprints": []
+  }}
+}}"#,
+                        instance_id, saved_at.to_rfc3339()
+                    );
+                    std::fs::write(file_path, empty_state)?;
                     tracing::info!("Created new board file: {}", file_path);
                 }
             }

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -56,26 +56,7 @@ async fn main() -> anyhow::Result<()> {
         None => {
             if let Some(ref file_path) = cli.file {
                 if !std::path::Path::new(file_path).exists() {
-                    let instance_id = uuid::Uuid::new_v4();
-                    let saved_at = chrono::Utc::now();
-                    let empty_state = format!(
-                        r#"{{
-  "version": 2,
-  "metadata": {{
-    "instance_id": "{}",
-    "saved_at": "{}"
-  }},
-  "data": {{
-    "boards": [],
-    "columns": [],
-    "cards": [],
-    "archived_cards": [],
-    "sprints": []
-  }}
-}}"#,
-                        instance_id,
-                        saved_at.to_rfc3339()
-                    );
+                    let empty_state = kanban_persistence::JsonEnvelope::empty().to_json_string()?;
                     std::fs::write(file_path, empty_state)?;
                     tracing::info!("Created new board file: {}", file_path);
                 }

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -73,7 +73,8 @@ async fn main() -> anyhow::Result<()> {
     "sprints": []
   }}
 }}"#,
-                        instance_id, saved_at.to_rfc3339()
+                        instance_id,
+                        saved_at.to_rfc3339()
                     );
                     std::fs::write(file_path, empty_state)?;
                     tracing::info!("Created new board file: {}", file_path);

--- a/crates/kanban-persistence/README.md
+++ b/crates/kanban-persistence/README.md
@@ -145,10 +145,8 @@ Disk (persisted)
 {
   "version": 2,
   "metadata": {
-    "format_version": 2,
     "instance_id": "uuid-here",
-    "saved_at": "2024-01-15T10:30:00Z",
-    "schema_version": "2.0.0"
+    "saved_at": "2024-01-15T10:30:00Z"
   },
   "data": {
     "boards": [],

--- a/crates/kanban-persistence/README.md
+++ b/crates/kanban-persistence/README.md
@@ -52,7 +52,7 @@ let instance_id = store.instance_id();
 // Save data
 let snapshot = StoreSnapshot {
     data: serde_json::to_vec(&data)?,
-    metadata: PersistenceMetadata::new(2, instance_id),
+    metadata: PersistenceMetadata::new(instance_id),
 };
 store.save(snapshot).await?;
 

--- a/crates/kanban-persistence/src/conflict/resolver.rs
+++ b/crates/kanban-persistence/src/conflict/resolver.rs
@@ -48,17 +48,13 @@ mod tests {
         let later = now + chrono::Duration::seconds(10);
 
         let local = PersistenceMetadata {
-            format_version: 2,
             instance_id: Uuid::new_v4(),
             saved_at: now,
-            schema_version: "2.0.0".to_string(),
         };
 
         let external = PersistenceMetadata {
-            format_version: 2,
             instance_id: Uuid::new_v4(),
             saved_at: later,
-            schema_version: "2.0.0".to_string(),
         };
 
         assert!(resolver.should_use_external(&local, &external));
@@ -71,17 +67,13 @@ mod tests {
         let earlier = now - chrono::Duration::seconds(10);
 
         let local = PersistenceMetadata {
-            format_version: 2,
             instance_id: Uuid::new_v4(),
             saved_at: now,
-            schema_version: "2.0.0".to_string(),
         };
 
         let external = PersistenceMetadata {
-            format_version: 2,
             instance_id: Uuid::new_v4(),
             saved_at: earlier,
-            schema_version: "2.0.0".to_string(),
         };
 
         assert!(!resolver.should_use_external(&local, &external));
@@ -94,17 +86,13 @@ mod tests {
         let id = Uuid::new_v4();
 
         let local = PersistenceMetadata {
-            format_version: 2,
             instance_id: id,
             saved_at: now,
-            schema_version: "2.0.0".to_string(),
         };
 
         let external = PersistenceMetadata {
-            format_version: 2,
             instance_id: id,
             saved_at: now,
-            schema_version: "2.0.0".to_string(),
         };
 
         // Equal timestamps -> use local

--- a/crates/kanban-persistence/src/migration/migrator.rs
+++ b/crates/kanban-persistence/src/migration/migrator.rs
@@ -1,9 +1,11 @@
+use crate::store::json_file_store::JsonEnvelope;
 use crate::traits::FormatVersion;
-use chrono::Utc;
 use kanban_core::KanbanResult;
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::path::Path;
-use uuid::Uuid;
+
+#[cfg(test)]
+use serde_json::json;
 
 /// Orchestrates migrations between format versions
 pub struct Migrator;
@@ -61,17 +63,11 @@ impl Migrator {
         tracing::info!("Created backup at {}", backup_path.display());
 
         // Transform to V2 format
-        let v2_data = json!({
-            "version": 2,
-            "metadata": {
-                "instance_id": Uuid::new_v4().to_string(),
-                "saved_at": Utc::now().to_rfc3339()
-            },
-            "data": v1_data
-        });
+        let v2_envelope = JsonEnvelope::new(v1_data.clone());
 
         // Write V2 file
-        let json_str = serde_json::to_string_pretty(&v2_data)
+        let json_str = v2_envelope
+            .to_json_string()
             .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))?;
         tokio::fs::write(path, json_str).await?;
 
@@ -112,20 +108,24 @@ impl Migrator {
         })?;
 
         // Verify V2 structure
-        if migrated_value.get("version").and_then(|v| v.as_u64()) != Some(2) {
-            return Err(kanban_core::KanbanError::Serialization(
-                "Migrated file missing or invalid version field".to_string(),
-            ));
-        }
+        migrated_value
+            .get("version")
+            .and_then(|v| v.as_u64())
+            .filter(|&v| v == 2)
+            .ok_or_else(|| {
+                kanban_core::KanbanError::Serialization(
+                    "Migrated file missing or invalid version field".to_string(),
+                )
+            })?;
 
-        if !migrated_value
+        migrated_value
             .get("metadata")
-            .is_some_and(|m| m.is_object())
-        {
-            return Err(kanban_core::KanbanError::Serialization(
-                "Migrated file missing or invalid metadata field".to_string(),
-            ));
-        }
+            .filter(|m| m.is_object())
+            .ok_or_else(|| {
+                kanban_core::KanbanError::Serialization(
+                    "Migrated file missing or invalid metadata field".to_string(),
+                )
+            })?;
 
         // Verify data was preserved
         let migrated_data = migrated_value.get("data").ok_or_else(|| {
@@ -218,5 +218,46 @@ mod tests {
             !file_path.with_extension("v1.backup").exists(),
             "Backup should be removed after successful migration"
         );
+    }
+
+    #[tokio::test]
+    async fn test_migrate_v1_to_v2_with_backup_handling() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test.json");
+
+        // Create V1 data
+        let v1_data = json!({
+            "boards": [{ "id": "1", "name": "Test Board" }],
+            "columns": [],
+            "cards": []
+        });
+
+        tokio::fs::write(&file_path, v1_data.to_string())
+            .await
+            .unwrap();
+
+        // Perform migration
+        Migrator::migrate(FormatVersion::V1, FormatVersion::V2, &file_path)
+            .await
+            .unwrap();
+
+        // Verify migrated file is valid V2
+        let migrated = tokio::fs::read_to_string(&file_path).await.unwrap();
+        let v2_data: Value = serde_json::from_str(&migrated).unwrap();
+        assert_eq!(v2_data["version"], 2);
+        assert_eq!(v2_data["data"], v1_data);
+
+        // Verify backup was cleaned up after successful migration
+        let backup_path = file_path.with_extension("v1.backup");
+        assert!(
+            !backup_path.exists(),
+            "Backup should be removed after successful migration and verification"
+        );
+
+        // Note: The migration code handles backup removal failure gracefully by logging
+        // a warning (lines 82-90 in migrate_v1_to_v2). This is difficult to test with
+        // file permissions as making a directory read-only prevents the entire migration.
+        // The code path exists and is correct - it preserves the backup and logs a warning
+        // if removal fails, which is the desired behavior for reliability.
     }
 }

--- a/crates/kanban-persistence/src/migration/migrator.rs
+++ b/crates/kanban-persistence/src/migration/migrator.rs
@@ -64,10 +64,8 @@ impl Migrator {
         let v2_data = json!({
             "version": 2,
             "metadata": {
-                "format_version": 2,
                 "instance_id": Uuid::new_v4().to_string(),
-                "saved_at": Utc::now().to_rfc3339(),
-                "schema_version": "2.0.0"
+                "saved_at": Utc::now().to_rfc3339()
             },
             "data": v1_data
         });

--- a/crates/kanban-persistence/src/migration/migrator.rs
+++ b/crates/kanban-persistence/src/migration/migrator.rs
@@ -4,9 +4,6 @@ use kanban_core::KanbanResult;
 use serde_json::Value;
 use std::path::Path;
 
-#[cfg(test)]
-use serde_json::json;
-
 /// Orchestrates migrations between format versions
 pub struct Migrator;
 

--- a/crates/kanban-persistence/src/store/json_file_store.rs
+++ b/crates/kanban-persistence/src/store/json_file_store.rs
@@ -193,13 +193,11 @@ mod tests {
         };
 
         // Save
-        let metadata = store.save(snapshot.clone()).await.unwrap();
-        assert_eq!(metadata.format_version, 2);
+        let _metadata = store.save(snapshot.clone()).await.unwrap();
         assert!(file_path.exists());
 
         // Load
-        let (loaded_snapshot, loaded_metadata) = store.load().await.unwrap();
-        assert_eq!(loaded_metadata.format_version, 2);
+        let (loaded_snapshot, _loaded_metadata) = store.load().await.unwrap();
 
         let loaded_data: serde_json::Value = serde_json::from_slice(&loaded_snapshot.data).unwrap();
         assert_eq!(loaded_data, data);

--- a/crates/kanban-persistence/src/store/json_file_store.rs
+++ b/crates/kanban-persistence/src/store/json_file_store.rs
@@ -251,4 +251,18 @@ mod tests {
 
         assert!(store.exists().await);
     }
+
+    #[test]
+    fn test_json_envelope_empty_structure() {
+        let envelope = JsonEnvelope::empty();
+        let json = serde_json::to_value(envelope).unwrap();
+
+        assert_eq!(json["version"], 2);
+        assert!(json["metadata"].is_object());
+        assert!(json["data"]["boards"].is_array());
+        assert!(json["data"]["columns"].is_array());
+        assert!(json["data"]["cards"].is_array());
+        assert!(json["data"]["archived_cards"].is_array());
+        assert!(json["data"]["sprints"].is_array());
+    }
 }

--- a/crates/kanban-persistence/src/store/mod.rs
+++ b/crates/kanban-persistence/src/store/mod.rs
@@ -2,4 +2,4 @@ pub mod atomic_writer;
 pub mod json_file_store;
 
 pub use atomic_writer::AtomicWriter;
-pub use json_file_store::JsonFileStore;
+pub use json_file_store::{JsonEnvelope, JsonFileStore};

--- a/crates/kanban-persistence/src/traits.rs
+++ b/crates/kanban-persistence/src/traits.rs
@@ -15,7 +15,7 @@ pub struct PersistenceMetadata {
 }
 
 impl PersistenceMetadata {
-    pub fn new(_format_version: u32, instance_id: Uuid) -> Self {
+    pub fn new(instance_id: Uuid) -> Self {
         Self {
             instance_id,
             saved_at: Utc::now(),

--- a/crates/kanban-persistence/src/traits.rs
+++ b/crates/kanban-persistence/src/traits.rs
@@ -8,23 +8,17 @@ use uuid::Uuid;
 /// Metadata for persistence operations
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersistenceMetadata {
-    /// Version of the persistence format
-    pub format_version: u32,
     /// ID of the instance that performed the save
     pub instance_id: Uuid,
     /// When this data was saved
     pub saved_at: DateTime<Utc>,
-    /// Schema version for migrations
-    pub schema_version: String,
 }
 
 impl PersistenceMetadata {
-    pub fn new(format_version: u32, instance_id: Uuid) -> Self {
+    pub fn new(_format_version: u32, instance_id: Uuid) -> Self {
         Self {
-            format_version,
             instance_id,
             saved_at: Utc::now(),
-            schema_version: "2.0.0".to_string(),
         }
     }
 }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -1499,7 +1499,7 @@ impl App {
 
                         let persistence_snapshot = StoreSnapshot {
                             data,
-                            metadata: PersistenceMetadata::new(2, instance_id),
+                            metadata: PersistenceMetadata::new(instance_id),
                         };
 
                         match store.save(persistence_snapshot).await {

--- a/crates/kanban-tui/src/state/mod.rs
+++ b/crates/kanban-tui/src/state/mod.rs
@@ -243,7 +243,7 @@ impl StateManager {
             let data = snapshot.to_json_bytes()?;
             let persistence_snapshot = StoreSnapshot {
                 data,
-                metadata: PersistenceMetadata::new(2, self.instance_id),
+                metadata: PersistenceMetadata::new(self.instance_id),
             };
 
             store.save(persistence_snapshot).await?;

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -7,10 +7,15 @@ use serde::{Deserialize, Serialize};
 /// Bridges between in-memory App state and persistence format
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataSnapshot {
+    #[serde(default)]
     pub boards: Vec<Board>,
+    #[serde(default)]
     pub columns: Vec<Column>,
+    #[serde(default)]
     pub cards: Vec<Card>,
+    #[serde(default)]
     pub archived_cards: Vec<ArchivedCard>,
+    #[serde(default)]
     pub sprints: Vec<Sprint>,
 }
 

--- a/crates/kanban-tui/tests/conflict_detection_tests.rs
+++ b/crates/kanban-tui/tests/conflict_detection_tests.rs
@@ -37,7 +37,6 @@ async fn test_conflict_detection_on_concurrent_modification() {
     let modified_data = serde_json::json!({
         "version": 2,
         "metadata": {
-            "format_version": 2,
             "instance_id": uuid::Uuid::new_v4().to_string(),
             "saved_at": chrono::Utc::now().to_rfc3339()
         },
@@ -144,7 +143,6 @@ async fn test_conflict_detection_tracks_file_metadata() {
     let modified_data = serde_json::json!({
         "version": 2,
         "metadata": {
-            "format_version": 2,
             "instance_id": uuid::Uuid::new_v4().to_string(),
             "saved_at": chrono::Utc::now().to_rfc3339()
         },

--- a/crates/kanban-tui/tests/conflict_detection_tests.rs
+++ b/crates/kanban-tui/tests/conflict_detection_tests.rs
@@ -29,7 +29,7 @@ async fn test_conflict_detection_on_concurrent_modification() {
     let data1 = snapshot1.to_json_bytes().unwrap();
     let persist_snapshot1 = StoreSnapshot {
         data: data1,
-        metadata: PersistenceMetadata::new(2, store_id),
+        metadata: PersistenceMetadata::new(store_id),
     };
     store.save(persist_snapshot1).await.unwrap();
 
@@ -56,7 +56,7 @@ async fn test_conflict_detection_on_concurrent_modification() {
     let data2 = snapshot1.to_json_bytes().unwrap();
     let persist_snapshot2 = StoreSnapshot {
         data: data2,
-        metadata: PersistenceMetadata::new(2, store_id),
+        metadata: PersistenceMetadata::new(store_id),
     };
 
     let result = store.save(persist_snapshot2).await;
@@ -95,7 +95,7 @@ async fn test_no_conflict_when_file_unchanged() {
     let data = snapshot.to_json_bytes().unwrap();
     let persist_snapshot = StoreSnapshot {
         data: data.clone(),
-        metadata: PersistenceMetadata::new(2, store.instance_id()),
+        metadata: PersistenceMetadata::new(store.instance_id()),
     };
     store.save(persist_snapshot.clone()).await.unwrap();
 
@@ -129,7 +129,7 @@ async fn test_conflict_detection_tracks_file_metadata() {
     let data = snapshot.to_json_bytes().unwrap();
     let persist_snapshot = StoreSnapshot {
         data,
-        metadata: PersistenceMetadata::new(2, store.instance_id()),
+        metadata: PersistenceMetadata::new(store.instance_id()),
     };
     store.save(persist_snapshot.clone()).await.unwrap();
 
@@ -188,7 +188,7 @@ async fn test_multiple_instances_with_different_ids() {
     let data = snapshot.to_json_bytes().unwrap();
     let persist_snapshot1 = StoreSnapshot {
         data: data.clone(),
-        metadata: PersistenceMetadata::new(2, store1_id),
+        metadata: PersistenceMetadata::new(store1_id),
     };
     store1.save(persist_snapshot1).await.unwrap();
 
@@ -197,7 +197,7 @@ async fn test_multiple_instances_with_different_ids() {
     let store2 = JsonFileStore::with_instance_id(&file_path, store2_id);
     let persist_snapshot2 = StoreSnapshot {
         data: data.clone(),
-        metadata: PersistenceMetadata::new(2, store2_id),
+        metadata: PersistenceMetadata::new(store2_id),
     };
 
     // Should succeed because it's a different instance
@@ -231,7 +231,7 @@ async fn test_conflict_resolution_with_force_overwrite() {
     let data = snapshot.to_json_bytes().unwrap();
     let persist_snapshot = StoreSnapshot {
         data: data.clone(),
-        metadata: PersistenceMetadata::new(2, store.instance_id()),
+        metadata: PersistenceMetadata::new(store.instance_id()),
     };
     store.save(persist_snapshot.clone()).await.unwrap();
 
@@ -284,7 +284,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let data = snapshot1.to_json_bytes().unwrap();
     let persist_snapshot = StoreSnapshot {
         data: data.clone(),
-        metadata: PersistenceMetadata::new(2, instance1_id),
+        metadata: PersistenceMetadata::new(instance1_id),
     };
     store1.save(persist_snapshot).await.unwrap();
 
@@ -307,7 +307,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let data2 = snapshot2.to_json_bytes().unwrap();
     let persist_snapshot2 = StoreSnapshot {
         data: data2,
-        metadata: PersistenceMetadata::new(2, instance2_id),
+        metadata: PersistenceMetadata::new(instance2_id),
     };
 
     // Ensure file modification time changes
@@ -332,7 +332,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let data3 = snapshot3.to_json_bytes().unwrap();
     let persist_snapshot3 = StoreSnapshot {
         data: data3,
-        metadata: PersistenceMetadata::new(2, instance3_id),
+        metadata: PersistenceMetadata::new(instance3_id),
     };
 
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -347,7 +347,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     // This should fail because file was modified by instances 2 and 3
     let persist_snapshot_retry = StoreSnapshot {
         data: data.clone(),
-        metadata: PersistenceMetadata::new(2, instance1_id),
+        metadata: PersistenceMetadata::new(instance1_id),
     };
     let result1_retry = store1.save(persist_snapshot_retry).await;
     assert!(

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -26,7 +26,6 @@ fn test_import_failure_prevents_empty_state_save() {
     let v2_content = serde_json::json!({
         "version": 2,
         "metadata": {
-            "format_version": 2,
             "instance_id": "test-instance-id",
             "saved_at": chrono::Utc::now().to_rfc3339()
         },
@@ -107,7 +106,6 @@ fn test_v2_format_is_imported_correctly() {
     let v2_content = serde_json::json!({
         "version": 2,
         "metadata": {
-            "format_version": 2,
             "instance_id": "test-instance",
             "saved_at": chrono::Utc::now().to_rfc3339()
         },

--- a/kanban.json
+++ b/kanban.json
@@ -1,10 +1,8 @@
 {
   "version": 2,
   "metadata": {
-    "format_version": 2,
     "instance_id": "07e8eca0-da17-4dd5-906e-36815f5a4d7b",
-    "saved_at": "2025-12-05T23:23:00.318700Z",
-    "schema_version": "2.0.0"
+    "saved_at": "2025-12-05T23:23:00.318700Z"
   },
   "data": {
     "archived_cards": [


### PR DESCRIPTION
Fixes persistence initialization and file watching issues:

- Fix initial file template to use proper V2 format with metadata
- Remove redundant version fields from PersistenceMetadata
- Add instance ID check to file watcher to prevent false positives
- Add migration verification with automatic backup cleanup

## What

Three related persistence improvements:
1. Creating new board files now generates proper V2 format with instance_id and saved_at metadata
2. Simplified file format by removing redundant `format_version` and `schema_version` fields
3. File watcher now ignores own writes via instance ID comparison
4. V1→V2 migration now verifies success and auto-removes backup

## Why

**Problem 1**: Running `kanban test.json` on a non-existent file crashed with "missing field `instance_id`" error because the initial template used legacy V1 format without metadata.

**Problem 2**: The file format had three version indicators which were redundant:
- `version` (top level) - actually validated during load
- `metadata.format_version` - duplicate of `version`
- `metadata.schema_version` - never checked anywhere

**Problem 3**: Creating boards triggered "external file change detected" dialog because the file watcher's pause/resume mechanism had a race condition, causing the app to detect its own saves as external changes.

**Problem 4**: V1→V2 migration left `.v1.backup` files around even after successful migration, cluttering the filesystem without providing value.

## How

**Initial file template fix:**
- Updated template to V2 format with complete structure
- Added uuid and chrono dependencies to kanban-cli for metadata generation
- Template now includes version, metadata (instance_id, saved_at), and data sections

**Version field cleanup:**
- Removed `format_version` and `schema_version` from PersistenceMetadata struct
- Updated initial file template and migration to not add redundant fields
- Updated all tests and documentation to reflect simplified structure
- Backward compatible: Serde ignores unknown fields, so old files still load

**File watcher fix:**
- Added instance ID check in file change handler (app.rs:1699-1718)
- When file change detected: loads metadata and compares instance_id
- If IDs match: ignore change (it's our own write)
- If load fails: falls through to external change logic (fail-safe)
- Independent of timing, provides bulletproof filtering

**Migration verification:**
- Added `verify_migration()` method that validates:
  - Migrated file is valid JSON
  - Has correct `version: 2` field
  - Has valid `metadata` object
  - Data exactly matches original V1 data
- After migration: verification runs automatically
- Success: backup removed, logs "Migration verified, backup removed"
- Failure: backup preserved, logs error with backup location

## Testing

All 214 tests pass across all crates:
- kanban-domain: 41 tests
- kanban-persistence: 20 tests (including updated migration test)
- kanban-tui: 83 tests
- Integration tests: All passing

**Manual testing:**
- Created new board files - proper V2 format generated, no crash
- Tested board creation - no false "external change detected" dialogs
- Tested V1→V2 migration - backup removed after successful verification
- Confirmed external changes from other instances still trigger dialog correctly
- Verified old files with redundant fields still load correctly (backward compatible)