### PR TITLE
KAN-146/kanban-mcp

### DIFF
--- a/.changeset/kan-146-kanban-mcp.md
+++ b/.changeset/kan-146-kanban-mcp.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+- feat: add kanban-mcp server
+- feat(mcp): add McpTools trait for compile-time parity with KanbanOperations
+- docs(mcp): add subprocess architecture documentation and Nix wrapper
+- feat(mcp): add CLI executor for subprocess-based operations
+- feat(mcp): enhance card operations and add delete/archive functionality
+- feat: add kanban-mcp: Model Context Protocol server implementation
+

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "git": {
+      "command": "nix",
+      "args": ["run", ".#mcp-server-git"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "git": {
       "command": "nix",
       "args": ["run", ".#mcp-server-git"]
+    },
+    "kanban": {
+      "command": "nix",
+      "args": ["run", ".#kanban-mcp", "--", "kanban.json"]
     }
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,20 +969,13 @@ name = "kanban-mcp"
 version = "0.1.13"
 dependencies = [
  "anyhow",
- "async-trait",
- "chrono",
- "kanban-core",
- "kanban-domain",
- "kanban-persistence",
  "rmcp",
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,8 +383,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -396,12 +412,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn",
 ]
@@ -448,6 +489,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -574,6 +621,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -738,7 +874,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -825,6 +961,27 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
+name = "kanban-mcp"
+version = "0.1.13"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "kanban-core",
+ "kanban-domain",
+ "kanban-persistence",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1199,6 +1356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1372,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "png"
@@ -1353,6 +1522,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1569,41 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rmcp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df440eaa43f8573491ed4a5899719b6d29099500774abba12214a095a4083ed"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef03779cccab8337dd8617c53fce5c98ec21794febc397531555472ca28f8c3"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
 
 [[package]]
 name = "rustix"
@@ -1429,6 +1653,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1708,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1536,6 +1797,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1706,6 +1973,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,7 @@ name = "kanban-mcp"
 version = "0.1.13"
 dependencies = [
  "anyhow",
+ "async-trait",
  "rmcp",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/kanban-persistence",
     "crates/kanban-tui",
     "crates/kanban-cli",
+    "crates/kanban-mcp",
 ]
 
 [workspace.package]

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "kanban-mcp"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Model Context Protocol server for the kanban project management tool"
+keywords = ["kanban", "mcp", "model-context-protocol", "project-management"]
+categories = ["command-line-utilities"]
+
+[[bin]]
+name = "kanban-mcp"
+path = "src/main.rs"
+
+[dependencies]
+kanban-core = { path = "../kanban-core", version = "^0.1" }
+kanban-domain = { path = "../kanban-domain", version = "^0.1" }
+kanban-persistence = { path = "../kanban-persistence", version = "^0.1" }
+
+# MCP SDK
+rmcp = { version = "0.11", features = ["server", "transport-io"] }
+schemars = "1.0"
+
+# Async runtime
+tokio.workspace = true
+async-trait.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Error handling
+anyhow.workspace = true
+thiserror.workspace = true
+
+# UUID and time
+uuid.workspace = true
+chrono.workspace = true
+
+# Logging
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -15,29 +15,19 @@ name = "kanban-mcp"
 path = "src/main.rs"
 
 [dependencies]
-kanban-core = { path = "../kanban-core", version = "^0.1" }
-kanban-domain = { path = "../kanban-domain", version = "^0.1" }
-kanban-persistence = { path = "../kanban-persistence", version = "^0.1" }
-
 # MCP SDK
 rmcp = { version = "0.11", features = ["server", "transport-io"] }
 schemars = "1.0"
 
-# Async runtime
+# Async runtime (uses "process" feature for subprocess execution)
 tokio.workspace = true
-async-trait.workspace = true
 
 # Serialization
 serde.workspace = true
 serde_json.workspace = true
 
-# Error handling
+# Error handling (for main.rs only)
 anyhow.workspace = true
-thiserror.workspace = true
-
-# UUID and time
-uuid.workspace = true
-chrono.workspace = true
 
 # Logging
 tracing.workspace = true

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 rmcp = { version = "0.11", features = ["server", "transport-io"] }
 schemars = "1.0"
 
-# Async runtime (uses "process" feature for subprocess execution)
+# Async runtime
 tokio.workspace = true
 async-trait.workspace = true
 

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -21,6 +21,7 @@ schemars = "1.0"
 
 # Async runtime (uses "process" feature for subprocess execution)
 tokio.workspace = true
+async-trait.workspace = true
 
 # Serialization
 serde.workspace = true

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -1,0 +1,181 @@
+# kanban-mcp
+
+Model Context Protocol (MCP) server for kanban project management.
+
+## Architecture
+
+This MCP server delegates all operations to the `kanban` CLI via subprocess execution. This architecture provides:
+
+- **Single source of truth**: CLI is the canonical implementation
+- **Automatic capability inheritance**: New CLI commands automatically become available
+- **Decoupled runtime**: Only binary dependency, no shared Rust library code
+- **Natural conflict handling**: Each subprocess reloads state from disk
+- **Retry with backoff**: Automatic retry on file conflicts
+
+```
+┌─────────────────┐
+│  Claude/MCP     │
+│    Client       │
+└────────┬────────┘
+         │ JSON-RPC
+         ▼
+┌─────────────────────────────────────────────┐
+│              kanban-mcp                      │
+│  ┌─────────────────────────────────────┐    │
+│  │  MCP Tool Handlers                   │    │
+│  │  - create_board → spawn CLI          │    │
+│  │  - list_cards → spawn CLI            │    │
+│  │  - move_card → spawn CLI             │    │
+│  └─────────────────────────────────────┘    │
+│  ┌─────────────────────────────────────┐    │
+│  │  CliExecutor                         │    │
+│  │  - spawn("kanban", args)             │    │
+│  │  - parse CliResponse<T>              │    │
+│  │  - retry on conflict                 │    │
+│  └─────────────────────────────────────┘    │
+└────────┬────────────────────────────────────┘
+         │ subprocess
+         ▼
+┌─────────────────┐
+│  kanban CLI     │
+│  (executable)   │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  kanban.json    │  ← Atomic writes + conflict detection
+└─────────────────┘
+```
+
+## Installation
+
+### From Nix (recommended)
+
+```bash
+nix build .#kanban-mcp
+```
+
+The Nix derivation automatically wraps the binary with the `kanban` CLI in PATH.
+
+### From Cargo
+
+```bash
+cargo install --path crates/kanban-mcp
+
+# Ensure kanban CLI is in PATH
+cargo install --path crates/kanban-cli
+```
+
+## Usage
+
+```bash
+kanban-mcp /path/to/kanban.json
+```
+
+### MCP Client Configuration
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "kanban": {
+      "command": "kanban-mcp",
+      "args": ["/path/to/kanban.json"]
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `create_board` | Create a new kanban board |
+| `list_boards` | List all boards |
+| `get_board` | Get a specific board by ID |
+| `delete_board` | Delete a board and all its contents |
+| `create_column` | Create a new column in a board |
+| `list_columns` | List columns in a board |
+| `delete_column` | Delete a column and its cards |
+| `create_card` | Create a new card in a column |
+| `list_cards` | List cards with optional filters |
+| `get_card` | Get a specific card by ID |
+| `move_card` | Move a card to a different column |
+| `update_card` | Update card properties |
+| `archive_card` | Archive a card |
+| `delete_card` | Permanently delete a card |
+
+## Concurrency Model
+
+The kanban CLI uses optimistic concurrency control with file metadata:
+
+1. **Load**: Read file + capture metadata (mtime, size, hash)
+2. **Modify**: Execute operation in memory
+3. **Save**: Verify metadata unchanged, then atomic write
+4. **Conflict**: If metadata changed, return error
+
+When conflicts occur, the MCP server automatically retries with exponential backoff:
+
+```
+Attempt 1 → ConflictDetected → Wait 50ms
+Attempt 2 → ConflictDetected → Wait 100ms
+Attempt 3 → Success ✓
+```
+
+**Default Configuration:**
+- Max attempts: 3
+- Initial delay: 50ms
+- Max delay: 1000ms
+- Backoff multiplier: 2.0x
+
+## Testing
+
+```bash
+# Unit tests
+cargo test --package kanban-mcp
+
+# With logging
+RUST_LOG=debug cargo test --package kanban-mcp
+```
+
+## CLI Command Mapping
+
+| MCP Tool | CLI Command |
+|----------|-------------|
+| `create_board` | `kanban board create --name X` |
+| `list_boards` | `kanban board list` |
+| `get_board` | `kanban board get <id>` |
+| `delete_board` | `kanban board delete <id>` |
+| `create_column` | `kanban column create --board-id X --name Y` |
+| `list_columns` | `kanban column list --board-id X` |
+| `delete_column` | `kanban column delete <id>` |
+| `create_card` | `kanban card create --board-id X --column-id Y --title Z` |
+| `list_cards` | `kanban card list --board-id X` |
+| `get_card` | `kanban card get <id>` |
+| `move_card` | `kanban card move <id> --column-id X` |
+| `update_card` | `kanban card update <id> --title X` |
+| `archive_card` | `kanban card archive <id>` |
+| `delete_card` | `kanban card delete <id>` |
+
+## CLI Response Format
+
+The kanban CLI outputs JSON responses:
+
+```json
+{
+  "success": true,
+  "api_version": "0.1.0",
+  "data": { ... }
+}
+```
+
+On error:
+
+```json
+{
+  "success": false,
+  "api_version": "0.1.0",
+  "error": "Error message"
+}
+```

--- a/crates/kanban-mcp/default.nix
+++ b/crates/kanban-mcp/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, rustPlatform
+}:
+
+let
+  cargoToml = lib.importTOML ../../Cargo.toml;
+in
+rustPlatform.buildRustPackage {
+  inherit (cargoToml.workspace.package) version;
+  pname = "kanban-mcp";
+
+  src = lib.cleanSource ../..;
+
+  cargoLock = {
+    lockFile = ../../Cargo.lock;
+  };
+
+  # Only build the kanban-mcp binary
+  cargoBuildFlags = [ "--package" "kanban-mcp" ];
+  cargoTestFlags = [ "--package" "kanban-mcp" ];
+
+  meta = {
+    inherit (cargoToml.workspace.package) description homepage;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fulsomenko ];
+    mainProgram = "kanban-mcp";
+    platforms = lib.platforms.all;
+  };
+}

--- a/crates/kanban-mcp/default.nix
+++ b/crates/kanban-mcp/default.nix
@@ -1,5 +1,7 @@
 { lib
 , rustPlatform
+, makeWrapper
+, kanban
 }:
 
 let
@@ -15,9 +17,17 @@ rustPlatform.buildRustPackage {
     lockFile = ../../Cargo.lock;
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   # Only build the kanban-mcp binary
   cargoBuildFlags = [ "--package" "kanban-mcp" ];
   cargoTestFlags = [ "--package" "kanban-mcp" ];
+
+  # Wrap the binary to include kanban CLI in PATH
+  postInstall = ''
+    wrapProgram $out/bin/kanban-mcp \
+      --prefix PATH : ${lib.makeBinPath [ kanban ]}
+  '';
 
   meta = {
     inherit (cargoToml.workspace.package) description homepage;

--- a/crates/kanban-mcp/src/executor.rs
+++ b/crates/kanban-mcp/src/executor.rs
@@ -50,10 +50,7 @@ impl CliExecutor {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let response: CliResponse<T> = serde_json::from_str(&stdout).map_err(|e| {
             McpError::internal_error(
-                format!(
-                    "Failed to parse CLI response: {} (output: {})",
-                    e, stdout
-                ),
+                format!("Failed to parse CLI response: {} (output: {})", e, stdout),
                 None,
             )
         })?;

--- a/crates/kanban-mcp/src/executor.rs
+++ b/crates/kanban-mcp/src/executor.rs
@@ -9,6 +9,8 @@ use rmcp::model::ErrorData as McpError;
 #[derive(Debug, serde::Deserialize)]
 pub struct CliResponse<T> {
     pub success: bool,
+    /// API version from CLI response. Parsed to validate response format;
+    /// reserved for future version compatibility checks.
     #[allow(dead_code)]
     pub api_version: String,
     pub data: Option<T>,

--- a/crates/kanban-mcp/src/executor.rs
+++ b/crates/kanban-mcp/src/executor.rs
@@ -1,0 +1,164 @@
+use serde::de::DeserializeOwned;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::Command;
+
+use rmcp::model::ErrorData as McpError;
+
+/// Response format from kanban CLI (matches crates/kanban-cli/src/output.rs)
+#[derive(Debug, serde::Deserialize)]
+pub struct CliResponse<T> {
+    pub success: bool,
+    #[allow(dead_code)]
+    pub api_version: String,
+    pub data: Option<T>,
+    pub error: Option<String>,
+}
+
+/// Executor that spawns kanban CLI subprocess for each operation
+pub struct CliExecutor {
+    kanban_path: String,
+    data_file: String,
+}
+
+impl CliExecutor {
+    /// Create a new executor
+    ///
+    /// # Arguments
+    /// * `data_file` - Path to the kanban.json data file
+    pub fn new(data_file: String) -> Self {
+        Self {
+            kanban_path: "kanban".to_string(), // Assumes in PATH via Nix wrapper
+            data_file,
+        }
+    }
+
+    /// Execute a kanban CLI command and parse the JSON response
+    pub async fn execute<T: DeserializeOwned>(&self, args: &[&str]) -> Result<T, McpError> {
+        let output = Command::new(&self.kanban_path)
+            .arg(&self.data_file) // First arg is always the data file
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| {
+                McpError::internal_error(format!("Failed to execute kanban CLI: {}", e), None)
+            })?;
+
+        // Parse stdout as JSON
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let response: CliResponse<T> = serde_json::from_str(&stdout).map_err(|e| {
+            McpError::internal_error(
+                format!(
+                    "Failed to parse CLI response: {} (output: {})",
+                    e, stdout
+                ),
+                None,
+            )
+        })?;
+
+        if response.success {
+            response.data.ok_or_else(|| {
+                McpError::internal_error("Success response missing data".to_string(), None)
+            })
+        } else {
+            let error_msg = response
+                .error
+                .unwrap_or_else(|| "Unknown error".to_string());
+
+            // Check for conflict error (retryable)
+            if error_msg.contains("conflict") || error_msg.contains("modified by another") {
+                Err(McpError::internal_error(
+                    error_msg,
+                    Some(serde_json::json!({"retryable": true})),
+                ))
+            } else {
+                Err(McpError::internal_error(error_msg, None))
+            }
+        }
+    }
+
+    /// Execute with retry on conflict (exponential backoff)
+    pub async fn execute_with_retry<T: DeserializeOwned>(
+        &self,
+        args: &[&str],
+        max_attempts: u32,
+    ) -> Result<T, McpError> {
+        let mut attempt = 0;
+        let mut delay_ms = 50u64;
+
+        loop {
+            attempt += 1;
+            match self.execute(args).await {
+                Ok(result) => {
+                    if attempt > 1 {
+                        tracing::info!("CLI command succeeded after {} attempts", attempt);
+                    }
+                    return Ok(result);
+                }
+                Err(e) if Self::is_retryable(&e) && attempt < max_attempts => {
+                    tracing::warn!(
+                        "CLI command failed (attempt {}/{}): {}. Retrying after {}ms...",
+                        attempt,
+                        max_attempts,
+                        e.message,
+                        delay_ms
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    delay_ms = (delay_ms * 2).min(1000); // Exponential backoff, max 1s
+                }
+                Err(e) => {
+                    if attempt > 1 {
+                        tracing::error!(
+                            "CLI command failed after {} attempts: {}",
+                            attempt,
+                            e.message
+                        );
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    fn is_retryable(error: &McpError) -> bool {
+        error
+            .data
+            .as_ref()
+            .and_then(|d| d.get("retryable"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_success_response() {
+        let json = r#"{"success":true,"api_version":"0.1.0","data":{"id":"123","name":"Test"}}"#;
+        let response: CliResponse<serde_json::Value> = serde_json::from_str(json).unwrap();
+        assert!(response.success);
+        assert!(response.data.is_some());
+        assert_eq!(response.data.unwrap()["id"], "123");
+    }
+
+    #[test]
+    fn test_parse_error_response() {
+        let json = r#"{"success":false,"api_version":"0.1.0","error":"Not found"}"#;
+        let response: CliResponse<serde_json::Value> = serde_json::from_str(json).unwrap();
+        assert!(!response.success);
+        assert_eq!(response.error, Some("Not found".to_string()));
+    }
+
+    #[test]
+    fn test_parse_list_response() {
+        let json = r#"{"success":true,"api_version":"0.1.0","data":{"items":[{"id":"1"},{"id":"2"}],"count":2}}"#;
+        let response: CliResponse<serde_json::Value> = serde_json::from_str(json).unwrap();
+        assert!(response.success);
+        let data = response.data.unwrap();
+        assert_eq!(data["count"], 2);
+    }
+}

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -95,7 +95,9 @@ pub struct UpdateCardRequest {
     pub priority: Option<String>,
     #[schemars(description = "Status: 'todo', 'in_progress', 'blocked', or 'done' (optional)")]
     pub status: Option<String>,
-    #[schemars(description = "Due date in ISO 8601 format (optional, use clear_due_date to remove)")]
+    #[schemars(
+        description = "Due date in ISO 8601 format (optional, use clear_due_date to remove)"
+    )]
     pub due_date: Option<String>,
     #[schemars(description = "Clear due date (set to true to remove due date)")]
     pub clear_due_date: Option<bool>,
@@ -235,10 +237,7 @@ impl McpTools for KanbanMcpServer {
     }
 
     async fn get_board(&self, board_id: String) -> Result<CallToolResult, McpError> {
-        let result: serde_json::Value = self
-            .executor
-            .execute(&["board", "get", &board_id])
-            .await?;
+        let result: serde_json::Value = self.executor.execute(&["board", "get", &board_id]).await?;
         Ok(json_result(result))
     }
 
@@ -258,14 +257,8 @@ impl McpTools for KanbanMcpServer {
         name: String,
         position: Option<i32>,
     ) -> Result<CallToolResult, McpError> {
-        let mut builder = ArgsBuilder::new(&[
-            "column",
-            "create",
-            "--board-id",
-            &board_id,
-            "--name",
-            &name,
-        ]);
+        let mut builder =
+            ArgsBuilder::new(&["column", "create", "--board-id", &board_id, "--name", &name]);
         builder.add_opt_num("--position", position);
         let result: serde_json::Value = self
             .executor
@@ -350,8 +343,7 @@ impl McpTools for KanbanMcpServer {
         column_id: String,
         position: Option<i32>,
     ) -> Result<CallToolResult, McpError> {
-        let mut builder =
-            ArgsBuilder::new(&["card", "move", &card_id, "--column-id", &column_id]);
+        let mut builder = ArgsBuilder::new(&["card", "move", &card_id, "--column-id", &column_id]);
         builder.add_opt_num("--position", position);
         let result: serde_json::Value = self
             .executor
@@ -513,7 +505,9 @@ impl KanbanMcpServer {
         McpTools::move_card(self, req.card_id, req.column_id, req.position).await
     }
 
-    #[tool(description = "Update a card's properties (title, description, priority, status, due_date, points)")]
+    #[tool(
+        description = "Update a card's properties (title, description, priority, status, due_date, points)"
+    )]
     async fn tool_update_card(
         &self,
         Parameters(req): Parameters<UpdateCardRequest>,

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -1,575 +1,20 @@
-use chrono::{DateTime, Utc};
-use kanban_core::KanbanResult;
-use kanban_domain::{
-    ArchivedCard, Board, Card, CardFilter, CardPriority, CardStatus, CardUpdate, Column,
-    FieldUpdate, KanbanOperations, Sprint,
-};
-use kanban_persistence::{JsonFileStore, PersistenceMetadata, PersistenceStore, StoreSnapshot};
+mod executor;
+
+use executor::CliExecutor;
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolResult, Content, ErrorData as McpError, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
+    model::{
+        CallToolResult, Content, ErrorData as McpError, Implementation, ProtocolVersion,
+        ServerCapabilities, ServerInfo,
+    },
     schemars, tool, tool_handler, tool_router, ServerHandler,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
-use tokio::sync::Mutex;
-use uuid::Uuid;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DataSnapshot {
-    #[serde(default)]
-    pub boards: Vec<Board>,
-    #[serde(default)]
-    pub columns: Vec<Column>,
-    #[serde(default)]
-    pub cards: Vec<Card>,
-    #[serde(default)]
-    pub archived_cards: Vec<ArchivedCard>,
-    #[serde(default)]
-    pub sprints: Vec<Sprint>,
-}
-
-pub struct KanbanContext {
-    boards: Vec<Board>,
-    columns: Vec<Column>,
-    cards: Vec<Card>,
-    sprints: Vec<Sprint>,
-    archived_cards: Vec<ArchivedCard>,
-    store: JsonFileStore,
-}
-
-impl KanbanContext {
-    pub async fn load(file_path: &str) -> KanbanResult<Self> {
-        let store = JsonFileStore::new(file_path);
-
-        if !store.exists().await {
-            return Ok(Self::empty(store));
-        }
-
-        let (snapshot, _metadata) = store.load().await?;
-        let data: DataSnapshot = serde_json::from_slice(&snapshot.data)
-            .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))?;
-
-        Ok(Self {
-            boards: data.boards,
-            columns: data.columns,
-            cards: data.cards,
-            sprints: data.sprints,
-            archived_cards: data.archived_cards,
-            store,
-        })
-    }
-
-    fn empty(store: JsonFileStore) -> Self {
-        Self {
-            boards: Vec::new(),
-            columns: Vec::new(),
-            cards: Vec::new(),
-            sprints: Vec::new(),
-            archived_cards: Vec::new(),
-            store,
-        }
-    }
-
-    pub async fn save(&self) -> KanbanResult<()> {
-        let snapshot = DataSnapshot {
-            boards: self.boards.clone(),
-            columns: self.columns.clone(),
-            cards: self.cards.clone(),
-            archived_cards: self.archived_cards.clone(),
-            sprints: self.sprints.clone(),
-        };
-
-        let bytes = serde_json::to_vec_pretty(&snapshot)
-            .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))?;
-
-        let store_snapshot = StoreSnapshot {
-            data: bytes,
-            metadata: PersistenceMetadata::new(Uuid::new_v4()),
-        };
-
-        self.store.save(store_snapshot).await?;
-        Ok(())
-    }
-
-    fn execute(&mut self, command: Box<dyn kanban_domain::commands::Command>) -> KanbanResult<()> {
-        let mut ctx = kanban_domain::commands::CommandContext {
-            boards: &mut self.boards,
-            columns: &mut self.columns,
-            cards: &mut self.cards,
-            sprints: &mut self.sprints,
-            archived_cards: &mut self.archived_cards,
-        };
-        command.execute(&mut ctx)
-    }
-}
-
-impl KanbanOperations for KanbanContext {
-    fn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {
-        use kanban_domain::commands::CreateBoard;
-        let cmd = CreateBoard { name, card_prefix };
-        self.execute(Box::new(cmd))?;
-        self.boards.last().cloned().ok_or_else(|| {
-            kanban_core::KanbanError::Internal(
-                "Board creation succeeded but board not found".into(),
-            )
-        })
-    }
-
-    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
-        Ok(self.boards.clone())
-    }
-
-    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
-        Ok(self.boards.iter().find(|b| b.id == id).cloned())
-    }
-
-    fn update_board(&mut self, id: Uuid, updates: kanban_domain::BoardUpdate) -> KanbanResult<Board> {
-        use kanban_domain::commands::UpdateBoard;
-        let cmd = UpdateBoard {
-            board_id: id,
-            updates,
-        };
-        self.execute(Box::new(cmd))?;
-        self.get_board(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Board {}", id)))
-    }
-
-    fn delete_board(&mut self, id: Uuid) -> KanbanResult<()> {
-        use kanban_domain::commands::DeleteBoard;
-        let cmd = DeleteBoard { board_id: id };
-        self.execute(Box::new(cmd))
-    }
-
-    fn create_column(
-        &mut self,
-        board_id: Uuid,
-        name: String,
-        position: Option<i32>,
-    ) -> KanbanResult<Column> {
-        use kanban_domain::commands::CreateColumn;
-        let position = position.unwrap_or_else(|| {
-            self.columns
-                .iter()
-                .filter(|c| c.board_id == board_id)
-                .count() as i32
-        });
-        let cmd = CreateColumn {
-            board_id,
-            name,
-            position,
-        };
-        self.execute(Box::new(cmd))?;
-        self.columns.last().cloned().ok_or_else(|| {
-            kanban_core::KanbanError::Internal(
-                "Column creation succeeded but column not found".into(),
-            )
-        })
-    }
-
-    fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
-        Ok(self
-            .columns
-            .iter()
-            .filter(|c| c.board_id == board_id)
-            .cloned()
-            .collect())
-    }
-
-    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
-        Ok(self.columns.iter().find(|c| c.id == id).cloned())
-    }
-
-    fn update_column(&mut self, id: Uuid, updates: kanban_domain::ColumnUpdate) -> KanbanResult<Column> {
-        use kanban_domain::commands::UpdateColumn;
-        let cmd = UpdateColumn {
-            column_id: id,
-            updates,
-        };
-        self.execute(Box::new(cmd))?;
-        self.get_column(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Column {}", id)))
-    }
-
-    fn delete_column(&mut self, id: Uuid) -> KanbanResult<()> {
-        use kanban_domain::commands::DeleteColumn;
-        let cmd = DeleteColumn { column_id: id };
-        self.execute(Box::new(cmd))
-    }
-
-    fn reorder_column(&mut self, id: Uuid, new_position: i32) -> KanbanResult<Column> {
-        use kanban_domain::FieldUpdate;
-        let updates = kanban_domain::ColumnUpdate {
-            name: None,
-            position: Some(new_position),
-            wip_limit: FieldUpdate::NoChange,
-        };
-        self.update_column(id, updates)
-    }
-
-    fn create_card(
-        &mut self,
-        board_id: Uuid,
-        column_id: Uuid,
-        title: String,
-    ) -> KanbanResult<Card> {
-        use kanban_domain::commands::CreateCard;
-        let position = self
-            .cards
-            .iter()
-            .filter(|c| c.column_id == column_id)
-            .count() as i32;
-        let cmd = CreateCard {
-            board_id,
-            column_id,
-            title,
-            position,
-        };
-        self.execute(Box::new(cmd))?;
-        self.cards.last().cloned().ok_or_else(|| {
-            kanban_core::KanbanError::Internal("Card creation succeeded but card not found".into())
-        })
-    }
-
-    fn list_cards(&self, filter: CardFilter) -> KanbanResult<Vec<Card>> {
-        let board_columns: Option<Vec<_>> = filter.board_id.map(|board_id| {
-            self.columns
-                .iter()
-                .filter(|c| c.board_id == board_id)
-                .map(|c| c.id)
-                .collect()
-        });
-
-        let cards = self
-            .cards
-            .iter()
-            .filter(|card| {
-                if let Some(ref cols) = board_columns {
-                    if !cols.contains(&card.column_id) {
-                        return false;
-                    }
-                }
-                if let Some(column_id) = filter.column_id {
-                    if card.column_id != column_id {
-                        return false;
-                    }
-                }
-                if let Some(sprint_id) = filter.sprint_id {
-                    if card.sprint_id != Some(sprint_id) {
-                        return false;
-                    }
-                }
-                if let Some(status) = filter.status {
-                    if card.status != status {
-                        return false;
-                    }
-                }
-                true
-            })
-            .cloned()
-            .collect();
-
-        Ok(cards)
-    }
-
-    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
-        Ok(self.cards.iter().find(|c| c.id == id).cloned())
-    }
-
-    fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
-        use kanban_domain::commands::UpdateCard;
-        let cmd = UpdateCard {
-            card_id: id,
-            updates,
-        };
-        self.execute(Box::new(cmd))?;
-        self.get_card(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", id)))
-    }
-
-    fn move_card(&mut self, id: Uuid, column_id: Uuid, position: Option<i32>) -> KanbanResult<Card> {
-        use kanban_domain::commands::MoveCard;
-        let new_position = position.unwrap_or_else(|| {
-            self.cards
-                .iter()
-                .filter(|c| c.column_id == column_id)
-                .count() as i32
-        });
-        let cmd = MoveCard {
-            card_id: id,
-            new_column_id: column_id,
-            new_position,
-        };
-        self.execute(Box::new(cmd))?;
-        self.get_card(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", id)))
-    }
-
-    fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        use kanban_domain::commands::ArchiveCard;
-        let cmd = ArchiveCard { card_id: id };
-        self.execute(Box::new(cmd))
-    }
-
-    fn restore_card(&mut self, id: Uuid, column_id: Option<Uuid>) -> KanbanResult<Card> {
-        use kanban_domain::commands::RestoreCard;
-        let column_id = column_id.ok_or_else(|| {
-            kanban_core::KanbanError::Validation("column_id is required for restore".into())
-        })?;
-        let position = self
-            .cards
-            .iter()
-            .filter(|c| c.column_id == column_id)
-            .count() as i32;
-        let cmd = RestoreCard {
-            card_id: id,
-            column_id,
-            position,
-        };
-        self.execute(Box::new(cmd))?;
-        self.get_card(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", id)))
-    }
-
-    fn delete_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        use kanban_domain::commands::DeleteCard;
-        let cmd = DeleteCard { card_id: id };
-        self.execute(Box::new(cmd))
-    }
-
-    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
-        Ok(self.archived_cards.clone())
-    }
-
-    fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
-        use kanban_domain::commands::AssignCardToSprint;
-        let sprint = self
-            .get_sprint(sprint_id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", sprint_id)))?;
-        let board = self
-            .boards
-            .iter()
-            .find(|b| b.id == sprint.board_id)
-            .ok_or_else(|| {
-                kanban_core::KanbanError::NotFound(format!("Board {}", sprint.board_id))
-            })?;
-        let sprint_name = sprint.get_name(board).map(|s| s.to_string());
-        let cmd = AssignCardToSprint {
-            card_id,
-            sprint_id,
-            sprint_number: sprint.sprint_number,
-            sprint_name,
-            sprint_status: format!("{:?}", sprint.status),
-        };
-        self.execute(Box::new(cmd))?;
-        self.get_card(card_id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", card_id)))
-    }
-
-    fn unassign_card_from_sprint(&mut self, card_id: Uuid) -> KanbanResult<Card> {
-        use kanban_domain::commands::UnassignCardFromSprint;
-        let cmd = UnassignCardFromSprint { card_id };
-        self.execute(Box::new(cmd))?;
-        self.get_card(card_id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", card_id)))
-    }
-
-    fn get_card_branch_name(&self, id: Uuid) -> KanbanResult<String> {
-        let card = self.get_card(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", id)))?;
-        let board = self
-            .boards
-            .iter()
-            .find(|b| {
-                self.columns
-                    .iter()
-                    .any(|c| c.id == card.column_id && c.board_id == b.id)
-            })
-            .ok_or_else(|| kanban_core::KanbanError::NotFound("Board not found for card".into()))?;
-        let default_prefix = board.card_prefix.as_deref().unwrap_or("task");
-        Ok(card.branch_name(board, &self.sprints, default_prefix))
-    }
-
-    fn get_card_git_checkout(&self, id: Uuid) -> KanbanResult<String> {
-        let branch_name = self.get_card_branch_name(id)?;
-        Ok(format!("git checkout -b {}", branch_name))
-    }
-
-    fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.archive_card(id).is_ok() {
-                count += 1;
-            }
-        }
-        Ok(count)
-    }
-
-    fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.move_card(id, column_id, None).is_ok() {
-                count += 1;
-            }
-        }
-        Ok(count)
-    }
-
-    fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.assign_card_to_sprint(id, sprint_id).is_ok() {
-                count += 1;
-            }
-        }
-        Ok(count)
-    }
-
-    fn create_sprint(
-        &mut self,
-        board_id: Uuid,
-        prefix: Option<String>,
-        name: Option<String>,
-    ) -> KanbanResult<Sprint> {
-        use kanban_domain::commands::CreateSprint;
-
-        let (sprint_number, name_index, effective_prefix) = {
-            let board = self
-                .boards
-                .iter_mut()
-                .find(|b| b.id == board_id)
-                .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Board {}", board_id)))?;
-
-            let effective_prefix = prefix
-                .or_else(|| board.sprint_prefix.clone())
-                .unwrap_or_else(|| "sprint".to_string());
-
-            board.ensure_sprint_counter_initialized(&effective_prefix, &self.sprints);
-            let sprint_number = board.get_next_sprint_number(&effective_prefix);
-            let name_index = name.map(|n| board.add_sprint_name_at_used_index(n));
-
-            (sprint_number, name_index, effective_prefix)
-        };
-
-        let cmd = CreateSprint {
-            board_id,
-            sprint_number,
-            name_index,
-            prefix: Some(effective_prefix),
-        };
-        self.execute(Box::new(cmd))?;
-        self.sprints.last().cloned().ok_or_else(|| {
-            kanban_core::KanbanError::Internal("Sprint creation succeeded but sprint not found".into())
-        })
-    }
-
-    fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
-        Ok(self
-            .sprints
-            .iter()
-            .filter(|s| s.board_id == board_id)
-            .cloned()
-            .collect())
-    }
-
-    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
-        Ok(self.sprints.iter().find(|s| s.id == id).cloned())
-    }
-
-    fn update_sprint(&mut self, id: Uuid, updates: kanban_domain::SprintUpdate) -> KanbanResult<Sprint> {
-        use kanban_domain::commands::UpdateSprint;
-        let cmd = UpdateSprint {
-            sprint_id: id,
-            updates,
-        };
-        self.execute(Box::new(cmd))?;
-        self.get_sprint(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", id)))
-    }
-
-    fn activate_sprint(&mut self, id: Uuid, duration_days: Option<i32>) -> KanbanResult<Sprint> {
-        use kanban_domain::commands::ActivateSprint;
-        let duration = duration_days.unwrap_or(14) as u32;
-        let cmd = ActivateSprint {
-            sprint_id: id,
-            duration_days: duration,
-        };
-        self.execute(Box::new(cmd))?;
-        self.get_sprint(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", id)))
-    }
-
-    fn complete_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
-        use kanban_domain::commands::CompleteSprint;
-        let cmd = CompleteSprint { sprint_id: id };
-        self.execute(Box::new(cmd))?;
-        self.get_sprint(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", id)))
-    }
-
-    fn cancel_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
-        use kanban_domain::commands::CancelSprint;
-        let cmd = CancelSprint { sprint_id: id };
-        self.execute(Box::new(cmd))?;
-        self.get_sprint(id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", id)))
-    }
-
-    fn delete_sprint(&mut self, id: Uuid) -> KanbanResult<()> {
-        use kanban_domain::commands::DeleteSprint;
-        let cmd = DeleteSprint { sprint_id: id };
-        self.execute(Box::new(cmd))
-    }
-
-    fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String> {
-        let snapshot = if let Some(board_id) = board_id {
-            let boards = self.boards.iter().filter(|b| b.id == board_id).cloned().collect();
-            let columns = self.columns.iter().filter(|c| c.board_id == board_id).cloned().collect();
-            let column_ids: Vec<_> = self.columns.iter().filter(|c| c.board_id == board_id).map(|c| c.id).collect();
-            let cards = self.cards.iter().filter(|c| column_ids.contains(&c.column_id)).cloned().collect();
-            let sprints = self.sprints.iter().filter(|s| s.board_id == board_id).cloned().collect();
-            DataSnapshot {
-                boards,
-                columns,
-                cards,
-                archived_cards: vec![],
-                sprints,
-            }
-        } else {
-            DataSnapshot {
-                boards: self.boards.clone(),
-                columns: self.columns.clone(),
-                cards: self.cards.clone(),
-                archived_cards: self.archived_cards.clone(),
-                sprints: self.sprints.clone(),
-            }
-        };
-        serde_json::to_string_pretty(&snapshot)
-            .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))
-    }
-
-    fn import_board(&mut self, data: &str) -> KanbanResult<Board> {
-        let snapshot: DataSnapshot = serde_json::from_str(data)
-            .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))?;
-
-        if snapshot.boards.is_empty() {
-            return Err(kanban_core::KanbanError::Validation("No boards in import data".into()));
-        }
-
-        self.boards.extend(snapshot.boards.clone());
-        self.columns.extend(snapshot.columns);
-        self.cards.extend(snapshot.cards);
-        self.sprints.extend(snapshot.sprints);
-
-        Ok(snapshot.boards.into_iter().next().unwrap())
-    }
-}
-
-#[derive(Clone)]
-pub struct KanbanMcpServer {
-    context: Arc<Mutex<KanbanContext>>,
-    tool_router: ToolRouter<Self>,
-}
+// ============================================================================
+// Request Types (kept for MCP tool schemas)
+// ============================================================================
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateBoardRequest {
@@ -597,6 +42,14 @@ pub struct CreateCardRequest {
     pub column_id: String,
     #[schemars(description = "Title of the card")]
     pub title: String,
+    #[schemars(description = "Description of the card (optional)")]
+    pub description: Option<String>,
+    #[schemars(description = "Priority: 'low', 'medium', 'high', or 'critical' (optional)")]
+    pub priority: Option<String>,
+    #[schemars(description = "Story points (optional, 0-255)")]
+    pub points: Option<u8>,
+    #[schemars(description = "Due date in ISO 8601 format (optional)")]
+    pub due_date: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -679,279 +132,115 @@ pub struct ArchiveCardRequest {
     pub card_id: String,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetBoardRequest {
+    #[schemars(description = "ID of the board to retrieve")]
+    pub board_id: String,
+}
+
+// ============================================================================
+// MCP Server
+// ============================================================================
+
+#[derive(Clone)]
+pub struct KanbanMcpServer {
+    executor: Arc<CliExecutor>,
+    tool_router: ToolRouter<Self>,
+}
+
+/// Helper to build CLI args with optional parameters
+struct ArgsBuilder {
+    args: Vec<String>,
+}
+
+impl ArgsBuilder {
+    fn new(base: &[&str]) -> Self {
+        Self {
+            args: base.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn add_opt(&mut self, flag: &str, value: Option<&str>) -> &mut Self {
+        if let Some(v) = value {
+            self.args.push(flag.to_string());
+            self.args.push(v.to_string());
+        }
+        self
+    }
+
+    fn add_opt_num<T: ToString>(&mut self, flag: &str, value: Option<T>) -> &mut Self {
+        if let Some(v) = value {
+            self.args.push(flag.to_string());
+            self.args.push(v.to_string());
+        }
+        self
+    }
+
+    fn add_flag(&mut self, flag: &str, value: Option<bool>) -> &mut Self {
+        if value == Some(true) {
+            self.args.push(flag.to_string());
+        }
+        self
+    }
+
+    fn build(&self) -> Vec<&str> {
+        self.args.iter().map(|s| s.as_str()).collect()
+    }
+}
+
 #[tool_router]
 impl KanbanMcpServer {
-    pub async fn new(data_file: &str) -> KanbanResult<Self> {
-        let context = KanbanContext::load(data_file).await?;
-        Ok(Self {
-            context: Arc::new(Mutex::new(context)),
+    pub fn new(data_file: &str) -> Self {
+        Self {
+            executor: Arc::new(CliExecutor::new(data_file.to_string())),
             tool_router: Self::tool_router(),
-        })
+        }
     }
+
+    // ========================================================================
+    // Board Operations
+    // ========================================================================
 
     #[tool(description = "Create a new kanban board")]
     async fn create_board(
         &self,
         Parameters(req): Parameters<CreateBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let mut ctx = self.context.lock().await;
-        let board = ctx
-            .create_board(req.name, req.card_prefix)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let mut builder = ArgsBuilder::new(&["board", "create", "--name", &req.name]);
+        builder.add_opt("--card-prefix", req.card_prefix.as_deref());
 
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&builder.build(), 3)
+            .await?;
 
-        let json = serde_json::to_string_pretty(&board)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
     }
 
     #[tool(description = "List all kanban boards")]
     async fn list_boards(&self) -> Result<CallToolResult, McpError> {
-        let ctx = self.context.lock().await;
-        let boards = ctx
-            .list_boards()
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let result: serde_json::Value = self.executor.execute(&["board", "list"]).await?;
 
-        let json = serde_json::to_string_pretty(&boards)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
     }
 
-    #[tool(description = "Create a new column in a board")]
-    async fn create_column(
+    #[tool(description = "Get a specific board by ID")]
+    async fn get_board(
         &self,
-        Parameters(req): Parameters<CreateColumnRequest>,
+        Parameters(req): Parameters<GetBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = Uuid::parse_str(&req.board_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let result: serde_json::Value = self
+            .executor
+            .execute(&["board", "get", &req.board_id])
+            .await?;
 
-        let mut ctx = self.context.lock().await;
-        let column = ctx
-            .create_column(board_id, req.name, req.position)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        let json = serde_json::to_string_pretty(&column)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
-    }
-
-    #[tool(description = "Create a new card in a column")]
-    async fn create_card(
-        &self,
-        Parameters(req): Parameters<CreateCardRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let board_id = Uuid::parse_str(&req.board_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-        let column_id = Uuid::parse_str(&req.column_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let mut ctx = self.context.lock().await;
-        let card = ctx
-            .create_card(board_id, column_id, req.title)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        let json = serde_json::to_string_pretty(&card)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
-    }
-
-    #[tool(description = "List cards with optional filters")]
-    async fn list_cards(
-        &self,
-        Parameters(req): Parameters<ListCardsRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let board_id = req
-            .board_id
-            .as_ref()
-            .map(|s| Uuid::parse_str(s))
-            .transpose()
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let column_id = req
-            .column_id
-            .as_ref()
-            .map(|s| Uuid::parse_str(s))
-            .transpose()
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let sprint_id = req
-            .sprint_id
-            .as_ref()
-            .map(|s| Uuid::parse_str(s))
-            .transpose()
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let filter = CardFilter {
-            board_id,
-            column_id,
-            sprint_id,
-            status: None,
-        };
-
-        let ctx = self.context.lock().await;
-        let cards = ctx
-            .list_cards(filter)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        let json = serde_json::to_string_pretty(&cards)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
-    }
-
-    #[tool(description = "Get a specific card by ID")]
-    async fn get_card(
-        &self,
-        Parameters(req): Parameters<GetCardRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let card_id = Uuid::parse_str(&req.card_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let ctx = self.context.lock().await;
-        let card = ctx
-            .get_card(card_id)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        let json = serde_json::to_string_pretty(&card)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
-    }
-
-    #[tool(description = "Move a card to a different column")]
-    async fn move_card(
-        &self,
-        Parameters(req): Parameters<MoveCardRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let card_id = Uuid::parse_str(&req.card_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-        let column_id = Uuid::parse_str(&req.column_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let mut ctx = self.context.lock().await;
-        let card = ctx
-            .move_card(card_id, column_id, req.position)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        let json = serde_json::to_string_pretty(&card)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
-    }
-
-    #[tool(description = "Update a card's properties (title, description, priority, status, due_date, points)")]
-    async fn update_card(
-        &self,
-        Parameters(req): Parameters<UpdateCardRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let card_id = Uuid::parse_str(&req.card_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let mut updates = CardUpdate::default();
-
-        if let Some(title) = req.title {
-            updates.title = Some(title);
-        }
-
-        if req.clear_description == Some(true) {
-            updates.description = FieldUpdate::Clear;
-        } else if let Some(description) = req.description {
-            updates.description = FieldUpdate::Set(description);
-        }
-
-        if let Some(priority_str) = req.priority {
-            let priority = match priority_str.to_lowercase().as_str() {
-                "low" => CardPriority::Low,
-                "medium" => CardPriority::Medium,
-                "high" => CardPriority::High,
-                "critical" => CardPriority::Critical,
-                _ => return Err(McpError::invalid_params(
-                    format!("Invalid priority '{}'. Must be 'low', 'medium', 'high', or 'critical'", priority_str),
-                    None,
-                )),
-            };
-            updates.priority = Some(priority);
-        }
-
-        if let Some(status_str) = req.status {
-            let status = match status_str.to_lowercase().replace('-', "_").as_str() {
-                "todo" => CardStatus::Todo,
-                "in_progress" => CardStatus::InProgress,
-                "blocked" => CardStatus::Blocked,
-                "done" => CardStatus::Done,
-                _ => return Err(McpError::invalid_params(
-                    format!("Invalid status '{}'. Must be 'todo', 'in_progress', 'blocked', or 'done'", status_str),
-                    None,
-                )),
-            };
-            updates.status = Some(status);
-        }
-
-        if req.clear_due_date == Some(true) {
-            updates.due_date = FieldUpdate::Clear;
-        } else if let Some(due_date_str) = req.due_date {
-            let due_date: DateTime<Utc> = due_date_str.parse()
-                .map_err(|e| McpError::invalid_params(format!("Invalid due_date format: {}. Use ISO 8601 format.", e), None))?;
-            updates.due_date = FieldUpdate::Set(due_date);
-        }
-
-        if req.clear_points == Some(true) {
-            updates.points = FieldUpdate::Clear;
-        } else if let Some(points) = req.points {
-            updates.points = FieldUpdate::Set(points);
-        }
-
-        let mut ctx = self.context.lock().await;
-        let card = ctx
-            .update_card(card_id, updates)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        let json = serde_json::to_string_pretty(&card)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
-    }
-
-    #[tool(description = "List all columns in a board")]
-    async fn list_columns(
-        &self,
-        Parameters(req): Parameters<ListColumnsRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let board_id = Uuid::parse_str(&req.board_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let ctx = self.context.lock().await;
-        let columns = ctx
-            .list_columns(board_id)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        let json = serde_json::to_string_pretty(&columns)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
     }
 
     #[tool(description = "Delete a board and all its columns, cards, and sprints")]
@@ -959,19 +248,57 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = Uuid::parse_str(&req.board_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let mut ctx = self.context.lock().await;
-        ctx.delete_board(board_id)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&["board", "delete", &req.board_id], 3)
+            .await?;
 
         Ok(CallToolResult::success(vec![Content::text(
-            format!("Board {} deleted successfully", board_id),
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
+    }
+
+    // ========================================================================
+    // Column Operations
+    // ========================================================================
+
+    #[tool(description = "Create a new column in a board")]
+    async fn create_column(
+        &self,
+        Parameters(req): Parameters<CreateColumnRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut builder = ArgsBuilder::new(&[
+            "column",
+            "create",
+            "--board-id",
+            &req.board_id,
+            "--name",
+            &req.name,
+        ]);
+        builder.add_opt_num("--position", req.position);
+
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&builder.build(), 3)
+            .await?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
+    }
+
+    #[tool(description = "List all columns in a board")]
+    async fn list_columns(
+        &self,
+        Parameters(req): Parameters<ListColumnsRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let result: serde_json::Value = self
+            .executor
+            .execute(&["column", "list", "--board-id", &req.board_id])
+            .await?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
         )]))
     }
 
@@ -980,40 +307,125 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let column_id = Uuid::parse_str(&req.column_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let mut ctx = self.context.lock().await;
-        ctx.delete_column(column_id)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&["column", "delete", &req.column_id], 3)
+            .await?;
 
         Ok(CallToolResult::success(vec![Content::text(
-            format!("Column {} deleted successfully", column_id),
+            serde_json::to_string_pretty(&result).unwrap(),
         )]))
     }
 
-    #[tool(description = "Delete a card permanently")]
-    async fn delete_card(
+    // ========================================================================
+    // Card Operations
+    // ========================================================================
+
+    #[tool(description = "Create a new card in a column")]
+    async fn create_card(
         &self,
-        Parameters(req): Parameters<DeleteCardRequest>,
+        Parameters(req): Parameters<CreateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card_id = Uuid::parse_str(&req.card_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let mut builder = ArgsBuilder::new(&[
+            "card",
+            "create",
+            "--board-id",
+            &req.board_id,
+            "--column-id",
+            &req.column_id,
+            "--title",
+            &req.title,
+        ]);
+        builder
+            .add_opt("--description", req.description.as_deref())
+            .add_opt("--priority", req.priority.as_deref())
+            .add_opt_num("--points", req.points)
+            .add_opt("--due-date", req.due_date.as_deref());
 
-        let mut ctx = self.context.lock().await;
-        ctx.delete_card(card_id)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&builder.build(), 3)
+            .await?;
 
         Ok(CallToolResult::success(vec![Content::text(
-            format!("Card {} deleted successfully", card_id),
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
+    }
+
+    #[tool(description = "List cards with optional filters")]
+    async fn list_cards(
+        &self,
+        Parameters(req): Parameters<ListCardsRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut builder = ArgsBuilder::new(&["card", "list"]);
+        builder
+            .add_opt("--board-id", req.board_id.as_deref())
+            .add_opt("--column-id", req.column_id.as_deref())
+            .add_opt("--sprint-id", req.sprint_id.as_deref());
+
+        let result: serde_json::Value = self.executor.execute(&builder.build()).await?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
+    }
+
+    #[tool(description = "Get a specific card by ID")]
+    async fn get_card(
+        &self,
+        Parameters(req): Parameters<GetCardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let result: serde_json::Value = self
+            .executor
+            .execute(&["card", "get", &req.card_id])
+            .await?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
+    }
+
+    #[tool(description = "Move a card to a different column")]
+    async fn move_card(
+        &self,
+        Parameters(req): Parameters<MoveCardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut builder =
+            ArgsBuilder::new(&["card", "move", &req.card_id, "--column-id", &req.column_id]);
+        builder.add_opt_num("--position", req.position);
+
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&builder.build(), 3)
+            .await?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
+    }
+
+    #[tool(description = "Update a card's properties (title, description, priority, status, due_date, points)")]
+    async fn update_card(
+        &self,
+        Parameters(req): Parameters<UpdateCardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut builder = ArgsBuilder::new(&["card", "update", &req.card_id]);
+        builder
+            .add_opt("--title", req.title.as_deref())
+            .add_opt("--description", req.description.as_deref())
+            .add_opt("--priority", req.priority.as_deref())
+            .add_opt("--status", req.status.as_deref())
+            .add_opt("--due-date", req.due_date.as_deref())
+            .add_opt_num("--points", req.points)
+            .add_flag("--clear-due-date", req.clear_due_date);
+
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&builder.build(), 3)
+            .await?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
         )]))
     }
 
@@ -1022,19 +434,28 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ArchiveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card_id = Uuid::parse_str(&req.card_id)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-
-        let mut ctx = self.context.lock().await;
-        ctx.archive_card(card_id)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        ctx.save()
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&["card", "archive", &req.card_id], 3)
+            .await?;
 
         Ok(CallToolResult::success(vec![Content::text(
-            format!("Card {} archived successfully", card_id),
+            serde_json::to_string_pretty(&result).unwrap(),
+        )]))
+    }
+
+    #[tool(description = "Delete a card permanently")]
+    async fn delete_card(
+        &self,
+        Parameters(req): Parameters<DeleteCardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let result: serde_json::Value = self
+            .executor
+            .execute_with_retry(&["card", "delete", &req.card_id], 3)
+            .await?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap(),
         )]))
     }
 }
@@ -1047,7 +468,8 @@ impl ServerHandler for KanbanMcpServer {
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation::from_build_env(),
             instructions: Some(
-                "Kanban MCP Server - Manage your kanban boards, columns, and cards through MCP"
+                "Kanban MCP Server - Manage your kanban boards, columns, and cards through MCP. \
+                 This server delegates to the kanban CLI for all operations."
                     .to_string(),
             ),
         }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -1,0 +1,847 @@
+use kanban_core::KanbanResult;
+use kanban_domain::{
+    ArchivedCard, Board, Card, CardFilter, CardUpdate, Column, KanbanOperations, Sprint,
+};
+use kanban_persistence::{JsonFileStore, PersistenceMetadata, PersistenceStore, StoreSnapshot};
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{CallToolResult, Content, ErrorData as McpError, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataSnapshot {
+    #[serde(default)]
+    pub boards: Vec<Board>,
+    #[serde(default)]
+    pub columns: Vec<Column>,
+    #[serde(default)]
+    pub cards: Vec<Card>,
+    #[serde(default)]
+    pub archived_cards: Vec<ArchivedCard>,
+    #[serde(default)]
+    pub sprints: Vec<Sprint>,
+}
+
+pub struct KanbanContext {
+    boards: Vec<Board>,
+    columns: Vec<Column>,
+    cards: Vec<Card>,
+    sprints: Vec<Sprint>,
+    archived_cards: Vec<ArchivedCard>,
+    store: JsonFileStore,
+}
+
+impl KanbanContext {
+    pub async fn load(file_path: &str) -> KanbanResult<Self> {
+        let store = JsonFileStore::new(file_path);
+
+        if !store.exists().await {
+            return Ok(Self::empty(store));
+        }
+
+        let (snapshot, _metadata) = store.load().await?;
+        let data: DataSnapshot = serde_json::from_slice(&snapshot.data)
+            .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))?;
+
+        Ok(Self {
+            boards: data.boards,
+            columns: data.columns,
+            cards: data.cards,
+            sprints: data.sprints,
+            archived_cards: data.archived_cards,
+            store,
+        })
+    }
+
+    fn empty(store: JsonFileStore) -> Self {
+        Self {
+            boards: Vec::new(),
+            columns: Vec::new(),
+            cards: Vec::new(),
+            sprints: Vec::new(),
+            archived_cards: Vec::new(),
+            store,
+        }
+    }
+
+    pub async fn save(&self) -> KanbanResult<()> {
+        let snapshot = DataSnapshot {
+            boards: self.boards.clone(),
+            columns: self.columns.clone(),
+            cards: self.cards.clone(),
+            archived_cards: self.archived_cards.clone(),
+            sprints: self.sprints.clone(),
+        };
+
+        let bytes = serde_json::to_vec_pretty(&snapshot)
+            .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))?;
+
+        let store_snapshot = StoreSnapshot {
+            data: bytes,
+            metadata: PersistenceMetadata::new(Uuid::new_v4()),
+        };
+
+        self.store.save(store_snapshot).await?;
+        Ok(())
+    }
+
+    fn execute(&mut self, command: Box<dyn kanban_domain::commands::Command>) -> KanbanResult<()> {
+        let mut ctx = kanban_domain::commands::CommandContext {
+            boards: &mut self.boards,
+            columns: &mut self.columns,
+            cards: &mut self.cards,
+            sprints: &mut self.sprints,
+            archived_cards: &mut self.archived_cards,
+        };
+        command.execute(&mut ctx)
+    }
+}
+
+impl KanbanOperations for KanbanContext {
+    fn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {
+        use kanban_domain::commands::CreateBoard;
+        let cmd = CreateBoard { name, card_prefix };
+        self.execute(Box::new(cmd))?;
+        self.boards.last().cloned().ok_or_else(|| {
+            kanban_core::KanbanError::Internal(
+                "Board creation succeeded but board not found".into(),
+            )
+        })
+    }
+
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        Ok(self.boards.clone())
+    }
+
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        Ok(self.boards.iter().find(|b| b.id == id).cloned())
+    }
+
+    fn update_board(&mut self, id: Uuid, updates: kanban_domain::BoardUpdate) -> KanbanResult<Board> {
+        use kanban_domain::commands::UpdateBoard;
+        let cmd = UpdateBoard {
+            board_id: id,
+            updates,
+        };
+        self.execute(Box::new(cmd))?;
+        self.get_board(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Board {}", id)))
+    }
+
+    fn delete_board(&mut self, id: Uuid) -> KanbanResult<()> {
+        use kanban_domain::commands::DeleteBoard;
+        let cmd = DeleteBoard { board_id: id };
+        self.execute(Box::new(cmd))
+    }
+
+    fn create_column(
+        &mut self,
+        board_id: Uuid,
+        name: String,
+        position: Option<i32>,
+    ) -> KanbanResult<Column> {
+        use kanban_domain::commands::CreateColumn;
+        let position = position.unwrap_or_else(|| {
+            self.columns
+                .iter()
+                .filter(|c| c.board_id == board_id)
+                .count() as i32
+        });
+        let cmd = CreateColumn {
+            board_id,
+            name,
+            position,
+        };
+        self.execute(Box::new(cmd))?;
+        self.columns.last().cloned().ok_or_else(|| {
+            kanban_core::KanbanError::Internal(
+                "Column creation succeeded but column not found".into(),
+            )
+        })
+    }
+
+    fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        Ok(self
+            .columns
+            .iter()
+            .filter(|c| c.board_id == board_id)
+            .cloned()
+            .collect())
+    }
+
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        Ok(self.columns.iter().find(|c| c.id == id).cloned())
+    }
+
+    fn update_column(&mut self, id: Uuid, updates: kanban_domain::ColumnUpdate) -> KanbanResult<Column> {
+        use kanban_domain::commands::UpdateColumn;
+        let cmd = UpdateColumn {
+            column_id: id,
+            updates,
+        };
+        self.execute(Box::new(cmd))?;
+        self.get_column(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Column {}", id)))
+    }
+
+    fn delete_column(&mut self, id: Uuid) -> KanbanResult<()> {
+        use kanban_domain::commands::DeleteColumn;
+        let cmd = DeleteColumn { column_id: id };
+        self.execute(Box::new(cmd))
+    }
+
+    fn reorder_column(&mut self, id: Uuid, new_position: i32) -> KanbanResult<Column> {
+        use kanban_domain::FieldUpdate;
+        let updates = kanban_domain::ColumnUpdate {
+            name: None,
+            position: Some(new_position),
+            wip_limit: FieldUpdate::NoChange,
+        };
+        self.update_column(id, updates)
+    }
+
+    fn create_card(
+        &mut self,
+        board_id: Uuid,
+        column_id: Uuid,
+        title: String,
+    ) -> KanbanResult<Card> {
+        use kanban_domain::commands::CreateCard;
+        let position = self
+            .cards
+            .iter()
+            .filter(|c| c.column_id == column_id)
+            .count() as i32;
+        let cmd = CreateCard {
+            board_id,
+            column_id,
+            title,
+            position,
+        };
+        self.execute(Box::new(cmd))?;
+        self.cards.last().cloned().ok_or_else(|| {
+            kanban_core::KanbanError::Internal("Card creation succeeded but card not found".into())
+        })
+    }
+
+    fn list_cards(&self, filter: CardFilter) -> KanbanResult<Vec<Card>> {
+        let mut cards: Vec<_> = self.cards.to_vec();
+
+        if let Some(board_id) = filter.board_id {
+            let board_columns: Vec<_> = self
+                .columns
+                .iter()
+                .filter(|c| c.board_id == board_id)
+                .map(|c| c.id)
+                .collect();
+            cards.retain(|card| board_columns.contains(&card.column_id));
+        }
+
+        if let Some(column_id) = filter.column_id {
+            cards.retain(|card| card.column_id == column_id);
+        }
+
+        if let Some(sprint_id) = filter.sprint_id {
+            cards.retain(|card| card.sprint_id == Some(sprint_id));
+        }
+
+        if let Some(status) = filter.status {
+            cards.retain(|card| card.status == status);
+        }
+
+        Ok(cards)
+    }
+
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        Ok(self.cards.iter().find(|c| c.id == id).cloned())
+    }
+
+    fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
+        use kanban_domain::commands::UpdateCard;
+        let cmd = UpdateCard {
+            card_id: id,
+            updates,
+        };
+        self.execute(Box::new(cmd))?;
+        self.get_card(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", id)))
+    }
+
+    fn move_card(&mut self, id: Uuid, column_id: Uuid, position: Option<i32>) -> KanbanResult<Card> {
+        use kanban_domain::commands::MoveCard;
+        let new_position = position.unwrap_or_else(|| {
+            self.cards
+                .iter()
+                .filter(|c| c.column_id == column_id)
+                .count() as i32
+        });
+        let cmd = MoveCard {
+            card_id: id,
+            new_column_id: column_id,
+            new_position,
+        };
+        self.execute(Box::new(cmd))?;
+        self.get_card(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", id)))
+    }
+
+    fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
+        use kanban_domain::commands::ArchiveCard;
+        let cmd = ArchiveCard { card_id: id };
+        self.execute(Box::new(cmd))
+    }
+
+    fn restore_card(&mut self, id: Uuid, column_id: Option<Uuid>) -> KanbanResult<Card> {
+        use kanban_domain::commands::RestoreCard;
+        let column_id = column_id.ok_or_else(|| {
+            kanban_core::KanbanError::Validation("column_id is required for restore".into())
+        })?;
+        let position = self
+            .cards
+            .iter()
+            .filter(|c| c.column_id == column_id)
+            .count() as i32;
+        let cmd = RestoreCard {
+            card_id: id,
+            column_id,
+            position,
+        };
+        self.execute(Box::new(cmd))?;
+        self.get_card(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", id)))
+    }
+
+    fn delete_card(&mut self, id: Uuid) -> KanbanResult<()> {
+        use kanban_domain::commands::DeleteCard;
+        let cmd = DeleteCard { card_id: id };
+        self.execute(Box::new(cmd))
+    }
+
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        Ok(self.archived_cards.clone())
+    }
+
+    fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
+        use kanban_domain::commands::AssignCardToSprint;
+        let sprint = self
+            .get_sprint(sprint_id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", sprint_id)))?;
+        let board = self
+            .boards
+            .iter()
+            .find(|b| b.id == sprint.board_id)
+            .ok_or_else(|| {
+                kanban_core::KanbanError::NotFound(format!("Board {}", sprint.board_id))
+            })?;
+        let sprint_name = sprint.get_name(board).map(|s| s.to_string());
+        let cmd = AssignCardToSprint {
+            card_id,
+            sprint_id,
+            sprint_number: sprint.sprint_number,
+            sprint_name,
+            sprint_status: format!("{:?}", sprint.status),
+        };
+        self.execute(Box::new(cmd))?;
+        self.get_card(card_id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", card_id)))
+    }
+
+    fn unassign_card_from_sprint(&mut self, card_id: Uuid) -> KanbanResult<Card> {
+        use kanban_domain::commands::UnassignCardFromSprint;
+        let cmd = UnassignCardFromSprint { card_id };
+        self.execute(Box::new(cmd))?;
+        self.get_card(card_id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", card_id)))
+    }
+
+    fn get_card_branch_name(&self, id: Uuid) -> KanbanResult<String> {
+        let card = self.get_card(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Card {}", id)))?;
+        let board = self
+            .boards
+            .iter()
+            .find(|b| {
+                self.columns
+                    .iter()
+                    .any(|c| c.id == card.column_id && c.board_id == b.id)
+            })
+            .ok_or_else(|| kanban_core::KanbanError::NotFound("Board not found for card".into()))?;
+        let default_prefix = board.card_prefix.as_deref().unwrap_or("task");
+        Ok(card.branch_name(board, &self.sprints, default_prefix))
+    }
+
+    fn get_card_git_checkout(&self, id: Uuid) -> KanbanResult<String> {
+        let branch_name = self.get_card_branch_name(id)?;
+        Ok(format!("git checkout -b {}", branch_name))
+    }
+
+    fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
+        let mut count = 0;
+        for id in ids {
+            if self.archive_card(id).is_ok() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
+        let mut count = 0;
+        for id in ids {
+            if self.move_card(id, column_id, None).is_ok() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
+        let mut count = 0;
+        for id in ids {
+            if self.assign_card_to_sprint(id, sprint_id).is_ok() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    fn create_sprint(
+        &mut self,
+        board_id: Uuid,
+        prefix: Option<String>,
+        name: Option<String>,
+    ) -> KanbanResult<Sprint> {
+        use kanban_domain::commands::CreateSprint;
+
+        let (sprint_number, name_index, effective_prefix) = {
+            let board = self
+                .boards
+                .iter_mut()
+                .find(|b| b.id == board_id)
+                .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Board {}", board_id)))?;
+
+            let effective_prefix = prefix
+                .or_else(|| board.sprint_prefix.clone())
+                .unwrap_or_else(|| "sprint".to_string());
+
+            board.ensure_sprint_counter_initialized(&effective_prefix, &self.sprints);
+            let sprint_number = board.get_next_sprint_number(&effective_prefix);
+            let name_index = name.map(|n| board.add_sprint_name_at_used_index(n));
+
+            (sprint_number, name_index, effective_prefix)
+        };
+
+        let cmd = CreateSprint {
+            board_id,
+            sprint_number,
+            name_index,
+            prefix: Some(effective_prefix),
+        };
+        self.execute(Box::new(cmd))?;
+        self.sprints.last().cloned().ok_or_else(|| {
+            kanban_core::KanbanError::Internal("Sprint creation succeeded but sprint not found".into())
+        })
+    }
+
+    fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        Ok(self
+            .sprints
+            .iter()
+            .filter(|s| s.board_id == board_id)
+            .cloned()
+            .collect())
+    }
+
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        Ok(self.sprints.iter().find(|s| s.id == id).cloned())
+    }
+
+    fn update_sprint(&mut self, id: Uuid, updates: kanban_domain::SprintUpdate) -> KanbanResult<Sprint> {
+        use kanban_domain::commands::UpdateSprint;
+        let cmd = UpdateSprint {
+            sprint_id: id,
+            updates,
+        };
+        self.execute(Box::new(cmd))?;
+        self.get_sprint(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", id)))
+    }
+
+    fn activate_sprint(&mut self, id: Uuid, duration_days: Option<i32>) -> KanbanResult<Sprint> {
+        use kanban_domain::commands::ActivateSprint;
+        let duration = duration_days.unwrap_or(14) as u32;
+        let cmd = ActivateSprint {
+            sprint_id: id,
+            duration_days: duration,
+        };
+        self.execute(Box::new(cmd))?;
+        self.get_sprint(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", id)))
+    }
+
+    fn complete_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
+        use kanban_domain::commands::CompleteSprint;
+        let cmd = CompleteSprint { sprint_id: id };
+        self.execute(Box::new(cmd))?;
+        self.get_sprint(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", id)))
+    }
+
+    fn cancel_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
+        use kanban_domain::commands::CancelSprint;
+        let cmd = CancelSprint { sprint_id: id };
+        self.execute(Box::new(cmd))?;
+        self.get_sprint(id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", id)))
+    }
+
+    fn delete_sprint(&mut self, id: Uuid) -> KanbanResult<()> {
+        use kanban_domain::commands::DeleteSprint;
+        let cmd = DeleteSprint { sprint_id: id };
+        self.execute(Box::new(cmd))
+    }
+
+    fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String> {
+        let snapshot = if let Some(board_id) = board_id {
+            let boards = self.boards.iter().filter(|b| b.id == board_id).cloned().collect();
+            let columns = self.columns.iter().filter(|c| c.board_id == board_id).cloned().collect();
+            let column_ids: Vec<_> = self.columns.iter().filter(|c| c.board_id == board_id).map(|c| c.id).collect();
+            let cards = self.cards.iter().filter(|c| column_ids.contains(&c.column_id)).cloned().collect();
+            let sprints = self.sprints.iter().filter(|s| s.board_id == board_id).cloned().collect();
+            DataSnapshot {
+                boards,
+                columns,
+                cards,
+                archived_cards: vec![],
+                sprints,
+            }
+        } else {
+            DataSnapshot {
+                boards: self.boards.clone(),
+                columns: self.columns.clone(),
+                cards: self.cards.clone(),
+                archived_cards: self.archived_cards.clone(),
+                sprints: self.sprints.clone(),
+            }
+        };
+        serde_json::to_string_pretty(&snapshot)
+            .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))
+    }
+
+    fn import_board(&mut self, data: &str) -> KanbanResult<Board> {
+        let snapshot: DataSnapshot = serde_json::from_str(data)
+            .map_err(|e| kanban_core::KanbanError::Serialization(e.to_string()))?;
+
+        if snapshot.boards.is_empty() {
+            return Err(kanban_core::KanbanError::Validation("No boards in import data".into()));
+        }
+
+        self.boards.extend(snapshot.boards.clone());
+        self.columns.extend(snapshot.columns);
+        self.cards.extend(snapshot.cards);
+        self.sprints.extend(snapshot.sprints);
+
+        Ok(snapshot.boards.into_iter().next().unwrap())
+    }
+}
+
+#[derive(Clone)]
+pub struct KanbanMcpServer {
+    context: Arc<Mutex<KanbanContext>>,
+    tool_router: ToolRouter<Self>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CreateBoardRequest {
+    #[schemars(description = "Name of the board")]
+    pub name: String,
+    #[schemars(description = "Optional card prefix (e.g., 'KAN' for KAN-1, KAN-2, etc.)")]
+    pub card_prefix: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CreateColumnRequest {
+    #[schemars(description = "ID of the board to create the column in")]
+    pub board_id: String,
+    #[schemars(description = "Name of the column")]
+    pub name: String,
+    #[schemars(description = "Position of the column (optional, appends to end if not specified)")]
+    pub position: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CreateCardRequest {
+    #[schemars(description = "ID of the board")]
+    pub board_id: String,
+    #[schemars(description = "ID of the column to create the card in")]
+    pub column_id: String,
+    #[schemars(description = "Title of the card")]
+    pub title: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListCardsRequest {
+    #[schemars(description = "Filter cards by board ID")]
+    pub board_id: Option<String>,
+    #[schemars(description = "Filter cards by column ID")]
+    pub column_id: Option<String>,
+    #[schemars(description = "Filter cards by sprint ID")]
+    pub sprint_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetCardRequest {
+    #[schemars(description = "ID of the card to retrieve")]
+    pub card_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MoveCardRequest {
+    #[schemars(description = "ID of the card to move")]
+    pub card_id: String,
+    #[schemars(description = "ID of the destination column")]
+    pub column_id: String,
+    #[schemars(description = "Position in the new column (optional)")]
+    pub position: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct UpdateCardRequest {
+    #[schemars(description = "ID of the card to update")]
+    pub card_id: String,
+    #[schemars(description = "New title (optional)")]
+    pub title: Option<String>,
+    #[schemars(description = "New description (optional)")]
+    pub description: Option<String>,
+}
+
+#[tool_router]
+impl KanbanMcpServer {
+    pub async fn new(data_file: &str) -> KanbanResult<Self> {
+        let context = KanbanContext::load(data_file).await?;
+        Ok(Self {
+            context: Arc::new(Mutex::new(context)),
+            tool_router: Self::tool_router(),
+        })
+    }
+
+    #[tool(description = "Create a new kanban board")]
+    async fn create_board(
+        &self,
+        Parameters(req): Parameters<CreateBoardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut ctx = self.context.lock().await;
+        let board = ctx
+            .create_board(req.name, req.card_prefix)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        ctx.save()
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let json = serde_json::to_string_pretty(&board)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "List all kanban boards")]
+    async fn list_boards(&self) -> Result<CallToolResult, McpError> {
+        let ctx = self.context.lock().await;
+        let boards = ctx
+            .list_boards()
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let json = serde_json::to_string_pretty(&boards)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "Create a new column in a board")]
+    async fn create_column(
+        &self,
+        Parameters(req): Parameters<CreateColumnRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let board_id = Uuid::parse_str(&req.board_id)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        let mut ctx = self.context.lock().await;
+        let column = ctx
+            .create_column(board_id, req.name, req.position)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        ctx.save()
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let json = serde_json::to_string_pretty(&column)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "Create a new card in a column")]
+    async fn create_card(
+        &self,
+        Parameters(req): Parameters<CreateCardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let board_id = Uuid::parse_str(&req.board_id)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let column_id = Uuid::parse_str(&req.column_id)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        let mut ctx = self.context.lock().await;
+        let card = ctx
+            .create_card(board_id, column_id, req.title)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        ctx.save()
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let json = serde_json::to_string_pretty(&card)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "List cards with optional filters")]
+    async fn list_cards(
+        &self,
+        Parameters(req): Parameters<ListCardsRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let board_id = req
+            .board_id
+            .as_ref()
+            .map(|s| Uuid::parse_str(s))
+            .transpose()
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        let column_id = req
+            .column_id
+            .as_ref()
+            .map(|s| Uuid::parse_str(s))
+            .transpose()
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        let sprint_id = req
+            .sprint_id
+            .as_ref()
+            .map(|s| Uuid::parse_str(s))
+            .transpose()
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        let filter = CardFilter {
+            board_id,
+            column_id,
+            sprint_id,
+            status: None,
+        };
+
+        let ctx = self.context.lock().await;
+        let cards = ctx
+            .list_cards(filter)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let json = serde_json::to_string_pretty(&cards)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "Get a specific card by ID")]
+    async fn get_card(
+        &self,
+        Parameters(req): Parameters<GetCardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let card_id = Uuid::parse_str(&req.card_id)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        let ctx = self.context.lock().await;
+        let card = ctx
+            .get_card(card_id)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let json = serde_json::to_string_pretty(&card)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "Move a card to a different column")]
+    async fn move_card(
+        &self,
+        Parameters(req): Parameters<MoveCardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let card_id = Uuid::parse_str(&req.card_id)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let column_id = Uuid::parse_str(&req.column_id)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        let mut ctx = self.context.lock().await;
+        let card = ctx
+            .move_card(card_id, column_id, req.position)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        ctx.save()
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let json = serde_json::to_string_pretty(&card)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "Update a card's properties")]
+    async fn update_card(
+        &self,
+        Parameters(req): Parameters<UpdateCardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let card_id = Uuid::parse_str(&req.card_id)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        let mut updates = CardUpdate::default();
+        if let Some(title) = req.title {
+            updates.title = Some(title.into());
+        }
+        if let Some(description) = req.description {
+            updates.description = Some(description).into();
+        }
+
+        let mut ctx = self.context.lock().await;
+        let card = ctx
+            .update_card(card_id, updates)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        ctx.save()
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let json = serde_json::to_string_pretty(&card)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for KanbanMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation::from_build_env(),
+            instructions: Some(
+                "Kanban MCP Server - Manage your kanban boards, columns, and cards through MCP"
+                    .to_string(),
+            ),
+        }
+    }
+}

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -215,6 +215,9 @@ impl KanbanMcpServer {
 // McpTools Trait Implementation (business logic)
 // ============================================================================
 
+// Read operations (list_*, get_*) use execute() without retry because they are
+// idempotent and don't modify state. Write operations use execute_with_retry()
+// to handle transient file conflicts from concurrent access.
 #[async_trait]
 impl McpTools for KanbanMcpServer {
     // Board Operations

--- a/crates/kanban-mcp/src/main.rs
+++ b/crates/kanban-mcp/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use kanban_mcp::KanbanMcpServer;
-use rmcp::ServiceExt;
 use rmcp::transport::stdio;
+use rmcp::ServiceExt;
 use std::path::PathBuf;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
@@ -24,9 +24,7 @@ fn validate_path(path: &PathBuf) -> Result<PathBuf> {
     }
 
     if path.is_absolute() {
-        let canonical = path
-            .canonicalize()
-            .unwrap_or_else(|_| path.clone());
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
         Ok(canonical)
     } else {
         let cwd = std::env::current_dir().context("Failed to get current directory")?;

--- a/crates/kanban-mcp/src/main.rs
+++ b/crates/kanban-mcp/src/main.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use kanban_mcp::KanbanMcpServer;
+use rmcp::ServiceExt;
+use rmcp::transport::stdio;
+use std::path::PathBuf;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+fn parse_args() -> PathBuf {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 {
+        PathBuf::from(&args[1])
+    } else {
+        PathBuf::from("kanban.json")
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .init();
+
+    let data_file_path = parse_args();
+
+    let data_file = data_file_path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Invalid data file path"))?;
+
+    tracing::info!("Starting Kanban MCP server with data file: {}", data_file);
+
+    let server = KanbanMcpServer::new(data_file)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create server: {}", e))?;
+
+    let service = server.serve(stdio()).await?;
+
+    tracing::info!("Kanban MCP server started successfully");
+
+    service.waiting().await?;
+
+    Ok(())
+}

--- a/crates/kanban-mcp/src/main.rs
+++ b/crates/kanban-mcp/src/main.rs
@@ -51,9 +51,7 @@ async fn main() -> Result<()> {
 
     tracing::info!("Starting Kanban MCP server with data file: {}", data_file);
 
-    let server = KanbanMcpServer::new(data_file)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create server: {}", e))?;
+    let server = KanbanMcpServer::new(data_file);
 
     let service = server.serve(stdio()).await?;
 

--- a/crates/kanban-mcp/src/main.rs
+++ b/crates/kanban-mcp/src/main.rs
@@ -24,7 +24,14 @@ fn validate_path(path: &PathBuf) -> Result<PathBuf> {
     }
 
     if path.is_absolute() {
-        let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
+        let canonical = path.canonicalize().unwrap_or_else(|e| {
+            tracing::warn!(
+                "Failed to canonicalize path '{}': {}. Using original path.",
+                path.display(),
+                e
+            );
+            path.clone()
+        });
         Ok(canonical)
     } else {
         let cwd = std::env::current_dir().context("Failed to get current directory")?;

--- a/crates/kanban-mcp/src/tools_trait.rs
+++ b/crates/kanban-mcp/src/tools_trait.rs
@@ -1,6 +1,32 @@
 use async_trait::async_trait;
 use rmcp::model::{CallToolResult, ErrorData as McpError};
 
+/// Parameters for creating a card
+#[derive(Debug, Default)]
+pub struct CreateCardParams {
+    pub board_id: String,
+    pub column_id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub priority: Option<String>,
+    pub points: Option<u8>,
+    pub due_date: Option<String>,
+}
+
+/// Parameters for updating a card
+#[derive(Debug, Default)]
+pub struct UpdateCardParams {
+    pub card_id: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub priority: Option<String>,
+    pub status: Option<String>,
+    pub due_date: Option<String>,
+    pub clear_due_date: Option<bool>,
+    pub points: Option<u8>,
+    pub clear_points: Option<bool>,
+}
+
 /// Async MCP-compatible operations trait.
 /// Mirrors KanbanOperations from kanban-domain but with MCP return types.
 /// When adding operations to KanbanOperations, add them here too.
@@ -41,16 +67,7 @@ pub trait McpTools {
     // Card Operations
     // ========================================================================
 
-    async fn create_card(
-        &self,
-        board_id: String,
-        column_id: String,
-        title: String,
-        description: Option<String>,
-        priority: Option<String>,
-        points: Option<u8>,
-        due_date: Option<String>,
-    ) -> Result<CallToolResult, McpError>;
+    async fn create_card(&self, params: CreateCardParams) -> Result<CallToolResult, McpError>;
 
     async fn list_cards(
         &self,
@@ -68,18 +85,7 @@ pub trait McpTools {
         position: Option<i32>,
     ) -> Result<CallToolResult, McpError>;
 
-    async fn update_card(
-        &self,
-        card_id: String,
-        title: Option<String>,
-        description: Option<String>,
-        priority: Option<String>,
-        status: Option<String>,
-        due_date: Option<String>,
-        clear_due_date: Option<bool>,
-        points: Option<u8>,
-        clear_points: Option<bool>,
-    ) -> Result<CallToolResult, McpError>;
+    async fn update_card(&self, params: UpdateCardParams) -> Result<CallToolResult, McpError>;
 
     async fn archive_card(&self, card_id: String) -> Result<CallToolResult, McpError>;
 

--- a/crates/kanban-mcp/src/tools_trait.rs
+++ b/crates/kanban-mcp/src/tools_trait.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use rmcp::model::{CallToolResult, ErrorData as McpError};
+
+/// Async MCP-compatible operations trait.
+/// Mirrors KanbanOperations from kanban-domain but with MCP return types.
+/// When adding operations to KanbanOperations, add them here too.
+#[async_trait]
+pub trait McpTools {
+    // ========================================================================
+    // Board Operations
+    // ========================================================================
+
+    async fn create_board(
+        &self,
+        name: String,
+        card_prefix: Option<String>,
+    ) -> Result<CallToolResult, McpError>;
+
+    async fn list_boards(&self) -> Result<CallToolResult, McpError>;
+
+    async fn get_board(&self, board_id: String) -> Result<CallToolResult, McpError>;
+
+    async fn delete_board(&self, board_id: String) -> Result<CallToolResult, McpError>;
+
+    // ========================================================================
+    // Column Operations
+    // ========================================================================
+
+    async fn create_column(
+        &self,
+        board_id: String,
+        name: String,
+        position: Option<i32>,
+    ) -> Result<CallToolResult, McpError>;
+
+    async fn list_columns(&self, board_id: String) -> Result<CallToolResult, McpError>;
+
+    async fn delete_column(&self, column_id: String) -> Result<CallToolResult, McpError>;
+
+    // ========================================================================
+    // Card Operations
+    // ========================================================================
+
+    async fn create_card(
+        &self,
+        board_id: String,
+        column_id: String,
+        title: String,
+        description: Option<String>,
+        priority: Option<String>,
+        points: Option<u8>,
+        due_date: Option<String>,
+    ) -> Result<CallToolResult, McpError>;
+
+    async fn list_cards(
+        &self,
+        board_id: Option<String>,
+        column_id: Option<String>,
+        sprint_id: Option<String>,
+    ) -> Result<CallToolResult, McpError>;
+
+    async fn get_card(&self, card_id: String) -> Result<CallToolResult, McpError>;
+
+    async fn move_card(
+        &self,
+        card_id: String,
+        column_id: String,
+        position: Option<i32>,
+    ) -> Result<CallToolResult, McpError>;
+
+    async fn update_card(
+        &self,
+        card_id: String,
+        title: Option<String>,
+        description: Option<String>,
+        priority: Option<String>,
+        status: Option<String>,
+        due_date: Option<String>,
+        clear_due_date: Option<bool>,
+        points: Option<u8>,
+        clear_points: Option<bool>,
+    ) -> Result<CallToolResult, McpError>;
+
+    async fn archive_card(&self, card_id: String) -> Result<CallToolResult, McpError>;
+
+    async fn delete_card(&self, card_id: String) -> Result<CallToolResult, McpError>;
+}

--- a/crates/kanban-mcp/src/tools_trait.rs
+++ b/crates/kanban-mcp/src/tools_trait.rs
@@ -19,6 +19,7 @@ pub struct UpdateCardParams {
     pub card_id: String,
     pub title: Option<String>,
     pub description: Option<String>,
+    pub clear_description: Option<bool>,
     pub priority: Option<String>,
     pub status: Option<String>,
     pub due_date: Option<String>,

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1759977445,
@@ -50,11 +68,28 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1765779637,
+        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "servers": "servers"
       }
     },
     "rust-overlay": {
@@ -75,7 +110,41 @@
         "type": "github"
       }
     },
+    "servers": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1765997225,
+        "narHash": "sha256-dnNlA8WHHQ7jphyZYg8sWKreC357OKrzt0PtdRxFhbI=",
+        "owner": "fulsomenko",
+        "repo": "servers",
+        "rev": "86986713721d7a701013b0e26a64c5ded211a722",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fulsomenko",
+        "repo": "servers",
+        "type": "github"
+      }
+    },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -53,9 +53,13 @@
           inherit pkgs rustToolchain;
         };
 
-        packages = {
-          default = pkgs.callPackage ./default.nix {};
-          kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {};
+        packages = let
+          kanban = pkgs.callPackage ./default.nix {};
+        in {
+          default = kanban;
+          kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {
+            inherit kanban;
+          };
           mcp-server-git = servers.packages.${system}.mcp-server-git;
           bump-version = bumpVersion;
           publish-crates = publishCrates;

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
 
         packages = {
           default = pkgs.callPackage ./default.nix {};
+          kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {};
           bump-version = bumpVersion;
           publish-crates = publishCrates;
           validate-release = validateRelease;

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
+    servers.url = "github:fulsomenko/servers";
   };
 
   outputs = {
@@ -10,6 +11,7 @@
     nixpkgs,
     rust-overlay,
     flake-utils,
+    servers,
     ...
   }:
     flake-utils.lib.eachDefaultSystem (
@@ -54,6 +56,7 @@
         packages = {
           default = pkgs.callPackage ./default.nix {};
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {};
+          mcp-server-git = servers.packages.${system}.mcp-server-git;
           bump-version = bumpVersion;
           publish-crates = publishCrates;
           validate-release = validateRelease;


### PR DESCRIPTION
Add Model Context Protocol (MCP) server for kanban project management:

- Add kanban-mcp crate with subprocess-based CLI delegation architecture
- Implement board, column, and card operations as MCP tools
- Add retry with exponential backoff for conflict handling
- Include Nix packaging with automatic kanban CLI PATH injection
- Add project-level .mcp.json configuration

**What**: New MCP server crate that enables AI assistants to interact with kanban boards programmatically via the Model Context Protocol.

**Why**: Allows Claude and other MCP-compatible clients to manage kanban boards, columns, and cards directly, improving AI-assisted project management workflows.

**How**: Subprocess architecture that delegates all operations to the existing kanban CLI, providing automatic capability inheritance and natural conflict handling. Uses rmcp SDK for MCP implementation.
