### PR TITLE
Kan 230/submit kanban to aur

### DIFF
--- a/.changeset/kan-230-submit-kanban-to-aur.md
+++ b/.changeset/kan-230-submit-kanban-to-aur.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- ci: add AUR auto-publish workflow on release
+- docs: add AUR installation instructions

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -13,14 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update PKGBUILD version
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" ./aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" ./aur/PKGBUILD
+
       - name: Deploy to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1
         with:
           pkgname: kanban
-          pkgver: ${{ github.event.release.tag_name }}
-          pkgbuild-path: ./aur/PKGBUILD
+          pkgbuild: ./aur/PKGBUILD
           commit-username: github-actions[bot]
-          commit-email: github-actions[bot]@users.noreply.github.com
+          commit-email: 41898282+github-actions[bot]@users.noreply.github.com
           commit-message: "Update to ${{ github.event.release.tag_name }}"
           ssh-private-key: ${{ secrets.AUR_SSH_KEY }}
           updpkgsums: true

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,27 @@
+name: Publish to AUR
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  aur-publish:
+    name: Update AUR package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.repository == 'fulsomenko/kanban'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        with:
+          pkgname: kanban
+          pkgver: ${{ github.event.release.tag_name }}
+          pkgbuild-path: ./aur/PKGBUILD
+          commit-username: github-actions[bot]
+          commit-email: github-actions[bot]@users.noreply.github.com
+          commit-message: "Update to ${{ github.event.release.tag_name }}"
+          ssh-private-key: ${{ secrets.AUR_SSH_KEY }}
+          updpkgsums: true
+          allow-empty-commits: false

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -10,15 +10,36 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.repository == 'fulsomenko/kanban'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update PKGBUILD version
+      - name: Update PKGBUILD version and sha256
         run: |
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
+          URL="https://github.com/fulsomenko/kanban/archive/v${VERSION}.tar.gz"
+          SHA256=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" ./aur/PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" ./aur/PKGBUILD
+          sed -i "s/sha256sums=.*/sha256sums=(\"${SHA256}\")/" ./aur/PKGBUILD
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Generate .SRCINFO
+        run: nix shell nixpkgs#pacman -c sh -c "cd aur && makepkg --printsrcinfo > .SRCINFO"
+
+      - name: Commit updated AUR files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add aur/PKGBUILD aur/.SRCINFO
+          git diff --cached --quiet || git commit -m "chore: update AUR package to ${{ github.event.release.tag_name }}"
+          git push
 
       - name: Deploy to AUR
         uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1
@@ -29,5 +50,5 @@ jobs:
           commit-email: 41898282+github-actions[bot]@users.noreply.github.com
           commit-message: "Update to ${{ github.event.release.tag_name }}"
           ssh-private-key: ${{ secrets.AUR_SSH_KEY }}
-          updpkgsums: true
+          updpkgsums: false
           allow-empty-commits: false

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ cargo install --path crates/kanban-cli
 nix run github:fulsomenko/kanban
 ```
 
+### Arch Linux (AUR)
+```bash
+yay -S kanban
+```
+
 ### Linux Clipboard Support
 
 For clipboard operations (`y`/`Y` to copy branch names) to persist after exiting, you need a clipboard manager running:

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,0 +1,14 @@
+pkgbase = kanban
+	pkgdesc = Terminal-based kanban board with MCP server integration
+	pkgver = 0.3.5
+	pkgrel = 1
+	url = https://github.com/fulsomenko/kanban
+	arch = x86_64
+	arch = aarch64
+	license = Apache-2.0
+	makedepends = rust
+	makedepends = cargo
+	source = kanban-0.3.5.tar.gz::https://github.com/fulsomenko/kanban/archive/v0.3.5.tar.gz
+	sha256sums = bee0a6d589665101fbc7d68c448230dd18be8f0f0887ae91f88718f2dcc94041
+
+pkgname = kanban

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -10,9 +10,19 @@ makedepends=("rust" "cargo")
 source=("$pkgname-$pkgver.tar.gz::https://github.com/fulsomenko/kanban/archive/v$pkgver.tar.gz")
 sha256sums=("bee0a6d589665101fbc7d68c448230dd18be8f0f0887ae91f88718f2dcc94041")
 
+prepare() {
+    cd "$pkgname-$pkgver"
+    cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
 build() {
     cd "$pkgname-$pkgver"
     cargo build --release --locked --bin kanban --bin kanban-mcp
+}
+
+check() {
+    cd "$pkgname-$pkgver"
+    cargo test --release --locked
 }
 
 package() {

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Max Emil Yoon Blomstervall <max.blomstervall@gmail.com>
 pkgname=kanban
-pkgver=0.0.0
+pkgver=0.3.5
 pkgrel=1
 pkgdesc="Terminal-based kanban board with MCP server integration"
-arch=("x86_64")
+arch=("x86_64" "aarch64")
 url="https://github.com/fulsomenko/kanban"
 license=("Apache-2.0")
 makedepends=("rust" "cargo")
 source=("$pkgname-$pkgver.tar.gz::https://github.com/fulsomenko/kanban/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=("bee0a6d589665101fbc7d68c448230dd18be8f0f0887ae91f88718f2dcc94041")
 
 build() {
     cd "$pkgname-$pkgver"

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: Max Emil Yoon Blomstervall <max.blomstervall@gmail.com>
+pkgname=kanban
+pkgver=0.0.0
+pkgrel=1
+pkgdesc="Terminal-based kanban board with MCP server integration"
+arch=("x86_64")
+url="https://github.com/fulsomenko/kanban"
+license=("Apache-2.0")
+makedepends=("rust" "cargo")
+source=("$pkgname-$pkgver.tar.gz::https://github.com/fulsomenko/kanban/archive/v$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+    cd "$pkgname-$pkgver"
+    cargo build --release --locked --bin kanban --bin kanban-mcp
+}
+
+package() {
+    cd "$pkgname-$pkgver"
+    install -Dm755 "target/release/kanban" "$pkgdir/usr/bin/kanban"
+    install -Dm755 "target/release/kanban-mcp" "$pkgdir/usr/bin/kanban-mcp"
+    install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,11 @@
         </div>
 
         <div class="install-method">
+          <h3>Arch Linux (AUR)</h3>
+          <pre><code class="code-block nohighlight"><span class="prompt">$</span> yay -S kanban</code></pre>
+        </div>
+
+        <div class="install-method">
           <h3>From Source</h3>
           <pre><code class="code-block nohighlight"><span class="prompt">$</span> git clone https://github.com/fulsomenko/kanban
 <span class="prompt">$</span> cd kanban


### PR DESCRIPTION
Adds automated AUR publishing on release and documents the AUR installation method.

## Changes

- **`.github/workflows/aur-publish.yml`** — new workflow that triggers on published releases, updates `PKGBUILD` and `.SRCINFO` with the new version and SHA256, then pushes to the AUR repo via SSH
- **`aur/PKGBUILD`** — new PKGBUILD with `prepare()` (offline dep fetch), `build()`, `check()` (test suite), and `package()` functions
- **`aur/.SRCINFO`** — generated SRCINFO for v0.3.5
- **`README.md`** — adds `yay -S kanban` under a new Arch Linux (AUR) install section
- **`web/index.html`** — adds the same AUR install method to the web install page

## Setup required

The `AUR_SSH_KEY` secret must be added to the repository for the workflow to authenticate with the AUR.