### PR TITLE
KAN-211/disambiguate-card-identifier-lookup-across-boards

### DIFF
--- a/.changeset/kan-211-disambiguate-card-identifier-lookup-across-boards.md
+++ b/.changeset/kan-211-disambiguate-card-identifier-lookup-across-boards.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+- test: add CLI integration tests for ambiguous identifier resolution
+- feat: return all matches from card get for ambiguous identifier
+- test: add find_cards_by_identifier integration tests for MCP context
+- feat: return ambiguity error when multiple cards match identifier
+- refactor: rename find_card_by_identifier to find_cards_by_identifier returning Vec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,10 +155,35 @@ cargo tarpaulin        # Code coverage
 - Tokio runtime for async execution
 
 ### Testing
-- Unit tests in same file as implementation
-- Integration tests in `tests/` directory
-- Use `mockall` for mocking traits
-- Test domain logic independently of infrastructure
+
+**TDD workflow (mandatory — Red → Green → Refactor):**
+
+1. **Red**: Write a failing test that specifies the expected behavior. Present tests to the user for review before implementing anything.
+2. **Green**: Write the minimum implementation needed to make the test pass. Do not over-engineer at this step.
+3. **Refactor**: Clean up implementation and tests without breaking anything. This step is not optional.
+4. No feature or fix is complete until all tests pass and the refactor step is done.
+
+**Test naming:** Names are living documentation. Use the pattern `test_<scenario>_<expected_outcome>`, e.g. `test_move_card_to_full_column_returns_wip_limit_error`. Avoid generic names like `test1` or `it_works`.
+
+**Test return types:** Prefer `-> KanbanResult<()>` over `#[should_panic]`. This gives better failure messages and composes with `?`. Use `#[should_panic]` only for unrecoverable invariant violations.
+
+**Test requirements by layer:**
+
+| Layer | Test Type | Pattern |
+|---|---|---|
+| `kanban-core`, `kanban-domain` | Inline unit tests (`#[cfg(test)]`) | Pure logic, no I/O, no mocks needed |
+| `kanban-persistence` | Inline unit tests + real tempfile I/O | Serialization, migration, round-trips |
+| `kanban-service` | Integration tests in `tests/` | `#[tokio::test]`, `KanbanContext` with real persistence via `TempDir` |
+| `kanban-tui` | Integration tests in `tests/` | Component instantiation, key event simulation, export/import flows |
+| `kanban-cli` | Integration tests in `tests/` | `assert_cmd` + real binary invocation via `cargo_bin_cmd!` |
+| `kanban-mcp` | Integration tests in `tests/` | End-to-end tool calls against a real `KanbanContext` |
+
+**Coverage:** Use `cargo tarpaulin` to verify no untested paths exist. 100% line coverage is the floor, not the goal — every assertion must verify observable behavior or an invariant, not just execute a code path.
+
+**Refactoring for testability:** If a function cannot be tested in isolation, refactor before writing tests:
+- Extract logic from handlers/renderers into pure functions
+- Introduce trait abstractions for dependencies (e.g. I/O, time)
+- Use `mockall` for mocking traits where real I/O is impractical
 
 ## Inspirations from lazygit
 
@@ -170,6 +195,7 @@ cargo tarpaulin        # Code coverage
 
 ## Development Workflow
 
+0. **Tests First**: Follow the TDD workflow in [Testing](#testing) — write and present failing tests before any implementation.
 1. **Domain First**: Define models in `kanban-domain`
 2. **Persistence Layer**: Implement storage in `kanban-persistence`
 3. **Service Layer**: Orchestrate operations in `kanban-service`

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -112,8 +112,8 @@ impl KanbanOperations for CliContext {
         self.inner.get_card(id)
     }
 
-    fn find_card_by_identifier(&self, identifier: &str) -> KanbanResult<Option<Card>> {
-        self.inner.find_card_by_identifier(identifier)
+    fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
+        self.inner.find_cards_by_identifier(identifier)
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -17,9 +17,14 @@ fn resolve_card_id(ctx: &CliContext, id: &str) -> anyhow::Result<Uuid> {
         [] => Err(anyhow::anyhow!("Card not found: '{}'", id)),
         [card] => Ok(card.id),
         matches => Err(anyhow::anyhow!(
-            "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.",
+            "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.\n{}",
             id,
-            matches.len()
+            matches.len(),
+            matches
+                .iter()
+                .map(|c| format!("  {} — {}", c.id, c.title))
+                .collect::<Vec<_>>()
+                .join("\n")
         )),
     }
 }
@@ -52,13 +57,18 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             }
         }
         CardAction::Get { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
-                Err(e) => return output::output_error(&e.to_string()),
-            };
-            match ctx.get_card(uuid)? {
-                Some(card) => output::output_success(&card),
-                None => return output::output_error(&format!("Card not found: {}", id)),
+            if let Ok(uuid) = Uuid::parse_str(&id) {
+                match ctx.get_card(uuid)? {
+                    Some(card) => output::output_success(&card),
+                    None => return output::output_error(&format!("Card not found: '{}'", id)),
+                }
+            } else {
+                let cards = ctx.find_cards_by_identifier(&id)?;
+                match cards.as_slice() {
+                    [] => return output::output_error(&format!("Card not found: '{}'", id)),
+                    [card] => output::output_success(card),
+                    _ => output::output_success(&cards),
+                }
             }
         }
         CardAction::Update(args) => {

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -3,8 +3,8 @@ use crate::context::CliContext;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions,
-    FieldUpdate, KanbanOperations,
+    format_ambiguous_matches, ArchivedCardSummary, CardListFilter, CardPriority, CardStatus,
+    CardUpdate, CreateCardOptions, FieldUpdate, KanbanOperations,
 };
 
 use uuid::Uuid;
