### PR TITLE
release 0.3.2

### DIFF
--- a/.changeset/kan-217-mcp-list-cards-pagination-returns-max-50-cards-instead-of-all-cards.md
+++ b/.changeset/kan-217-mcp-list-cards-pagination-returns-max-50-cards-instead-of-all-cards.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- fix: pass page/page_size through to CLI subprocess in MCP list_cards
+- refactor: change list_cards to return Vec<CardSummary> instead of Vec<Card>

--- a/.changeset/kan-218-gate-kanban-tui-behind-default-feature-flag-in-kanban-cli.md
+++ b/.changeset/kan-218-gate-kanban-tui-behind-default-feature-flag-in-kanban-cli.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+- ci: add no-tui build check
+- fix: improve no-tui error message to point to --help
+- feat: build kanban-mcp with no-tui kanban binary to skip wayland/xcb
+- feat: gate kanban-tui behind optional 'tui' default feature

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,21 @@ jobs:
       - name: Build workspace
         run: nix develop --command cargo build --all-features --workspace
 
+  build-no-tui:
+    name: Build (no-tui)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check no-tui build
+        run: nix develop --command cargo check --package kanban-cli --no-default-features
+
   changeset:
     name: Validate Changeset
     if: github.event_name == 'pull_request' && github.base_ref == 'develop'

--- a/crates/kanban-cli/Cargo.toml
+++ b/crates/kanban-cli/Cargo.toml
@@ -14,11 +14,15 @@ categories = ["command-line-utilities"]
 name = "kanban"
 path = "src/main.rs"
 
+[features]
+default = ["tui"]
+tui = ["dep:kanban-tui"]
+
 [dependencies]
 kanban-core = { path = "../kanban-core", version = "^0.3" }
 kanban-domain = { path = "../kanban-domain", version = "^0.3" }
 kanban-persistence = { path = "../kanban-persistence", version = "^0.3" }
-kanban-tui = { path = "../kanban-tui", version = "^0.3" }
+kanban-tui = { path = "../kanban-tui", version = "^0.3", optional = true }
 clap.workspace = true
 clap_complete.workspace = true
 tokio.workspace = true

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -1,8 +1,8 @@
 use kanban_core::KanbanResult;
 use kanban_domain::commands::{Command, CommandContext};
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardUpdate, Column, ColumnUpdate,
-    DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
+    ColumnUpdate, DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
 };
 use kanban_persistence::{JsonFileStore, PersistenceMetadata, PersistenceStore, StoreSnapshot};
 use serde::{Deserialize, Serialize};
@@ -297,7 +297,7 @@ impl KanbanOperations for CliContext {
         })
     }
 
-    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<Card>> {
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
         let mut cards: Vec<_> = self.cards.to_vec();
 
         if let Some(board_id) = filter.board_id {
@@ -322,7 +322,7 @@ impl KanbanOperations for CliContext {
             cards.retain(|c| c.status == status);
         }
 
-        Ok(cards)
+        Ok(cards.iter().map(CardSummary::from).collect())
     }
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -3,8 +3,8 @@ use crate::context::CliContext;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardSummary, CardUpdate,
-    CreateCardOptions, FieldUpdate, KanbanOperations,
+    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions,
+    FieldUpdate, KanbanOperations,
 };
 
 use uuid::Uuid;
@@ -42,8 +42,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                     Ok(f) => f,
                     Err(e) => return output::output_error(&e),
                 };
-                let cards = ctx.list_cards(filter)?;
-                let summaries: Vec<CardSummary> = cards.iter().map(CardSummary::from).collect();
+                let summaries = ctx.list_cards(filter)?;
                 output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
             }
         }

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -6,6 +6,7 @@ mod output;
 use clap::{CommandFactory, Parser};
 use cli::{Cli, Commands};
 use context::CliContext;
+#[cfg(feature = "tui")]
 use kanban_tui::App;
 
 #[tokio::main]
