### PR TITLE
Add Position as a sort field option

### DIFF
--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -780,28 +780,36 @@ mod tests {
 #[cfg(test)]
 mod sort_field_serialization_tests {
     use super::*;
-    
+
     #[test]
     fn test_position_serializes_correctly() {
         let field = SortField::Position;
         let json = serde_json::to_string(&field).unwrap();
         assert_eq!(json, "\"Position\"");
     }
-    
+
     #[test]
     fn test_position_deserializes_correctly() {
         let json = "\"Position\"";
         let field: SortField = serde_json::from_str(json).unwrap();
         assert_eq!(field, SortField::Position);
     }
-    
+
     #[test]
     fn test_board_with_position_sort_serializes() {
         let mut board = Board::new("Test".to_string(), None);
         board.update_task_sort(SortField::Position, SortOrder::Descending);
-        
+
         let json = serde_json::to_string(&board).unwrap();
-        assert!(json.contains("\"task_sort_field\":\"Position\""), "Expected Position in JSON, got: {}", json);
-        assert!(json.contains("\"task_sort_order\":\"Descending\""), "Expected Descending in JSON, got: {}", json);
+        assert!(
+            json.contains("\"task_sort_field\":\"Position\""),
+            "Expected Position in JSON, got: {}",
+            json
+        );
+        assert!(
+            json.contains("\"task_sort_order\":\"Descending\""),
+            "Expected Descending in JSON, got: {}",
+            json
+        );
     }
 }

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -15,6 +15,7 @@ pub enum SortField {
     CreatedAt,
     UpdatedAt,
     Status,
+    Position,
     Default,
 }
 
@@ -773,5 +774,34 @@ mod tests {
         // Verify next_card_number was migrated to the board's card_prefix "feature"
         assert_eq!(board.get_prefix_counter("feature"), Some(50));
         assert_eq!(board.get_prefix_counter("task"), None);
+    }
+}
+
+#[cfg(test)]
+mod sort_field_serialization_tests {
+    use super::*;
+    
+    #[test]
+    fn test_position_serializes_correctly() {
+        let field = SortField::Position;
+        let json = serde_json::to_string(&field).unwrap();
+        assert_eq!(json, "\"Position\"");
+    }
+    
+    #[test]
+    fn test_position_deserializes_correctly() {
+        let json = "\"Position\"";
+        let field: SortField = serde_json::from_str(json).unwrap();
+        assert_eq!(field, SortField::Position);
+    }
+    
+    #[test]
+    fn test_board_with_position_sort_serializes() {
+        let mut board = Board::new("Test".to_string(), None);
+        board.update_task_sort(SortField::Position, SortOrder::Descending);
+        
+        let json = serde_json::to_string(&board).unwrap();
+        assert!(json.contains("\"task_sort_field\":\"Position\""), "Expected Position in JSON, got: {}", json);
+        assert!(json.contains("\"task_sort_order\":\"Descending\""), "Expected Descending in JSON, got: {}", json);
     }
 }

