### PR TITLE
KAN-300/make-version-readout-of-web-landing-dynamic

### DIFF
--- a/.changeset/kan-300-make-version-readout-of-web-landing-dynamic.md
+++ b/.changeset/kan-300-make-version-readout-of-web-landing-dynamic.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- feat(web): inject version from workspace Cargo.toml at build time
+- feat(web): replace hardcoded version with @VERSION@ placeholder

--- a/web/default.nix
+++ b/web/default.nix
@@ -3,17 +3,23 @@
   stdenv,
 }:
 
+let
+  cargoVersion = (lib.importTOML ../Cargo.toml).workspace.package.version;
+in
 stdenv.mkDerivation {
   pname = "kanban-web";
-  version = "1.0.0";
+  version = cargoVersion;
 
   src = lib.cleanSource ./.;
 
-  dontBuild = true;
+  buildPhase = ''
+    substitute index.html index.html.out \
+      --replace-fail "@VERSION@" "${cargoVersion}"
+  '';
 
   installPhase = ''
     mkdir -p $out
-    cp index.html $out/
+    cp index.html.out $out/index.html
     cp styles.css $out/
   '';
 

--- a/web/index.html
+++ b/web/index.html
@@ -103,7 +103,7 @@
     <!-- Roadmap Section -->
     <section class="roadmap">
       <h2>Roadmap</h2>
-      <p class="roadmap-status">Version 0.2.0</p>
+      <p class="roadmap-status">Version @VERSION@</p>
 
       <div class="roadmap-categories">
         <div class="roadmap-category">


### PR DESCRIPTION
Dynamic version injection for the web landing page:

- Replace hardcoded `0.2.0` with `@VERSION@` placeholder in `index.html`
- Read `[workspace.package].version` from `Cargo.toml` via `lib.importTOML` in `web/default.nix`
- Substitute placeholder at Nix build time using `substitute`

**What**: The version shown in the roadmap section of the landing page is now sourced from the workspace `Cargo.toml` at build time instead of being hardcoded.

**Why**: Bumping the workspace version previously required a manual update to `web/index.html`. Now it flows automatically.

**How**: `lib.importTOML ../Cargo.toml` reads the version at Nix eval time; `substitute` replaces `@VERSION@` in the build phase before copying to `$out`.

**Testing**: `nix build .#kanban-web` and verify the rendered `index.html` contains the current workspace version.