### PR TITLE
KAN-139/if-no-sprints-cant-scroll-to-column-settings

### DIFF
--- a/.changeset/kan-139-if-no-sprints-cant-scroll-to-column-settings.md
+++ b/.changeset/kan-139-if-no-sprints-cant-scroll-to-column-settings.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- fix(tui): skip empty sprints section when navigating board details

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -232,7 +232,7 @@ impl App {
                                 .filter(|s| s.board_id == board.id)
                                 .count();
                             let current_idx = self.sprint_selection.get().unwrap_or(0);
-                            if sprint_count > 0 && current_idx >= sprint_count - 1 {
+                            if sprint_count == 0 || current_idx >= sprint_count - 1 {
                                 self.board_focus = BoardFocus::Columns;
                                 self.column_selection.set(Some(0));
                             } else {
@@ -287,8 +287,7 @@ impl App {
                 BoardFocus::Columns => {
                     let current_idx = self.column_selection.get().unwrap_or(0);
                     if current_idx == 0 {
-                        self.board_focus = BoardFocus::Sprints;
-                        let last_sprint_idx = self
+                        let sprint_count = self
                             .board_selection
                             .get()
                             .and_then(|idx| self.ctx.boards.get(idx))
@@ -298,10 +297,14 @@ impl App {
                                     .iter()
                                     .filter(|s| s.board_id == board.id)
                                     .count()
-                                    .saturating_sub(1)
                             })
                             .unwrap_or(0);
-                        self.sprint_selection.set(Some(last_sprint_idx));
+                        if sprint_count == 0 {
+                            self.board_focus = BoardFocus::Settings;
+                        } else {
+                            self.board_focus = BoardFocus::Sprints;
+                            self.sprint_selection.set(Some(sprint_count - 1));
+                        }
                     } else {
                         self.column_selection.prev();
                     }


### PR DESCRIPTION
Fix board details navigation when no sprints exist:

- Skip empty Sprints section when pressing `j` (down) from Settings
- Skip empty Sprints section when pressing `k` (up) from Columns

**What**: Navigation in the board details view now correctly skips the Sprints section when there are no sprints.

**Why**: Previously, pressing `j`/`k` would get stuck at the Sprints section because the navigation logic only handled transitions when there were items to navigate through.

**How**: Added `sprint_count == 0` check to both navigation directions in `detail_view_handlers.rs` to immediately transition to the next/previous section when sprints list is empty.

**Testing**: Built with `cargo build`, ran tests with `cargo test --package kanban-tui` (all 154 tests pass), manually verified navigation works correctly in board details view with and without sprints.