@@ -42,15 +43,23 @@ async fn run() -> anyhow::Result<()> {
 
     match cli.command {
         None => {
-            if let Some(ref file_path) = cli.file {
-                if !std::path::Path::new(file_path).exists() {
-                    let empty_state = kanban_persistence::JsonEnvelope::empty().to_json_string()?;
-                    std::fs::write(file_path, empty_state)?;
-                    tracing::info!("Created new board file: {}", file_path);
+            #[cfg(feature = "tui")]
+            {
+                if let Some(ref file_path) = cli.file {
+                    if !std::path::Path::new(file_path).exists() {
+                        let empty_state =
+                            kanban_persistence::JsonEnvelope::empty().to_json_string()?;
+                        std::fs::write(file_path, empty_state)?;
+                        tracing::info!("Created new board file: {}", file_path);
+                    }
                 }
+                let (mut app, save_rx) = App::new(cli.file);
+                app.run(save_rx).await?;
             }
-            let (mut app, save_rx) = App::new(cli.file);
-            app.run(save_rx).await?;
+            #[cfg(not(feature = "tui"))]
+            anyhow::bail!(
+                "TUI not available in this build. Run `kanban --help` for available subcommands."
+            );
         }
         Some(Commands::Completions { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "kanban", &mut std::io::stdout());

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ArchivedCard, Board, BoardUpdate, Card, CardStatus, CardUpdate, Column, ColumnUpdate,
-    CreateCardOptions, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardUpdate, Card, CardStatus, CardSummary, CardUpdate, Column,
+    ColumnUpdate, CreateCardOptions, Sprint, SprintUpdate,
 };
 use kanban_core::KanbanResult;
 use uuid::Uuid;
@@ -45,7 +45,7 @@ pub trait KanbanOperations {
         title: String,
         options: CreateCardOptions,
     ) -> KanbanResult<Card>;
-    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<Card>>;
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>>;
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>>;
     fn find_card_by_identifier(&self, identifier: &str) -> KanbanResult<Option<Card>>;
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card>;

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -1,15 +1,10 @@
 use crate::executor::SyncExecutor;
-use kanban_core::KanbanResult;
+use kanban_core::{KanbanResult, PaginatedList, MAX_PAGE_SIZE};
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardUpdate, Column, ColumnUpdate,
-    CreateCardOptions, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
+    ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
 };
 use uuid::Uuid;
-
-#[derive(serde::Deserialize)]
-struct ListResponse<T> {
-    items: Vec<T>,
-}
 
 #[derive(serde::Deserialize)]
 struct DeletedResponse {
@@ -112,9 +107,45 @@ impl McpContext {
         }
     }
 
-    fn execute_list<T: serde::de::DeserializeOwned>(&self, args: &[&str]) -> KanbanResult<Vec<T>> {
-        let response: ListResponse<T> = self.executor.execute(args)?;
-        Ok(response.items)
+    fn execute_list<T: serde::de::DeserializeOwned>(
+        &self,
+        args: &[&str],
+        page: usize,
+        page_size: usize,
+    ) -> KanbanResult<PaginatedList<T>> {
+        let page_str = page.to_string();
+        let page_size_str = page_size.to_string();
+        let mut paged_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        paged_args.extend([
+            "--page".into(),
+            page_str,
+            "--page-size".into(),
+            page_size_str,
+        ]);
+        let paged_refs: Vec<&str> = paged_args.iter().map(|s| s.as_str()).collect();
+        self.executor.execute(&paged_refs)
+    }
+
+    /// MCP-specific method that exposes real pagination metadata from the CLI.
+    /// `KanbanOperations::list_cards` cannot carry pagination params, so `tool_list_cards`
+    /// calls this directly to forward the MCP request's page/page_size to the subprocess.
+    pub fn list_cards_paged(
+        &self,
+        filter: CardListFilter,
+        page: usize,
+        page_size: usize,
+    ) -> KanbanResult<PaginatedList<CardSummary>> {
+        let board_id_str = filter.board_id.map(|id| id.to_string());
+        let column_id_str = filter.column_id.map(|id| id.to_string());
+        let sprint_id_str = filter.sprint_id.map(|id| id.to_string());
+        let status_str = filter.status.map(|s| s.to_string());
+        let mut builder = ArgsBuilder::new(&["card", "list"]);
+        builder
+            .add_opt("--board-id", board_id_str.as_deref())
+            .add_opt("--column-id", column_id_str.as_deref())
+            .add_opt("--sprint-id", sprint_id_str.as_deref())
+            .add_opt("--status", status_str.as_deref());
+        self.execute_list(&builder.build(), page, page_size)
     }
 }
 
@@ -130,7 +161,9 @@ impl KanbanOperations for McpContext {
     }
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
-        self.execute_list(&["board", "list"])
+        Ok(self
+            .execute_list(&["board", "list"], 1, MAX_PAGE_SIZE)?
+            .items)
     }
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
@@ -182,7 +215,13 @@ impl KanbanOperations for McpContext {
 
     fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
         let board_id_str = board_id.to_string();
-        self.execute_list(&["column", "list", "--board-id", &board_id_str])
+        Ok(self
+            .execute_list(
+                &["column", "list", "--board-id", &board_id_str],
+                1,
+                MAX_PAGE_SIZE,
+            )?
+            .items)
     }
 
     fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
@@ -252,19 +291,8 @@ impl KanbanOperations for McpContext {
         self.executor.execute_with_retry(&builder.build())
     }
 
-    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<Card>> {
-        let board_id_str = filter.board_id.map(|id| id.to_string());
-        let column_id_str = filter.column_id.map(|id| id.to_string());
-        let sprint_id_str = filter.sprint_id.map(|id| id.to_string());
-        let status_str = filter.status.map(|s| s.to_string());
-
-        let mut builder = ArgsBuilder::new(&["card", "list"]);
-        builder
-            .add_opt("--board-id", board_id_str.as_deref())
-            .add_opt("--column-id", column_id_str.as_deref())
-            .add_opt("--sprint-id", sprint_id_str.as_deref())
-            .add_opt("--status", status_str.as_deref());
-        self.execute_list(&builder.build())
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
+        Ok(self.list_cards_paged(filter, 1, MAX_PAGE_SIZE)?.items)
     }
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
@@ -351,7 +379,9 @@ impl KanbanOperations for McpContext {
     }
 
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
-        self.execute_list(&["card", "list", "--archived"])
+        Ok(self
+            .execute_list(&["card", "list", "--archived"], 1, MAX_PAGE_SIZE)?
+            .items)
     }
 
     // ========================================================================
@@ -465,7 +495,13 @@ impl KanbanOperations for McpContext {
 
     fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
         let board_id_str = board_id.to_string();
-        self.execute_list(&["sprint", "list", "--board-id", &board_id_str])
+        Ok(self
+            .execute_list(
+                &["sprint", "list", "--board-id", &board_id_str],
+                1,
+                MAX_PAGE_SIZE,
+            )?
+            .items)
     }
 
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -5,8 +5,8 @@ use context::McpContext;
 use kanban_core::KanbanError;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardSummary, BoardUpdate, Card, CardListFilter, CardPriority, CardStatus, CardSummary,
-    CardUpdate, ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, SprintUpdate,
+    ArchivedCardSummary, BoardUpdate, Card, CardListFilter, CardPriority, CardStatus, CardUpdate,
+    ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, SprintUpdate,
 };
 use parking_lot::Mutex;
 use rmcp::{
@@ -703,13 +703,10 @@ impl KanbanMcpServer {
             sprint_id,
             status,
         };
-        let cards = spawn_op_ref!(self.ctx, list_cards, filter)?;
         let (page, page_size) =
             resolve_page_params(req.page, req.page_size).map_err(kanban_err_to_mcp)?;
-        let summaries: Vec<CardSummary> = cards.iter().map(CardSummary::from).collect();
-        to_call_tool_result(
-            &PaginatedList::paginate(summaries, page, page_size).map_err(kanban_err_to_mcp)?,
-        )
+        let result = spawn_op_ref!(self.ctx, list_cards_paged, filter, page, page_size)?;
+        to_call_tool_result(&result)
     }
 
     #[tool(description = "Get a specific card by UUID or identifier (e.g. KAN-5)")]

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -8,8 +8,8 @@ use kanban_domain::commands::{
 };
 use kanban_domain::Snapshot;
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardUpdate, Column, ColumnUpdate,
-    DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
+    ColumnUpdate, DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
 };
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -197,7 +197,7 @@ impl KanbanOperations for TuiContext {
         Ok(self.cards.last().unwrap().clone())
     }
 
