### PR TITLE
Kan 217/mcp list cards pagination returns max 50 cards instead of all cards

### DIFF
--- a/.changeset/kan-217-mcp-list-cards-pagination-returns-max-50-cards-instead-of-all-cards.md
+++ b/.changeset/kan-217-mcp-list-cards-pagination-returns-max-50-cards-instead-of-all-cards.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+- fix: pass page/page_size through to CLI subprocess in MCP list_cards
+- fix: pass page/page_size through to CLI subprocess in MCP list_cards
+- refactor: change list_cards to return Vec<CardSummary> instead of Vec<Card>

--- a/.changeset/kan-217-mcp-list-cards-pagination-returns-max-50-cards-instead-of-all-cards.md
+++ b/.changeset/kan-217-mcp-list-cards-pagination-returns-max-50-cards-instead-of-all-cards.md
@@ -3,5 +3,4 @@ bump: patch
 ---
 
 - fix: pass page/page_size through to CLI subprocess in MCP list_cards
-- fix: pass page/page_size through to CLI subprocess in MCP list_cards
 - refactor: change list_cards to return Vec<CardSummary> instead of Vec<Card>

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -1,8 +1,8 @@
 use kanban_core::KanbanResult;
 use kanban_domain::commands::{Command, CommandContext};
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardUpdate, Column, ColumnUpdate,
-    DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
+    ColumnUpdate, DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
 };
 use kanban_persistence::{JsonFileStore, PersistenceMetadata, PersistenceStore, StoreSnapshot};
 use serde::{Deserialize, Serialize};
@@ -297,7 +297,7 @@ impl KanbanOperations for CliContext {
         })
     }
 
-    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<Card>> {
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
         let mut cards: Vec<_> = self.cards.to_vec();
 
         if let Some(board_id) = filter.board_id {
@@ -322,7 +322,7 @@ impl KanbanOperations for CliContext {
             cards.retain(|c| c.status == status);
         }
 
-        Ok(cards)
+        Ok(cards.iter().map(CardSummary::from).collect())
     }
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -3,8 +3,8 @@ use crate::context::CliContext;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate,
-    CreateCardOptions, FieldUpdate, KanbanOperations,
+    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions,
+    FieldUpdate, KanbanOperations,
 };
 
 use uuid::Uuid;

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -3,7 +3,7 @@ use crate::context::CliContext;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardSummary, CardUpdate,
+    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate,
     CreateCardOptions, FieldUpdate, KanbanOperations,
 };
 
@@ -42,8 +42,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                     Ok(f) => f,
                     Err(e) => return output::output_error(&e),
                 };
-                let cards = ctx.list_cards(filter)?;
-                let summaries: Vec<CardSummary> = cards.iter().map(CardSummary::from).collect();
+                let summaries = ctx.list_cards(filter)?;
                 output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
             }
         }

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ArchivedCard, Board, BoardUpdate, Card, CardStatus, CardUpdate, Column, ColumnUpdate,
-    CreateCardOptions, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardUpdate, Card, CardStatus, CardSummary, CardUpdate, Column,
+    ColumnUpdate, CreateCardOptions, Sprint, SprintUpdate,
 };
 use kanban_core::KanbanResult;
 use uuid::Uuid;
@@ -45,7 +45,7 @@ pub trait KanbanOperations {
         title: String,
         options: CreateCardOptions,
     ) -> KanbanResult<Card>;
-    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<Card>>;
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>>;
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>>;
     fn find_card_by_identifier(&self, identifier: &str) -> KanbanResult<Option<Card>>;
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card>;

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -1,5 +1,5 @@
 use crate::executor::SyncExecutor;
