### PR TITLE
KAN-258/unify-initial-file-loading-path-follow-up-to-kan-256

### DIFF
--- a/.changeset/kan-258-unify-initial-file-loading-path-follow-up-to-kan-256.md
+++ b/.changeset/kan-258-unify-initial-file-loading-path-follow-up-to-kan-256.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+- test(tui): update tests to use async load_initial_state()
+- fix(tui): unify initial file loading into async load_initial_state()
+- feat(persistence-json): implement JSON content detection with BOM support
+- feat(persistence-sqlite): implement SQLite content detection via magic bytes
+- feat(persistence): add content-based detection to StoreFactory trait

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,7 @@ dependencies = [
  "kanban-domain",
  "kanban-persistence",
  "kanban-persistence-json",
+ "kanban-persistence-sqlite",
  "kanban-service",
  "pulldown-cmark",
  "ratatui",

--- a/crates/kanban-persistence-json/README.md
+++ b/crates/kanban-persistence-json/README.md
@@ -28,9 +28,9 @@ Provides `JsonFileStore` (implements `PersistenceStore`) and `JsonStoreFactory` 
 use kanban_persistence_json::JsonStoreFactory;
 
 let factory = JsonStoreFactory;
-assert!(factory.matches("board.json"));
-assert!(factory.matches("myboard"));        // catch-all
-assert!(!factory.matches("http://example")); // URI excluded
+assert!(factory.matches_locator("board.json"));
+assert!(factory.matches_locator("myboard"));        // catch-all
+assert!(!factory.matches_locator("http://example")); // URI excluded
 ```
 
 ### `JsonFileStore`

--- a/crates/kanban-persistence-json/src/lib.rs
+++ b/crates/kanban-persistence-json/src/lib.rs
@@ -20,7 +20,7 @@ impl StoreFactory for JsonStoreFactory {
         &["*.json", "<path without extension>"]
     }
 
-    fn matches(&self, locator: &str) -> bool {
+    fn matches_locator(&self, locator: &str) -> bool {
         let ext = std::path::Path::new(locator)
             .extension()
             .and_then(|e| e.to_str())
@@ -28,10 +28,55 @@ impl StoreFactory for JsonStoreFactory {
         ext == "json" || (!locator.contains("://") && ext.is_empty())
     }
 
+    fn matches_content(&self, header: &[u8]) -> bool {
+        let mut iter = header.iter();
+        // Skip UTF-8 BOM if present
+        if header.starts_with(&[0xEF, 0xBB, 0xBF]) {
+            iter = header[3..].iter();
+        }
+        // Skip whitespace, check for JSON start
+        let first = iter.find(|b| !b.is_ascii_whitespace());
+        matches!(first, Some(b'{') | Some(b'['))
+    }
+
     fn create(
         &self,
         locator: &str,
     ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
         Ok(Arc::new(JsonFileStore::new(locator)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matches_content_json_object() {
+        let factory = JsonStoreFactory;
+        assert!(factory.matches_content(b"{\"boards\": []}"));
+    }
+
+    #[test]
+    fn test_matches_content_json_array() {
+        let factory = JsonStoreFactory;
+        assert!(factory.matches_content(b"[1, 2, 3]"));
+    }
+
+    #[test]
+    fn test_matches_content_json_with_bom() {
+        let factory = JsonStoreFactory;
+        let mut data = vec![0xEF, 0xBB, 0xBF]; // UTF-8 BOM
+        data.extend_from_slice(b"  {\"key\": true}");
+        assert!(factory.matches_content(&data));
+    }
+
+    #[test]
+    fn test_matches_content_not_json() {
+        let factory = JsonStoreFactory;
+        assert!(!factory.matches_content(b"SQLite format 3\0"));
+        assert!(!factory.matches_content(b""));
+        assert!(!factory.matches_content(b"plain text"));
+        assert!(!factory.matches_content(b"   \t\n  "));
     }
 }

--- a/crates/kanban-persistence-sqlite/README.md
+++ b/crates/kanban-persistence-sqlite/README.md
@@ -29,10 +29,10 @@ Provides `SqliteStore` (implements `PersistenceStore`) and `SqliteStoreFactory` 
 use kanban_persistence_sqlite::SqliteStoreFactory;
 
 let factory = SqliteStoreFactory;
-assert!(factory.matches("board.sqlite"));
-assert!(factory.matches("project.sqlite3"));
-assert!(factory.matches("board.db"));
-assert!(!factory.matches("board.json"));
+assert!(factory.matches_locator("board.sqlite"));
+assert!(factory.matches_locator("project.sqlite3"));
+assert!(factory.matches_locator("board.db"));
+assert!(!factory.matches_locator("board.json"));
 ```
 
 ### `SqliteStore`

--- a/crates/kanban-persistence-sqlite/src/lib.rs
+++ b/crates/kanban-persistence-sqlite/src/lib.rs
@@ -19,7 +19,7 @@ impl StoreFactory for SqliteStoreFactory {
         &["*.sqlite", "*.sqlite3", "*.db"]
     }
 
-    fn matches(&self, locator: &str) -> bool {
+    fn matches_locator(&self, locator: &str) -> bool {
         let ext = std::path::Path::new(locator)
             .extension()
             .and_then(|e| e.to_str())
@@ -27,10 +27,35 @@ impl StoreFactory for SqliteStoreFactory {
         matches!(ext, "sqlite" | "sqlite3" | "db")
     }
 
+    fn matches_content(&self, header: &[u8]) -> bool {
+        header.starts_with(b"SQLite format 3\0")
+    }
+
     fn create(
         &self,
         locator: &str,
     ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
         Ok(Arc::new(SqliteStore::new(locator)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matches_content_valid_sqlite_header() {
+        let factory = SqliteStoreFactory;
+        assert!(factory.matches_content(b"SQLite format 3\0"));
+        assert!(factory.matches_content(b"SQLite format 3\0extra data"));
+    }
+
+    #[test]
+    fn test_matches_content_invalid_header() {
+        let factory = SqliteStoreFactory;
+        assert!(!factory.matches_content(b""));
+        assert!(!factory.matches_content(b"{\"boards\": []}"));
+        assert!(!factory.matches_content(b"SQLite format 2\0"));
+        assert!(!factory.matches_content(b"not sqlite"));
     }
 }

--- a/crates/kanban-persistence/README.md
+++ b/crates/kanban-persistence/README.md
@@ -40,7 +40,8 @@ Backend registration interface. Each backend provides a factory that declares wh
 pub trait StoreFactory: Send + Sync {
     fn name(&self) -> &str;
     fn supported_patterns(&self) -> &[&str];
-    fn matches(&self, locator: &str) -> bool;
+    fn matches_locator(&self, locator: &str) -> bool;
+    fn matches_content(&self, header: &[u8]) -> bool { false }
     fn create(&self, locator: &str) -> Result<Arc<dyn PersistenceStore>>;
 }
 ```

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -46,7 +46,7 @@ impl StoreRegistry {
 
         // Phase 1: If the file exists, try content-based detection
         if path.exists() {
-            if let Ok(header) = read_header(path, 16) {
+            if let Ok(header) = read_header(path, 32) {
                 for factory in &self.factories {
                     if factory.matches_content(&header) {
                         return factory.create(locator);
@@ -204,7 +204,7 @@ mod tests {
         let path = dir.path().join("data.json");
         std::fs::write(&path, b"{\"boards\": []}").unwrap();
 
-        let header = read_header(&path, 16).unwrap();
+        let header = read_header(&path, 32).unwrap();
         assert!(FakeJsonFactory.matches_content(&header));
         assert!(!FakeSqliteFactory.matches_content(&header));
     }
@@ -216,7 +216,7 @@ mod tests {
         let path = dir.path().join("misleading.json");
         std::fs::write(&path, b"SQLite format 3\0").unwrap();
 
-        let header = read_header(&path, 16).unwrap();
+        let header = read_header(&path, 32).unwrap();
         assert!(FakeSqliteFactory.matches_content(&header));
         assert!(!FakeJsonFactory.matches_content(&header));
     }

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -128,8 +128,7 @@ mod tests {
         fn matches_content(&self, header: &[u8]) -> bool {
             let trimmed = header
                 .iter()
-                .skip_while(|b| b.is_ascii_whitespace())
-                .next();
+                .find(|b| !b.is_ascii_whitespace());
             matches!(trimmed, Some(b'{') | Some(b'['))
         }
         fn create(

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -83,6 +83,43 @@ impl Default for StoreRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::traits::{PersistenceMetadata, StoreSnapshot};
+    use async_trait::async_trait;
+    use std::path::{Path, PathBuf};
+
+    const SQLITE_INSTANCE_ID: uuid::Uuid = uuid::Uuid::from_u128(1);
+    const JSON_INSTANCE_ID: uuid::Uuid = uuid::Uuid::from_u128(2);
+
+    struct StubStore {
+        instance_id: uuid::Uuid,
+        path: PathBuf,
+    }
+
+    #[async_trait]
+    impl PersistenceStore for StubStore {
+        async fn save(
+            &self,
+            _snapshot: StoreSnapshot,
+        ) -> crate::PersistenceResult<PersistenceMetadata> {
+            unimplemented!()
+        }
+
+        async fn load(&self) -> crate::PersistenceResult<(StoreSnapshot, PersistenceMetadata)> {
+            unimplemented!()
+        }
+
+        async fn exists(&self) -> bool {
+            unimplemented!()
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn instance_id(&self) -> uuid::Uuid {
+            self.instance_id
+        }
+    }
 
     struct FakeSqliteFactory;
     impl StoreFactory for FakeSqliteFactory {
@@ -104,9 +141,12 @@ mod tests {
         }
         fn create(
             &self,
-            _locator: &str,
+            locator: &str,
         ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
-            unimplemented!("test only checks matching")
+            Ok(Arc::new(StubStore {
+                instance_id: SQLITE_INSTANCE_ID,
+                path: PathBuf::from(locator),
+            }))
         }
     }
 
@@ -131,10 +171,20 @@ mod tests {
         }
         fn create(
             &self,
-            _locator: &str,
+            locator: &str,
         ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
-            unimplemented!("test only checks matching")
+            Ok(Arc::new(StubStore {
+                instance_id: JSON_INSTANCE_ID,
+                path: PathBuf::from(locator),
+            }))
         }
+    }
+
+    fn registry_with_both_factories() -> StoreRegistry {
+        let mut registry = StoreRegistry::new();
+        registry.register(Box::new(FakeSqliteFactory));
+        registry.register(Box::new(FakeJsonFactory));
+        registry
     }
 
     #[test]
@@ -180,5 +230,57 @@ mod tests {
 
         assert!(FakeJsonFactory.matches_locator(path.to_str().unwrap()));
         assert!(!FakeSqliteFactory.matches_locator(path.to_str().unwrap()));
+    }
+
+    #[test]
+    fn test_create_store_content_beats_wrong_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("misleading.json");
+        std::fs::write(&path, b"SQLite format 3\0").unwrap();
+
+        let registry = registry_with_both_factories();
+        let store = registry.create_store(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(store.instance_id(), SQLITE_INSTANCE_ID);
+    }
+
+    #[test]
+    fn test_create_store_new_file_uses_locator() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new_board.json");
+        assert!(!path.exists());
+
+        let registry = registry_with_both_factories();
+        let store = registry.create_store(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(store.instance_id(), JSON_INSTANCE_ID);
+    }
+
+    #[test]
+    fn test_create_store_json_content_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.db");
+        std::fs::write(&path, b"{\"boards\":[]}").unwrap();
+
+        let registry = registry_with_both_factories();
+        let store = registry.create_store(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(store.instance_id(), JSON_INSTANCE_ID);
+    }
+
+    #[test]
+    fn test_create_store_unsupported_locator() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.xyz");
+        assert!(!path.exists());
+
+        let registry = registry_with_both_factories();
+        let result = registry.create_store(path.to_str().unwrap());
+
+        match result {
+            Err(PersistenceError::UnsupportedLocator { .. }) => {}
+            Err(e) => panic!("expected UnsupportedLocator, got: {e:?}"),
+            Ok(_) => panic!("expected error, got Ok"),
+        }
     }
 }

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -126,9 +126,7 @@ mod tests {
             ext == "json" || ext.is_empty()
         }
         fn matches_content(&self, header: &[u8]) -> bool {
-            let trimmed = header
-                .iter()
-                .find(|b| !b.is_ascii_whitespace());
+            let trimmed = header.iter().find(|b| !b.is_ascii_whitespace());
             matches!(trimmed, Some(b'{') | Some(b'['))
         }
         fn create(

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 pub trait StoreFactory: Send + Sync {
     fn name(&self) -> &str;
     fn supported_patterns(&self) -> &[&str];
-    fn matches(&self, locator: &str) -> bool;
+    fn matches_locator(&self, locator: &str) -> bool;
+    fn matches_content(&self, _header: &[u8]) -> bool {
+        false
+    }
     fn create(
         &self,
         locator: &str,
@@ -13,6 +16,15 @@ pub trait StoreFactory: Send + Sync {
 
 pub struct StoreRegistry {
     factories: Vec<Box<dyn StoreFactory>>,
+}
+
+fn read_header(path: &std::path::Path, n: usize) -> std::io::Result<Vec<u8>> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut buf = vec![0u8; n];
+    let bytes_read = file.read(&mut buf)?;
+    buf.truncate(bytes_read);
+    Ok(buf)
 }
 
 impl StoreRegistry {
@@ -30,11 +42,26 @@ impl StoreRegistry {
         &self,
         locator: &str,
     ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
+        let path = std::path::Path::new(locator);
+
+        // Phase 1: If the file exists, try content-based detection
+        if path.exists() {
+            if let Ok(header) = read_header(path, 16) {
+                for factory in &self.factories {
+                    if factory.matches_content(&header) {
+                        return factory.create(locator);
+                    }
+                }
+            }
+        }
+
+        // Phase 2: Fall back to locator-based (extension) matching
         for factory in &self.factories {
-            if factory.matches(locator) {
+            if factory.matches_locator(locator) {
                 return factory.create(locator);
             }
         }
+
         let supported: Vec<String> = self
             .factories
             .iter()
@@ -50,5 +77,111 @@ impl StoreRegistry {
 impl Default for StoreRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeSqliteFactory;
+    impl StoreFactory for FakeSqliteFactory {
+        fn name(&self) -> &str {
+            "sqlite"
+        }
+        fn supported_patterns(&self) -> &[&str] {
+            &["*.sqlite", "*.db"]
+        }
+        fn matches_locator(&self, locator: &str) -> bool {
+            let ext = std::path::Path::new(locator)
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            matches!(ext, "sqlite" | "sqlite3" | "db")
+        }
+        fn matches_content(&self, header: &[u8]) -> bool {
+            header.starts_with(b"SQLite format 3\0")
+        }
+        fn create(
+            &self,
+            _locator: &str,
+        ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
+            unimplemented!("test only checks matching")
+        }
+    }
+
+    struct FakeJsonFactory;
+    impl StoreFactory for FakeJsonFactory {
+        fn name(&self) -> &str {
+            "json"
+        }
+        fn supported_patterns(&self) -> &[&str] {
+            &["*.json"]
+        }
+        fn matches_locator(&self, locator: &str) -> bool {
+            let ext = std::path::Path::new(locator)
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            ext == "json" || ext.is_empty()
+        }
+        fn matches_content(&self, header: &[u8]) -> bool {
+            let trimmed = header
+                .iter()
+                .skip_while(|b| b.is_ascii_whitespace())
+                .next();
+            matches!(trimmed, Some(b'{') | Some(b'['))
+        }
+        fn create(
+            &self,
+            _locator: &str,
+        ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
+            unimplemented!("test only checks matching")
+        }
+    }
+
+    #[test]
+    fn test_content_sniff_sqlite_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.db");
+        std::fs::write(&path, b"SQLite format 3\0extra bytes here").unwrap();
+
+        let header = read_header(&path, 16).unwrap();
+        assert!(FakeSqliteFactory.matches_content(&header));
+        assert!(!FakeJsonFactory.matches_content(&header));
+    }
+
+    #[test]
+    fn test_content_sniff_json_object() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.json");
+        std::fs::write(&path, b"{\"boards\": []}").unwrap();
+
+        let header = read_header(&path, 16).unwrap();
+        assert!(FakeJsonFactory.matches_content(&header));
+        assert!(!FakeSqliteFactory.matches_content(&header));
+    }
+
+    #[test]
+    fn test_content_beats_wrong_extension() {
+        // A .json file with SQLite content should be detected as SQLite
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("misleading.json");
+        std::fs::write(&path, b"SQLite format 3\0").unwrap();
+
+        let header = read_header(&path, 16).unwrap();
+        assert!(FakeSqliteFactory.matches_content(&header));
+        assert!(!FakeJsonFactory.matches_content(&header));
+    }
+
+    #[test]
+    fn test_new_file_falls_back_to_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new_board.json");
+        // File does not exist — should fall back to locator matching
+        assert!(!path.exists());
+
+        assert!(FakeJsonFactory.matches_locator(path.to_str().unwrap()));
+        assert!(!FakeSqliteFactory.matches_locator(path.to_str().unwrap()));
     }
 }

--- a/crates/kanban-tui/Cargo.toml
+++ b/crates/kanban-tui/Cargo.toml
@@ -35,4 +35,5 @@ pulldown-cmark = "0.13"
 
 [dev-dependencies]
 kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.3" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.3" }
 tempfile = "3.13"

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1366,6 +1366,7 @@ impl App {
         Ok(())
     }
 
+    #[doc(hidden)]
     pub async fn load_initial_state(&mut self) {
         if let Some(store) = self.ctx.state_manager.store().cloned() {
             if store.exists().await {

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -105,7 +105,7 @@ impl App {
     )> {
         let app_config = AppConfig::load();
         let (ctx, save_rx, save_completion_rx) = TuiContext::new(save_file.clone())?;
-        let mut app = Self {
+        let app = Self {
             should_quit: false,
             quit_with_pending: false,
             mode: AppMode::Normal,
@@ -126,26 +126,6 @@ impl App {
             relationship: RelationshipState::default(),
             pending_key: None,
         };
-
-        if let Some(ref filename) = save_file {
-            let path = std::path::Path::new(filename);
-            let needs_async_load = matches!(
-                path.extension().and_then(|e| e.to_str()),
-                Some("db" | "sqlite" | "sqlite3")
-            );
-            if !needs_async_load && path.exists() {
-                if let Err(e) = app.import_board_from_file(filename) {
-                    tracing::error!("Failed to load file {}: {}", filename, e);
-                    app.persistence.save_file = None;
-                    app.ctx.state_manager.clear_store();
-                } else {
-                    app.ctx.state_manager.clear_history();
-                }
-            }
-        }
-
-        app.migrate_sprint_logs();
-        app.check_ended_sprints();
 
         Ok((app, save_rx))
     }
@@ -1386,11 +1366,7 @@ impl App {
         Ok(())
     }
 
-    pub async fn run(
-        &mut self,
-        save_rx: Option<tokio::sync::mpsc::Receiver<kanban_domain::Snapshot>>,
-    ) -> KanbanResult<()> {
-        // Load initial state from persistence store (async)
+    pub async fn load_initial_state(&mut self) {
         if let Some(store) = self.ctx.state_manager.store().cloned() {
             if store.exists().await {
                 match store.load().await {
@@ -1399,9 +1375,8 @@ impl App {
                             Ok(data) => {
                                 data.apply_to_app(self);
                                 self.ctx.state_manager.mark_clean();
+                                // Clear undo/redo history after initial file load (not an undoable action)
                                 self.ctx.state_manager.clear_history();
-                                self.migrate_sprint_logs();
-                                self.check_ended_sprints();
                                 tracing::info!("Loaded initial state from store");
                             }
                             Err(e) => {
@@ -1419,6 +1394,15 @@ impl App {
                 }
             }
         }
+        self.migrate_sprint_logs();
+        self.check_ended_sprints();
+    }
+
+    pub async fn run(
+        &mut self,
+        save_rx: Option<tokio::sync::mpsc::Receiver<kanban_domain::Snapshot>>,
+    ) -> KanbanResult<()> {
+        self.load_initial_state().await;
 
         let mut terminal = setup_terminal()?;
 

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -176,17 +176,61 @@ fn test_auto_save() {
     assert_eq!(parsed["boards"][0]["board"]["name"], "Auto Save Board");
 }
 
-#[test]
-fn test_failed_import_clears_save_file() {
+#[tokio::test]
+async fn test_failed_import_clears_save_file() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("test_bad.json");
 
     let json = r#"{"boards": [{"invalid": true}]}"#;
     fs::write(&file_path, json).unwrap();
 
-    let (app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
+    let (mut app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
+    app.load_initial_state().await;
 
     assert!(app.persistence.save_file.is_none());
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_async_load_initial_state_sqlite() {
+    use kanban_domain::{Board, Column};
+    use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
+    use uuid::Uuid;
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test_load.db");
+
+    // Create and populate a SQLite store
+    let store = kanban_persistence_sqlite::SqliteStore::new(db_path.to_str().unwrap());
+
+    let board = Board::new("SQLite Board".to_string(), None);
+    let column = Column::new(board.id, "Backlog".to_string(), 0);
+
+    let snapshot = kanban_domain::Snapshot {
+        boards: vec![board.clone()],
+        columns: vec![column.clone()],
+        cards: vec![],
+        archived_cards: vec![],
+        sprints: vec![],
+        graph: Default::default(),
+    };
+    let data = serde_json::to_vec(&snapshot).unwrap();
+    store
+        .save(StoreSnapshot {
+            data,
+            metadata: PersistenceMetadata::new(Uuid::new_v4()),
+        })
+        .await
+        .unwrap();
+
+    // Now load via App
+    let (mut app, _rx) = App::new(Some(db_path.to_str().unwrap().to_string())).unwrap();
+    app.load_initial_state().await;
+
+    assert_eq!(app.ctx.boards.len(), 1);
+    assert_eq!(app.ctx.boards[0].name, "SQLite Board");
+    assert_eq!(app.ctx.columns.len(), 1);
+    assert_eq!(app.ctx.columns[0].name, "Backlog");
 }
 
 #[test]

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -3,8 +3,8 @@ use kanban_tui::App;
 use std::fs;
 use tempfile::tempdir;
 
-#[test]
-fn test_import_failure_prevents_empty_state_save() {
+#[tokio::test]
+async fn test_import_failure_prevents_empty_state_save() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
@@ -27,7 +27,7 @@ fn test_import_failure_prevents_empty_state_save() {
     let v2_content = serde_json::json!({
         "version": 2,
         "metadata": {
-            "instance_id": "test-instance-id",
+            "instance_id": "00000000-0000-0000-0000-000000000001",
             "saved_at": chrono::Utc::now().to_rfc3339()
         },
         "data": snapshot_json
@@ -40,7 +40,8 @@ fn test_import_failure_prevents_empty_state_save() {
     .unwrap();
 
     // Create app with the V2 format file - should handle it gracefully now
-    let (app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
+    let (mut app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
+    app.load_initial_state().await;
 
     // App should load the board from V2 format
     assert_eq!(
@@ -55,8 +56,8 @@ fn test_import_failure_prevents_empty_state_save() {
     );
 }
 
-#[test]
-fn test_import_failure_disables_save_file() {
+#[tokio::test]
+async fn test_import_failure_disables_save_file() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
@@ -64,7 +65,8 @@ fn test_import_failure_disables_save_file() {
     fs::write(&file_path, "{ invalid json }").unwrap();
 
     // Create app with invalid file
-    let (app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
+    let (mut app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
+    app.load_initial_state().await;
 
     // save_file should be None due to import failure
     assert!(
@@ -76,8 +78,8 @@ fn test_import_failure_disables_save_file() {
     assert_eq!(app.ctx.boards.len(), 0);
 }
 
-#[test]
-fn test_v2_format_is_imported_correctly() {
+#[tokio::test]
+async fn test_v2_format_is_imported_correctly() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
@@ -108,7 +110,7 @@ fn test_v2_format_is_imported_correctly() {
     let v2_content = serde_json::json!({
         "version": 2,
         "metadata": {
-            "instance_id": "test-instance",
+            "instance_id": "00000000-0000-0000-0000-000000000002",
             "saved_at": chrono::Utc::now().to_rfc3339()
         },
         "data": snapshot_json
@@ -121,7 +123,8 @@ fn test_v2_format_is_imported_correctly() {
     .unwrap();
 
     // Create app with V2 format file
-    let (app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
+    let (mut app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
+    app.load_initial_state().await;
 
     // Should successfully import the board with its column and card
     assert_eq!(app.ctx.boards.len(), 1);


### PR DESCRIPTION
Follow-up to KAN-256. Removes the duplicated sync load path in `App::new()` and replaces extension-based factory matching with content-based detection (magic bytes).

**What:**
- Add `matches_content(&self, header: &[u8]) -> bool` to `StoreFactory` trait alongside renamed `matches_locator`
- `StoreRegistry::create_store` now uses two-phase resolution: read first 16 bytes for content sniffing, then fall back to extension matching
- SQLite detection via `"SQLite format 3\0"` magic bytes
- JSON detection via BOM-aware `{`/`[` check
- Remove sync load block from `App::new()`; extract `pub async fn load_initial_state()` called from `run()`

**Why:**
- JSON files were loaded twice (sync in `new()`, async in `run()`)
- Hardcoded extension allowlist in `App::new()` duplicated `SqliteStoreFactory::matches`
- Files with wrong extensions (e.g. `.json` containing SQLite data) were misrouted

**How:**
- `StoreFactory` trait gains `matches_content` with default `false`; `matches` renamed to `matches_locator`
- Registry reads first 16 bytes of existing files and tries content match before locator match
- All initial loading unified into `load_initial_state()` which uses `store.load()` exclusively

**Testing:**
- `cargo test` — all pass
- `cargo clippy` — no warnings
- New inline tests for content detection in all three persistence crates
- Existing TUI tests converted from sync to async `load_initial_state()` path
- New `test_async_load_initial_state_sqlite` for SQLite round-trip