### PR TITLE
Kan 218/gate kanban tui behind default feature flag in kanban cli

### DIFF
--- a/.changeset/kan-218-gate-kanban-tui-behind-default-feature-flag-in-kanban-cli.md
+++ b/.changeset/kan-218-gate-kanban-tui-behind-default-feature-flag-in-kanban-cli.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+- ci: add no-tui build check
+- fix: improve no-tui error message to point to --help
+- feat: build kanban-mcp with no-tui kanban binary to skip wayland/xcb
+- feat: gate kanban-tui behind optional 'tui' default feature

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,21 @@ jobs:
       - name: Build workspace
         run: nix develop --command cargo build --all-features --workspace
 
+  build-no-tui:
+    name: Build (no-tui)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check no-tui build
+        run: nix develop --command cargo check --package kanban-cli --no-default-features
+
   changeset:
     name: Validate Changeset
     if: github.event_name == 'pull_request' && github.base_ref == 'develop'

--- a/crates/kanban-cli/Cargo.toml
+++ b/crates/kanban-cli/Cargo.toml
@@ -14,11 +14,15 @@ categories = ["command-line-utilities"]
 name = "kanban"
 path = "src/main.rs"
 
+[features]
+default = ["tui"]
+tui = ["dep:kanban-tui"]
+
 [dependencies]
 kanban-core = { path = "../kanban-core", version = "^0.3" }
 kanban-domain = { path = "../kanban-domain", version = "^0.3" }
 kanban-persistence = { path = "../kanban-persistence", version = "^0.3" }
-kanban-tui = { path = "../kanban-tui", version = "^0.3" }
+kanban-tui = { path = "../kanban-tui", version = "^0.3", optional = true }
 clap.workspace = true
 clap_complete.workspace = true
 tokio.workspace = true

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -47,7 +47,8 @@ async fn run() -> anyhow::Result<()> {
             {
                 if let Some(ref file_path) = cli.file {
                     if !std::path::Path::new(file_path).exists() {
-                        let empty_state = kanban_persistence::JsonEnvelope::empty().to_json_string()?;
+                        let empty_state =
+                            kanban_persistence::JsonEnvelope::empty().to_json_string()?;
                         std::fs::write(file_path, empty_state)?;
                         tracing::info!("Created new board file: {}", file_path);
                     }
@@ -56,7 +57,9 @@ async fn run() -> anyhow::Result<()> {
                 app.run(save_rx).await?;
             }
             #[cfg(not(feature = "tui"))]
-            anyhow::bail!("TUI not available in this build. Run `kanban --help` for available subcommands.");
+            anyhow::bail!(
+                "TUI not available in this build. Run `kanban --help` for available subcommands."
+            );
         }
         Some(Commands::Completions { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "kanban", &mut std::io::stdout());

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -6,6 +6,7 @@ mod output;
 use clap::{CommandFactory, Parser};
 use cli::{Cli, Commands};
 use context::CliContext;
+#[cfg(feature = "tui")]
 use kanban_tui::App;
 
 #[tokio::main]
@@ -42,15 +43,20 @@ async fn run() -> anyhow::Result<()> {
 
     match cli.command {
         None => {
-            if let Some(ref file_path) = cli.file {
-                if !std::path::Path::new(file_path).exists() {
-                    let empty_state = kanban_persistence::JsonEnvelope::empty().to_json_string()?;
-                    std::fs::write(file_path, empty_state)?;
-                    tracing::info!("Created new board file: {}", file_path);
+            #[cfg(feature = "tui")]
+            {
+                if let Some(ref file_path) = cli.file {
+                    if !std::path::Path::new(file_path).exists() {
+                        let empty_state = kanban_persistence::JsonEnvelope::empty().to_json_string()?;
+                        std::fs::write(file_path, empty_state)?;
+                        tracing::info!("Created new board file: {}", file_path);
+                    }
                 }
+                let (mut app, save_rx) = App::new(cli.file);
+                app.run(save_rx).await?;
             }
-            let (mut app, save_rx) = App::new(cli.file);
-            app.run(save_rx).await?;
+            #[cfg(not(feature = "tui"))]
+            anyhow::bail!("TUI not available in this build. Use a subcommand (e.g. kanban card list).");
         }
         Some(Commands::Completions { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "kanban", &mut std::io::stdout());

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -56,7 +56,7 @@ async fn run() -> anyhow::Result<()> {
                 app.run(save_rx).await?;
             }
             #[cfg(not(feature = "tui"))]
-            anyhow::bail!("TUI not available in this build. Use a subcommand (e.g. kanban card list).");
+            anyhow::bail!("TUI not available in this build. Run `kanban --help` for available subcommands.");
         }
         Some(Commands::Completions { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "kanban", &mut std::io::stdout());

--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,7 @@
   pkgs,
   rustPlatform,
   gitRev ? null,
+  withTui ? true,
 }:
 
 let
@@ -17,12 +18,13 @@ rustPlatform.buildRustPackage {
   cargoLock.lockFile = ./Cargo.lock;
 
   nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = lib.optionals pkgs.stdenv.isLinux [
+  buildInputs = lib.optionals (pkgs.stdenv.isLinux && withTui) [
     pkgs.wayland
     pkgs.xorg.libxcb
   ];
 
-  cargoBuildFlags = [ "--package" "kanban-cli" ];
+  cargoBuildFlags = [ "--package" "kanban-cli" ]
+    ++ lib.optionals (!withTui) [ "--no-default-features" ];
   doCheck = false;
 
   preBuild = lib.optionalString (gitRev != null) ''

--- a/flake.nix
+++ b/flake.nix
@@ -62,10 +62,12 @@
 
         packages = let
           kanban = pkgs.callPackage ./default.nix { gitRev = self.rev or null; };
+          kanban-cli = pkgs.callPackage ./default.nix { gitRev = self.rev or null; withTui = false; };
         in {
           default = kanban;
+          kanban-cli = kanban-cli;
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {
-            inherit kanban;
+            kanban = kanban-cli;
           };
           kanban-web = pkgs.callPackage ./web/default.nix {};
           mcp-server-git = servers.packages.${system}.mcp-server-git;


### PR DESCRIPTION
## Challenge

`nix build .#kanban-mcp` was slow because the `kanban-mcp` derivation depended on the full `kanban` package, which compiles `kanban-cli → kanban-tui → wayland/xcb`. The MCP server only needs a lightweight CLI binary at runtime — no TUI.

## Solution

Add a `tui` **default feature** to `kanban-cli` so:
- Normal users still get TUI by default (`nix run github:fulsomenko/kanban` unchanged)
- The `kanban-mcp` Nix derivation now builds a no-tui `kanban` binary, skipping wayland/xcb entirely

## Changes

- `crates/kanban-cli/Cargo.toml` — add `[features]` with `default = ["tui"]`, make `kanban-tui` an optional dep
- `crates/kanban-cli/src/main.rs` — gate `use kanban_tui::App` and TUI launch behind `#[cfg(feature = "tui")]`; bail with a helpful message in no-tui builds
- `default.nix` — add `withTui ? true` param; conditionally include wayland/xcb and `--no-default-features`
- `flake.nix` — add `kanban-cli` (no-tui) derivation and pass it to `kanban-mcp`