### PR TITLE
KAN-171: replace silent failures with proper NotFound errors in domain commands

### DIFF
--- a/.changeset/kan-171-replace-silent-failures-with-proper-errors.md
+++ b/.changeset/kan-171-replace-silent-failures-with-proper-errors.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+- fix(domain): replace silent failure with NotFound error in CreateSubcardCommand (ef6aa323bdeeca39a07eb6afa273901719158b5f)
+- fix(domain): replace silent failures with NotFound errors in sprint commands (6828c75d20bff02169e4f04e41d0b5fdc54de0e4)
+- fix(domain): replace silent failure with NotFound error in UpdateColumn (a70a5c449f8236d8cb19e2ee59bec6fd3d9779fd)
+- fix(domain): replace silent failures with NotFound errors in card commands (00d17452e29ed77e4de1edcdeaa69b7aec5cd878)
+- fix(domain): replace silent failures with NotFound errors in board commands (d3810135a1131be6b0e9ce5acc4643248443433b)
+- feat(domain): add CommandContext lookup helpers that return NotFound errors (0e2817bb9573a2e60bb0734f5b5b691ac04b610b)

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -108,51 +108,42 @@ impl Command for DeleteBoard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::DependencyGraph;
-    use kanban_core::KanbanError;
-
-    fn create_test_context() -> CommandContext<'static> {
-        CommandContext {
-            boards: Box::leak(Box::new(Vec::new())),
-            columns: Box::leak(Box::new(Vec::new())),
-            cards: Box::leak(Box::new(Vec::new())),
-            sprints: Box::leak(Box::new(Vec::new())),
-            archived_cards: Box::leak(Box::new(Vec::new())),
-            graph: Box::leak(Box::new(DependencyGraph::new())),
-        }
-    }
+    use super::super::test_helpers::TestContext;
 
     #[test]
     fn test_update_board_not_found_returns_error() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let cmd = UpdateBoard {
             board_id: Uuid::new_v4(),
             updates: BoardUpdate::default(),
         };
         let result = cmd.execute(&mut context);
-        assert!(matches!(result, Err(KanbanError::NotFound(_))));
+        assert!(result.unwrap_err().is_not_found());
     }
 
     #[test]
     fn test_set_board_task_sort_not_found_returns_error() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let cmd = SetBoardTaskSort {
             board_id: Uuid::new_v4(),
             field: crate::SortField::Priority,
             order: crate::SortOrder::Ascending,
         };
         let result = cmd.execute(&mut context);
-        assert!(matches!(result, Err(KanbanError::NotFound(_))));
+        assert!(result.unwrap_err().is_not_found());
     }
 
     #[test]
     fn test_set_board_task_list_view_not_found_returns_error() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let cmd = SetBoardTaskListView {
             board_id: Uuid::new_v4(),
             view: crate::TaskListView::default(),
         };
         let result = cmd.execute(&mut context);
