### PR TITLE
KAN-170/cascade cleanup delete operations

### DIFF
--- a/.changeset/kan-170-cascade-cleanup-delete-operations.md
+++ b/.changeset/kan-170-cascade-cleanup-delete-operations.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+- test: add cycle detection tests for dependency graph
+- test: add integration tests for cascade cleanup operations
+- feat(domain): unassign cards when deleting sprints
+- feat(domain): add validation to DeleteColumn command
+- feat(domain): implement cascade cleanup in card deletion and archival
+- feat(domain): add cascade cleanup methods to DependencyGraph trait

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -1,5 +1,6 @@
 use super::{Command, CommandContext};
 use crate::SprintUpdate;
+use chrono::Utc;
 use kanban_core::KanbanResult;
 use uuid::Uuid;
 
@@ -109,6 +110,21 @@ pub struct DeleteSprint {
 
 impl Command for DeleteSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        let now = Utc::now();
+        for card in context.cards.iter_mut() {
+            if card.sprint_id == Some(self.sprint_id) {
+                card.sprint_id = None;
+                card.updated_at = now;
+            }
+        }
+
+        for archived_card in context.archived_cards.iter_mut() {
+            if archived_card.card.sprint_id == Some(self.sprint_id) {
+                archived_card.card.sprint_id = None;
+                archived_card.card.updated_at = now;
+            }
+        }
+
         context.sprints.retain(|s| s.id != self.sprint_id);
         Ok(())
     }

