### PR TITLE
feat(cli): include git commit hash in version output

### DIFF
--- a/.changeset/kan-129-include-commit-hash-in-v.md
+++ b/.changeset/kan-129-include-commit-hash-in-v.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- feat(cli): include git commit hash in version output

--- a/crates/kanban-cli/build.rs
+++ b/crates/kanban-cli/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo::rerun-if-changed=../../.git/HEAD");
+    println!("cargo::rerun-if-changed=../../.git/refs/heads/");
+
+    let commit_hash = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo::rustc-env=GIT_COMMIT_HASH={}", commit_hash);
+}

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -1,10 +1,16 @@
 use clap::{Args, Parser, Subcommand};
 use uuid::Uuid;
 
+const VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    "\ncommit: ",
+    env!("GIT_COMMIT_HASH")
+);
+
 #[derive(Parser)]
 #[command(name = "kanban")]
 #[command(about = "A terminal-based kanban board", long_about = None)]
-#[command(version, arg_required_else_help = false)]
+#[command(version = VERSION, arg_required_else_help = false)]
 pub struct Cli {
     /// Path to kanban data file (or set KANBAN_FILE env var)
     #[arg(value_name = "FILE", env = "KANBAN_FILE")]


### PR DESCRIPTION
Include git commit hash in version output for better traceability:

- Add `build.rs` to capture git commit hash at compile time
- Display commit hash alongside version in `kanban -V` output

**What**: Enhance version output to include the git commit hash.

**Why**: Released versions don't always reflect the exact source code state. Including the commit hash helps identify which specific commit a binary was built from, improving debugging and support.

**How**: 
- Created `build.rs` that runs `git rev-parse HEAD` at build time
- Set `GIT_COMMIT_HASH` as a compile-time environment variable
- Modified `cli.rs` to use a custom `VERSION` const combining package version and commit hash

**Testing**: Built and ran `kanban -V`:
```
kanban 0.1.13
commit: 675a97cc6eeff3cc00ad4d52eebf691a7011899e
```