### PR TITLE
KAN-154/p-dialog-does-not-correctly-set-points

### DIFF
--- a/.changeset/kan-154-p-dialog-does-not-correctly-set-points.md
+++ b/.changeset/kan-154-p-dialog-does-not-correctly-set-points.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- fix: points dialog now correctly updates card from detail view

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -132,8 +132,13 @@ impl App {
                     return false;
                 };
 
-                if let Some(card) = self.get_selected_card_in_context() {
-                    let card_id = card.id;
+                let card_id = self
+                    .active_card_index
+                    .and_then(|idx| self.ctx.cards.get(idx))
+                    .map(|c| c.id)
+                    .or_else(|| self.get_selected_card_in_context().map(|c| c.id));
+
+                if let Some(card_id) = card_id {
                     let cmd = Box::new(crate::state::commands::UpdateCard {
                         card_id,
                         updates: kanban_domain::CardUpdate {


### PR DESCRIPTION
Fixes points dialog not updating card when opened from card detail view:

- Check `active_card_index` first for CardDetail mode
- Fall back to `get_selected_card_in_context()` for regular cards view

**What**: Fix regression where pressing `p` in card detail view opens the points dialog but the entered value is not saved to the card.

**Why**: The `handle_set_card_points_dialog` function used `get_selected_card_in_context()` which relies on the view strategy's active task list. In CardDetail mode, there's no active task list - the card is tracked via `active_card_index` instead.

**How**: Updated the handler to first check `active_card_index` (like the similar `handle_set_card_priority_popup` does), then fall back to `get_selected_card_in_context()` for when the dialog is opened from the regular cards view.

**Testing**: Built and ran test suite - all 254 tests pass.