### PR TITLE
release 0.3.5

### DIFF
--- a/.changeset/kan-229-fix-publish-crates-order-add-kanban-service-before-kanban-mcp.md
+++ b/.changeset/kan-229-fix-publish-crates-order-add-kanban-service-before-kanban-mcp.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- fix(ci): add kanban-service to publish script and order mcp as last

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -4,16 +4,18 @@ set -uo pipefail
 # Crates must be published in dependency order:
 # - kanban-core: no internal deps
 # - kanban-domain: depends on kanban-core
-# - kanban-mcp: depends on kanban-core, kanban-domain
 # - kanban-persistence: depends on kanban-core, kanban-domain
+# - kanban-service: depends on kanban-core, kanban-domain, kanban-persistence
 # - kanban-tui: depends on kanban-core, kanban-domain, kanban-persistence
+# - kanban-mcp: depends on kanban-core, kanban-domain, kanban-persistence, kanban-service
 # - kanban-cli: depends on all above
 CRATES=(
   "crates/kanban-core"
   "crates/kanban-domain"
-  "crates/kanban-mcp"
   "crates/kanban-persistence"
+  "crates/kanban-service"
   "crates/kanban-tui"
+  "crates/kanban-mcp"
   "crates/kanban-cli"
 )
 


### PR DESCRIPTION
Release v0.3.5 — patch release fixing the crates.io publish pipeline.

- Cherry-pick fix for broken `publish-crates.sh` from KAN-229 (#192)

**What**: Merges the hotfix that corrects crate publish ordering into master to re-trigger the release.

**Why**: The v0.3.4 release job failed because `kanban-service` was missing from `publish-crates.sh` and `kanban-mcp` was ordered before it in the publish list. crates.io rejected `kanban-mcp` with `no matching package named kanban-service found`.

**How**: Cherry-picked the fix from #192 which adds `kanban-service` to the publish list and moves `kanban-mcp` after it to match the actual dependency graph.

**Testing**: Validated by re-running the release workflow after merge.