### PR TITLE
Kan 215/version flag

### DIFF
--- a/.changeset/kan-215-version-flag.md
+++ b/.changeset/kan-215-version-flag.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+- nix: inject self.rev as GIT_COMMIT_HASH in Nix builds
+- fix: suppress commit: line in -V when git hash is unknown
+- fmt: wrap long lines

--- a/crates/kanban-cli/build.rs
+++ b/crates/kanban-cli/build.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(has_git_commit)");
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs/heads/");
     println!("cargo::rerun-if-env-changed=GIT_COMMIT_HASH");
@@ -25,4 +26,7 @@ fn main() {
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo::rustc-env=GIT_COMMIT_HASH={}", commit_hash);
+    if commit_hash != "unknown" {
+        println!("cargo::rustc-cfg=has_git_commit");
+    }
 }

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -1,11 +1,15 @@
 use clap::{Args, Parser, Subcommand};
 use uuid::Uuid;
 
+#[cfg(has_git_commit)]
 const VERSION: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     "\ncommit: ",
     env!("GIT_COMMIT_HASH")
 );
+
+#[cfg(not(has_git_commit))]
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Parser)]
 #[command(name = "kanban")]

--- a/crates/kanban-core/src/paginated_list.rs
+++ b/crates/kanban-core/src/paginated_list.rs
@@ -23,7 +23,10 @@ pub const MAX_PAGE_SIZE: usize = 500;
 ///
 /// Returns [`KanbanError::Validation`] if the resolved `page` is 0, `page_size`
 /// is 0, or `page_size` exceeds [`MAX_PAGE_SIZE`].
-pub fn resolve_page_params(page: Option<u32>, page_size: Option<u32>) -> KanbanResult<(usize, usize)> {
+pub fn resolve_page_params(
+    page: Option<u32>,
+    page_size: Option<u32>,
+) -> KanbanResult<(usize, usize)> {
     let page = page.map(|p| p as usize).unwrap_or(DEFAULT_PAGE);
     let page_size = page_size.map(|p| p as usize).unwrap_or(DEFAULT_PAGE_SIZE);
     if page == 0 {

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -704,7 +704,8 @@ impl KanbanMcpServer {
             status,
         };
         let cards = spawn_op_ref!(self.ctx, list_cards, filter)?;
-        let (page, page_size) = resolve_page_params(req.page, req.page_size).map_err(kanban_err_to_mcp)?;
+        let (page, page_size) =
+            resolve_page_params(req.page, req.page_size).map_err(kanban_err_to_mcp)?;
         let summaries: Vec<CardSummary> = cards.iter().map(CardSummary::from).collect();
         to_call_tool_result(
             &PaginatedList::paginate(summaries, page, page_size).map_err(kanban_err_to_mcp)?,
@@ -812,7 +813,8 @@ impl KanbanMcpServer {
         Parameters(req): Parameters<ListArchivedCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
         let cards = spawn_op_ref!(self.ctx, list_archived_cards)?;
-        let (page, page_size) = resolve_page_params(req.page, req.page_size).map_err(kanban_err_to_mcp)?;
+        let (page, page_size) =
+            resolve_page_params(req.page, req.page_size).map_err(kanban_err_to_mcp)?;
         let summaries: Vec<ArchivedCardSummary> =
             cards.iter().map(ArchivedCardSummary::from).collect();
         to_call_tool_result(

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   rustPlatform,
+  gitRev ? null,
 }:
 
 let
@@ -23,6 +24,10 @@ rustPlatform.buildRustPackage {
 
   cargoBuildFlags = [ "--package" "kanban-cli" ];
   doCheck = false;
+
+  preBuild = lib.optionalString (gitRev != null) ''
+    export GIT_COMMIT_HASH="${gitRev}"
+  '';
 
   meta = {
     inherit (cargoToml.workspace.package) description homepage;

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
         };
 
         packages = let
-          kanban = pkgs.callPackage ./default.nix {};
+          kanban = pkgs.callPackage ./default.nix { gitRev = self.rev or null; };
         in {
           default = kanban;
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {


### PR DESCRIPTION
## Problem

`kanban -V` always printed `commit: unknown` in release/Nix builds because `lib.cleanSource` strips `.git` before the build, so `git rev-parse HEAD` fails and the build script falls back to the string `"unknown"`.

## Solution

**Suppress the `commit:` line when the hash is unavailable** — the version output now only includes the commit hash when one was actually resolved.

**Inject `self.rev` in Nix builds** — when building from a clean committed tree, the flake passes `self.rev` into the derivation via a `preBuild` hook, so `kanban -V` shows the real commit hash even without `.git`.

## Changes

- `build.rs` — emit `cargo::rustc-cfg=has_git_commit` only when a real hash is resolved; declare it with `rustc-check-cfg` to silence the unknown-cfg warning
- `cli.rs` — two cfg-guarded `VERSION` constants: includes `\ncommit: <hash>` only when `has_git_commit` is set
- `flake.nix` — pass `gitRev = self.rev or null` to `callPackage`
- `default.nix` — accept `gitRev ? null` parameter; add `preBuild` hook to export it as `GIT_COMMIT_HASH`

## Behaviour

| Build context | `kanban -V` output |
|---|---|
| Dev (git available) | `0.2.0\ncommit: <full hash>` |
| Nix, clean tree | `0.2.0\ncommit: <rev>` |
| Nix, dirty tree | `0.2.0` |
| Release without git | `0.2.0` |