### PR TITLE
Kan 210/carry over cards from ended sprint

### DIFF
--- a/.changeset/kan-210-carry-over-cards-from-ended-sprint.md
+++ b/.changeset/kan-210-carry-over-cards-from-ended-sprint.md
@@ -1,0 +1,16 @@
+---
+bump: patch
+---
+
+- feat: rebind carry-over from R to M, always moves all uncompleted cards
+- test: verify carry_over_sprint_cards skips Done cards
+- feat: add R carry-over keybinding to sprint detail help
+- feat: add R carry-over and bulk c/d actions in sprint detail view
+- feat: add carry-over sprint popup navigation and confirm handler
+- feat: trigger carry-over dialog on sprint completion with uncompleted cards
+- feat: add CarryOverSprintDialog render component
+- feat: add CarryOverSprint dialog mode and state
+- feat: add carry_over_sprint_cards MCP tool
+- feat: add sprint carry-over CLI subcommand
+- feat: implement carry_over_sprint_cards on KanbanContext
+- feat: add carry_over_sprint_cards to KanbanOperations trait

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -359,6 +359,15 @@ pub enum SprintAction {
         /// Sprint ID
         id: Uuid,
     },
+    /// Carry over uncompleted cards from a completed sprint to a planning sprint
+    CarryOver {
+        /// ID of the completed sprint to carry cards from
+        #[arg(long)]
+        from: Uuid,
+        /// ID of the planning sprint to carry cards to
+        #[arg(long)]
+        to: Uuid,
+    },
 }
 
 #[derive(Args)]

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -178,7 +178,8 @@ impl KanbanOperations for CliContext {
         from_sprint_id: Uuid,
         to_sprint_id: Uuid,
     ) -> KanbanResult<usize> {
-        self.inner.carry_over_sprint_cards(from_sprint_id, to_sprint_id)
+        self.inner
+            .carry_over_sprint_cards(from_sprint_id, to_sprint_id)
     }
 
     fn create_sprint(

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -173,6 +173,14 @@ impl KanbanOperations for CliContext {
         self.inner.bulk_assign_sprint(ids, sprint_id)
     }
 
+    fn carry_over_sprint_cards(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<usize> {
+        self.inner.carry_over_sprint_cards(from_sprint_id, to_sprint_id)
+    }
+
     fn create_sprint(
         &mut self,
         board_id: Uuid,

--- a/crates/kanban-cli/src/handlers/sprint.rs
+++ b/crates/kanban-cli/src/handlers/sprint.rs
@@ -72,6 +72,11 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": id.to_string()}));
         }
+        SprintAction::CarryOver { from, to } => {
+            let count = ctx.carry_over_sprint_cards(from, to)?;
+            ctx.save().await?;
+            output::output_success(serde_json::json!({ "carried_over": count }));
+        }
     }
     Ok(())
 }

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -68,6 +68,11 @@ pub trait KanbanOperations {
     fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize>;
     fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize>;
     fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize>;
+    fn carry_over_sprint_cards(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<usize>;
 
     // Sprint operations
     fn create_sprint(

--- a/crates/kanban-domain/src/query/sprint.rs
+++ b/crates/kanban-domain/src/query/sprint.rs
@@ -230,7 +230,11 @@ mod tests {
         card_blocked.sprint_id = Some(sprint_id);
         card_blocked.status = CardStatus::Blocked;
 
-        let cards = vec![card_todo.clone(), card_in_progress.clone(), card_blocked.clone()];
+        let cards = vec![
+            card_todo.clone(),
+            card_in_progress.clone(),
+            card_blocked.clone(),
+        ];
         let result = get_sprint_uncompleted_cards(sprint_id, &cards);
 
         assert_eq!(result.len(), 3);

--- a/crates/kanban-domain/src/query/sprint.rs
+++ b/crates/kanban-domain/src/query/sprint.rs
@@ -193,6 +193,96 @@ mod tests {
     }
 
     #[test]
+    fn get_sprint_uncompleted_cards_excludes_done() {
+        let mut board = create_test_board();
+        let column = create_test_column(&board);
+        let sprint_id = Uuid::new_v4();
+
+        let mut card_done = create_test_card(&mut board, &column, "Done Task");
+        card_done.sprint_id = Some(sprint_id);
+        card_done.status = CardStatus::Done;
+
+        let mut card_todo = create_test_card(&mut board, &column, "Todo Task");
+        card_todo.sprint_id = Some(sprint_id);
+
+        let cards = vec![card_done, card_todo.clone()];
+        let result = get_sprint_uncompleted_cards(sprint_id, &cards);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card_todo.id);
+    }
+
+    #[test]
+    fn get_sprint_uncompleted_cards_includes_all_non_done_statuses() {
+        let mut board = create_test_board();
+        let column = create_test_column(&board);
+        let sprint_id = Uuid::new_v4();
+
+        let mut card_todo = create_test_card(&mut board, &column, "Todo");
+        card_todo.sprint_id = Some(sprint_id);
+        card_todo.status = CardStatus::Todo;
+
+        let mut card_in_progress = create_test_card(&mut board, &column, "InProgress");
+        card_in_progress.sprint_id = Some(sprint_id);
+        card_in_progress.status = CardStatus::InProgress;
+
+        let mut card_blocked = create_test_card(&mut board, &column, "Blocked");
+        card_blocked.sprint_id = Some(sprint_id);
+        card_blocked.status = CardStatus::Blocked;
+
+        let cards = vec![card_todo.clone(), card_in_progress.clone(), card_blocked.clone()];
+        let result = get_sprint_uncompleted_cards(sprint_id, &cards);
+
+        assert_eq!(result.len(), 3);
+        let ids: Vec<_> = result.iter().map(|c| c.id).collect();
+        assert!(ids.contains(&card_todo.id));
+        assert!(ids.contains(&card_in_progress.id));
+        assert!(ids.contains(&card_blocked.id));
+    }
+
+    #[test]
+    fn get_sprint_uncompleted_cards_excludes_other_sprints() {
+        let mut board = create_test_board();
+        let column = create_test_column(&board);
+        let sprint_id = Uuid::new_v4();
+        let other_sprint_id = Uuid::new_v4();
+
+        let mut card_this_sprint = create_test_card(&mut board, &column, "This Sprint");
+        card_this_sprint.sprint_id = Some(sprint_id);
+
+        let mut card_other_sprint = create_test_card(&mut board, &column, "Other Sprint");
+        card_other_sprint.sprint_id = Some(other_sprint_id);
+
+        let card_no_sprint = create_test_card(&mut board, &column, "No Sprint");
+
+        let cards = vec![card_this_sprint.clone(), card_other_sprint, card_no_sprint];
+        let result = get_sprint_uncompleted_cards(sprint_id, &cards);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card_this_sprint.id);
+    }
+
+    #[test]
+    fn get_sprint_uncompleted_cards_returns_empty_when_all_done() {
+        let mut board = create_test_board();
+        let column = create_test_column(&board);
+        let sprint_id = Uuid::new_v4();
+
+        let mut card1 = create_test_card(&mut board, &column, "Done 1");
+        card1.sprint_id = Some(sprint_id);
+        card1.status = CardStatus::Done;
+
+        let mut card2 = create_test_card(&mut board, &column, "Done 2");
+        card2.sprint_id = Some(sprint_id);
+        card2.status = CardStatus::Done;
+
+        let cards = vec![card1, card2];
+        let result = get_sprint_uncompleted_cards(sprint_id, &cards);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
     fn test_sort_card_ids() {
         let mut board = create_test_board();
         let column = create_test_column(&board);

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -197,7 +197,8 @@ impl KanbanOperations for McpContext {
         from_sprint_id: Uuid,
         to_sprint_id: Uuid,
     ) -> KanbanResult<usize> {
-        self.inner.carry_over_sprint_cards(from_sprint_id, to_sprint_id)
+        self.inner
+            .carry_over_sprint_cards(from_sprint_id, to_sprint_id)
     }
 
     // ========================================================================

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -192,6 +192,14 @@ impl KanbanOperations for McpContext {
         self.inner.bulk_assign_sprint(ids, sprint_id)
     }
 
+    fn carry_over_sprint_cards(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<usize> {
+        self.inner.carry_over_sprint_cards(from_sprint_id, to_sprint_id)
+    }
+
     // ========================================================================
     // Sprint Operations
     // ========================================================================

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -1051,10 +1051,7 @@ impl KanbanMcpServer {
                 })?;
             if to_sprint.status != kanban_domain::SprintStatus::Planning {
                 return Err(McpError::invalid_params(
-                    format!(
-                        "Target sprint must be Planning, got {:?}",
-                        to_sprint.status
-                    ),
+                    format!("Target sprint must be Planning, got {:?}", to_sprint.status),
                     None,
                 ));
             }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -1023,40 +1023,6 @@ impl KanbanMcpServer {
         let from_id = parse_uuid(&req.from_sprint_id)?;
         let to_id = parse_uuid(&req.to_sprint_id)?;
 
-        // Validate sprint statuses
-        {
-            let guard = self.ctx.lock().await;
-            let from_sprint = guard
-                .get_sprint(from_id)
-                .map_err(kanban_err_to_mcp)?
-                .ok_or_else(|| {
-                    McpError::invalid_params(format!("Sprint not found: {}", from_id), None)
-                })?;
-            if from_sprint.status != kanban_domain::SprintStatus::Completed
-                && from_sprint.status != kanban_domain::SprintStatus::Cancelled
-            {
-                return Err(McpError::invalid_params(
-                    format!(
-                        "Source sprint must be Completed or Cancelled, got {:?}",
-                        from_sprint.status
-                    ),
-                    None,
-                ));
-            }
-            let to_sprint = guard
-                .get_sprint(to_id)
-                .map_err(kanban_err_to_mcp)?
-                .ok_or_else(|| {
-                    McpError::invalid_params(format!("Sprint not found: {}", to_id), None)
-                })?;
-            if to_sprint.status != kanban_domain::SprintStatus::Planning {
-                return Err(McpError::invalid_params(
-                    format!("Target sprint must be Planning, got {:?}", to_sprint.status),
-                    None,
-                ));
-            }
-        }
-
         let count = mutating_op!(self.ctx, carry_over_sprint_cards, from_id, to_id)?;
         to_call_tool_result_json(serde_json::json!({ "carried_over_count": count }))
     }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -464,6 +464,16 @@ pub struct DeleteSprintRequest {
     pub sprint_id: String,
 }
 
+// Carry-over
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CarryOverSprintCardsRequest {
+    #[schemars(description = "ID of the completed or cancelled sprint to carry cards from")]
+    pub from_sprint_id: String,
+    #[schemars(description = "ID of the planning sprint to carry cards to")]
+    pub to_sprint_id: String,
+}
+
 // Export/Import
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1001,6 +1011,57 @@ impl KanbanMcpServer {
         let id = parse_uuid(&req.sprint_id)?;
         mutating_op!(self.ctx, delete_sprint, id)?;
         to_call_tool_result_json(serde_json::json!({"deleted": req.sprint_id}))
+    }
+
+    #[tool(
+        description = "Carry over uncompleted cards from a completed/cancelled sprint to a planning sprint"
+    )]
+    async fn tool_carry_over_sprint_cards(
+        &self,
+        Parameters(req): Parameters<CarryOverSprintCardsRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let from_id = parse_uuid(&req.from_sprint_id)?;
+        let to_id = parse_uuid(&req.to_sprint_id)?;
+
+        // Validate sprint statuses
+        {
+            let guard = self.ctx.lock().await;
+            let from_sprint = guard
+                .get_sprint(from_id)
+                .map_err(kanban_err_to_mcp)?
+                .ok_or_else(|| {
+                    McpError::invalid_params(format!("Sprint not found: {}", from_id), None)
+                })?;
+            if from_sprint.status != kanban_domain::SprintStatus::Completed
+                && from_sprint.status != kanban_domain::SprintStatus::Cancelled
+            {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "Source sprint must be Completed or Cancelled, got {:?}",
+                        from_sprint.status
+                    ),
+                    None,
+                ));
+            }
+            let to_sprint = guard
+                .get_sprint(to_id)
+                .map_err(kanban_err_to_mcp)?
+                .ok_or_else(|| {
+                    McpError::invalid_params(format!("Sprint not found: {}", to_id), None)
+                })?;
+            if to_sprint.status != kanban_domain::SprintStatus::Planning {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "Target sprint must be Planning, got {:?}",
+                        to_sprint.status
+                    ),
+                    None,
+                ));
+            }
+        }
+
+        let count = mutating_op!(self.ctx, carry_over_sprint_cards, from_id, to_id)?;
+        to_call_tool_result_json(serde_json::json!({ "carried_over_count": count }))
     }
 
     // Export/Import

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -555,6 +555,19 @@ impl KanbanOperations for KanbanContext {
         Ok(count)
     }
 
