### PR TITLE
KAN-221/help-menu-list-doesnt-scroll

### DIFF
--- a/.changeset/kan-221-help-menu-list-doesnt-scroll.md
+++ b/.changeset/kan-221-help-menu-list-doesnt-scroll.md
@@ -2,10 +2,10 @@
 bump: patch
 ---
 
-- feat(help): fixed header/footer layout with ListComponent scroll in render_help_popup
-- feat(help): replace help_selection+help_page with help_list ListComponent
+- fix(help): fixed header/footer layout with ListComponent scroll in render_help_popup
+- refactor(help): replace help_selection+help_page with help_list ListComponent
 - refactor(generic_list): delegate get_adjusted_viewport_height to Page
-- feat(pagination): add get_adjusted_viewport_height to Page
+- refactor(pagination): add get_adjusted_viewport_height to Page
 - refactor: use render_scroll_indicators helper at all scroll indicator sites
 - feat: add scroll support to help menu popup (KAN-221)
 - refactor: generalize render_scroll_indicators to accept plain args and label

--- a/.changeset/kan-221-help-menu-list-doesnt-scroll.md
+++ b/.changeset/kan-221-help-menu-list-doesnt-scroll.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+- feat(help): fixed header/footer layout with ListComponent scroll in render_help_popup
+- feat(help): replace help_selection+help_page with help_list ListComponent
+- refactor(generic_list): delegate get_adjusted_viewport_height to Page
+- feat(pagination): add get_adjusted_viewport_height to Page
+- refactor: use render_scroll_indicators helper at all scroll indicator sites
+- feat: add scroll support to help menu popup (KAN-221)
+- refactor: generalize render_scroll_indicators to accept plain args and label

--- a/crates/kanban-core/src/pagination.rs
+++ b/crates/kanban-core/src/pagination.rs
@@ -148,7 +148,11 @@ impl Page {
         }
         let above = if self.scroll_offset > 0 { 1 } else { 0 };
         let available = raw_viewport_height.saturating_sub(above);
-        let below = if self.scroll_offset + available < self.total_items { 1 } else { 0 };
+        let below = if self.scroll_offset + available < self.total_items {
+            1
+        } else {
+            0
+        };
         available.saturating_sub(below)
     }
 

--- a/crates/kanban-core/src/pagination.rs
+++ b/crates/kanban-core/src/pagination.rs
@@ -137,6 +137,21 @@ impl Page {
         }
     }
 
