### PR TITLE
fix: publish kanban-domain before kanban-mcp in release scripts

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -3,15 +3,15 @@ set -uo pipefail
 
 # Crates must be published in dependency order:
 # - kanban-core: no internal deps
-# - kanban-mcp: no internal deps
 # - kanban-domain: depends on kanban-core
+# - kanban-mcp: depends on kanban-core, kanban-domain
 # - kanban-persistence: depends on kanban-core, kanban-domain
 # - kanban-tui: depends on kanban-core, kanban-domain, kanban-persistence
 # - kanban-cli: depends on all above
 CRATES=(
   "crates/kanban-core"
-  "crates/kanban-mcp"
   "crates/kanban-domain"
+  "crates/kanban-mcp"
   "crates/kanban-persistence"
   "crates/kanban-tui"
   "crates/kanban-cli"

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 CRATES=(
   "crates/kanban-core"
-  "crates/kanban-mcp"
   "crates/kanban-domain"
+  "crates/kanban-mcp"
   "crates/kanban-persistence"
   "crates/kanban-tui"
   "crates/kanban-cli"


### PR DESCRIPTION
## Summary

- `kanban-mcp` depends on both `kanban-core` and `kanban-domain`, but was listed before `kanban-domain` in the publish order of `publish-crates.sh` and `validate-release.sh`
- crates.io would reject `kanban-mcp@x.y.z` if `kanban-domain@x.y.z` hasn't been published yet
- Fix: move `kanban-domain` before `kanban-mcp` in both scripts

## Test plan
- [x] Verify `kanban-mcp/Cargo.toml` lists `kanban-domain` as a dependency
- [x] Confirm publish order in both scripts now matches the dependency grap