-use kanban_core::KanbanResult;
+use kanban_core::{KanbanResult, PaginatedList};
 use kanban_domain::{
     ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
     ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
@@ -115,6 +115,39 @@ impl McpContext {
     fn execute_list<T: serde::de::DeserializeOwned>(&self, args: &[&str]) -> KanbanResult<Vec<T>> {
         let response: ListResponse<T> = self.executor.execute(args)?;
         Ok(response.items)
+    }
+
+    fn execute_list_paged<T: serde::de::DeserializeOwned>(
+        &self,
+        args: &[&str],
+        page: usize,
+        page_size: usize,
+    ) -> KanbanResult<PaginatedList<T>> {
+        let page_str = page.to_string();
+        let page_size_str = page_size.to_string();
+        let mut paged_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        paged_args.extend(["--page".into(), page_str, "--page-size".into(), page_size_str]);
+        let paged_refs: Vec<&str> = paged_args.iter().map(|s| s.as_str()).collect();
+        self.executor.execute(&paged_refs)
+    }
+
+    pub fn list_cards_paged(
+        &self,
+        filter: CardListFilter,
+        page: usize,
+        page_size: usize,
+    ) -> KanbanResult<PaginatedList<CardSummary>> {
+        let board_id_str = filter.board_id.map(|id| id.to_string());
+        let column_id_str = filter.column_id.map(|id| id.to_string());
+        let sprint_id_str = filter.sprint_id.map(|id| id.to_string());
+        let status_str = filter.status.map(|s| s.to_string());
+        let mut builder = ArgsBuilder::new(&["card", "list"]);
+        builder
+            .add_opt("--board-id", board_id_str.as_deref())
+            .add_opt("--column-id", column_id_str.as_deref())
+            .add_opt("--sprint-id", sprint_id_str.as_deref())
+            .add_opt("--status", status_str.as_deref());
+        self.execute_list_paged(&builder.build(), page, page_size)
     }
 }
 

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -126,6 +126,9 @@ impl McpContext {
         self.executor.execute(&paged_refs)
     }
 
+    /// MCP-specific method that exposes real pagination metadata from the CLI.
+    /// `KanbanOperations::list_cards` cannot carry pagination params, so `tool_list_cards`
+    /// calls this directly to forward the MCP request's page/page_size to the subprocess.
     pub fn list_cards_paged(
         &self,
         filter: CardListFilter,
@@ -289,18 +292,7 @@ impl KanbanOperations for McpContext {
     }
 
     fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
-        let board_id_str = filter.board_id.map(|id| id.to_string());
-        let column_id_str = filter.column_id.map(|id| id.to_string());
-        let sprint_id_str = filter.sprint_id.map(|id| id.to_string());
-        let status_str = filter.status.map(|s| s.to_string());
-
-        let mut builder = ArgsBuilder::new(&["card", "list"]);
-        builder
-            .add_opt("--board-id", board_id_str.as_deref())
-            .add_opt("--column-id", column_id_str.as_deref())
-            .add_opt("--sprint-id", sprint_id_str.as_deref())
-            .add_opt("--status", status_str.as_deref());
-        Ok(self.execute_list(&builder.build(), 1, MAX_PAGE_SIZE)?.items)
+        Ok(self.list_cards_paged(filter, 1, MAX_PAGE_SIZE)?.items)
     }
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -6,7 +6,6 @@ use kanban_domain::{
 };
 use uuid::Uuid;
 
-
 #[derive(serde::Deserialize)]
 struct DeletedResponse {
     #[allow(dead_code)]
@@ -117,7 +116,12 @@ impl McpContext {
         let page_str = page.to_string();
         let page_size_str = page_size.to_string();
         let mut paged_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-        paged_args.extend(["--page".into(), page_str, "--page-size".into(), page_size_str]);
+        paged_args.extend([
+            "--page".into(),
+            page_str,
+            "--page-size".into(),
+            page_size_str,
+        ]);
         let paged_refs: Vec<&str> = paged_args.iter().map(|s| s.as_str()).collect();
         self.executor.execute(&paged_refs)
     }
@@ -154,7 +158,9 @@ impl KanbanOperations for McpContext {
     }
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
-        Ok(self.execute_list(&["board", "list"], 1, MAX_PAGE_SIZE)?.items)
+        Ok(self
+            .execute_list(&["board", "list"], 1, MAX_PAGE_SIZE)?
+            .items)
     }
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
@@ -206,7 +212,13 @@ impl KanbanOperations for McpContext {
 
     fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
         let board_id_str = board_id.to_string();
-        Ok(self.execute_list(&["column", "list", "--board-id", &board_id_str], 1, MAX_PAGE_SIZE)?.items)
+        Ok(self
+            .execute_list(
+                &["column", "list", "--board-id", &board_id_str],
+                1,
+                MAX_PAGE_SIZE,
+            )?
+            .items)
     }
 
     fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
@@ -375,7 +387,9 @@ impl KanbanOperations for McpContext {
     }
 
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
-        Ok(self.execute_list(&["card", "list", "--archived"], 1, MAX_PAGE_SIZE)?.items)
+        Ok(self
+            .execute_list(&["card", "list", "--archived"], 1, MAX_PAGE_SIZE)?
+            .items)
     }
 
     // ========================================================================
