### PR TITLE
fix: filter completed/cancelled sprints from assignment handlers

### DIFF
--- a/.changeset/kan-194-fix-tui-sprint-assignment-selecting-wrong-sprint-index-mismatch.md
+++ b/.changeset/kan-194-fix-tui-sprint-assignment-selecting-wrong-sprint-index-mismatch.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- refactor: extract Sprint::assignable to deduplicate sprint filtering
+- fix: filter completed/cancelled sprints from assignment handlers

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -33,6 +33,14 @@ pub struct Sprint {
 pub type SprintId = Uuid;
 
 impl Sprint {
+    pub fn assignable(sprints: &[Sprint], board_id: Uuid) -> Vec<&Sprint> {
+        sprints
+            .iter()
+            .filter(|s| s.board_id == board_id)
+            .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
+            .collect()
+    }
+
     pub fn new(
         board_id: Uuid,
         sprint_number: u32,

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -1922,11 +1922,13 @@ impl App {
                 if let Some(card_sprint_id) = card.sprint_id {
                     if let Some(board_idx) = self.active_board_index {
                         if let Some(board) = self.ctx.boards.get(board_idx) {
+                            use kanban_domain::SprintStatus;
                             let board_sprints: Vec<_> = self
                                 .ctx
                                 .sprints
                                 .iter()
                                 .filter(|s| s.board_id == board.id)
+                                .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
                                 .collect();
                             for (idx, sprint) in board_sprints.iter().enumerate() {
                                 if sprint.id == card_sprint_id {

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -1922,14 +1922,7 @@ impl App {
                 if let Some(card_sprint_id) = card.sprint_id {
                     if let Some(board_idx) = self.active_board_index {
                         if let Some(board) = self.ctx.boards.get(board_idx) {
-                            use kanban_domain::SprintStatus;
-                            let board_sprints: Vec<_> = self
-                                .ctx
-                                .sprints
-                                .iter()
-                                .filter(|s| s.board_id == board.id)
-                                .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
-                                .collect();
+                            let board_sprints = Sprint::assignable(&self.ctx.sprints, board.id);
                             for (idx, sprint) in board_sprints.iter().enumerate() {
                                 if sprint.id == card_sprint_id {
                                     return idx + 1;

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+use kanban_domain::Sprint;
 use ratatui::Frame;
 
 pub trait SelectionDialog {
@@ -136,18 +137,9 @@ impl SelectionDialog for SprintAssignDialog {
     }
 
     fn options_count(&self, app: &App) -> usize {
-        use kanban_domain::SprintStatus;
         if let Some(board_idx) = app.active_board_index {
             if let Some(board) = app.ctx.boards.get(board_idx) {
-                let sprint_count = app
-                    .ctx
-                    .sprints
-                    .iter()
-                    .filter(|s| s.board_id == board.id)
-                    .filter(|s| {
-                        s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled
-                    })
-                    .count();
+                let sprint_count = Sprint::assignable(&app.ctx.sprints, board.id).len();
                 sprint_count + 1 // +1 for None option
             } else {
                 1
@@ -190,16 +182,7 @@ impl SelectionDialog for SprintAssignDialog {
 
         if let Some(board_idx) = app.active_board_index {
             if let Some(board) = app.ctx.boards.get(board_idx) {
-                use kanban_domain::SprintStatus;
-                let board_sprints: Vec<_> = app
-                    .ctx
-                    .sprints
-                    .iter()
-                    .filter(|s| s.board_id == board.id)
-                    .filter(|s| {
-                        s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled
-                    })
-                    .collect();
+                let board_sprints = Sprint::assignable(&app.ctx.sprints, board.id);
 
                 let current_sprint_id = if let Some(card_idx) = app.active_card_index {
                     app.ctx.cards.get(card_idx).and_then(|c| c.sprint_id)

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -61,11 +61,13 @@ impl App {
         } else if self.get_selected_card_id().is_some() {
             if let Some(board_idx) = self.active_board_index {
                 if let Some(board) = self.ctx.boards.get(board_idx) {
+                    use kanban_domain::SprintStatus;
                     let sprint_count = self
                         .ctx
                         .sprints
                         .iter()
                         .filter(|s| s.board_id == board.id)
+                        .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
                         .count();
                     if sprint_count > 0 {
                         if let Some(selected_card) = self.get_selected_card_in_context() {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -4,7 +4,7 @@ use crate::events::EventHandler;
 use kanban_domain::commands::{
     ArchiveCard, CreateCard, DeleteCard, MoveCard, RestoreCard, SetBoardTaskSort, UpdateCard,
 };
-use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, Column, SortOrder};
+use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, Column, SortOrder, Sprint};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -61,14 +61,7 @@ impl App {
         } else if self.get_selected_card_id().is_some() {
             if let Some(board_idx) = self.active_board_index {
                 if let Some(board) = self.ctx.boards.get(board_idx) {
-                    use kanban_domain::SprintStatus;
-                    let sprint_count = self
-                        .ctx
-                        .sprints
-                        .iter()
-                        .filter(|s| s.board_id == board.id)
-                        .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
-                        .count();
+                    let sprint_count = Sprint::assignable(&self.ctx.sprints, board.id).len();
                     if sprint_count > 0 {
                         if let Some(selected_card) = self.get_selected_card_in_context() {
                             let card_id = selected_card.id;

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,7 +1,9 @@
 use crate::app::App;
 use crate::state::TuiSnapshot;
 use crossterm::event::KeyCode;
-use kanban_domain::{dependencies::CardGraphExt, FieldUpdate, Snapshot, SortField, SortOrder, Sprint};
+use kanban_domain::{
+    dependencies::CardGraphExt, FieldUpdate, Snapshot, SortField, SortOrder, Sprint,
+};
 
 impl App {
     pub fn handle_import_board_popup(&mut self, key_code: KeyCode) {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -161,11 +161,13 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(board_idx) = self.active_board_index {
                     if let Some(board) = self.ctx.boards.get(board_idx) {
+                        use kanban_domain::SprintStatus;
                         let sprint_count = self
                             .ctx
                             .sprints
                             .iter()
                             .filter(|s| s.board_id == board.id)
+                            .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
                             .count();
                         self.sprint_assign_selection.next(sprint_count + 1);
                     }
@@ -206,11 +208,13 @@ impl App {
                             }
                         } else if let Some(board_idx) = self.active_board_index {
                             if let Some(board_id) = self.ctx.boards.get(board_idx).map(|b| b.id) {
+                                use kanban_domain::SprintStatus;
                                 let board_sprints: Vec<_> = self
                                     .ctx
                                     .sprints
                                     .iter()
                                     .filter(|s| s.board_id == board_id)
+                                    .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
                                     .collect();
                                 if let Some(sprint) = board_sprints.get(selection_idx - 1) {
                                     let sprint_id = sprint.id;
@@ -295,11 +299,13 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(board_idx) = self.active_board_index {
                     if let Some(board) = self.ctx.boards.get(board_idx) {
+                        use kanban_domain::SprintStatus;
                         let sprint_count = self
                             .ctx
                             .sprints
                             .iter()
                             .filter(|s| s.board_id == board.id)
+                            .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
                             .count();
                         self.sprint_assign_selection.next(sprint_count + 1);
                     }
@@ -334,11 +340,13 @@ impl App {
                         }
                     } else if let Some(board_idx) = self.active_board_index {
                         if let Some(board_id) = self.ctx.boards.get(board_idx).map(|b| b.id) {
+                            use kanban_domain::SprintStatus;
                             let board_sprints: Vec<_> = self
                                 .ctx
                                 .sprints
                                 .iter()
                                 .filter(|s| s.board_id == board_id)
+                                .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
                                 .collect();
                             if let Some(sprint) = board_sprints.get(selection_idx - 1) {
                                 let sprint_id = sprint.id;

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,7 +1,7 @@
 use crate::app::App;
 use crate::state::TuiSnapshot;
 use crossterm::event::KeyCode;
-use kanban_domain::{dependencies::CardGraphExt, FieldUpdate, Snapshot, SortField, SortOrder};
+use kanban_domain::{dependencies::CardGraphExt, FieldUpdate, Snapshot, SortField, SortOrder, Sprint};
 
 impl App {
     pub fn handle_import_board_popup(&mut self, key_code: KeyCode) {
@@ -161,14 +161,7 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(board_idx) = self.active_board_index {
                     if let Some(board) = self.ctx.boards.get(board_idx) {
-                        use kanban_domain::SprintStatus;
-                        let sprint_count = self
-                            .ctx
-                            .sprints
-                            .iter()
-                            .filter(|s| s.board_id == board.id)
-                            .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
-                            .count();
+                        let sprint_count = Sprint::assignable(&self.ctx.sprints, board.id).len();
                         self.sprint_assign_selection.next(sprint_count + 1);
                     }
                 }
@@ -208,14 +201,7 @@ impl App {
                             }
                         } else if let Some(board_idx) = self.active_board_index {
                             if let Some(board_id) = self.ctx.boards.get(board_idx).map(|b| b.id) {
-                                use kanban_domain::SprintStatus;
-                                let board_sprints: Vec<_> = self
-                                    .ctx
-                                    .sprints
-                                    .iter()
-                                    .filter(|s| s.board_id == board_id)
-                                    .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
-                                    .collect();
+                                let board_sprints = Sprint::assignable(&self.ctx.sprints, board_id);
                                 if let Some(sprint) = board_sprints.get(selection_idx - 1) {
                                     let sprint_id = sprint.id;
                                     let sprint_number = sprint.sprint_number;
@@ -299,14 +285,7 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(board_idx) = self.active_board_index {
                     if let Some(board) = self.ctx.boards.get(board_idx) {
-                        use kanban_domain::SprintStatus;
-                        let sprint_count = self
-                            .ctx
-                            .sprints
-                            .iter()
-                            .filter(|s| s.board_id == board.id)
-                            .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
-                            .count();
+                        let sprint_count = Sprint::assignable(&self.ctx.sprints, board.id).len();
                         self.sprint_assign_selection.next(sprint_count + 1);
                     }
                 }
@@ -340,14 +319,7 @@ impl App {
                         }
                     } else if let Some(board_idx) = self.active_board_index {
                         if let Some(board_id) = self.ctx.boards.get(board_idx).map(|b| b.id) {
-                            use kanban_domain::SprintStatus;
-                            let board_sprints: Vec<_> = self
-                                .ctx
-                                .sprints
-                                .iter()
-                                .filter(|s| s.board_id == board_id)
-                                .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
-                                .collect();
+                            let board_sprints = Sprint::assignable(&self.ctx.sprints, board_id);
                             if let Some(sprint) = board_sprints.get(selection_idx - 1) {
                                 let sprint_id = sprint.id;
                                 let sprint_number = sprint.sprint_number;

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1124,15 +1124,7 @@ fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
 
     if let Some(board_idx) = app.active_board_index {
         if let Some(board) = app.ctx.boards.get(board_idx) {
-            let board_sprints: Vec<_> = app
-                .ctx
-                .sprints
-                .iter()
-                .filter(|s| s.board_id == board.id)
-                .filter(|s| {
-                    s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled
-                })
-                .collect();
+            let board_sprints = Sprint::assignable(&app.ctx.sprints, board.id);
 
             for (idx, sprint_option) in std::iter::once(None)
                 .chain(board_sprints.iter().map(|s| Some(*s)))


### PR DESCRIPTION
The sprint selection dialog filters out Completed/Cancelled sprints for display, but the handlers that process the selection used the unfiltered list. This caused the user's selection index to map to the wrong sprint.

Add the same status filter to all 6 locations that build sprint lists: navigation bounds, selection handlers, dialog open guard, and pre-selection index calculation.

KAN-194