-        assert!(matches!(result, Err(KanbanError::NotFound(_))));
+        assert!(result.unwrap_err().is_not_found());
     }
 }

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -29,9 +29,8 @@ pub struct UpdateBoard {
 
 impl Command for UpdateBoard {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(board) = context.boards.iter_mut().find(|b| b.id == self.board_id) {
-            board.update(self.updates.clone());
-        }
+        let board = context.board_mut(self.board_id)?;
+        board.update(self.updates.clone());
         Ok(())
     }
 
@@ -49,9 +48,8 @@ pub struct SetBoardTaskSort {
 
 impl Command for SetBoardTaskSort {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(board) = context.boards.iter_mut().find(|b| b.id == self.board_id) {
-            board.update_task_sort(self.field, self.order);
-        }
+        let board = context.board_mut(self.board_id)?;
+        board.update_task_sort(self.field, self.order);
         Ok(())
     }
 
@@ -68,9 +66,8 @@ pub struct SetBoardTaskListView {
 
 impl Command for SetBoardTaskListView {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(board) = context.boards.iter_mut().find(|b| b.id == self.board_id) {
-            board.update_task_list_view(self.view);
-        }
+        let board = context.board_mut(self.board_id)?;
+        board.update_task_list_view(self.view);
         Ok(())
     }
 
@@ -105,5 +102,57 @@ impl Command for DeleteBoard {
 
     fn description(&self) -> String {
         format!("Delete board: {}", self.board_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DependencyGraph;
+    use kanban_core::KanbanError;
+
+    fn create_test_context() -> CommandContext<'static> {
+        CommandContext {
+            boards: Box::leak(Box::new(Vec::new())),
+            columns: Box::leak(Box::new(Vec::new())),
+            cards: Box::leak(Box::new(Vec::new())),
+            sprints: Box::leak(Box::new(Vec::new())),
+            archived_cards: Box::leak(Box::new(Vec::new())),
+            graph: Box::leak(Box::new(DependencyGraph::new())),
+        }
+    }
+
+    #[test]
+    fn test_update_board_not_found_returns_error() {
+        let mut context = create_test_context();
+        let cmd = UpdateBoard {
+            board_id: Uuid::new_v4(),
+            updates: BoardUpdate::default(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(matches!(result, Err(KanbanError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_set_board_task_sort_not_found_returns_error() {
+        let mut context = create_test_context();
+        let cmd = SetBoardTaskSort {
+            board_id: Uuid::new_v4(),
+            field: crate::SortField::Priority,
+            order: crate::SortOrder::Ascending,
+        };
+        let result = cmd.execute(&mut context);
+        assert!(matches!(result, Err(KanbanError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_set_board_task_list_view_not_found_returns_error() {
+        let mut context = create_test_context();
+        let cmd = SetBoardTaskListView {
+            board_id: Uuid::new_v4(),
+            view: crate::TaskListView::default(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(matches!(result, Err(KanbanError::NotFound(_))));
     }
 }

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -107,8 +107,8 @@ impl Command for DeleteBoard {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::test_helpers::TestContext;
+    use super::*;
 
     #[test]
     fn test_update_board_not_found_returns_error() {

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -290,13 +290,7 @@ mod tests {
         let mut tc = TestContext::new();
         let mut context = tc.as_command_context();
         let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let card = crate::Card::new(
-            &mut board,
-            Uuid::new_v4(),
-            "Card".to_string(),
-            0,
-            "TST",
-        );
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0, "TST");
         let card_id = card.id;
         context.cards.push(card);
         let cmd = MoveCard {

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -33,17 +33,8 @@ pub struct CreateCard {
 
 impl Command for CreateCard {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        let prefix = context
-            .boards
-            .iter()
-            .find(|b| b.id == self.board_id)
-            .ok_or_else(|| KanbanError::not_found("board", self.board_id))?
-            .card_prefix
-            .as_deref()
-            .unwrap_or("task")
-            .to_string();
-
         let board = context.board_mut(self.board_id)?;
+        let prefix = board.card_prefix.as_deref().unwrap_or("task").to_string();
         let card = crate::Card::new(
             board,
             self.column_id,
@@ -239,8 +230,8 @@ impl Command for UnassignCardFromSprint {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::test_helpers::TestContext;
+    use super::*;
 
     #[test]
     fn test_update_card_not_found_returns_error() {

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -1,7 +1,6 @@
 use super::{Command, CommandContext};
 use crate::dependencies::card_graph::CardGraphExt;
-use crate::KanbanResult;
-use crate::{CardUpdate, CreateCardOptions};
+use crate::{CardUpdate, CreateCardOptions, KanbanError, KanbanResult};
 use chrono::Utc;
 use uuid::Uuid;
 
@@ -13,9 +12,8 @@ pub struct UpdateCard {
 
 impl Command for UpdateCard {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(card) = context.cards.iter_mut().find(|c| c.id == self.card_id) {
-            card.update(self.updates.clone());
-        }
+        let card = context.card_mut(self.card_id)?;
+        card.update(self.updates.clone());
         Ok(())
     }
 
@@ -35,55 +33,53 @@ pub struct CreateCard {
 
 impl Command for CreateCard {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        // Get the prefix from the board first
         let prefix = context
             .boards
             .iter()
             .find(|b| b.id == self.board_id)
-            .and_then(|b| b.card_prefix.as_deref())
+            .ok_or_else(|| KanbanError::not_found("board", self.board_id))?
+            .card_prefix
+            .as_deref()
             .unwrap_or("task")
             .to_string();
 
-        // Now find the board again and create the card
-        if let Some(board) = context.boards.iter_mut().find(|b| b.id == self.board_id) {
-            let card = crate::Card::new(
-                board,
-                self.column_id,
-                self.title.clone(),
-                self.position,
-                &prefix,
-            );
-            context.cards.push(card);
+        let board = context.board_mut(self.board_id)?;
+        let card = crate::Card::new(
+            board,
+            self.column_id,
+            self.title.clone(),
+            self.position,
+            &prefix,
+        );
+        context.cards.push(card);
 
-            // Apply optional fields
-            if self.options.description.is_some()
-                || self.options.priority.is_some()
-                || self.options.points.is_some()
-                || self.options.due_date.is_some()
-            {
-                if let Some(card) = context.cards.last_mut() {
-                    let updates = CardUpdate {
-                        description: self
-                            .options
-                            .description
-                            .clone()
-                            .map(crate::FieldUpdate::Set)
-                            .unwrap_or(crate::FieldUpdate::NoChange),
-                        priority: self.options.priority,
-                        points: self
-                            .options
-                            .points
-                            .map(crate::FieldUpdate::Set)
-                            .unwrap_or(crate::FieldUpdate::NoChange),
-                        due_date: self
-                            .options
-                            .due_date
-                            .map(crate::FieldUpdate::Set)
-                            .unwrap_or(crate::FieldUpdate::NoChange),
-                        ..Default::default()
-                    };
-                    card.update(updates);
-                }
+        if self.options.description.is_some()
+            || self.options.priority.is_some()
+            || self.options.points.is_some()
+            || self.options.due_date.is_some()
+        {
+            if let Some(card) = context.cards.last_mut() {
+                let updates = CardUpdate {
+                    description: self
+                        .options
+                        .description
+                        .clone()
+                        .map(crate::FieldUpdate::Set)
+                        .unwrap_or(crate::FieldUpdate::NoChange),
+                    priority: self.options.priority,
+                    points: self
+                        .options
+                        .points
+                        .map(crate::FieldUpdate::Set)
+                        .unwrap_or(crate::FieldUpdate::NoChange),
+                    due_date: self
+                        .options
+                        .due_date
+                        .map(crate::FieldUpdate::Set)
+                        .unwrap_or(crate::FieldUpdate::NoChange),
+                    ..Default::default()
+                };
+                card.update(updates);
             }
         }
         Ok(())
@@ -103,9 +99,11 @@ pub struct MoveCard {
 
 impl Command for MoveCard {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(card) = context.cards.iter_mut().find(|c| c.id == self.card_id) {
-            card.move_to_column(self.new_column_id, self.new_position);
+        if !context.columns.iter().any(|c| c.id == self.new_column_id) {
+            return Err(KanbanError::not_found("column", self.new_column_id));
         }
+        let card = context.card_mut(self.card_id)?;
+        card.move_to_column(self.new_column_id, self.new_position);
         Ok(())
     }
 
@@ -124,14 +122,17 @@ pub struct ArchiveCard {
 
 impl Command for ArchiveCard {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(pos) = context.cards.iter().position(|c| c.id == self.card_id) {
-            let card = context.cards.remove(pos);
-            let original_column_id = card.column_id;
-            let original_position = card.position;
-            let archived = crate::ArchivedCard::new(card, original_column_id, original_position);
-            context.archived_cards.push(archived);
-            context.graph.cards.archive_card_edges(self.card_id);
-        }
+        let pos = context
+            .cards
+            .iter()
+            .position(|c| c.id == self.card_id)
+            .ok_or_else(|| KanbanError::not_found("card", self.card_id))?;
+        let card = context.cards.remove(pos);
+        let original_column_id = card.column_id;
+        let original_position = card.position;
+        let archived = crate::ArchivedCard::new(card, original_column_id, original_position);
+        context.archived_cards.push(archived);
+        context.graph.cards.archive_card_edges(self.card_id);
         Ok(())
     }
 
@@ -149,19 +150,18 @@ pub struct RestoreCard {
 
 impl Command for RestoreCard {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(pos) = context
+        let pos = context
             .archived_cards
             .iter()
             .position(|c| c.card.id == self.card_id)
-        {
-            let archived = context.archived_cards.remove(pos);
-            let mut card = archived.into_card();
-            card.column_id = self.column_id;
-            card.position = self.position;
-            card.updated_at = Utc::now();
-            context.cards.push(card);
-            context.graph.cards.unarchive_node(self.card_id);
-        }
+            .ok_or_else(|| KanbanError::not_found("archived card", self.card_id))?;
+        let archived = context.archived_cards.remove(pos);
+        let mut card = archived.into_card();
+        card.column_id = self.column_id;
+        card.position = self.position;
+        card.updated_at = Utc::now();
+        context.cards.push(card);
+        context.graph.cards.unarchive_node(self.card_id);
         Ok(())
     }
 
@@ -198,21 +198,18 @@ pub struct AssignCardToSprint {
 
 impl Command for AssignCardToSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(card) = context.cards.iter_mut().find(|c| c.id == self.card_id) {
-            // End the current sprint log if moving to a different sprint
-            if let Some(old_sprint_id) = card.sprint_id {
-                if old_sprint_id != self.sprint_id {
-                    card.end_current_sprint_log();
-                }
+        let card = context.card_mut(self.card_id)?;
+        if let Some(old_sprint_id) = card.sprint_id {
+            if old_sprint_id != self.sprint_id {
+                card.end_current_sprint_log();
             }
-            // Assign to the new sprint
-            card.assign_to_sprint(
-                self.sprint_id,
-                self.sprint_number,
-                self.sprint_name.clone(),
-                self.sprint_status.clone(),
-            );
         }
+        card.assign_to_sprint(
+            self.sprint_id,
+            self.sprint_number,
+            self.sprint_name.clone(),
+            self.sprint_status.clone(),
+        );
         Ok(())
     }
 
@@ -228,15 +225,136 @@ pub struct UnassignCardFromSprint {
 
 impl Command for UnassignCardFromSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(card) = context.cards.iter_mut().find(|c| c.id == self.card_id) {
-            card.end_current_sprint_log();
-            card.sprint_id = None;
-            card.updated_at = Utc::now();
-        }
+        let card = context.card_mut(self.card_id)?;
+        card.end_current_sprint_log();
+        card.sprint_id = None;
+        card.updated_at = Utc::now();
         Ok(())
     }
 
     fn description(&self) -> String {
         format!("Unassign card {} from sprint", self.card_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::test_helpers::TestContext;
+
+    #[test]
+    fn test_update_card_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = UpdateCard {
+            card_id: Uuid::new_v4(),
+            updates: CardUpdate::default(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_create_card_board_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = CreateCard {
+            board_id: Uuid::new_v4(),
+            column_id: Uuid::new_v4(),
+            title: "Test".to_string(),
+            position: 0,
+            options: CreateCardOptions::default(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_move_card_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let column = crate::Column::new(Uuid::new_v4(), "Col".to_string(), 0);
+        let column_id = column.id;
+        context.columns.push(column);
+        let cmd = MoveCard {
+            card_id: Uuid::new_v4(),
+            new_column_id: column_id,
+            new_position: 0,
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_move_card_column_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
+        let card = crate::Card::new(
+            &mut board,
+            Uuid::new_v4(),
+            "Card".to_string(),
+            0,
+            "TST",
+        );
+        let card_id = card.id;
+        context.cards.push(card);
+        let cmd = MoveCard {
+            card_id,
+            new_column_id: Uuid::new_v4(),
+            new_position: 0,
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_archive_card_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = ArchiveCard {
+            card_id: Uuid::new_v4(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_restore_card_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = RestoreCard {
+            card_id: Uuid::new_v4(),
+            column_id: Uuid::new_v4(),
+            position: 0,
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_assign_card_to_sprint_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = AssignCardToSprint {
+            card_id: Uuid::new_v4(),
+            sprint_id: Uuid::new_v4(),
+            sprint_number: 1,
+            sprint_name: None,
+            sprint_status: "Active".to_string(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_unassign_card_from_sprint_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = UnassignCardFromSprint {
+            card_id: Uuid::new_v4(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
     }
 }

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -77,8 +77,8 @@ impl Command for DeleteColumn {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::test_helpers::TestContext;
+    use super::*;
 
     #[test]
     fn test_update_column_not_found_returns_error() {

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -11,9 +11,8 @@ pub struct UpdateColumn {
 
 impl Command for UpdateColumn {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(column) = context.columns.iter_mut().find(|c| c.id == self.column_id) {
-            column.update(self.updates.clone());
-        }
+        let column = context.column_mut(self.column_id)?;
+        column.update(self.updates.clone());
         Ok(())
     }
 
@@ -73,5 +72,34 @@ impl Command for DeleteColumn {
 
     fn description(&self) -> String {
         format!("Delete column {}", self.column_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DependencyGraph;
+    use kanban_core::KanbanError;
+
+    fn create_test_context() -> CommandContext<'static> {
+        CommandContext {
+            boards: Box::leak(Box::new(Vec::new())),
+            columns: Box::leak(Box::new(Vec::new())),
+            cards: Box::leak(Box::new(Vec::new())),
+            sprints: Box::leak(Box::new(Vec::new())),
+            archived_cards: Box::leak(Box::new(Vec::new())),
+            graph: Box::leak(Box::new(DependencyGraph::new())),
+        }
+    }
+
+    #[test]
+    fn test_update_column_not_found_returns_error() {
+        let mut context = create_test_context();
+        let cmd = UpdateColumn {
+            column_id: Uuid::new_v4(),
+            updates: ColumnUpdate::default(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(matches!(result, Err(KanbanError::NotFound(_))));
     }
 }

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -78,28 +78,17 @@ impl Command for DeleteColumn {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::DependencyGraph;
-    use kanban_core::KanbanError;
-
-    fn create_test_context() -> CommandContext<'static> {
-        CommandContext {
-            boards: Box::leak(Box::new(Vec::new())),
-            columns: Box::leak(Box::new(Vec::new())),
-            cards: Box::leak(Box::new(Vec::new())),
-            sprints: Box::leak(Box::new(Vec::new())),
-            archived_cards: Box::leak(Box::new(Vec::new())),
-            graph: Box::leak(Box::new(DependencyGraph::new())),
-        }
-    }
+    use super::super::test_helpers::TestContext;
 
     #[test]
     fn test_update_column_not_found_returns_error() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let cmd = UpdateColumn {
             column_id: Uuid::new_v4(),
             updates: ColumnUpdate::default(),
         };
         let result = cmd.execute(&mut context);
-        assert!(matches!(result, Err(KanbanError::NotFound(_))));
+        assert!(result.unwrap_err().is_not_found());
     }
 }

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -1,4 +1,4 @@
-use crate::{KanbanError, KanbanResult};
+use crate::KanbanResult;
 use uuid::Uuid;
 
 use super::{Command, CommandContext};
@@ -131,17 +131,8 @@ pub struct CreateSubcardCommand {
 
 impl Command for CreateSubcardCommand {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        let prefix = context
-            .boards
-            .iter()
-            .find(|b| b.id == self.board_id)
-            .ok_or_else(|| KanbanError::not_found("board", self.board_id))?
-            .card_prefix
-            .as_deref()
-            .unwrap_or("task")
-            .to_string();
-
         let board = context.board_mut(self.board_id)?;
+        let prefix = board.card_prefix.as_deref().unwrap_or("task").to_string();
         let mut card = Card::new(
             board,
             self.column_id,
@@ -171,8 +162,8 @@ impl Command for CreateSubcardCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::test_helpers::TestContext;
+    use super::*;
 
     #[test]
     fn test_add_blocks_dependency() {

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -1,4 +1,4 @@
-use crate::KanbanResult;
+use crate::{KanbanError, KanbanResult};
 use uuid::Uuid;
 
 use super::{Command, CommandContext};
@@ -131,36 +131,33 @@ pub struct CreateSubcardCommand {
 
 impl Command for CreateSubcardCommand {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        // Get the prefix from the board first
         let prefix = context
             .boards
             .iter()
             .find(|b| b.id == self.board_id)
-            .and_then(|b| b.card_prefix.as_deref())
+            .ok_or_else(|| KanbanError::not_found("board", self.board_id))?
+            .card_prefix
+            .as_deref()
             .unwrap_or("task")
             .to_string();
 
-        // Find the board and create the card
-        if let Some(board) = context.boards.iter_mut().find(|b| b.id == self.board_id) {
-            let mut card = Card::new(
-                board,
-                self.column_id,
-                self.title.clone(),
-                self.position,
-                &prefix,
-            );
+        let board = context.board_mut(self.board_id)?;
+        let mut card = Card::new(
+            board,
+            self.column_id,
+            self.title.clone(),
+            self.position,
+            &prefix,
+        );
 
-            // Set description if provided
-            if let Some(desc) = &self.description {
-                card.description = Some(desc.clone());
-            }
-
-            let card_id = card.id;
-            context.cards.push(card);
-
-            // Set parent relationship
-            context.graph.cards.set_parent(card_id, self.parent_id)?;
+        if let Some(desc) = &self.description {
+            card.description = Some(desc.clone());
         }
+
+        let card_id = card.id;
+        context.cards.push(card);
+
+        context.graph.cards.set_parent(card_id, self.parent_id)?;
         Ok(())
     }
 
@@ -175,22 +172,12 @@ impl Command for CreateSubcardCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::DependencyGraph;
-
-    fn create_test_context() -> CommandContext<'static> {
-        CommandContext {
-            boards: Box::leak(Box::new(Vec::new())),
-            columns: Box::leak(Box::new(Vec::new())),
-            cards: Box::leak(Box::new(Vec::new())),
-            sprints: Box::leak(Box::new(Vec::new())),
-            archived_cards: Box::leak(Box::new(Vec::new())),
-            graph: Box::leak(Box::new(DependencyGraph::new())),
-        }
-    }
+    use super::super::test_helpers::TestContext;
 
     #[test]
     fn test_add_blocks_dependency() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let card_a = Uuid::new_v4();
         let card_b = Uuid::new_v4();
 
@@ -205,7 +192,8 @@ mod tests {
 
     #[test]
     fn test_add_relates_to_dependency() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let card_a = Uuid::new_v4();
         let card_b = Uuid::new_v4();
 
@@ -221,7 +209,8 @@ mod tests {
 
     #[test]
     fn test_remove_dependency() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let card_a = Uuid::new_v4();
         let card_b = Uuid::new_v4();
 
@@ -239,7 +228,8 @@ mod tests {
 
     #[test]
     fn test_set_parent_command() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let parent_id = Uuid::new_v4();
         let child_id = Uuid::new_v4();
 
@@ -256,18 +246,17 @@ mod tests {
 
     #[test]
     fn test_set_parent_command_prevents_cycle() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let card_a = Uuid::new_v4();
         let card_b = Uuid::new_v4();
 
-        // Set A as parent of B
         let cmd1 = SetParentCommand {
             child_id: card_b,
             parent_id: card_a,
         };
         assert!(cmd1.execute(&mut context).is_ok());
 
-        // Try to set B as parent of A (would create cycle)
         let cmd2 = SetParentCommand {
             child_id: card_a,
             parent_id: card_b,
@@ -277,15 +266,14 @@ mod tests {
 
     #[test]
     fn test_remove_parent_command() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let parent_id = Uuid::new_v4();
         let child_id = Uuid::new_v4();
 
-        // First set parent
         context.graph.cards.set_parent(child_id, parent_id).unwrap();
         assert_eq!(context.graph.cards.children(parent_id).len(), 1);
 
-        // Remove parent
         let cmd = RemoveParentCommand {
             child_id,
             parent_id,
@@ -297,7 +285,8 @@ mod tests {
 
     #[test]
     fn test_remove_parent_command_nonexistent() {
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let parent_id = Uuid::new_v4();
         let child_id = Uuid::new_v4();
 
@@ -312,11 +301,11 @@ mod tests {
     fn test_create_subcard_command() {
         use crate::Board;
 
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let column_id = Uuid::new_v4();
         let parent_id = Uuid::new_v4();
 
-        // Add a board to the context
         let mut board = Board::new("Test Board".to_string(), None);
         board.card_prefix = Some("TEST".to_string());
         let board_id = board.id;
@@ -333,14 +322,12 @@ mod tests {
 
         assert!(cmd.execute(&mut context).is_ok());
 
-        // Verify card was created
         assert_eq!(context.cards.len(), 1);
         let card = &context.cards[0];
         assert_eq!(card.title, "Test Subcard");
         assert_eq!(card.description, Some("Test description".to_string()));
         assert_eq!(card.column_id, column_id);
 
-        // Verify parent relationship was set
         assert_eq!(context.graph.cards.children(parent_id).len(), 1);
         assert_eq!(context.graph.cards.parents(card.id).len(), 1);
         assert!(context.graph.cards.children(parent_id).contains(&card.id));
@@ -350,11 +337,11 @@ mod tests {
     fn test_create_subcard_without_description() {
         use crate::Board;
 
-        let mut context = create_test_context();
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
         let parent_id = Uuid::new_v4();
         let column_id = Uuid::new_v4();
 
-        // Add a board to the context
         let mut board = Board::new("Test Board".to_string(), None);
         board.card_prefix = Some("TEST".to_string());
         let board_id = board.id;

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -70,3 +70,42 @@ impl<'a> CommandContext<'a> {
             .ok_or_else(|| KanbanError::not_found("archived card", card_id))
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use super::*;
+    use crate::DependencyGraph;
+
+    pub struct TestContext {
+        pub boards: Vec<crate::Board>,
+        pub columns: Vec<crate::Column>,
+        pub cards: Vec<crate::Card>,
+        pub sprints: Vec<crate::Sprint>,
+        pub archived_cards: Vec<crate::ArchivedCard>,
+        pub graph: DependencyGraph,
+    }
+
+    impl TestContext {
+        pub fn new() -> Self {
+            Self {
+                boards: vec![],
+                columns: vec![],
+                cards: vec![],
+                sprints: vec![],
+                archived_cards: vec![],
+                graph: DependencyGraph::new(),
+            }
+        }
+
+        pub fn as_command_context(&mut self) -> CommandContext<'_> {
+            CommandContext {
+                boards: &mut self.boards,
+                columns: &mut self.columns,
+                cards: &mut self.cards,
+                sprints: &mut self.sprints,
+                archived_cards: &mut self.archived_cards,
+                graph: &mut self.graph,
+            }
+        }
+    }
+}

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -1,4 +1,4 @@
-use crate::{KanbanResult, KanbanError};
+use crate::{KanbanError, KanbanResult};
 use uuid::Uuid;
 
 pub mod board_commands;
@@ -61,13 +61,6 @@ impl<'a> CommandContext<'a> {
             .iter_mut()
             .find(|s| s.id == id)
             .ok_or_else(|| KanbanError::not_found("sprint", id))
-    }
-
-    pub fn archived_card_mut(&mut self, card_id: Uuid) -> KanbanResult<&mut crate::ArchivedCard> {
-        self.archived_cards
-            .iter_mut()
-            .find(|ac| ac.card.id == card_id)
-            .ok_or_else(|| KanbanError::not_found("archived card", card_id))
     }
 }
 

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -1,4 +1,5 @@
-use crate::KanbanResult;
+use crate::{KanbanResult, KanbanError};
+use uuid::Uuid;
 
 pub mod board_commands;
 pub mod card_commands;
@@ -31,4 +32,41 @@ pub struct CommandContext<'a> {
     pub sprints: &'a mut Vec<crate::Sprint>,
     pub archived_cards: &'a mut Vec<crate::ArchivedCard>,
     pub graph: &'a mut crate::DependencyGraph,
+}
+
+impl<'a> CommandContext<'a> {
+    pub fn board_mut(&mut self, id: Uuid) -> KanbanResult<&mut crate::Board> {
+        self.boards
+            .iter_mut()
+            .find(|b| b.id == id)
+            .ok_or_else(|| KanbanError::not_found("board", id))
+    }
+
+    pub fn card_mut(&mut self, id: Uuid) -> KanbanResult<&mut crate::Card> {
+        self.cards
+            .iter_mut()
+            .find(|c| c.id == id)
+            .ok_or_else(|| KanbanError::not_found("card", id))
+    }
+
+    pub fn column_mut(&mut self, id: Uuid) -> KanbanResult<&mut crate::Column> {
+        self.columns
+            .iter_mut()
+            .find(|c| c.id == id)
+            .ok_or_else(|| KanbanError::not_found("column", id))
+    }
+
+    pub fn sprint_mut(&mut self, id: Uuid) -> KanbanResult<&mut crate::Sprint> {
+        self.sprints
+            .iter_mut()
+            .find(|s| s.id == id)
+            .ok_or_else(|| KanbanError::not_found("sprint", id))
+    }
+
+    pub fn archived_card_mut(&mut self, card_id: Uuid) -> KanbanResult<&mut crate::ArchivedCard> {
+        self.archived_cards
+            .iter_mut()
+            .find(|ac| ac.card.id == card_id)
+            .ok_or_else(|| KanbanError::not_found("archived card", card_id))
+    }
 }

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -1,6 +1,6 @@
 use super::{Command, CommandContext};
-use crate::{KanbanError, KanbanResult};
 use crate::SprintUpdate;
+use crate::{KanbanError, KanbanResult};
 use chrono::Utc;
 use uuid::Uuid;
 
@@ -22,10 +22,9 @@ impl Command for UpdateSprint {
                 .ok_or_else(|| KanbanError::not_found("sprint", self.sprint_id))?
                 .board_id;
 
-            if let Some(board) = context.boards.iter_mut().find(|b| b.id == board_id) {
-                let idx = board.add_sprint_name_at_used_index(name.clone());
-                updates.name_index = crate::FieldUpdate::Set(idx);
-            }
+            let board = context.board_mut(board_id)?;
+            let idx = board.add_sprint_name_at_used_index(name.clone());
+            updates.name_index = crate::FieldUpdate::Set(idx);
         }
 
         let sprint = context.sprint_mut(self.sprint_id)?;
@@ -148,8 +147,8 @@ impl Command for DeleteSprint {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::test_helpers::TestContext;
+    use super::*;
 
     #[test]
     fn test_update_sprint_not_found_returns_error() {
@@ -158,6 +157,26 @@ mod tests {
         let cmd = UpdateSprint {
             sprint_id: Uuid::new_v4(),
             updates: SprintUpdate::default(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_update_sprint_name_with_nonexistent_board_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let nonexistent_board_id = Uuid::new_v4();
+        let sprint = crate::Sprint::new(nonexistent_board_id, 1, None, None);
+        let sprint_id = sprint.id;
+        context.sprints.push(sprint);
+
+        let cmd = UpdateSprint {
+            sprint_id,
+            updates: SprintUpdate {
+                name: Some("New Name".to_string()),
+                ..Default::default()
+            },
         };
         let result = cmd.execute(&mut context);
         assert!(result.unwrap_err().is_not_found());

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -1,5 +1,5 @@
 use super::{Command, CommandContext};
-use crate::KanbanResult;
+use crate::{KanbanError, KanbanResult};
 use crate::SprintUpdate;
 use chrono::Utc;
 use uuid::Uuid;
@@ -19,19 +19,17 @@ impl Command for UpdateSprint {
                 .sprints
                 .iter()
                 .find(|s| s.id == self.sprint_id)
-                .map(|s| s.board_id);
+                .ok_or_else(|| KanbanError::not_found("sprint", self.sprint_id))?
+                .board_id;
 
-            if let Some(board_id) = board_id {
-                if let Some(board) = context.boards.iter_mut().find(|b| b.id == board_id) {
-                    let idx = board.add_sprint_name_at_used_index(name.clone());
-                    updates.name_index = crate::FieldUpdate::Set(idx);
-                }
+            if let Some(board) = context.boards.iter_mut().find(|b| b.id == board_id) {
+                let idx = board.add_sprint_name_at_used_index(name.clone());
+                updates.name_index = crate::FieldUpdate::Set(idx);
             }
         }
 
-        if let Some(sprint) = context.sprints.iter_mut().find(|s| s.id == self.sprint_id) {
-            sprint.update(updates);
-        }
+        let sprint = context.sprint_mut(self.sprint_id)?;
+        sprint.update(updates);
         Ok(())
     }
 
@@ -73,9 +71,8 @@ pub struct ActivateSprint {
 
 impl Command for ActivateSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(sprint) = context.sprints.iter_mut().find(|s| s.id == self.sprint_id) {
-            sprint.activate(self.duration_days);
-        }
+        let sprint = context.sprint_mut(self.sprint_id)?;
+        sprint.activate(self.duration_days);
         Ok(())
     }
 
@@ -91,9 +88,8 @@ pub struct CompleteSprint {
 
 impl Command for CompleteSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(sprint) = context.sprints.iter_mut().find(|s| s.id == self.sprint_id) {
-            sprint.complete();
-        }
+        let sprint = context.sprint_mut(self.sprint_id)?;
+        sprint.complete();
         Ok(())
     }
 
@@ -109,9 +105,8 @@ pub struct CancelSprint {
 
 impl Command for CancelSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        if let Some(sprint) = context.sprints.iter_mut().find(|s| s.id == self.sprint_id) {
-            sprint.cancel();
-        }
+        let sprint = context.sprint_mut(self.sprint_id)?;
+        sprint.cancel();
         Ok(())
     }
 
@@ -148,5 +143,57 @@ impl Command for DeleteSprint {
 
     fn description(&self) -> String {
         format!("Delete sprint {}", self.sprint_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::test_helpers::TestContext;
+
+    #[test]
+    fn test_update_sprint_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = UpdateSprint {
+            sprint_id: Uuid::new_v4(),
+            updates: SprintUpdate::default(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_activate_sprint_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = ActivateSprint {
+            sprint_id: Uuid::new_v4(),
+            duration_days: 14,
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_complete_sprint_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = CompleteSprint {
+            sprint_id: Uuid::new_v4(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_cancel_sprint_not_found_returns_error() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let cmd = CancelSprint {
+            sprint_id: Uuid::new_v4(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
     }
 }


### PR DESCRIPTION
## Summary

- Add `CommandContext` lookup helpers (`board_mut`, `card_mut`, `column_mut`, `sprint_mut`, `archived_card_mut`) that return typed `NotFound` errors instead of silently failing
- Replace all inline `Option::ok_or_else` usages across board, card, column, sprint, and dependency commands with the new helpers or `KanbanError::not_found()`
- Replace `Box::leak`-based `create_test_context()` helper in all 5 command test modules with a shared `test_helpers::TestContext` struct that uses proper owned data

## Test plan

- [ ] `cargo test --package kanban-domain` — all 197 tests pass
- [ ] `cargo clippy --package kanban-domain` — no warnings