### PR TITLE
KAN-155/publish-new-version

### DIFF
--- a/.changeset/kan-155-publish-new-version.md
+++ b/.changeset/kan-155-publish-new-version.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- fix: stabilize release pipeline for v0.1.15
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           echo "last=$LAST_VERSION" >> $GITHUB_OUTPUT
 
           # Check if current version is greater than last version using sort -V
+          # Note: sort -V is a GNU extension, available on Ubuntu runners
           version_gt() {
             [ "$1" != "$2" ] && [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,27 +60,19 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:fulsomenko/kanban.git
 
-      - name: Get bump type from changesets
+      - name: Aggregate changelog from changesets
         if: steps.versions.outputs.should_release == 'true'
-        id: bump
         run: |
-          bash scripts/aggregate-changesets.sh || echo "bump_type=patch" >> $GITHUB_OUTPUT
+          bash scripts/aggregate-changelog.sh
 
-      - name: Bump version and update changelog
-        if: steps.versions.outputs.should_release == 'true'
-        id: new_version
-        run: |
-          nix develop --command bash scripts/bump-version.sh "${{ steps.bump.outputs.bump_type }}"
-
-      - name: Commit version bump
+      - name: Commit changelog update
         if: steps.versions.outputs.should_release == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: |
-          # bump-version.sh already commits, so this is just a safety net
-          git add Cargo.toml CHANGELOG.md || true
-          git commit -m "chore: bump version to ${{ steps.new_version.outputs.new_version }}" || true
-          git push origin master
+          git add CHANGELOG.md
+          git commit -m "docs: update changelog for v${{ steps.versions.outputs.current }}" || echo "No changelog changes to commit"
+          git push origin master || echo "Nothing to push"
 
       - name: Validate release build
         if: steps.versions.outputs.should_release == 'true'
@@ -101,21 +93,28 @@ jobs:
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: |
-          git tag "v${{ steps.new_version.outputs.new_version }}"
-          git push origin "v${{ steps.new_version.outputs.new_version }}"
+          git tag "v${{ steps.versions.outputs.current }}"
+          git push origin "v${{ steps.versions.outputs.current }}"
 
       - name: Create GitHub Release
         if: steps.versions.outputs.should_release == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.new_version.outputs.new_version }}
+          tag_name: v${{ steps.versions.outputs.current }}
           generate_release_notes: true
 
-      - name: Sync develop with master
+      - name: Clean up changesets and sync develop
         if: steps.versions.outputs.should_release == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: |
+          # Delete changesets on master (after successful publish)
+          find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" -delete
+          git add .changeset/
+          git commit -m "chore: clean up changesets for v${{ steps.versions.outputs.current }}" || echo "No changesets to clean up"
+          git push origin master || echo "Nothing to push"
+
+          # Sync develop with master (gets changelog + changeset cleanup)
           git checkout develop
           git pull origin develop
           git merge origin/master --no-edit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,21 @@ jobs:
           echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "last=$LAST_VERSION" >> $GITHUB_OUTPUT
 
-          if [ "$CURRENT_VERSION" != "$LAST_VERSION" ]; then
+          # Check if current version is greater than last version using sort -V
+          version_gt() {
+            [ "$1" != "$2" ] && [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+          }
+
+          if version_gt "$CURRENT_VERSION" "$LAST_VERSION"; then
             echo "should_release=true" >> $GITHUB_OUTPUT
-            echo "Version changed: $LAST_VERSION → $CURRENT_VERSION"
-          else
+            echo "Version increased: $LAST_VERSION → $CURRENT_VERSION"
+          elif [ "$CURRENT_VERSION" = "$LAST_VERSION" ]; then
             echo "should_release=false" >> $GITHUB_OUTPUT
             echo "Version unchanged ($CURRENT_VERSION), skipping release"
+          else
+            echo "should_release=false" >> $GITHUB_OUTPUT
+            echo "::error::Version decreased: $LAST_VERSION → $CURRENT_VERSION (must be greater)"
+            exit 1
           fi
 
       - uses: cachix/install-nix-action@v27

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "kanban-cli"
-version = "0.1.13"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "kanban-core"
-version = "0.1.13"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "kanban-domain"
-version = "0.1.13"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "kanban-mcp"
-version = "0.1.13"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "kanban-persistence"
-version = "0.1.13"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "kanban-tui"
-version = "0.1.13"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.13"
+version = "0.1.15"
 edition = "2021"
 authors = ["Max Emil Yoon Blomstervall"]
 license = "Apache-2.0"

--- a/scripts/aggregate-changelog.sh
+++ b/scripts/aggregate-changelog.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+cleanup() {
+  rm -f CHANGELOG.md.new
+}
+trap cleanup EXIT
+
 # Get current version from Cargo.toml (already set in PR)
 CURRENT_VERSION=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)
 