@@ -489,7 +503,13 @@ impl KanbanOperations for McpContext {
 
     fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
         let board_id_str = board_id.to_string();
-        Ok(self.execute_list(&["sprint", "list", "--board-id", &board_id_str], 1, MAX_PAGE_SIZE)?.items)
+        Ok(self
+            .execute_list(
+                &["sprint", "list", "--board-id", &board_id_str],
+                1,
+                MAX_PAGE_SIZE,
+            )?
+            .items)
     }
 
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -1,8 +1,8 @@
 use crate::executor::SyncExecutor;
 use kanban_core::KanbanResult;
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardUpdate, Column, ColumnUpdate,
-    CreateCardOptions, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
+    ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
 };
 use uuid::Uuid;
 
@@ -252,7 +252,7 @@ impl KanbanOperations for McpContext {
         self.executor.execute_with_retry(&builder.build())
     }
 
-    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<Card>> {
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
         let board_id_str = filter.board_id.map(|id| id.to_string());
         let column_id_str = filter.column_id.map(|id| id.to_string());
         let sprint_id_str = filter.sprint_id.map(|id| id.to_string());

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -1,15 +1,11 @@
 use crate::executor::SyncExecutor;
-use kanban_core::{KanbanResult, PaginatedList};
+use kanban_core::{KanbanResult, PaginatedList, MAX_PAGE_SIZE};
 use kanban_domain::{
     ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
     ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
 };
 use uuid::Uuid;
 
-#[derive(serde::Deserialize)]
-struct ListResponse<T> {
-    items: Vec<T>,
-}
 
 #[derive(serde::Deserialize)]
 struct DeletedResponse {
@@ -112,12 +108,7 @@ impl McpContext {
         }
     }
 
-    fn execute_list<T: serde::de::DeserializeOwned>(&self, args: &[&str]) -> KanbanResult<Vec<T>> {
-        let response: ListResponse<T> = self.executor.execute(args)?;
-        Ok(response.items)
-    }
-
-    fn execute_list_paged<T: serde::de::DeserializeOwned>(
+    fn execute_list<T: serde::de::DeserializeOwned>(
         &self,
         args: &[&str],
         page: usize,
@@ -147,7 +138,7 @@ impl McpContext {
             .add_opt("--column-id", column_id_str.as_deref())
             .add_opt("--sprint-id", sprint_id_str.as_deref())
             .add_opt("--status", status_str.as_deref());
-        self.execute_list_paged(&builder.build(), page, page_size)
+        self.execute_list(&builder.build(), page, page_size)
     }
 }
 
@@ -163,7 +154,7 @@ impl KanbanOperations for McpContext {
     }
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
-        self.execute_list(&["board", "list"])
+        Ok(self.execute_list(&["board", "list"], 1, MAX_PAGE_SIZE)?.items)
     }
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
@@ -215,7 +206,7 @@ impl KanbanOperations for McpContext {
 
     fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
         let board_id_str = board_id.to_string();
-        self.execute_list(&["column", "list", "--board-id", &board_id_str])
+        Ok(self.execute_list(&["column", "list", "--board-id", &board_id_str], 1, MAX_PAGE_SIZE)?.items)
     }
 
     fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
@@ -297,7 +288,7 @@ impl KanbanOperations for McpContext {
             .add_opt("--column-id", column_id_str.as_deref())
             .add_opt("--sprint-id", sprint_id_str.as_deref())
             .add_opt("--status", status_str.as_deref());
-        self.execute_list(&builder.build())
+        Ok(self.execute_list(&builder.build(), 1, MAX_PAGE_SIZE)?.items)
     }
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
@@ -384,7 +375,7 @@ impl KanbanOperations for McpContext {
     }
 
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
-        self.execute_list(&["card", "list", "--archived"])
+        Ok(self.execute_list(&["card", "list", "--archived"], 1, MAX_PAGE_SIZE)?.items)
     }
 
     // ========================================================================