+    fn carry_over_sprint_cards(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<usize> {
+        use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+        let ids: Vec<Uuid> = get_sprint_uncompleted_cards(from_sprint_id, &self.cards)
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        self.bulk_assign_sprint(ids, to_sprint_id)
+    }
+
     fn create_sprint(
         &mut self,
         board_id: Uuid,

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -562,9 +562,9 @@ impl KanbanOperations for KanbanContext {
     ) -> KanbanResult<usize> {
         use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
 
-        let from_sprint = self
-            .get_sprint(from_sprint_id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", from_sprint_id)))?;
+        let from_sprint = self.get_sprint(from_sprint_id)?.ok_or_else(|| {
+            kanban_core::KanbanError::NotFound(format!("Sprint {}", from_sprint_id))
+        })?;
         if from_sprint.status != kanban_domain::SprintStatus::Completed
             && from_sprint.status != kanban_domain::SprintStatus::Cancelled
         {
@@ -573,9 +573,9 @@ impl KanbanOperations for KanbanContext {
                 from_sprint.status
             )));
         }
-        let to_sprint = self
-            .get_sprint(to_sprint_id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", to_sprint_id)))?;
+        let to_sprint = self.get_sprint(to_sprint_id)?.ok_or_else(|| {
+            kanban_core::KanbanError::NotFound(format!("Sprint {}", to_sprint_id))
+        })?;
         if to_sprint.status != kanban_domain::SprintStatus::Planning {
             return Err(kanban_core::KanbanError::Validation(format!(
                 "Target sprint must be Planning, got {:?}",

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -561,6 +561,28 @@ impl KanbanOperations for KanbanContext {
         to_sprint_id: Uuid,
     ) -> KanbanResult<usize> {
         use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+
+        let from_sprint = self
+            .get_sprint(from_sprint_id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", from_sprint_id)))?;
+        if from_sprint.status != kanban_domain::SprintStatus::Completed
+            && from_sprint.status != kanban_domain::SprintStatus::Cancelled
+        {
+            return Err(kanban_core::KanbanError::Validation(format!(
+                "Source sprint must be Completed or Cancelled, got {:?}",
+                from_sprint.status
+            )));
+        }
+        let to_sprint = self
+            .get_sprint(to_sprint_id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", to_sprint_id)))?;
+        if to_sprint.status != kanban_domain::SprintStatus::Planning {
+            return Err(kanban_core::KanbanError::Validation(format!(
+                "Target sprint must be Planning, got {:?}",
+                to_sprint.status
+            )));
+        }
+
         let ids: Vec<Uuid> = get_sprint_uncompleted_cards(from_sprint_id, &self.cards)
             .iter()
             .map(|c| c.id)

--- a/crates/kanban-service/tests/carry_over.rs
+++ b/crates/kanban-service/tests/carry_over.rs
@@ -76,3 +76,112 @@ async fn carry_over_skips_done_cards() {
     let done_card = ctx.get_card(card_done.id).unwrap().unwrap();
     assert_eq!(done_card.sprint_id, Some(from_sprint.id));
 }
+
+#[tokio::test]
+async fn carry_over_returns_zero_when_sprint_has_no_cards() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = KanbanContext::load_json(&path).await.unwrap();
+
+    let board = ctx.create_board("Test Board".into(), None).unwrap();
+    let from_sprint = ctx.create_sprint(board.id, None, None).unwrap();
+    let to_sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    ctx.activate_sprint(from_sprint.id, Some(14)).unwrap();
+    ctx.complete_sprint(from_sprint.id).unwrap();
+
+    let count = ctx
+        .carry_over_sprint_cards(from_sprint.id, to_sprint.id)
+        .unwrap();
+
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn carry_over_returns_zero_when_all_cards_are_done() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = KanbanContext::load_json(&path).await.unwrap();
+
+    let board = ctx.create_board("Test Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Done".into(), None).unwrap();
+
+    let from_sprint = ctx.create_sprint(board.id, None, None).unwrap();
+    let to_sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    ctx.activate_sprint(from_sprint.id, Some(14)).unwrap();
+    ctx.complete_sprint(from_sprint.id).unwrap();
+
+    let card1 = ctx
+        .create_card(board.id, col.id, "Done card 1".into(), CreateCardOptions::default())
+        .unwrap();
+    ctx.assign_card_to_sprint(card1.id, from_sprint.id).unwrap();
+    ctx.update_card(card1.id, CardUpdate { status: Some(CardStatus::Done), ..Default::default() })
+        .unwrap();
+
+    let card2 = ctx
+        .create_card(board.id, col.id, "Done card 2".into(), CreateCardOptions::default())
+        .unwrap();
+    ctx.assign_card_to_sprint(card2.id, from_sprint.id).unwrap();
+    ctx.update_card(card2.id, CardUpdate { status: Some(CardStatus::Done), ..Default::default() })
+        .unwrap();
+
+    let count = ctx
+        .carry_over_sprint_cards(from_sprint.id, to_sprint.id)
+        .unwrap();
+
+    assert_eq!(count, 0);
+
+    let c1 = ctx.get_card(card1.id).unwrap().unwrap();
+    assert_eq!(c1.sprint_id, Some(from_sprint.id));
+    let c2 = ctx.get_card(card2.id).unwrap().unwrap();
+    assert_eq!(c2.sprint_id, Some(from_sprint.id));
+}
+
+#[tokio::test]
+async fn carry_over_includes_blocked_cards() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = KanbanContext::load_json(&path).await.unwrap();
+
+    let board = ctx.create_board("Test Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Backlog".into(), None).unwrap();
+
+    let from_sprint = ctx.create_sprint(board.id, None, None).unwrap();
+    let to_sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    ctx.activate_sprint(from_sprint.id, Some(14)).unwrap();
+    ctx.complete_sprint(from_sprint.id).unwrap();
+
+    let card_blocked = ctx
+        .create_card(board.id, col.id, "Blocked card".into(), CreateCardOptions::default())
+        .unwrap();
+    ctx.assign_card_to_sprint(card_blocked.id, from_sprint.id).unwrap();
+    ctx.update_card(
+        card_blocked.id,
+        CardUpdate { status: Some(CardStatus::Blocked), ..Default::default() },
+    )
+    .unwrap();
+
+    let card_done = ctx
+        .create_card(board.id, col.id, "Done card".into(), CreateCardOptions::default())
+        .unwrap();
+    ctx.assign_card_to_sprint(card_done.id, from_sprint.id).unwrap();
+    ctx.update_card(card_done.id, CardUpdate { status: Some(CardStatus::Done), ..Default::default() })
+        .unwrap();
+
+    let count = ctx
+        .carry_over_sprint_cards(from_sprint.id, to_sprint.id)
+        .unwrap();
+
+    assert_eq!(count, 1);
+
+    let moved = ctx.get_card(card_blocked.id).unwrap().unwrap();
+    assert_eq!(moved.sprint_id, Some(to_sprint.id));
+
+    let stayed = ctx.get_card(card_done.id).unwrap().unwrap();
+    assert_eq!(stayed.sprint_id, Some(from_sprint.id));
+}

--- a/crates/kanban-service/tests/carry_over.rs
+++ b/crates/kanban-service/tests/carry_over.rs
@@ -1,0 +1,78 @@
+use kanban_domain::{CardStatus, CardUpdate, CreateCardOptions, KanbanOperations};
+use kanban_service::KanbanContext;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn carry_over_skips_done_cards() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = KanbanContext::load_json(&path).await.unwrap();
+
+    let board = ctx.create_board("Test Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Backlog".into(), None).unwrap();
+
+    let from_sprint = ctx.create_sprint(board.id, None, None).unwrap();
+    let to_sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    // Activate then complete the from_sprint so it's eligible
+    ctx.activate_sprint(from_sprint.id, Some(14)).unwrap();
+    ctx.complete_sprint(from_sprint.id).unwrap();
+
+    // Create three cards and assign them to from_sprint
+    let card_todo = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Todo card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.assign_card_to_sprint(card_todo.id, from_sprint.id).unwrap();
+
+    let card_in_progress = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "In Progress card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.assign_card_to_sprint(card_in_progress.id, from_sprint.id).unwrap();
+
+    let card_done = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Done card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.assign_card_to_sprint(card_done.id, from_sprint.id).unwrap();
+
+    // Mark the done card as Done
+    ctx.update_card(
+        card_done.id,
+        CardUpdate {
+            status: Some(CardStatus::Done),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let count = ctx
+        .carry_over_sprint_cards(from_sprint.id, to_sprint.id)
+        .unwrap();
+
+    // Only the two non-Done cards should be moved
+    assert_eq!(count, 2);
+
+    let moved_todo = ctx.get_card(card_todo.id).unwrap().unwrap();
+    assert_eq!(moved_todo.sprint_id, Some(to_sprint.id));
+
+    let moved_in_progress = ctx.get_card(card_in_progress.id).unwrap().unwrap();
+    assert_eq!(moved_in_progress.sprint_id, Some(to_sprint.id));
+
+    let done_card = ctx.get_card(card_done.id).unwrap().unwrap();
+    assert_eq!(done_card.sprint_id, Some(from_sprint.id));
+}

--- a/crates/kanban-service/tests/carry_over.rs
+++ b/crates/kanban-service/tests/carry_over.rs
@@ -28,7 +28,8 @@ async fn carry_over_skips_done_cards() {
             CreateCardOptions::default(),
         )
         .unwrap();
-    ctx.assign_card_to_sprint(card_todo.id, from_sprint.id).unwrap();
+    ctx.assign_card_to_sprint(card_todo.id, from_sprint.id)
+        .unwrap();
 
     let card_in_progress = ctx
         .create_card(
@@ -38,7 +39,8 @@ async fn carry_over_skips_done_cards() {
             CreateCardOptions::default(),
         )
         .unwrap();
-    ctx.assign_card_to_sprint(card_in_progress.id, from_sprint.id).unwrap();
+    ctx.assign_card_to_sprint(card_in_progress.id, from_sprint.id)
+        .unwrap();
 
     let card_done = ctx
         .create_card(
@@ -48,7 +50,8 @@ async fn carry_over_skips_done_cards() {
             CreateCardOptions::default(),
         )
         .unwrap();
-    ctx.assign_card_to_sprint(card_done.id, from_sprint.id).unwrap();
+    ctx.assign_card_to_sprint(card_done.id, from_sprint.id)
+        .unwrap();
 
     // Mark the done card as Done
     ctx.update_card(
@@ -115,18 +118,40 @@ async fn carry_over_returns_zero_when_all_cards_are_done() {
     ctx.complete_sprint(from_sprint.id).unwrap();
 
     let card1 = ctx
-        .create_card(board.id, col.id, "Done card 1".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Done card 1".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
     ctx.assign_card_to_sprint(card1.id, from_sprint.id).unwrap();
-    ctx.update_card(card1.id, CardUpdate { status: Some(CardStatus::Done), ..Default::default() })
-        .unwrap();
+    ctx.update_card(
+        card1.id,
+        CardUpdate {
+            status: Some(CardStatus::Done),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     let card2 = ctx
-        .create_card(board.id, col.id, "Done card 2".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Done card 2".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
     ctx.assign_card_to_sprint(card2.id, from_sprint.id).unwrap();
-    ctx.update_card(card2.id, CardUpdate { status: Some(CardStatus::Done), ..Default::default() })
-        .unwrap();
+    ctx.update_card(
+        card2.id,
+        CardUpdate {
+            status: Some(CardStatus::Done),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     let count = ctx
         .carry_over_sprint_cards(from_sprint.id, to_sprint.id)
@@ -157,21 +182,42 @@ async fn carry_over_includes_blocked_cards() {
     ctx.complete_sprint(from_sprint.id).unwrap();
 
     let card_blocked = ctx
-        .create_card(board.id, col.id, "Blocked card".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Blocked card".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
-    ctx.assign_card_to_sprint(card_blocked.id, from_sprint.id).unwrap();
+    ctx.assign_card_to_sprint(card_blocked.id, from_sprint.id)
+        .unwrap();
     ctx.update_card(
         card_blocked.id,
-        CardUpdate { status: Some(CardStatus::Blocked), ..Default::default() },
+        CardUpdate {
+            status: Some(CardStatus::Blocked),
+            ..Default::default()
+        },
     )
     .unwrap();
 
     let card_done = ctx
-        .create_card(board.id, col.id, "Done card".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Done card".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
-    ctx.assign_card_to_sprint(card_done.id, from_sprint.id).unwrap();
-    ctx.update_card(card_done.id, CardUpdate { status: Some(CardStatus::Done), ..Default::default() })
+    ctx.assign_card_to_sprint(card_done.id, from_sprint.id)
         .unwrap();
+    ctx.update_card(
+        card_done.id,
+        CardUpdate {
+            status: Some(CardStatus::Done),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     let count = ctx
         .carry_over_sprint_cards(from_sprint.id, to_sprint.id)

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -1,4 +1,5 @@
 use kanban_core::SelectionState;
+use uuid::Uuid;
 
 #[derive(Default)]
 pub struct DialogInputState {
@@ -8,4 +9,7 @@ pub struct DialogInputState {
     pub column_selection: SelectionState,
     pub sprint_assign_selection: SelectionState,
     pub task_list_view_selection: SelectionState,
+    pub carry_over_sprint_selection: SelectionState,
+    pub carry_over_source_sprint_id: Option<Uuid>,
+    pub carry_over_card_ids: Vec<Uuid>,
 }

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -11,5 +11,4 @@ pub struct DialogInputState {
     pub task_list_view_selection: SelectionState,
     pub carry_over_sprint_selection: SelectionState,
     pub carry_over_source_sprint_id: Option<Uuid>,
-    pub carry_over_card_ids: Vec<Uuid>,
 }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -638,6 +638,7 @@ impl App {
                 }
                 DialogMode::ManageParents => self.handle_manage_parents_popup(key.code),
                 DialogMode::ManageChildren => self.handle_manage_children_popup(key.code),
+                DialogMode::CarryOverSprint => self.handle_carry_over_sprint_popup(key.code),
             },
         }
         should_restart_events

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -297,6 +297,7 @@ impl App {
             KeybindingAction::JumpHalfViewportDown => self.handle_jump_half_viewport_down(),
             KeybindingAction::ManageParents => self.handle_manage_parents(),
             KeybindingAction::ManageChildren => self.handle_manage_children(),
+            KeybindingAction::CarryOver => {}
             KeybindingAction::Undo => {
                 if let Err(e) = self.undo() {
                     self.set_error(format!("Undo failed: {}", e));

--- a/crates/kanban-tui/src/app/mode.rs
+++ b/crates/kanban-tui/src/app/mode.rs
@@ -26,6 +26,7 @@ pub enum DialogMode {
     ExternalChangeDetected,
     ManageParents,
     ManageChildren,
+    CarryOverSprint,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/kanban-tui/src/components/banner.rs
+++ b/crates/kanban-tui/src/components/banner.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     layout::{Alignment, Rect},
     style::{Color, Modifier, Style},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 use std::time::{Duration, Instant};
@@ -78,6 +78,7 @@ impl Banner {
             .alignment(Alignment::Center)
             .block(block);
 
+        frame.render_widget(Clear, banner_area);
         frame.render_widget(widget, banner_area);
     }
 }

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use kanban_domain::Sprint;
+use kanban_domain::{Sprint, SprintStatus};
 use ratatui::Frame;
 
 pub trait SelectionDialog {
@@ -172,6 +172,103 @@ impl SelectionDialog for SortFieldDialog {
             60,
             50,
         );
+    }
+}
+
+pub struct CarryOverSprintDialog {
+    pub card_count: usize,
+}
+
+impl SelectionDialog for CarryOverSprintDialog {
+    fn title(&self) -> &str {
+        "Carry Over to Sprint"
+    }
+
+    fn get_current_selection(&self, app: &App) -> usize {
+        app.dialog_input.carry_over_sprint_selection.get().unwrap_or(0)
+    }
+
+    fn options_count(&self, app: &App) -> usize {
+        if let Some(board_idx) = app.selection.active_board_index {
+            if let Some(board) = app.ctx.boards.get(board_idx) {
+                app.ctx
+                    .sprints
+                    .iter()
+                    .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
+                    .count()
+            } else {
+                0
+            }
+        } else {
+            0
+        }
+    }
+
+    fn render(&self, app: &App, frame: &mut Frame) {
+        use crate::components::centered_rect;
+        use ratatui::{
+            layout::{Constraint, Direction, Layout},
+            style::{Color, Style},
+            text::{Line, Span},
+            widgets::{Block, Borders, Clear, Paragraph},
+        };
+
+        let area = centered_rect(60, 50, frame.area());
+        frame.render_widget(Clear, area);
+
+        let title = format!("Carry Over to Sprint ({} cards)", self.card_count);
+        let block = Block::default()
+            .title(title.as_str())
+            .borders(Borders::ALL)
+            .style(Style::default().bg(Color::Black));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(2)
+            .constraints([Constraint::Length(1), Constraint::Min(0)])
+            .split(inner);
+
+        let label =
+            Paragraph::new("Select target sprint:").style(Style::default().fg(Color::Yellow));
+        frame.render_widget(label, chunks[0]);
+
+        let mut lines = vec![];
+
+        if let Some(board_idx) = app.selection.active_board_index {
+            if let Some(board) = app.ctx.boards.get(board_idx) {
+                let planning_sprints: Vec<_> = app
+                    .ctx
+                    .sprints
+                    .iter()
+                    .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
+                    .collect();
+
+                for (idx, sprint) in planning_sprints.iter().enumerate() {
+                    let is_selected =
+                        app.dialog_input.carry_over_sprint_selection.get() == Some(idx);
+
+                    let style = if is_selected {
+                        Style::default().fg(Color::White).bg(Color::Blue)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+
+                    let prefix = if is_selected { "> " } else { "  " };
+                    let sprint_name = sprint.formatted_name(board, "sprint");
+
+                    lines.push(Line::from(Span::styled(
+                        format!("{}{}", prefix, sprint_name),
+                        style,
+                    )));
+                }
+            }
+        }
+
+        let list = Paragraph::new(lines);
+        frame.render_widget(list, chunks[1]);
     }
 }
 

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -185,7 +185,10 @@ impl SelectionDialog for CarryOverSprintDialog {
     }
 
     fn get_current_selection(&self, app: &App) -> usize {
-        app.dialog_input.carry_over_sprint_selection.get().unwrap_or(0)
+        app.dialog_input
+            .carry_over_sprint_selection
+            .get()
+            .unwrap_or(0)
     }
 
     fn options_count(&self, app: &App) -> usize {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -621,7 +621,7 @@ impl App {
         self.multi_select.selection_mode_active = false;
     }
 
-    fn start_delete_animation(&mut self, card_id: uuid::Uuid) {
+    pub fn start_delete_animation(&mut self, card_id: uuid::Uuid) {
         use crate::app::CardAnimation;
         use kanban_domain::AnimationType;
         use std::time::Instant;

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -648,14 +648,7 @@ impl App {
                             || sprint.status == SprintStatus::Cancelled
                         {
                             let sprint_id = sprint.id;
-                            use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-                            let card_ids = get_sprint_uncompleted_cards(sprint_id, &self.ctx.cards)
-                                .iter()
-                                .map(|c| c.id)
-                                .collect::<Vec<_>>();
-                            if !card_ids.is_empty() {
-                                self.handle_carry_over_for_sprint(sprint_id, card_ids);
-                            }
+                            self.handle_carry_over_for_sprint(sprint_id);
                         }
                     }
                 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1183,12 +1183,6 @@ impl App {
                 None => continue,
             };
 
-            let new_status = if card.status == CardStatus::Done {
-                CardStatus::Todo
-            } else {
-                CardStatus::Done
-            };
-
             let toggle_result = self.selection.active_board_index.and_then(|idx| {
                 self.ctx.boards.get(idx).and_then(|board| {
                     kanban_domain::card_lifecycle::compute_completion_toggle(
@@ -1200,16 +1194,24 @@ impl App {
                 })
             });
 
-            let mut updates = CardUpdate {
-                status: Some(new_status),
-                ..Default::default()
+            let updates = if let Some(ref result) = toggle_result {
+                CardUpdate {
+                    status: Some(result.new_status),
+                    column_id: Some(result.target_column_id),
+                    position: Some(result.new_position),
+                    ..Default::default()
+                }
+            } else {
+                let fallback = if card.status == CardStatus::Done {
+                    CardStatus::Todo
+                } else {
+                    CardStatus::Done
+                };
+                CardUpdate {
+                    status: Some(fallback),
+                    ..Default::default()
+                }
             };
-
-            if let Some(ref result) = toggle_result {
-                updates.column_id = Some(result.target_column_id);
-                updates.position = Some(result.new_position);
-                updates.status = Some(result.new_status);
-            }
 
             update_commands.push(Box::new(UpdateCard {
                 card_id: *card_id,

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1219,8 +1219,10 @@ impl App {
                 updates.status = Some(result.new_status);
             }
 
-            update_commands.push(Box::new(UpdateCard { card_id: *card_id, updates })
-                as Box<dyn kanban_domain::commands::Command>);
+            update_commands.push(Box::new(UpdateCard {
+                card_id: *card_id,
+                updates,
+            }) as Box<dyn kanban_domain::commands::Command>);
         }
 
         if !update_commands.is_empty() {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -640,7 +640,7 @@ impl App {
                     }
                 }
             }
-            KeyCode::Char('R') => {
+            KeyCode::Char('M') => {
                 if let Some(sprint_idx) = self.selection.active_sprint_index {
                     if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
                         use kanban_domain::SprintStatus;
@@ -648,17 +648,11 @@ impl App {
                             || sprint.status == SprintStatus::Cancelled
                         {
                             let sprint_id = sprint.id;
-                            let selected =
-                                self.sprint_view.uncompleted_component.get_multi_selected();
-                            let card_ids = if selected.is_empty() {
-                                use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-                                get_sprint_uncompleted_cards(sprint_id, &self.ctx.cards)
-                                    .iter()
-                                    .map(|c| c.id)
-                                    .collect()
-                            } else {
-                                selected
-                            };
+                            use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+                            let card_ids = get_sprint_uncompleted_cards(sprint_id, &self.ctx.cards)
+                                .iter()
+                                .map(|c| c.id)
+                                .collect::<Vec<_>>();
                             if !card_ids.is_empty() {
                                 self.handle_carry_over_for_sprint(sprint_id, card_ids);
                             }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -580,14 +580,13 @@ impl App {
                 self.handle_activate_sprint_key();
             }
             KeyCode::Char('c') => {
-                let selected = if self.sprint_view.panel == SprintTaskPanel::Uncompleted {
-                    self.sprint_view.uncompleted_component.get_multi_selected()
-                } else {
-                    vec![]
-                };
-                if !selected.is_empty() {
-                    self.toggle_completion_for_card_ids(selected);
-                    self.sprint_view.uncompleted_component.clear_multi_select();
+                if self.sprint_view.panel == SprintTaskPanel::Uncompleted {
+                    let selected = self.sprint_view.uncompleted_component.get_multi_selected();
+                    if !selected.is_empty() {
+                        self.toggle_completion_for_card_ids(selected);
+                        self.sprint_view.uncompleted_component.clear_multi_select();
+                    }
+                    // else: no-op; avoid accidentally completing the sprint
                 } else {
                     self.handle_complete_sprint_key();
                 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -580,7 +580,28 @@ impl App {
                 self.handle_activate_sprint_key();
             }
             KeyCode::Char('c') => {
-                self.handle_complete_sprint_key();
+                let selected = if self.sprint_view.panel == SprintTaskPanel::Uncompleted {
+                    self.sprint_view.uncompleted_component.get_multi_selected()
+                } else {
+                    vec![]
+                };
+                if !selected.is_empty() {
+                    self.toggle_completion_for_card_ids(selected);
+                    self.sprint_view.uncompleted_component.clear_multi_select();
+                } else {
+                    self.handle_complete_sprint_key();
+                }
+            }
+            KeyCode::Char('d') => {
+                let selected = if self.sprint_view.panel == SprintTaskPanel::Uncompleted {
+                    self.sprint_view.uncompleted_component.get_multi_selected()
+                } else {
+                    vec![]
+                };
+                if !selected.is_empty() {
+                    self.start_delete_animations_for_card_ids(selected);
+                    self.sprint_view.uncompleted_component.clear_multi_select();
+                }
             }
             KeyCode::Char('p') => {
                 if let Some(sprint_idx) = self.selection.active_sprint_index {
@@ -616,6 +637,32 @@ impl App {
                     if let Some(field) = self.filter.current_sort_field {
                         self.apply_sort_to_sprint_lists(field, new_order);
                         tracing::info!("Toggled sort order to: {:?}", new_order);
+                    }
+                }
+            }
+            KeyCode::Char('R') => {
+                if let Some(sprint_idx) = self.selection.active_sprint_index {
+                    if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
+                        use kanban_domain::SprintStatus;
+                        if sprint.status == SprintStatus::Completed
+                            || sprint.status == SprintStatus::Cancelled
+                        {
+                            let sprint_id = sprint.id;
+                            let selected =
+                                self.sprint_view.uncompleted_component.get_multi_selected();
+                            let card_ids = if selected.is_empty() {
+                                use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+                                get_sprint_uncompleted_cards(sprint_id, &self.ctx.cards)
+                                    .iter()
+                                    .map(|c| c.id)
+                                    .collect()
+                            } else {
+                                selected
+                            };
+                            if !card_ids.is_empty() {
+                                self.handle_carry_over_for_sprint(sprint_id, card_ids);
+                            }
+                        }
                     }
                 }
             }
@@ -1130,5 +1177,65 @@ impl App {
                     .update_item_count(new_children.len());
             }
         }
+    }
+
+    pub fn start_delete_animations_for_card_ids(&mut self, ids: Vec<uuid::Uuid>) {
+        for card_id in ids {
+            self.start_delete_animation(card_id);
+        }
+    }
+
+    pub fn toggle_completion_for_card_ids(&mut self, ids: Vec<uuid::Uuid>) {
+        use kanban_domain::commands::UpdateCard;
+        use kanban_domain::{CardStatus, CardUpdate};
+
+        let mut update_commands: Vec<Box<dyn kanban_domain::commands::Command>> = Vec::new();
+
+        for card_id in &ids {
+            let card = match self.ctx.cards.iter().find(|c| c.id == *card_id) {
+                Some(c) => c.clone(),
+                None => continue,
+            };
+
+            let new_status = if card.status == CardStatus::Done {
+                CardStatus::Todo
+            } else {
+                CardStatus::Done
+            };
+
+            let toggle_result = self.selection.active_board_index.and_then(|idx| {
+                self.ctx.boards.get(idx).and_then(|board| {
+                    kanban_domain::card_lifecycle::compute_completion_toggle(
+                        &card,
+                        board,
+                        &self.ctx.columns,
+                        &self.ctx.cards,
+                    )
+                })
+            });
+
+            let mut updates = CardUpdate {
+                status: Some(new_status),
+                ..Default::default()
+            };
+
+            if let Some(ref result) = toggle_result {
+                updates.column_id = Some(result.target_column_id);
+                updates.position = Some(result.new_position);
+                updates.status = Some(result.new_status);
+            }
+
+            update_commands.push(Box::new(UpdateCard { card_id: *card_id, updates })
+                as Box<dyn kanban_domain::commands::Command>);
+        }
+
+        if !update_commands.is_empty() {
+            if let Err(e) = self.execute_commands_batch(update_commands) {
+                tracing::error!("Failed to toggle card completion: {}", e);
+                return;
+            }
+        }
+
+        self.refresh_view();
     }
 }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -483,7 +483,6 @@ impl App {
                 self.pop_mode();
                 self.dialog_input.carry_over_sprint_selection.clear();
                 self.dialog_input.carry_over_source_sprint_id = None;
-                self.dialog_input.carry_over_card_ids.clear();
             }
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(source_id) = self.dialog_input.carry_over_source_sprint_id {
@@ -540,19 +539,18 @@ impl App {
                                     })
                                     .unwrap_or_else(|| "sprint".to_string());
 
-                                let card_ids =
-                                    std::mem::take(&mut self.dialog_input.carry_over_card_ids);
-                                let count = card_ids.len();
-                                if let Err(e) = self.ctx.bulk_assign_sprint(card_ids, to_sprint_id)
-                                {
-                                    tracing::error!("Carry-over failed: {}", e);
-                                    self.set_error(format!("Carry-over failed: {}", e));
-                                } else {
-                                    self.set_success(format!(
-                                        "Carried over {} card(s) to {}",
-                                        count, sprint_label
-                                    ));
-                                    self.populate_sprint_task_lists(source_id);
+                                match self.ctx.carry_over_sprint_cards(source_id, to_sprint_id) {
+                                    Ok(count) => {
+                                        self.set_success(format!(
+                                            "Carried over {} card(s) to {}",
+                                            count, sprint_label
+                                        ));
+                                        self.populate_sprint_task_lists(source_id);
+                                    }
+                                    Err(e) => {
+                                        tracing::error!("Carry-over failed: {}", e);
+                                        self.set_error(format!("Carry-over failed: {}", e));
+                                    }
                                 }
                             }
                         }
@@ -561,7 +559,6 @@ impl App {
                 self.pop_mode();
                 self.dialog_input.carry_over_sprint_selection.clear();
                 self.dialog_input.carry_over_source_sprint_id = None;
-                self.dialog_input.carry_over_card_ids.clear();
             }
             _ => {}
         }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -2,7 +2,8 @@ use crate::app::App;
 use crate::state::TuiSnapshot;
 use crossterm::event::KeyCode;
 use kanban_domain::{
-    dependencies::CardGraphExt, FieldUpdate, Snapshot, SortField, SortOrder, Sprint,
+    dependencies::CardGraphExt, FieldUpdate, KanbanOperations, Snapshot, SortField, SortOrder,
+    Sprint,
 };
 
 const PRIORITY_COUNT: usize = 4;
@@ -474,6 +475,77 @@ impl App {
 
     pub fn handle_manage_children_popup(&mut self, key_code: KeyCode) {
         self.handle_relationship_popup(key_code, false);
+    }
+
+    pub fn handle_carry_over_sprint_popup(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Esc => {
+                self.pop_mode();
+                self.dialog_input.carry_over_sprint_selection.clear();
+                self.dialog_input.carry_over_source_sprint_id = None;
+                self.dialog_input.carry_over_card_ids.clear();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if let Some(source_id) = self.dialog_input.carry_over_source_sprint_id {
+                    if let Some(sprint) = self.ctx.sprints.iter().find(|s| s.id == source_id) {
+                        let board_id = sprint.board_id;
+                        let count = self
+                            .ctx
+                            .sprints
+                            .iter()
+                            .filter(|s| {
+                                s.board_id == board_id
+                                    && s.status == kanban_domain::SprintStatus::Planning
+                            })
+                            .count();
+                        self.dialog_input.carry_over_sprint_selection.next(count);
+                    }
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.dialog_input.carry_over_sprint_selection.prev();
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if let Some(idx) = self.dialog_input.carry_over_sprint_selection.get() {
+                    if let Some(source_id) = self.dialog_input.carry_over_source_sprint_id {
+                        if let Some(sprint) = self.ctx.sprints.iter().find(|s| s.id == source_id) {
+                            let board_id = sprint.board_id;
+                            let planning_sprint_ids: Vec<uuid::Uuid> = self
+                                .ctx
+                                .sprints
+                                .iter()
+                                .filter(|s| {
+                                    s.board_id == board_id
+                                        && s.status == kanban_domain::SprintStatus::Planning
+                                })
+                                .map(|s| s.id)
+                                .collect();
+
+                            if let Some(&to_sprint_id) = planning_sprint_ids.get(idx) {
+                                let card_ids =
+                                    std::mem::take(&mut self.dialog_input.carry_over_card_ids);
+                                let count = card_ids.len();
+                                if let Err(e) = self.ctx.bulk_assign_sprint(card_ids, to_sprint_id)
+                                {
+                                    tracing::error!("Carry-over failed: {}", e);
+                                    self.set_error(format!("Carry-over failed: {}", e));
+                                } else {
+                                    self.set_success(format!(
+                                        "Carried over {} card(s) to sprint",
+                                        count
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                self.pop_mode();
+                self.dialog_input.carry_over_sprint_selection.clear();
+                self.dialog_input.carry_over_source_sprint_id = None;
+                self.dialog_input.carry_over_card_ids.clear();
+            }
+            _ => {}
+        }
     }
 
     fn handle_relationship_popup(&mut self, key_code: KeyCode, is_parent_mode: bool) {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -522,6 +522,24 @@ impl App {
                                 .collect();
 
                             if let Some(&to_sprint_id) = planning_sprint_ids.get(idx) {
+                                let sprint_label = self
+                                    .ctx
+                                    .sprints
+                                    .iter()
+                                    .find(|s| s.id == to_sprint_id)
+                                    .map(|s| {
+                                        self.ctx
+                                            .boards
+                                            .iter()
+                                            .find(|b| b.id == board_id)
+                                            .and_then(|b| s.get_name(b))
+                                            .map(|n| n.to_string())
+                                            .unwrap_or_else(|| {
+                                                format!("Sprint {}", s.sprint_number)
+                                            })
+                                    })
+                                    .unwrap_or_else(|| "sprint".to_string());
+
                                 let card_ids =
                                     std::mem::take(&mut self.dialog_input.carry_over_card_ids);
                                 let count = card_ids.len();
@@ -531,9 +549,10 @@ impl App {
                                     self.set_error(format!("Carry-over failed: {}", e));
                                 } else {
                                     self.set_success(format!(
-                                        "Carried over {} card(s) to sprint",
-                                        count
+                                        "Carried over {} card(s) to {}",
+                                        count, sprint_label
                                     ));
+                                    self.populate_sprint_task_lists(source_id);
                                 }
                             }
                         }

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -1,6 +1,6 @@
 use crate::app::{App, BoardFocus, DialogMode};
 use kanban_domain::commands::{ActivateSprint, CompleteSprint, CreateSprint, UpdateBoard};
-use kanban_domain::{BoardUpdate, FieldUpdate, KanbanOperations, SprintStatus};
+use kanban_domain::{BoardUpdate, FieldUpdate, SprintStatus};
 use uuid::Uuid;
 
 impl App {
@@ -162,15 +162,6 @@ impl App {
         match planning_sprint_ids.len() {
             0 => {
                 self.set_error("No Planning sprint available for carry-over");
-            }
-            1 => {
-                let to_sprint_id = planning_sprint_ids[0];
-                let count = card_ids.len();
-                if let Err(e) = self.ctx.bulk_assign_sprint(card_ids, to_sprint_id) {
-                    self.set_error(format!("Carry-over failed: {}", e));
-                } else {
-                    self.set_success(format!("Carried over {} card(s) to sprint", count));
-                }
             }
             _ => {
                 self.dialog_input.carry_over_source_sprint_id = Some(from_sprint_id);

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -1,6 +1,7 @@
 use crate::app::{App, BoardFocus, DialogMode};
 use kanban_domain::commands::{ActivateSprint, CompleteSprint, CreateSprint, UpdateBoard};
-use kanban_domain::{BoardUpdate, FieldUpdate, SprintStatus};
+use kanban_domain::{BoardUpdate, FieldUpdate, KanbanOperations, SprintStatus};
+use uuid::Uuid;
 
 impl App {
     pub fn handle_create_sprint_key(&mut self) {
@@ -125,9 +126,57 @@ impl App {
 
                 tracing::info!("Completed sprint: {}", sprint_name);
 
+                let uncompleted_ids: Vec<Uuid> = {
+                    use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+                    get_sprint_uncompleted_cards(sprint_id, &self.ctx.cards)
+                        .iter()
+                        .map(|c| c.id)
+                        .collect()
+                };
+
                 self.pop_mode();
                 self.focus.board_focus = BoardFocus::Sprints;
                 self.selection.active_sprint_index = None;
+
+                if !uncompleted_ids.is_empty() {
+                    self.handle_carry_over_for_sprint(sprint_id, uncompleted_ids);
+                }
+            }
+        }
+    }
+
+    pub fn handle_carry_over_for_sprint(&mut self, from_sprint_id: Uuid, card_ids: Vec<Uuid>) {
+        let board_id = match self.ctx.sprints.iter().find(|s| s.id == from_sprint_id) {
+            Some(sprint) => sprint.board_id,
+            None => return,
+        };
+
+        let planning_sprint_ids: Vec<Uuid> = self
+            .ctx
+            .sprints
+            .iter()
+            .filter(|s| s.board_id == board_id && s.status == SprintStatus::Planning)
+            .map(|s| s.id)
+            .collect();
+
+        match planning_sprint_ids.len() {
+            0 => {
+                self.set_error("No Planning sprint available for carry-over");
+            }
+            1 => {
+                let to_sprint_id = planning_sprint_ids[0];
+                let count = card_ids.len();
+                if let Err(e) = self.ctx.bulk_assign_sprint(card_ids, to_sprint_id) {
+                    self.set_error(format!("Carry-over failed: {}", e));
+                } else {
+                    self.set_success(format!("Carried over {} card(s) to sprint", count));
+                }
+            }
+            _ => {
+                self.dialog_input.carry_over_source_sprint_id = Some(from_sprint_id);
+                self.dialog_input.carry_over_card_ids = card_ids;
+                self.dialog_input.carry_over_sprint_selection.set(Some(0));
+                self.open_dialog(DialogMode::CarryOverSprint);
             }
         }
     }

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -126,49 +126,38 @@ impl App {
 
                 tracing::info!("Completed sprint: {}", sprint_name);
 
-                let uncompleted_ids: Vec<Uuid> = {
-                    use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-                    get_sprint_uncompleted_cards(sprint_id, &self.ctx.cards)
-                        .iter()
-                        .map(|c| c.id)
-                        .collect()
-                };
-
                 self.pop_mode();
                 self.focus.board_focus = BoardFocus::Sprints;
                 self.selection.active_sprint_index = None;
 
-                if !uncompleted_ids.is_empty() {
-                    self.handle_carry_over_for_sprint(sprint_id, uncompleted_ids);
+                {
+                    use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+                    if !get_sprint_uncompleted_cards(sprint_id, &self.ctx.cards).is_empty() {
+                        self.handle_carry_over_for_sprint(sprint_id);
+                    }
                 }
             }
         }
     }
 
-    pub fn handle_carry_over_for_sprint(&mut self, from_sprint_id: Uuid, card_ids: Vec<Uuid>) {
+    pub fn handle_carry_over_for_sprint(&mut self, from_sprint_id: Uuid) {
         let board_id = match self.ctx.sprints.iter().find(|s| s.id == from_sprint_id) {
             Some(sprint) => sprint.board_id,
             None => return,
         };
 
-        let planning_sprint_ids: Vec<Uuid> = self
+        let has_planning_sprint = self
             .ctx
             .sprints
             .iter()
-            .filter(|s| s.board_id == board_id && s.status == SprintStatus::Planning)
-            .map(|s| s.id)
-            .collect();
+            .any(|s| s.board_id == board_id && s.status == SprintStatus::Planning);
 
-        match planning_sprint_ids.len() {
-            0 => {
-                self.set_error("No Planning sprint available for carry-over");
-            }
-            _ => {
-                self.dialog_input.carry_over_source_sprint_id = Some(from_sprint_id);
-                self.dialog_input.carry_over_card_ids = card_ids;
-                self.dialog_input.carry_over_sprint_selection.set(Some(0));
-                self.open_dialog(DialogMode::CarryOverSprint);
-            }
+        if has_planning_sprint {
+            self.dialog_input.carry_over_source_sprint_id = Some(from_sprint_id);
+            self.dialog_input.carry_over_sprint_selection.set(Some(0));
+            self.open_dialog(DialogMode::CarryOverSprint);
+        } else {
+            self.set_error("No Planning sprint available for carry-over");
         }
     }
 

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -56,6 +56,7 @@ pub enum KeybindingAction {
     JumpHalfViewportDown,
     ManageParents,
     ManageChildren,
+    CarryOver,
     Undo,
     Redo,
 }

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -94,6 +94,9 @@ impl KeybindingRegistry {
                 DialogMode::ManageChildren => {
                     Box::new(DialogSelectionProvider::new("Set Children"))
                 }
+                DialogMode::CarryOverSprint => {
+                    Box::new(DialogSelectionProvider::new("Carry Over to Sprint"))
+                }
             },
         }
     }

--- a/crates/kanban-tui/src/keybindings/sprint_detail.rs
+++ b/crates/kanban-tui/src/keybindings/sprint_detail.rs
@@ -106,6 +106,12 @@ impl KeybindingProvider for SprintDetailProvider {
                     "Copy git checkout command",
                     KeybindingAction::EditCard,
                 ),
+                Keybinding::new(
+                    "R",
+                    "carry-over",
+                    "Carry over uncompleted tasks to a planning sprint",
+                    KeybindingAction::RestoreCard,
+                ),
             ],
         )
     }

--- a/crates/kanban-tui/src/keybindings/sprint_detail.rs
+++ b/crates/kanban-tui/src/keybindings/sprint_detail.rs
@@ -110,7 +110,7 @@ impl KeybindingProvider for SprintDetailProvider {
                     "M",
                     "move all",
                     "Move all uncompleted tasks to a planning sprint",
-                    KeybindingAction::RestoreCard,
+                    KeybindingAction::CarryOver,
                 ),
             ],
         )

--- a/crates/kanban-tui/src/keybindings/sprint_detail.rs
+++ b/crates/kanban-tui/src/keybindings/sprint_detail.rs
@@ -107,9 +107,9 @@ impl KeybindingProvider for SprintDetailProvider {
                     KeybindingAction::EditCard,
                 ),
                 Keybinding::new(
-                    "R",
-                    "carry-over",
-                    "Carry over uncompleted tasks to a planning sprint",
+                    "M",
+                    "move all",
+                    "Move all uncompleted tasks to a planning sprint",
                     KeybindingAction::RestoreCard,
                 ),
             ],

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -482,9 +482,9 @@ impl KanbanOperations for TuiContext {
     ) -> KanbanResult<usize> {
         use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
 
-        let from_sprint = self
-            .get_sprint(from_sprint_id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", from_sprint_id)))?;
+        let from_sprint = self.get_sprint(from_sprint_id)?.ok_or_else(|| {
+            kanban_core::KanbanError::NotFound(format!("Sprint {}", from_sprint_id))
+        })?;
         if from_sprint.status != kanban_domain::SprintStatus::Completed
             && from_sprint.status != kanban_domain::SprintStatus::Cancelled
         {
@@ -493,9 +493,9 @@ impl KanbanOperations for TuiContext {
                 from_sprint.status
             )));
         }
-        let to_sprint = self
-            .get_sprint(to_sprint_id)?
-            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", to_sprint_id)))?;
+        let to_sprint = self.get_sprint(to_sprint_id)?.ok_or_else(|| {
+            kanban_core::KanbanError::NotFound(format!("Sprint {}", to_sprint_id))
+        })?;
         if to_sprint.status != kanban_domain::SprintStatus::Planning {
             return Err(kanban_core::KanbanError::Validation(format!(
                 "Target sprint must be Planning, got {:?}",

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -403,31 +403,74 @@ impl KanbanOperations for TuiContext {
     }
 
     fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.archive_card(id).is_ok() {
-                count += 1;
-            }
+        let commands: Vec<Box<dyn Command>> = ids
+            .iter()
+            .filter(|id| self.cards.iter().any(|c| c.id == **id))
+            .map(|&card_id| Box::new(ArchiveCard { card_id }) as Box<dyn Command>)
+            .collect();
+        let count = commands.len();
+        if !commands.is_empty() {
+            self.execute_commands_batch(commands)?;
         }
         Ok(count)
     }
 
     fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.move_card(id, column_id, None).is_ok() {
-                count += 1;
-            }
+        let valid_ids: Vec<Uuid> = ids
+            .into_iter()
+            .filter(|id| self.cards.iter().any(|c| c.id == *id))
+            .collect();
+        let count = valid_ids.len();
+        if count == 0 {
+            return Ok(0);
         }
+        let base_position =
+            kanban_domain::card_lifecycle::next_position_in_column(&self.cards, column_id);
+        let commands: Vec<Box<dyn Command>> = valid_ids
+            .into_iter()
+            .enumerate()
+            .map(|(i, card_id)| {
+                Box::new(MoveCard {
+                    card_id,
+                    new_column_id: column_id,
+                    new_position: base_position + i as i32,
+                }) as Box<dyn Command>
+            })
+            .collect();
+        self.execute_commands_batch(commands)?;
         Ok(count)
     }
 
     fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.assign_card_to_sprint(id, sprint_id).is_ok() {
-                count += 1;
-            }
+        let sprint = self
+            .get_sprint(sprint_id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", sprint_id)))?;
+        let board = self
+            .boards
+            .iter()
+            .find(|b| b.id == sprint.board_id)
+            .ok_or_else(|| {
+                kanban_core::KanbanError::NotFound(format!("Board {}", sprint.board_id))
+            })?;
+        let sprint_name = sprint.get_name(board).map(|s| s.to_string());
+        let sprint_number = sprint.sprint_number;
+        let sprint_status = format!("{:?}", sprint.status);
+        let commands: Vec<Box<dyn Command>> = ids
+            .into_iter()
+            .filter(|id| self.cards.iter().any(|c| c.id == *id))
+            .map(|card_id| {
+                Box::new(AssignCardToSprint {
+                    card_id,
+                    sprint_id,
+                    sprint_number,
+                    sprint_name: sprint_name.clone(),
+                    sprint_status: sprint_status.clone(),
+                }) as Box<dyn Command>
+            })
+            .collect();
+        let count = commands.len();
+        if !commands.is_empty() {
+            self.execute_commands_batch(commands)?;
         }
         Ok(count)
     }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -432,6 +432,19 @@ impl KanbanOperations for TuiContext {
         Ok(count)
     }
 
+    fn carry_over_sprint_cards(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<usize> {
+        use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+        let ids: Vec<Uuid> = get_sprint_uncompleted_cards(from_sprint_id, &self.cards)
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        self.bulk_assign_sprint(ids, to_sprint_id)
+    }
+
     fn create_sprint(
         &mut self,
         board_id: Uuid,

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -481,6 +481,28 @@ impl KanbanOperations for TuiContext {
         to_sprint_id: Uuid,
     ) -> KanbanResult<usize> {
         use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+
+        let from_sprint = self
+            .get_sprint(from_sprint_id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", from_sprint_id)))?;
+        if from_sprint.status != kanban_domain::SprintStatus::Completed
+            && from_sprint.status != kanban_domain::SprintStatus::Cancelled
+        {
+            return Err(kanban_core::KanbanError::Validation(format!(
+                "Source sprint must be Completed or Cancelled, got {:?}",
+                from_sprint.status
+            )));
+        }
+        let to_sprint = self
+            .get_sprint(to_sprint_id)?
+            .ok_or_else(|| kanban_core::KanbanError::NotFound(format!("Sprint {}", to_sprint_id)))?;
+        if to_sprint.status != kanban_domain::SprintStatus::Planning {
+            return Err(kanban_core::KanbanError::Validation(format!(
+                "Target sprint must be Planning, got {:?}",
+                to_sprint.status
+            )));
+        }
+
         let ids: Vec<Uuid> = get_sprint_uncompleted_cards(from_sprint_id, &self.cards)
             .iter()
             .map(|c| c.id)

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -1689,7 +1689,14 @@ fn render_manage_children_popup(app: &App, frame: &mut Frame) {
 fn render_carry_over_sprint_popup(app: &App, frame: &mut Frame) {
     use crate::components::selection_dialog::CarryOverSprintDialog;
     use crate::components::SelectionDialog;
-    let card_count = app.dialog_input.carry_over_card_ids.len();
+    let card_count = app
+        .dialog_input
+        .carry_over_source_sprint_id
+        .map(|id| {
+            use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
+            get_sprint_uncompleted_cards(id, &app.ctx.cards).len()
+        })
+        .unwrap_or(0);
     CarryOverSprintDialog { card_count }.render(app, frame);
 }
 

--- a/crates/kanban-tui/src/ui.rs
+++ b/crates/kanban-tui/src/ui.rs
@@ -77,6 +77,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                 DialogMode::ConfirmSprintPrefixCollision => {}
                 DialogMode::ManageParents => render_manage_parents_popup(app, frame),
                 DialogMode::ManageChildren => render_manage_children_popup(app, frame),
+                DialogMode::CarryOverSprint => render_carry_over_sprint_popup(app, frame),
             }
         }
     } else {
@@ -1683,6 +1684,13 @@ fn render_manage_parents_popup(app: &App, frame: &mut Frame) {
 
 fn render_manage_children_popup(app: &App, frame: &mut Frame) {
     render_relationship_popup(app, frame, "Set Children", false);
+}
+
+fn render_carry_over_sprint_popup(app: &App, frame: &mut Frame) {
+    use crate::components::selection_dialog::CarryOverSprintDialog;
+    use crate::components::SelectionDialog;
+    let card_count = app.dialog_input.carry_over_card_ids.len();
+    CarryOverSprintDialog { card_count }.render(app, frame);
 }
 
 fn render_relationship_popup(app: &App, frame: &mut Frame, title: &str, _is_parent_mode: bool) {


### PR DESCRIPTION
Implements carry-over of uncompleted cards from a completed sprint to a planning sprint.

**What:**
- Add `carry_over_sprint_cards` operation to `KanbanOperations` trait and `KanbanContext`
- Add carry-over dialog that triggers on sprint completion when uncompleted cards remain
- Carry-over moves all uncompleted cards (Todo, InProgress, Blocked) to a selected planning sprint — Done cards stay in the completed sprint
- Rebind carry-over to `M` in sprint detail view (always moves all uncompleted cards)
- Expose carry-over as a CLI subcommand and MCP tool
- Batch bulk card operations into a single save to prevent file watcher flooding

**Why:**
Sprint wrap-up requires moving unfinished work forward. Without this, users had to manually reassign every uncompleted card after ending a sprint.

**How:**
- `get_sprint_uncompleted_cards` filters cards by sprint ID and non-Done status — used as the single source of truth for what gets moved
- A `CarryOverSprint` dialog mode collects the target sprint, then `carry_over_sprint_cards` reassigns cards in one batch save
- The dialog is shown automatically on sprint completion if there are uncompleted cards

**Testing:**
- Unit tests for `get_sprint_uncompleted_cards`: excludes Done, includes all non-Done statuses, excludes other sprints, empty result when all Done
- Integration tests: skips Done cards, returns zero when sprint has no cards, returns zero when all cards are Done, includes Blocked cards