--- a/scripts/aggregate-changelog.sh
+++ b/scripts/aggregate-changelog.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get current version from Cargo.toml (already set in PR)
+CURRENT_VERSION=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)
+
+# Check for changesets (excluding README.md)
+changeset_count=$(find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$changeset_count" -eq 0 ]; then
+  echo "No changesets to aggregate"
+  exit 0
+fi
+
+echo "Aggregating $changeset_count changesets into CHANGELOG.md for version $CURRENT_VERSION"
+
+# Aggregate changeset entries
+CHANGELOG_ENTRIES=""
+for changeset in .changeset/*.md; do
+  [ -e "$changeset" ] || continue
+  [ "$(basename "$changeset")" = "README.md" ] && continue
+
+  # Extract description (everything outside the --- frontmatter)
+  description=$(sed -n '/^---$/,/^---$/!p' "$changeset" | sed '/^---$/d' | sed '/^$/d')
+  CHANGELOG_ENTRIES+="$description\n"
+done
+
+# Prepend to CHANGELOG.md
+DATE=$(date +%Y-%m-%d)
+{
+  echo "## [$CURRENT_VERSION] - $DATE"
+  echo ""
+  echo -e "$CHANGELOG_ENTRIES"
+  echo ""
+  cat CHANGELOG.md
+} > CHANGELOG.md.new
+mv CHANGELOG.md.new CHANGELOG.md
+
+echo "Aggregated changesets into CHANGELOG.md for version $CURRENT_VERSION"

--- a/scripts/aggregate-changelog.sh
+++ b/scripts/aggregate-changelog.sh
@@ -29,9 +29,9 @@ DATE=$(date +%Y-%m-%d)
 {
   echo "## [$CURRENT_VERSION] - $DATE"
   echo ""
-  echo -e "$CHANGELOG_ENTRIES"
+  printf '%b' "$CHANGELOG_ENTRIES"
   echo ""
-  cat CHANGELOG.md
+  [ -f CHANGELOG.md ] && cat CHANGELOG.md
 } > CHANGELOG.md.new
 mv CHANGELOG.md.new CHANGELOG.md
 

--- a/scripts/create-changeset.sh
+++ b/scripts/create-changeset.sh
@@ -24,8 +24,14 @@ if [ $# -gt 0 ]; then
 fi
 
 if [ -z "$DESCRIPTION" ]; then
-  BASE_BRANCH="${BASE_BRANCH:-master}"
-  COMMITS=$(git log --oneline "$BASE_BRANCH"..HEAD --pretty=format:"- %s")
+  BASE_BRANCH="${BASE_BRANCH:-develop}"
+  # Find where this branch diverged from base, only show commits since then
+  MERGE_BASE=$(git merge-base "$BASE_BRANCH" HEAD 2>/dev/null || echo "")
+  if [ -n "$MERGE_BASE" ]; then
+    COMMITS=$(git log --oneline "$MERGE_BASE"..HEAD --pretty=format:"- %s")
+  else
+    COMMITS=$(git log --oneline -1 --pretty=format:"- %s")
+  fi
 
   if [ -z "$COMMITS" ]; then
     echo "Error: No commits found and no description provided"

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 CRATES=(
   "crates/kanban-core"
+  "crates/kanban-mcp"
   "crates/kanban-domain"
+  "crates/kanban-persistence"
   "crates/kanban-tui"
   "crates/kanban-cli"
 )

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Crates must be published in dependency order:
+# - kanban-core: no internal deps
+# - kanban-mcp: no internal deps
+# - kanban-domain: depends on kanban-core
+# - kanban-persistence: depends on kanban-core, kanban-domain
+# - kanban-tui: depends on kanban-core, kanban-domain, kanban-persistence
+# - kanban-cli: depends on all above
 CRATES=(
   "crates/kanban-core"
   "crates/kanban-mcp"

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -37,35 +37,17 @@ echo "✓ Version consistency verified"
 
 echo ""
 echo "Step 3: Checking cross-crate dependencies..."
+INTERNAL_DEPS=("kanban-core" "kanban-domain" "kanban-tui" "kanban-persistence" "kanban-mcp")
 for crate in "${CRATES[@]}"; do
-  if grep -q 'kanban-core = { path = ' "$crate/Cargo.toml" 2>/dev/null; then
-    if ! grep 'kanban-core = { path = ' "$crate/Cargo.toml" | grep -q 'version = '; then
-      echo "❌ Error: $crate is missing version spec for kanban-core"
-      echo "   Use: kanban-core = { path = \"../kanban-core\", version = \"^0.1\" }"
-      exit 1
+  for dep in "${INTERNAL_DEPS[@]}"; do
+    if grep -q "$dep = { path = " "$crate/Cargo.toml" 2>/dev/null; then
+      if ! grep "$dep = { path = " "$crate/Cargo.toml" | grep -q 'version = '; then
+        echo "❌ Error: $crate is missing version spec for $dep"
+        echo "   Use: $dep = { path = \"../$dep\", version = \"^0.1\" }"
+        exit 1
+      fi
     fi
-  fi
-  if grep -q 'kanban-domain = { path = ' "$crate/Cargo.toml" 2>/dev/null; then
-    if ! grep 'kanban-domain = { path = ' "$crate/Cargo.toml" | grep -q 'version = '; then
-      echo "❌ Error: $crate is missing version spec for kanban-domain"
-      echo "   Use: kanban-domain = { path = \"../kanban-domain\", version = \"^0.1\" }"
-      exit 1
-    fi
-  fi
-  if grep -q 'kanban-tui = { path = ' "$crate/Cargo.toml" 2>/dev/null; then
-    if ! grep 'kanban-tui = { path = ' "$crate/Cargo.toml" | grep -q 'version = '; then
-      echo "❌ Error: $crate is missing version spec for kanban-tui"
-      echo "   Use: kanban-tui = { path = \"../kanban-tui\", version = \"^0.1\" }"
-      exit 1
-    fi
-  fi
-  if grep -q 'kanban-persistence = { path = ' "$crate/Cargo.toml" 2>/dev/null; then
-    if ! grep 'kanban-persistence = { path = ' "$crate/Cargo.toml" | grep -q 'version = '; then
-      echo "❌ Error: $crate is missing version spec for kanban-persistence"
-      echo "   Use: kanban-persistence = { path = \"../kanban-persistence\", version = \"^0.1\" }"
-      exit 1
-    fi
-  fi
+  done
 done
 echo "✓ Cross-crate dependencies have proper version specs"
 

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 CRATES=(
   "crates/kanban-core"
+  "crates/kanban-mcp"
   "crates/kanban-domain"
+  "crates/kanban-persistence"
   "crates/kanban-tui"
   "crates/kanban-cli"
 )
@@ -54,6 +56,13 @@ for crate in "${CRATES[@]}"; do
     if ! grep 'kanban-tui = { path = ' "$crate/Cargo.toml" | grep -q 'version = '; then
       echo "❌ Error: $crate is missing version spec for kanban-tui"
       echo "   Use: kanban-tui = { path = \"../kanban-tui\", version = \"^0.1\" }"
+      exit 1
+    fi
+  fi
+  if grep -q 'kanban-persistence = { path = ' "$crate/Cargo.toml" 2>/dev/null; then
+    if ! grep 'kanban-persistence = { path = ' "$crate/Cargo.toml" | grep -q 'version = '; then
+      echo "❌ Error: $crate is missing version spec for kanban-persistence"
+      echo "   Use: kanban-persistence = { path = \"../kanban-persistence\", version = \"^0.1\" }"
       exit 1
     fi
   fi

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -37,7 +37,7 @@ echo "✓ Version consistency verified"
 
 echo ""
 echo "Step 3: Checking cross-crate dependencies..."
-INTERNAL_DEPS=("kanban-core" "kanban-domain" "kanban-tui" "kanban-persistence" "kanban-mcp")
+INTERNAL_DEPS=("kanban-core" "kanban-mcp" "kanban-domain" "kanban-persistence" "kanban-tui")
 for crate in "${CRATES[@]}"; do
   for dep in "${INTERNAL_DEPS[@]}"; do
     if grep -q "$dep = { path = " "$crate/Cargo.toml" 2>/dev/null; then


### PR DESCRIPTION
Stabilizes release pipeline and prepares v0.1.15 release:

- Remove double version bump from release workflow
- Add automated changelog aggregation from changesets
- Add kanban-persistence and kanban-mcp to publish pipeline
- Fix crate publish order to respect dependencies
- Move changeset cleanup to after successful publish
- Sync both master and develop with changelog updates

**What**: Fixes the release pipeline that was causing version mismatches between Cargo.toml (0.1.13), git tags (v0.1.14), and crates.io (0.1.14).

**Why**: Previous releases failed due to double version bumping - the workflow was bumping the version even when it was already set in the PR. Additionally, two new crates (kanban-persistence, kanban-mcp) were missing from the publish pipeline.

**How**: 
- Simplified `release.yml` to use the version from Cargo.toml directly (no auto-bump)
- Created `aggregate-changelog.sh` to aggregate changesets into CHANGELOG.md during release
- Updated `publish-crates.sh` and `validate-release.sh` with all 6 crates in dependency order
- Changesets now deleted only after successful publish, then synced to develop

**Testing**:
- `cargo check --workspace` passes
- `scripts/validate-release.sh` passes
- `scripts/aggregate-changelog.sh` tested locally - correctly aggregates 26 changesets