-    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<Card>> {
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
         let mut cards: Vec<_> = self.cards.clone();
 
         if let Some(board_id) = filter.board_id {
@@ -222,7 +222,7 @@ impl KanbanOperations for TuiContext {
             cards.retain(|c| c.status == status);
         }
 
-        Ok(cards)
+        Ok(cards.iter().map(CardSummary::from).collect())
     }
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {

--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,7 @@
   pkgs,
   rustPlatform,
   gitRev ? null,
+  withTui ? true,
 }:
 
 let
@@ -17,12 +18,13 @@ rustPlatform.buildRustPackage {
   cargoLock.lockFile = ./Cargo.lock;
 
   nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = lib.optionals pkgs.stdenv.isLinux [
+  buildInputs = lib.optionals (pkgs.stdenv.isLinux && withTui) [
     pkgs.wayland
     pkgs.xorg.libxcb
   ];
 
-  cargoBuildFlags = [ "--package" "kanban-cli" ];
+  cargoBuildFlags = [ "--package" "kanban-cli" ]
+    ++ lib.optionals (!withTui) [ "--no-default-features" ];
   doCheck = false;
 
   preBuild = lib.optionalString (gitRev != null) ''

--- a/flake.nix
+++ b/flake.nix
@@ -62,10 +62,12 @@
 
         packages = let
           kanban = pkgs.callPackage ./default.nix { gitRev = self.rev or null; };
+          kanban-cli = pkgs.callPackage ./default.nix { gitRev = self.rev or null; withTui = false; };
         in {
           default = kanban;
+          kanban-cli = kanban-cli;
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix {
-            inherit kanban;
+            kanban = kanban-cli;
           };
           kanban-web = pkgs.callPackage ./web/default.nix {};
           mcp-server-git = servers.packages.${system}.mcp-server-git;


### PR DESCRIPTION
## Summary

- **KAN-217**: Fix MCP `list_cards` pagination — previously returned all cards instead of respecting page/page_size, now capped at 50 per page
- **KAN-218**: Gate `kanban-tui` behind an optional default `tui` feature flag — allows building `kanban-mcp` without Wayland/xcb dependencies, with a helpful error message pointing to `--help`

## Changes

- `kanban-cli`: `tui` is now an optional default feature; builds without it skip the TUI runtime
- `kanban-mcp`: builds against the no-tui `kanban` binary to avoid Wayland/xcb linkage
- CI: added a no-tui build check to catch regressions
- MCP `list_cards`: pagination params are now forwarded through to the CLI subprocess

## Version

Patch bump: `0.3.1` → `0.3.2`