@@ -20,16 +20,7 @@ fn resolve_card_id(ctx: &CliContext, id: &str) -> anyhow::Result<Uuid> {
     {
         [] => Err(anyhow::anyhow!("Card not found: '{}'", id)),
         [card] => Ok(card.id),
-        matches => Err(anyhow::anyhow!(
-            "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.\n{}",
-            id,
-            matches.len(),
-            matches
-                .iter()
-                .map(|c| format!("  {} — {}", c.id, c.title))
-                .collect::<Vec<_>>()
-                .join("\n")
-        )),
+        matches => Err(anyhow::anyhow!("{}", format_ambiguous_matches(id, matches))),
     }
 }
 

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -13,7 +13,11 @@ fn resolve_card_id(ctx: &CliContext, id: &str) -> anyhow::Result<Uuid> {
     if let Ok(uuid) = Uuid::parse_str(id) {
         return Ok(uuid);
     }
-    match ctx.find_cards_by_identifier(id).map_err(anyhow::Error::from)?.as_slice() {
+    match ctx
+        .find_cards_by_identifier(id)
+        .map_err(anyhow::Error::from)?
+        .as_slice()
+    {
         [] => Err(anyhow::anyhow!("Card not found: '{}'", id)),
         [card] => Ok(card.id),
         matches => Err(anyhow::anyhow!(

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -13,10 +13,15 @@ fn resolve_card_id(ctx: &CliContext, id: &str) -> anyhow::Result<Uuid> {
     if let Ok(uuid) = Uuid::parse_str(id) {
         return Ok(uuid);
     }
-    ctx.find_card_by_identifier(id)
-        .map_err(anyhow::Error::from)?
-        .map(|c| c.id)
-        .ok_or_else(|| anyhow::anyhow!("Card not found: '{}'", id))
+    match ctx.find_cards_by_identifier(id).map_err(anyhow::Error::from)?.as_slice() {
+        [] => Err(anyhow::anyhow!("Card not found: '{}'", id)),
+        [card] => Ok(card.id),
+        matches => Err(anyhow::anyhow!(
+            "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.",
+            id,
+            matches.len()
+        )),
+    }
 }
 
 pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<()> {

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1345,6 +1345,189 @@ mod card_tests {
         assert!(json["success"].as_bool().unwrap());
         assert_eq!(json["data"]["archived"], card_uuid);
     }
+
+    #[test]
+    fn test_card_get_ambiguous_identifier_returns_all_matches() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+
+        let (board_a_id, col_a_id) = setup_board_and_column_with_prefix(&file, "KAN");
+        let (board_b_id, col_b_id) = {
+            let board_output = kanban()
+                .args([
+                    file.to_str().unwrap(),
+                    "board",
+                    "create",
+                    "--name",
+                    "Board B",
+                    "--card-prefix",
+                    "KAN",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout
+                .clone();
+            let board_json = parse_json_output(&String::from_utf8_lossy(&board_output));
+            let board_b_id = extract_id(&board_json);
+            let col_output = kanban()
+                .args([
+                    file.to_str().unwrap(),
+                    "column",
+                    "create",
+                    "--board-id",
+                    &board_b_id,
+                    "--name",
+                    "TODO",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout
+                .clone();
+            let col_json = parse_json_output(&String::from_utf8_lossy(&col_output));
+            (board_b_id, extract_id(&col_json))
+        };
+
+        let _ = board_a_id;
+        let _ = board_b_id;
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board-id",
+                &board_a_id,
+                "--column-id",
+                &col_a_id,
+                "--title",
+                "Card on A",
+            ])
+            .assert()
+            .success();
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board-id",
+                &board_b_id,
+                "--column-id",
+                &col_b_id,
+                "--title",
+                "Card on B",
+            ])
+            .assert()
+            .success();
+
+        let output = kanban()
+            .args([file.to_str().unwrap(), "card", "get", "KAN-1"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        let items = json["data"].as_array().expect("data should be an array when multiple cards match");
+        assert_eq!(items.len(), 2);
+        let titles: Vec<&str> = items.iter().map(|c| c["title"].as_str().unwrap()).collect();
+        assert!(titles.contains(&"Card on A"));
+        assert!(titles.contains(&"Card on B"));
+    }
+
+    #[test]
+    fn test_card_mutate_ambiguous_identifier_error_lists_candidates() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+
+        let (board_a_id, col_a_id) = setup_board_and_column_with_prefix(&file, "KAN");
+        let (board_b_id, col_b_id) = {
+            let board_output = kanban()
+                .args([
+                    file.to_str().unwrap(),
+                    "board",
+                    "create",
+                    "--name",
+                    "Board B",
+                    "--card-prefix",
+                    "KAN",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout
+                .clone();
+            let board_json = parse_json_output(&String::from_utf8_lossy(&board_output));
+            let board_b_id = extract_id(&board_json);
+            let col_output = kanban()
+                .args([
+                    file.to_str().unwrap(),
+                    "column",
+                    "create",
+                    "--board-id",
+                    &board_b_id,
+                    "--name",
+                    "TODO",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout
+                .clone();
+            let col_json = parse_json_output(&String::from_utf8_lossy(&col_output));
+            (board_b_id, extract_id(&col_json))
+        };
+
+        let card_a_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board-id",
+                &board_a_id,
+                "--column-id",
+                &col_a_id,
+                "--title",
+                "Card on A",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let card_a_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&card_a_output)));
+
+        let card_b_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board-id",
+                &board_b_id,
+                "--column-id",
+                &col_b_id,
+                "--title",
+                "Card on B",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let card_b_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&card_b_output)));
+
+        kanban()
+            .args([file.to_str().unwrap(), "card", "archive", "KAN-1"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Ambiguous"))
+            .stderr(predicate::str::contains(&card_a_id))
+            .stderr(predicate::str::contains(&card_b_id));
+    }
 }
 
 mod sprint_tests {

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1432,7 +1432,9 @@ mod card_tests {
 
         let json = parse_json_output(&String::from_utf8_lossy(&output));
         assert!(json["success"].as_bool().unwrap());
-        let items = json["data"].as_array().expect("data should be an array when multiple cards match");
+        let items = json["data"]
+            .as_array()
+            .expect("data should be an array when multiple cards match");
         assert_eq!(items.len(), 2);
         let titles: Vec<&str> = items.iter().map(|c| c["title"].as_str().unwrap()).collect();
         assert!(titles.contains(&"Card on A"));

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1346,107 +1346,10 @@ mod card_tests {
         assert_eq!(json["data"]["archived"], card_uuid);
     }
 
-    #[test]
-    fn test_card_get_ambiguous_identifier_returns_all_matches() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-
-        let (board_a_id, col_a_id) = setup_board_and_column_with_prefix(&file, "KAN");
-        let (board_b_id, col_b_id) = {
-            let board_output = kanban()
-                .args([
-                    file.to_str().unwrap(),
-                    "board",
-                    "create",
-                    "--name",
-                    "Board B",
-                    "--card-prefix",
-                    "KAN",
-                ])
-                .assert()
-                .success()
-                .get_output()
-                .stdout
-                .clone();
-            let board_json = parse_json_output(&String::from_utf8_lossy(&board_output));
-            let board_b_id = extract_id(&board_json);
-            let col_output = kanban()
-                .args([
-                    file.to_str().unwrap(),
-                    "column",
-                    "create",
-                    "--board-id",
-                    &board_b_id,
-                    "--name",
-                    "TODO",
-                ])
-                .assert()
-                .success()
-                .get_output()
-                .stdout
-                .clone();
-            let col_json = parse_json_output(&String::from_utf8_lossy(&col_output));
-            (board_b_id, extract_id(&col_json))
-        };
-
-        let _ = board_a_id;
-        let _ = board_b_id;
-
-        kanban()
-            .args([
-                file.to_str().unwrap(),
-                "card",
-                "create",
-                "--board-id",
-                &board_a_id,
-                "--column-id",
-                &col_a_id,
-                "--title",
-                "Card on A",
-            ])
-            .assert()
-            .success();
-
-        kanban()
-            .args([
-                file.to_str().unwrap(),
-                "card",
-                "create",
-                "--board-id",
-                &board_b_id,
-                "--column-id",
-                &col_b_id,
-                "--title",
-                "Card on B",
-            ])
-            .assert()
-            .success();
-
-        let output = kanban()
-            .args([file.to_str().unwrap(), "card", "get", "KAN-1"])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-
-        let json = parse_json_output(&String::from_utf8_lossy(&output));
-        assert!(json["success"].as_bool().unwrap());
-        let items = json["data"]
-            .as_array()
-            .expect("data should be an array when multiple cards match");
-        assert_eq!(items.len(), 2);
-        let titles: Vec<&str> = items.iter().map(|c| c["title"].as_str().unwrap()).collect();
-        assert!(titles.contains(&"Card on A"));
-        assert!(titles.contains(&"Card on B"));
-    }
-
-    #[test]
-    fn test_card_mutate_ambiguous_identifier_error_lists_candidates() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-
-        let (board_a_id, col_a_id) = setup_board_and_column_with_prefix(&file, "KAN");
+    fn setup_two_boards_same_prefix(
+        file: &std::path::Path,
+    ) -> (String, String, String, String, String, String) {
+        let (board_a_id, col_a_id) = setup_board_and_column_with_prefix(file, "KAN");
         let (board_b_id, col_b_id) = {
             let board_output = kanban()
                 .args([
@@ -1521,6 +1424,42 @@ mod card_tests {
             .stdout
             .clone();
         let card_b_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&card_b_output)));
+
+        (
+            board_a_id, col_a_id, board_b_id, col_b_id, card_a_id, card_b_id,
+        )
+    }
+
+    #[test]
+    fn test_card_get_ambiguous_identifier_returns_all_matches() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (_, _, _, _, _, _) = setup_two_boards_same_prefix(&file);
+
+        let output = kanban()
+            .args([file.to_str().unwrap(), "card", "get", "KAN-1"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        let items = json["data"]
+            .as_array()
+            .expect("data should be an array when multiple cards match");
+        assert_eq!(items.len(), 2);
+        let titles: Vec<&str> = items.iter().map(|c| c["title"].as_str().unwrap()).collect();
+        assert!(titles.contains(&"Card on A"));
+        assert!(titles.contains(&"Card on B"));
+    }
+
+    #[test]
+    fn test_card_mutate_ambiguous_identifier_error_lists_candidates() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (_, _, _, _, card_a_id, card_b_id) = setup_two_boards_same_prefix(&file);
 
         kanban()
             .args([file.to_str().unwrap(), "card", "archive", "KAN-1"])

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -44,7 +44,10 @@ pub use query::{
     },
     CardQueryBuilder,
 };
-pub use search::{BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy, TitleSearcher};
+pub use search::{
+    format_ambiguous_matches, BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy,
+    TitleSearcher,
+};
 pub use snapshot::Snapshot;
 pub use sort::{get_sorter_for_field, OrderedSorter, SortBy};
 pub use sprint::{Sprint, SprintId, SprintStatus, SprintUpdate};

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -47,7 +47,7 @@ pub trait KanbanOperations {
     ) -> KanbanResult<Card>;
     fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>>;
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>>;
-    fn find_card_by_identifier(&self, identifier: &str) -> KanbanResult<Option<Card>>;
+    fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>>;
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card>;
     fn move_card(&mut self, id: Uuid, column_id: Uuid, position: Option<i32>)
         -> KanbanResult<Card>;

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -714,6 +714,8 @@ mod tests {
         assert!(find_cards_by_identifier("KAN-", &cards, &columns, &boards, &[]).is_empty());
         assert!(find_cards_by_identifier("KAN-abc", &cards, &columns, &boards, &[]).is_empty());
         assert!(find_cards_by_identifier("-5", &cards, &columns, &boards, &[]).is_empty());
-        assert!(find_cards_by_identifier("not-a-number", &cards, &columns, &boards, &[]).is_empty());
+        assert!(
+            find_cards_by_identifier("not-a-number", &cards, &columns, &boards, &[]).is_empty()
+        );
     }
 }

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -268,6 +268,22 @@ pub fn find_cards_by_identifier<'a>(
         .collect()
 }
 
+/// Format an error message listing ambiguous card matches.
+///
+/// Used by both CLI and MCP when an identifier resolves to multiple cards.
+pub fn format_ambiguous_matches(identifier: &str, cards: &[Card]) -> String {
+    format!(
+        "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.\n{}",
+        identifier,
+        cards.len(),
+        cards
+            .iter()
+            .map(|c| format!("  {} — {}", c.id, c.title))
+            .collect::<Vec<_>>()
+            .join("\n")
+    )
+}
+
 impl CardSearcher for CompositeSearcher {
     fn matches(&self, card: &Card, board: &Board, sprints: &[Sprint]) -> bool {
         if self.searchers.is_empty() {

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -222,45 +222,50 @@ fn parse_identifier(identifier: &str) -> Option<ParsedIdentifier> {
     }
 }
 
-/// Find a card by identifier (e.g. `"KAN-5"` or `"5"`), searching across all boards.
+/// Find all cards matching an identifier (e.g. `"KAN-5"` or `"5"`), searching across all boards.
 ///
-/// - `"PREFIX-N"`: matches the first card whose resolved prefix equals `PREFIX` (case-insensitive)
+/// - `"PREFIX-N"`: returns all cards whose resolved prefix equals `PREFIX` (case-insensitive)
 ///   and whose `card_number` equals `N`. Prefix resolution follows:
 ///   `card.card_prefix → card.assigned_prefix → sprint.card_prefix → board.card_prefix`.
-/// - `"N"` (bare number): matches the **first** card with `card_number == N` regardless of board.
-///   When multiple boards share card numbers, insertion order in `cards` determines the result.
-pub fn find_card_by_identifier<'a>(
+/// - `"N"` (bare number): returns all cards with `card_number == N` regardless of board.
+/// - Returns an empty `Vec` if the identifier cannot be parsed or no cards match.
+pub fn find_cards_by_identifier<'a>(
     identifier: &str,
     cards: &'a [Card],
     columns: &[Column],
     boards: &[Board],
     sprints: &[Sprint],
-) -> Option<&'a Card> {
-    let parsed = parse_identifier(identifier)?;
-    cards.iter().find(|card| match &parsed {
-        ParsedIdentifier::PrefixAndNumber { prefix, number } => {
-            let board = columns
-                .iter()
-                .find(|col| col.id == card.column_id)
-                .and_then(|col| boards.iter().find(|b| b.id == col.board_id));
-            let Some(board) = board else { return false };
-            let resolved_prefix = card
-                .card_prefix
-                .as_deref()
-                .or(card.assigned_prefix.as_deref())
-                .or_else(|| {
-                    card.sprint_id
-                        .and_then(|sid| sprints.iter().find(|s| s.id == sid))
-                        .and_then(|s| s.card_prefix.as_deref())
-                })
-                .or(board.card_prefix.as_deref());
-            resolved_prefix
-                .map(|p| p.to_lowercase() == *prefix)
-                .unwrap_or(false)
-                && card.card_number == *number
-        }
-        ParsedIdentifier::NumberOnly(number) => card.card_number == *number,
-    })
+) -> Vec<&'a Card> {
+    let Some(parsed) = parse_identifier(identifier) else {
+        return vec![];
+    };
+    cards
+        .iter()
+        .filter(|card| match &parsed {
+            ParsedIdentifier::PrefixAndNumber { prefix, number } => {
+                let board = columns
+                    .iter()
+                    .find(|col| col.id == card.column_id)
+                    .and_then(|col| boards.iter().find(|b| b.id == col.board_id));
+                let Some(board) = board else { return false };
+                let resolved_prefix = card
+                    .card_prefix
+                    .as_deref()
+                    .or(card.assigned_prefix.as_deref())
+                    .or_else(|| {
+                        card.sprint_id
+                            .and_then(|sid| sprints.iter().find(|s| s.id == sid))
+                            .and_then(|s| s.card_prefix.as_deref())
+                    })
+                    .or(board.card_prefix.as_deref());
+                resolved_prefix
+                    .map(|p| p.to_lowercase() == *prefix)
+                    .unwrap_or(false)
+                    && card.card_number == *number
+            }
+            ParsedIdentifier::NumberOnly(number) => card.card_number == *number,
+        })
+        .collect()
 }
 
 impl CardSearcher for CompositeSearcher {
@@ -375,7 +380,25 @@ mod tests {
     }
 
     #[test]
-    fn test_find_card_by_identifier_prefix_format() {
+    fn test_find_cards_by_identifier_empty_cards_returns_empty() {
+        assert!(find_cards_by_identifier("KAN-1", &[], &[], &[], &[]).is_empty());
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_unparseable_identifier_returns_empty() {
+        let mut board = Board::new("Project".to_string(), None);
+        board.card_prefix = Some("KAN".to_string());
+        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
+        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0, "KAN");
+        let boards = vec![board];
+        let columns = vec![column];
+        let cards = vec![card];
+        assert!(find_cards_by_identifier("", &cards, &columns, &boards, &[]).is_empty());
+        assert!(find_cards_by_identifier("---", &cards, &columns, &boards, &[]).is_empty());
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_single_prefix_match_returns_one() {
         let mut board = Board::new("Project".to_string(), None);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -384,18 +407,33 @@ mod tests {
         let columns = vec![column];
         let cards = vec![card.clone()];
 
-        assert_eq!(
-            find_card_by_identifier("KAN-1", &cards, &columns, &boards, &[]).map(|c| c.id),
-            Some(card.id)
-        );
-        assert_eq!(
-            find_card_by_identifier("kan-1", &cards, &columns, &boards, &[]).map(|c| c.id),
-            Some(card.id)
-        );
+        let result = find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card.id);
     }
 
     #[test]
-    fn test_find_card_by_identifier_number_only() {
+    fn test_find_cards_by_identifier_ambiguous_prefix_returns_both() {
+        let mut board1 = Board::new("Board One".to_string(), None);
+        board1.card_prefix = Some("KAN".to_string());
+        let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
+        let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0, "KAN");
+
+        let mut board2 = Board::new("Board Two".to_string(), None);
+        board2.card_prefix = Some("KAN".to_string());
+        let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
+        let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0, "KAN");
+
+        let boards = vec![board1, board2];
+        let columns = vec![col1, col2];
+        let cards = vec![card1.clone(), card2.clone()];
+
+        let result = find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[]);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_single_bare_number_returns_one() {
         let mut board = Board::new("Project".to_string(), None);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -404,14 +442,33 @@ mod tests {
         let columns = vec![column];
         let cards = vec![card.clone()];
 
-        assert_eq!(
-            find_card_by_identifier("1", &cards, &columns, &boards, &[]).map(|c| c.id),
-            Some(card.id)
-        );
+        let result = find_cards_by_identifier("1", &cards, &columns, &boards, &[]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card.id);
     }
 
     #[test]
-    fn test_find_card_by_identifier_not_found() {
+    fn test_find_cards_by_identifier_ambiguous_bare_number_returns_both() {
+        let mut board1 = Board::new("Board One".to_string(), None);
+        board1.card_prefix = Some("AAA".to_string());
+        let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
+        let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0, "AAA");
+
+        let mut board2 = Board::new("Board Two".to_string(), None);
+        board2.card_prefix = Some("BBB".to_string());
+        let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
+        let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0, "BBB");
+
+        let boards = vec![board1, board2];
+        let columns = vec![col1, col2];
+        let cards = vec![card1.clone(), card2.clone()];
+
+        let result = find_cards_by_identifier("1", &cards, &columns, &boards, &[]);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_no_match_returns_empty() {
         let mut board = Board::new("Project".to_string(), None);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -420,11 +477,91 @@ mod tests {
         let columns = vec![column];
         let cards = vec![card];
 
-        assert!(find_card_by_identifier("KAN-99", &cards, &columns, &boards, &[]).is_none());
+        assert!(find_cards_by_identifier("KAN-99", &cards, &columns, &boards, &[]).is_empty());
     }
 
     #[test]
-    fn test_find_card_by_identifier_second_board() {
+    fn test_find_cards_by_identifier_ambiguous_sprint_prefix_returns_both() {
+        let mut board_a = Board::new("Board A".to_string(), None);
+        board_a.card_prefix = Some("PROJ".to_string());
+        let col_a = crate::Column::new(board_a.id, "Todo".to_string(), 0);
+        let card_a = Card::new(&mut board_a, col_a.id, "Card A".to_string(), 0, "PROJ");
+
+        let mut board_b = Board::new("Board B".to_string(), None);
+        let col_b = crate::Column::new(board_b.id, "Todo".to_string(), 0);
+        let mut sprint = crate::Sprint::new(board_b.id, 1, None, None);
+        sprint.card_prefix = Some("PROJ".to_string());
+        let mut card_b = Card::new(&mut board_b, col_b.id, "Card B".to_string(), 0, "task");
+        card_b.sprint_id = Some(sprint.id);
+        card_b.assigned_prefix = None;
+        card_b.card_prefix = None;
+
+        let boards = vec![board_a, board_b];
+        let columns = vec![col_a, col_b];
+        let cards = vec![card_a.clone(), card_b.clone()];
+        let sprints = vec![sprint];
+
+        let result = find_cards_by_identifier("PROJ-1", &cards, &columns, &boards, &sprints);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_prefix_format() {
+        let mut board = Board::new("Project".to_string(), None);
+        board.card_prefix = Some("KAN".to_string());
+        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
+        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0, "KAN");
+        let boards = vec![board];
+        let columns = vec![column];
+        let cards = vec![card.clone()];
+
+        assert_eq!(
+            find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[])
+                .first()
+                .map(|c| c.id),
+            Some(card.id)
+        );
+        assert_eq!(
+            find_cards_by_identifier("kan-1", &cards, &columns, &boards, &[])
+                .first()
+                .map(|c| c.id),
+            Some(card.id)
+        );
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_number_only() {
+        let mut board = Board::new("Project".to_string(), None);
+        board.card_prefix = Some("KAN".to_string());
+        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
+        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0, "KAN");
+        let boards = vec![board];
+        let columns = vec![column];
+        let cards = vec![card.clone()];
+
+        assert_eq!(
+            find_cards_by_identifier("1", &cards, &columns, &boards, &[])
+                .first()
+                .map(|c| c.id),
+            Some(card.id)
+        );
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_not_found() {
+        let mut board = Board::new("Project".to_string(), None);
+        board.card_prefix = Some("KAN".to_string());
+        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
+        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0, "KAN");
+        let boards = vec![board];
+        let columns = vec![column];
+        let cards = vec![card];
+
+        assert!(find_cards_by_identifier("KAN-99", &cards, &columns, &boards, &[]).is_empty());
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_second_board() {
         let mut board1 = Board::new("Board One".to_string(), None);
         board1.card_prefix = Some("AAA".to_string());
         let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
@@ -440,13 +577,15 @@ mod tests {
         let cards = vec![card1, card2.clone()];
 
         assert_eq!(
-            find_card_by_identifier("BBB-1", &cards, &columns, &boards, &[]).map(|c| c.id),
+            find_cards_by_identifier("BBB-1", &cards, &columns, &boards, &[])
+                .first()
+                .map(|c| c.id),
             Some(card2.id)
         );
     }
 
     #[test]
-    fn test_find_card_by_identifier_no_prefix_collision() {
+    fn test_find_cards_by_identifier_no_prefix_collision() {
         let mut board = Board::new("Project".to_string(), None);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -458,12 +597,13 @@ mod tests {
         let columns = vec![column];
         let cards = vec![card1.clone(), card11];
 
-        let result = find_card_by_identifier("KAN-1", &cards, &columns, &boards, &[]);
-        assert_eq!(result.map(|c| c.id), Some(card1.id));
+        let result = find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card1.id);
     }
 
     #[test]
-    fn test_find_card_by_identifier_exact_number() {
+    fn test_find_cards_by_identifier_exact_number() {
         let mut board = Board::new("Project".to_string(), None);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -481,12 +621,13 @@ mod tests {
         let columns = vec![column];
         let cards = vec![card11.clone(), card111];
 
-        let result = find_card_by_identifier("KAN-11", &cards, &columns, &boards, &[]);
-        assert_eq!(result.map(|c| c.id), Some(card11.id));
+        let result = find_cards_by_identifier("KAN-11", &cards, &columns, &boards, &[]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card11.id);
     }
 
     #[test]
-    fn test_find_card_by_identifier_sprint_prefix() {
+    fn test_find_cards_by_identifier_sprint_prefix() {
         let mut board = Board::new("Project".to_string(), None);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -501,18 +642,14 @@ mod tests {
         let cards = vec![card.clone()];
         let sprints = vec![sprint];
 
-        assert_eq!(
-            find_card_by_identifier("SP-1", &cards, &columns, &boards, &sprints).map(|c| c.id),
-            Some(card.id)
-        );
-        assert_eq!(
-            find_card_by_identifier("KAN-1", &cards, &columns, &boards, &sprints).map(|c| c.id),
-            None
-        );
+        let result = find_cards_by_identifier("SP-1", &cards, &columns, &boards, &sprints);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card.id);
+        assert!(find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &sprints).is_empty());
     }
 
     #[test]
-    fn test_find_card_by_identifier_card_prefix_override() {
+    fn test_find_cards_by_identifier_card_prefix_override() {
         let mut board = Board::new("Project".to_string(), None);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -523,21 +660,15 @@ mod tests {
         let columns = vec![column];
         let cards = vec![card.clone()];
 
-        // card_prefix takes priority over assigned_prefix
-        assert_eq!(
-            find_card_by_identifier("CARD-1", &cards, &columns, &boards, &[]).map(|c| c.id),
-            Some(card.id)
-        );
-        assert_eq!(
-            find_card_by_identifier("ASSIGNED-1", &cards, &columns, &boards, &[]).map(|c| c.id),
-            None
-        );
+        let result = find_cards_by_identifier("CARD-1", &cards, &columns, &boards, &[]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card.id);
+        assert!(find_cards_by_identifier("ASSIGNED-1", &cards, &columns, &boards, &[]).is_empty());
     }
 
     #[test]
-    fn test_find_card_by_identifier_no_prefix_no_match() {
+    fn test_find_cards_by_identifier_no_prefix_no_match() {
         let mut board = Board::new("Project".to_string(), None);
-        // No board card_prefix
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let mut card = Card::new(
             &mut board,
@@ -552,32 +683,8 @@ mod tests {
         let columns = vec![column];
         let cards = vec![card];
 
-        // PrefixAndNumber with no resolved prefix → no match
-        assert!(find_card_by_identifier("task-1", &cards, &columns, &boards, &[]).is_none());
-        assert!(find_card_by_identifier("KAN-1", &cards, &columns, &boards, &[]).is_none());
-    }
-
-    #[test]
-    fn test_find_card_by_identifier_number_only_multi_board() {
-        let mut board1 = Board::new("Board One".to_string(), None);
-        board1.card_prefix = Some("AAA".to_string());
-        let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
-        let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0, "AAA");
-
-        let mut board2 = Board::new("Board Two".to_string(), None);
-        board2.card_prefix = Some("BBB".to_string());
-        let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
-        let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0, "BBB");
-
-        let boards = vec![board1, board2];
-        let columns = vec![col1, col2];
-        // card1 comes first in the slice — bare number returns the first match
-        let cards = vec![card1.clone(), card2];
-
-        assert_eq!(
-            find_card_by_identifier("1", &cards, &columns, &boards, &[]).map(|c| c.id),
-            Some(card1.id)
-        );
+        assert!(find_cards_by_identifier("task-1", &cards, &columns, &boards, &[]).is_empty());
+        assert!(find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[]).is_empty());
     }
 
     #[test]
@@ -603,10 +710,10 @@ mod tests {
         let boards = vec![];
         let columns = vec![];
         let cards = vec![];
-        assert!(find_card_by_identifier("", &cards, &columns, &boards, &[]).is_none());
-        assert!(find_card_by_identifier("KAN-", &cards, &columns, &boards, &[]).is_none());
-        assert!(find_card_by_identifier("KAN-abc", &cards, &columns, &boards, &[]).is_none());
-        assert!(find_card_by_identifier("-5", &cards, &columns, &boards, &[]).is_none());
-        assert!(find_card_by_identifier("not-a-number", &cards, &columns, &boards, &[]).is_none());
+        assert!(find_cards_by_identifier("", &cards, &columns, &boards, &[]).is_empty());
+        assert!(find_cards_by_identifier("KAN-", &cards, &columns, &boards, &[]).is_empty());
+        assert!(find_cards_by_identifier("KAN-abc", &cards, &columns, &boards, &[]).is_empty());
+        assert!(find_cards_by_identifier("-5", &cards, &columns, &boards, &[]).is_empty());
+        assert!(find_cards_by_identifier("not-a-number", &cards, &columns, &boards, &[]).is_empty());
     }
 }

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -119,8 +119,8 @@ impl KanbanOperations for McpContext {
         self.inner.get_card(id)
     }
 
-    fn find_card_by_identifier(&self, identifier: &str) -> KanbanResult<Option<Card>> {
-        self.inner.find_card_by_identifier(identifier)
+    fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
+        self.inner.find_cards_by_identifier(identifier)
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -109,14 +109,22 @@ async fn resolve_card_id(ctx: &Arc<Mutex<McpContext>>, s: &str) -> Result<Uuid, 
     if let Ok(id) = Uuid::parse_str(s) {
         return Ok(id);
     }
-    let card = {
+    let matches = {
         let guard = ctx.lock().await;
-        guard
-            .find_card_by_identifier(s)
-            .map_err(kanban_err_to_mcp)?
+        guard.find_cards_by_identifier(s).map_err(kanban_err_to_mcp)?
     };
-    card.map(|c| c.id)
-        .ok_or_else(|| McpError::invalid_params(format!("Card not found: '{}'", s), None))
+    match matches.as_slice() {
+        [] => Err(McpError::invalid_params(format!("Card not found: '{}'", s), None)),
+        [card] => Ok(card.id),
+        cards => Err(McpError::invalid_params(
+            format!(
+                "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.",
+                s,
+                cards.len()
+            ),
+            None,
+        )),
+    }
 }
 
 /// Lock, mutate, save.

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -118,9 +118,14 @@ async fn resolve_card_id(ctx: &Arc<Mutex<McpContext>>, s: &str) -> Result<Uuid, 
         [card] => Ok(card.id),
         cards => Err(McpError::invalid_params(
             format!(
-                "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.",
+                "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.\n{}",
                 s,
-                cards.len()
+                cards.len(),
+                cards
+                    .iter()
+                    .map(|c| format!("  {} — {}", c.id, c.title))
+                    .collect::<Vec<_>>()
+                    .join("\n")
             ),
             None,
         )),
@@ -713,14 +718,29 @@ impl KanbanMcpServer {
         to_call_tool_result(&result)
     }
 
-    #[tool(description = "Get a specific card by UUID or identifier (e.g. KAN-5)")]
+    #[tool(description = "Get a specific card by UUID or identifier (e.g. KAN-5). Returns a single card for UUID or unambiguous identifier, or a list of all matching cards if the identifier is ambiguous.")]
     async fn tool_get_card(
         &self,
         Parameters(req): Parameters<GetCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let card = read_op!(self.ctx, get_card, id)?;
-        to_call_tool_result(&card)
+        if let Ok(uuid) = uuid::Uuid::parse_str(&req.card_id) {
+            let card = read_op!(self.ctx, get_card, uuid)?;
+            return to_call_tool_result(&card);
+        }
+        let cards = {
+            let guard = self.ctx.lock().await;
+            guard
+                .find_cards_by_identifier(&req.card_id)
+                .map_err(kanban_err_to_mcp)?
+        };
+        match cards.as_slice() {
+            [] => Err(McpError::invalid_params(
+                format!("Card not found: '{}'", req.card_id),
+                None,
+            )),
+            [_] => to_call_tool_result(&cards[0]),
+            _ => to_call_tool_result(&cards),
+        }
     }
 
     #[tool(

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -4,8 +4,9 @@ use context::McpContext;
 use kanban_core::KanbanError;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardSummary, BoardUpdate, CardListFilter, CardPriority, CardStatus, CardUpdate,
-    ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, SprintUpdate,
+    format_ambiguous_matches, ArchivedCardSummary, BoardUpdate, CardListFilter, CardPriority,
+    CardStatus, CardUpdate, ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations,
+    SprintUpdate,
 };
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -122,16 +123,7 @@ async fn resolve_card_id(ctx: &Arc<Mutex<McpContext>>, s: &str) -> Result<Uuid, 
         )),
         [card] => Ok(card.id),
         cards => Err(McpError::invalid_params(
-            format!(
-                "Ambiguous identifier '{}': {} cards match. Use a UUID to be specific.\n{}",
-                s,
-                cards.len(),
-                cards
-                    .iter()
-                    .map(|c| format!("  {} — {}", c.id, c.title))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            ),
+            format_ambiguous_matches(s, cards),
             None,
         )),
     }
@@ -745,7 +737,7 @@ impl KanbanMcpServer {
                 format!("Card not found: '{}'", req.card_id),
                 None,
             )),
-            [_] => to_call_tool_result(&cards[0]),
+            [card] => to_call_tool_result(card),
             _ => to_call_tool_result(&cards),
         }
     }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -111,10 +111,15 @@ async fn resolve_card_id(ctx: &Arc<Mutex<McpContext>>, s: &str) -> Result<Uuid, 
     }
     let matches = {
         let guard = ctx.lock().await;
-        guard.find_cards_by_identifier(s).map_err(kanban_err_to_mcp)?
+        guard
+            .find_cards_by_identifier(s)
+            .map_err(kanban_err_to_mcp)?
     };
     match matches.as_slice() {
-        [] => Err(McpError::invalid_params(format!("Card not found: '{}'", s), None)),
+        [] => Err(McpError::invalid_params(
+            format!("Card not found: '{}'", s),
+            None,
+        )),
         [card] => Ok(card.id),
         cards => Err(McpError::invalid_params(
             format!(
@@ -718,7 +723,9 @@ impl KanbanMcpServer {
         to_call_tool_result(&result)
     }
 
-    #[tool(description = "Get a specific card by UUID or identifier (e.g. KAN-5). Returns a single card for UUID or unambiguous identifier, or a list of all matching cards if the identifier is ambiguous.")]
+    #[tool(
+        description = "Get a specific card by UUID or identifier (e.g. KAN-5). Returns a single card for UUID or unambiguous identifier, or a list of all matching cards if the identifier is ambiguous."
+    )]
     async fn tool_get_card(
         &self,
         Parameters(req): Parameters<GetCardRequest>,

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -339,7 +339,9 @@ async fn test_delete_persists() {
 #[tokio::test]
 async fn find_cards_by_identifier_single_match() {
     let (mut ctx, _tmp) = setup().await;
-    let board = ctx.create_board("Project".into(), Some("KAN".into())).unwrap();
+    let board = ctx
+        .create_board("Project".into(), Some("KAN".into()))
+        .unwrap();
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
     let card = ctx
         .create_card(board.id, col.id, "My Task".into(), Default::default())
@@ -354,13 +356,17 @@ async fn find_cards_by_identifier_single_match() {
 async fn find_cards_by_identifier_multiple_matches() {
     let (mut ctx, _tmp) = setup().await;
 
-    let board_a = ctx.create_board("Board A".into(), Some("KAN".into())).unwrap();
+    let board_a = ctx
+        .create_board("Board A".into(), Some("KAN".into()))
+        .unwrap();
     let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
     let card_a = ctx
         .create_card(board_a.id, col_a.id, "Card on A".into(), Default::default())
         .unwrap();
 
-    let board_b = ctx.create_board("Board B".into(), Some("KAN".into())).unwrap();
+    let board_b = ctx
+        .create_board("Board B".into(), Some("KAN".into()))
+        .unwrap();
     let col_b = ctx.create_column(board_b.id, "Todo".into(), None).unwrap();
     let card_b = ctx
         .create_card(board_b.id, col_b.id, "Card on B".into(), Default::default())
@@ -376,7 +382,9 @@ async fn find_cards_by_identifier_multiple_matches() {
 #[tokio::test]
 async fn find_cards_by_identifier_not_found() {
     let (mut ctx, _tmp) = setup().await;
-    let board = ctx.create_board("Project".into(), Some("KAN".into())).unwrap();
+    let board = ctx
+        .create_board("Project".into(), Some("KAN".into()))
+        .unwrap();
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
     ctx.create_card(board.id, col.id, "My Task".into(), Default::default())
         .unwrap();

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -333,3 +333,54 @@ async fn test_delete_persists() {
     let fresh = KanbanContext::load_json(&path_str).await.unwrap();
     assert!(fresh.list_boards().unwrap().is_empty());
 }
+
+// find_cards_by_identifier
+
+#[tokio::test]
+async fn find_cards_by_identifier_single_match() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx.create_board("Project".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "My Task".into(), Default::default())
+        .unwrap();
+
+    let results = ctx.find_cards_by_identifier("KAN-1").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, card.id);
+}
+
+#[tokio::test]
+async fn find_cards_by_identifier_multiple_matches() {
+    let (mut ctx, _tmp) = setup().await;
+
+    let board_a = ctx.create_board("Board A".into(), Some("KAN".into())).unwrap();
+    let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
+    let card_a = ctx
+        .create_card(board_a.id, col_a.id, "Card on A".into(), Default::default())
+        .unwrap();
+
+    let board_b = ctx.create_board("Board B".into(), Some("KAN".into())).unwrap();
+    let col_b = ctx.create_column(board_b.id, "Todo".into(), None).unwrap();
+    let card_b = ctx
+        .create_card(board_b.id, col_b.id, "Card on B".into(), Default::default())
+        .unwrap();
+
+    let results = ctx.find_cards_by_identifier("KAN-1").unwrap();
+    assert_eq!(results.len(), 2);
+    let ids: Vec<_> = results.iter().map(|c| c.id).collect();
+    assert!(ids.contains(&card_a.id));
+    assert!(ids.contains(&card_b.id));
+}
+
+#[tokio::test]
+async fn find_cards_by_identifier_not_found() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx.create_board("Project".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    ctx.create_card(board.id, col.id, "My Task".into(), Default::default())
+        .unwrap();
+
+    let results = ctx.find_cards_by_identifier("KAN-99").unwrap();
+    assert!(results.is_empty());
+}

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -349,16 +349,12 @@ impl KanbanOperations for KanbanContext {
         Ok(self.cards.iter().find(|c| c.id == id).cloned())
     }
 
-    fn find_card_by_identifier(&self, identifier: &str) -> KanbanResult<Option<Card>> {
-        use kanban_domain::search::find_card_by_identifier as search_by_identifier;
-        Ok(search_by_identifier(
-            identifier,
-            &self.cards,
-            &self.columns,
-            &self.boards,
-            &self.sprints,
-        )
-        .cloned())
+    fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
+        use kanban_domain::search::find_cards_by_identifier as search;
+        Ok(search(identifier, &self.cards, &self.columns, &self.boards, &self.sprints)
+            .into_iter()
+            .cloned()
+            .collect())
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -351,10 +351,16 @@ impl KanbanOperations for KanbanContext {
 
     fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
         use kanban_domain::search::find_cards_by_identifier as search;
-        Ok(search(identifier, &self.cards, &self.columns, &self.boards, &self.sprints)
-            .into_iter()
-            .cloned()
-            .collect())
+        Ok(search(
+            identifier,
+            &self.cards,
+            &self.columns,
+            &self.boards,
+            &self.sprints,
+        )
+        .into_iter()
+        .cloned()
+        .collect())
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -229,16 +229,12 @@ impl KanbanOperations for TuiContext {
         Ok(self.cards.iter().find(|c| c.id == id).cloned())
     }
 
-    fn find_card_by_identifier(&self, identifier: &str) -> KanbanResult<Option<Card>> {
-        use kanban_domain::search::find_card_by_identifier as search_by_identifier;
-        Ok(search_by_identifier(
-            identifier,
-            &self.cards,
-            &self.columns,
-            &self.boards,
-            &self.sprints,
-        )
-        .cloned())
+    fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
+        use kanban_domain::search::find_cards_by_identifier as search;
+        Ok(search(identifier, &self.cards, &self.columns, &self.boards, &self.sprints)
+            .into_iter()
+            .cloned()
+            .collect())
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -231,10 +231,16 @@ impl KanbanOperations for TuiContext {
 
     fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
         use kanban_domain::search::find_cards_by_identifier as search;
-        Ok(search(identifier, &self.cards, &self.columns, &self.boards, &self.sprints)
-            .into_iter()
-            .cloned()
-            .collect())
+        Ok(search(
+            identifier,
+            &self.cards,
+            &self.columns,
+            &self.boards,
+            &self.sprints,
+        )
+        .into_iter()
+        .cloned()
+        .collect())
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {


### PR DESCRIPTION
Disambiguates card identifier lookup across boards by returning all matches instead of silently picking the first.

## What

- `find_card_by_identifier` renamed to `find_cards_by_identifier`, return type changed from `Option<&Card>` to `Vec<&Card>` — returns all matching cards rather than the first
- `KanbanOperations::find_cards_by_identifier` trait method updated to `KanbanResult<Vec<Card>>`
- `card get` / `tool_get_card` now return all matching cards when an identifier is ambiguous, instead of erroring
- `resolve_card_id` (used for mutations) errors on ambiguity and lists each candidate UUID + title so the caller knows what to pass
- All context implementations updated: kanban-service, kanban-tui, kanban-cli, kanban-mcp

## Why

The previous implementation used `.find()` and silently returned the first match when multiple cards resolved to the same identifier (e.g. two boards with the same `card_prefix`, or a board prefix colliding with a sprint `card_prefix` on another board, or a bare number query like `"1"` across any multi-board setup). This made ambiguous lookups invisible and non-deterministic.

## How

- Domain function uses `.filter().collect()` instead of `.find()` — same match predicate, no logic changes
- Read operations (`card get`, `tool_get_card`) call `find_cards_by_identifier` directly: 1 match returns a single card (backwards compatible), 2+ matches return the full list
- Mutating operations still require an unambiguous identifier and error with the candidate list if multiple match
- MCP and CLI `resolve_card_id` helpers updated consistently

## Testing

- 8 new domain unit tests covering empty input, unparseable identifiers, single match, ambiguous prefix, bare number, ambiguous bare number, no match, and ambiguous sprint prefix
- 3 new MCP context integration tests: single match, multiple matches, not found
- 2 new CLI integration tests: ambiguous `card get` returns all matches; ambiguous mutation errors with both candidate UUIDs listed