### PR TITLE
chore: add sqlite3 and WAL auxiliary files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 .pgdata/
 *.db
 *.sqlite
+*.sqlite3
+*-wal
+*-shm
+*-journal
 
 # IDE
 .vscode/


### PR DESCRIPTION
Add missing gitignore rules for SQLite runtime files:

- `*.sqlite3` — supported by `SqliteStoreFactory` but wasn't ignored
- `*-wal` — Write-Ahead Log files (WAL mode)
- `*-shm` — shared memory index for WAL
- `*-journal` — rollback journal (fallback mode)

These files are created at runtime by the SQLite persistence backend and should never be tracked.