### PR TITLE
KAN-263/rework-migrate-cli-backend-as-positional-arg-filename-as-option

### DIFF
--- a/.changeset/kan-263-rework-migrate-cli-backend-as-positional-arg-filename-as-option.md
+++ b/.changeset/kan-263-rework-migrate-cli-backend-as-positional-arg-filename-as-option.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+- feat(cli): rework migrate command to use positional backend arg
+- feat(service): add make_store_for_backend for explicit backend selection
+- feat(persistence): add create_by_name and available_backend_names to StoreRegistry

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -396,11 +396,12 @@ pub struct SprintUpdateArgs {
 #[derive(Args)]
 pub struct MigrateArgs {
     /// Path to source file
-    #[arg(long)]
-    pub from: String,
-    /// Path to destination file
-    #[arg(long)]
-    pub to: String,
+    pub source: String,
+    /// Target storage backend (e.g. json, sqlite)
+    pub backend: String,
+    /// Output file path (default: derived from source filename + backend extension)
+    #[arg(long, short)]
+    pub output: Option<String>,
 }
 
 // Export/Import commands

--- a/crates/kanban-cli/src/handlers/migrate.rs
+++ b/crates/kanban-cli/src/handlers/migrate.rs
@@ -62,5 +62,8 @@ fn default_output_path(source: &str, backend: &str) -> anyhow::Result<String> {
         .ok_or_else(|| anyhow::anyhow!("No default extension for backend {backend:?}"))?;
 
     let dir = src.parent().unwrap_or_else(|| Path::new("."));
-    Ok(dir.join(format!("{stem}.{ext}")).to_string_lossy().into())
+    let path = dir.join(format!("{stem}.{ext}"));
+    path.to_str()
+        .ok_or_else(|| anyhow::anyhow!("Output path is not valid UTF-8"))
+        .map(|s| s.to_string())
 }

--- a/crates/kanban-cli/src/handlers/migrate.rs
+++ b/crates/kanban-cli/src/handlers/migrate.rs
@@ -58,11 +58,8 @@ fn default_output_path(source: &str, backend: &str) -> anyhow::Result<String> {
         .and_then(|s| s.to_str())
         .ok_or_else(|| anyhow::anyhow!("Cannot derive filename from source path"))?;
 
-    let ext = match backend {
-        "sqlite" => "db",
-        "json" => "json",
-        other => other,
-    };
+    let ext = kanban_service::default_extension_for(backend)
+        .ok_or_else(|| anyhow::anyhow!("No default extension for backend {backend:?}"))?;
 
     let dir = src.parent().unwrap_or_else(|| Path::new("."));
     Ok(dir.join(format!("{stem}.{ext}")).to_string_lossy().into())

--- a/crates/kanban-cli/src/handlers/migrate.rs
+++ b/crates/kanban-cli/src/handlers/migrate.rs
@@ -3,13 +3,28 @@ use crate::cli::MigrateArgs;
 pub async fn handle(args: MigrateArgs) -> anyhow::Result<()> {
     use std::path::Path;
 
-    let from = Path::new(&args.from);
-    let to = Path::new(&args.to);
+    let registry = kanban_service::default_registry();
+    let available = registry.available_backend_names();
+    if !available.contains(&args.backend) {
+        anyhow::bail!(
+            "Unknown backend {:?}. Available backends: {}",
+            args.backend,
+            available.join(", ")
+        );
+    }
+
+    let from = Path::new(&args.source);
 
     if !from.exists() {
         anyhow::bail!("Source file not found: {}", from.display());
     }
 
+    let output_path = match &args.output {
+        Some(p) => p.clone(),
+        None => default_output_path(&args.source, &args.backend)?,
+    };
+
+    let to = Path::new(&output_path);
     if to.exists() {
         anyhow::bail!(
             "Destination already exists: {}. Remove it first or use a different path.",
@@ -17,14 +32,38 @@ pub async fn handle(args: MigrateArgs) -> anyhow::Result<()> {
         );
     }
 
-    println!("Migrating from {} to {}", from.display(), to.display());
+    println!(
+        "Migrating {} -> {} (backend: {})",
+        from.display(),
+        to.display(),
+        args.backend
+    );
 
-    let source = kanban_service::make_store(&args.from)?;
+    let source = kanban_service::make_store(&args.source)?;
     let (snapshot, _metadata) = source.load().await?;
 
-    let target = kanban_service::make_store(&args.to)?;
+    let target = kanban_service::make_store_for_backend(&args.backend, &output_path)?;
     target.save(snapshot).await?;
 
     println!("Migration completed successfully");
     Ok(())
+}
+
+fn default_output_path(source: &str, backend: &str) -> anyhow::Result<String> {
+    use std::path::Path;
+
+    let src = Path::new(source);
+    let stem = src
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow::anyhow!("Cannot derive filename from source path"))?;
+
+    let ext = match backend {
+        "sqlite" => "db",
+        "json" => "json",
+        other => other,
+    };
+
+    let dir = src.parent().unwrap_or_else(|| Path::new("."));
+    Ok(dir.join(format!("{stem}.{ext}")).to_string_lossy().into())
 }

--- a/crates/kanban-cli/tests/migrate.rs
+++ b/crates/kanban-cli/tests/migrate.rs
@@ -121,11 +121,7 @@ async fn test_migrate_rejects_missing_source() {
     let missing = dir.path().join("nonexistent.json");
 
     let output = cargo_bin_cmd!("kanban")
-        .args([
-            "migrate",
-            missing.to_str().unwrap(),
-            "sqlite",
-        ])
+        .args(["migrate", missing.to_str().unwrap(), "sqlite"])
         .output()
         .unwrap();
 
@@ -212,11 +208,7 @@ async fn test_migrate_cli_default_output_path() {
     create_populated_context(src_store).await;
 
     let output = cargo_bin_cmd!("kanban")
-        .args([
-            "migrate",
-            src_path.to_str().unwrap(),
-            "sqlite",
-        ])
+        .args(["migrate", src_path.to_str().unwrap(), "sqlite"])
         .output()
         .unwrap();
 

--- a/crates/kanban-cli/tests/migrate.rs
+++ b/crates/kanban-cli/tests/migrate.rs
@@ -119,15 +119,12 @@ async fn test_migrate_rejects_missing_source() {
 
     let dir = TempDir::new().unwrap();
     let missing = dir.path().join("nonexistent.json");
-    let dest = dir.path().join("dest.db");
 
     let output = cargo_bin_cmd!("kanban")
         .args([
             "migrate",
-            "--from",
             missing.to_str().unwrap(),
-            "--to",
-            dest.to_str().unwrap(),
+            "sqlite",
         ])
         .output()
         .unwrap();
@@ -143,7 +140,7 @@ async fn test_migrate_rejects_existing_target() {
 
     let dir = TempDir::new().unwrap();
     let src_path = dir.path().join("source.json");
-    let dst_path = dir.path().join("dest.json");
+    let dst_path = dir.path().join("dest.db");
 
     let src_store = Arc::new(JsonFileStore::new(&src_path));
     create_populated_context(src_store).await;
@@ -153,9 +150,9 @@ async fn test_migrate_rejects_existing_target() {
     let output = cargo_bin_cmd!("kanban")
         .args([
             "migrate",
-            "--from",
             src_path.to_str().unwrap(),
-            "--to",
+            "sqlite",
+            "--output",
             dst_path.to_str().unwrap(),
         ])
         .output()
@@ -167,4 +164,97 @@ async fn test_migrate_rejects_existing_target() {
         stderr.contains("Destination already exists"),
         "stderr: {stderr}"
     );
+}
+
+#[tokio::test]
+async fn test_migrate_cli_with_explicit_output() {
+    use assert_cmd::cargo_bin_cmd;
+
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("source.json");
+    let dst_path = dir.path().join("custom_output.db");
+
+    let src_store = Arc::new(JsonFileStore::new(&src_path));
+    create_populated_context(src_store).await;
+
+    let output = cargo_bin_cmd!("kanban")
+        .args([
+            "migrate",
+            src_path.to_str().unwrap(),
+            "sqlite",
+            "--output",
+            dst_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(dst_path.exists());
+
+    let loaded = KanbanContext::load(Arc::new(SqliteStore::new(&dst_path)))
+        .await
+        .unwrap();
+    assert_eq!(loaded.list_boards().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_migrate_cli_default_output_path() {
+    use assert_cmd::cargo_bin_cmd;
+
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("myboard.json");
+
+    let src_store = Arc::new(JsonFileStore::new(&src_path));
+    create_populated_context(src_store).await;
+
+    let output = cargo_bin_cmd!("kanban")
+        .args([
+            "migrate",
+            src_path.to_str().unwrap(),
+            "sqlite",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let expected_output = dir.path().join("myboard.db");
+    assert!(
+        expected_output.exists(),
+        "Expected default output at {}",
+        expected_output.display()
+    );
+
+    let loaded = KanbanContext::load(Arc::new(SqliteStore::new(&expected_output)))
+        .await
+        .unwrap();
+    assert_eq!(loaded.list_boards().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_migrate_rejects_unknown_backend() {
+    use assert_cmd::cargo_bin_cmd;
+
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("source.json");
+
+    let src_store = Arc::new(JsonFileStore::new(&src_path));
+    create_populated_context(src_store).await;
+
+    let output = cargo_bin_cmd!("kanban")
+        .args(["migrate", src_path.to_str().unwrap(), "postgres"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unknown backend"), "stderr: {stderr}");
 }

--- a/crates/kanban-persistence-json/src/lib.rs
+++ b/crates/kanban-persistence-json/src/lib.rs
@@ -16,10 +16,6 @@ impl StoreFactory for JsonStoreFactory {
         "json"
     }
 
-    fn default_extension(&self) -> &str {
-        "json"
-    }
-
     fn supported_patterns(&self) -> &[&str] {
         &["*.json", "<path without extension>"]
     }

--- a/crates/kanban-persistence-json/src/lib.rs
+++ b/crates/kanban-persistence-json/src/lib.rs
@@ -16,6 +16,10 @@ impl StoreFactory for JsonStoreFactory {
         "json"
     }
 
+    fn default_extension(&self) -> &str {
+        "json"
+    }
+
     fn supported_patterns(&self) -> &[&str] {
         &["*.json", "<path without extension>"]
     }

--- a/crates/kanban-persistence-sqlite/src/lib.rs
+++ b/crates/kanban-persistence-sqlite/src/lib.rs
@@ -15,6 +15,10 @@ impl StoreFactory for SqliteStoreFactory {
         "sqlite"
     }
 
+    fn default_extension(&self) -> &str {
+        "db"
+    }
+
     fn supported_patterns(&self) -> &[&str] {
         &["*.sqlite", "*.sqlite3", "*.db"]
     }

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 pub trait StoreFactory: Send + Sync {
     fn name(&self) -> &str;
+    fn default_extension(&self) -> &str;
     fn supported_patterns(&self) -> &[&str];
     fn matches_locator(&self, locator: &str) -> bool;
     fn matches_content(&self, _header: &[u8]) -> bool {
@@ -95,6 +96,13 @@ impl StoreRegistry {
             .map(|f| f.name().to_string())
             .collect()
     }
+
+    pub fn default_extension_for(&self, backend: &str) -> Option<&str> {
+        self.factories
+            .iter()
+            .find(|f| f.name() == backend)
+            .map(|f| f.default_extension())
+    }
 }
 
 impl Default for StoreRegistry {
@@ -149,6 +157,9 @@ mod tests {
         fn name(&self) -> &str {
             "sqlite"
         }
+        fn default_extension(&self) -> &str {
+            "db"
+        }
         fn supported_patterns(&self) -> &[&str] {
             &["*.sqlite", "*.db"]
         }
@@ -176,6 +187,9 @@ mod tests {
     struct FakeJsonFactory;
     impl StoreFactory for FakeJsonFactory {
         fn name(&self) -> &str {
+            "json"
+        }
+        fn default_extension(&self) -> &str {
             "json"
         }
         fn supported_patterns(&self) -> &[&str] {
@@ -327,6 +341,19 @@ mod tests {
         assert!(names.contains(&"sqlite".to_string()));
         assert!(names.contains(&"json".to_string()));
         assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn test_default_extension_for_known_backends() {
+        let registry = registry_with_both_factories();
+        assert_eq!(registry.default_extension_for("sqlite"), Some("db"));
+        assert_eq!(registry.default_extension_for("json"), Some("json"));
+    }
+
+    #[test]
+    fn test_default_extension_for_unknown_backend_returns_none() {
+        let registry = registry_with_both_factories();
+        assert_eq!(registry.default_extension_for("postgres"), None);
     }
 
     #[test]

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -72,6 +72,26 @@ impl StoreRegistry {
             supported,
         })
     }
+
+    pub fn create_by_name(
+        &self,
+        backend: &str,
+        locator: &str,
+    ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
+        for factory in &self.factories {
+            if factory.name() == backend {
+                return factory.create(locator);
+            }
+        }
+        Err(PersistenceError::UnsupportedLocator {
+            locator: format!("backend={backend}"),
+            supported: self.available_backend_names(),
+        })
+    }
+
+    pub fn available_backend_names(&self) -> Vec<String> {
+        self.factories.iter().map(|f| f.name().to_string()).collect()
+    }
 }
 
 impl Default for StoreRegistry {
@@ -266,6 +286,44 @@ mod tests {
         let store = registry.create_store(path.to_str().unwrap()).unwrap();
 
         assert_eq!(store.instance_id(), JSON_INSTANCE_ID);
+    }
+
+    #[test]
+    fn test_create_by_name_returns_correct_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.anything");
+
+        let registry = registry_with_both_factories();
+        let store = registry
+            .create_by_name("json", path.to_str().unwrap())
+            .unwrap();
+        assert_eq!(store.instance_id(), JSON_INSTANCE_ID);
+
+        let path2 = dir.path().join("data2.anything");
+        let store2 = registry
+            .create_by_name("sqlite", path2.to_str().unwrap())
+            .unwrap();
+        assert_eq!(store2.instance_id(), SQLITE_INSTANCE_ID);
+    }
+
+    #[test]
+    fn test_create_by_name_unknown_backend_returns_error() {
+        let registry = registry_with_both_factories();
+        let result = registry.create_by_name("postgres", "/tmp/test");
+        match result {
+            Err(PersistenceError::UnsupportedLocator { .. }) => {}
+            Err(e) => panic!("expected UnsupportedLocator, got: {e:?}"),
+            Ok(_) => panic!("expected error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn test_available_backend_names() {
+        let registry = registry_with_both_factories();
+        let names = registry.available_backend_names();
+        assert!(names.contains(&"sqlite".to_string()));
+        assert!(names.contains(&"json".to_string()));
+        assert_eq!(names.len(), 2);
     }
 
     #[test]

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 pub trait StoreFactory: Send + Sync {
     fn name(&self) -> &str;
-    fn default_extension(&self) -> &str;
+    fn default_extension(&self) -> &str {
+        self.name()
+    }
     fn supported_patterns(&self) -> &[&str];
     fn matches_locator(&self, locator: &str) -> bool;
     fn matches_content(&self, _header: &[u8]) -> bool {
@@ -187,9 +189,6 @@ mod tests {
     struct FakeJsonFactory;
     impl StoreFactory for FakeJsonFactory {
         fn name(&self) -> &str {
-            "json"
-        }
-        fn default_extension(&self) -> &str {
             "json"
         }
         fn supported_patterns(&self) -> &[&str] {

--- a/crates/kanban-persistence/src/registry.rs
+++ b/crates/kanban-persistence/src/registry.rs
@@ -90,7 +90,10 @@ impl StoreRegistry {
     }
 
     pub fn available_backend_names(&self) -> Vec<String> {
-        self.factories.iter().map(|f| f.name().to_string()).collect()
+        self.factories
+            .iter()
+            .map(|f| f.name().to_string())
+            .collect()
     }
 }
 

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -28,3 +28,9 @@ pub fn make_store_for_backend(
 ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, KanbanError> {
     Ok(default_registry().create_by_name(backend, locator)?)
 }
+
+pub fn default_extension_for(backend: &str) -> Option<String> {
+    default_registry()
+        .default_extension_for(backend)
+        .map(|s| s.to_string())
+}

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -21,3 +21,10 @@ pub fn default_registry() -> StoreRegistry {
 pub fn make_store(locator: &str) -> Result<Arc<dyn PersistenceStore + Send + Sync>, KanbanError> {
     Ok(default_registry().create_store(locator)?)
 }
+
+pub fn make_store_for_backend(
+    backend: &str,
+    locator: &str,
+) -> Result<Arc<dyn PersistenceStore + Send + Sync>, KanbanError> {
+    Ok(default_registry().create_by_name(backend, locator)?)
+}


### PR DESCRIPTION
Rework migrate CLI: backend as positional arg, filename as option

**What**: Replace `--from`/`--to` flags with positional `SOURCE` and `BACKEND` args, plus optional `--output`/`-o`.

**Why**: Inferring the target backend from the output file extension was implicit and surprising. Explicit backend selection is clearer.

**How**:
- Add `create_by_name` and `available_backend_names` to `StoreRegistry`
- Add `make_store_for_backend` to `kanban-service`
- Rework `MigrateArgs` to `<SOURCE> <BACKEND> [--output <FILE>]`
- Validate backend name upfront with clear error message
- Auto-derive output path from source stem + backend extension when `--output` omitted

**Testing**: 9 integration tests covering roundtrips, CLI invocation, default output path, and validation of missing source / existing target / unknown backend.