### PR TITLE
KAN-123/escape-bind-to-clear-search-enter-to-apply

### DIFF
--- a/.changeset/kan-123-escape-bind-to-clear-search-enter-to-apply.md
+++ b/.changeset/kan-123-escape-bind-to-clear-search-enter-to-apply.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+- fix: remove trailing spaces from active search footer text
+- KAN-123: update search mode keybinding descriptions
+- KAN-123: show active search filter indicator in footer
+- KAN-123: highlight search matches in card titles
+- KAN-123: split Enter/Esc in search mode and add n/N navigation

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -564,9 +564,19 @@ impl App {
                 }
                 KeyCode::Char('n') => {
                     self.pending_key = None;
-                    match self.focus {
-                        Focus::Boards => self.handle_create_board_key(),
-                        Focus::Cards => self.handle_create_card_key(),
+                    if self.search.is_active {
+                        self.handle_navigation_down();
+                    } else {
+                        match self.focus {
+                            Focus::Boards => self.handle_create_board_key(),
+                            Focus::Cards => self.handle_create_card_key(),
+                        }
+                    }
+                }
+                KeyCode::Char('N') => {
+                    self.pending_key = None;
+                    if self.search.is_active {
+                        self.handle_navigation_up();
                     }
                 }
                 KeyCode::Char('r') => {
@@ -800,9 +810,14 @@ impl App {
                 self.search.input.backspace();
                 self.refresh_view();
             }
-            KeyCode::Esc | KeyCode::Enter => {
+            KeyCode::Enter => {
+                self.mode = AppMode::Normal;
+                self.refresh_view();
+            }
+            KeyCode::Esc => {
                 self.search.deactivate();
                 self.mode = AppMode::Normal;
+                self.refresh_view();
             }
             _ => {}
         }

--- a/crates/kanban-tui/src/components/card_list_item.rs
+++ b/crates/kanban-tui/src/components/card_list_item.rs
@@ -15,6 +15,7 @@ pub struct CardListItemConfig<'a> {
     pub is_multi_selected: bool,
     pub show_sprint_name: bool,
     pub animation_type: Option<AnimationType>,
+    pub search_query: Option<&'a str>,
 }
 
 pub fn render_card_list_item(config: CardListItemConfig) -> Line<'static> {
@@ -98,13 +99,15 @@ pub fn render_card_list_item(config: CardListItemConfig) -> Line<'static> {
         .map(|p| p.to_string())
         .unwrap_or_else(|| " ".to_string());
 
+    let title_spans = build_title_spans(&config.card.title, title_style, config.search_query);
+
     let mut spans = vec![
         Span::styled("● ", priority_style_val),
         Span::styled(points_text, points_style),
         Span::raw(" "),
         Span::styled(format!("{}{} ", select_indicator, checkbox), base_style),
-        Span::styled(config.card.title.clone(), title_style),
     ];
+    spans.extend(title_spans);
 
     if !suffix_text.is_empty() {
         let mut suffix_style = label_text();
@@ -115,4 +118,30 @@ pub fn render_card_list_item(config: CardListItemConfig) -> Line<'static> {
     }
 
     Line::from(spans)
+}
+
+fn build_title_spans(title: &str, base_style: Style, query: Option<&str>) -> Vec<Span<'static>> {
+    let Some(q) = query.filter(|q| !q.is_empty()) else {
+        return vec![Span::styled(title.to_owned(), base_style)];
+    };
+
+    let title_lower = title.to_lowercase();
+    let query_lower = q.to_lowercase();
+    let highlight_style = base_style.fg(HIGHLIGHT_TEXT).add_modifier(Modifier::BOLD);
+
+    let mut spans = Vec::new();
+    let mut pos = 0;
+    while let Some(idx) = title_lower[pos..].find(&query_lower) {
+        let abs = pos + idx;
+        if abs > pos {
+            spans.push(Span::styled(title[pos..abs].to_owned(), base_style));
+        }
+        let end = abs + q.len();
+        spans.push(Span::styled(title[abs..end].to_owned(), highlight_style));
+        pos = end;
+    }
+    if pos < title.len() {
+        spans.push(Span::styled(title[pos..].to_owned(), base_style));
+    }
+    spans
 }

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -496,6 +496,12 @@ impl App {
     }
 
     pub fn handle_escape_key(&mut self) {
+        if self.search.is_active {
+            self.search.deactivate();
+            self.refresh_view();
+            return;
+        }
+
         // Clear selection mode first (only when actively in selection mode)
         if self.selection_mode_active {
             self.selection_mode_active = false;

--- a/crates/kanban-tui/src/keybindings/dialog_modes.rs
+++ b/crates/kanban-tui/src/keybindings/dialog_modes.rs
@@ -7,11 +7,16 @@ impl KeybindingProvider for SearchModeProvider {
         KeybindingContext::new(
             "Search Mode",
             vec![
-                Keybinding::new("ESC", "exit", "Exit search mode", KeybindingAction::Escape),
+                Keybinding::new(
+                    "ESC",
+                    "clear",
+                    "Clear search and return",
+                    KeybindingAction::Escape,
+                ),
                 Keybinding::new(
                     "Enter",
-                    "confirm",
-                    "Confirm search and filter",
+                    "apply",
+                    "Apply filter and browse results",
                     KeybindingAction::SelectItem,
                 ),
                 Keybinding::new(
@@ -19,6 +24,12 @@ impl KeybindingProvider for SearchModeProvider {
                     "query",
                     "Enter search query",
                     KeybindingAction::Search,
+                ),
+                Keybinding::new(
+                    "n/N",
+                    "navigate",
+                    "Next/previous hit (after applying)",
+                    KeybindingAction::NavigateDown,
                 ),
             ],
         )

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -189,6 +189,11 @@ impl RenderStrategy for SinglePanelRenderer {
                                                 .contains(&card.id),
                                             show_sprint_name: app.active_sprint_filters.is_empty(),
                                             animation_type,
+                                            search_query: if app.search.is_active {
+                                                Some(app.search.query())
+                                            } else {
+                                                None
+                                            },
                                         });
                                         lines.push(line);
                                     }
@@ -272,6 +277,11 @@ impl RenderStrategy for SinglePanelRenderer {
                                         is_multi_selected: app.selected_cards.contains(&card.id),
                                         show_sprint_name: app.active_sprint_filters.is_empty(),
                                         animation_type,
+                                        search_query: if app.search.is_active {
+                                            Some(app.search.query())
+                                        } else {
+                                            None
+                                        },
                                     });
                                     lines.push(line);
                                 }
