### PR TITLE
Fix release workflow: guard against missing .changeset directory

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,27 @@
+# Changesets
+
+When creating a PR, add a changeset file to describe your changes.
+
+## Creating a Changeset
+
+```bash
+nix run .#changeset
+```
+
+Or create a file `.changeset/<descriptive-name>.md` manually:
+
+```md
+---
+bump: patch
+---
+
+Brief description of changes for the changelog
+```
+
+## Bump Types
+
+- `patch` - Bug fixes, small changes (0.1.0 → 0.1.1)
+- `minor` - New features, backwards compatible (0.1.0 → 0.2.0)
+- `major` - Breaking changes (0.1.0 → 1.0.0)
+
+On merge to master, changesets are aggregated and the highest bump type determines the version increment.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,10 @@ jobs:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: |
           # Delete changesets on master (after successful publish)
-          find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" -delete
-          git add .changeset/
+          if [ -d ".changeset" ]; then
+            find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" -delete
+            git add .changeset/
+          fi
           git commit -m "chore: clean up changesets for v${{ steps.versions.outputs.current }}" || echo "No changesets to clean up"
           git push origin master || echo "Nothing to push"
 

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -174,7 +174,7 @@ All CLI commands output JSON for easy parsing and scripting:
 ```json
 {
   "success": true,
-  "api_version": "0.1.13",
+  "api_version": "0.2.0",
   "data": { ... }
 }
 ```
@@ -282,8 +282,7 @@ When launching with a file path:
 
 ### Auto-Save Behavior
 
-- **On graceful exit** (press `q` in TUI): File automatically updated with latest state
-- **On force quit** (Ctrl+C): Changes may be lost (graceful shutdown recommended)
+- **Immediate save**: Changes are saved automatically after each action
 - **In-memory only**: Without file argument, all data discarded on exit
 
 ## Logging and Diagnostics

--- a/scripts/aggregate-changelog.sh
+++ b/scripts/aggregate-changelog.sh
@@ -10,7 +10,12 @@ trap cleanup EXIT
 CURRENT_VERSION=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)
 
 # Check for changesets (excluding README.md)
-changeset_count=$(find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" 2>/dev/null | wc -l | tr -d ' ')
+if [ ! -d ".changeset" ]; then
+  echo "No changesets to aggregate"
+  exit 0
+fi
+
+changeset_count=$(find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" | wc -l | tr -d ' ')
 if [ "$changeset_count" -eq 0 ]; then
   echo "No changesets to aggregate"
   exit 0

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -88,7 +88,9 @@ fi
 
 cargo update --workspace
 
-find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" -delete
+if [ -d ".changeset" ]; then
+  find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" -delete
+fi
 
 echo "Version bumped to $NEW_VERSION"
 echo "CHANGELOG.md updated"


### PR DESCRIPTION
## Summary

The v0.2.0 release workflow failed immediately at the "Aggregate changelog from changesets" step because the `.changeset/` directory was deleted during the version bump on `develop`.

**Root cause:** `aggregate-changelog.sh` runs `find .changeset ...` in a pipeline with `set -euo pipefail`. When the directory doesn't exist, `find` returns exit code 1. Despite `2>/dev/null` suppressing stderr, `pipefail` propagates the non-zero exit through the pipeline, and `set -e` terminates the script.

**Fix:** Add `[ -d ".changeset" ]` guards before all `find .changeset` calls:
- `scripts/aggregate-changelog.sh` — early return if directory missing
- `scripts/bump-version.sh` — skip changeset cleanup if directory missing
- `.github/workflows/release.yml` — skip cleanup step if directory missing
- Restore `.changeset/README.md` so the directory persists across releases

After merging, re-run the failed release workflow to publish v0.2.0.