### PR TITLE
Kan 220/fix kanban binary discovery in mcp integration tests for nix builds

### DIFF
--- a/.changeset/kan-220-fix-kanban-binary-discovery-in-mcp-integration-tests-for-nix-builds.md
+++ b/.changeset/kan-220-fix-kanban-binary-discovery-in-mcp-integration-tests-for-nix-builds.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- fix: check direct target profiles before triple subdirs in kanban_bin()
+- fix: discover kanban binary across target triples and profiles in integration tests

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -10,12 +10,18 @@ fn kanban_bin() -> String {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| {
             std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                .parent().unwrap()
-                .parent().unwrap()
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
                 .join("target")
         });
     // Search subdirectories (target-triple) and both profiles
-    for entry in std::fs::read_dir(&target_dir).into_iter().flatten().flatten() {
+    for entry in std::fs::read_dir(&target_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+    {
         for profile in &["release", "debug"] {
             let p = entry.path().join(profile).join("kanban");
             if p.is_file() {

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -6,19 +6,27 @@ fn kanban_bin() -> String {
     if let Ok(path) = std::env::var("KANBAN_BIN") {
         return path;
     }
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let workspace_root = std::path::Path::new(manifest_dir)
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap();
-    let bin = workspace_root.join("target/debug/kanban");
-    assert!(
-        bin.exists(),
-        "kanban binary not found at {:?}. Run `cargo build --bin kanban` first.",
-        bin
+    let target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent().unwrap()
+                .parent().unwrap()
+                .join("target")
+        });
+    // Search subdirectories (target-triple) and both profiles
+    for entry in std::fs::read_dir(&target_dir).into_iter().flatten().flatten() {
+        for profile in &["release", "debug"] {
+            let p = entry.path().join(profile).join("kanban");
+            if p.is_file() {
+                return p.to_string_lossy().into_owned();
+            }
+        }
+    }
+    panic!(
+        "kanban binary not found under {:?}. Run `cargo build --bin kanban` or set KANBAN_BIN.",
+        target_dir
     );
-    bin.to_string_lossy().to_string()
 }
 
 fn setup() -> (McpContext, TempDir) {

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -16,7 +16,14 @@ fn kanban_bin() -> String {
                 .unwrap()
                 .join("target")
         });
-    // Search subdirectories (target-triple) and both profiles
+    // Check direct profiles first (plain `cargo build` without --target)
+    for profile in &["release", "debug"] {
+        let p = target_dir.join(profile).join("kanban");
+        if p.is_file() {
+            return p.to_string_lossy().into_owned();
+        }
+    }
+    // Search target-triple subdirectories (nix / cross-compiled builds)
     for entry in std::fs::read_dir(&target_dir)
         .into_iter()
         .flatten()


### PR DESCRIPTION
fix: discover kanban binary across target triples and profiles in integration tests

- Search `CARGO_TARGET_DIR` subdirectories for the kanban binary instead of hardcoding `target/debug/kanban`
- Check `release/` before `debug/` so nix sandbox builds (which compile release + cross-compile target triple) are found automatically
- Fall back to walking up from `CARGO_MANIFEST_DIR` to `target/` when `CARGO_TARGET_DIR` is not set
- `KANBAN_BIN` env var override preserved for explicit control

**What**: Replace hardcoded `target/debug/kanban` path in `kanban_bin()` with a directory search across all target subdirs and both profiles.

**Why**: nixpkgs bumped to v0.3.1 and the nix sandbox builds with `--profile release --target x86_64-unknown-linux-gnu`, placing the binary at `target/x86_64-unknown-linux-gnu/release/kanban`. Neither the old hardcoded path nor an injected `KANBAN_BIN` matched, breaking all 13 MCP integration tests.

**How**: Reads `CARGO_TARGET_DIR` (always set by cargo during `cargo test`) as the base, iterates its subdirectories, and checks `release/kanban` then `debug/kanban` in each. Falls back to `<workspace_root>/target` if the env var is absent.

**Testing**: Verified locally with debug build (`cargo build --bin kanban && cargo test --package kanban-mcp`) and simulated nix build (`cargo build --bin kanban --release --target x86_64-unknown-linux-gnu`).