--- a/crates/kanban-domain/src/dependencies/card_graph.rs
+++ b/crates/kanban-domain/src/dependencies/card_graph.rs
@@ -54,6 +54,12 @@ pub trait CardGraphExt {
 
     /// Count of direct children (for [N] badge)
     fn child_count(&self, parent_id: CardId) -> usize;
+
+    /// Remove all dependency edges for a card (for permanent deletion)
+    fn remove_card_edges(&mut self, card_id: CardId);
+
+    /// Archive all dependency edges for a card (for soft deletion)
+    fn archive_card_edges(&mut self, card_id: CardId);
 }
 
 impl CardGraphExt for CardDependencyGraph {
@@ -245,6 +251,14 @@ impl CardGraphExt for CardDependencyGraph {
 
     fn child_count(&self, parent_id: CardId) -> usize {
         self.children(parent_id).len()
+    }
+
+    fn remove_card_edges(&mut self, card_id: CardId) {
+        self.remove_node(card_id);
+    }
+
+    fn archive_card_edges(&mut self, card_id: CardId) {
+        self.archive_node(card_id);
     }
 }
 

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -1,0 +1,490 @@
+use kanban_domain::commands::*;
+use kanban_domain::*;
+
+#[test]
+fn test_delete_card_cleans_dependencies() {
+    let mut boards = vec![Board::new("Test Board".to_string(), None)];
+    let mut columns = vec![Column::new(boards[0].id, "Todo".to_string(), 0)];
+    let mut cards = vec![];
+    let mut sprints = vec![];
+    let mut archived_cards = vec![];
+    let mut graph = DependencyGraph::new();
+
+    let card_a = {
+        let cmd = CreateCard {
+            board_id: boards[0].id,
+            column_id: columns[0].id,
+            title: "Card A".to_string(),
+            position: 0,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+        cards.last().unwrap().id
+    };
+
+    let card_b = {
+        let cmd = CreateCard {
+            board_id: boards[0].id,
+            column_id: columns[0].id,
+            title: "Card B".to_string(),
+            position: 1,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+        cards.last().unwrap().id
+    };
+
+    {
+        let ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        ctx.graph.cards.add_blocks(card_a, card_b).unwrap();
+        assert_eq!(ctx.graph.cards.blockers(card_b).len(), 1);
+    }
+
+    {
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        let cmd = DeleteCard { card_id: card_a };
+        cmd.execute(&mut ctx).unwrap();
+    }
+
+    {
+        let ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        assert_eq!(ctx.graph.cards.blockers(card_b).len(), 0);
+    }
+}
+
+#[test]
+fn test_delete_column_with_cards_fails() {
+    let mut boards = vec![Board::new("Test Board".to_string(), None)];
+    let mut columns = vec![Column::new(boards[0].id, "Todo".to_string(), 0)];
+    let mut cards = vec![];
+    let mut sprints = vec![];
+    let mut archived_cards = vec![];
+    let mut graph = DependencyGraph::new();
+
+    {
+        let cmd = CreateCard {
+            board_id: boards[0].id,
+            column_id: columns[0].id,
+            title: "Test Card".to_string(),
+            position: 0,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+    }
+
+    let column_id = columns[0].id;
+
+    {
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        let cmd = DeleteColumn { column_id };
+        let result = cmd.execute(&mut ctx);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(kanban_core::KanbanError::Validation(_))
+        ));
+    }
+
+    assert!(columns.iter().any(|c| c.id == column_id));
+}
+
+#[test]
+fn test_delete_column_with_archived_cards_fails() {
+    let mut boards = vec![Board::new("Test Board".to_string(), None)];
+    let mut columns = vec![Column::new(boards[0].id, "Todo".to_string(), 0)];
+    let mut cards = vec![];
+    let mut sprints = vec![];
+    let mut archived_cards = vec![];
+    let mut graph = DependencyGraph::new();
+
+    let card_id = {
+        let cmd = CreateCard {
+            board_id: boards[0].id,
+            column_id: columns[0].id,
+            title: "Test Card".to_string(),
+            position: 0,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+        cards.last().unwrap().id
+    };
+
+    {
+        let cmd = ArchiveCard { card_id };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+    }
+
+    let column_id = columns[0].id;
+
+    {
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        let cmd = DeleteColumn { column_id };
+        let result = cmd.execute(&mut ctx);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(kanban_core::KanbanError::Validation(_))
+        ));
+    }
+
+    assert!(columns.iter().any(|c| c.id == column_id));
+}
+
+#[test]
+fn test_delete_sprint_unassigns_cards() {
+    let mut boards = vec![Board::new("Test Board".to_string(), None)];
+    let mut columns = vec![Column::new(boards[0].id, "Todo".to_string(), 0)];
+    let mut cards = vec![];
+    let mut sprints = vec![Sprint::new(boards[0].id, 1, None, None)];
+    let mut archived_cards = vec![];
+    let mut graph = DependencyGraph::new();
+
+    let sprint_id = sprints[0].id;
+    let board_id = boards[0].id;
+    let column_id = columns[0].id;
+
+    let card_a = {
+        let cmd = CreateCard {
+            board_id,
+            column_id,
+            title: "Card A".to_string(),
+            position: 0,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+        cards.last().unwrap().id
+    };
+
+    let card_b = {
+        let cmd = CreateCard {
+            board_id,
+            column_id,
+            title: "Card B".to_string(),
+            position: 1,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+        cards.last().unwrap().id
+    };
+
+    {
+        let cmd = AssignCardToSprint {
+            card_id: card_a,
+            sprint_id,
+            sprint_number: 1,
+            sprint_name: Some("Sprint 1".to_string()),
+            sprint_status: "Active".to_string(),
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+    }
+
+    {
+        let cmd = AssignCardToSprint {
+            card_id: card_b,
+            sprint_id,
+            sprint_number: 1,
+            sprint_name: Some("Sprint 1".to_string()),
+            sprint_status: "Active".to_string(),
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+    }
+
+    {
+        let ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        assert_eq!(
+            ctx.cards
+                .iter()
+                .filter(|c| c.sprint_id == Some(sprint_id))
+                .count(),
+            2
+        );
+    }
+
+    {
+        let cmd = DeleteSprint { sprint_id };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+    }
+
+    {
+        let ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        assert_eq!(
+            ctx.cards
+                .iter()
+                .filter(|c| c.sprint_id == Some(sprint_id))
+                .count(),
+            0
+        );
+    }
+}
+
+#[test]
+fn test_archive_card_preserves_edges() {
+    let mut boards = vec![Board::new("Test Board".to_string(), None)];
+    let mut columns = vec![Column::new(boards[0].id, "Todo".to_string(), 0)];
+    let mut cards = vec![];
+    let mut sprints = vec![];
+    let mut archived_cards = vec![];
+    let mut graph = DependencyGraph::new();
+
+    let board_id = boards[0].id;
+    let column_id = columns[0].id;
+
+    let card_a = {
+        let cmd = CreateCard {
+            board_id,
+            column_id,
+            title: "Card A".to_string(),
+            position: 0,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+        cards.last().unwrap().id
+    };
+
+    let card_b = {
+        let cmd = CreateCard {
+            board_id,
+            column_id,
+            title: "Card B".to_string(),
+            position: 1,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+        cards.last().unwrap().id
+    };
+
+    {
+        let ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        ctx.graph.cards.add_blocks(card_a, card_b).unwrap();
+        assert_eq!(ctx.graph.cards.blockers(card_b).len(), 1);
+    }
+
+    {
+        let cmd = ArchiveCard { card_id: card_a };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+    }
+
+    {
+        let ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        assert_eq!(ctx.graph.cards.blockers(card_b).len(), 0);
+    }
+
+    {
+        let cmd = RestoreCard {
+            card_id: card_a,
+            column_id,
+            position: 0,
+        };
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        cmd.execute(&mut ctx).unwrap();
+    }
+
+    {
+        let ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        assert_eq!(ctx.graph.cards.blockers(card_b).len(), 1);
+    }
+}
+
+#[test]
+fn test_delete_column_succeeds_when_empty() {
+    let mut boards = vec![Board::new("Test Board".to_string(), None)];
+    let mut columns = vec![Column::new(boards[0].id, "Todo".to_string(), 0)];
+    let mut cards = vec![];
+    let mut sprints = vec![];
+    let mut archived_cards = vec![];
+    let mut graph = DependencyGraph::new();
+
+    let column_id = columns[0].id;
+
+    {
+        let mut ctx = CommandContext {
+            boards: &mut boards,
+            columns: &mut columns,
+            cards: &mut cards,
+            sprints: &mut sprints,
+            archived_cards: &mut archived_cards,
+            graph: &mut graph,
+        };
+        let cmd = DeleteColumn { column_id };
+        let result = cmd.execute(&mut ctx);
+
+        assert!(result.is_ok());
+    }
+
+    assert!(!columns.iter().any(|c| c.id == column_id));
+}

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -559,7 +559,7 @@ fn test_cycle_detection_parent_child() {
     };
 
     {
-        let mut ctx = CommandContext {
+        let ctx = CommandContext {
             boards: &mut boards,
             columns: &mut columns,
             cards: &mut cards,
@@ -572,7 +572,7 @@ fn test_cycle_detection_parent_child() {
     }
 
     {
-        let mut ctx = CommandContext {
+        let ctx = CommandContext {
             boards: &mut boards,
             columns: &mut columns,
             cards: &mut cards,
@@ -659,7 +659,7 @@ fn test_cycle_detection_blocks() {
     };
 
     {
-        let mut ctx = CommandContext {
+        let ctx = CommandContext {
             boards: &mut boards,
             columns: &mut columns,
             cards: &mut cards,
@@ -672,7 +672,7 @@ fn test_cycle_detection_blocks() {
     }
 
     {
-        let mut ctx = CommandContext {
+        let ctx = CommandContext {
             boards: &mut boards,
             columns: &mut columns,
             cards: &mut cards,

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -582,7 +582,10 @@ fn test_cycle_detection_parent_child() {
         };
         let result = ctx.graph.cards.set_parent(card_a, card_c);
         assert!(result.is_err());
-        assert!(matches!(result, Err(kanban_core::KanbanError::CycleDetected)));
+        assert!(matches!(
+            result,
+            Err(kanban_core::KanbanError::CycleDetected)
+        ));
     }
 }
 
@@ -679,6 +682,9 @@ fn test_cycle_detection_blocks() {
         };
         let result = ctx.graph.cards.add_blocks(card_c, card_a);
         assert!(result.is_err());
-        assert!(matches!(result, Err(kanban_core::KanbanError::CycleDetected)));
+        assert!(matches!(
+            result,
+            Err(kanban_core::KanbanError::CycleDetected)
+        ));
     }
 }

--- a/kanban.json
+++ b/kanban.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "metadata": {
-    "instance_id": "2485375f-465f-44c8-988a-db4e9e6b35a6",
-    "saved_at": "2026-01-10T00:51:33.552084Z"
+    "instance_id": "e6a4a5ba-99b6-4248-ae4d-da44d7f3b4b1",
+    "saved_at": "2026-01-10T10:37:07.064081Z"
   },
   "data": {
     "archived_cards": [
@@ -4119,14 +4119,14 @@
         "assigned_prefix": "KAN",
         "card_number": 134,
         "card_prefix": null,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-01-10T02:34:01.947587Z",
         "created_at": "2025-11-17T23:09:18.569124Z",
-        "description": "hitting like `c` is easy and we can loose track of cards that go across columns if we have not read the card name\n\nIt would be nice to have an undo function\n",
+        "description": "hitting like `c` is easy and we can loose track of cards that go across columns if we have not read the card name\n\nor performing any action is easy and it would be beneficial to quickly undo an action. in any context. `u` for keybind. command patterna and audit log dependencies? What is needed to make this happen?\n\nIt would be nice to have an undo function\n",
         "due_date": null,
         "id": "23b91acd-d6a8-4972-9065-8d0f0d2ba12f",
         "points": 4,
-        "position": 35,
+        "position": 98,
         "priority": "High",
         "sprint_id": "63d7a91a-cd0f-42fa-8fac-73ae015431f8",
         "sprint_logs": [
@@ -4147,9 +4147,9 @@
             "status": "Planning"
           }
         ],
-        "status": "Todo",
+        "status": "Done",
         "title": "undo action",
-        "updated_at": "2025-12-15T20:35:57.264709Z"
+        "updated_at": "2026-01-10T02:34:01.947588Z"
       },
       {
         "assigned_prefix": "KAN",
@@ -5050,6 +5050,11 @@
         "wip_limit": null
       }
     ],
+    "graph": {
+      "cards": {
+        "edges": []
+      }
+    },
     "sprints": [
       {
         "board_id": "e119c091-e1fa-4596-9bc7-038ceab6adec",


### PR DESCRIPTION
## Summary

Implement cascade cleanup for delete/archive operations to prevent orphaned data and broken relationships.

- Add `remove_card_edges()` and `archive_card_edges()` methods to DependencyGraph
- Update DeleteCard, ArchiveCard, and RestoreCard to clean up dependency edges
- Add validation to DeleteColumn to prevent deletion of columns with cards
- Update DeleteSprint to unassign cards before deletion

## What

Deleting cards, columns, or sprints currently leaves orphaned data:
- Orphaned dependency edges in graph
- Cards with invalid column_id references become invisible
- Cards with invalid sprint_id references corrupt audit trail

## Why

**Challenge**: Cascade operations must clean up related data to maintain data integrity. Without proper cleanup, deletion operations create inconsistent state that silently corrupts the board.

**Impact**: Users can unknowingly create invisible cards and broken relationships by deleting entities that other entities depend on.

## How

1. **DependencyGraph Enhancement**: Added two new trait methods that delegate to existing core graph infrastructure (`remove_node()` and `archive_node()`)

2. **Card Operations**: 
   - DeleteCard: Removes all dependency edges
   - ArchiveCard: Archives all dependency edges (preserves for restoration)
   - RestoreCard: Unarchives edges when card is restored

3. **Column Validation**: DeleteColumn now validates that no cards reference the column before allowing deletion

4. **Sprint Cleanup**: DeleteSprint unassigns all cards before deletion, updating timestamps for modified cards

## Testing

- Added 6 comprehensive integration tests:
  - `test_delete_card_cleans_dependencies`: Verifies graph edges removed when card deleted
  - `test_delete_column_with_cards_fails`: Validates column deletion prevention
  - `test_delete_column_with_archived_cards_fails`: Handles archived cards
  - `test_delete_sprint_unassigns_cards`: Verifies sprint deletion unassigns cards
  - `test_archive_card_preserves_edges`: Tests edge preservation on archive
  - `test_delete_column_succeeds_when_empty`: Positive test case

- All tests pass ✅
- All existing tests pass ✅
- Clippy checks pass with no warnings ✅
- Code formatted with rustfmt ✅