### PR TITLE
KAN-222/fix-post-search-ux-issues-gg-scroll-unicode-panic-footer-hint-n-n-nav

### DIFF
--- a/.changeset/kan-222-fix-post-search-ux-issues-gg-scroll-unicode-panic-footer-hint-n-n-nav.md
+++ b/.changeset/kan-222-fix-post-search-ux-issues-gg-scroll-unicode-panic-footer-hint-n-n-nav.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+- fix: remove n/N search-navigation shortcuts — n is for new card only
+- fix: drop n/N from active-search footer hint — redundant with j/k when results are filtered
+- fix: active-search footer shows navigation hint alongside ESC
+- refactor: add SearchState::active_query() and collapse repeated search_query expressions
+- fix: Unicode panic in build_title_spans — map lowercase byte offsets back to original
+- fix: gg jumps to top but doesn't scroll view — call ensure_selected_visible

--- a/crates/kanban-tui/src/app.rs
+++ b/crates/kanban-tui/src/app.rs
@@ -564,19 +564,9 @@ impl App {
                 }
                 KeyCode::Char('n') => {
                     self.pending_key = None;
-                    if self.search.is_active {
-                        self.handle_navigation_down();
-                    } else {
-                        match self.focus {
-                            Focus::Boards => self.handle_create_board_key(),
-                            Focus::Cards => self.handle_create_card_key(),
-                        }
-                    }
-                }
-                KeyCode::Char('N') => {
-                    self.pending_key = None;
-                    if self.search.is_active {
-                        self.handle_navigation_up();
+                    match self.focus {
+                        Focus::Boards => self.handle_create_board_key(),
+                        Focus::Cards => self.handle_create_card_key(),
                     }
                 }
                 KeyCode::Char('r') => {

--- a/crates/kanban-tui/src/components/card_list_item.rs
+++ b/crates/kanban-tui/src/components/card_list_item.rs
@@ -129,19 +129,42 @@ fn build_title_spans(title: &str, base_style: Style, query: Option<&str>) -> Vec
     let query_lower = q.to_lowercase();
     let highlight_style = base_style.fg(HIGHLIGHT_TEXT).add_modifier(Modifier::BOLD);
 
+    // Map byte offset in title_lower → byte offset in title.
+    // to_lowercase() can expand chars (e.g. İ → "i\u{307}"), so offsets
+    // into title_lower are not valid offsets into title without this map.
+    let lower_to_orig: Vec<usize> = {
+        let mut map = vec![0usize; title_lower.len() + 1];
+        let mut lower_pos = 0usize;
+        for (orig_byte, orig_char) in title.char_indices() {
+            for lc in orig_char.to_lowercase() {
+                let lc_len = lc.len_utf8();
+                for i in 0..lc_len {
+                    map[lower_pos + i] = orig_byte;
+                }
+                lower_pos += lc_len;
+            }
+        }
+        map[lower_pos] = title.len();
+        map
+    };
+
     let mut spans = Vec::new();
-    let mut pos = 0;
+    let mut pos = 0usize; // byte cursor in title_lower
     while let Some(idx) = title_lower[pos..].find(&query_lower) {
         let abs = pos + idx;
-        if abs > pos {
-            spans.push(Span::styled(title[pos..abs].to_owned(), base_style));
+        let end = abs + query_lower.len();
+        let orig_pos = lower_to_orig[pos];
+        let orig_abs = lower_to_orig[abs];
+        let orig_end = lower_to_orig[end];
+
+        if orig_abs > orig_pos {
+            spans.push(Span::styled(title[orig_pos..orig_abs].to_owned(), base_style));
         }
-        let end = abs + q.len();
-        spans.push(Span::styled(title[abs..end].to_owned(), highlight_style));
+        spans.push(Span::styled(title[orig_abs..orig_end].to_owned(), highlight_style));
         pos = end;
     }
-    if pos < title.len() {
-        spans.push(Span::styled(title[pos..].to_owned(), base_style));
+    if pos < title_lower.len() {
+        spans.push(Span::styled(title[lower_to_orig[pos]..].to_owned(), base_style));
     }
     spans
 }

--- a/crates/kanban-tui/src/components/card_list_item.rs
+++ b/crates/kanban-tui/src/components/card_list_item.rs
@@ -158,13 +158,22 @@ fn build_title_spans(title: &str, base_style: Style, query: Option<&str>) -> Vec
         let orig_end = lower_to_orig[end];
 
         if orig_abs > orig_pos {
-            spans.push(Span::styled(title[orig_pos..orig_abs].to_owned(), base_style));
+            spans.push(Span::styled(
+                title[orig_pos..orig_abs].to_owned(),
+                base_style,
+            ));
         }
-        spans.push(Span::styled(title[orig_abs..orig_end].to_owned(), highlight_style));
+        spans.push(Span::styled(
+            title[orig_abs..orig_end].to_owned(),
+            highlight_style,
+        ));
         pos = end;
     }
     if pos < title_lower.len() {
-        spans.push(Span::styled(title[lower_to_orig[pos]..].to_owned(), base_style));
+        spans.push(Span::styled(
+            title[lower_to_orig[pos]..].to_owned(),
+            base_style,
+        ));
     }
     spans
 }

--- a/crates/kanban-tui/src/components/card_list_item.rs
+++ b/crates/kanban-tui/src/components/card_list_item.rs
@@ -177,3 +177,103 @@ fn build_title_spans(title: &str, base_style: Style, query: Option<&str>) -> Vec
     }
     spans
 }