+    /// Content rows available after reserving lines for scroll indicators.
+    ///
+    /// Above indicator takes 1 row when `scroll_offset > 0`. Below indicator
+    /// takes 1 row when items extend past the available space. This mirrors
+    /// the logic in `ListComponent::get_adjusted_viewport_height`.
+    pub fn get_adjusted_viewport_height(&self, raw_viewport_height: usize) -> usize {
+        if self.total_items == 0 || raw_viewport_height == 0 {
+            return raw_viewport_height;
+        }
+        let above = if self.scroll_offset > 0 { 1 } else { 0 };
+        let available = raw_viewport_height.saturating_sub(above);
+        let below = if self.scroll_offset + available < self.total_items { 1 } else { 0 };
+        available.saturating_sub(below)
+    }
+
     /// Set scroll offset, clamping to valid range.
     pub fn set_scroll_offset(&mut self, offset: usize) {
         self.scroll_offset = offset.min(self.total_items.saturating_sub(1));

--- a/crates/kanban-core/src/pagination.rs
+++ b/crates/kanban-core/src/pagination.rs
@@ -298,4 +298,45 @@ mod tests {
         page.set_total_items(10);
         assert_eq!(page.scroll_offset, 9);
     }
+
+    #[test]
+    fn test_adjusted_viewport_height_empty_list() {
+        let page = Page::new(0);
+        assert_eq!(page.get_adjusted_viewport_height(5), 5);
+    }
+
+    #[test]
+    fn test_adjusted_viewport_height_zero_raw() {
+        let page = Page::new(10);
+        assert_eq!(page.get_adjusted_viewport_height(0), 0);
+    }
+
+    #[test]
+    fn test_adjusted_viewport_height_all_fit() {
+        let page = Page::new(5);
+        assert_eq!(page.get_adjusted_viewport_height(10), 10);
+    }
+
+    #[test]
+    fn test_adjusted_viewport_height_at_top_with_below() {
+        let page = Page::new(10);
+        // offset=0: no above indicator; 0+5=5 < 10 → below indicator → raw-1
+        assert_eq!(page.get_adjusted_viewport_height(5), 4);
+    }
+
+    #[test]
+    fn test_adjusted_viewport_height_middle_both_indicators() {
+        let mut page = Page::new(10);
+        page.set_scroll_offset(3);
+        // offset=3: above indicator; available=4; 3+4=7 < 10 → below indicator → raw-2
+        assert_eq!(page.get_adjusted_viewport_height(5), 3);
+    }
+
+    #[test]
+    fn test_adjusted_viewport_height_near_end_above_only() {
+        let mut page = Page::new(10);
+        page.set_scroll_offset(6);
+        // offset=6: above indicator; available=4; 6+4=10 >= 10 → no below → raw-1
+        assert_eq!(page.get_adjusted_viewport_height(5), 4);
+    }
 }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -2035,12 +2035,14 @@ mod tests {
 
     #[test]
     fn test_scroll_help_into_view_scrolls_deep_item() {
-        let mut app = App::default();
-        app.last_frame_area = Rect {
-            x: 0,
-            y: 0,
-            width: 100,
-            height: 50,
+        let mut app = App {
+            last_frame_area: Rect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 50,
+            },
+            ..App::default()
         };
         app.help_list.update_item_count(50);
         app.help_list.jump_to(49);

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -16,7 +16,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use kanban_core::{AppConfig, Editable, InputState, KanbanResult, Page, SelectionState};
+use kanban_core::{AppConfig, Editable, InputState, KanbanResult, SelectionState};
 use kanban_domain::AnimationType;
 use kanban_domain::{
     export::{AllBoardsExport, BoardExporter, BoardImporter},
@@ -69,8 +69,7 @@ pub struct App {
     pub priority_selection: SelectionState,
     pub column_selection: SelectionState,
     pub task_list_view_selection: SelectionState,
-    pub help_selection: SelectionState,
-    pub help_page: Page,
+    pub help_list: ListComponent,
     pub help_viewport_height: usize,
     pub help_pending_action: Option<(Instant, crate::keybindings::KeybindingAction)>,
     pub sprint_task_panel: SprintTaskPanel,
@@ -221,8 +220,7 @@ impl App {
             priority_selection: SelectionState::new(),
             column_selection: SelectionState::new(),
             task_list_view_selection: SelectionState::new(),
-            help_selection: SelectionState::new(),
-            help_page: Page::new(0),
+            help_list: ListComponent::new(false),
             help_viewport_height: 0,
             help_pending_action: None,
             sprint_task_panel: SprintTaskPanel::Uncompleted,
@@ -515,11 +513,10 @@ impl App {
             && !matches!(self.mode, AppMode::Help(_))
         {
             let previous_mode = self.mode.clone();
-            self.help_selection.set(Some(0));
             let provider = crate::keybindings::KeybindingRegistry::get_provider(self);
             let context = provider.get_context();
-            let total_lines = context.bindings.len() + 4;
-            self.help_page = Page::new(total_lines);
+            self.help_list.update_item_count(context.bindings.len());
+            self.help_list.set_scroll_offset(0);
             self.mode = AppMode::Help(Box::new(previous_mode));
             return false;
         }
@@ -840,18 +837,22 @@ impl App {
         match key_code {
             KeyCode::Char('j') | KeyCode::Down => {
                 self.help_pending_action = None;
-                let provider = KeybindingRegistry::get_provider(self);
-                let context = provider.get_context();
-                self.help_selection.next(context.bindings.len());
-                if let Some(sel_idx) = self.help_selection.get() {
-                    self.help_page.scroll_to_visible(sel_idx + 2, self.help_viewport_height);
+                let initial_adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                self.help_list.navigate_down();
+                self.help_list.ensure_selected_visible(initial_adjusted);
+                let final_adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                if final_adjusted != initial_adjusted {
+                    self.help_list.ensure_selected_visible(final_adjusted);
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.help_pending_action = None;
-                self.help_selection.prev();
-                if let Some(sel_idx) = self.help_selection.get() {
-                    self.help_page.scroll_to_visible(sel_idx + 2, self.help_viewport_height);
+                let initial_adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                self.help_list.navigate_up();
+                self.help_list.ensure_selected_visible(initial_adjusted);
+                let final_adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                if final_adjusted != initial_adjusted {
+                    self.help_list.ensure_selected_visible(final_adjusted);
                 }
             }
             KeyCode::Char('h') | KeyCode::Char('l') => {
@@ -859,7 +860,7 @@ impl App {
             }
             KeyCode::Enter => {
                 self.help_pending_action = None;
-                if let Some(index) = self.help_selection.get() {
+                if let Some(index) = self.help_list.get_selected_index() {
                     let provider = KeybindingRegistry::get_provider(self);
                     let context = provider.get_context();
 
@@ -869,8 +870,7 @@ impl App {
                         } else {
                             self.mode = AppMode::Normal;
                         }
-                        self.help_selection.clear();
-                        self.help_page = Page::new(0);
+                        self.help_list.update_item_count(0);
                         self.help_viewport_height = 0;
 
                         self.execute_action(&binding.action);
@@ -884,8 +884,7 @@ impl App {
                 } else {
                     self.mode = AppMode::Normal;
                 }
-                self.help_selection.clear();
-                self.help_page = Page::new(0);
+                self.help_list.update_item_count(0);
                 self.help_viewport_height = 0;
             }
             _ => {
@@ -898,8 +897,9 @@ impl App {
                     .enumerate()
                     .find(|(_, b)| Self::keycode_matches_binding_key(&key_code, &b.key))
                 {
-                    self.help_selection.set(Some(index));
-                    self.help_page.scroll_to_visible(index + 2, self.help_viewport_height);
+                    self.help_list.jump_to(index);
+                    let adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                    self.help_list.ensure_selected_visible(adjusted);
                     self.help_pending_action = Some((Instant::now(), binding.action));
                 }
             }
@@ -1704,8 +1704,7 @@ impl App {
                                         } else {
                                             self.mode = AppMode::Normal;
                                         }
-                                        self.help_selection.clear();
-                                        self.help_page = Page::new(0);
+                                        self.help_list.update_item_count(0);
                                         self.help_viewport_height = 0;
 
                                         let action = *action;

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -830,6 +830,18 @@ impl App {
         }
     }
 
+    fn scroll_help_into_view(&mut self) {
+        if self.help_viewport_height == 0 {
+            return;
+        }
+        let h0 = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+        self.help_list.ensure_selected_visible(h0);
+        let h1 = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+        if h1 != h0 {
+            self.help_list.ensure_selected_visible(h1);
+        }
+    }
+
     fn handle_help_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crate::keybindings::KeybindingRegistry;
         use crossterm::event::KeyCode;
@@ -838,34 +850,12 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => {
                 self.help_pending_action = None;
                 self.help_list.navigate_down();
-                if self.help_viewport_height > 0 {
-                    let initial_adjusted = self
-                        .help_list
-                        .get_adjusted_viewport_height(self.help_viewport_height);
-                    self.help_list.ensure_selected_visible(initial_adjusted);
-                    let final_adjusted = self
-                        .help_list
-                        .get_adjusted_viewport_height(self.help_viewport_height);
-                    if final_adjusted != initial_adjusted {
-                        self.help_list.ensure_selected_visible(final_adjusted);
-                    }
-                }
+                self.scroll_help_into_view();
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.help_pending_action = None;
                 self.help_list.navigate_up();
-                if self.help_viewport_height > 0 {
-                    let initial_adjusted = self
-                        .help_list
-                        .get_adjusted_viewport_height(self.help_viewport_height);
-                    self.help_list.ensure_selected_visible(initial_adjusted);
-                    let final_adjusted = self
-                        .help_list
-                        .get_adjusted_viewport_height(self.help_viewport_height);
-                    if final_adjusted != initial_adjusted {
-                        self.help_list.ensure_selected_visible(final_adjusted);
-                    }
-                }
+                self.scroll_help_into_view();
             }
             KeyCode::Char('h') | KeyCode::Char('l') => {
                 self.help_pending_action = None;
@@ -910,12 +900,7 @@ impl App {
                     .find(|(_, b)| Self::keycode_matches_binding_key(&key_code, &b.key))
                 {
                     self.help_list.jump_to(index);
-                    if self.help_viewport_height > 0 {
-                        let adjusted = self
-                            .help_list
-                            .get_adjusted_viewport_height(self.help_viewport_height);
-                        self.help_list.ensure_selected_visible(adjusted);
-                    }
+                    self.scroll_help_into_view();
                     self.help_pending_action = Some((Instant::now(), binding.action));
                 }
             }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -2027,3 +2027,27 @@ impl Default for App {
         app
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Rect;
+
+    #[test]
+    fn test_scroll_help_into_view_scrolls_deep_item() {
+        let mut app = App::default();
+        app.last_frame_area = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 50,
+        };
+        app.help_list.update_item_count(50);
+        app.help_list.jump_to(49);
+        app.scroll_help_into_view();
+        assert!(
+            app.help_list.get_scroll_offset() > 0,
+            "help list should have scrolled to bring item 49 into view"
+        );
+    }
+}

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -70,7 +70,7 @@ pub struct App {
     pub column_selection: SelectionState,
     pub task_list_view_selection: SelectionState,
     pub help_list: ListComponent,
-    pub help_viewport_height: usize,
+    pub last_frame_area: ratatui::layout::Rect,
     pub help_pending_action: Option<(Instant, crate::keybindings::KeybindingAction)>,
     pub sprint_task_panel: SprintTaskPanel,
     pub sprint_uncompleted_cards: CardList,
@@ -221,7 +221,7 @@ impl App {
             column_selection: SelectionState::new(),
             task_list_view_selection: SelectionState::new(),
             help_list: ListComponent::new(false),
-            help_viewport_height: 0,
+            last_frame_area: ratatui::layout::Rect::default(),
             help_pending_action: None,
             sprint_task_panel: SprintTaskPanel::Uncompleted,
             sprint_uncompleted_cards: CardList::new(CardListId::All),
@@ -830,13 +830,20 @@ impl App {
         }
     }
 
+    /// Scrolls the help list so the selected item is visible.
+    ///
+    /// Two passes are needed because `get_adjusted_viewport_height` reserves rows
+    /// for scroll indicators, and an indicator can appear or disappear after the
+    /// first `ensure_selected_visible` call — changing the available height. A
+    /// second pass with the updated height corrects any residual mis-alignment.
     fn scroll_help_into_view(&mut self) {
-        if self.help_viewport_height == 0 {
+        let raw = crate::ui::help_popup_viewport_height(self.last_frame_area);
+        if raw == 0 {
             return;
         }
-        let h0 = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+        let h0 = self.help_list.get_adjusted_viewport_height(raw);
         self.help_list.ensure_selected_visible(h0);
-        let h1 = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+        let h1 = self.help_list.get_adjusted_viewport_height(raw);
         if h1 != h0 {
             self.help_list.ensure_selected_visible(h1);
         }
@@ -873,7 +880,6 @@ impl App {
                             self.mode = AppMode::Normal;
                         }
                         self.help_list.reset();
-                        self.help_viewport_height = 0;
 
                         self.execute_action(&binding.action);
                     }
@@ -887,7 +893,6 @@ impl App {
                     self.mode = AppMode::Normal;
                 }
                 self.help_list.reset();
-                self.help_viewport_height = 0;
             }
             _ => {
                 let provider = KeybindingRegistry::get_provider(self);
@@ -1706,7 +1711,6 @@ impl App {
                                             self.mode = AppMode::Normal;
                                         }
                                         self.help_list.reset();
-                                        self.help_viewport_height = 0;
 
                                         let action = *action;
                                         self.help_pending_action = None;

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -837,20 +837,28 @@ impl App {
         match key_code {
             KeyCode::Char('j') | KeyCode::Down => {
                 self.help_pending_action = None;
-                let initial_adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                let initial_adjusted = self
+                    .help_list
+                    .get_adjusted_viewport_height(self.help_viewport_height);
                 self.help_list.navigate_down();
                 self.help_list.ensure_selected_visible(initial_adjusted);
-                let final_adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                let final_adjusted = self
+                    .help_list
+                    .get_adjusted_viewport_height(self.help_viewport_height);
                 if final_adjusted != initial_adjusted {
                     self.help_list.ensure_selected_visible(final_adjusted);
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.help_pending_action = None;
-                let initial_adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                let initial_adjusted = self
+                    .help_list
+                    .get_adjusted_viewport_height(self.help_viewport_height);
                 self.help_list.navigate_up();
                 self.help_list.ensure_selected_visible(initial_adjusted);
-                let final_adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                let final_adjusted = self
+                    .help_list
+                    .get_adjusted_viewport_height(self.help_viewport_height);
                 if final_adjusted != initial_adjusted {
                     self.help_list.ensure_selected_visible(final_adjusted);
                 }
@@ -898,7 +906,9 @@ impl App {
                     .find(|(_, b)| Self::keycode_matches_binding_key(&key_code, &b.key))
                 {
                     self.help_list.jump_to(index);
-                    let adjusted = self.help_list.get_adjusted_viewport_height(self.help_viewport_height);
+                    let adjusted = self
+                        .help_list
+                        .get_adjusted_viewport_height(self.help_viewport_height);
                     self.help_list.ensure_selected_visible(adjusted);
                     self.help_pending_action = Some((Instant::now(), binding.action));
                 }

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -837,30 +837,34 @@ impl App {
         match key_code {
             KeyCode::Char('j') | KeyCode::Down => {
                 self.help_pending_action = None;
-                let initial_adjusted = self
-                    .help_list
-                    .get_adjusted_viewport_height(self.help_viewport_height);
                 self.help_list.navigate_down();
-                self.help_list.ensure_selected_visible(initial_adjusted);
-                let final_adjusted = self
-                    .help_list
-                    .get_adjusted_viewport_height(self.help_viewport_height);
-                if final_adjusted != initial_adjusted {
-                    self.help_list.ensure_selected_visible(final_adjusted);
+                if self.help_viewport_height > 0 {
+                    let initial_adjusted = self
+                        .help_list
+                        .get_adjusted_viewport_height(self.help_viewport_height);
+                    self.help_list.ensure_selected_visible(initial_adjusted);
+                    let final_adjusted = self
+                        .help_list
+                        .get_adjusted_viewport_height(self.help_viewport_height);
+                    if final_adjusted != initial_adjusted {
+                        self.help_list.ensure_selected_visible(final_adjusted);
+                    }
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.help_pending_action = None;
-                let initial_adjusted = self
-                    .help_list
-                    .get_adjusted_viewport_height(self.help_viewport_height);
                 self.help_list.navigate_up();
-                self.help_list.ensure_selected_visible(initial_adjusted);
-                let final_adjusted = self
-                    .help_list
-                    .get_adjusted_viewport_height(self.help_viewport_height);
-                if final_adjusted != initial_adjusted {
-                    self.help_list.ensure_selected_visible(final_adjusted);
+                if self.help_viewport_height > 0 {
+                    let initial_adjusted = self
+                        .help_list
+                        .get_adjusted_viewport_height(self.help_viewport_height);
+                    self.help_list.ensure_selected_visible(initial_adjusted);
+                    let final_adjusted = self
+                        .help_list
+                        .get_adjusted_viewport_height(self.help_viewport_height);
+                    if final_adjusted != initial_adjusted {
+                        self.help_list.ensure_selected_visible(final_adjusted);
+                    }
                 }
             }
             KeyCode::Char('h') | KeyCode::Char('l') => {
@@ -878,7 +882,7 @@ impl App {
                         } else {
                             self.mode = AppMode::Normal;
                         }
-                        self.help_list.update_item_count(0);
+                        self.help_list.reset();
                         self.help_viewport_height = 0;
 
                         self.execute_action(&binding.action);
@@ -892,7 +896,7 @@ impl App {
                 } else {
                     self.mode = AppMode::Normal;
                 }
-                self.help_list.update_item_count(0);
+                self.help_list.reset();
                 self.help_viewport_height = 0;
             }
             _ => {
@@ -906,10 +910,12 @@ impl App {
                     .find(|(_, b)| Self::keycode_matches_binding_key(&key_code, &b.key))
                 {
                     self.help_list.jump_to(index);
-                    let adjusted = self
-                        .help_list
-                        .get_adjusted_viewport_height(self.help_viewport_height);
-                    self.help_list.ensure_selected_visible(adjusted);
+                    if self.help_viewport_height > 0 {
+                        let adjusted = self
+                            .help_list
+                            .get_adjusted_viewport_height(self.help_viewport_height);
+                        self.help_list.ensure_selected_visible(adjusted);
+                    }
                     self.help_pending_action = Some((Instant::now(), binding.action));
                 }
             }
@@ -1714,7 +1720,7 @@ impl App {
                                         } else {
                                             self.mode = AppMode::Normal;
                                         }
-                                        self.help_list.update_item_count(0);
+                                        self.help_list.reset();
                                         self.help_viewport_height = 0;
 
                                         let action = *action;

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -16,7 +16,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use kanban_core::{AppConfig, Editable, InputState, KanbanResult, SelectionState};
+use kanban_core::{AppConfig, Editable, InputState, KanbanResult, Page, SelectionState};
 use kanban_domain::AnimationType;
 use kanban_domain::{
     export::{AllBoardsExport, BoardExporter, BoardImporter},
@@ -70,6 +70,8 @@ pub struct App {
     pub column_selection: SelectionState,
     pub task_list_view_selection: SelectionState,
     pub help_selection: SelectionState,
+    pub help_page: Page,
+    pub help_viewport_height: usize,
     pub help_pending_action: Option<(Instant, crate::keybindings::KeybindingAction)>,
     pub sprint_task_panel: SprintTaskPanel,
     pub sprint_uncompleted_cards: CardList,
@@ -220,6 +222,8 @@ impl App {
             column_selection: SelectionState::new(),
             task_list_view_selection: SelectionState::new(),
             help_selection: SelectionState::new(),
+            help_page: Page::new(0),
+            help_viewport_height: 0,
             help_pending_action: None,
             sprint_task_panel: SprintTaskPanel::Uncompleted,
             sprint_uncompleted_cards: CardList::new(CardListId::All),
@@ -512,6 +516,10 @@ impl App {
         {
             let previous_mode = self.mode.clone();
             self.help_selection.set(Some(0));
+            let provider = crate::keybindings::KeybindingRegistry::get_provider(self);
+            let context = provider.get_context();
+            let total_lines = context.bindings.len() + 4;
+            self.help_page = Page::new(total_lines);
             self.mode = AppMode::Help(Box::new(previous_mode));
             return false;
         }
@@ -835,10 +843,16 @@ impl App {
                 let provider = KeybindingRegistry::get_provider(self);
                 let context = provider.get_context();
                 self.help_selection.next(context.bindings.len());
+                if let Some(sel_idx) = self.help_selection.get() {
+                    self.help_page.scroll_to_visible(sel_idx + 2, self.help_viewport_height);
+                }
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.help_pending_action = None;
                 self.help_selection.prev();
+                if let Some(sel_idx) = self.help_selection.get() {
+                    self.help_page.scroll_to_visible(sel_idx + 2, self.help_viewport_height);
+                }
             }
             KeyCode::Char('h') | KeyCode::Char('l') => {
                 self.help_pending_action = None;
@@ -856,6 +870,8 @@ impl App {
                             self.mode = AppMode::Normal;
                         }
                         self.help_selection.clear();
+                        self.help_page = Page::new(0);
+                        self.help_viewport_height = 0;
 
                         self.execute_action(&binding.action);
                     }
@@ -869,6 +885,8 @@ impl App {
                     self.mode = AppMode::Normal;
                 }
                 self.help_selection.clear();
+                self.help_page = Page::new(0);
+                self.help_viewport_height = 0;
             }
             _ => {
                 let provider = KeybindingRegistry::get_provider(self);
@@ -881,6 +899,7 @@ impl App {
                     .find(|(_, b)| Self::keycode_matches_binding_key(&key_code, &b.key))
                 {
                     self.help_selection.set(Some(index));
+                    self.help_page.scroll_to_visible(index + 2, self.help_viewport_height);
                     self.help_pending_action = Some((Instant::now(), binding.action));
                 }
             }
@@ -1686,6 +1705,8 @@ impl App {
                                             self.mode = AppMode::Normal;
                                         }
                                         self.help_selection.clear();
+                                        self.help_page = Page::new(0);
+                                        self.help_viewport_height = 0;
 
                                         let action = *action;
                                         self.help_pending_action = None;

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -149,7 +149,11 @@ impl CardList {
 }
 
 /// Render an "N items above" indicator line, or `None` if not shown.
-pub fn render_above_indicator<'a>(show: bool, count: usize, label: &str) -> Option<ratatui::text::Line<'a>> {
+pub fn render_above_indicator<'a>(
+    show: bool,
+    count: usize,
+    label: &str,
+) -> Option<ratatui::text::Line<'a>> {
     use ratatui::style::{Color, Style};
     use ratatui::text::{Line, Span};
 
@@ -165,7 +169,11 @@ pub fn render_above_indicator<'a>(show: bool, count: usize, label: &str) -> Opti
 }
 
 /// Render an "N items below" indicator line, or `None` if not shown.
-pub fn render_below_indicator<'a>(show: bool, count: usize, label: &str) -> Option<ratatui::text::Line<'a>> {
+pub fn render_below_indicator<'a>(
+    show: bool,
+    count: usize,
+    label: &str,
+) -> Option<ratatui::text::Line<'a>> {
     use ratatui::style::{Color, Style};
     use ratatui::text::{Line, Span};
 

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -148,27 +148,35 @@ impl CardList {
     }
 }
 
-/// Helper function to render scroll indicators based on render info
-pub fn render_scroll_indicators(render_info: &CardListRenderInfo) -> Vec<ratatui::text::Line<'_>> {
+/// Render scroll indicators for any scrollable list.
+///
+/// Produces 0, 1, or 2 lines indicating how many items lie above or below
+/// the current viewport. `label` is the singular noun used in the message
+/// (e.g. `"Task"`, `"item"`, `"entry"`).
+pub fn render_scroll_indicators<'a>(
+    show_above: bool,
+    items_above: usize,
+    show_below: bool,
+    items_below: usize,
+    label: &str,
+) -> Vec<ratatui::text::Line<'a>> {
     use ratatui::style::{Color, Style};
     use ratatui::text::{Line, Span};
 
     let mut lines = Vec::new();
 
-    if render_info.show_above_indicator {
-        let count = render_info.cards_above_count;
-        let plural = if count == 1 { "" } else { "s" };
+    if show_above {
+        let plural = if items_above == 1 { "" } else { "s" };
         lines.push(Line::from(Span::styled(
-            format!("  {} Task{} above", count, plural),
+            format!("  {} {}{} above", items_above, label, plural),
             Style::default().fg(Color::DarkGray),
         )));
     }
 
-    if render_info.show_below_indicator {
-        let count = render_info.cards_below_count;
-        let plural = if count == 1 { "" } else { "s" };
+    if show_below {
+        let plural = if items_below == 1 { "" } else { "s" };
         lines.push(Line::from(Span::styled(
-            format!("  {} Task{} below", count, plural),
+            format!("  {} {}{} below", items_below, label, plural),
             Style::default().fg(Color::DarkGray),
         )));
     }

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -148,63 +148,6 @@ impl CardList {
     }
 }
 
-/// Render an "N items above" indicator line, or `None` if not shown.
-pub fn render_above_indicator<'a>(
-    show: bool,
-    count: usize,
-    label: &str,
-) -> Option<ratatui::text::Line<'a>> {
-    use ratatui::style::{Color, Style};
-    use ratatui::text::{Line, Span};
-
-    if show {
-        let plural = if count == 1 { "" } else { "s" };
-        Some(Line::from(Span::styled(
-            format!("  {} {}{} above", count, label, plural),
-            Style::default().fg(Color::DarkGray),
-        )))
-    } else {
-        None
-    }
-}
-
-/// Render an "N items below" indicator line, or `None` if not shown.
-pub fn render_below_indicator<'a>(
-    show: bool,
-    count: usize,
-    label: &str,
-) -> Option<ratatui::text::Line<'a>> {
-    use ratatui::style::{Color, Style};
-    use ratatui::text::{Line, Span};
-
-    if show {
-        let plural = if count == 1 { "" } else { "s" };
-        Some(Line::from(Span::styled(
-            format!("  {} {}{} below", count, label, plural),
-            Style::default().fg(Color::DarkGray),
-        )))
-    } else {
-        None
-    }
-}
-
-/// Render scroll indicators for any scrollable list.
-///
-/// Produces 0, 1, or 2 lines indicating how many items lie above or below
-/// the current viewport. `label` is the singular noun used in the message
-/// (e.g. `"Task"`, `"item"`, `"entry"`).
-pub fn render_scroll_indicators<'a>(
-    show_above: bool,
-    items_above: usize,
-    show_below: bool,
-    items_below: usize,
-    label: &str,
-) -> Vec<ratatui::text::Line<'a>> {
-    let mut lines = Vec::new();
-    lines.extend(render_above_indicator(show_above, items_above, label));
-    lines.extend(render_below_indicator(show_below, items_below, label));
-    lines
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -148,6 +148,38 @@ impl CardList {
     }
 }
 
+/// Render an "N items above" indicator line, or `None` if not shown.
+pub fn render_above_indicator<'a>(show: bool, count: usize, label: &str) -> Option<ratatui::text::Line<'a>> {
+    use ratatui::style::{Color, Style};
+    use ratatui::text::{Line, Span};
+
+    if show {
+        let plural = if count == 1 { "" } else { "s" };
+        Some(Line::from(Span::styled(
+            format!("  {} {}{} above", count, label, plural),
+            Style::default().fg(Color::DarkGray),
+        )))
+    } else {
+        None
+    }
+}
+
+/// Render an "N items below" indicator line, or `None` if not shown.
+pub fn render_below_indicator<'a>(show: bool, count: usize, label: &str) -> Option<ratatui::text::Line<'a>> {
+    use ratatui::style::{Color, Style};
+    use ratatui::text::{Line, Span};
+
+    if show {
+        let plural = if count == 1 { "" } else { "s" };
+        Some(Line::from(Span::styled(
+            format!("  {} {}{} below", count, label, plural),
+            Style::default().fg(Color::DarkGray),
+        )))
+    } else {
+        None
+    }
+}
+
 /// Render scroll indicators for any scrollable list.
 ///
 /// Produces 0, 1, or 2 lines indicating how many items lie above or below
@@ -160,27 +192,9 @@ pub fn render_scroll_indicators<'a>(
     items_below: usize,
     label: &str,
 ) -> Vec<ratatui::text::Line<'a>> {
-    use ratatui::style::{Color, Style};
-    use ratatui::text::{Line, Span};
-
     let mut lines = Vec::new();
-
-    if show_above {
-        let plural = if items_above == 1 { "" } else { "s" };
-        lines.push(Line::from(Span::styled(
-            format!("  {} {}{} above", items_above, label, plural),
-            Style::default().fg(Color::DarkGray),
-        )));
-    }
-
-    if show_below {
-        let plural = if items_below == 1 { "" } else { "s" };
-        lines.push(Line::from(Span::styled(
-            format!("  {} {}{} below", items_below, label, plural),
-            Style::default().fg(Color::DarkGray),
-        )));
-    }
-
+    lines.extend(render_above_indicator(show_above, items_above, label));
+    lines.extend(render_below_indicator(show_below, items_below, label));
     lines
 }
 

--- a/crates/kanban-tui/src/card_list.rs
+++ b/crates/kanban-tui/src/card_list.rs
@@ -148,7 +148,6 @@ impl CardList {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-tui/src/components/generic_list.rs
+++ b/crates/kanban-tui/src/components/generic_list.rs
@@ -167,6 +167,12 @@ impl ListComponent {
     pub fn is_empty(&self) -> bool {
         self.page.total_items == 0
     }
+
+    /// Reset list state: clear item count, selection, and scroll position
+    pub fn reset(&mut self) {
+        self.update_item_count(0);
+        self.page.set_scroll_offset(0);
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-tui/src/components/generic_list.rs
+++ b/crates/kanban-tui/src/components/generic_list.rs
@@ -143,27 +143,7 @@ impl ListComponent {
     /// # Returns
     /// The number of lines available for actual item content after accounting for indicators
     pub fn get_adjusted_viewport_height(&self, raw_viewport_height: usize) -> usize {
-        if self.page.total_items == 0 || raw_viewport_height == 0 {
-            return raw_viewport_height;
-        }
-
-        let scroll_offset = self.page.scroll_offset;
-
-        // Calculate "above" indicator overhead (1 line if scrolled down)
-        let above_indicator_height = if scroll_offset > 0 { 1 } else { 0 };
-
-        // Start with space available after above indicator
-        let available_space = raw_viewport_height.saturating_sub(above_indicator_height);
-
-        // Calculate if we need "below" indicator (1 line if more items exist)
-        let below_indicator_height = if scroll_offset + available_space < self.page.total_items {
-            1
-        } else {
-            0
-        };
-
-        // Return actual content slots
-        available_space.saturating_sub(below_indicator_height)
+        self.page.get_adjusted_viewport_height(raw_viewport_height)
     }
 
     /// Get rendering information given a viewport height (raw lines, all overhead pre-accounted)

--- a/crates/kanban-tui/src/components/generic_list.rs
+++ b/crates/kanban-tui/src/components/generic_list.rs
@@ -479,6 +479,20 @@ mod tests {
     }
 
     #[test]
+    fn test_reset_clears_items_and_selection() {
+        let mut list = ListComponent::new(false);
+        list.update_item_count(10);
+        list.set_selected_index(Some(5));
+        list.set_scroll_offset(3);
+
+        list.reset();
+
+        assert_eq!(list.len(), 0);
+        assert_eq!(list.get_selected_index(), None);
+        assert_eq!(list.get_scroll_offset(), 0);
+    }
+
+    #[test]
     fn test_navigation_with_adjusted_viewport_bug_scenario() {
         // Exact bug scenario: 6 cards in viewport 5
         // User reports card 6 not visible when scrolling

--- a/crates/kanban-tui/src/components/generic_list.rs
+++ b/crates/kanban-tui/src/components/generic_list.rs
@@ -168,7 +168,10 @@ impl ListComponent {
         self.page.total_items == 0
     }
 
-    /// Reset list state: clear item count, selection, and scroll position
+    /// Reset list state: clear item count, selection, and scroll position.
+    ///
+    /// `update_item_count(0)` implicitly clears the selection; the explicit
+    /// `set_scroll_offset(0)` ensures no stale scroll position remains.
     pub fn reset(&mut self) {
         self.update_item_count(0);
         self.page.set_scroll_offset(0);

--- a/crates/kanban-tui/src/components/relationship_section.rs
+++ b/crates/kanban-tui/src/components/relationship_section.rs
@@ -2,7 +2,6 @@ use crate::components::generic_list::ListComponent;
 use crate::components::ListItemConfig;
 use crate::theme::*;
 use kanban_domain::Card;
-use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use uuid::Uuid;
 
@@ -29,14 +28,13 @@ pub fn render_relationship_section(
         let page_info = list_component.get_render_info(viewport_height);
 
         // Above indicator
-        if page_info.show_above_indicator {
-            let count = page_info.items_above;
-            let plural = if count == 1 { "" } else { "s" };
-            lines.push(Line::from(Span::styled(
-                format!("  {} item{} above", count, plural),
-                Style::default().fg(Color::DarkGray),
-            )));
-        }
+        lines.extend(crate::card_list::render_scroll_indicators(
+            page_info.show_above_indicator,
+            page_info.items_above,
+            false,
+            0,
+            "item",
+        ));
 
         // Render visible items
         for &idx in &page_info.visible_indices {
@@ -60,14 +58,13 @@ pub fn render_relationship_section(
         }
 
         // Below indicator
-        if page_info.show_below_indicator {
-            let count = page_info.items_below;
-            let plural = if count == 1 { "" } else { "s" };
-            lines.push(Line::from(Span::styled(
-                format!("  {} item{} below", count, plural),
-                Style::default().fg(Color::DarkGray),
-            )));
-        }
+        lines.extend(crate::card_list::render_scroll_indicators(
+            false,
+            0,
+            page_info.show_below_indicator,
+            page_info.items_below,
+            "item",
+        ));
     }
 
     // Pad to viewport_height with blank lines

--- a/crates/kanban-tui/src/components/relationship_section.rs
+++ b/crates/kanban-tui/src/components/relationship_section.rs
@@ -28,11 +28,9 @@ pub fn render_relationship_section(
         let page_info = list_component.get_render_info(viewport_height);
 
         // Above indicator
-        lines.extend(crate::card_list::render_scroll_indicators(
+        lines.extend(crate::card_list::render_above_indicator(
             page_info.show_above_indicator,
             page_info.items_above,
-            false,
-            0,
             "item",
         ));
 
@@ -58,9 +56,7 @@ pub fn render_relationship_section(
         }
 
         // Below indicator
-        lines.extend(crate::card_list::render_scroll_indicators(
-            false,
-            0,
+        lines.extend(crate::card_list::render_below_indicator(
             page_info.show_below_indicator,
             page_info.items_below,
             "item",

--- a/crates/kanban-tui/src/components/relationship_section.rs
+++ b/crates/kanban-tui/src/components/relationship_section.rs
@@ -28,7 +28,7 @@ pub fn render_relationship_section(
         let page_info = list_component.get_render_info(viewport_height);
 
         // Above indicator
-        lines.extend(crate::card_list::render_above_indicator(
+        lines.extend(crate::scroll_indicators::render_above_indicator(
             page_info.show_above_indicator,
             page_info.items_above,
             "item",
@@ -56,7 +56,7 @@ pub fn render_relationship_section(
         }
 
         // Below indicator
-        lines.extend(crate::card_list::render_below_indicator(
+        lines.extend(crate::scroll_indicators::render_below_indicator(
             page_info.show_below_indicator,
             page_info.items_below,
             "item",

--- a/crates/kanban-tui/src/lib.rs
+++ b/crates/kanban-tui/src/lib.rs
@@ -12,6 +12,7 @@ pub mod keybindings;
 pub mod layout_strategy;
 pub mod markdown_renderer;
 pub mod render_strategy;
+pub mod scroll_indicators;
 pub mod search;
 pub mod state;
 pub mod theme;

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -138,11 +138,9 @@ impl RenderStrategy for SinglePanelRenderer {
                             let render_info = task_list.get_render_info(adjusted_viewport_height);
 
                             // Render above indicator
-                            lines.extend(crate::card_list::render_scroll_indicators(
+                            lines.extend(crate::card_list::render_above_indicator(
                                 render_info.show_above_indicator,
                                 render_info.cards_above_count,
-                                false,
-                                0,
                                 "Task",
                             ));
 
@@ -198,9 +196,7 @@ impl RenderStrategy for SinglePanelRenderer {
                             }
 
                             // Render below indicator
-                            lines.extend(crate::card_list::render_scroll_indicators(
-                                false,
-                                0,
+                            lines.extend(crate::card_list::render_below_indicator(
                                 render_info.show_below_indicator,
                                 render_info.cards_below_count,
                                 "Task",
@@ -255,11 +251,9 @@ impl RenderStrategy for SinglePanelRenderer {
 
                         let render_info = task_list.get_render_info(adjusted_viewport_height);
 
-                        lines.extend(crate::card_list::render_scroll_indicators(
+                        lines.extend(crate::card_list::render_above_indicator(
                             render_info.show_above_indicator,
                             render_info.cards_above_count,
-                            false,
-                            0,
                             "Task",
                         ));
 
@@ -284,9 +278,7 @@ impl RenderStrategy for SinglePanelRenderer {
                             }
                         }
 
-                        lines.extend(crate::card_list::render_scroll_indicators(
-                            false,
-                            0,
+                        lines.extend(crate::card_list::render_below_indicator(
                             render_info.show_below_indicator,
                             render_info.cards_below_count,
                             "Task",
@@ -389,11 +381,9 @@ impl RenderStrategy for MultiPanelRenderer {
 
                         let render_info = task_list.get_render_info(adjusted_viewport_height);
 
-                        lines.extend(crate::card_list::render_scroll_indicators(
+                        lines.extend(crate::card_list::render_above_indicator(
                             render_info.show_above_indicator,
                             render_info.cards_above_count,
-                            false,
-                            0,
                             "Task",
                         ));
 
@@ -424,9 +414,7 @@ impl RenderStrategy for MultiPanelRenderer {
                             }
                         }
 
-                        lines.extend(crate::card_list::render_scroll_indicators(
-                            false,
-                            0,
+                        lines.extend(crate::card_list::render_below_indicator(
                             render_info.show_below_indicator,
                             render_info.cards_below_count,
                             "Task",

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -138,7 +138,7 @@ impl RenderStrategy for SinglePanelRenderer {
                             let render_info = task_list.get_render_info(adjusted_viewport_height);
 
                             // Render above indicator
-                            lines.extend(crate::card_list::render_above_indicator(
+                            lines.extend(crate::scroll_indicators::render_above_indicator(
                                 render_info.show_above_indicator,
                                 render_info.cards_above_count,
                                 "Task",
@@ -196,7 +196,7 @@ impl RenderStrategy for SinglePanelRenderer {
                             }
 
                             // Render below indicator
-                            lines.extend(crate::card_list::render_below_indicator(
+                            lines.extend(crate::scroll_indicators::render_below_indicator(
                                 render_info.show_below_indicator,
                                 render_info.cards_below_count,
                                 "Task",
@@ -251,7 +251,7 @@ impl RenderStrategy for SinglePanelRenderer {
 
                         let render_info = task_list.get_render_info(adjusted_viewport_height);
 
-                        lines.extend(crate::card_list::render_above_indicator(
+                        lines.extend(crate::scroll_indicators::render_above_indicator(
                             render_info.show_above_indicator,
                             render_info.cards_above_count,
                             "Task",
@@ -278,7 +278,7 @@ impl RenderStrategy for SinglePanelRenderer {
                             }
                         }
 
-                        lines.extend(crate::card_list::render_below_indicator(
+                        lines.extend(crate::scroll_indicators::render_below_indicator(
                             render_info.show_below_indicator,
                             render_info.cards_below_count,
                             "Task",
@@ -381,7 +381,7 @@ impl RenderStrategy for MultiPanelRenderer {
 
                         let render_info = task_list.get_render_info(adjusted_viewport_height);
 
-                        lines.extend(crate::card_list::render_above_indicator(
+                        lines.extend(crate::scroll_indicators::render_above_indicator(
                             render_info.show_above_indicator,
                             render_info.cards_above_count,
                             "Task",
@@ -414,7 +414,7 @@ impl RenderStrategy for MultiPanelRenderer {
                             }
                         }
 
-                        lines.extend(crate::card_list::render_below_indicator(
+                        lines.extend(crate::scroll_indicators::render_below_indicator(
                             render_info.show_below_indicator,
                             render_info.cards_below_count,
                             "Task",

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -138,15 +138,13 @@ impl RenderStrategy for SinglePanelRenderer {
                             let render_info = task_list.get_render_info(adjusted_viewport_height);
 
                             // Render above indicator
-                            if render_info.show_above_indicator {
-                                let count = render_info.cards_above_count;
-                                let plural = if count == 1 { "" } else { "s" };
-                                lines.push(Line::from(Span::styled(
-                                    format!("  {} Task{} above", count, plural),
-                                    ratatui::style::Style::default()
-                                        .fg(ratatui::style::Color::DarkGray),
-                                )));
-                            }
+                            lines.extend(crate::card_list::render_scroll_indicators(
+                                render_info.show_above_indicator,
+                                render_info.cards_above_count,
+                                false,
+                                0,
+                                "Task",
+                            ));
 
                             // Render all cards with column headers interspersed
                             let mut columns_shown = std::collections::HashSet::new();
@@ -200,15 +198,13 @@ impl RenderStrategy for SinglePanelRenderer {
                             }
 
                             // Render below indicator
-                            if render_info.show_below_indicator {
-                                let count = render_info.cards_below_count;
-                                let plural = if count == 1 { "" } else { "s" };
-                                lines.push(Line::from(Span::styled(
-                                    format!("  {} Task{} below", count, plural),
-                                    ratatui::style::Style::default()
-                                        .fg(ratatui::style::Color::DarkGray),
-                                )));
-                            }
+                            lines.extend(crate::card_list::render_scroll_indicators(
+                                false,
+                                0,
+                                render_info.show_below_indicator,
+                                render_info.cards_below_count,
+                                "Task",
+                            ));
                         }
                     } else if let Some(board) = app.ctx.boards.get(board_idx.unwrap()) {
                         let mut board_columns: Vec<_> = app
@@ -259,15 +255,13 @@ impl RenderStrategy for SinglePanelRenderer {
 
                         let render_info = task_list.get_render_info(adjusted_viewport_height);
 
-                        if render_info.show_above_indicator {
-                            let count = render_info.cards_above_count;
-                            let plural = if count == 1 { "" } else { "s" };
-                            lines.push(Line::from(Span::styled(
-                                format!("  {} Task{} above", count, plural),
-                                ratatui::style::Style::default()
-                                    .fg(ratatui::style::Color::DarkGray),
-                            )));
-                        }
+                        lines.extend(crate::card_list::render_scroll_indicators(
+                            render_info.show_above_indicator,
+                            render_info.cards_above_count,
+                            false,
+                            0,
+                            "Task",
+                        ));
 
                         for card_idx in &render_info.visible_card_indices {
                             if let Some(card_id) = task_list.cards.get(*card_idx) {
@@ -290,15 +284,13 @@ impl RenderStrategy for SinglePanelRenderer {
                             }
                         }
 
-                        if render_info.show_below_indicator {
-                            let count = render_info.cards_below_count;
-                            let plural = if count == 1 { "" } else { "s" };
-                            lines.push(Line::from(Span::styled(
-                                format!("  {} Task{} below", count, plural),
-                                ratatui::style::Style::default()
-                                    .fg(ratatui::style::Color::DarkGray),
-                            )));
-                        }
+                        lines.extend(crate::card_list::render_scroll_indicators(
+                            false,
+                            0,
+                            render_info.show_below_indicator,
+                            render_info.cards_below_count,
+                            "Task",
+                        ));
                     }
                 }
             }
@@ -397,15 +389,13 @@ impl RenderStrategy for MultiPanelRenderer {
 
                         let render_info = task_list.get_render_info(adjusted_viewport_height);
 
-                        if render_info.show_above_indicator {
-                            let count = render_info.cards_above_count;
-                            let plural = if count == 1 { "" } else { "s" };
-                            lines.push(Line::from(Span::styled(
-                                format!("  {} Task{} above", count, plural),
-                                ratatui::style::Style::default()
-                                    .fg(ratatui::style::Color::DarkGray),
-                            )));
-                        }
+                        lines.extend(crate::card_list::render_scroll_indicators(
+                            render_info.show_above_indicator,
+                            render_info.cards_above_count,
+                            false,
+                            0,
+                            "Task",
+                        ));
 
                         for card_idx in &render_info.visible_card_indices {
                             if let Some(card_id) = task_list.cards.get(*card_idx) {
@@ -434,15 +424,13 @@ impl RenderStrategy for MultiPanelRenderer {
                             }
                         }
 
-                        if render_info.show_below_indicator {
-                            let count = render_info.cards_below_count;
-                            let plural = if count == 1 { "" } else { "s" };
-                            lines.push(Line::from(Span::styled(
-                                format!("  {} Task{} below", count, plural),
-                                ratatui::style::Style::default()
-                                    .fg(ratatui::style::Color::DarkGray),
-                            )));
-                        }
+                        lines.extend(crate::card_list::render_scroll_indicators(
+                            false,
+                            0,
+                            render_info.show_below_indicator,
+                            render_info.cards_below_count,
+                            "Task",
+                        ));
                     }
 
                     let column_name =

--- a/crates/kanban-tui/src/scroll_indicators.rs
+++ b/crates/kanban-tui/src/scroll_indicators.rs
@@ -1,0 +1,57 @@
+/// Render an "N items above" indicator line, or `None` if not shown.
+pub fn render_above_indicator<'a>(
+    show: bool,
+    count: usize,
+    label: &str,
+) -> Option<ratatui::text::Line<'a>> {
+    use ratatui::style::{Color, Style};
+    use ratatui::text::{Line, Span};
+
+    if show {
+        let plural = if count == 1 { "" } else { "s" };
+        Some(Line::from(Span::styled(
+            format!("  {} {}{} above", count, label, plural),
+            Style::default().fg(Color::DarkGray),
+        )))
+    } else {
+        None
+    }
+}
+
+/// Render an "N items below" indicator line, or `None` if not shown.
+pub fn render_below_indicator<'a>(
+    show: bool,
+    count: usize,
+    label: &str,
+) -> Option<ratatui::text::Line<'a>> {
+    use ratatui::style::{Color, Style};
+    use ratatui::text::{Line, Span};
+
+    if show {
+        let plural = if count == 1 { "" } else { "s" };
+        Some(Line::from(Span::styled(
+            format!("  {} {}{} below", count, label, plural),
+            Style::default().fg(Color::DarkGray),
+        )))
+    } else {
+        None
+    }
+}
+
+/// Render scroll indicators for any scrollable list.
+///
+/// Produces 0, 1, or 2 lines indicating how many items lie above or below
+/// the current viewport. `label` is the singular noun used in the message
+/// (e.g. `"Task"`, `"item"`, `"entry"`).
+pub fn render_scroll_indicators<'a>(
+    show_above: bool,
+    items_above: usize,
+    show_below: bool,
+    items_below: usize,
+    label: &str,
+) -> Vec<ratatui::text::Line<'a>> {
+    let mut lines = Vec::new();
+    lines.extend(render_above_indicator(show_above, items_above, label));
+    lines.extend(render_below_indicator(show_below, items_below, label));
+    lines
+}

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -88,7 +88,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             AppMode::SprintDetail => render_sprint_detail_view(app, frame, frame.area()),
             _ => render_main(app, frame, frame.area()),
         }
-        render_help_popup(app, frame);
+        let vh = render_help_popup(app, frame);
+        app.help_viewport_height = vh;
     }
 
     // Render banner on top if present
@@ -395,11 +396,9 @@ fn render_sprint_task_panel_with_selection(
         let viewport_height = area.height.saturating_sub(2) as usize;
         let render_info = task_list.get_render_info(viewport_height);
 
-        lines.extend(crate::card_list::render_scroll_indicators(
+        lines.extend(crate::card_list::render_above_indicator(
             render_info.show_above_indicator,
             render_info.cards_above_count,
-            false,
-            0,
             "Task",
         ));
 
@@ -424,9 +423,7 @@ fn render_sprint_task_panel_with_selection(
             }
         }
 
-        lines.extend(crate::card_list::render_scroll_indicators(
-            false,
-            0,
+        lines.extend(crate::card_list::render_below_indicator(
             render_info.show_below_indicator,
             render_info.cards_below_count,
             "Task",
@@ -1412,9 +1409,7 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
     }
 }
 
-// Takes `&mut App` to write `help_viewport_height` after measuring the popup area,
-// so the event handler can use it for scroll calculations on the next keypress.
-fn render_help_popup(app: &mut App, frame: &mut Frame) {
+fn render_help_popup(app: &App, frame: &mut Frame) -> usize {
     use crate::components::ListItemConfig;
     use crate::keybindings::KeybindingRegistry;
 
@@ -1460,7 +1455,6 @@ fn render_help_popup(app: &mut App, frame: &mut Frame) {
 
     // Scrollable bindings body
     let raw_height = chunks[1].height as usize;
-    app.help_viewport_height = raw_height;
 
     let selected_idx = app.help_list.get_selected_index();
 
@@ -1512,6 +1506,7 @@ fn render_help_popup(app: &mut App, frame: &mut Frame) {
         )),
     ]);
     frame.render_widget(footer, chunks[2]);
+    raw_height
 }
 
 fn render_conflict_resolution_popup(_app: &App, frame: &mut Frame) {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1427,72 +1427,70 @@ fn render_help_popup(app: &mut App, frame: &mut Frame) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    // Layout: fixed header (context name + blank), scrollable bindings, fixed footer
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .margin(2)
-        .constraints([Constraint::Min(0)])
+        .horizontal_margin(2)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(0),
+            Constraint::Length(2),
+        ])
         .split(inner);
-
-    let raw_height = chunks[0].height as usize;
-    app.help_viewport_height = raw_height;
 
     // Get keybindings for the underlying mode
     let provider = KeybindingRegistry::get_provider(app);
     let context = provider.get_context();
-    let selected_idx = app.help_selection.get();
 
-    // Build all lines: header + blank + N bindings + blank + hint
-    let mut all_lines: Vec<Line> = vec![
-        Line::from(Span::styled(
-            context.name.clone(),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::from(""),
-    ];
+    // Fixed header
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                context.name.clone(),
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+        ]),
+        chunks[0],
+    );
 
-    for (idx, binding) in context.bindings.iter().enumerate() {
-        let is_selected = selected_idx == Some(idx);
-        let config = ListItemConfig::new().selected(is_selected).focused(true);
-        let prefix = config.item_prefix();
-        let style = config.item_style();
+    // Scrollable bindings body
+    let raw_height = chunks[1].height as usize;
+    app.help_viewport_height = raw_height;
 
-        all_lines.push(Line::from(vec![
-            Span::styled(prefix.to_string(), style),
-            Span::styled(binding.key.to_string(), Style::default().fg(Color::Yellow)),
-            Span::raw(" "),
-            Span::styled(binding.description.clone(), style),
-        ]));
-    }
+    let selected_idx = app.help_list.get_selected_index();
 
-    all_lines.push(Line::from(""));
-    all_lines.push(Line::from(Span::styled(
-        "j/k or ↑↓: navigate | Enter: activate | ESC or ?: close",
-        Style::default()
-            .fg(Color::DarkGray)
-            .add_modifier(Modifier::ITALIC),
-    )));
+    let all_lines: Vec<Line> = context
+        .bindings
+        .iter()
+        .enumerate()
+        .map(|(idx, binding)| {
+            let is_selected = selected_idx == Some(idx);
+            let config = ListItemConfig::new().selected(is_selected).focused(true);
+            let prefix = config.item_prefix();
+            let style = config.item_style();
+            Line::from(vec![
+                Span::styled(prefix.to_string(), style),
+                Span::styled(binding.key.to_string(), Style::default().fg(Color::Yellow)),
+                Span::raw(" "),
+                Span::styled(binding.description.clone(), style),
+            ])
+        })
+        .collect();
 
-    app.help_page.set_total_items(all_lines.len());
+    let adjusted_height = app.help_list.get_adjusted_viewport_height(raw_height);
+    let page_info = app.help_list.get_render_info(adjusted_height);
 
-    let page_info = app.help_page.get_page_info(raw_height);
-    let indicator_lines =
-        page_info.show_above_indicator as usize + page_info.show_below_indicator as usize;
-    let content_budget = raw_height.saturating_sub(indicator_lines);
-
-    let mut rendered_lines: Vec<Line> =
-        crate::card_list::render_scroll_indicators(
-            page_info.show_above_indicator,
-            page_info.items_above,
-            false,
-            0,
-            "entry",
-        );
+    let mut rendered_lines: Vec<Line> = crate::card_list::render_scroll_indicators(
+        page_info.show_above_indicator,
+        page_info.items_above,
+        false,
+        0,
+        "item",
+    );
     let visible: Vec<Line> = page_info
         .visible_indices
         .iter()
-        .take(content_budget)
         .filter_map(|&i| all_lines.get(i).cloned())
         .collect();
     rendered_lines.extend(visible);
@@ -1501,11 +1499,22 @@ fn render_help_popup(app: &mut App, frame: &mut Frame) {
         0,
         page_info.show_below_indicator,
         page_info.items_below,
-        "entry",
+        "item",
     ));
 
-    let content = Paragraph::new(rendered_lines);
-    frame.render_widget(content, chunks[0]);
+    frame.render_widget(Paragraph::new(rendered_lines), chunks[1]);
+
+    // Fixed footer — always visible regardless of scroll position
+    let footer = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "j/k or ↑↓: navigate | Enter: activate | ESC or ?: close",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
+        )),
+    ]);
+    frame.render_widget(footer, chunks[2]);
 }
 
 fn render_conflict_resolution_popup(_app: &App, frame: &mut Frame) {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -88,8 +88,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             AppMode::SprintDetail => render_sprint_detail_view(app, frame, frame.area()),
             _ => render_main(app, frame, frame.area()),
         }
-        let vh = render_help_popup(app, frame);
-        app.help_viewport_height = vh;
+        app.last_frame_area = frame.area();
+        render_help_popup(app, frame);
     }
 
     // Render banner on top if present
@@ -396,7 +396,7 @@ fn render_sprint_task_panel_with_selection(
         let viewport_height = area.height.saturating_sub(2) as usize;
         let render_info = task_list.get_render_info(viewport_height);
 
-        lines.extend(crate::card_list::render_above_indicator(
+        lines.extend(crate::scroll_indicators::render_above_indicator(
             render_info.show_above_indicator,
             render_info.cards_above_count,
             "Task",
@@ -423,7 +423,7 @@ fn render_sprint_task_panel_with_selection(
             }
         }
 
-        lines.extend(crate::card_list::render_below_indicator(
+        lines.extend(crate::scroll_indicators::render_below_indicator(
             render_info.show_below_indicator,
             render_info.cards_below_count,
             "Task",
@@ -1409,7 +1409,23 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
     }
 }
 
-fn render_help_popup(app: &App, frame: &mut Frame) -> usize {
+pub fn help_popup_viewport_height(frame_area: Rect) -> usize {
+    let popup = centered_rect(80, 80, frame_area);
+    let block = Block::default().borders(Borders::ALL);
+    let inner = block.inner(popup);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .horizontal_margin(2)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(0),
+            Constraint::Length(2),
+        ])
+        .split(inner);
+    chunks[1].height as usize
+}
+
+fn render_help_popup(app: &App, frame: &mut Frame) {
     use crate::components::ListItemConfig;
     use crate::keybindings::KeybindingRegistry;
 
@@ -1454,14 +1470,14 @@ fn render_help_popup(app: &App, frame: &mut Frame) -> usize {
     );
 
     // Scrollable bindings body
-    let raw_height = chunks[1].height as usize;
+    let raw_height = help_popup_viewport_height(frame.area());
 
     let selected_idx = app.help_list.get_selected_index();
 
     let adjusted_height = app.help_list.get_adjusted_viewport_height(raw_height);
     let page_info = app.help_list.get_render_info(adjusted_height);
 
-    let mut rendered_lines: Vec<Line> = crate::card_list::render_above_indicator(
+    let mut rendered_lines: Vec<Line> = crate::scroll_indicators::render_above_indicator(
         page_info.show_above_indicator,
         page_info.items_above,
         "item",
@@ -1487,7 +1503,7 @@ fn render_help_popup(app: &App, frame: &mut Frame) -> usize {
         })
         .collect();
     rendered_lines.extend(visible_lines);
-    rendered_lines.extend(crate::card_list::render_below_indicator(
+    rendered_lines.extend(crate::scroll_indicators::render_below_indicator(
         page_info.show_below_indicator,
         page_info.items_below,
         "item",
@@ -1506,7 +1522,6 @@ fn render_help_popup(app: &App, frame: &mut Frame) -> usize {
         )),
     ]);
     frame.render_widget(footer, chunks[2]);
-    raw_height
 }
 
 fn render_conflict_resolution_popup(_app: &App, frame: &mut Frame) {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1447,7 +1447,9 @@ fn render_help_popup(app: &mut App, frame: &mut Frame) {
         Paragraph::new(vec![
             Line::from(Span::styled(
                 context.name.clone(),
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
             )),
             Line::from(""),
         ]),

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -395,14 +395,13 @@ fn render_sprint_task_panel_with_selection(
         let viewport_height = area.height.saturating_sub(2) as usize;
         let render_info = task_list.get_render_info(viewport_height);
 
-        if render_info.show_above_indicator {
-            let count = render_info.cards_above_count;
-            let plural = if count == 1 { "" } else { "s" };
-            lines.push(Line::from(Span::styled(
-                format!("  {} Task{} above", count, plural),
-                Style::default().fg(Color::DarkGray),
-            )));
-        }
+        lines.extend(crate::card_list::render_scroll_indicators(
+            render_info.show_above_indicator,
+            render_info.cards_above_count,
+            false,
+            0,
+            "Task",
+        ));
 
         for card_idx in &render_info.visible_card_indices {
             if let Some(card_id) = task_list.cards.get(*card_idx) {
@@ -425,14 +424,13 @@ fn render_sprint_task_panel_with_selection(
             }
         }
 
-        if render_info.show_below_indicator {
-            let count = render_info.cards_below_count;
-            let plural = if count == 1 { "" } else { "s" };
-            lines.push(Line::from(Span::styled(
-                format!("  {} Task{} below", count, plural),
-                Style::default().fg(Color::DarkGray),
-            )));
-        }
+        lines.extend(crate::card_list::render_scroll_indicators(
+            false,
+            0,
+            render_info.show_below_indicator,
+            render_info.cards_below_count,
+            "Task",
+        ));
     }
 
     // Calculate points from cards in this panel
@@ -1414,7 +1412,7 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
     }
 }
 
-fn render_help_popup(app: &App, frame: &mut Frame) {
+fn render_help_popup(app: &mut App, frame: &mut Frame) {
     use crate::components::ListItemConfig;
     use crate::keybindings::KeybindingRegistry;
 
@@ -1435,13 +1433,16 @@ fn render_help_popup(app: &App, frame: &mut Frame) {
         .constraints([Constraint::Min(0)])
         .split(inner);
 
+    let raw_height = chunks[0].height as usize;
+    app.help_viewport_height = raw_height;
+
     // Get keybindings for the underlying mode
     let provider = KeybindingRegistry::get_provider(app);
     let context = provider.get_context();
     let selected_idx = app.help_selection.get();
 
-    // Build lines for each keybinding
-    let mut lines = vec![
+    // Build all lines: header + blank + N bindings + blank + hint
+    let mut all_lines: Vec<Line> = vec![
         Line::from(Span::styled(
             context.name.clone(),
             Style::default()
@@ -1457,7 +1458,7 @@ fn render_help_popup(app: &App, frame: &mut Frame) {
         let prefix = config.item_prefix();
         let style = config.item_style();
 
-        lines.push(Line::from(vec![
+        all_lines.push(Line::from(vec![
             Span::styled(prefix.to_string(), style),
             Span::styled(binding.key.to_string(), Style::default().fg(Color::Yellow)),
             Span::raw(" "),
@@ -1465,15 +1466,45 @@ fn render_help_popup(app: &App, frame: &mut Frame) {
         ]));
     }
 
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
+    all_lines.push(Line::from(""));
+    all_lines.push(Line::from(Span::styled(
         "j/k or ↑↓: navigate | Enter: activate | ESC or ?: close",
         Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::ITALIC),
     )));
 
-    let content = Paragraph::new(lines);
+    app.help_page.set_total_items(all_lines.len());
+
+    let page_info = app.help_page.get_page_info(raw_height);
+    let indicator_lines =
+        page_info.show_above_indicator as usize + page_info.show_below_indicator as usize;
+    let content_budget = raw_height.saturating_sub(indicator_lines);
+
+    let mut rendered_lines: Vec<Line> =
+        crate::card_list::render_scroll_indicators(
+            page_info.show_above_indicator,
+            page_info.items_above,
+            false,
+            0,
+            "entry",
+        );
+    let visible: Vec<Line> = page_info
+        .visible_indices
+        .iter()
+        .take(content_budget)
+        .filter_map(|&i| all_lines.get(i).cloned())
+        .collect();
+    rendered_lines.extend(visible);
+    rendered_lines.extend(crate::card_list::render_scroll_indicators(
+        false,
+        0,
+        page_info.show_below_indicator,
+        page_info.items_below,
+        "entry",
+    ));
+
+    let content = Paragraph::new(rendered_lines);
     frame.render_widget(content, chunks[0]);
 }
 

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1467,10 +1467,13 @@ fn render_help_popup(app: &mut App, frame: &mut Frame) {
     let adjusted_height = app.help_list.get_adjusted_viewport_height(raw_height);
     let page_info = app.help_list.get_render_info(adjusted_height);
 
-    let mut rendered_lines: Vec<Line> =
-        crate::card_list::render_above_indicator(page_info.show_above_indicator, page_info.items_above, "item")
-            .into_iter()
-            .collect();
+    let mut rendered_lines: Vec<Line> = crate::card_list::render_above_indicator(
+        page_info.show_above_indicator,
+        page_info.items_above,
+        "item",
+    )
+    .into_iter()
+    .collect();
 
     let visible_lines: Vec<Line> = page_info
         .visible_indices
@@ -1490,9 +1493,11 @@ fn render_help_popup(app: &mut App, frame: &mut Frame) {
         })
         .collect();
     rendered_lines.extend(visible_lines);
-    rendered_lines.extend(
-        crate::card_list::render_below_indicator(page_info.show_below_indicator, page_info.items_below, "item")
-    );
+    rendered_lines.extend(crate::card_list::render_below_indicator(
+        page_info.show_below_indicator,
+        page_info.items_below,
+        "item",
+    ));
 
     frame.render_widget(Paragraph::new(rendered_lines), chunks[1]);
 

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1412,6 +1412,8 @@ fn render_filter_options_popup(app: &App, frame: &mut Frame) {
     }
 }
 
+// Takes `&mut App` to write `help_viewport_height` after measuring the popup area,
+// so the event handler can use it for scroll calculations on the next keypress.
 fn render_help_popup(app: &mut App, frame: &mut Frame) {
     use crate::components::ListItemConfig;
     use crate::keybindings::KeybindingRegistry;
@@ -1462,47 +1464,35 @@ fn render_help_popup(app: &mut App, frame: &mut Frame) {
 
     let selected_idx = app.help_list.get_selected_index();
 
-    let all_lines: Vec<Line> = context
-        .bindings
+    let adjusted_height = app.help_list.get_adjusted_viewport_height(raw_height);
+    let page_info = app.help_list.get_render_info(adjusted_height);
+
+    let mut rendered_lines: Vec<Line> =
+        crate::card_list::render_above_indicator(page_info.show_above_indicator, page_info.items_above, "item")
+            .into_iter()
+            .collect();
+
+    let visible_lines: Vec<Line> = page_info
+        .visible_indices
         .iter()
-        .enumerate()
-        .map(|(idx, binding)| {
-            let is_selected = selected_idx == Some(idx);
+        .filter_map(|&i| {
+            let binding = context.bindings.get(i)?;
+            let is_selected = selected_idx == Some(i);
             let config = ListItemConfig::new().selected(is_selected).focused(true);
             let prefix = config.item_prefix();
             let style = config.item_style();
-            Line::from(vec![
+            Some(Line::from(vec![
                 Span::styled(prefix.to_string(), style),
                 Span::styled(binding.key.to_string(), Style::default().fg(Color::Yellow)),
                 Span::raw(" "),
                 Span::styled(binding.description.clone(), style),
-            ])
+            ]))
         })
         .collect();
-
-    let adjusted_height = app.help_list.get_adjusted_viewport_height(raw_height);
-    let page_info = app.help_list.get_render_info(adjusted_height);
-
-    let mut rendered_lines: Vec<Line> = crate::card_list::render_scroll_indicators(
-        page_info.show_above_indicator,
-        page_info.items_above,
-        false,
-        0,
-        "item",
+    rendered_lines.extend(visible_lines);
+    rendered_lines.extend(
+        crate::card_list::render_below_indicator(page_info.show_below_indicator, page_info.items_below, "item")
     );
-    let visible: Vec<Line> = page_info
-        .visible_indices
-        .iter()
-        .filter_map(|&i| all_lines.get(i).cloned())
-        .collect();
-    rendered_lines.extend(visible);
-    rendered_lines.extend(crate::card_list::render_scroll_indicators(
-        false,
-        0,
-        page_info.show_below_indicator,
-        page_info.items_below,
-        "item",
-    ));
 
     frame.render_widget(Paragraph::new(rendered_lines), chunks[1]);
 


### PR DESCRIPTION
**What:** Add scrollable help menu — keybindings no longer cut off when the terminal is small.

**Why:** The help popup rendered all keybindings in a single `Paragraph` with no scroll support. Items beyond the visible area were silently clipped.

**How:**
- Replaced bare `Page + SelectionState` with `ListComponent` (same scroll component used by card lists)
- Fixed layout: `[Length(2), Min(0), Length(2)]` — pinned context header, scrollable bindings body, pinned footer hint
- Navigation (j/k) uses the two-step `ensure_selected_visible` pattern from `navigation_handlers.rs`
- `Page::get_adjusted_viewport_height` extracted to `kanban-core` so both `ListComponent` and the help popup share indicator-aware viewport logic
- Scroll indicators via shared `render_scroll_indicators` helper with label `"item"` (fixes "entrys" pluralisation bug)

**Testing:** Resize terminal to < 15 lines, open `?` help, navigate with j/k — selection stays visible and indicators appear/disappear correctly.