@@ -498,7 +489,7 @@ impl KanbanOperations for McpContext {
 
     fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
         let board_id_str = board_id.to_string();
-        self.execute_list(&["sprint", "list", "--board-id", &board_id_str])
+        Ok(self.execute_list(&["sprint", "list", "--board-id", &board_id_str], 1, MAX_PAGE_SIZE)?.items)
     }
 
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -5,8 +5,8 @@ use context::McpContext;
 use kanban_core::KanbanError;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardSummary, BoardUpdate, Card, CardListFilter, CardPriority, CardStatus, CardSummary,
-    CardUpdate, ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, SprintUpdate,
+    ArchivedCardSummary, BoardUpdate, Card, CardListFilter, CardPriority, CardStatus, CardUpdate,
+    ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, SprintUpdate,
 };
 use parking_lot::Mutex;
 use rmcp::{
@@ -703,10 +703,9 @@ impl KanbanMcpServer {
             sprint_id,
             status,
         };
-        let cards = spawn_op_ref!(self.ctx, list_cards, filter)?;
+        let summaries = spawn_op_ref!(self.ctx, list_cards, filter)?;
         let (page, page_size) =
             resolve_page_params(req.page, req.page_size).map_err(kanban_err_to_mcp)?;
-        let summaries: Vec<CardSummary> = cards.iter().map(CardSummary::from).collect();
         to_call_tool_result(
             &PaginatedList::paginate(summaries, page, page_size).map_err(kanban_err_to_mcp)?,
         )

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -703,12 +703,10 @@ impl KanbanMcpServer {
             sprint_id,
             status,
         };
-        let summaries = spawn_op_ref!(self.ctx, list_cards, filter)?;
         let (page, page_size) =
             resolve_page_params(req.page, req.page_size).map_err(kanban_err_to_mcp)?;
-        to_call_tool_result(
-            &PaginatedList::paginate(summaries, page, page_size).map_err(kanban_err_to_mcp)?,
-        )
+        let result = spawn_op_ref!(self.ctx, list_cards_paged, filter, page, page_size)?;
+        to_call_tool_result(&result)
     }
 
     #[tool(description = "Get a specific card by UUID or identifier (e.g. KAN-5)")]

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -8,8 +8,8 @@ use kanban_domain::commands::{
 };
 use kanban_domain::Snapshot;
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardUpdate, Column, ColumnUpdate,
-    DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
+    ColumnUpdate, DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
 };
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -197,7 +197,7 @@ impl KanbanOperations for TuiContext {
         Ok(self.cards.last().unwrap().clone())
     }
 
-    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<Card>> {
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
         let mut cards: Vec<_> = self.cards.clone();
 
         if let Some(board_id) = filter.board_id {
@@ -222,7 +222,7 @@ impl KanbanOperations for TuiContext {
             cards.retain(|c| c.status == status);
         }
 
-        Ok(cards)
+        Ok(cards.iter().map(CardSummary::from).collect())
     }
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {


### PR DESCRIPTION
## Challenge

`tool_list_cards` in the MCP server always returned at most 50 cards with `total: 50` and `total_pages: 1`, regardless of how many cards actually exist on the board.

## Root Cause

The MCP context delegates all operations to the CLI binary via subprocess. `execute_list` was calling `card list` without `--page`/`--page-size` args, so the CLI defaulted to page 1 with page_size 50. The MCP layer then re-paginated those 50 items — meaning `total` was always capped at 50, never reflecting the real count.

Additionally, `list_cards` was declared to return `Vec<Card>` in the `KanbanOperations` trait, but the CLI subprocess outputs `CardSummary` (no description). This worked silently because `description` is `Option<String>` and serde defaults missing fields to `None`.

## Changes

- **`list_cards` now returns `Vec<CardSummary>`** across the trait, CLI context, TUI context, and MCP context — matching what the CLI actually outputs and removing the silent data loss
- **`execute_list` now takes `page`/`page_size`** and deserializes directly into `PaginatedList<T>`, forwarding the CLI's real pagination metadata
- **`list_cards_paged`** added to `McpContext` — passes the MCP request's page/page_size through to the CLI subprocess and returns the real `PaginatedList<CardSummary>` with correct `total` and `total_pages`
- `tool_list_cards` now calls `list_cards_paged` directly instead of re-paginating stale data