### PR TITLE
fix/correct-git-hash-in-build

### DIFF
--- a/crates/kanban-cli/build.rs
+++ b/crates/kanban-cli/build.rs
@@ -3,19 +3,25 @@ use std::process::Command;
 fn main() {
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs/heads/");
+    println!("cargo::rerun-if-env-changed=GIT_COMMIT_HASH");
 
-    let commit_hash = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
+    let commit_hash = std::env::var("GIT_COMMIT_HASH")
         .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                String::from_utf8(output.stdout).ok()
-            } else {
-                None
-            }
+        .filter(|s| !s.is_empty() && s != "unknown")
+        .or_else(|| {
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .ok()
+                .and_then(|output| {
+                    if output.status.success() {
+                        String::from_utf8(output.stdout).ok()
+                    } else {
+                        None
+                    }
+                })
+                .map(|s| s.trim().to_string())
         })
-        .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo::rustc-env=GIT_COMMIT_HASH={}", commit_hash);

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { lib
 , rustPlatform
+, gitCommitHash ? "unknown"
 }:
 
 let
@@ -13,6 +14,10 @@ rustPlatform.buildRustPackage {
 
   cargoLock = {
     lockFile = ./Cargo.lock;
+  };
+
+  env = {
+    GIT_COMMIT_HASH = gitCommitHash;
   };
 
   meta = {

--- a/default.nix
+++ b/default.nix
@@ -1,30 +1,38 @@
-{ lib
-, rustPlatform
-, gitCommitHash ? "unknown"
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
 }:
 
-let
-  cargoToml = lib.importTOML ./Cargo.toml;
-in
-rustPlatform.buildRustPackage {
-  inherit (cargoToml.workspace.package) version;
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kanban";
+  version = "0.1.15";
 
-  src = lib.cleanSource ./.;
-
-  cargoLock = {
-    lockFile = ./Cargo.lock;
+  src = fetchFromGitHub {
+    owner = "fulsomenko";
+    repo = "kanban";
+    rev = "6557b7343975b73e76f1289842597fc41c4900ba";
+    hash = "sha256-YJ9dUfZO8bWXexfX6Y3eTOW72qogVrGOLCVwaRoHlAA=";
   };
 
-  env = {
-    GIT_COMMIT_HASH = gitCommitHash;
-  };
+  GIT_COMMIT_HASH = finalAttrs.src.rev;
+
+  cargoHash = "sha256-Q/o5MHjVRrJpfhkzNNJ6j4oASV5wDg/0Zi43zPlp5p8=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    inherit (cargoToml.workspace.package) description homepage;
+    description = "Terminal-based project management solution";
+    longDescription = ''
+      A terminal-based kanban/project management tool inspired by lazygit,
+      built with Rust. Features include file persistence, keyboard-driven
+      navigation, multi-select capabilities, and sprint management.
+    '';
+    homepage = "https://github.com/fulsomenko/kanban";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fulsomenko ];
     mainProgram = "kanban";
     platforms = lib.platforms.all;
   };
-}
+})

--- a/flake.nix
+++ b/flake.nix
@@ -54,9 +54,7 @@
         };
 
         packages = let
-          kanban = pkgs.callPackage ./default.nix {
-            gitCommitHash = self.rev or self.dirtyRev or "unknown";
-          };
+          kanban = pkgs.callPackage ./default.nix {};
         in {
           default = kanban;
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,9 @@
         };
 
         packages = let
-          kanban = pkgs.callPackage ./default.nix {};
+          kanban = pkgs.callPackage ./default.nix {
+            gitCommitHash = self.rev or self.dirtyRev or "unknown";
+          };
         in {
           default = kanban;
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {


### PR DESCRIPTION
Fixes version output showing "commit: unknown" when running via `nix run`:

- Update build.rs to check `GIT_COMMIT_HASH` env var before falling back to git command
- Refactor default.nix to use `fetchFromGitHub` pattern for nixpkgs compatibility
- Derive `GIT_COMMIT_HASH` from source revision in Nix build
- Add `cargoHash` and `nix-update-script` for reproducible builds

**What**: Ensure git commit hash is embedded in version output for Nix builds.

**Why**: When building with Nix, the `.git` directory is not available in the sandbox, causing `git rev-parse HEAD` to fail and version to show "unknown".

**How**: 
1. Build script now checks `GIT_COMMIT_HASH` env var first (set by Nix)
2. Falls back to git command for local development
3. Nix derivation passes `finalAttrs.src.rev` as the commit hash

**Testing**: Run `nix run . -- --version` and verify commit hash is displayed correctly.