@@ -408,6 +418,11 @@ impl RenderStrategy for MultiPanelRenderer {
                                         is_multi_selected: app.selected_cards.contains(&card.id),
                                         show_sprint_name: app.active_sprint_filters.is_empty(),
                                         animation_type,
+                                        search_query: if app.search.is_active {
+                                            Some(app.search.query())
+                                        } else {
+                                            None
+                                        },
                                     });
                                     lines.push(line);
                                 }

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -474,7 +474,7 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
         };
 
     if app.search.is_active && app.mode != AppMode::Search {
-        let search_text = format!("/{}   ", app.search.query());
+        let search_text = format!("/{}", app.search.query());
         let help_text = "ESC: clear search";
 
         let available_width = area.width.saturating_sub(4);

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -417,6 +417,7 @@ fn render_sprint_task_panel_with_selection(
                         is_multi_selected: false,
                         show_sprint_name: false,
                         animation_type,
+                        search_query: None,
                     });
                     lines.push(line);
                 }
@@ -472,9 +473,39 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
             false
         };
 
+    if app.search.is_active && app.mode != AppMode::Search {
+        let search_text = format!("/{}   ", app.search.query());
+        let help_text = "ESC: clear search";
+
+        let available_width = area.width.saturating_sub(4);
+        let help_len = help_text.len() as u16;
+        let search_len = search_text.len() as u16;
+
+        let padding = if available_width > search_len + help_len + 1 {
+            available_width
+                .saturating_sub(search_len)
+                .saturating_sub(help_len)
+        } else {
+            1
+        };
+
+        let footer_line = Line::from(vec![
+            Span::styled(search_text, Style::default().fg(Color::Yellow)),
+            Span::styled(
+                format!("{:width$}", "", width = padding as usize),
+                label_text(),
+            ),
+            Span::styled(help_text, label_text()),
+        ]);
+
+        let help = Paragraph::new(footer_line).block(Block::default().borders(Borders::ALL));
+        frame.render_widget(help, area);
+        return;
+    }
+
     if app.mode == AppMode::Search {
         let search_text = format!("/{}", app.search.query());
-        let help_text = "ESC/ENTER: exit search";
+        let help_text = "ESC: clear | Enter: apply";
 
         let available_width = area.width.saturating_sub(4);
         let help_len = help_text.len() as u16;


### PR DESCRIPTION
Fixes search mode key bindings and adds search result navigation/highlighting.

**What:**
- Enter applies the search filter and returns to normal mode (filter stays active)
- Escape clears the active search filter (both from search input mode and normal mode)
- n/N navigate down/up through filtered results when search is active
- Search query matches highlighted yellow+bold in card titles
- Footer shows active filter indicator (`/query   ESC: clear search`) when search is applied but not in input mode

**Why:**
Previously both Escape and Enter called `search.deactivate()`, which cleared the filter — so any subsequent view refresh (completing a card, moving, etc.) would remove the filter unexpectedly. Escape in normal mode also exited the board instead of clearing the search.

**How:**
- Split `Esc | Enter` arm in `handle_search_mode` into two separate handlers
- Added early return in `handle_escape_key` to clear search before board-exit logic
- Made `n`/`N` context-sensitive in normal mode: navigate hits when search active, otherwise create new card/board
- Added `search_query: Option<&str>` to `CardListItemConfig` with a `build_title_spans` helper for highlighted rendering
- Added active-filter footer block in `ui.rs`

**Testing:**
- Press `/`, type query → live filter works
- Press Enter → exits input mode, filter stays active, cards remain filtered
- Press n/N → navigates down/up through filtered results
- Matches highlighted yellow+bold in card titles
- Press Esc → clears filter, all cards visible
- Footer shows active filter indicator when search is applied but not in input mode