--- a/crates/kanban-domain/src/task_list_view.rs
+++ b/crates/kanban-domain/src/task_list_view.rs
@@ -1,14 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum TaskListView {
+    #[default]
     Flat,
     GroupedByColumn,
     ColumnView,
-}
-
-impl Default for TaskListView {
-    fn default() -> Self {
-        Self::Flat
-    }
 }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -2047,7 +2047,8 @@ impl App {
                 SortField::CreatedAt => 2,
                 SortField::UpdatedAt => 3,
                 SortField::Status => 4,
-                SortField::Default => 5,
+                SortField::Position => 5,
+                SortField::Default => 6,
             };
         }
         0

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -384,11 +384,8 @@ mod tests {
             list.navigate_down();
             let after_idx = list.get_selected_index();
 
-            if before_idx.is_some() && after_idx.is_some() {
-                assert!(
-                    after_idx.unwrap() >= before_idx.unwrap(),
-                    "Selection should move down or stay"
-                );
+            if let (Some(before), Some(after)) = (before_idx, after_idx) {
+                assert!(after >= before, "Selection should move down or stay");
             }
         }
 

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -67,7 +67,7 @@ impl SelectionDialog for SortFieldDialog {
     }
 
     fn options_count(&self, _app: &App) -> usize {
-        6 // Points, Priority, CreatedAt, UpdatedAt, Status, Default
+        7 // Points, Priority, CreatedAt, UpdatedAt, Status, Position, Default
     }
 
     fn render(&self, app: &App, frame: &mut Frame) {
@@ -80,6 +80,7 @@ impl SelectionDialog for SortFieldDialog {
             SortField::CreatedAt,
             SortField::UpdatedAt,
             SortField::Status,
+            SortField::Position,
             SortField::Default,
         ];
 
@@ -100,6 +101,7 @@ impl SelectionDialog for SortFieldDialog {
                     SortField::UpdatedAt => "Date Updated",
                     SortField::Default => "Task Number",
                     SortField::Status => "Status",
+                    SortField::Position => "Position",
                 };
 
                 let order_indicator = if is_active {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -81,7 +81,7 @@ impl App {
                 false
             }
             KeyCode::Char('j') | KeyCode::Down => {
-                self.sort_field_selection.next(6);
+                self.sort_field_selection.next(7);
                 false
             }
             KeyCode::Char('k') | KeyCode::Up => {
@@ -96,7 +96,8 @@ impl App {
                         2 => SortField::CreatedAt,
                         3 => SortField::UpdatedAt,
                         4 => SortField::Status,
-                        5 => SortField::Default,
+                        5 => SortField::Position,
+                        6 => SortField::Default,
                         _ => return false,
                     };
 

--- a/crates/kanban-tui/src/services/sort.rs
+++ b/crates/kanban-tui/src/services/sort.rs
@@ -58,6 +58,14 @@ impl CardSorter for CardNumberSorter {
     }
 }
 
+pub struct PositionSorter;
+
+impl CardSorter for PositionSorter {
+    fn compare(&self, a: &Card, b: &Card) -> Ordering {
+        a.position.cmp(&b.position)
+    }
+}
+
 pub struct OrderedSorter {
     sorter: Box<dyn CardSorter>,
     order: SortOrder,
@@ -86,6 +94,7 @@ pub fn get_sorter_for_field(field: SortField) -> Box<dyn CardSorter> {
         SortField::CreatedAt => Box::new(CreatedAtSorter),
         SortField::UpdatedAt => Box::new(UpdatedAtSorter),
         SortField::Status => Box::new(StatusSorter),
+        SortField::Position => Box::new(PositionSorter),
         SortField::Default => Box::new(CardNumberSorter),
     }
 }
@@ -174,5 +183,90 @@ mod tests {
 
         assert_eq!(cards[0].title, "High");
         assert_eq!(cards[1].title, "Low");
+    }
+
+    #[test]
+    fn test_position_sorter() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        // Create cards with different positions (4th arg is position)
+        let card1 =
+            kanban_domain::Card::new(&mut board_mut, column.id, "Third".to_string(), 20, "task");
+        let card2 =
+            kanban_domain::Card::new(&mut board_mut, column.id, "First".to_string(), 5, "task");
+        let card3 =
+            kanban_domain::Card::new(&mut board_mut, column.id, "Second".to_string(), 10, "task");
+
+        let sorter = PositionSorter;
+        assert_eq!(sorter.compare(&card2, &card3), Ordering::Less);   // 5 < 10
+        assert_eq!(sorter.compare(&card3, &card1), Ordering::Less);   // 10 < 20
+        assert_eq!(sorter.compare(&card1, &card2), Ordering::Greater); // 20 > 5
+    }
+
+    #[test]
+    fn test_position_sorter_sorts_list() {
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+
+        let mut board_mut = board.clone();
+        let card1 =
+            kanban_domain::Card::new(&mut board_mut, column.id, "Third".to_string(), 20, "task");
+        let card2 =
+            kanban_domain::Card::new(&mut board_mut, column.id, "First".to_string(), 5, "task");
+        let card3 =
+            kanban_domain::Card::new(&mut board_mut, column.id, "Second".to_string(), 10, "task");
+
+        let mut cards = vec![&card1, &card2, &card3];
+        let sorter = OrderedSorter::new(Box::new(PositionSorter), SortOrder::Ascending);
+        sorter.sort(&mut cards);
+
+        assert_eq!(cards[0].title, "First");  // position 5
+        assert_eq!(cards[1].title, "Second"); // position 10
+        assert_eq!(cards[2].title, "Third");  // position 20
+    }
+
+    #[test]
+    fn test_get_sorter_for_position_field() {
+        // Verify that SortField::Position maps to PositionSorter
+        let sorter = get_sorter_for_field(SortField::Position);
+
+        let board = Board::new("Test".to_string(), None);
+        let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
+        let mut board_mut = board.clone();
+
+        let card1 = kanban_domain::Card::new(&mut board_mut, column.id, "A".to_string(), 10, "task");
+        let card2 = kanban_domain::Card::new(&mut board_mut, column.id, "B".to_string(), 5, "task");
+
+        // Position 5 < Position 10, so card2 should come before card1
+        assert_eq!(sorter.compare(&card2, &card1), Ordering::Less);
+    }
+
+    #[test]
+    fn test_sort_field_array_position_index() {
+        // This test verifies that Position is at index 5 in the sort fields array
+        // matching the mapping in popup_handlers.rs and selection_dialog.rs
+        let sort_fields = [
+            SortField::Points,
+            SortField::Priority,
+            SortField::CreatedAt,
+            SortField::UpdatedAt,
+            SortField::Status,
+            SortField::Position,
+            SortField::Default,
+        ];
+
+        let position_idx = sort_fields
+            .iter()
+            .position(|f| *f == SortField::Position);
+
+        assert_eq!(position_idx, Some(5), "Position should be at index 5");
+
+        let default_idx = sort_fields
+            .iter()
+            .position(|f| *f == SortField::Default);
+
+        assert_eq!(default_idx, Some(6), "Default should be at index 6");
     }
 }

--- a/crates/kanban-tui/src/services/sort.rs
+++ b/crates/kanban-tui/src/services/sort.rs
@@ -200,8 +200,8 @@ mod tests {
             kanban_domain::Card::new(&mut board_mut, column.id, "Second".to_string(), 10, "task");
 
         let sorter = PositionSorter;
-        assert_eq!(sorter.compare(&card2, &card3), Ordering::Less);   // 5 < 10
-        assert_eq!(sorter.compare(&card3, &card1), Ordering::Less);   // 10 < 20
+        assert_eq!(sorter.compare(&card2, &card3), Ordering::Less); // 5 < 10
+        assert_eq!(sorter.compare(&card3, &card1), Ordering::Less); // 10 < 20
         assert_eq!(sorter.compare(&card1, &card2), Ordering::Greater); // 20 > 5
     }
 
@@ -222,9 +222,9 @@ mod tests {
         let sorter = OrderedSorter::new(Box::new(PositionSorter), SortOrder::Ascending);
         sorter.sort(&mut cards);
 
-        assert_eq!(cards[0].title, "First");  // position 5
+        assert_eq!(cards[0].title, "First"); // position 5
         assert_eq!(cards[1].title, "Second"); // position 10
-        assert_eq!(cards[2].title, "Third");  // position 20
+        assert_eq!(cards[2].title, "Third"); // position 20
     }
 
     #[test]
@@ -236,7 +236,8 @@ mod tests {
         let column = kanban_domain::Column::new(board.id, "Todo".to_string(), 0);
         let mut board_mut = board.clone();
 
-        let card1 = kanban_domain::Card::new(&mut board_mut, column.id, "A".to_string(), 10, "task");
+        let card1 =
+            kanban_domain::Card::new(&mut board_mut, column.id, "A".to_string(), 10, "task");
         let card2 = kanban_domain::Card::new(&mut board_mut, column.id, "B".to_string(), 5, "task");
 
         // Position 5 < Position 10, so card2 should come before card1
@@ -257,15 +258,11 @@ mod tests {
             SortField::Default,
         ];
 
-        let position_idx = sort_fields
-            .iter()
-            .position(|f| *f == SortField::Position);
+        let position_idx = sort_fields.iter().position(|f| *f == SortField::Position);
 
         assert_eq!(position_idx, Some(5), "Position should be at index 5");
 
-        let default_idx = sort_fields
-            .iter()
-            .position(|f| *f == SortField::Default);
+        let default_idx = sort_fields.iter().position(|f| *f == SortField::Default);
 
         assert_eq!(default_idx, Some(6), "Default should be at index 6");
     }

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -105,9 +105,11 @@ mod tests {
         };
 
         // Create a minimal app with active_board_index set
-        let mut app = App::default();
-        app.active_board_index = Some(0);
-        app.current_sort_field = Some(SortField::Default); // Old value
+        let mut app = App {
+            active_board_index: Some(0),
+            current_sort_field: Some(SortField::Default), // Old value
+            ..Default::default()
+        };
 
         // Apply snapshot - should sync sort field from board
         snapshot.apply_to_app(&mut app);


### PR DESCRIPTION
## Summary

- Adds Position to the sort field options, allowing cards to be sorted by their `position` field
- This is useful when cards are reordered via MCP's `move_card` command or other external tools
- Also fixes a bug where the selected sort field would revert after file reload

## Changes

1. **Position sort field** - Add `Position` variant to `SortField` enum with corresponding `PositionSorter` implementation
2. **Sort field sync** - Fix bug where `current_sort_field` wasn't being synced from the board after file reload (affected all sort fields, not just Position)

## Test plan

- [x] Unit tests for PositionSorter
- [x] Unit tests for Position serialization/deserialization
- [x] Unit test for sort field sync after reload
- [x] Manual testing with MCP move_card + TUI