+
+#[cfg(test)]
+mod tests {
+    use super::build_title_spans;
+    use crate::theme::HIGHLIGHT_TEXT;
+    use ratatui::style::{Modifier, Style};
+
+    fn highlight_style(base: Style) -> Style {
+        base.fg(HIGHLIGHT_TEXT).add_modifier(Modifier::BOLD)
+    }
+
+    #[test]
+    fn no_query() {
+        let base = Style::default();
+        let spans = build_title_spans("Hello", base, None);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, "Hello");
+        assert_eq!(spans[0].style, base);
+    }
+
+    #[test]
+    fn empty_query() {
+        let base = Style::default();
+        let spans = build_title_spans("Hello", base, Some(""));
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, "Hello");
+        assert_eq!(spans[0].style, base);
+    }
+
+    #[test]
+    fn no_match() {
+        let base = Style::default();
+        let spans = build_title_spans("Hello world", base, Some("xyz"));
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, "Hello world");
+        assert_eq!(spans[0].style, base);
+    }
+
+    #[test]
+    fn ascii_match_middle() {
+        let base = Style::default();
+        let spans = build_title_spans("Hello world", base, Some("lo"));
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[0].content, "Hel");
+        assert_eq!(spans[0].style, base);
+        assert_eq!(spans[1].content, "lo");
+        assert_eq!(spans[1].style, highlight_style(base));
+        assert_eq!(spans[2].content, " world");
+        assert_eq!(spans[2].style, base);
+    }
+
+    #[test]
+    fn ascii_match_at_start() {
+        let base = Style::default();
+        let spans = build_title_spans("rust is great", base, Some("rust"));
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].content, "rust");
+        assert_eq!(spans[0].style, highlight_style(base));
+        assert_eq!(spans[1].content, " is great");
+        assert_eq!(spans[1].style, base);
+    }
+
+    #[test]
+    fn ascii_match_at_end() {
+        let base = Style::default();
+        let spans = build_title_spans("Hello world", base, Some("world"));
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].content, "Hello ");
+        assert_eq!(spans[0].style, base);
+        assert_eq!(spans[1].content, "world");
+        assert_eq!(spans[1].style, highlight_style(base));
+    }
+
+    #[test]
+    fn unicode_expanding_lowercase() {
+        // İ (U+0130, LATIN CAPITAL LETTER I WITH DOT ABOVE) lowercases to "i\u{307}" (3 bytes
+        // for 2 code points) while the original char is 2 bytes.  Naive byte-offset arithmetic
+        // would panic; the lower_to_orig map keeps offsets safe.
+        //
+        // Semantically, "i" matches the 'i' sub-byte of İ but can't split the original char,
+        // so the highlighted slice is empty and the full title appears in a trailing span.
+        // The critical invariant is: no panic and the spans reconstruct the original string.
+        let base = Style::default();
+        let spans = build_title_spans("İstanbul", base, Some("i"));
+        assert!(!spans.is_empty());
+        let reconstructed: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(reconstructed, "İstanbul");
+    }
+
+    #[test]
+    fn unicode_no_expansion_match() {
+        let base = Style::default();
+        let spans = build_title_spans("über", base, Some("ü"));
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].content, "ü");
+        assert_eq!(spans[0].style, highlight_style(base));
+        assert_eq!(spans[1].content, "ber");
+        assert_eq!(spans[1].style, base);
+    }
+}

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -582,8 +582,10 @@ impl App {
                 self.switch_view_strategy(TaskListView::GroupedByColumn);
             }
             Focus::Cards => {
+                let adjusted_viewport = self.get_adjusted_viewport_height();
                 if let Some(list) = self.view_strategy.get_active_task_list_mut() {
                     list.jump_to_top();
+                    list.ensure_selected_visible(adjusted_viewport);
                 }
             }
         }

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -189,11 +189,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                                 .contains(&card.id),
                                             show_sprint_name: app.active_sprint_filters.is_empty(),
                                             animation_type,
