### PR TITLE
KAN-152/dont-include-description-of-card-for-get-cards

### DIFF
--- a/.changeset/kan-152-dont-include-description-of-card-for-get-cards.md
+++ b/.changeset/kan-152-dont-include-description-of-card-for-get-cards.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+- feat(mcp): omit description and sprint_logs from card list responses
+- feat(cli): include git commit hash in version output (#132)
+

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -2,7 +2,7 @@ use crate::cli::{CardAction, CardCreateArgs, CardListArgs, CardUpdateArgs};
 use crate::context::CliContext;
 use crate::output;
 use kanban_domain::{
-    CardFilter, CardPriority, CardStatus, CardUpdate, FieldUpdate, KanbanOperations,
+    CardFilter, CardPriority, CardStatus, CardSummary, CardUpdate, FieldUpdate, KanbanOperations,
 };
 
 pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<()> {
@@ -31,7 +31,8 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             } else {
                 let filter = build_filter(&args).map_err(|e| anyhow::anyhow!(e))?;
                 let cards = ctx.list_cards(filter)?;
-                output::output_list(cards);
+                let summaries: Vec<CardSummary> = cards.iter().map(CardSummary::from).collect();
+                output::output_list(summaries);
             }
         }
         CardAction::Get { id } => match ctx.get_card(id)? {

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -49,6 +49,52 @@ pub struct Card {
     pub sprint_logs: Vec<SprintLog>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CardSummary {
+    pub id: CardId,
+    pub column_id: ColumnId,
+    pub title: String,
+    pub priority: CardPriority,
+    pub status: CardStatus,
+    pub position: i32,
+    pub due_date: Option<DateTime<Utc>>,
+    pub points: Option<u8>,
+    #[serde(default)]
+    pub card_number: u32,
+    #[serde(default)]
+    pub sprint_id: Option<Uuid>,
+    #[serde(default)]
+    pub assigned_prefix: Option<String>,
+    #[serde(default)]
+    pub card_prefix: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+impl From<&Card> for CardSummary {
+    fn from(card: &Card) -> Self {
+        Self {
+            id: card.id,
+            column_id: card.column_id,
+            title: card.title.clone(),
+            priority: card.priority,
+            status: card.status,
+            position: card.position,
+            due_date: card.due_date,
+            points: card.points,
+            card_number: card.card_number,
+            sprint_id: card.sprint_id,
+            assigned_prefix: card.assigned_prefix.clone(),
+            card_prefix: card.card_prefix.clone(),
+            created_at: card.created_at,
+            updated_at: card.updated_at,
+            completed_at: card.completed_at,
+        }
+    }
+}
+
 impl Card {
     pub fn new(
         board: &mut Board,

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -13,7 +13,7 @@ pub mod task_list_view;
 
 pub use archived_card::ArchivedCard;
 pub use board::{Board, BoardId, BoardUpdate, SortField, SortOrder};
-pub use card::{Card, CardId, CardPriority, CardStatus, CardUpdate};
+pub use card::{Card, CardId, CardPriority, CardStatus, CardSummary, CardUpdate};
 pub use column::{Column, ColumnId, ColumnUpdate};
 pub use editable::{BoardSettingsDto, CardMetadataDto};
 pub use field_update::FieldUpdate;


### PR DESCRIPTION
Reduces token consumption when MCP clients list cards:

- Add `CardSummary` type that excludes `description` and `sprint_logs` fields
- CLI `card list` now outputs `CardSummary` instead of full `Card`
- `card get` continues returning full card details

**What**: Lightweight card representation for list operations

**Why**: MCP `list_cards` was returning full card objects including potentially large description fields, consuming excessive tokens when boards have many cards

**How**: Added `CardSummary` struct in domain layer with `From<&Card>` impl, updated CLI handler to convert cards to summaries for list output

**Testing**: `cargo test` (255 tests pass), manual verification of CLI output