### PR TITLE
fix(nix): embed git commit hash in version output (#142)

### DIFF
--- a/crates/kanban-cli/build.rs
+++ b/crates/kanban-cli/build.rs
@@ -3,19 +3,25 @@ use std::process::Command;
 fn main() {
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs/heads/");
+    println!("cargo::rerun-if-env-changed=GIT_COMMIT_HASH");
 
-    let commit_hash = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
+    let commit_hash = std::env::var("GIT_COMMIT_HASH")
         .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                String::from_utf8(output.stdout).ok()
-            } else {
-                None
-            }
+        .filter(|s| !s.is_empty() && s != "unknown")
+        .or_else(|| {
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .ok()
+                .and_then(|output| {
+                    if output.status.success() {
+                        String::from_utf8(output.stdout).ok()
+                    } else {
+                        None
+                    }
+                })
+                .map(|s| s.trim().to_string())
         })
-        .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo::rustc-env=GIT_COMMIT_HASH={}", commit_hash);

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { lib
 , rustPlatform
+, gitCommitHash ? "unknown"
 }:
 
 let
@@ -13,6 +14,10 @@ rustPlatform.buildRustPackage {
 
   cargoLock = {
     lockFile = ./Cargo.lock;
+  };
+
+  env = {
+    GIT_COMMIT_HASH = gitCommitHash;
   };
 
   meta = {

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,9 @@
         };
 
         packages = let
-          kanban = pkgs.callPackage ./default.nix {};
+          kanban = pkgs.callPackage ./default.nix {
+            gitCommitHash = self.rev or self.dirtyRev or "unknown";
+          };
         in {
           default = kanban;
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {


### PR DESCRIPTION
Pass self.rev from flake.nix to default.nix as GIT_COMMIT_HASH env var. Update build.rs to check this env var before falling back to git command.

Fixes "commit: unknown" when running via nix run.