### PR TITLE
KAN-259/make-sqlite-a-default-feature-in-kanban-cli

### DIFF
--- a/.changeset/kan-259-make-sqlite-a-default-feature-in-kanban-cli.md
+++ b/.changeset/kan-259-make-sqlite-a-default-feature-in-kanban-cli.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- feat: make sqlite-storage a default feature and remove redundant sqlite feature flags
+

--- a/crates/kanban-cli/Cargo.toml
+++ b/crates/kanban-cli/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 [features]
 default = ["tui"]
 tui = ["dep:kanban-tui"]
-sqlite = ["kanban-service/sqlite-storage", "kanban-tui/sqlite"]
 
 [dependencies]
 kanban-core = { path = "../kanban-core", version = "^0.3" }

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -14,9 +14,6 @@ categories = ["command-line-utilities"]
 name = "kanban-mcp"
 path = "src/main.rs"
 
-[features]
-sqlite = ["kanban-service/sqlite-storage"]
-
 [dependencies]
 # Workspace crates
 kanban-core = { path = "../kanban-core", version = "^0.3" }

--- a/crates/kanban-service/Cargo.toml
+++ b/crates/kanban-service/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "Shared service layer implementing KanbanOperations over a pluggable PersistenceStore"
 
 [features]
-default = ["json-storage"]
+default = ["json-storage", "sqlite-storage"]
 json-storage = ["dep:kanban-persistence-json"]
 sqlite-storage = ["dep:kanban-persistence-sqlite"]
 test-helpers = ["dep:tempfile"]

--- a/crates/kanban-tui/Cargo.toml
+++ b/crates/kanban-tui/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["command-line-utilities"]
 
 [features]
 default = []
-sqlite = ["kanban-service/sqlite-storage"]
 
 [dependencies]
 kanban-core = { path = "../kanban-core", version = "^0.3" }

--- a/crates/kanban-tui/Cargo.toml
+++ b/crates/kanban-tui/Cargo.toml
@@ -10,9 +10,6 @@ description = "Terminal user interface for the kanban project management tool"
 keywords = ["kanban", "tui", "terminal", "ratatui", "project-management"]
 categories = ["command-line-utilities"]
 
-[features]
-default = []
-
 [dependencies]
 kanban-core = { path = "../kanban-core", version = "^0.3" }
 kanban-domain = { path = "../kanban-domain", version = "^0.3" }

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -190,7 +190,6 @@ async fn test_failed_import_clears_save_file() {
     assert!(app.persistence.save_file.is_none());
 }
 
-#[cfg(feature = "sqlite")]
 #[tokio::test]
 async fn test_async_load_initial_state_sqlite() {
     use kanban_domain::{Board, Column};


### PR DESCRIPTION
Makes sqlite-storage ship by default across all crates:

**What**: Add `sqlite-storage` to `kanban-service` default features and remove now-redundant `sqlite` feature flags from `kanban-cli`, `kanban-tui`, and `kanban-mcp`.

**Why**: SQLite support was opt-in, meaning default builds (including Nix packages) couldn't open `.db`/`.sqlite`/`.sqlite3` files. Since sqlx bundles its own SQLite with no extra system deps, there's no reason to gate it.

**How**:
- Added `sqlite-storage` to `kanban-service` default features — all downstream crates get it transitively
- Removed redundant `sqlite` feature from `kanban-cli`, `kanban-tui`, and `kanban-mcp` (they only forwarded `kanban-service/sqlite-storage`, which is now a default)
- Ungated `test_async_load_initial_state_sqlite` test in `kanban-tui` (no longer behind a feature flag)

**Testing**: `cargo test` — all tests pass, including the previously feature-gated sqlite test.