### PR TITLE
KAN-229/fix-publish-crates-order-add-kanban-service-before-kanban-mcp

### DIFF
--- a/.changeset/kan-229-fix-publish-crates-order-add-kanban-service-before-kanban-mcp.md
+++ b/.changeset/kan-229-fix-publish-crates-order-add-kanban-service-before-kanban-mcp.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- fix(ci): add kanban-service to publish script and order mcp as last

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -4,16 +4,18 @@ set -uo pipefail
 # Crates must be published in dependency order:
 # - kanban-core: no internal deps
 # - kanban-domain: depends on kanban-core
-# - kanban-mcp: depends on kanban-core, kanban-domain
 # - kanban-persistence: depends on kanban-core, kanban-domain
+# - kanban-service: depends on kanban-core, kanban-domain, kanban-persistence
 # - kanban-tui: depends on kanban-core, kanban-domain, kanban-persistence
+# - kanban-mcp: depends on kanban-core, kanban-domain, kanban-persistence, kanban-service
 # - kanban-cli: depends on all above
 CRATES=(
   "crates/kanban-core"
   "crates/kanban-domain"
-  "crates/kanban-mcp"
   "crates/kanban-persistence"
+  "crates/kanban-service"
   "crates/kanban-tui"
+  "crates/kanban-mcp"
   "crates/kanban-cli"
 )
 


### PR DESCRIPTION
Fix crate publish order in `scripts/publish-crates.sh`:

- Add `kanban-service` to the publish list (it was missing entirely)
- Move `kanban-mcp` after `kanban-service` (mcp depends on service)

**What**: `publish-crates.sh` was missing `kanban-service` from the publish list, and `kanban-mcp` was ordered before it despite depending on it. This caused the release to fail when crates.io couldn't resolve `kanban-service` as a dependency of `kanban-mcp`.

**Why**: The release job failed at the `kanban-mcp` publish step with `no matching package named kanban-service found` because `kanban-service` had never been published.

**How**: Added `crates/kanban-service` to the `CRATES` array and reordered entries to match the true dependency graph: `kanban-service` before `kanban-tui` and `kanban-mcp`.

**Testing**: Verified dependency order against each crate's `Cargo.toml`. Fix will be confirmed by re-running the release job.