-                                            search_query: if app.search.is_active {
-                                                Some(app.search.query())
-                                            } else {
-                                                None
-                                            },
+                                            search_query: app.search.active_query(),
                                         });
                                         lines.push(line);
                                     }
@@ -277,11 +273,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                         is_multi_selected: app.selected_cards.contains(&card.id),
                                         show_sprint_name: app.active_sprint_filters.is_empty(),
                                         animation_type,
-                                        search_query: if app.search.is_active {
-                                            Some(app.search.query())
-                                        } else {
-                                            None
-                                        },
+                                        search_query: app.search.active_query(),
                                     });
                                     lines.push(line);
                                 }
@@ -418,11 +410,7 @@ impl RenderStrategy for MultiPanelRenderer {
                                         is_multi_selected: app.selected_cards.contains(&card.id),
                                         show_sprint_name: app.active_sprint_filters.is_empty(),
                                         animation_type,
-                                        search_query: if app.search.is_active {
-                                            Some(app.search.query())
-                                        } else {
-                                            None
-                                        },
+                                        search_query: app.search.active_query(),
                                     });
                                     lines.push(line);
                                 }

--- a/crates/kanban-tui/src/search.rs
+++ b/crates/kanban-tui/src/search.rs
@@ -36,7 +36,11 @@ impl SearchState {
     }
 
     pub fn active_query(&self) -> Option<&str> {
-        if self.is_active { Some(self.query()) } else { None }
+        if self.is_active {
+            Some(self.query())
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/kanban-tui/src/search.rs
+++ b/crates/kanban-tui/src/search.rs
@@ -34,6 +34,10 @@ impl SearchState {
     pub fn is_empty(&self) -> bool {
         self.input.as_str().is_empty()
     }
+
+    pub fn active_query(&self) -> Option<&str> {
+        if self.is_active { Some(self.query()) } else { None }
+    }
 }
 
 impl Default for SearchState {

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -475,7 +475,7 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
 
     if app.search.is_active && app.mode != AppMode::Search {
         let search_text = format!("/{}", app.search.query());
-        let help_text = "j/k/n/N: navigate | ESC: clear";
+        let help_text = "j/k: navigate | ESC: clear";
 
         let available_width = area.width.saturating_sub(4);
         let help_len = help_text.len() as u16;

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -475,7 +475,7 @@ fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
 
     if app.search.is_active && app.mode != AppMode::Search {
         let search_text = format!("/{}", app.search.query());
-        let help_text = "ESC: clear search";
+        let help_text = "j/k/n/N: navigate | ESC: clear";
 
         let available_width = area.width.saturating_sub(4);
         let help_len = help_text.len() as u16;


### PR DESCRIPTION
Fix post-search UX issues from KAN-123

**What:**
- `gg` now scrolls the view to top (was missing `ensure_selected_visible` call, unlike `G`)
- Fix Unicode panic risk in `build_title_spans` — `to_lowercase()` can expand chars (e.g. Turkish İ → `i\u{307}`), causing byte offsets into `title_lower` to diverge from `title`; now mapped back correctly
- Add `SearchState::active_query()` to collapse 3 identical `search_query: if app.search.is_active { ... }` blocks in `render_strategy.rs`
- Active-search footer updated from `ESC: clear search` to `j/k: navigate | ESC: clear`
- Remove `n`/`N` search-navigation shortcuts — all results already filtered so redundant with `j`/`k`; `n` now always creates a new card

**Why:**
Post-merge cleanup of KAN-123 search improvements.

**Testing:**
- `cargo test --package kanban-tui` — all 76 tests pass
- Manual: search for a term, scroll down, press `gg` → view snaps to top
- Manual: `n` during active search opens new card dialog