### PR TITLE
CAT-264/lift-undo-redo-historymanager-into-kanbancontext

### DIFF
--- a/.changeset/cat-264-lift-undo-redo-historymanager-into-kanbancontext.md
+++ b/.changeset/cat-264-lift-undo-redo-historymanager-into-kanbancontext.md
@@ -1,9 +1,10 @@
 ---
-bump: patch
+bump: minor
 ---
 
 History-aware execute, StateManager slimming, and TuiContext encapsulation
 
+- Unify `execute()` and `execute_batch()` into a single `execute(Vec<Box<dyn Command>>)` — fixes spurious undo-on-failure bug and provides one uniform API with atomic rollback semantics
 - Make `execute()` capture undo history by default — all `KanbanOperations` consumers get undo/redo for free
 - Add native batch commands (`ArchiveCards`, `MoveCards`, `AssignCardsToSprint`) with single undo entry
 - Extract `clear_history()` from `reload()` — callers decide whether to clear

--- a/.changeset/cat-264-lift-undo-redo-historymanager-into-kanbancontext.md
+++ b/.changeset/cat-264-lift-undo-redo-historymanager-into-kanbancontext.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+---
+
+History-aware execute and StateManager slimming
+
+- Make `execute()` capture undo history by default — all `KanbanOperations` consumers get undo/redo for free
+- Add native `BulkArchiveCards` and `BulkMoveCards` batch commands (single undo entry per bulk op)
+- Extract `clear_history()` from `reload()` — callers decide whether to clear
+- Move conflict detection (`has_conflict`/`set_conflict`/`clear_conflict`) from StateManager to KanbanContext
+- Slim StateManager to purely a save coordinator (channels + file watcher)
+- Add MCP `undo` and `redo` tools

--- a/.changeset/cat-264-lift-undo-redo-historymanager-into-kanbancontext.md
+++ b/.changeset/cat-264-lift-undo-redo-historymanager-into-kanbancontext.md
@@ -2,11 +2,15 @@
 bump: patch
 ---
 
-History-aware execute and StateManager slimming
+History-aware execute, StateManager slimming, and TuiContext encapsulation
 
 - Make `execute()` capture undo history by default — all `KanbanOperations` consumers get undo/redo for free
-- Add native `BulkArchiveCards` and `BulkMoveCards` batch commands (single undo entry per bulk op)
+- Add native batch commands (`ArchiveCards`, `MoveCards`, `AssignCardsToSprint`) with single undo entry
 - Extract `clear_history()` from `reload()` — callers decide whether to clear
 - Move conflict detection (`has_conflict`/`set_conflict`/`clear_conflict`) from StateManager to KanbanContext
 - Slim StateManager to purely a save coordinator (channels + file watcher)
 - Add MCP `undo` and `redo` tools
+- Encapsulate `TuiContext` by removing `Deref` and making `inner` private
+- Remove all `_mut()` accessors from `TuiContext`, routing every mutation through domain commands
+- Add `ImportEntities`, `ApplyBoardSettings`, `ApplyCardMetadata`, `CompactColumnPositions`, `MigrateSprintLogs` commands
+- Lift sprint counter/name logic into `CreateSprint` command, eliminating caller-side board mutations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -229,19 +229,22 @@ pub enum CardAction {
         id: String,
     },
     /// Archive multiple cards
-    BulkArchive {
+    #[command(name = "archive-cards")]
+    ArchiveCards {
         #[arg(long, value_delimiter = ',')]
         ids: Vec<Uuid>,
     },
     /// Move multiple cards to a column
-    BulkMove {
+    #[command(name = "move-cards")]
+    MoveCards {
         #[arg(long, value_delimiter = ',')]
         ids: Vec<Uuid>,
         #[arg(long)]
         column_id: Uuid,
     },
     /// Assign multiple cards to a sprint
-    BulkAssignSprint {
+    #[command(name = "assign-cards-to-sprint")]
+    AssignCardsToSprint {
         #[arg(long, value_delimiter = ',')]
         ids: Vec<Uuid>,
         #[arg(long)]

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -7,7 +7,7 @@ use kanban_domain::{
 use kanban_service::KanbanContext;
 use uuid::Uuid;
 
-pub use kanban_service::BulkOperationResult;
+pub use kanban_service::BatchOperationResult;
 
 pub struct CliContext {
     inner: KanbanContext,
@@ -32,11 +32,11 @@ impl CliContext {
         self.inner.save().await
     }
 
-    pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BulkOperationResult {
+    pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {
         self.inner.archive_cards_detailed(ids)
     }
 
-    pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BulkOperationResult {
+    pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BatchOperationResult {
         self.inner.move_cards_detailed(ids, column_id)
     }
 
@@ -44,7 +44,7 @@ impl CliContext {
         &mut self,
         ids: Vec<Uuid>,
         sprint_id: Uuid,
-    ) -> BulkOperationResult {
+    ) -> BatchOperationResult {
         self.inner.assign_cards_to_sprint_detailed(ids, sprint_id)
     }
 }

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -32,24 +32,20 @@ impl CliContext {
         self.inner.save().await
     }
 
-    pub fn bulk_archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BulkOperationResult {
-        self.inner.bulk_archive_cards_detailed(ids)
+    pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BulkOperationResult {
+        self.inner.archive_cards_detailed(ids)
     }
 
-    pub fn bulk_move_cards_detailed(
-        &mut self,
-        ids: Vec<Uuid>,
-        column_id: Uuid,
-    ) -> BulkOperationResult {
-        self.inner.bulk_move_cards_detailed(ids, column_id)
+    pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BulkOperationResult {
+        self.inner.move_cards_detailed(ids, column_id)
     }
 
-    pub fn bulk_assign_sprint_detailed(
+    pub fn assign_cards_to_sprint_detailed(
         &mut self,
         ids: Vec<Uuid>,
         sprint_id: Uuid,
     ) -> BulkOperationResult {
-        self.inner.bulk_assign_sprint_detailed(ids, sprint_id)
+        self.inner.assign_cards_to_sprint_detailed(ids, sprint_id)
     }
 }
 
@@ -170,16 +166,16 @@ impl KanbanOperations for CliContext {
         self.inner.get_card_git_checkout(id)
     }
 
-    fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        self.inner.bulk_archive_cards(ids)
+    fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
+        self.inner.archive_cards(ids)
     }
 
-    fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        self.inner.bulk_move_cards(ids, column_id)
+    fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
+        self.inner.move_cards(ids, column_id)
     }
 
-    fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        self.inner.bulk_assign_sprint(ids, sprint_id)
+    fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
+        self.inner.assign_cards_to_sprint(ids, sprint_id)
     }
 
     fn carry_over_sprint_cards(

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -154,7 +154,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             output::output_success(serde_json::json!({"command": cmd}));
         }
         CardAction::BulkArchive { ids } => {
-            let result = ctx.bulk_archive_cards_detailed(ids);
+            let result = ctx.archive_cards_detailed(ids);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),
@@ -164,7 +164,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             }));
         }
         CardAction::BulkMove { ids, column_id } => {
-            let result = ctx.bulk_move_cards_detailed(ids, column_id);
+            let result = ctx.move_cards_detailed(ids, column_id);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),
@@ -174,7 +174,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             }));
         }
         CardAction::BulkAssignSprint { ids, sprint_id } => {
-            let result = ctx.bulk_assign_sprint_detailed(ids, sprint_id);
+            let result = ctx.assign_cards_to_sprint_detailed(ids, sprint_id);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -153,7 +153,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             let cmd = ctx.get_card_git_checkout(uuid)?;
             output::output_success(serde_json::json!({"command": cmd}));
         }
-        CardAction::BulkArchive { ids } => {
+        CardAction::ArchiveCards { ids } => {
             let result = ctx.archive_cards_detailed(ids);
             ctx.save().await?;
             output::output_success(serde_json::json!({
@@ -163,7 +163,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 "failed": result.failed
             }));
         }
-        CardAction::BulkMove { ids, column_id } => {
+        CardAction::MoveCards { ids, column_id } => {
             let result = ctx.move_cards_detailed(ids, column_id);
             ctx.save().await?;
             output::output_success(serde_json::json!({
@@ -173,7 +173,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 "failed": result.failed
             }));
         }
-        CardAction::BulkAssignSprint { ids, sprint_id } => {
+        CardAction::AssignCardsToSprint { ids, sprint_id } => {
             let result = ctx.assign_cards_to_sprint_detailed(ids, sprint_id);
             ctx.save().await?;
             output::output_success(serde_json::json!({

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1023,7 +1023,7 @@ mod card_tests {
     }
 
     #[test]
-    fn test_card_bulk_archive() {
+    fn test_card_archive_cards() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
         let (board_id, column_id) = setup_board_and_column(&file);
@@ -1074,7 +1074,7 @@ mod card_tests {
             .args([
                 file.to_str().unwrap(),
                 "card",
-                "bulk-archive",
+                "archive-cards",
                 "--ids",
                 &format!("{},{}", card1_id, card2_id),
             ])
@@ -1091,7 +1091,7 @@ mod card_tests {
     }
 
     #[test]
-    fn test_card_bulk_move() {
+    fn test_card_move_cards() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
         let (board_id, column_id) = setup_board_and_column(&file);
@@ -1161,7 +1161,7 @@ mod card_tests {
             .args([
                 file.to_str().unwrap(),
                 "card",
-                "bulk-move",
+                "move-cards",
                 "--ids",
                 &format!("{},{}", card1_id, card2_id),
                 "--column-id",

--- a/crates/kanban-domain/Cargo.toml
+++ b/crates/kanban-domain/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 async-trait.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -137,6 +137,56 @@ pub struct ImportEntities {
 
 impl Command for ImportEntities {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        use std::collections::HashSet;
+
+        let existing_board_ids: HashSet<Uuid> = context.boards.iter().map(|b| b.id).collect();
+        let existing_column_ids: HashSet<Uuid> = context.columns.iter().map(|c| c.id).collect();
+        let existing_card_ids: HashSet<Uuid> = context.cards.iter().map(|c| c.id).collect();
+        let existing_sprint_ids: HashSet<Uuid> = context.sprints.iter().map(|s| s.id).collect();
+        let existing_archived_ids: HashSet<Uuid> =
+            context.archived_cards.iter().map(|ac| ac.card.id).collect();
+
+        for b in &self.boards {
+            if existing_board_ids.contains(&b.id) {
+                return Err(crate::KanbanError::validation(format!(
+                    "Duplicate board ID: {}",
+                    b.id
+                )));
+            }
+        }
+        for c in &self.columns {
+            if existing_column_ids.contains(&c.id) {
+                return Err(crate::KanbanError::validation(format!(
+                    "Duplicate column ID: {}",
+                    c.id
+                )));
+            }
+        }
+        for c in &self.cards {
+            if existing_card_ids.contains(&c.id) {
+                return Err(crate::KanbanError::validation(format!(
+                    "Duplicate card ID: {}",
+                    c.id
+                )));
+            }
+        }
+        for ac in &self.archived_cards {
+            if existing_archived_ids.contains(&ac.card.id) {
+                return Err(crate::KanbanError::validation(format!(
+                    "Duplicate archived card ID: {}",
+                    ac.card.id
+                )));
+            }
+        }
+        for s in &self.sprints {
+            if existing_sprint_ids.contains(&s.id) {
+                return Err(crate::KanbanError::validation(format!(
+                    "Duplicate sprint ID: {}",
+                    s.id
+                )));
+            }
+        }
+
         context.boards.extend(self.boards.clone());
         context.columns.extend(self.columns.clone());
         context.cards.extend(self.cards.clone());
@@ -193,6 +243,59 @@ mod tests {
         };
         let result = cmd.execute(&mut context);
         assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_import_entities_with_duplicate_board_id_returns_error() {
+        let mut tc = TestContext::new();
+        let b1 = Board::new("B1".to_string(), None);
+        let dup_id = b1.id;
+        tc.boards.push(b1);
+
+        let mut dup = Board::new("Dup".to_string(), None);
+        dup.id = dup_id;
+
+        let cmd = ImportEntities {
+            boards: vec![dup],
+            columns: vec![],
+            cards: vec![],
+            archived_cards: vec![],
+            sprints: vec![],
+            graph: None,
+        };
+        let mut context = tc.as_command_context();
+        let result = cmd.execute(&mut context);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_validation());
+    }
+
+    #[test]
+    fn test_import_entities_with_duplicate_card_id_returns_error() {
+        let mut tc = TestContext::new();
+        let mut board = Board::new("B".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let card = crate::Card::new(&mut board, col.id, "Card".to_string(), 0, "TST");
+        let dup_card_id = card.id;
+        tc.boards.push(board.clone());
+        tc.columns.push(col);
+        tc.cards.push(card);
+
+        let mut dup_card =
+            crate::Card::new(&mut board, Uuid::new_v4(), "Dup".to_string(), 0, "TST");
+        dup_card.id = dup_card_id;
+
+        let cmd = ImportEntities {
+            boards: vec![],
+            columns: vec![],
+            cards: vec![dup_card],
+            archived_cards: vec![],
+            sprints: vec![],
+            graph: None,
+        };
+        let mut context = tc.as_command_context();
+        let result = cmd.execute(&mut context);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_validation());
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -1,6 +1,7 @@
 use super::{Command, CommandContext};
 use crate::KanbanResult;
-use crate::{Board, BoardUpdate};
+use crate::{ArchivedCard, Board, BoardUpdate, Card, Column, DependencyGraph, Sprint};
+use kanban_core::Editable;
 use uuid::Uuid;
 
 /// Create a new board
@@ -105,6 +106,53 @@ impl Command for DeleteBoard {
     }
 }
 
+/// Apply board settings from a DTO (used by JSON editor).
+pub struct ApplyBoardSettings {
+    pub board_id: Uuid,
+    pub dto: crate::editable::BoardSettingsDto,
+}
+
+impl Command for ApplyBoardSettings {
+    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        let board = context.board_mut(self.board_id)?;
+        self.dto.clone().apply_to(board);
+        Ok(())
+    }
+
+    fn description(&self) -> String {
+        format!("Apply board settings for {}", self.board_id)
+    }
+}
+
+/// Import entities (boards, columns, cards, etc.) into the context.
+/// Used by TUI import functionality. Appends without replacing existing data.
+pub struct ImportEntities {
+    pub boards: Vec<Board>,
+    pub columns: Vec<Column>,
+    pub cards: Vec<Card>,
+    pub archived_cards: Vec<ArchivedCard>,
+    pub sprints: Vec<Sprint>,
+    pub graph: Option<DependencyGraph>,
+}
+
+impl Command for ImportEntities {
+    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        context.boards.extend(self.boards.clone());
+        context.columns.extend(self.columns.clone());
+        context.cards.extend(self.cards.clone());
+        context.archived_cards.extend(self.archived_cards.clone());
+        context.sprints.extend(self.sprints.clone());
+        if let Some(ref graph) = self.graph {
+            *context.graph = graph.clone();
+        }
+        Ok(())
+    }
+
+    fn description(&self) -> String {
+        format!("Import {} board(s)", self.boards.len())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::TestContext;
@@ -145,5 +193,35 @@ mod tests {
         };
         let result = cmd.execute(&mut context);
         assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_import_entities_appends_without_replacing() {
+        let mut tc = TestContext::new();
+        let b1 = Board::new("B1".to_string(), None);
+        tc.boards.push(b1.clone());
+
+        let b2 = Board::new("B2".to_string(), None);
+        let col = crate::Column::new(b2.id, "Todo".to_string(), 0);
+        let mut b2_clone = b2.clone();
+        let card = crate::Card::new(&mut b2_clone, col.id, "Card".to_string(), 0, "TST");
+
+        let cmd = ImportEntities {
+            boards: vec![b2],
+            columns: vec![col],
+            cards: vec![card],
+            archived_cards: vec![],
+            sprints: vec![],
+            graph: None,
+        };
+
+        let mut context = tc.as_command_context();
+        cmd.execute(&mut context).unwrap();
+
+        assert_eq!(context.boards.len(), 2);
+        assert_eq!(context.boards[0].name, "B1");
+        assert_eq!(context.boards[1].name, "B2");
+        assert_eq!(context.columns.len(), 1);
+        assert_eq!(context.cards.len(), 1);
     }
 }

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -2,6 +2,7 @@ use super::{Command, CommandContext};
 use crate::dependencies::card_graph::CardGraphExt;
 use crate::{CardUpdate, CreateCardOptions, KanbanError, KanbanResult};
 use chrono::Utc;
+use kanban_core::Editable;
 use uuid::Uuid;
 
 /// Update card properties (title, description, priority, status, etc.)
@@ -321,6 +322,54 @@ impl Command for UnassignCardFromSprint {
     }
 }
 
+/// Apply card metadata from a DTO (used by JSON editor).
+pub struct ApplyCardMetadata {
+    pub card_id: Uuid,
+    pub dto: crate::editable::CardMetadataDto,
+}
+
+impl Command for ApplyCardMetadata {
+    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        let card = context.card_mut(self.card_id)?;
+        self.dto.clone().apply_to(card);
+        Ok(())
+    }
+
+    fn description(&self) -> String {
+        format!("Apply card metadata for {}", self.card_id)
+    }
+}
+
+/// Compact card positions in a column to be sequential (0, 1, 2, ...).
+pub struct CompactColumnPositions {
+    pub column_id: Uuid,
+}
+
+impl Command for CompactColumnPositions {
+    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        crate::card_lifecycle::compact_column_positions(context.cards, self.column_id);
+        Ok(())
+    }
+
+    fn description(&self) -> String {
+        format!("Compact positions in column {}", self.column_id)
+    }
+}
+
+/// Backfill sprint_logs for cards that have a sprint_id but empty logs.
+pub struct MigrateSprintLogs;
+
+impl Command for MigrateSprintLogs {
+    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        crate::card_lifecycle::migrate_sprint_logs(context.cards, context.sprints, context.boards);
+        Ok(())
+    }
+
+    fn description(&self) -> String {
+        "Migrate sprint logs".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::TestContext;
@@ -523,5 +572,28 @@ mod tests {
         };
         let result = cmd.execute(&mut context);
         assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_compact_column_positions_makes_sequential() {
+        let mut tc = TestContext::new();
+        let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let column_id = col.id;
+        let mut card1 = crate::Card::new(&mut board, column_id, "C1".to_string(), 0, "TST");
+        card1.position = 0;
+        let mut card2 = crate::Card::new(&mut board, column_id, "C2".to_string(), 5, "TST");
+        card2.position = 5;
+        tc.boards.push(board);
+        tc.columns.push(col);
+        tc.cards.push(card1);
+        tc.cards.push(card2);
+
+        let cmd = CompactColumnPositions { column_id };
+        let mut context = tc.as_command_context();
+        cmd.execute(&mut context).unwrap();
+
+        assert_eq!(context.cards[0].position, 0);
+        assert_eq!(context.cards[1].position, 1);
     }
 }

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -106,32 +106,6 @@ impl Command for MoveCard {
     }
 }
 
-/// Archive a card (move to archived_cards)
-pub struct ArchiveCard {
-    pub card_id: Uuid,
-}
-
-impl Command for ArchiveCard {
-    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        let pos = context
-            .cards
-            .iter()
-            .position(|c| c.id == self.card_id)
-            .ok_or_else(|| KanbanError::not_found("card", self.card_id))?;
-        let card = context.cards.remove(pos);
-        let original_column_id = card.column_id;
-        let original_position = card.position;
-        let archived = crate::ArchivedCard::new(card, original_column_id, original_position);
-        context.archived_cards.push(archived);
-        context.graph.cards.archive_card_edges(self.card_id);
-        Ok(())
-    }
-
-    fn description(&self) -> String {
-        format!("Archive card {}", self.card_id)
-    }
-}
-
 /// Restore an archived card
 pub struct RestoreCard {
     pub card_id: Uuid,
@@ -209,19 +183,21 @@ impl Command for AssignCardToSprint {
     }
 }
 
-/// Archive multiple cards in a single command (single undo entry)
-pub struct BulkArchiveCards {
+/// Archive one or more cards in a single command (single undo entry)
+pub struct ArchiveCards {
     pub ids: Vec<Uuid>,
 }
 
-impl Command for BulkArchiveCards {
+impl Command for ArchiveCards {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        // Validate all IDs exist before mutating
         for id in &self.ids {
-            let pos = context
-                .cards
-                .iter()
-                .position(|c| c.id == *id)
-                .ok_or_else(|| KanbanError::not_found("card", *id))?;
+            if !context.cards.iter().any(|c| c.id == *id) {
+                return Err(KanbanError::not_found("card", *id));
+            }
+        }
+        for id in &self.ids {
+            let pos = context.cards.iter().position(|c| c.id == *id).unwrap();
             let card = context.cards.remove(pos);
             let original_column_id = card.column_id;
             let original_position = card.position;
@@ -233,20 +209,26 @@ impl Command for BulkArchiveCards {
     }
 
     fn description(&self) -> String {
-        format!("Bulk archive {} cards", self.ids.len())
+        format!("Archive {} card(s)", self.ids.len())
     }
 }
 
-/// Move multiple cards to a target column in a single command
-pub struct BulkMoveCards {
+/// Move one or more cards to a target column in a single command
+pub struct MoveCards {
     pub ids: Vec<Uuid>,
     pub column_id: Uuid,
 }
 
-impl Command for BulkMoveCards {
+impl Command for MoveCards {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
         if !context.columns.iter().any(|c| c.id == self.column_id) {
             return Err(KanbanError::not_found("column", self.column_id));
+        }
+        // Validate all card IDs exist before mutating
+        for id in &self.ids {
+            if !context.cards.iter().any(|c| c.id == *id) {
+                return Err(KanbanError::not_found("card", *id));
+            }
         }
         for (i, id) in self.ids.iter().enumerate() {
             let card = context.card_mut(*id)?;
@@ -257,7 +239,7 @@ impl Command for BulkMoveCards {
 
     fn description(&self) -> String {
         format!(
-            "Bulk move {} cards to column {}",
+            "Move {} card(s) to column {}",
             self.ids.len(),
             self.column_id
         )
@@ -349,14 +331,59 @@ mod tests {
     }
 
     #[test]
-    fn test_archive_card_not_found_returns_error() {
+    fn test_archive_cards_not_found_returns_error() {
         let mut tc = TestContext::new();
         let mut context = tc.as_command_context();
-        let cmd = ArchiveCard {
-            card_id: Uuid::new_v4(),
+        let cmd = ArchiveCards {
+            ids: vec![Uuid::new_v4()],
         };
         let result = cmd.execute(&mut context);
         assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_archive_cards_invalid_id_does_not_mutate() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0, "TST");
+        let valid_id = card.id;
+        context.cards.push(card);
+
+        let cmd = ArchiveCards {
+            ids: vec![valid_id, Uuid::new_v4()],
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.is_err());
+        // Valid card must NOT have been archived — validate-before-mutate
+        assert_eq!(context.cards.len(), 1);
+        assert_eq!(context.archived_cards.len(), 0);
+    }
+
+    #[test]
+    fn test_move_cards_invalid_id_does_not_mutate() {
+        let mut tc = TestContext::new();
+        let mut context = tc.as_command_context();
+        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
+        let column = crate::Column::new(board.id, "Col".to_string(), 0);
+        let column_id = column.id;
+        let card = crate::Card::new(&mut board, column_id, "Card".to_string(), 0, "TST");
+        let original_column = card.column_id;
+        let valid_id = card.id;
+        context.columns.push(column);
+        let col2 = crate::Column::new(board.id, "Done".to_string(), 1);
+        let target_id = col2.id;
+        context.columns.push(col2);
+        context.cards.push(card);
+
+        let cmd = MoveCards {
+            ids: vec![valid_id, Uuid::new_v4()],
+            column_id: target_id,
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.is_err());
+        // Valid card must NOT have been moved — validate-before-mutate
+        assert_eq!(context.cards[0].column_id, original_column);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -209,6 +209,58 @@ impl Command for AssignCardToSprint {
     }
 }
 
+/// Archive multiple cards in a single command (single undo entry)
+pub struct BulkArchiveCards {
+    pub ids: Vec<Uuid>,
+}
+
+impl Command for BulkArchiveCards {
+    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        for id in &self.ids {
+            let pos = context
+                .cards
+                .iter()
+                .position(|c| c.id == *id)
+                .ok_or_else(|| KanbanError::not_found("card", *id))?;
+            let card = context.cards.remove(pos);
+            let original_column_id = card.column_id;
+            let original_position = card.position;
+            let archived =
+                crate::ArchivedCard::new(card, original_column_id, original_position);
+            context.archived_cards.push(archived);
+            context.graph.cards.archive_card_edges(*id);
+        }
+        Ok(())
+    }
+
+    fn description(&self) -> String {
+        format!("Bulk archive {} cards", self.ids.len())
+    }
+}
+
+/// Move multiple cards to a target column in a single command
+pub struct BulkMoveCards {
+    pub ids: Vec<Uuid>,
+    pub column_id: Uuid,
+}
+
+impl Command for BulkMoveCards {
+    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        if !context.columns.iter().any(|c| c.id == self.column_id) {
+            return Err(KanbanError::not_found("column", self.column_id));
+        }
+        for (i, id) in self.ids.iter().enumerate() {
+            let card = context.card_mut(*id)?;
+            card.move_to_column(self.column_id, i as i32);
+        }
+        Ok(())
+    }
+
+    fn description(&self) -> String {
+        format!("Bulk move {} cards to column {}", self.ids.len(), self.column_id)
+    }
+}
+
 /// Unassign card from current sprint
 pub struct UnassignCardFromSprint {
     pub card_id: Uuid,

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -191,15 +191,8 @@ pub struct ArchiveCards {
 
 impl Command for ArchiveCards {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        use std::collections::HashSet;
-        let id_set: HashSet<Uuid> = self.ids.iter().copied().collect();
-        // Validate all IDs exist before mutating
-        for id in &id_set {
-            if !context.cards.iter().any(|c| c.id == *id) {
-                return Err(KanbanError::not_found("card", *id));
-            }
-        }
-        for id in &self.ids {
+        let valid_ids = context.filter_valid_card_ids(&self.ids, "ArchiveCards");
+        for id in &valid_ids {
             let pos = context.cards.iter().position(|c| c.id == *id).unwrap();
             let card = context.cards.remove(pos);
             let original_column_id = card.column_id;
@@ -229,19 +222,14 @@ impl Command for MoveCards {
         if !context.columns.iter().any(|c| c.id == self.column_id) {
             return Err(KanbanError::not_found("column", self.column_id));
         }
-        let id_set: HashSet<Uuid> = self.ids.iter().copied().collect();
-        // Validate all card IDs exist before mutating
-        for id in &id_set {
-            if !context.cards.iter().any(|c| c.id == *id) {
-                return Err(KanbanError::not_found("card", *id));
-            }
-        }
+        let valid_ids = context.filter_valid_card_ids(&self.ids, "MoveCards");
+        let id_set: HashSet<Uuid> = valid_ids.iter().copied().collect();
         let base = context
             .cards
             .iter()
             .filter(|c| c.column_id == self.column_id && !id_set.contains(&c.id))
             .count();
-        for (i, id) in self.ids.iter().enumerate() {
+        for (i, id) in valid_ids.iter().enumerate() {
             let card = context.card_mut(*id)?;
             card.move_to_column(self.column_id, (base + i) as i32);
         }
@@ -279,19 +267,8 @@ impl Command for AssignCardsToSprint {
         let sprint_name = sprint.get_name(board).map(|s| s.to_string());
         let sprint_status = format!("{:?}", sprint.status);
 
-        // Validate all card IDs exist before mutating
-        {
-            use std::collections::HashSet;
-            let id_set: HashSet<Uuid> = self.ids.iter().copied().collect();
-            for id in &id_set {
-                if !context.cards.iter().any(|c| c.id == *id) {
-                    return Err(KanbanError::not_found("card", *id));
-                }
-            }
-        }
-
-        // Mutate
-        for id in &self.ids {
+        let valid_ids = context.filter_valid_card_ids(&self.ids, "AssignCardsToSprint");
+        for id in &valid_ids {
             let card = context.card_mut(*id)?;
             if let Some(old_sprint_id) = card.sprint_id {
                 if old_sprint_id != self.sprint_id {
@@ -375,7 +352,11 @@ pub struct MigrateSprintLogs;
 
 impl Command for MigrateSprintLogs {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        crate::card_lifecycle::migrate_sprint_logs(context.cards, context.sprints, context.boards);
+        let count =
+            crate::card_lifecycle::migrate_sprint_logs(context.cards, context.sprints, context.boards);
+        if count > 0 {
+            tracing::info!("Migrated sprint logs for {} card(s)", count);
+        }
         Ok(())
     }
 
@@ -455,18 +436,19 @@ mod tests {
     }
 
     #[test]
-    fn test_archive_cards_not_found_returns_error() {
+    fn test_archive_cards_all_invalid_ids_skipped_returns_ok() {
         let mut tc = TestContext::new();
         let mut context = tc.as_command_context();
         let cmd = ArchiveCards {
             ids: vec![Uuid::new_v4()],
         };
         let result = cmd.execute(&mut context);
-        assert!(result.unwrap_err().is_not_found());
+        assert!(result.is_ok());
+        assert_eq!(context.archived_cards.len(), 0);
     }
 
     #[test]
-    fn test_archive_cards_invalid_id_does_not_mutate() {
+    fn test_archive_cards_invalid_ids_skipped_valid_ids_archived() {
         let mut tc = TestContext::new();
         let mut context = tc.as_command_context();
         let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
@@ -478,21 +460,20 @@ mod tests {
             ids: vec![valid_id, Uuid::new_v4()],
         };
         let result = cmd.execute(&mut context);
-        assert!(result.is_err());
-        // Valid card must NOT have been archived — validate-before-mutate
-        assert_eq!(context.cards.len(), 1);
-        assert_eq!(context.archived_cards.len(), 0);
+        assert!(result.is_ok());
+        // Valid card IS archived; invalid ID is skipped
+        assert_eq!(context.cards.len(), 0);
+        assert_eq!(context.archived_cards.len(), 1);
     }
 
     #[test]
-    fn test_move_cards_invalid_id_does_not_mutate() {
+    fn test_move_cards_invalid_ids_skipped_valid_ids_moved() {
         let mut tc = TestContext::new();
         let mut context = tc.as_command_context();
         let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
         let column = crate::Column::new(board.id, "Col".to_string(), 0);
         let column_id = column.id;
         let card = crate::Card::new(&mut board, column_id, "Card".to_string(), 0, "TST");
-        let original_column = card.column_id;
         let valid_id = card.id;
         context.columns.push(column);
         let col2 = crate::Column::new(board.id, "Done".to_string(), 1);
@@ -505,9 +486,9 @@ mod tests {
             column_id: target_id,
         };
         let result = cmd.execute(&mut context);
-        assert!(result.is_err());
-        // Valid card must NOT have been moved — validate-before-mutate
-        assert_eq!(context.cards[0].column_id, original_column);
+        assert!(result.is_ok());
+        // Valid card IS moved; invalid ID is skipped
+        assert_eq!(context.cards[0].column_id, target_id);
     }
 
     #[test]
@@ -555,7 +536,7 @@ mod tests {
     }
 
     #[test]
-    fn test_assign_cards_to_sprint_validates_before_mutating() {
+    fn test_assign_cards_to_sprint_invalid_ids_skipped_valid_ids_assigned() {
         let mut tc = TestContext::new();
         let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
         let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0, "TST");
@@ -572,9 +553,9 @@ mod tests {
             sprint_id,
         };
         let result = cmd.execute(&mut context);
-        assert!(result.is_err());
-        // Valid card must NOT have been assigned — validate-before-mutate
-        assert_eq!(context.cards[0].sprint_id, None);
+        assert!(result.is_ok());
+        // Valid card IS assigned; invalid ID is skipped
+        assert_eq!(context.cards[0].sprint_id, Some(sprint_id));
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -352,8 +352,11 @@ pub struct MigrateSprintLogs;
 
 impl Command for MigrateSprintLogs {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        let count =
-            crate::card_lifecycle::migrate_sprint_logs(context.cards, context.sprints, context.boards);
+        let count = crate::card_lifecycle::migrate_sprint_logs(
+            context.cards,
+            context.sprints,
+            context.boards,
+        );
         if count > 0 {
             tracing::info!("Migrated sprint logs for {} card(s)", count);
         }

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -153,37 +153,6 @@ impl Command for DeleteCard {
     }
 }
 
-/// Assign card to a sprint with logging
-pub struct AssignCardToSprint {
-    pub card_id: Uuid,
-    pub sprint_id: Uuid,
-    pub sprint_number: u32,
-    pub sprint_name: Option<String>,
-    pub sprint_status: String,
-}
-
-impl Command for AssignCardToSprint {
-    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        let card = context.card_mut(self.card_id)?;
-        if let Some(old_sprint_id) = card.sprint_id {
-            if old_sprint_id != self.sprint_id {
-                card.end_current_sprint_log();
-            }
-        }
-        card.assign_to_sprint(
-            self.sprint_id,
-            self.sprint_number,
-            self.sprint_name.clone(),
-            self.sprint_status.clone(),
-        );
-        Ok(())
-    }
-
-    fn description(&self) -> String {
-        format!("Assign card {} to sprint {}", self.card_id, self.sprint_id)
-    }
-}
-
 /// Archive one or more cards in a single command (single undo entry)
 pub struct ArchiveCards {
     pub ids: Vec<Uuid>,
@@ -508,21 +477,6 @@ mod tests {
     }
 
     #[test]
-    fn test_assign_card_to_sprint_not_found_returns_error() {
-        let mut tc = TestContext::new();
-        let mut context = tc.as_command_context();
-        let cmd = AssignCardToSprint {
-            card_id: Uuid::new_v4(),
-            sprint_id: Uuid::new_v4(),
-            sprint_number: 1,
-            sprint_name: None,
-            sprint_status: "Active".to_string(),
-        };
-        let result = cmd.execute(&mut context);
-        assert!(result.unwrap_err().is_not_found());
-    }
-
-    #[test]
     fn test_assign_cards_to_sprint_validates_sprint_exists() {
         let mut tc = TestContext::new();
         let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
@@ -641,6 +595,33 @@ mod tests {
         let c3 = context.cards.iter().find(|c| c.id == c3_id).unwrap();
         assert_eq!(c1.position, 1, "first moved card should be at base(1) + 0");
         assert_eq!(c3.position, 2, "second moved card should be at base(1) + 1");
+    }
+
+    #[test]
+    fn test_migrate_sprint_logs_backfills_cards_missing_sprint_log() {
+        let mut tc = TestContext::new();
+        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("Alpha".to_string()));
+        let sprint_id = sprint.id;
+        let mut card = crate::Card::new(&mut board, col.id, "Card".to_string(), 0, "TST");
+        // Card has sprint_id set but no sprint logs
+        card.sprint_id = Some(sprint_id);
+        assert!(card.sprint_logs.is_empty());
+        tc.boards.push(board);
+        tc.sprints.push(sprint);
+        tc.cards.push(card);
+
+        let cmd = MigrateSprintLogs;
+        let mut context = tc.as_command_context();
+        cmd.execute(&mut context).unwrap();
+
+        assert_eq!(
+            context.cards[0].sprint_logs.len(),
+            1,
+            "sprint log should be backfilled for card with sprint_id but empty logs"
+        );
+        assert_eq!(context.cards[0].sprint_logs[0].sprint_number, 1);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -246,6 +246,62 @@ impl Command for MoveCards {
     }
 }
 
+/// Assign one or more cards to a sprint in a single command (single undo entry)
+pub struct AssignCardsToSprint {
+    pub ids: Vec<Uuid>,
+    pub sprint_id: Uuid,
+}
+
+impl Command for AssignCardsToSprint {
+    fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        let sprint = context
+            .sprints
+            .iter()
+            .find(|s| s.id == self.sprint_id)
+            .ok_or_else(|| KanbanError::not_found("sprint", self.sprint_id))?;
+        let board = context
+            .boards
+            .iter()
+            .find(|b| b.id == sprint.board_id)
+            .ok_or_else(|| KanbanError::not_found("board", sprint.board_id))?;
+        let sprint_number = sprint.sprint_number;
+        let sprint_name = sprint.get_name(board).map(|s| s.to_string());
+        let sprint_status = format!("{:?}", sprint.status);
+
+        // Validate all card IDs exist before mutating
+        for id in &self.ids {
+            if !context.cards.iter().any(|c| c.id == *id) {
+                return Err(KanbanError::not_found("card", *id));
+            }
+        }
+
+        // Mutate
+        for id in &self.ids {
+            let card = context.card_mut(*id)?;
+            if let Some(old_sprint_id) = card.sprint_id {
+                if old_sprint_id != self.sprint_id {
+                    card.end_current_sprint_log();
+                }
+            }
+            card.assign_to_sprint(
+                self.sprint_id,
+                sprint_number,
+                sprint_name.clone(),
+                sprint_status.clone(),
+            );
+        }
+        Ok(())
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "Assign {} card(s) to sprint {}",
+            self.ids.len(),
+            self.sprint_id
+        )
+    }
+}
+
 /// Unassign card from current sprint
 pub struct UnassignCardFromSprint {
     pub card_id: Uuid,
@@ -269,6 +325,11 @@ impl Command for UnassignCardFromSprint {
 mod tests {
     use super::super::test_helpers::TestContext;
     use super::*;
+
+    fn context_push_board_and_card(tc: &mut TestContext, board: crate::Board, card: crate::Card) {
+        tc.boards.push(board);
+        tc.cards.push(card);
+    }
 
     #[test]
     fn test_update_card_not_found_returns_error() {
@@ -412,6 +473,45 @@ mod tests {
         };
         let result = cmd.execute(&mut context);
         assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_assign_cards_to_sprint_validates_sprint_exists() {
+        let mut tc = TestContext::new();
+        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0, "TST");
+        context_push_board_and_card(&mut tc, board, card);
+        let mut context = tc.as_command_context();
+
+        let cmd = AssignCardsToSprint {
+            ids: vec![context.cards[0].id],
+            sprint_id: Uuid::new_v4(),
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_assign_cards_to_sprint_validates_before_mutating() {
+        let mut tc = TestContext::new();
+        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0, "TST");
+        let valid_id = card.id;
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
+        let sprint_id = sprint.id;
+        tc.boards.push(board);
+        tc.cards.push(card);
+        tc.sprints.push(sprint);
+        let mut context = tc.as_command_context();
+
+        let cmd = AssignCardsToSprint {
+            ids: vec![valid_id, Uuid::new_v4()],
+            sprint_id,
+        };
+        let result = cmd.execute(&mut context);
+        assert!(result.is_err());
+        // Valid card must NOT have been assigned — validate-before-mutate
+        assert_eq!(context.cards[0].sprint_id, None);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -225,8 +225,7 @@ impl Command for BulkArchiveCards {
             let card = context.cards.remove(pos);
             let original_column_id = card.column_id;
             let original_position = card.position;
-            let archived =
-                crate::ArchivedCard::new(card, original_column_id, original_position);
+            let archived = crate::ArchivedCard::new(card, original_column_id, original_position);
             context.archived_cards.push(archived);
             context.graph.cards.archive_card_edges(*id);
         }
@@ -257,7 +256,11 @@ impl Command for BulkMoveCards {
     }
 
     fn description(&self) -> String {
-        format!("Bulk move {} cards to column {}", self.ids.len(), self.column_id)
+        format!(
+            "Bulk move {} cards to column {}",
+            self.ids.len(),
+            self.column_id
+        )
     }
 }
 

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -191,8 +191,10 @@ pub struct ArchiveCards {
 
 impl Command for ArchiveCards {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        use std::collections::HashSet;
+        let id_set: HashSet<Uuid> = self.ids.iter().copied().collect();
         // Validate all IDs exist before mutating
-        for id in &self.ids {
+        for id in &id_set {
             if !context.cards.iter().any(|c| c.id == *id) {
                 return Err(KanbanError::not_found("card", *id));
             }
@@ -222,18 +224,26 @@ pub struct MoveCards {
 
 impl Command for MoveCards {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        use std::collections::HashSet;
+
         if !context.columns.iter().any(|c| c.id == self.column_id) {
             return Err(KanbanError::not_found("column", self.column_id));
         }
+        let id_set: HashSet<Uuid> = self.ids.iter().copied().collect();
         // Validate all card IDs exist before mutating
-        for id in &self.ids {
+        for id in &id_set {
             if !context.cards.iter().any(|c| c.id == *id) {
                 return Err(KanbanError::not_found("card", *id));
             }
         }
+        let base = context
+            .cards
+            .iter()
+            .filter(|c| c.column_id == self.column_id && !id_set.contains(&c.id))
+            .count();
         for (i, id) in self.ids.iter().enumerate() {
             let card = context.card_mut(*id)?;
-            card.move_to_column(self.column_id, i as i32);
+            card.move_to_column(self.column_id, (base + i) as i32);
         }
         Ok(())
     }
@@ -270,9 +280,13 @@ impl Command for AssignCardsToSprint {
         let sprint_status = format!("{:?}", sprint.status);
 
         // Validate all card IDs exist before mutating
-        for id in &self.ids {
-            if !context.cards.iter().any(|c| c.id == *id) {
-                return Err(KanbanError::not_found("card", *id));
+        {
+            use std::collections::HashSet;
+            let id_set: HashSet<Uuid> = self.ids.iter().copied().collect();
+            for id in &id_set {
+                if !context.cards.iter().any(|c| c.id == *id) {
+                    return Err(KanbanError::not_found("card", *id));
+                }
             }
         }
 
@@ -572,6 +586,77 @@ mod tests {
         };
         let result = cmd.execute(&mut context);
         assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_move_cards_with_existing_cards_appends_after_last_position() {
+        let mut tc = TestContext::new();
+        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
+        let col1 = crate::Column::new(board.id, "From".to_string(), 0);
+        let col2 = crate::Column::new(board.id, "To".to_string(), 1);
+        let col1_id = col1.id;
+        let col2_id = col2.id;
+
+        let existing1 = crate::Card::new(&mut board, col2_id, "Existing1".to_string(), 0, "TST");
+        let existing2 = crate::Card::new(&mut board, col2_id, "Existing2".to_string(), 1, "TST");
+        let move1 = crate::Card::new(&mut board, col1_id, "Move1".to_string(), 0, "TST");
+        let move2 = crate::Card::new(&mut board, col1_id, "Move2".to_string(), 1, "TST");
+        let move1_id = move1.id;
+        let move2_id = move2.id;
+
+        tc.boards.push(board);
+        tc.columns.push(col1);
+        tc.columns.push(col2);
+        tc.cards.push(existing1);
+        tc.cards.push(existing2);
+        tc.cards.push(move1);
+        tc.cards.push(move2);
+
+        let cmd = MoveCards {
+            ids: vec![move1_id, move2_id],
+            column_id: col2_id,
+        };
+        let mut context = tc.as_command_context();
+        cmd.execute(&mut context).unwrap();
+
+        let m1 = context.cards.iter().find(|c| c.id == move1_id).unwrap();
+        let m2 = context.cards.iter().find(|c| c.id == move2_id).unwrap();
+        assert_eq!(m1.position, 2, "first moved card should be at position 2");
+        assert_eq!(m2.position, 3, "second moved card should be at position 3");
+    }
+
+    #[test]
+    fn test_move_cards_within_same_column_reindexes() {
+        let mut tc = TestContext::new();
+        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let col_id = col.id;
+
+        let card1 = crate::Card::new(&mut board, col_id, "C1".to_string(), 0, "TST");
+        let card2 = crate::Card::new(&mut board, col_id, "C2".to_string(), 1, "TST");
+        let card3 = crate::Card::new(&mut board, col_id, "C3".to_string(), 2, "TST");
+        let c1_id = card1.id;
+        let c3_id = card3.id;
+
+        tc.boards.push(board);
+        tc.columns.push(col);
+        tc.cards.push(card1);
+        tc.cards.push(card2);
+        tc.cards.push(card3);
+
+        // Move cards 1 and 3 within the same column — card2 stays
+        let cmd = MoveCards {
+            ids: vec![c1_id, c3_id],
+            column_id: col_id,
+        };
+        let mut context = tc.as_command_context();
+        cmd.execute(&mut context).unwrap();
+
+        // card2 is the only non-moved card in the column, so base = 1
+        let c1 = context.cards.iter().find(|c| c.id == c1_id).unwrap();
+        let c3 = context.cards.iter().find(|c| c.id == c3_id).unwrap();
+        assert_eq!(c1.position, 1, "first moved card should be at base(1) + 0");
+        assert_eq!(c3.position, 2, "second moved card should be at base(1) + 1");
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -62,6 +62,17 @@ impl<'a> CommandContext<'a> {
             .find(|s| s.id == id)
             .ok_or_else(|| KanbanError::not_found("sprint", id))
     }
+
+    pub fn filter_valid_card_ids(&self, ids: &[Uuid], command_name: &str) -> Vec<Uuid> {
+        let (valid, rejected): (Vec<_>, Vec<_>) = ids
+            .iter()
+            .copied()
+            .partition(|&id| self.cards.iter().any(|c| c.id == id));
+        for id in &rejected {
+            tracing::warn!("{}: card {} not found, skipping", command_name, id);
+        }
+        valid
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -53,7 +53,6 @@ pub struct CreateSprint {
     pub explicit_prefix: Option<String>,
     /// If true and `name` is None, consume next name from the board's name pool.
     /// Used by TUI; CLI/MCP pass false.
-    #[allow(dead_code)]
     pub auto_consume_name: bool,
 }
 
@@ -250,5 +249,33 @@ mod tests {
         };
         let result = cmd.execute(&mut context);
         assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[test]
+    fn test_create_sprint_auto_consume_name_uses_name_pool() {
+        let mut tc = TestContext::new();
+        let mut board = crate::Board::new("Test".to_string(), None);
+        board.sprint_names = vec!["Alpha".to_string(), "Beta".to_string()];
+        let board_id = board.id;
+        tc.boards.push(board);
+        let mut context = tc.as_command_context();
+
+        let cmd = CreateSprint {
+            board_id,
+            name: None,
+            default_sprint_prefix: "Sprint".to_string(),
+            explicit_prefix: None,
+            auto_consume_name: true,
+        };
+        cmd.execute(&mut context).unwrap();
+
+        assert_eq!(context.sprints.len(), 1);
+        let sprint = &context.sprints[0];
+        let board = &context.boards[0];
+        assert_eq!(
+            sprint.get_name(board),
+            Some("Alpha"),
+            "auto_consume_name should consume the first available sprint name"
+        );
     }
 }

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -37,28 +37,60 @@ impl Command for UpdateSprint {
     }
 }
 
-/// Create a new sprint
+/// Create a new sprint.
+///
+/// Handles sprint counter initialization, number generation, and name assignment
+/// internally. The effective prefix is resolved as:
+///   `explicit_prefix` > `board.sprint_prefix` > `default_sprint_prefix`
+///
+/// If `auto_consume_name` is true and no explicit name is provided, the next
+/// available sprint name from the board's name pool will be consumed.
 pub struct CreateSprint {
     pub board_id: Uuid,
-    pub sprint_number: u32,
-    pub name_index: Option<usize>,
-    pub prefix: Option<String>,
+    pub name: Option<String>,
+    pub default_sprint_prefix: String,
+    /// If set, overrides both board prefix and default prefix.
+    pub explicit_prefix: Option<String>,
+    /// If true and `name` is None, consume next name from the board's name pool.
+    /// Used by TUI; CLI/MCP pass false.
+    #[allow(dead_code)]
+    pub auto_consume_name: bool,
 }
 
 impl Command for CreateSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
+        // Read sprints snapshot before mutable borrow of board
+        let sprints_snapshot: Vec<_> = context.sprints.clone();
+
+        let board = context.board_mut(self.board_id)?;
+        let effective_prefix = self
+            .explicit_prefix
+            .clone()
+            .or_else(|| board.sprint_prefix.clone())
+            .unwrap_or_else(|| self.default_sprint_prefix.clone());
+
+        board.ensure_sprint_counter_initialized(&effective_prefix, &sprints_snapshot);
+        let sprint_number = board.get_next_sprint_number(&effective_prefix);
+        let name_index = match &self.name {
+            Some(name) if !name.trim().is_empty() => {
+                Some(board.add_sprint_name_at_used_index(name.clone()))
+            }
+            _ if self.auto_consume_name => board.consume_sprint_name(),
+            _ => None,
+        };
+
         let sprint = crate::Sprint::new(
             self.board_id,
-            self.sprint_number,
-            self.name_index,
-            self.prefix.clone(),
+            sprint_number,
+            name_index,
+            Some(effective_prefix),
         );
         context.sprints.push(sprint);
         Ok(())
     }
 
     fn description(&self) -> String {
-        format!("Create sprint {}", self.sprint_number)
+        format!("Create sprint for board {}", self.board_id)
     }
 }
 

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -59,8 +59,12 @@ pub struct CreateSprint {
 
 impl Command for CreateSprint {
     fn execute(&self, context: &mut CommandContext) -> KanbanResult<()> {
-        // Read sprints snapshot before mutable borrow of board
-        let sprints_snapshot: Vec<_> = context.sprints.clone();
+        let sprints_snapshot: Vec<_> = context
+            .sprints
+            .iter()
+            .filter(|s| s.board_id == self.board_id)
+            .cloned()
+            .collect();
 
         let board = context.board_mut(self.board_id)?;
         let effective_prefix = self

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -64,7 +64,7 @@ pub trait KanbanOperations {
     fn get_card_branch_name(&self, id: Uuid) -> KanbanResult<String>;
     fn get_card_git_checkout(&self, id: Uuid) -> KanbanResult<String>;
 
-    // Bulk card operations
+    // Multi-card operations
     fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize>;
     fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize>;
     fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize>;

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -65,9 +65,9 @@ pub trait KanbanOperations {
     fn get_card_git_checkout(&self, id: Uuid) -> KanbanResult<String>;
 
     // Bulk card operations
-    fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize>;
-    fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize>;
-    fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize>;
+    fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize>;
+    fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize>;
+    fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize>;
     fn carry_over_sprint_cards(
         &mut self,
         from_sprint_id: Uuid,

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// Contains the complete state of boards, columns, cards, sprints,
 /// archived cards, and the dependency graph. All fields use `#[serde(default)]`
 /// to support partial snapshots and backward compatibility with older formats.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct Snapshot {
     /// All boards in the workspace.
     #[serde(default)]
@@ -128,6 +128,13 @@ mod tests {
         assert_eq!(restored.boards.len(), 1);
         assert_eq!(restored.boards[0].name, "Test Board");
         assert!(restored.columns.is_empty());
+    }
+
+    #[test]
+    fn test_snapshot_partial_eq() {
+        let snap1 = Snapshot::new();
+        let snap2 = Snapshot::new();
+        assert_eq!(snap1, snap2);
     }
 
     #[test]

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -197,7 +197,7 @@ impl KanbanOperations for McpContext {
     }
 
     // ========================================================================
-    // Bulk Card Operations
+    // Multi-card operations
     // ========================================================================
 
     fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -25,6 +25,22 @@ impl McpContext {
         self.inner.reload().await
     }
 
+    pub fn undo(&mut self) -> bool {
+        self.inner.undo()
+    }
+
+    pub fn redo(&mut self) -> bool {
+        self.inner.redo()
+    }
+
+    pub fn can_undo(&self) -> bool {
+        self.inner.can_undo()
+    }
+
+    pub fn can_redo(&self) -> bool {
+        self.inner.can_redo()
+    }
+
     pub async fn save(&self) -> KanbanResult<()> {
         self.inner.save().await
     }

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -200,16 +200,16 @@ impl KanbanOperations for McpContext {
     // Bulk Card Operations
     // ========================================================================
 
-    fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        self.inner.bulk_archive_cards(ids)
+    fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
+        self.inner.archive_cards(ids)
     }
 
-    fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        self.inner.bulk_move_cards(ids, column_id)
+    fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
+        self.inner.move_cards(ids, column_id)
     }
 
-    fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        self.inner.bulk_assign_sprint(ids, sprint_id)
+    fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
+        self.inner.assign_cards_to_sprint(ids, sprint_id)
     }
 
     fn carry_over_sprint_cards(

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -25,6 +25,10 @@ impl McpContext {
         self.inner.reload().await
     }
 
+    pub fn clear_history(&mut self) {
+        self.inner.clear_history();
+    }
+
     pub fn undo(&mut self) -> bool {
         self.inner.undo()
     }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -890,34 +890,34 @@ impl KanbanMcpServer {
     // Bulk Operations
 
     #[tool(description = "Archive multiple cards at once")]
-    async fn tool_bulk_archive_cards(
+    async fn tool_archive_cards(
         &self,
         Parameters(req): Parameters<BulkArchiveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
         let ids = parse_uuids_csv(&req.ids)?;
-        let count = mutating_op!(self.ctx, bulk_archive_cards, ids)?;
+        let count = mutating_op!(self.ctx, archive_cards, ids)?;
         to_call_tool_result_json(serde_json::json!({"archived_count": count}))
     }
 
     #[tool(description = "Move multiple cards to a column")]
-    async fn tool_bulk_move_cards(
+    async fn tool_move_cards(
         &self,
         Parameters(req): Parameters<BulkMoveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
         let ids = parse_uuids_csv(&req.ids)?;
         let column_id = parse_uuid(&req.column_id)?;
-        let count = mutating_op!(self.ctx, bulk_move_cards, ids, column_id)?;
+        let count = mutating_op!(self.ctx, move_cards, ids, column_id)?;
         to_call_tool_result_json(serde_json::json!({"moved_count": count}))
     }
 
     #[tool(description = "Assign multiple cards to a sprint")]
-    async fn tool_bulk_assign_sprint(
+    async fn tool_assign_cards_to_sprint(
         &self,
         Parameters(req): Parameters<BulkAssignSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
         let ids = parse_uuids_csv(&req.ids)?;
         let sprint_id = parse_uuid(&req.sprint_id)?;
-        let count = mutating_op!(self.ctx, bulk_assign_sprint, ids, sprint_id)?;
+        let count = mutating_op!(self.ctx, assign_cards_to_sprint, ids, sprint_id)?;
         to_call_tool_result_json(serde_json::json!({"assigned_count": count}))
     }
 

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -380,16 +380,16 @@ pub struct GetCardGitCheckoutRequest {
     pub card_id: String,
 }
 
-// Bulk Operations
+// Multi-card operations
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-pub struct BulkArchiveCardsRequest {
+pub struct ArchiveCardsRequest {
     #[schemars(description = "Comma-separated card IDs to archive")]
     pub ids: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-pub struct BulkMoveCardsRequest {
+pub struct MoveCardsRequest {
     #[schemars(description = "Comma-separated card IDs to move")]
     pub ids: String,
     #[schemars(description = "ID of the destination column")]
@@ -397,7 +397,7 @@ pub struct BulkMoveCardsRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-pub struct BulkAssignSprintRequest {
+pub struct AssignCardsToSprintRequest {
     #[schemars(description = "Comma-separated card IDs")]
     pub ids: String,
     #[schemars(description = "ID of the sprint to assign to")]
@@ -887,12 +887,12 @@ impl KanbanMcpServer {
         to_call_tool_result_json(serde_json::json!({"command": command}))
     }
 
-    // Bulk Operations
+    // Multi-card operations
 
     #[tool(description = "Archive multiple cards at once")]
     async fn tool_archive_cards(
         &self,
-        Parameters(req): Parameters<BulkArchiveCardsRequest>,
+        Parameters(req): Parameters<ArchiveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
         let ids = parse_uuids_csv(&req.ids)?;
         let count = mutating_op!(self.ctx, archive_cards, ids)?;
@@ -902,7 +902,7 @@ impl KanbanMcpServer {
     #[tool(description = "Move multiple cards to a column")]
     async fn tool_move_cards(
         &self,
-        Parameters(req): Parameters<BulkMoveCardsRequest>,
+        Parameters(req): Parameters<MoveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
         let ids = parse_uuids_csv(&req.ids)?;
         let column_id = parse_uuid(&req.column_id)?;
@@ -913,7 +913,7 @@ impl KanbanMcpServer {
     #[tool(description = "Assign multiple cards to a sprint")]
     async fn tool_assign_cards_to_sprint(
         &self,
-        Parameters(req): Parameters<BulkAssignSprintRequest>,
+        Parameters(req): Parameters<AssignCardsToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
         let ids = parse_uuids_csv(&req.ids)?;
         let sprint_id = parse_uuid(&req.sprint_id)?;

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -1075,6 +1075,36 @@ impl KanbanMcpServer {
         let board = mutating_op!(self.ctx, import_board, &data)?;
         to_call_tool_result(&board)
     }
+
+    #[tool(description = "Undo the last operation")]
+    async fn tool_undo(&self) -> Result<CallToolResult, McpError> {
+        let mut guard = self.ctx.lock().await;
+        if guard.undo() {
+            guard.save().await.map_err(kanban_err_to_mcp)?;
+            Ok(CallToolResult::success(vec![Content::text(
+                "Undo successful",
+            )]))
+        } else {
+            Ok(CallToolResult::success(vec![Content::text(
+                "Nothing to undo",
+            )]))
+        }
+    }
+
+    #[tool(description = "Redo the last undone operation")]
+    async fn tool_redo(&self) -> Result<CallToolResult, McpError> {
+        let mut guard = self.ctx.lock().await;
+        if guard.redo() {
+            guard.save().await.map_err(kanban_err_to_mcp)?;
+            Ok(CallToolResult::success(vec![Content::text(
+                "Redo successful",
+            )]))
+        } else {
+            Ok(CallToolResult::success(vec![Content::text(
+                "Nothing to redo",
+            )]))
+        }
+    }
 }
 
 // ============================================================================

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -451,3 +451,19 @@ async fn test_mcp_undo_on_empty_returns_false() {
     assert!(!ctx.can_undo());
     assert!(!ctx.undo());
 }
+
+#[tokio::test]
+async fn test_mcp_reload_preserves_undo_history() {
+    // MCP reload is a pre-mutation freshness check, not a response to an external
+    // change. History remains valid across reloads so tool_undo can span multiple
+    // prior tool calls.
+    let (mut ctx, _tmp) = setup().await;
+    ctx.create_board("Board".into(), None).unwrap();
+    assert!(ctx.can_undo(), "should have undo entry after create");
+    ctx.save().await.unwrap();
+    ctx.reload().await.unwrap();
+    assert!(
+        ctx.can_undo(),
+        "reload should NOT clear history — undo must span multiple tool calls"
+    );
+}

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -444,7 +444,7 @@ async fn test_mcp_redo_restores_undone_board() {
 
 #[tokio::test]
 async fn test_mcp_undo_on_empty_returns_false() {
-    let (ctx, _tmp) = setup().await;
+    let (mut ctx, _tmp) = setup().await;
     assert!(!ctx.can_undo());
-    // undo() can't be called on immutable - just verify can_undo
+    assert!(!ctx.undo());
 }

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -239,7 +239,7 @@ async fn bulk_archive() {
         .create_card(board.id, col.id, "Card 2".into(), Default::default())
         .unwrap();
 
-    let count = ctx.bulk_archive_cards(vec![c1.id, c2.id]).unwrap();
+    let count = ctx.archive_cards(vec![c1.id, c2.id]).unwrap();
     assert_eq!(count, 2);
 }
 
@@ -256,7 +256,7 @@ async fn bulk_move() {
         .create_card(board.id, col1.id, "Card 2".into(), Default::default())
         .unwrap();
 
-    let count = ctx.bulk_move_cards(vec![c1.id, c2.id], col2.id).unwrap();
+    let count = ctx.move_cards(vec![c1.id, c2.id], col2.id).unwrap();
     assert_eq!(count, 2);
 }
 

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -418,3 +418,33 @@ async fn find_cards_by_identifier_not_found() {
     let results = ctx.find_cards_by_identifier("KAN-99").unwrap();
     assert!(results.is_empty());
 }
+
+// Undo/Redo
+
+#[tokio::test]
+async fn test_mcp_undo_reverses_create_board() {
+    let (mut ctx, _tmp) = setup().await;
+    ctx.create_board("Board".into(), None).unwrap();
+    assert_eq!(ctx.list_boards().unwrap().len(), 1);
+
+    assert!(ctx.undo());
+    assert!(ctx.list_boards().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_mcp_redo_restores_undone_board() {
+    let (mut ctx, _tmp) = setup().await;
+    ctx.create_board("Board".into(), None).unwrap();
+    ctx.undo();
+    assert!(ctx.list_boards().unwrap().is_empty());
+
+    assert!(ctx.redo());
+    assert_eq!(ctx.list_boards().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_mcp_undo_on_empty_returns_false() {
+    let (ctx, _tmp) = setup().await;
+    assert!(!ctx.can_undo());
+    // undo() can't be called on immutable - just verify can_undo
+}

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -225,10 +225,10 @@ async fn card_assign_unassign_sprint() {
     assert_eq!(unassigned.sprint_id, None);
 }
 
-// Bulk operations
+// Multi-card operations
 
 #[tokio::test]
-async fn bulk_archive() {
+async fn archive_cards() {
     let (mut ctx, _tmp) = setup().await;
     let board = ctx.create_board("Board".into(), None).unwrap();
     let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
@@ -244,7 +244,7 @@ async fn bulk_archive() {
 }
 
 #[tokio::test]
-async fn bulk_move() {
+async fn move_cards() {
     let (mut ctx, _tmp) = setup().await;
     let board = ctx.create_board("Board".into(), None).unwrap();
     let col1 = ctx.create_column(board.id, "From".into(), None).unwrap();
@@ -271,7 +271,10 @@ async fn export_import_roundtrip() {
     let json = ctx.export_board(Some(board.id)).unwrap();
     assert!(json.contains("Export Board"));
 
-    ctx.import_board(&json).unwrap();
+    // Import into a fresh context to avoid duplicate UUID errors
+    let (mut ctx2, _tmp2) = setup().await;
+    let imported = ctx2.import_board(&json).unwrap();
+    assert_eq!(imported.name, "Export Board");
 }
 
 // Persistence round-trips

--- a/crates/kanban-persistence-json/tests/roundtrip.rs
+++ b/crates/kanban-persistence-json/tests/roundtrip.rs
@@ -1,7 +1,7 @@
+use kanban_domain::Snapshot;
 use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
 use kanban_persistence_json::JsonFileStore;
 use kanban_service::test_helpers::helpers::fully_populated_snapshot;
-use kanban_service::DataSnapshot;
 use tempfile::TempDir;
 
 #[tokio::test]
@@ -21,7 +21,7 @@ async fn full_roundtrip_preserves_all_fields() {
         .unwrap();
 
     let (loaded_snap, _) = store.load().await.unwrap();
-    let loaded: DataSnapshot = serde_json::from_slice(&loaded_snap.data).unwrap();
+    let loaded: Snapshot = serde_json::from_slice(&loaded_snap.data).unwrap();
 
     assert_eq!(original, loaded);
 }

--- a/crates/kanban-persistence-sqlite/tests/roundtrip.rs
+++ b/crates/kanban-persistence-sqlite/tests/roundtrip.rs
@@ -1,7 +1,7 @@
+use kanban_domain::Snapshot;
 use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
 use kanban_persistence_sqlite::SqliteStore;
 use kanban_service::test_helpers::helpers::fully_populated_snapshot;
-use kanban_service::DataSnapshot;
 use tempfile::TempDir;
 
 #[tokio::test]
@@ -21,7 +21,7 @@ async fn full_roundtrip_preserves_all_fields() {
         .unwrap();
 
     let (loaded_snap, _) = store.load().await.unwrap();
-    let loaded: DataSnapshot = serde_json::from_slice(&loaded_snap.data).unwrap();
+    let loaded: Snapshot = serde_json::from_slice(&loaded_snap.data).unwrap();
 
     assert_eq!(original, loaded);
 }

--- a/crates/kanban-persistence/src/lib.rs
+++ b/crates/kanban-persistence/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod conflict;
 pub mod error;
+pub mod null_store;
 pub mod registry;
 pub mod serialization;
 pub mod snapshot_serde;
@@ -8,6 +9,7 @@ pub mod watch;
 
 pub use conflict::*;
 pub use error::{PersistenceError, PersistenceResult};
+pub use null_store::NullStore;
 pub use registry::{StoreFactory, StoreRegistry};
 pub use serialization::*;
 pub use snapshot_serde::{snapshot_from_json_bytes, snapshot_to_json_bytes};

--- a/crates/kanban-persistence/src/null_store.rs
+++ b/crates/kanban-persistence/src/null_store.rs
@@ -1,0 +1,82 @@
+use crate::{
+    PersistenceError, PersistenceMetadata, PersistenceResult, PersistenceStore, StoreSnapshot,
+};
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// A no-op persistence store for contexts that don't need real storage.
+/// `save()` succeeds silently; `load()` returns `NotFound`.
+pub struct NullStore {
+    instance_id: Uuid,
+    path: PathBuf,
+}
+
+impl NullStore {
+    pub fn new() -> Self {
+        Self {
+            instance_id: Uuid::new_v4(),
+            path: PathBuf::new(),
+        }
+    }
+}
+
+impl Default for NullStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl PersistenceStore for NullStore {
+    async fn save(&self, _snapshot: StoreSnapshot) -> PersistenceResult<PersistenceMetadata> {
+        Ok(PersistenceMetadata::new(self.instance_id))
+    }
+
+    async fn load(&self) -> PersistenceResult<(StoreSnapshot, PersistenceMetadata)> {
+        Err(PersistenceError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "NullStore has no data",
+        )))
+    }
+
+    async fn exists(&self) -> bool {
+        false
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn instance_id(&self) -> Uuid {
+        self.instance_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_null_store_exists_returns_false() {
+        let store = NullStore::new();
+        assert!(!store.exists().await);
+    }
+
+    #[tokio::test]
+    async fn test_null_store_load_returns_not_found() {
+        let store = NullStore::new();
+        let result = store.load().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_null_store_save_succeeds() {
+        let store = NullStore::new();
+        let snapshot = StoreSnapshot {
+            data: vec![],
+            metadata: PersistenceMetadata::new(store.instance_id()),
+        };
+        assert!(store.save(snapshot).await.is_ok());
+    }
+}

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -12,13 +12,13 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize)]
-pub struct BulkOperationResult {
+pub struct BatchOperationResult {
     pub succeeded: Vec<Uuid>,
-    pub failed: Vec<BulkOperationFailure>,
+    pub failed: Vec<BatchOperationFailure>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct BulkOperationFailure {
+pub struct BatchOperationFailure {
     pub id: Uuid,
     pub error: String,
 }
@@ -278,7 +278,7 @@ impl KanbanContext {
         Ok(())
     }
 
-    pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BulkOperationResult {
+    pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {
         use kanban_domain::commands::ArchiveCards;
         self.capture_before_command();
         let mut succeeded = Vec::new();
@@ -286,17 +286,19 @@ impl KanbanContext {
         for id in ids {
             match self.execute_raw(Box::new(ArchiveCards { ids: vec![id] })) {
                 Ok(()) => succeeded.push(id),
-                Err(e) => failed.push(BulkOperationFailure {
+                Err(e) => failed.push(BatchOperationFailure {
                     id,
                     error: e.to_string(),
                 }),
             }
         }
-        self.dirty = true;
-        BulkOperationResult { succeeded, failed }
+        if !succeeded.is_empty() {
+            self.dirty = true;
+        }
+        BatchOperationResult { succeeded, failed }
     }
 
-    pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BulkOperationResult {
+    pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BatchOperationResult {
         use kanban_domain::commands::MoveCard;
         self.capture_before_command();
         let mut succeeded = Vec::new();
@@ -313,21 +315,23 @@ impl KanbanContext {
                 new_position: position,
             })) {
                 Ok(_) => succeeded.push(id),
-                Err(e) => failed.push(BulkOperationFailure {
+                Err(e) => failed.push(BatchOperationFailure {
                     id,
                     error: e.to_string(),
                 }),
             }
         }
-        self.dirty = true;
-        BulkOperationResult { succeeded, failed }
+        if !succeeded.is_empty() {
+            self.dirty = true;
+        }
+        BatchOperationResult { succeeded, failed }
     }
 
     pub fn assign_cards_to_sprint_detailed(
         &mut self,
         ids: Vec<Uuid>,
         sprint_id: Uuid,
-    ) -> BulkOperationResult {
+    ) -> BatchOperationResult {
         use kanban_domain::commands::AssignCardsToSprint;
         self.capture_before_command();
         let mut succeeded = Vec::new();
@@ -339,15 +343,17 @@ impl KanbanContext {
                 sprint_id,
             })) {
                 Ok(_) => succeeded.push(id),
-                Err(e) => failed.push(BulkOperationFailure {
+                Err(e) => failed.push(BatchOperationFailure {
                     id,
                     error: e.to_string(),
                 }),
             }
         }
 
-        self.dirty = true;
-        BulkOperationResult { succeeded, failed }
+        if !succeeded.is_empty() {
+            self.dirty = true;
+        }
+        BatchOperationResult { succeeded, failed }
     }
 }
 
@@ -866,6 +872,8 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn import_board(&mut self, data: &str) -> KanbanResult<Board> {
+        use kanban_domain::commands::ImportEntities;
+
         let imported: DataSnapshot = serde_json::from_str(data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 
@@ -875,12 +883,14 @@ impl KanbanOperations for KanbanContext {
             .cloned()
             .ok_or_else(|| KanbanError::validation("No board in import data"))?;
 
-        self.capture_before_command();
-        self.boards.extend(imported.boards);
-        self.columns.extend(imported.columns);
-        self.cards.extend(imported.cards);
-        self.sprints.extend(imported.sprints);
-        self.dirty = true;
+        self.execute(Box::new(ImportEntities {
+            boards: imported.boards,
+            columns: imported.columns,
+            cards: imported.cards,
+            archived_cards: imported.archived_cards,
+            sprints: imported.sprints,
+            graph: Some(imported.graph),
+        }))?;
 
         Ok(board)
     }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -336,11 +336,19 @@ impl KanbanContext {
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
 
-        let sprint_info = self.get_sprint(sprint_id).ok().flatten().and_then(|sprint| {
-            let board = self.boards.iter().find(|b| b.id == sprint.board_id)?;
-            let sprint_name = sprint.get_name(board).map(|s| s.to_string());
-            Some((sprint.sprint_number, sprint_name, format!("{:?}", sprint.status)))
-        });
+        let sprint_info = self
+            .get_sprint(sprint_id)
+            .ok()
+            .flatten()
+            .and_then(|sprint| {
+                let board = self.boards.iter().find(|b| b.id == sprint.board_id)?;
+                let sprint_name = sprint.get_name(board).map(|s| s.to_string());
+                Some((
+                    sprint.sprint_number,
+                    sprint_name,
+                    format!("{:?}", sprint.status),
+                ))
+            });
 
         if let Some((sprint_number, sprint_name, sprint_status)) = sprint_info {
             for id in ids {

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -744,38 +744,19 @@ impl KanbanOperations for KanbanContext {
     ) -> KanbanResult<Sprint> {
         use kanban_domain::commands::CreateSprint;
 
-        self.capture_before_command();
-
-        let (sprint_number, name_index, effective_prefix) = {
-            let board = self
-                .boards
-                .iter_mut()
-                .find(|b| b.id == board_id)
-                .ok_or_else(|| KanbanError::not_found("board", board_id))?;
-
-            let effective_prefix = prefix
-                .or_else(|| board.sprint_prefix.clone())
-                .unwrap_or_else(|| {
-                    self.app_config
-                        .effective_default_sprint_prefix()
-                        .to_string()
-                });
-
-            board.ensure_sprint_counter_initialized(&effective_prefix, &self.sprints);
-            let sprint_number = board.get_next_sprint_number(&effective_prefix);
-            let name_index = name.map(|n| board.add_sprint_name_at_used_index(n));
-
-            (sprint_number, name_index, effective_prefix)
-        };
+        let default_sprint_prefix = self
+            .app_config
+            .effective_default_sprint_prefix()
+            .to_string();
 
         let cmd = CreateSprint {
             board_id,
-            sprint_number,
-            name_index,
-            prefix: Some(effective_prefix),
+            name,
+            default_sprint_prefix,
+            explicit_prefix: prefix,
+            auto_consume_name: false,
         };
-        self.execute_raw(Box::new(cmd))?;
-        self.dirty = true;
+        self.execute(Box::new(cmd))?;
         self.sprints.last().cloned().ok_or_else(|| {
             KanbanError::Internal("Sprint creation succeeded but sprint not found".into())
         })

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -359,12 +359,11 @@ impl KanbanContext {
             };
         }
         let succeeded = to_move.clone();
-        match self.execute(vec![
-            Box::new(MoveCards {
-                ids: to_move,
-                column_id,
-            }) as Box<dyn Command>
-        ]) {
+        match self.execute(vec![Box::new(MoveCards {
+            ids: to_move,
+            column_id,
+        }) as Box<dyn Command>])
+        {
             Ok(()) => BatchOperationResult { succeeded, failed },
             Err(e) => {
                 let err = e.to_string();
@@ -419,12 +418,11 @@ impl KanbanContext {
             };
         }
         let succeeded = to_assign.clone();
-        match self.execute(vec![
-            Box::new(AssignCardsToSprint {
-                ids: to_assign,
-                sprint_id,
-            }) as Box<dyn Command>
-        ]) {
+        match self.execute(vec![Box::new(AssignCardsToSprint {
+            ids: to_assign,
+            sprint_id,
+        }) as Box<dyn Command>])
+        {
             Ok(()) => BatchOperationResult { succeeded, failed },
             Err(e) => {
                 let err = e.to_string();

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -173,13 +173,6 @@ impl KanbanContext {
         command.execute(&mut ctx)
     }
 
-    pub fn execute(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
-        self.capture_before_command();
-        self.execute_raw(command)?;
-        self.dirty = true;
-        Ok(())
-    }
-
     pub fn snapshot(&self) -> Snapshot {
         Snapshot {
             boards: self.boards.clone(),
@@ -204,7 +197,7 @@ impl KanbanContext {
         self.history.capture_before_command(self.snapshot());
     }
 
-    pub fn execute_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
+    pub fn execute(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
         self.capture_before_command();
         for command in commands {
             if let Err(e) = self.execute_raw(command) {
@@ -332,6 +325,9 @@ impl KanbanContext {
 
     pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {
         use kanban_domain::commands::ArchiveCards;
+        // Capture a single undo entry for the whole batch before any mutations.
+        // execute_raw(ArchiveCards{ids: vec![id]}) never returns Err — ArchiveCards uses
+        // filter_valid_card_ids which warns and skips unknown IDs rather than failing.
         self.capture_before_command();
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
@@ -349,7 +345,10 @@ impl KanbanContext {
                 }),
             }
         }
-        if !succeeded.is_empty() {
+        if succeeded.is_empty() {
+            // Nothing changed — pop the phantom undo entry so the stack stays clean.
+            self.history.pop_undo();
+        } else {
             self.dirty = true;
         }
         BatchOperationResult { succeeded, failed }
@@ -443,7 +442,7 @@ impl KanbanOperations for KanbanContext {
     fn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {
         use kanban_domain::commands::CreateBoard;
         let cmd = CreateBoard { name, card_prefix };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.boards.last().cloned().ok_or_else(|| {
             KanbanError::Internal("Board creation succeeded but board not found".into())
         })
@@ -463,7 +462,7 @@ impl KanbanOperations for KanbanContext {
             board_id: id,
             updates,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_board(id)?
             .ok_or_else(|| KanbanError::not_found("board", id))
     }
@@ -471,7 +470,7 @@ impl KanbanOperations for KanbanContext {
     fn delete_board(&mut self, id: Uuid) -> KanbanResult<()> {
         use kanban_domain::commands::DeleteBoard;
         let cmd = DeleteBoard { board_id: id };
-        self.execute(Box::new(cmd))
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])
     }
 
     fn create_column(
@@ -492,7 +491,7 @@ impl KanbanOperations for KanbanContext {
             name,
             position,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.columns.last().cloned().ok_or_else(|| {
             KanbanError::Internal("Column creation succeeded but column not found".into())
         })
@@ -517,7 +516,7 @@ impl KanbanOperations for KanbanContext {
             column_id: id,
             updates,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_column(id)?
             .ok_or_else(|| KanbanError::not_found("column", id))
     }
@@ -525,7 +524,7 @@ impl KanbanOperations for KanbanContext {
     fn delete_column(&mut self, id: Uuid) -> KanbanResult<()> {
         use kanban_domain::commands::DeleteColumn;
         let cmd = DeleteColumn { column_id: id };
-        self.execute(Box::new(cmd))
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])
     }
 
     fn reorder_column(&mut self, id: Uuid, new_position: i32) -> KanbanResult<Column> {
@@ -557,7 +556,7 @@ impl KanbanOperations for KanbanContext {
             position,
             options,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.cards.last().cloned().ok_or_else(|| {
             KanbanError::Internal("Card creation succeeded but card not found".into())
         })
@@ -615,7 +614,7 @@ impl KanbanOperations for KanbanContext {
             card_id: id,
             updates,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_card(id)?
             .ok_or_else(|| KanbanError::not_found("card", id))
     }
@@ -638,7 +637,7 @@ impl KanbanOperations for KanbanContext {
             new_column_id: column_id,
             new_position: position,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_card(id)?
             .ok_or_else(|| KanbanError::not_found("card", id))
     }
@@ -677,7 +676,7 @@ impl KanbanOperations for KanbanContext {
             column_id: target_column,
             position,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_card(id)?
             .ok_or_else(|| KanbanError::not_found("card", id))
     }
@@ -685,7 +684,7 @@ impl KanbanOperations for KanbanContext {
     fn delete_card(&mut self, id: Uuid) -> KanbanResult<()> {
         use kanban_domain::commands::DeleteCard;
         let cmd = DeleteCard { card_id: id };
-        self.execute(Box::new(cmd))
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])
     }
 
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
@@ -710,7 +709,7 @@ impl KanbanOperations for KanbanContext {
             sprint_name,
             sprint_status: format!("{:?}", sprint.status),
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_card(card_id)?
             .ok_or_else(|| KanbanError::not_found("card", card_id))
     }
@@ -718,7 +717,7 @@ impl KanbanOperations for KanbanContext {
     fn unassign_card_from_sprint(&mut self, card_id: Uuid) -> KanbanResult<Card> {
         use kanban_domain::commands::UnassignCardFromSprint;
         let cmd = UnassignCardFromSprint { card_id };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_card(card_id)?
             .ok_or_else(|| KanbanError::not_found("card", card_id))
     }
@@ -768,7 +767,7 @@ impl KanbanOperations for KanbanContext {
     fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
         use kanban_domain::commands::ArchiveCards;
         let before = self.archived_cards.len();
-        self.execute(Box::new(ArchiveCards { ids }))?;
+        self.execute(vec![Box::new(ArchiveCards { ids }) as Box<dyn Command>])?;
         Ok(self.archived_cards.len() - before)
     }
 
@@ -779,7 +778,7 @@ impl KanbanOperations for KanbanContext {
             .iter()
             .filter(|c| c.column_id == column_id)
             .count();
-        self.execute(Box::new(MoveCards { ids, column_id }))?;
+        self.execute(vec![Box::new(MoveCards { ids, column_id }) as Box<dyn Command>])?;
         let after = self
             .cards
             .iter()
@@ -795,7 +794,7 @@ impl KanbanOperations for KanbanContext {
             .iter()
             .filter(|c| c.sprint_id == Some(sprint_id))
             .count();
-        self.execute(Box::new(AssignCardsToSprint { ids, sprint_id }))?;
+        self.execute(vec![Box::new(AssignCardsToSprint { ids, sprint_id }) as Box<dyn Command>])?;
         let after = self
             .cards
             .iter()
@@ -859,7 +858,7 @@ impl KanbanOperations for KanbanContext {
             explicit_prefix: prefix,
             auto_consume_name: false,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.sprints.last().cloned().ok_or_else(|| {
             KanbanError::Internal("Sprint creation succeeded but sprint not found".into())
         })
@@ -884,7 +883,7 @@ impl KanbanOperations for KanbanContext {
             sprint_id: id,
             updates,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_sprint(id)?
             .ok_or_else(|| KanbanError::not_found("sprint", id))
     }
@@ -896,7 +895,7 @@ impl KanbanOperations for KanbanContext {
             sprint_id: id,
             duration_days: duration,
         };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_sprint(id)?
             .ok_or_else(|| KanbanError::not_found("sprint", id))
     }
@@ -904,7 +903,7 @@ impl KanbanOperations for KanbanContext {
     fn complete_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
         use kanban_domain::commands::CompleteSprint;
         let cmd = CompleteSprint { sprint_id: id };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_sprint(id)?
             .ok_or_else(|| KanbanError::not_found("sprint", id))
     }
@@ -912,7 +911,7 @@ impl KanbanOperations for KanbanContext {
     fn cancel_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
         use kanban_domain::commands::CancelSprint;
         let cmd = CancelSprint { sprint_id: id };
-        self.execute(Box::new(cmd))?;
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_sprint(id)?
             .ok_or_else(|| KanbanError::not_found("sprint", id))
     }
@@ -920,7 +919,7 @@ impl KanbanOperations for KanbanContext {
     fn delete_sprint(&mut self, id: Uuid) -> KanbanResult<()> {
         use kanban_domain::commands::DeleteSprint;
         let cmd = DeleteSprint { sprint_id: id };
-        self.execute(Box::new(cmd))
+        self.execute(vec![Box::new(cmd) as Box<dyn Command>])
     }
 
     fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String> {
@@ -980,14 +979,14 @@ impl KanbanOperations for KanbanContext {
             .cloned()
             .ok_or_else(|| KanbanError::validation("No board in import data"))?;
 
-        self.execute(Box::new(ImportEntities {
+        self.execute(vec![Box::new(ImportEntities {
             boards: imported.boards,
             columns: imported.columns,
             cards: imported.cards,
             archived_cards: imported.archived_cards,
             sprints: imported.sprints,
             graph: Some(imported.graph),
-        }))?;
+        }) as Box<dyn Command>])?;
 
         Ok(board)
     }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -302,33 +302,43 @@ impl KanbanContext {
 
     pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {
         use kanban_domain::commands::ArchiveCards;
-        // Capture a single undo entry for the whole batch before any mutations.
-        // execute_raw(ArchiveCards{ids: vec![id]}) never returns Err — ArchiveCards uses
-        // filter_valid_card_ids which warns and skips unknown IDs rather than failing.
-        self.capture_before_command();
-        let mut succeeded = Vec::new();
+        let card_ids: std::collections::HashSet<Uuid> = self.cards.iter().map(|c| c.id).collect();
+        let mut to_archive = Vec::new();
         let mut failed = Vec::new();
         for id in ids {
-            let before_count = self.archived_cards.len();
-            match self.execute_raw(Box::new(ArchiveCards { ids: vec![id] })) {
-                Ok(()) if self.archived_cards.len() > before_count => succeeded.push(id),
-                Ok(()) => failed.push(BatchOperationFailure {
+            if card_ids.contains(&id) {
+                to_archive.push(id);
+            } else {
+                failed.push(BatchOperationFailure {
                     id,
                     error: KanbanError::not_found("card", id).to_string(),
-                }),
-                Err(e) => failed.push(BatchOperationFailure {
-                    id,
-                    error: e.to_string(),
-                }),
+                });
             }
         }
-        if succeeded.is_empty() {
-            // Nothing changed — pop the phantom undo entry so the stack stays clean.
-            self.history.pop_undo();
-        } else {
-            self.dirty = true;
+        if to_archive.is_empty() {
+            return BatchOperationResult {
+                succeeded: vec![],
+                failed,
+            };
         }
-        BatchOperationResult { succeeded, failed }
+        let succeeded = to_archive.clone();
+        match self.execute(vec![
+            Box::new(ArchiveCards { ids: to_archive }) as Box<dyn Command>
+        ]) {
+            Ok(()) => BatchOperationResult { succeeded, failed },
+            Err(e) => {
+                let err = e.to_string();
+                let mut all_failed = failed;
+                all_failed.extend(succeeded.into_iter().map(|id| BatchOperationFailure {
+                    id,
+                    error: err.clone(),
+                }));
+                BatchOperationResult {
+                    succeeded: vec![],
+                    failed: all_failed,
+                }
+            }
+        }
     }
 
     pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BatchOperationResult {

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -136,8 +136,14 @@ impl KanbanContext {
         self.graph = snapshot.graph;
     }
 
-    pub fn execute_with_history(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
+    /// Capture the current snapshot as a before-state for undo history.
+    /// Use this before direct mutations that bypass `execute_with_history`.
+    pub fn capture_before_command(&mut self) {
         self.history.capture_before_command(self.snapshot());
+    }
+
+    pub fn execute_with_history(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
+        self.capture_before_command();
         self.execute(command)?;
         self.dirty = true;
         Ok(())
@@ -147,7 +153,7 @@ impl KanbanContext {
         &mut self,
         commands: Vec<Box<dyn Command>>,
     ) -> KanbanResult<()> {
-        self.history.capture_before_command(self.snapshot());
+        self.capture_before_command();
         for command in commands {
             self.execute(command)?;
         }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -146,9 +146,7 @@ impl KanbanContext {
         self.graph = snapshot.graph;
     }
 
-    /// Capture the current snapshot as a before-state for undo history.
-    /// Use this before direct mutations that bypass `execute`.
-    pub fn capture_before_command(&mut self) {
+    fn capture_before_command(&mut self) {
         self.history.capture_before_command(self.snapshot());
     }
 
@@ -158,13 +156,12 @@ impl KanbanContext {
     }
 
     pub fn execute_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
+        let before = self.snapshot();
         self.capture_before_command();
         for command in commands {
             if let Err(e) = self.execute_raw(command) {
-                // Rollback: restore before-snapshot
-                if let Some(before) = self.history.pop_undo() {
-                    self.apply_snapshot(before);
-                }
+                self.apply_snapshot(before);
+                let _ = self.history.pop_undo();
                 return Err(e);
             }
         }
@@ -284,8 +281,13 @@ impl KanbanContext {
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
         for id in ids {
+            let before_count = self.archived_cards.len();
             match self.execute_raw(Box::new(ArchiveCards { ids: vec![id] })) {
-                Ok(()) => succeeded.push(id),
+                Ok(()) if self.archived_cards.len() > before_count => succeeded.push(id),
+                Ok(()) => failed.push(BatchOperationFailure {
+                    id,
+                    error: KanbanError::not_found("card", id).to_string(),
+                }),
                 Err(e) => failed.push(BatchOperationFailure {
                     id,
                     error: e.to_string(),
@@ -685,26 +687,23 @@ impl KanbanOperations for KanbanContext {
 
     fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
         use kanban_domain::commands::ArchiveCards;
-        let count = ids.len();
-        let cmd = ArchiveCards { ids };
-        self.execute(Box::new(cmd))?;
-        Ok(count)
+        let before = self.archived_cards.len();
+        self.execute(Box::new(ArchiveCards { ids }))?;
+        Ok(self.archived_cards.len() - before)
     }
 
     fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
         use kanban_domain::commands::MoveCards;
-        let count = ids.len();
-        let cmd = MoveCards { ids, column_id };
-        self.execute(Box::new(cmd))?;
-        Ok(count)
+        let valid_count = ids.iter().filter(|&&id| self.cards.iter().any(|c| c.id == id)).count();
+        self.execute(Box::new(MoveCards { ids, column_id }))?;
+        Ok(valid_count)
     }
 
     fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
         use kanban_domain::commands::AssignCardsToSprint;
-        let count = ids.len();
-        let cmd = AssignCardsToSprint { ids, sprint_id };
-        self.execute(Box::new(cmd))?;
-        Ok(count)
+        let valid_count = ids.iter().filter(|&&id| self.cards.iter().any(|c| c.id == id)).count();
+        self.execute(Box::new(AssignCardsToSprint { ids, sprint_id }))?;
+        Ok(valid_count)
     }
 
     fn carry_over_sprint_cards(

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -40,12 +40,12 @@ pub struct DataSnapshot {
 }
 
 pub struct KanbanContext {
-    pub boards: Vec<Board>,
-    pub columns: Vec<Column>,
-    pub cards: Vec<Card>,
-    pub sprints: Vec<Sprint>,
-    pub archived_cards: Vec<ArchivedCard>,
-    pub graph: DependencyGraph,
+    boards: Vec<Board>,
+    columns: Vec<Column>,
+    cards: Vec<Card>,
+    sprints: Vec<Sprint>,
+    archived_cards: Vec<ArchivedCard>,
+    graph: DependencyGraph,
     app_config: AppConfig,
     store: Arc<dyn PersistenceStore + Send + Sync>,
     history: HistoryManager,
@@ -107,6 +107,60 @@ impl KanbanContext {
         &self.app_config
     }
 
+    pub fn boards(&self) -> &[Board] {
+        &self.boards
+    }
+
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    pub fn cards(&self) -> &[Card] {
+        &self.cards
+    }
+
+    pub fn sprints(&self) -> &[Sprint] {
+        &self.sprints
+    }
+
+    pub fn archived_cards(&self) -> &[ArchivedCard] {
+        &self.archived_cards
+    }
+
+    pub fn graph(&self) -> &DependencyGraph {
+        &self.graph
+    }
+
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn boards_mut(&mut self) -> &mut Vec<Board> {
+        &mut self.boards
+    }
+
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn columns_mut(&mut self) -> &mut Vec<Column> {
+        &mut self.columns
+    }
+
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn cards_mut(&mut self) -> &mut Vec<Card> {
+        &mut self.cards
+    }
+
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn sprints_mut(&mut self) -> &mut Vec<Sprint> {
+        &mut self.sprints
+    }
+
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn archived_cards_mut(&mut self) -> &mut Vec<ArchivedCard> {
+        &mut self.archived_cards
+    }
+
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn graph_mut(&mut self) -> &mut DependencyGraph {
+        &mut self.graph
+    }
+
     fn execute_raw(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
         let mut ctx = CommandContext {
             boards: &mut self.boards,
@@ -150,18 +204,13 @@ impl KanbanContext {
         self.history.capture_before_command(self.snapshot());
     }
 
-    pub fn push_before_snapshot(&mut self, before: Snapshot) {
-        self.history.capture_before_command(before);
-        self.dirty = true;
-    }
-
     pub fn execute_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
-        let before = self.snapshot();
         self.capture_before_command();
         for command in commands {
             if let Err(e) = self.execute_raw(command) {
-                self.apply_snapshot(before);
-                let _ = self.history.pop_undo();
+                if let Some(before) = self.history.pop_undo() {
+                    self.apply_snapshot(before);
+                }
                 return Err(e);
             }
         }
@@ -170,33 +219,31 @@ impl KanbanContext {
     }
 
     pub fn undo(&mut self) -> bool {
-        if !self.history.can_undo() {
-            return false;
-        }
-        self.history.suppress();
-        let current = self.snapshot();
-        self.history.push_redo(current);
         if let Some(snapshot) = self.history.pop_undo() {
+            self.history.suppress();
+            let current = self.snapshot();
+            self.history.push_redo(current);
             self.apply_snapshot(snapshot);
             self.dirty = true;
+            self.history.unsuppress();
+            true
+        } else {
+            false
         }
-        self.history.unsuppress();
-        true
     }
 
     pub fn redo(&mut self) -> bool {
-        if !self.history.can_redo() {
-            return false;
-        }
-        self.history.suppress();
-        let current = self.snapshot();
-        self.history.push_undo(current);
         if let Some(snapshot) = self.history.pop_redo() {
+            self.history.suppress();
+            let current = self.snapshot();
+            self.history.push_undo(current);
             self.apply_snapshot(snapshot);
             self.dirty = true;
+            self.history.unsuppress();
+            true
+        } else {
+            false
         }
-        self.history.unsuppress();
-        true
     }
 
     pub fn can_undo(&self) -> bool {
@@ -209,6 +256,14 @@ impl KanbanContext {
 
     pub fn clear_history(&mut self) {
         self.history.clear();
+    }
+
+    pub fn undo_depth(&self) -> usize {
+        self.history.undo_depth()
+    }
+
+    pub fn redo_depth(&self) -> usize {
+        self.history.redo_depth()
     }
 
     pub fn is_dirty(&self) -> bool {
@@ -334,19 +389,44 @@ impl KanbanContext {
         ids: Vec<Uuid>,
         sprint_id: Uuid,
     ) -> BatchOperationResult {
-        use kanban_domain::commands::AssignCardsToSprint;
+        use kanban_domain::commands::AssignCardToSprint;
         self.capture_before_command();
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
 
-        for id in ids {
-            match self.execute_raw(Box::new(AssignCardsToSprint {
-                ids: vec![id],
+        let sprint_info = self.sprints.iter().find(|s| s.id == sprint_id).map(|s| {
+            let sprint_name = self
+                .boards
+                .iter()
+                .find(|b| b.id == s.board_id)
+                .and_then(|b| s.get_name(b).map(|n| n.to_string()));
+            (s.sprint_number, sprint_name, format!("{:?}", s.status))
+        });
+
+        let (sprint_number, sprint_name, sprint_status) = match sprint_info {
+            Some(info) => info,
+            None => {
+                for id in ids {
+                    failed.push(BatchOperationFailure {
+                        id,
+                        error: KanbanError::not_found("sprint", sprint_id).to_string(),
+                    });
+                }
+                return BatchOperationResult { succeeded, failed };
+            }
+        };
+
+        for card_id in ids {
+            match self.execute_raw(Box::new(AssignCardToSprint {
+                card_id,
                 sprint_id,
+                sprint_number,
+                sprint_name: sprint_name.clone(),
+                sprint_status: sprint_status.clone(),
             })) {
-                Ok(_) => succeeded.push(id),
+                Ok(_) => succeeded.push(card_id),
                 Err(e) => failed.push(BatchOperationFailure {
-                    id,
+                    id: card_id,
                     error: e.to_string(),
                 }),
             }
@@ -694,22 +774,34 @@ impl KanbanOperations for KanbanContext {
 
     fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
         use kanban_domain::commands::MoveCards;
-        let valid_count = ids
+        let before = self
+            .cards
             .iter()
-            .filter(|&&id| self.cards.iter().any(|c| c.id == id))
+            .filter(|c| c.column_id == column_id)
             .count();
         self.execute(Box::new(MoveCards { ids, column_id }))?;
-        Ok(valid_count)
+        let after = self
+            .cards
+            .iter()
+            .filter(|c| c.column_id == column_id)
+            .count();
+        Ok(after - before)
     }
 
     fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
         use kanban_domain::commands::AssignCardsToSprint;
-        let valid_count = ids
+        let before = self
+            .cards
             .iter()
-            .filter(|&&id| self.cards.iter().any(|c| c.id == id))
+            .filter(|c| c.sprint_id == Some(sprint_id))
             .count();
         self.execute(Box::new(AssignCardsToSprint { ids, sprint_id }))?;
-        Ok(valid_count)
+        let after = self
+            .cards
+            .iter()
+            .filter(|c| c.sprint_id == Some(sprint_id))
+            .count();
+        Ok(after - before)
     }
 
     fn carry_over_sprint_cards(

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -104,7 +104,7 @@ impl KanbanContext {
         &self.app_config
     }
 
-    pub fn execute(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
+    fn execute_raw(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
         let mut ctx = CommandContext {
             boards: &mut self.boards,
             columns: &mut self.columns,
@@ -114,6 +114,13 @@ impl KanbanContext {
             graph: &mut self.graph,
         };
         command.execute(&mut ctx)
+    }
+
+    pub fn execute(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
+        self.capture_before_command();
+        self.execute_raw(command)?;
+        self.dirty = true;
+        Ok(())
     }
 
     pub fn snapshot(&self) -> Snapshot {
@@ -144,7 +151,7 @@ impl KanbanContext {
 
     pub fn execute_with_history(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
         self.capture_before_command();
-        self.execute(command)?;
+        self.execute_raw(command)?;
         self.dirty = true;
         Ok(())
     }
@@ -155,7 +162,7 @@ impl KanbanContext {
     ) -> KanbanResult<()> {
         self.capture_before_command();
         for command in commands {
-            self.execute(command)?;
+            self.execute_raw(command)?;
         }
         self.dirty = true;
         Ok(())
@@ -234,7 +241,6 @@ impl KanbanContext {
             sprints: data.sprints,
             graph: data.graph,
         });
-        self.history.clear();
         Ok(())
     }
 
@@ -253,10 +259,12 @@ impl KanbanContext {
     }
 
     pub fn bulk_archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BulkOperationResult {
+        use kanban_domain::commands::ArchiveCard;
+        self.capture_before_command();
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
         for id in ids {
-            match self.archive_card(id) {
+            match self.execute_raw(Box::new(ArchiveCard { card_id: id })) {
                 Ok(()) => succeeded.push(id),
                 Err(e) => failed.push(BulkOperationFailure {
                     id,
@@ -264,6 +272,7 @@ impl KanbanContext {
                 }),
             }
         }
+        self.dirty = true;
         BulkOperationResult { succeeded, failed }
     }
 
@@ -272,10 +281,21 @@ impl KanbanContext {
         ids: Vec<Uuid>,
         column_id: Uuid,
     ) -> BulkOperationResult {
+        use kanban_domain::commands::MoveCard;
+        self.capture_before_command();
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
         for id in ids {
-            match self.move_card(id, column_id, None) {
+            let position = self
+                .cards
+                .iter()
+                .filter(|c| c.column_id == column_id)
+                .count() as i32;
+            match self.execute_raw(Box::new(MoveCard {
+                card_id: id,
+                new_column_id: column_id,
+                new_position: position,
+            })) {
                 Ok(_) => succeeded.push(id),
                 Err(e) => failed.push(BulkOperationFailure {
                     id,
@@ -283,6 +303,7 @@ impl KanbanContext {
                 }),
             }
         }
+        self.dirty = true;
         BulkOperationResult { succeeded, failed }
     }
 
@@ -291,17 +312,43 @@ impl KanbanContext {
         ids: Vec<Uuid>,
         sprint_id: Uuid,
     ) -> BulkOperationResult {
+        use kanban_domain::commands::AssignCardToSprint;
+        self.capture_before_command();
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
-        for id in ids {
-            match self.assign_card_to_sprint(id, sprint_id) {
-                Ok(_) => succeeded.push(id),
-                Err(e) => failed.push(BulkOperationFailure {
+
+        let sprint_info = self.get_sprint(sprint_id).ok().flatten().and_then(|sprint| {
+            let board = self.boards.iter().find(|b| b.id == sprint.board_id)?;
+            let sprint_name = sprint.get_name(board).map(|s| s.to_string());
+            Some((sprint.sprint_number, sprint_name, format!("{:?}", sprint.status)))
+        });
+
+        if let Some((sprint_number, sprint_name, sprint_status)) = sprint_info {
+            for id in ids {
+                match self.execute_raw(Box::new(AssignCardToSprint {
+                    card_id: id,
+                    sprint_id,
+                    sprint_number,
+                    sprint_name: sprint_name.clone(),
+                    sprint_status: sprint_status.clone(),
+                })) {
+                    Ok(_) => succeeded.push(id),
+                    Err(e) => failed.push(BulkOperationFailure {
+                        id,
+                        error: e.to_string(),
+                    }),
+                }
+            }
+        } else {
+            for id in ids {
+                failed.push(BulkOperationFailure {
                     id,
-                    error: e.to_string(),
-                }),
+                    error: format!("Sprint {} not found", sprint_id),
+                });
             }
         }
+
+        self.dirty = true;
         BulkOperationResult { succeeded, failed }
     }
 }
@@ -634,22 +681,18 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.archive_card(id).is_ok() {
-                count += 1;
-            }
-        }
+        use kanban_domain::commands::BulkArchiveCards;
+        let count = ids.len();
+        let cmd = BulkArchiveCards { ids };
+        self.execute(Box::new(cmd))?;
         Ok(count)
     }
 
     fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.move_card(id, column_id, None).is_ok() {
-                count += 1;
-            }
-        }
+        use kanban_domain::commands::BulkMoveCards;
+        let count = ids.len();
+        let cmd = BulkMoveCards { ids, column_id };
+        self.execute(Box::new(cmd))?;
         Ok(count)
     }
 
@@ -706,6 +749,8 @@ impl KanbanOperations for KanbanContext {
     ) -> KanbanResult<Sprint> {
         use kanban_domain::commands::CreateSprint;
 
+        self.capture_before_command();
+
         let (sprint_number, name_index, effective_prefix) = {
             let board = self
                 .boards
@@ -734,7 +779,8 @@ impl KanbanOperations for KanbanContext {
             name_index,
             prefix: Some(effective_prefix),
         };
-        self.execute(Box::new(cmd))?;
+        self.execute_raw(Box::new(cmd))?;
+        self.dirty = true;
         self.sprints.last().cloned().ok_or_else(|| {
             KanbanError::Internal("Sprint creation succeeded but sprint not found".into())
         })
@@ -853,10 +899,12 @@ impl KanbanOperations for KanbanContext {
             .cloned()
             .ok_or_else(|| KanbanError::validation("No board in import data"))?;
 
+        self.capture_before_command();
         self.boards.extend(imported.boards);
         self.columns.extend(imported.columns);
         self.cards.extend(imported.cards);
         self.sprints.extend(imported.sprints);
+        self.dirty = true;
 
         Ok(board)
     }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -620,7 +620,10 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        self.archive_cards(vec![id])?;
+        let count = self.archive_cards(vec![id])?;
+        if count == 0 {
+            return Err(KanbanError::not_found("card", id));
+        }
         Ok(())
     }
 

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -147,19 +147,17 @@ impl KanbanContext {
     }
 
     /// Capture the current snapshot as a before-state for undo history.
-    /// Use this before direct mutations that bypass `execute_with_history`.
+    /// Use this before direct mutations that bypass `execute`.
     pub fn capture_before_command(&mut self) {
         self.history.capture_before_command(self.snapshot());
     }
 
-    pub fn execute_with_history(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
-        self.capture_before_command();
-        self.execute_raw(command)?;
+    pub fn record_undo_snapshot(&mut self, before: Snapshot) {
+        self.history.capture_before_command(before);
         self.dirty = true;
-        Ok(())
     }
 
-    pub fn execute_batch_with_history(
+    pub fn execute_batch(
         &mut self,
         commands: Vec<Box<dyn Command>>,
     ) -> KanbanResult<()> {

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -778,7 +778,9 @@ impl KanbanOperations for KanbanContext {
             .iter()
             .filter(|c| c.column_id == column_id)
             .count();
-        self.execute(vec![Box::new(MoveCards { ids, column_id }) as Box<dyn Command>])?;
+        self.execute(vec![
+            Box::new(MoveCards { ids, column_id }) as Box<dyn Command>
+        ])?;
         let after = self
             .cards
             .iter()
@@ -794,7 +796,9 @@ impl KanbanOperations for KanbanContext {
             .iter()
             .filter(|c| c.sprint_id == Some(sprint_id))
             .count();
-        self.execute(vec![Box::new(AssignCardsToSprint { ids, sprint_id }) as Box<dyn Command>])?;
+        self.execute(vec![
+            Box::new(AssignCardsToSprint { ids, sprint_id }) as Box<dyn Command>
+        ])?;
         let after = self
             .cards
             .iter()

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -694,14 +694,20 @@ impl KanbanOperations for KanbanContext {
 
     fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
         use kanban_domain::commands::MoveCards;
-        let valid_count = ids.iter().filter(|&&id| self.cards.iter().any(|c| c.id == id)).count();
+        let valid_count = ids
+            .iter()
+            .filter(|&&id| self.cards.iter().any(|c| c.id == id))
+            .count();
         self.execute(Box::new(MoveCards { ids, column_id }))?;
         Ok(valid_count)
     }
 
     fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
         use kanban_domain::commands::AssignCardsToSprint;
-        let valid_count = ids.iter().filter(|&&id| self.cards.iter().any(|c| c.id == id)).count();
+        let valid_count = ids
+            .iter()
+            .filter(|&&id| self.cards.iter().any(|c| c.id == id))
+            .count();
         self.execute(Box::new(AssignCardsToSprint { ids, sprint_id }))?;
         Ok(valid_count)
     }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -7,7 +7,7 @@ use kanban_domain::{
 };
 use kanban_domain::{KanbanError, KanbanResult};
 use kanban_persistence::{PersistenceError, PersistenceMetadata, PersistenceStore, StoreSnapshot};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -21,22 +21,6 @@ pub struct BatchOperationResult {
 pub struct BatchOperationFailure {
     pub id: Uuid,
     pub error: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct DataSnapshot {
-    #[serde(default)]
-    pub boards: Vec<Board>,
-    #[serde(default)]
-    pub columns: Vec<Column>,
-    #[serde(default)]
-    pub cards: Vec<Card>,
-    #[serde(default)]
-    pub archived_cards: Vec<ArchivedCard>,
-    #[serde(default)]
-    pub sprints: Vec<Sprint>,
-    #[serde(default)]
-    pub graph: DependencyGraph,
 }
 
 pub struct KanbanContext {
@@ -63,7 +47,7 @@ impl KanbanContext {
         }
 
         let (snapshot, _metadata) = store.load().await?;
-        let data: DataSnapshot = serde_json::from_slice(&snapshot.data)
+        let data: Snapshot = serde_json::from_slice(&snapshot.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 
         Ok(Self {
@@ -296,16 +280,9 @@ impl KanbanContext {
             return Ok(());
         }
         let (snapshot, _metadata) = self.store.load().await?;
-        let data: DataSnapshot = serde_json::from_slice(&snapshot.data)
+        let data: Snapshot = serde_json::from_slice(&snapshot.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-        self.apply_snapshot(Snapshot {
-            boards: data.boards,
-            columns: data.columns,
-            cards: data.cards,
-            archived_cards: data.archived_cards,
-            sprints: data.sprints,
-            graph: data.graph,
-        });
+        self.apply_snapshot(data);
         Ok(())
     }
 
@@ -948,7 +925,7 @@ impl KanbanOperations for KanbanContext {
                 .filter(|s| s.board_id == id)
                 .cloned()
                 .collect();
-            DataSnapshot {
+            Snapshot {
                 boards,
                 columns,
                 cards,
@@ -957,7 +934,7 @@ impl KanbanOperations for KanbanContext {
                 graph: self.graph.clone(),
             }
         } else {
-            DataSnapshot {
+            Snapshot {
                 boards: self.boards.clone(),
                 columns: self.columns.clone(),
                 cards: self.cards.clone(),
@@ -974,7 +951,7 @@ impl KanbanOperations for KanbanContext {
     fn import_board(&mut self, data: &str) -> KanbanResult<Board> {
         use kanban_domain::commands::ImportEntities;
 
-        let imported: DataSnapshot = serde_json::from_str(data)
+        let imported: Snapshot = serde_json::from_str(data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 
         let board = imported

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -152,15 +152,12 @@ impl KanbanContext {
         self.history.capture_before_command(self.snapshot());
     }
 
-    pub fn record_undo_snapshot(&mut self, before: Snapshot) {
+    pub fn push_before_snapshot(&mut self, before: Snapshot) {
         self.history.capture_before_command(before);
         self.dirty = true;
     }
 
-    pub fn execute_batch(
-        &mut self,
-        commands: Vec<Box<dyn Command>>,
-    ) -> KanbanResult<()> {
+    pub fn execute_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
         self.capture_before_command();
         for command in commands {
             self.execute_raw(command)?;

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -177,12 +177,8 @@ impl KanbanContext {
         self.graph = snapshot.graph;
     }
 
-    fn capture_before_command(&mut self) {
-        self.history.capture_before_command(self.snapshot());
-    }
-
     pub fn execute(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
-        self.capture_before_command();
+        self.history.capture_before_command(self.snapshot());
         for command in commands {
             if let Err(e) = self.execute_raw(command) {
                 if let Some(before) = self.history.pop_undo() {
@@ -342,32 +338,47 @@ impl KanbanContext {
     }
 
     pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BatchOperationResult {
-        use kanban_domain::commands::MoveCard;
-        self.capture_before_command();
-        let mut succeeded = Vec::new();
+        use kanban_domain::commands::MoveCards;
+        let card_ids: std::collections::HashSet<Uuid> = self.cards.iter().map(|c| c.id).collect();
+        let mut to_move = Vec::new();
         let mut failed = Vec::new();
         for id in ids {
-            let position = self
-                .cards
-                .iter()
-                .filter(|c| c.column_id == column_id)
-                .count() as i32;
-            match self.execute_raw(Box::new(MoveCard {
-                card_id: id,
-                new_column_id: column_id,
-                new_position: position,
-            })) {
-                Ok(_) => succeeded.push(id),
-                Err(e) => failed.push(BatchOperationFailure {
+            if card_ids.contains(&id) {
+                to_move.push(id);
+            } else {
+                failed.push(BatchOperationFailure {
                     id,
-                    error: e.to_string(),
-                }),
+                    error: KanbanError::not_found("card", id).to_string(),
+                });
             }
         }
-        if !succeeded.is_empty() {
-            self.dirty = true;
+        if to_move.is_empty() {
+            return BatchOperationResult {
+                succeeded: vec![],
+                failed,
+            };
         }
-        BatchOperationResult { succeeded, failed }
+        let succeeded = to_move.clone();
+        match self.execute(vec![
+            Box::new(MoveCards {
+                ids: to_move,
+                column_id,
+            }) as Box<dyn Command>
+        ]) {
+            Ok(()) => BatchOperationResult { succeeded, failed },
+            Err(e) => {
+                let err = e.to_string();
+                let mut all_failed = failed;
+                all_failed.extend(succeeded.into_iter().map(|id| BatchOperationFailure {
+                    id,
+                    error: err.clone(),
+                }));
+                BatchOperationResult {
+                    succeeded: vec![],
+                    failed: all_failed,
+                }
+            }
+        }
     }
 
     pub fn assign_cards_to_sprint_detailed(
@@ -375,53 +386,59 @@ impl KanbanContext {
         ids: Vec<Uuid>,
         sprint_id: Uuid,
     ) -> BatchOperationResult {
-        use kanban_domain::commands::AssignCardToSprint;
-        self.capture_before_command();
-        let mut succeeded = Vec::new();
-        let mut failed = Vec::new();
-
-        let sprint_info = self.sprints.iter().find(|s| s.id == sprint_id).map(|s| {
-            let sprint_name = self
-                .boards
-                .iter()
-                .find(|b| b.id == s.board_id)
-                .and_then(|b| s.get_name(b).map(|n| n.to_string()));
-            (s.sprint_number, sprint_name, format!("{:?}", s.status))
-        });
-
-        let (sprint_number, sprint_name, sprint_status) = match sprint_info {
-            Some(info) => info,
-            None => {
-                for id in ids {
-                    failed.push(BatchOperationFailure {
+        use kanban_domain::commands::AssignCardsToSprint;
+        if !self.sprints.iter().any(|s| s.id == sprint_id) {
+            return BatchOperationResult {
+                succeeded: vec![],
+                failed: ids
+                    .into_iter()
+                    .map(|id| BatchOperationFailure {
                         id,
                         error: KanbanError::not_found("sprint", sprint_id).to_string(),
-                    });
-                }
-                return BatchOperationResult { succeeded, failed };
+                    })
+                    .collect(),
+            };
+        }
+        let card_ids: std::collections::HashSet<Uuid> = self.cards.iter().map(|c| c.id).collect();
+        let mut to_assign = Vec::new();
+        let mut failed = Vec::new();
+        for id in ids {
+            if card_ids.contains(&id) {
+                to_assign.push(id);
+            } else {
+                failed.push(BatchOperationFailure {
+                    id,
+                    error: KanbanError::not_found("card", id).to_string(),
+                });
             }
-        };
-
-        for card_id in ids {
-            match self.execute_raw(Box::new(AssignCardToSprint {
-                card_id,
+        }
+        if to_assign.is_empty() {
+            return BatchOperationResult {
+                succeeded: vec![],
+                failed,
+            };
+        }
+        let succeeded = to_assign.clone();
+        match self.execute(vec![
+            Box::new(AssignCardsToSprint {
+                ids: to_assign,
                 sprint_id,
-                sprint_number,
-                sprint_name: sprint_name.clone(),
-                sprint_status: sprint_status.clone(),
-            })) {
-                Ok(_) => succeeded.push(card_id),
-                Err(e) => failed.push(BatchOperationFailure {
-                    id: card_id,
-                    error: e.to_string(),
-                }),
+            }) as Box<dyn Command>
+        ]) {
+            Ok(()) => BatchOperationResult { succeeded, failed },
+            Err(e) => {
+                let err = e.to_string();
+                let mut all_failed = failed;
+                all_failed.extend(succeeded.into_iter().map(|id| BatchOperationFailure {
+                    id,
+                    error: err.clone(),
+                }));
+                BatchOperationResult {
+                    succeeded: vec![],
+                    failed: all_failed,
+                }
             }
         }
-
-        if !succeeded.is_empty() {
-            self.dirty = true;
-        }
-        BatchOperationResult { succeeded, failed }
     }
 }
 
@@ -682,22 +699,10 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
-        use kanban_domain::commands::AssignCardToSprint;
-        let sprint = self
-            .get_sprint(sprint_id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", sprint_id))?;
-        let board = self
-            .boards
-            .iter()
-            .find(|b| b.id == sprint.board_id)
-            .ok_or_else(|| KanbanError::not_found("board", sprint.board_id))?;
-        let sprint_name = sprint.get_name(board).map(|s| s.to_string());
-        let cmd = AssignCardToSprint {
-            card_id,
+        use kanban_domain::commands::AssignCardsToSprint;
+        let cmd = AssignCardsToSprint {
+            ids: vec![card_id],
             sprint_id,
-            sprint_number: sprint.sprint_number,
-            sprint_name,
-            sprint_status: format!("{:?}", sprint.status),
         };
         self.execute(vec![Box::new(cmd) as Box<dyn Command>])?;
         self.get_card(card_id)?

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -272,13 +272,13 @@ impl KanbanContext {
         Ok(())
     }
 
-    pub fn bulk_archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BulkOperationResult {
-        use kanban_domain::commands::ArchiveCard;
+    pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BulkOperationResult {
+        use kanban_domain::commands::ArchiveCards;
         self.capture_before_command();
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
         for id in ids {
-            match self.execute_raw(Box::new(ArchiveCard { card_id: id })) {
+            match self.execute_raw(Box::new(ArchiveCards { ids: vec![id] })) {
                 Ok(()) => succeeded.push(id),
                 Err(e) => failed.push(BulkOperationFailure {
                     id,
@@ -290,11 +290,7 @@ impl KanbanContext {
         BulkOperationResult { succeeded, failed }
     }
 
-    pub fn bulk_move_cards_detailed(
-        &mut self,
-        ids: Vec<Uuid>,
-        column_id: Uuid,
-    ) -> BulkOperationResult {
+    pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BulkOperationResult {
         use kanban_domain::commands::MoveCard;
         self.capture_before_command();
         let mut succeeded = Vec::new();
@@ -321,7 +317,7 @@ impl KanbanContext {
         BulkOperationResult { succeeded, failed }
     }
 
-    pub fn bulk_assign_sprint_detailed(
+    pub fn assign_cards_to_sprint_detailed(
         &mut self,
         ids: Vec<Uuid>,
         sprint_id: Uuid,
@@ -580,9 +576,8 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        use kanban_domain::commands::ArchiveCard;
-        let cmd = ArchiveCard { card_id: id };
-        self.execute(Box::new(cmd))
+        self.archive_cards(vec![id])?;
+        Ok(())
     }
 
     fn restore_card(&mut self, id: Uuid, column_id: Option<Uuid>) -> KanbanResult<Card> {
@@ -702,23 +697,23 @@ impl KanbanOperations for KanbanContext {
         ))
     }
 
-    fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        use kanban_domain::commands::BulkArchiveCards;
+    fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
+        use kanban_domain::commands::ArchiveCards;
         let count = ids.len();
-        let cmd = BulkArchiveCards { ids };
+        let cmd = ArchiveCards { ids };
         self.execute(Box::new(cmd))?;
         Ok(count)
     }
 
-    fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        use kanban_domain::commands::BulkMoveCards;
+    fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
+        use kanban_domain::commands::MoveCards;
         let count = ids.len();
-        let cmd = BulkMoveCards { ids, column_id };
+        let cmd = MoveCards { ids, column_id };
         self.execute(Box::new(cmd))?;
         Ok(count)
     }
 
-    fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
+    fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
         let mut count = 0;
         for id in ids {
             if self.assign_card_to_sprint(id, sprint_id).is_ok() {
@@ -760,7 +755,7 @@ impl KanbanOperations for KanbanContext {
             .iter()
             .map(|c| c.id)
             .collect();
-        self.bulk_assign_sprint(ids, to_sprint_id)
+        self.assign_cards_to_sprint(ids, to_sprint_id)
     }
 
     fn create_sprint(

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -2,7 +2,8 @@ use kanban_core::AppConfig;
 use kanban_domain::commands::{Command, CommandContext};
 use kanban_domain::{
     ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
-    ColumnUpdate, DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
+    ColumnUpdate, DependencyGraph, FieldUpdate, HistoryManager, KanbanOperations, Snapshot, Sprint,
+    SprintUpdate,
 };
 use kanban_domain::{KanbanError, KanbanResult};
 use kanban_persistence::{PersistenceError, PersistenceMetadata, PersistenceStore, StoreSnapshot};
@@ -47,6 +48,8 @@ pub struct KanbanContext {
     pub graph: DependencyGraph,
     app_config: AppConfig,
     store: Arc<dyn PersistenceStore + Send + Sync>,
+    history: HistoryManager,
+    dirty: bool,
 }
 
 impl KanbanContext {
@@ -71,6 +74,8 @@ impl KanbanContext {
             graph: data.graph,
             app_config: config,
             store,
+            history: HistoryManager::new(),
+            dirty: false,
         })
     }
 
@@ -80,7 +85,7 @@ impl KanbanContext {
         Self::load(store, AppConfig::default()).await
     }
 
-    fn empty(store: Arc<dyn PersistenceStore + Send + Sync>, config: AppConfig) -> Self {
+    pub fn empty(store: Arc<dyn PersistenceStore + Send + Sync>, config: AppConfig) -> Self {
         Self {
             boards: Vec::new(),
             columns: Vec::new(),
@@ -90,6 +95,8 @@ impl KanbanContext {
             graph: DependencyGraph::new(),
             app_config: config,
             store,
+            history: HistoryManager::new(),
+            dirty: false,
         }
     }
 
@@ -109,6 +116,103 @@ impl KanbanContext {
         command.execute(&mut ctx)
     }
 
+    pub fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            boards: self.boards.clone(),
+            columns: self.columns.clone(),
+            cards: self.cards.clone(),
+            archived_cards: self.archived_cards.clone(),
+            sprints: self.sprints.clone(),
+            graph: self.graph.clone(),
+        }
+    }
+
+    pub fn apply_snapshot(&mut self, snapshot: Snapshot) {
+        self.boards = snapshot.boards;
+        self.columns = snapshot.columns;
+        self.cards = snapshot.cards;
+        self.archived_cards = snapshot.archived_cards;
+        self.sprints = snapshot.sprints;
+        self.graph = snapshot.graph;
+    }
+
+    pub fn execute_with_history(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {
+        self.history.capture_before_command(self.snapshot());
+        self.execute(command)?;
+        self.dirty = true;
+        Ok(())
+    }
+
+    pub fn execute_batch_with_history(
+        &mut self,
+        commands: Vec<Box<dyn Command>>,
+    ) -> KanbanResult<()> {
+        self.history.capture_before_command(self.snapshot());
+        for command in commands {
+            self.execute(command)?;
+        }
+        self.dirty = true;
+        Ok(())
+    }
+
+    pub fn undo(&mut self) -> bool {
+        if !self.history.can_undo() {
+            return false;
+        }
+        self.history.suppress();
+        let current = self.snapshot();
+        self.history.push_redo(current);
+        if let Some(snapshot) = self.history.pop_undo() {
+            self.apply_snapshot(snapshot);
+            self.dirty = true;
+        }
+        self.history.unsuppress();
+        true
+    }
+
+    pub fn redo(&mut self) -> bool {
+        if !self.history.can_redo() {
+            return false;
+        }
+        self.history.suppress();
+        let current = self.snapshot();
+        self.history.push_undo(current);
+        if let Some(snapshot) = self.history.pop_redo() {
+            self.apply_snapshot(snapshot);
+            self.dirty = true;
+        }
+        self.history.unsuppress();
+        true
+    }
+
+    pub fn can_undo(&self) -> bool {
+        self.history.can_undo()
+    }
+
+    pub fn can_redo(&self) -> bool {
+        self.history.can_redo()
+    }
+
+    pub fn clear_history(&mut self) {
+        self.history.clear();
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    pub fn mark_dirty(&mut self) {
+        self.dirty = true;
+    }
+
+    pub fn mark_clean(&mut self) {
+        self.dirty = false;
+    }
+
+    pub fn store(&self) -> &Arc<dyn PersistenceStore + Send + Sync> {
+        &self.store
+    }
+
     pub async fn reload(&mut self) -> KanbanResult<()> {
         if !self.store.exists().await {
             return Ok(());
@@ -116,25 +220,20 @@ impl KanbanContext {
         let (snapshot, _metadata) = self.store.load().await?;
         let data: DataSnapshot = serde_json::from_slice(&snapshot.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-        self.boards = data.boards;
-        self.columns = data.columns;
-        self.cards = data.cards;
-        self.sprints = data.sprints;
-        self.archived_cards = data.archived_cards;
-        self.graph = data.graph;
+        self.apply_snapshot(Snapshot {
+            boards: data.boards,
+            columns: data.columns,
+            cards: data.cards,
+            archived_cards: data.archived_cards,
+            sprints: data.sprints,
+            graph: data.graph,
+        });
+        self.history.clear();
         Ok(())
     }
 
     pub async fn save(&self) -> KanbanResult<()> {
-        let snapshot = DataSnapshot {
-            boards: self.boards.clone(),
-            columns: self.columns.clone(),
-            cards: self.cards.clone(),
-            archived_cards: self.archived_cards.clone(),
-            sprints: self.sprints.clone(),
-            graph: self.graph.clone(),
-        };
-
+        let snapshot = self.snapshot();
         let bytes = serde_json::to_vec_pretty(&snapshot)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -160,7 +160,13 @@ impl KanbanContext {
     pub fn execute_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
         self.capture_before_command();
         for command in commands {
-            self.execute_raw(command)?;
+            if let Err(e) = self.execute_raw(command) {
+                // Rollback: restore before-snapshot
+                if let Some(before) = self.history.pop_undo() {
+                    self.apply_snapshot(before);
+                }
+                return Err(e);
+            }
         }
         self.dirty = true;
         Ok(())
@@ -322,47 +328,21 @@ impl KanbanContext {
         ids: Vec<Uuid>,
         sprint_id: Uuid,
     ) -> BulkOperationResult {
-        use kanban_domain::commands::AssignCardToSprint;
+        use kanban_domain::commands::AssignCardsToSprint;
         self.capture_before_command();
         let mut succeeded = Vec::new();
         let mut failed = Vec::new();
 
-        let sprint_info = self
-            .get_sprint(sprint_id)
-            .ok()
-            .flatten()
-            .and_then(|sprint| {
-                let board = self.boards.iter().find(|b| b.id == sprint.board_id)?;
-                let sprint_name = sprint.get_name(board).map(|s| s.to_string());
-                Some((
-                    sprint.sprint_number,
-                    sprint_name,
-                    format!("{:?}", sprint.status),
-                ))
-            });
-
-        if let Some((sprint_number, sprint_name, sprint_status)) = sprint_info {
-            for id in ids {
-                match self.execute_raw(Box::new(AssignCardToSprint {
-                    card_id: id,
-                    sprint_id,
-                    sprint_number,
-                    sprint_name: sprint_name.clone(),
-                    sprint_status: sprint_status.clone(),
-                })) {
-                    Ok(_) => succeeded.push(id),
-                    Err(e) => failed.push(BulkOperationFailure {
-                        id,
-                        error: e.to_string(),
-                    }),
-                }
-            }
-        } else {
-            for id in ids {
-                failed.push(BulkOperationFailure {
+        for id in ids {
+            match self.execute_raw(Box::new(AssignCardsToSprint {
+                ids: vec![id],
+                sprint_id,
+            })) {
+                Ok(_) => succeeded.push(id),
+                Err(e) => failed.push(BulkOperationFailure {
                     id,
-                    error: format!("Sprint {} not found", sprint_id),
-                });
+                    error: e.to_string(),
+                }),
             }
         }
 
@@ -714,12 +694,10 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        let mut count = 0;
-        for id in ids {
-            if self.assign_card_to_sprint(id, sprint_id).is_ok() {
-                count += 1;
-            }
-        }
+        use kanban_domain::commands::AssignCardsToSprint;
+        let count = ids.len();
+        let cmd = AssignCardsToSprint { ids, sprint_id };
+        self.execute(Box::new(cmd))?;
         Ok(count)
     }
 

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -50,6 +50,7 @@ pub struct KanbanContext {
     store: Arc<dyn PersistenceStore + Send + Sync>,
     history: HistoryManager,
     dirty: bool,
+    conflict_pending: bool,
 }
 
 impl KanbanContext {
@@ -76,6 +77,7 @@ impl KanbanContext {
             store,
             history: HistoryManager::new(),
             dirty: false,
+            conflict_pending: false,
         })
     }
 
@@ -97,6 +99,7 @@ impl KanbanContext {
             store,
             history: HistoryManager::new(),
             dirty: false,
+            conflict_pending: false,
         }
     }
 
@@ -220,6 +223,22 @@ impl KanbanContext {
 
     pub fn mark_clean(&mut self) {
         self.dirty = false;
+    }
+
+    pub fn has_conflict(&self) -> bool {
+        self.conflict_pending
+    }
+
+    pub fn set_conflict(&mut self) {
+        self.conflict_pending = true;
+    }
+
+    pub fn clear_conflict(&mut self) {
+        self.conflict_pending = false;
+    }
+
+    pub fn replace_store(&mut self, store: Arc<dyn PersistenceStore + Send + Sync>) {
+        self.store = store;
     }
 
     pub fn store(&self) -> &Arc<dyn PersistenceStore + Send + Sync> {

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod config;
 mod context;
 pub use config::AppConfigDto;
-pub use context::{BatchOperationFailure, BatchOperationResult, DataSnapshot, KanbanContext};
+pub use context::{BatchOperationFailure, BatchOperationResult, KanbanContext};
 
 #[cfg(feature = "test-helpers")]
 pub mod test_helpers;

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod config;
 mod context;
 pub use config::AppConfigDto;
-pub use context::{BulkOperationFailure, BulkOperationResult, DataSnapshot, KanbanContext};
+pub use context::{BatchOperationFailure, BatchOperationResult, DataSnapshot, KanbanContext};
 
 #[cfg(feature = "test-helpers")]
 pub mod test_helpers;

--- a/crates/kanban-service/src/test_helpers/contract/board.rs
+++ b/crates/kanban-service/src/test_helpers/contract/board.rs
@@ -85,7 +85,11 @@ pub async fn test_board_sprint_names_roundtrip(factory: &StoreFactory) {
 
     let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
 
-    let b = ctx.boards.iter_mut().find(|b| b.id == board.id).unwrap();
+    let b = ctx
+        .boards_mut()
+        .iter_mut()
+        .find(|b| b.id == board.id)
+        .unwrap();
     b.sprint_names = vec!["Alpha".into(), "Beta".into(), "Gamma".into()];
     b.sprint_name_used_count = 1;
 
@@ -109,7 +113,11 @@ pub async fn test_board_prefix_counters_roundtrip(factory: &StoreFactory) {
         .create_board("Board".into(), Some("PFX".into()))
         .unwrap();
 
-    let b = ctx.boards.iter_mut().find(|b| b.id == board.id).unwrap();
+    let b = ctx
+        .boards_mut()
+        .iter_mut()
+        .find(|b| b.id == board.id)
+        .unwrap();
     b.prefix_counters.insert("PFX".into(), 10);
     b.prefix_counters.insert("OTHER".into(), 5);
     b.sprint_counters.insert("SP".into(), 3);
@@ -135,7 +143,11 @@ pub async fn test_board_next_sprint_number_roundtrip(factory: &StoreFactory) {
 
     let board = ctx.create_board("Board".into(), None).unwrap();
 
-    let b = ctx.boards.iter_mut().find(|b| b.id == board.id).unwrap();
+    let b = ctx
+        .boards_mut()
+        .iter_mut()
+        .find(|b| b.id == board.id)
+        .unwrap();
     b.next_sprint_number = 42;
 
     ctx.save().await.unwrap();

--- a/crates/kanban-service/src/test_helpers/contract/edge.rs
+++ b/crates/kanban-service/src/test_helpers/contract/edge.rs
@@ -32,7 +32,7 @@ pub async fn test_blocks_edge_roundtrip(factory: &StoreFactory) {
         .unwrap();
 
     let now = chrono::Utc::now();
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card_a.id,
         target: card_b.id,
         edge_type: CardEdgeType::Blocks,
@@ -47,7 +47,7 @@ pub async fn test_blocks_edge_roundtrip(factory: &StoreFactory) {
         .await
         .unwrap();
 
-    let edges = ctx.graph.cards.edges();
+    let edges = ctx.graph().cards.edges();
     assert_eq!(edges.len(), 1);
     let e = &edges[0];
     assert_eq!(e.source, card_a.id);
@@ -76,7 +76,7 @@ pub async fn test_relates_to_edge_roundtrip(factory: &StoreFactory) {
         .unwrap();
 
     let now = chrono::Utc::now();
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card_a.id,
         target: card_b.id,
         edge_type: CardEdgeType::RelatesTo,
@@ -91,7 +91,7 @@ pub async fn test_relates_to_edge_roundtrip(factory: &StoreFactory) {
         .await
         .unwrap();
 
-    let edges = ctx.graph.cards.edges();
+    let edges = ctx.graph().cards.edges();
     assert_eq!(edges.len(), 1);
     let e = &edges[0];
     assert_eq!(e.edge_type, CardEdgeType::RelatesTo);
@@ -127,7 +127,7 @@ pub async fn test_parent_of_edge_roundtrip(factory: &StoreFactory) {
         .unwrap();
 
     let now = chrono::Utc::now();
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: parent.id,
         target: child.id,
         edge_type: CardEdgeType::ParentOf,
@@ -142,7 +142,7 @@ pub async fn test_parent_of_edge_roundtrip(factory: &StoreFactory) {
         .await
         .unwrap();
 
-    let edges = ctx.graph.cards.edges();
+    let edges = ctx.graph().cards.edges();
     assert_eq!(edges.len(), 1);
     assert_eq!(edges[0].edge_type, CardEdgeType::ParentOf);
 }
@@ -165,7 +165,7 @@ pub async fn test_archived_edge_roundtrip(factory: &StoreFactory) {
         .unwrap();
 
     let now = chrono::Utc::now();
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card_a.id,
         target: card_b.id,
         edge_type: CardEdgeType::Blocks,
@@ -180,7 +180,7 @@ pub async fn test_archived_edge_roundtrip(factory: &StoreFactory) {
         .await
         .unwrap();
 
-    let edges = ctx.graph.cards.edges();
+    let edges = ctx.graph().cards.edges();
     assert_eq!(edges.len(), 1);
     assert!(edges[0].archived_at.is_some());
     assert!((edges[0].weight.unwrap() - 2.5).abs() < f32::EPSILON);
@@ -207,7 +207,7 @@ pub async fn test_multiple_edges_roundtrip(factory: &StoreFactory) {
         .unwrap();
 
     let now = chrono::Utc::now();
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card_a.id,
         target: card_b.id,
         edge_type: CardEdgeType::Blocks,
@@ -216,7 +216,7 @@ pub async fn test_multiple_edges_roundtrip(factory: &StoreFactory) {
         created_at: now,
         archived_at: None,
     });
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card_b.id,
         target: card_c.id,
         edge_type: CardEdgeType::ParentOf,
@@ -225,7 +225,7 @@ pub async fn test_multiple_edges_roundtrip(factory: &StoreFactory) {
         created_at: now,
         archived_at: None,
     });
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card_a.id,
         target: card_c.id,
         edge_type: CardEdgeType::RelatesTo,
@@ -240,7 +240,7 @@ pub async fn test_multiple_edges_roundtrip(factory: &StoreFactory) {
         .await
         .unwrap();
 
-    assert_eq!(ctx.graph.cards.edges().len(), 3);
+    assert_eq!(ctx.graph().cards.edges().len(), 3);
 }
 
 pub async fn test_empty_graph_roundtrip(factory: &StoreFactory) {
@@ -256,5 +256,5 @@ pub async fn test_empty_graph_roundtrip(factory: &StoreFactory) {
     let ctx = KanbanContext::load_with_defaults(factory(&path))
         .await
         .unwrap();
-    assert!(ctx.graph.cards.edges().is_empty());
+    assert!(ctx.graph().cards.edges().is_empty());
 }

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -1,11 +1,12 @@
 use super::super::helpers::fully_populated_snapshot;
 use super::super::StoreFactory;
-use crate::{DataSnapshot, KanbanContext};
+use crate::KanbanContext;
 use kanban_core::{Edge, EdgeDirection};
 use kanban_domain::board::{SortField, SortOrder};
 use kanban_domain::card::{CardPriority, CardStatus};
 use kanban_domain::sprint::SprintStatus;
 use kanban_domain::task_list_view::TaskListView;
+use kanban_domain::Snapshot;
 use kanban_domain::{
     BoardUpdate, CardEdgeType, CardUpdate, ColumnUpdate, CreateCardOptions, FieldUpdate,
     KanbanOperations,
@@ -395,7 +396,7 @@ pub async fn test_full_roundtrip_preserves_all_fields(factory: &StoreFactory) {
         .unwrap();
 
     let (loaded_snap, _) = store.load().await.unwrap();
-    let loaded: DataSnapshot = serde_json::from_slice(&loaded_snap.data).unwrap();
+    let loaded: Snapshot = serde_json::from_slice(&loaded_snap.data).unwrap();
 
     assert_eq!(original, loaded);
 }

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -174,7 +174,11 @@ pub async fn test_full_populated_context_roundtrip(factory: &StoreFactory) {
     let board = ctx
         .create_board("Full Board".into(), Some("FB".into()))
         .unwrap();
-    let b = ctx.boards.iter_mut().find(|b| b.id == board.id).unwrap();
+    let b = ctx
+        .boards_mut()
+        .iter_mut()
+        .find(|b| b.id == board.id)
+        .unwrap();
     b.sprint_names = vec!["Alpha".into(), "Beta".into()];
     b.sprint_name_used_count = 1;
     b.prefix_counters.insert("FB".into(), 10);
@@ -287,7 +291,7 @@ pub async fn test_full_populated_context_roundtrip(factory: &StoreFactory) {
     ctx.archive_card(card4.id).unwrap();
 
     let now = chrono::Utc::now();
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card1.id,
         target: card2.id,
         edge_type: CardEdgeType::Blocks,
@@ -296,7 +300,7 @@ pub async fn test_full_populated_context_roundtrip(factory: &StoreFactory) {
         created_at: now,
         archived_at: None,
     });
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card1.id,
         target: card3.id,
         edge_type: CardEdgeType::RelatesTo,
@@ -305,7 +309,7 @@ pub async fn test_full_populated_context_roundtrip(factory: &StoreFactory) {
         created_at: now,
         archived_at: Some(now),
     });
-    ctx.graph.cards.add_edge(Edge {
+    ctx.graph_mut().cards.add_edge(Edge {
         source: card2.id,
         target: card3.id,
         edge_type: CardEdgeType::ParentOf,
@@ -371,7 +375,7 @@ pub async fn test_full_populated_context_roundtrip(factory: &StoreFactory) {
     assert_eq!(archived[0].card.points, Some(5));
     assert_eq!(archived[0].original_column_id, col_todo.id);
 
-    let edges = loaded.graph.cards.edges();
+    let edges = loaded.graph().cards.edges();
     assert_eq!(edges.len(), 3, "expected 3 edges, got {:?}", edges);
 }
 

--- a/crates/kanban-service/src/test_helpers/contract/sprint_log.rs
+++ b/crates/kanban-service/src/test_helpers/contract/sprint_log.rs
@@ -62,7 +62,11 @@ pub async fn test_sprint_log_with_name_roundtrip(factory: &StoreFactory) {
     let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
     let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
 
-    let b = ctx.boards.iter_mut().find(|b| b.id == board.id).unwrap();
+    let b = ctx
+        .boards_mut()
+        .iter_mut()
+        .find(|b| b.id == board.id)
+        .unwrap();
     b.sprint_names = vec!["Alpha".into(), "Beta".into()];
 
     let sprint = ctx

--- a/crates/kanban-service/src/test_helpers/helpers.rs
+++ b/crates/kanban-service/src/test_helpers/helpers.rs
@@ -1,12 +1,12 @@
-use crate::DataSnapshot;
 use chrono::Utc;
 use kanban_core::{Edge, EdgeDirection};
 use kanban_domain::card::{Card, CardPriority, CardStatus};
 use kanban_domain::sprint::{Sprint, SprintStatus};
+use kanban_domain::Snapshot;
 use kanban_domain::{ArchivedCard, Board, CardEdgeType, Column, DependencyGraph, SprintLog};
 use uuid::Uuid;
 
-pub fn fully_populated_snapshot() -> DataSnapshot {
+pub fn fully_populated_snapshot() -> Snapshot {
     let board_id = Uuid::new_v4();
     let col_id = Uuid::new_v4();
     let sprint_id = Uuid::new_v4();
@@ -139,7 +139,7 @@ pub fn fully_populated_snapshot() -> DataSnapshot {
         archived_at: Some(now),
     });
 
-    DataSnapshot {
+    Snapshot {
         boards: vec![board],
         columns: vec![column],
         cards: vec![card],

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -1,4 +1,4 @@
-use kanban_domain::commands::{CompactColumnPositions, CreateBoard, ImportEntities, UpdateBoard};
+use kanban_domain::commands::{Command, CompactColumnPositions, CreateBoard, ImportEntities, UpdateBoard};
 use kanban_domain::{BoardUpdate, CardUpdate, KanbanOperations, Snapshot};
 use kanban_persistence::NullStore;
 use kanban_service::KanbanContext;
@@ -32,22 +32,22 @@ async fn test_snapshot_roundtrip_preserves_all_fields() {
 #[tokio::test]
 async fn test_execute_enables_undo() {
     let mut ctx = make_ctx().await;
-    let cmd = Box::new(CreateBoard {
+    let cmd: Box<dyn Command> = Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
     });
-    ctx.execute(cmd).unwrap();
+    ctx.execute(vec![cmd]).unwrap();
     assert!(ctx.can_undo());
 }
 
 #[tokio::test]
 async fn test_undo_restores_previous_state() {
     let mut ctx = make_ctx().await;
-    let cmd = Box::new(CreateBoard {
+    let cmd: Box<dyn Command> = Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
     });
-    ctx.execute(cmd).unwrap();
+    ctx.execute(vec![cmd]).unwrap();
     assert_eq!(ctx.boards().len(), 1);
 
     assert!(ctx.undo());
@@ -57,11 +57,11 @@ async fn test_undo_restores_previous_state() {
 #[tokio::test]
 async fn test_redo_restores_undone_state() {
     let mut ctx = make_ctx().await;
-    let cmd = Box::new(CreateBoard {
+    let cmd: Box<dyn Command> = Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
     });
-    ctx.execute(cmd).unwrap();
+    ctx.execute(vec![cmd]).unwrap();
     ctx.undo();
     assert!(ctx.boards().is_empty());
 
@@ -79,18 +79,18 @@ async fn test_undo_on_empty_returns_false() {
 #[tokio::test]
 async fn test_new_action_after_undo_clears_redo() {
     let mut ctx = make_ctx().await;
-    ctx.execute(Box::new(CreateBoard {
+    ctx.execute(vec![Box::new(CreateBoard {
         name: "A".into(),
         card_prefix: None,
-    }))
+    }) as Box<dyn Command>])
     .unwrap();
     ctx.undo();
     assert!(ctx.can_redo());
 
-    ctx.execute(Box::new(CreateBoard {
+    ctx.execute(vec![Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
-    }))
+    }) as Box<dyn Command>])
     .unwrap();
     assert!(!ctx.can_redo());
 }
@@ -102,17 +102,17 @@ async fn test_reload_no_longer_clears_history() {
     let store = kanban_service::make_store("json", path.to_str().unwrap()).unwrap();
     let mut ctx = KanbanContext::empty(store, kanban_core::AppConfig::default());
 
-    ctx.execute(Box::new(CreateBoard {
+    ctx.execute(vec![Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
-    }))
+    }) as Box<dyn Command>])
     .unwrap();
     ctx.save().await.unwrap();
 
-    ctx.execute(Box::new(CreateBoard {
+    ctx.execute(vec![Box::new(CreateBoard {
         name: "B2".into(),
         card_prefix: None,
-    }))
+    }) as Box<dyn Command>])
     .unwrap();
     assert!(ctx.can_undo());
 
@@ -126,10 +126,10 @@ async fn test_dirty_flag_lifecycle() {
     let mut ctx = make_ctx().await;
     assert!(!ctx.is_dirty());
 
-    ctx.execute(Box::new(CreateBoard {
+    ctx.execute(vec![Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
-    }))
+    }) as Box<dyn Command>])
     .unwrap();
     assert!(ctx.is_dirty());
 
@@ -289,17 +289,17 @@ async fn test_reload_preserves_history() {
 #[tokio::test]
 async fn test_undo_pops_before_pushing_to_redo() {
     let mut ctx = make_ctx().await;
-    ctx.execute(Box::new(CreateBoard {
+    ctx.execute(vec![Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
-    }))
+    }) as Box<dyn Command>])
     .unwrap();
     ctx.clear_history();
 
-    ctx.execute(Box::new(CreateBoard {
+    ctx.execute(vec![Box::new(CreateBoard {
         name: "B2".into(),
         card_prefix: None,
-    }))
+    }) as Box<dyn Command>])
     .unwrap();
 
     assert!(ctx.undo());
@@ -310,10 +310,10 @@ async fn test_undo_pops_before_pushing_to_redo() {
 #[tokio::test]
 async fn test_redo_pops_before_pushing_to_undo() {
     let mut ctx = make_ctx().await;
-    ctx.execute(Box::new(CreateBoard {
+    ctx.execute(vec![Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
-    }))
+    }) as Box<dyn Command>])
     .unwrap();
     ctx.undo();
 
@@ -349,7 +349,7 @@ async fn test_execute_batch_partial_failure_rollback_leaves_clean_undo_stack() {
             },
         }),
     ];
-    assert!(ctx.execute_batch(batch).is_err());
+    assert!(ctx.execute(batch).is_err());
     assert_eq!(ctx.boards().len(), 1);
     assert!(!ctx.can_undo(), "undo stack should be empty after rollback");
 }
@@ -507,7 +507,7 @@ async fn test_execute_batch_partial_failure_rolls_back() {
             },
         }),
     ];
-    let result = ctx.execute_batch(batch);
+    let result = ctx.execute(batch);
     assert!(result.is_err());
 
     // Rolled back: B2 should not exist
@@ -534,7 +534,7 @@ async fn test_execute_batch_success_is_undoable() {
             card_prefix: None,
         }),
     ];
-    ctx.execute_batch(batch).unwrap();
+    ctx.execute(batch).unwrap();
     assert_eq!(ctx.boards().len(), 3);
 
     assert!(ctx.undo());
@@ -550,15 +550,15 @@ async fn test_import_entities_is_undoable() {
 
     let b2 = kanban_domain::Board::new("B2".to_string(), None);
     let col = kanban_domain::Column::new(b2.id, "Todo".to_string(), 0);
-    let cmd = ImportEntities {
+    let cmd: Box<dyn Command> = Box::new(ImportEntities {
         boards: vec![b2],
         columns: vec![col],
         cards: vec![],
         archived_cards: vec![],
         sprints: vec![],
         graph: None,
-    };
-    ctx.execute(Box::new(cmd)).unwrap();
+    });
+    ctx.execute(vec![cmd]).unwrap();
     assert_eq!(ctx.boards().len(), 2);
 
     assert!(ctx.undo());
@@ -576,6 +576,10 @@ async fn test_archive_cards_detailed_all_fail_does_not_set_dirty() {
     assert!(
         !ctx.is_dirty(),
         "dirty flag should not be set when all ops fail"
+    );
+    assert!(
+        !ctx.can_undo(),
+        "undo stack should be clean when all ops fail"
     );
 }
 
@@ -632,8 +636,8 @@ async fn test_compact_column_positions_is_undoable() {
     .unwrap();
     ctx.clear_history();
 
-    let cmd = CompactColumnPositions { column_id: col.id };
-    ctx.execute(Box::new(cmd)).unwrap();
+    let cmd: Box<dyn Command> = Box::new(CompactColumnPositions { column_id: col.id });
+    ctx.execute(vec![cmd]).unwrap();
     assert_eq!(
         ctx.cards().iter().find(|c| c.id == c1.id).unwrap().position,
         0

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -1,5 +1,5 @@
-use kanban_domain::commands::CreateBoard;
-use kanban_domain::{CardUpdate, KanbanOperations, Snapshot};
+use kanban_domain::commands::{CreateBoard, UpdateBoard};
+use kanban_domain::{BoardUpdate, CardUpdate, KanbanOperations, Snapshot};
 use kanban_persistence::NullStore;
 use kanban_service::KanbanContext;
 use std::sync::Arc;
@@ -354,4 +354,101 @@ async fn test_assign_cards_to_sprint_renamed_trait_method() {
         ctx.get_card(card.id).unwrap().unwrap().sprint_id,
         Some(sprint.id)
     );
+}
+
+#[tokio::test]
+async fn test_assign_cards_to_sprint_creates_single_undo_entry() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "Card 2".into(), Default::default())
+        .unwrap();
+    let c3 = ctx
+        .create_card(board.id, col.id, "Card 3".into(), Default::default())
+        .unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    ctx.clear_history();
+
+    ctx.assign_cards_to_sprint(vec![c1.id, c2.id, c3.id], sprint.id)
+        .unwrap();
+    assert_eq!(
+        ctx.get_card(c1.id).unwrap().unwrap().sprint_id,
+        Some(sprint.id)
+    );
+    assert_eq!(
+        ctx.get_card(c2.id).unwrap().unwrap().sprint_id,
+        Some(sprint.id)
+    );
+    assert_eq!(
+        ctx.get_card(c3.id).unwrap().unwrap().sprint_id,
+        Some(sprint.id)
+    );
+
+    // Single undo should restore all 3 cards
+    assert!(ctx.undo());
+    assert_eq!(ctx.get_card(c1.id).unwrap().unwrap().sprint_id, None);
+    assert_eq!(ctx.get_card(c2.id).unwrap().unwrap().sprint_id, None);
+    assert_eq!(ctx.get_card(c3.id).unwrap().unwrap().sprint_id, None);
+
+    // No more undo entries (it was a single batch)
+    assert!(!ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_execute_batch_partial_failure_rolls_back() {
+    let mut ctx = make_ctx().await;
+    ctx.create_board("B1".into(), None).unwrap();
+    ctx.clear_history();
+
+    let batch: Vec<Box<dyn kanban_domain::commands::Command>> = vec![
+        Box::new(CreateBoard {
+            name: "B2".into(),
+            card_prefix: None,
+        }),
+        Box::new(UpdateBoard {
+            board_id: uuid::Uuid::nil(),
+            updates: BoardUpdate {
+                name: Some("Nonexistent".into()),
+                ..Default::default()
+            },
+        }),
+    ];
+    let result = ctx.execute_batch(batch);
+    assert!(result.is_err());
+
+    // Rolled back: B2 should not exist
+    assert_eq!(ctx.boards.len(), 1);
+    assert_eq!(ctx.boards[0].name, "B1");
+
+    // Undo stack should be clean
+    assert!(!ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_execute_batch_success_is_undoable() {
+    let mut ctx = make_ctx().await;
+    ctx.create_board("B1".into(), None).unwrap();
+    ctx.clear_history();
+
+    let batch: Vec<Box<dyn kanban_domain::commands::Command>> = vec![
+        Box::new(CreateBoard {
+            name: "B2".into(),
+            card_prefix: None,
+        }),
+        Box::new(CreateBoard {
+            name: "B3".into(),
+            card_prefix: None,
+        }),
+    ];
+    ctx.execute_batch(batch).unwrap();
+    assert_eq!(ctx.boards.len(), 3);
+
+    assert!(ctx.undo());
+    assert_eq!(ctx.boards.len(), 1);
+    assert!(!ctx.can_undo());
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -14,13 +14,8 @@ async fn test_snapshot_roundtrip_preserves_all_fields() {
     let board_id = ctx.boards[0].id;
     ctx.create_column(board_id, "C".into(), None).unwrap();
     let col_id = ctx.columns[0].id;
-    ctx.create_card(
-        board_id,
-        col_id,
-        "Card".into(),
-        Default::default(),
-    )
-    .unwrap();
+    ctx.create_card(board_id, col_id, "Card".into(), Default::default())
+        .unwrap();
 
     let snap = ctx.snapshot();
     ctx.apply_snapshot(Snapshot::new());
@@ -142,7 +137,10 @@ async fn test_dirty_flag_lifecycle() {
 async fn test_operations_create_board_captures_history() {
     let mut ctx = make_ctx().await;
     ctx.create_board("B".into(), None).unwrap();
-    assert!(ctx.can_undo(), "create_board via KanbanOperations should capture history");
+    assert!(
+        ctx.can_undo(),
+        "create_board via KanbanOperations should capture history"
+    );
 }
 
 #[tokio::test]

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -1,10 +1,14 @@
 use kanban_domain::commands::CreateBoard;
 use kanban_domain::{CardUpdate, KanbanOperations, Snapshot};
+use kanban_persistence::NullStore;
 use kanban_service::KanbanContext;
+use std::sync::Arc;
 
 async fn make_ctx() -> KanbanContext {
-    let store = kanban_service::make_store("json", "/dev/null").unwrap();
-    KanbanContext::empty(store, kanban_core::AppConfig::default())
+    KanbanContext::empty(
+        Arc::new(NullStore::new()),
+        kanban_core::AppConfig::default(),
+    )
 }
 
 #[tokio::test]

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -231,6 +231,18 @@ async fn test_import_board_is_undoable() {
 }
 
 #[tokio::test]
+async fn test_conflict_flag_lifecycle() {
+    let mut ctx = make_ctx().await;
+    assert!(!ctx.has_conflict());
+
+    ctx.set_conflict();
+    assert!(ctx.has_conflict());
+
+    ctx.clear_conflict();
+    assert!(!ctx.has_conflict());
+}
+
+#[tokio::test]
 async fn test_reload_preserves_history() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("board.json");

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -569,6 +569,14 @@ async fn test_import_entities_is_undoable() {
 }
 
 #[tokio::test]
+async fn test_archive_card_not_found_returns_error() {
+    let mut ctx = make_ctx().await;
+    let result = ctx.archive_card(uuid::Uuid::new_v4());
+    assert!(result.is_err());
+    assert!(result.unwrap_err().is_not_found());
+}
+
+#[tokio::test]
 async fn test_archive_cards_detailed_all_fail_does_not_set_dirty() {
     let mut ctx = make_ctx().await;
     ctx.mark_clean();

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -316,7 +316,6 @@ async fn test_null_store_context_loads_empty() {
     assert!(ctx.cards.is_empty());
 }
 
-
 #[tokio::test]
 async fn test_move_cards_single_undo_entry() {
     let mut ctx = make_ctx().await;
@@ -487,7 +486,10 @@ async fn test_archive_cards_detailed_all_fail_does_not_set_dirty() {
     let result = ctx.archive_cards_detailed(vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()]);
     assert!(result.succeeded.is_empty());
     assert_eq!(result.failed.len(), 2);
-    assert!(!ctx.is_dirty(), "dirty flag should not be set when all ops fail");
+    assert!(
+        !ctx.is_dirty(),
+        "dirty flag should not be set when all ops fail"
+    );
 }
 
 #[tokio::test]

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -1,0 +1,138 @@
+use kanban_domain::commands::CreateBoard;
+use kanban_domain::{KanbanOperations, Snapshot};
+use kanban_service::KanbanContext;
+
+async fn make_ctx() -> KanbanContext {
+    let store = kanban_service::make_store("json", "/dev/null").unwrap();
+    KanbanContext::empty(store, kanban_core::AppConfig::default())
+}
+
+#[tokio::test]
+async fn test_snapshot_roundtrip_preserves_all_fields() {
+    let mut ctx = make_ctx().await;
+    ctx.create_board("B".into(), None).unwrap();
+    let board_id = ctx.boards[0].id;
+    ctx.create_column(board_id, "C".into(), None).unwrap();
+    let col_id = ctx.columns[0].id;
+    ctx.create_card(
+        board_id,
+        col_id,
+        "Card".into(),
+        Default::default(),
+    )
+    .unwrap();
+
+    let snap = ctx.snapshot();
+    ctx.apply_snapshot(Snapshot::new());
+    assert!(ctx.boards.is_empty());
+
+    ctx.apply_snapshot(snap.clone());
+    assert_eq!(ctx.snapshot(), snap);
+}
+
+#[tokio::test]
+async fn test_execute_with_history_enables_undo() {
+    let mut ctx = make_ctx().await;
+    let cmd = Box::new(CreateBoard {
+        name: "B".into(),
+        card_prefix: None,
+    });
+    ctx.execute_with_history(cmd).unwrap();
+    assert!(ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_undo_restores_previous_state() {
+    let mut ctx = make_ctx().await;
+    let cmd = Box::new(CreateBoard {
+        name: "B".into(),
+        card_prefix: None,
+    });
+    ctx.execute_with_history(cmd).unwrap();
+    assert_eq!(ctx.boards.len(), 1);
+
+    assert!(ctx.undo());
+    assert!(ctx.boards.is_empty());
+}
+
+#[tokio::test]
+async fn test_redo_restores_undone_state() {
+    let mut ctx = make_ctx().await;
+    let cmd = Box::new(CreateBoard {
+        name: "B".into(),
+        card_prefix: None,
+    });
+    ctx.execute_with_history(cmd).unwrap();
+    ctx.undo();
+    assert!(ctx.boards.is_empty());
+
+    assert!(ctx.redo());
+    assert_eq!(ctx.boards.len(), 1);
+}
+
+#[tokio::test]
+async fn test_undo_on_empty_returns_false() {
+    let ctx = make_ctx().await;
+    // fresh context has nothing to undo
+    assert!(!ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_new_action_after_undo_clears_redo() {
+    let mut ctx = make_ctx().await;
+    ctx.execute_with_history(Box::new(CreateBoard {
+        name: "A".into(),
+        card_prefix: None,
+    }))
+    .unwrap();
+    ctx.undo();
+    assert!(ctx.can_redo());
+
+    ctx.execute_with_history(Box::new(CreateBoard {
+        name: "B".into(),
+        card_prefix: None,
+    }))
+    .unwrap();
+    assert!(!ctx.can_redo());
+}
+
+#[tokio::test]
+async fn test_reload_clears_history() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("board.json");
+    let store = kanban_service::make_store("json", path.to_str().unwrap()).unwrap();
+    let mut ctx = KanbanContext::empty(store, kanban_core::AppConfig::default());
+
+    ctx.execute_with_history(Box::new(CreateBoard {
+        name: "B".into(),
+        card_prefix: None,
+    }))
+    .unwrap();
+    ctx.save().await.unwrap();
+
+    ctx.execute_with_history(Box::new(CreateBoard {
+        name: "B2".into(),
+        card_prefix: None,
+    }))
+    .unwrap();
+    assert!(ctx.can_undo());
+
+    ctx.reload().await.unwrap();
+    assert!(!ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_dirty_flag_lifecycle() {
+    let mut ctx = make_ctx().await;
+    assert!(!ctx.is_dirty());
+
+    ctx.execute_with_history(Box::new(CreateBoard {
+        name: "B".into(),
+        card_prefix: None,
+    }))
+    .unwrap();
+    assert!(ctx.is_dirty());
+
+    ctx.mark_clean();
+    assert!(!ctx.is_dirty());
+}

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -346,7 +346,12 @@ async fn test_assign_cards_to_sprint_renamed_trait_method() {
         .unwrap();
     let sprint = ctx.create_sprint(board.id, None, None).unwrap();
 
-    let count = ctx.assign_cards_to_sprint(vec![card.id], sprint.id).unwrap();
+    let count = ctx
+        .assign_cards_to_sprint(vec![card.id], sprint.id)
+        .unwrap();
     assert_eq!(count, 1);
-    assert_eq!(ctx.get_card(card.id).unwrap().unwrap().sprint_id, Some(sprint.id));
+    assert_eq!(
+        ctx.get_card(card.id).unwrap().unwrap().sprint_id,
+        Some(sprint.id)
+    );
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -26,13 +26,13 @@ async fn test_snapshot_roundtrip_preserves_all_fields() {
 }
 
 #[tokio::test]
-async fn test_execute_with_history_enables_undo() {
+async fn test_execute_enables_undo() {
     let mut ctx = make_ctx().await;
     let cmd = Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
     });
-    ctx.execute_with_history(cmd).unwrap();
+    ctx.execute(cmd).unwrap();
     assert!(ctx.can_undo());
 }
 
@@ -43,7 +43,7 @@ async fn test_undo_restores_previous_state() {
         name: "B".into(),
         card_prefix: None,
     });
-    ctx.execute_with_history(cmd).unwrap();
+    ctx.execute(cmd).unwrap();
     assert_eq!(ctx.boards.len(), 1);
 
     assert!(ctx.undo());
@@ -57,7 +57,7 @@ async fn test_redo_restores_undone_state() {
         name: "B".into(),
         card_prefix: None,
     });
-    ctx.execute_with_history(cmd).unwrap();
+    ctx.execute(cmd).unwrap();
     ctx.undo();
     assert!(ctx.boards.is_empty());
 
@@ -75,7 +75,7 @@ async fn test_undo_on_empty_returns_false() {
 #[tokio::test]
 async fn test_new_action_after_undo_clears_redo() {
     let mut ctx = make_ctx().await;
-    ctx.execute_with_history(Box::new(CreateBoard {
+    ctx.execute(Box::new(CreateBoard {
         name: "A".into(),
         card_prefix: None,
     }))
@@ -83,7 +83,7 @@ async fn test_new_action_after_undo_clears_redo() {
     ctx.undo();
     assert!(ctx.can_redo());
 
-    ctx.execute_with_history(Box::new(CreateBoard {
+    ctx.execute(Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
     }))
@@ -98,14 +98,14 @@ async fn test_reload_no_longer_clears_history() {
     let store = kanban_service::make_store("json", path.to_str().unwrap()).unwrap();
     let mut ctx = KanbanContext::empty(store, kanban_core::AppConfig::default());
 
-    ctx.execute_with_history(Box::new(CreateBoard {
+    ctx.execute(Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
     }))
     .unwrap();
     ctx.save().await.unwrap();
 
-    ctx.execute_with_history(Box::new(CreateBoard {
+    ctx.execute(Box::new(CreateBoard {
         name: "B2".into(),
         card_prefix: None,
     }))
@@ -122,7 +122,7 @@ async fn test_dirty_flag_lifecycle() {
     let mut ctx = make_ctx().await;
     assert!(!ctx.is_dirty());
 
-    ctx.execute_with_history(Box::new(CreateBoard {
+    ctx.execute(Box::new(CreateBoard {
         name: "B".into(),
         card_prefix: None,
     }))
@@ -255,4 +255,26 @@ async fn test_reload_preserves_history() {
 
     ctx.reload().await.unwrap();
     assert!(ctx.can_undo(), "reload should preserve history");
+}
+
+#[tokio::test]
+async fn test_record_undo_snapshot_enables_undo() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("Original".into(), None).unwrap();
+    ctx.clear_history();
+
+    let before = ctx.snapshot();
+    ctx.boards
+        .iter_mut()
+        .find(|b| b.id == board.id)
+        .unwrap()
+        .update_name("Mutated".into());
+    ctx.record_undo_snapshot(before);
+
+    assert_eq!(ctx.boards[0].name, "Mutated");
+    assert!(ctx.is_dirty());
+    assert!(ctx.can_undo());
+
+    ctx.undo();
+    assert_eq!(ctx.boards[0].name, "Original");
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -188,7 +188,7 @@ async fn test_bulk_archive_creates_single_undo_entry() {
     // Clear history from setup operations
     ctx.clear_history();
 
-    ctx.bulk_archive_cards(vec![c1.id, c2.id, c3.id]).unwrap();
+    ctx.archive_cards(vec![c1.id, c2.id, c3.id]).unwrap();
     assert_eq!(ctx.cards.len(), 0);
     assert_eq!(ctx.archived_cards.len(), 3);
 
@@ -281,4 +281,72 @@ async fn test_push_before_snapshot_enables_undo() {
 
     ctx.undo();
     assert_eq!(ctx.boards[0].name, "Original");
+}
+
+#[tokio::test]
+async fn test_null_store_context_loads_empty() {
+    let ctx = make_ctx().await;
+    assert!(ctx.boards.is_empty());
+    assert!(ctx.columns.is_empty());
+    assert!(ctx.cards.is_empty());
+}
+
+#[tokio::test]
+async fn test_archive_cards_single_undo_entry() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "Card 2".into(), Default::default())
+        .unwrap();
+    ctx.clear_history();
+
+    ctx.archive_cards(vec![c1.id, c2.id]).unwrap();
+    assert_eq!(ctx.cards.len(), 0);
+    assert_eq!(ctx.archived_cards.len(), 2);
+
+    assert!(ctx.undo());
+    assert_eq!(ctx.cards.len(), 2);
+    assert_eq!(ctx.archived_cards.len(), 0);
+    assert!(!ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_move_cards_single_undo_entry() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col1 = ctx.create_column(board.id, "From".into(), None).unwrap();
+    let col2 = ctx.create_column(board.id, "To".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col1.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col1.id, "Card 2".into(), Default::default())
+        .unwrap();
+    ctx.clear_history();
+
+    ctx.move_cards(vec![c1.id, c2.id], col2.id).unwrap();
+    assert!(ctx.cards.iter().all(|c| c.column_id == col2.id));
+
+    assert!(ctx.undo());
+    assert!(ctx.cards.iter().all(|c| c.column_id == col1.id));
+    assert!(!ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_assign_cards_to_sprint_renamed_trait_method() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "Card".into(), Default::default())
+        .unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    let count = ctx.assign_cards_to_sprint(vec![card.id], sprint.id).unwrap();
+    assert_eq!(count, 1);
+    assert_eq!(ctx.get_card(card.id).unwrap().unwrap().sprint_id, Some(sprint.id));
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -258,7 +258,7 @@ async fn test_reload_preserves_history() {
 }
 
 #[tokio::test]
-async fn test_record_undo_snapshot_enables_undo() {
+async fn test_push_before_snapshot_enables_undo() {
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("Original".into(), None).unwrap();
     ctx.clear_history();
@@ -269,7 +269,7 @@ async fn test_record_undo_snapshot_enables_undo() {
         .find(|b| b.id == board.id)
         .unwrap()
         .update_name("Mutated".into());
-    ctx.record_undo_snapshot(before);
+    ctx.push_before_snapshot(before);
 
     assert_eq!(ctx.boards[0].name, "Mutated");
     assert!(ctx.is_dirty());

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -171,7 +171,7 @@ async fn test_operations_update_card_is_undoable() {
 }
 
 #[tokio::test]
-async fn test_bulk_archive_creates_single_undo_entry() {
+async fn test_archive_cards_creates_single_undo_entry() {
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), None).unwrap();
     let col = ctx.create_column(board.id, "C".into(), None).unwrap();
@@ -221,15 +221,40 @@ async fn test_import_board_is_undoable() {
     let _col = ctx.create_column(board.id, "C".into(), None).unwrap();
     let json = ctx.export_board(Some(board.id)).unwrap();
 
-    // Clear and start fresh
-    ctx.clear_history();
-    let boards_before = ctx.boards.len();
+    // Import into a fresh context to avoid duplicate UUID errors
+    let mut ctx2 = make_ctx().await;
+    ctx2.import_board(&json).unwrap();
+    assert_eq!(ctx2.boards.len(), 1);
+    assert_eq!(ctx2.boards[0].name, "Export");
 
-    ctx.import_board(&json).unwrap();
-    assert_eq!(ctx.boards.len(), boards_before + 1);
+    ctx2.undo();
+    assert_eq!(ctx2.boards.len(), 0);
+}
 
-    ctx.undo();
-    assert_eq!(ctx.boards.len(), boards_before);
+#[tokio::test]
+async fn test_import_board_includes_archived_cards() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("Export".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "Card".into(), Default::default())
+        .unwrap();
+    ctx.archive_card(card.id).unwrap();
+    assert_eq!(ctx.archived_cards.len(), 1);
+
+    let json = ctx.export_board(None).unwrap();
+
+    // Import into a fresh context to avoid duplicate UUID errors
+    let mut ctx2 = make_ctx().await;
+    ctx2.import_board(&json).unwrap();
+    assert_eq!(
+        ctx2.archived_cards.len(),
+        1,
+        "imported archived cards should appear"
+    );
+
+    ctx2.undo();
+    assert_eq!(ctx2.archived_cards.len(), 0);
 }
 
 #[tokio::test]
@@ -475,6 +500,38 @@ async fn test_import_entities_is_undoable() {
     assert!(ctx.undo());
     assert_eq!(ctx.boards.len(), 1);
     assert_eq!(ctx.boards[0].name, "B1");
+}
+
+#[tokio::test]
+async fn test_archive_cards_detailed_all_fail_does_not_set_dirty() {
+    let mut ctx = make_ctx().await;
+    ctx.mark_clean();
+    let result = ctx.archive_cards_detailed(vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()]);
+    assert!(result.succeeded.is_empty());
+    assert_eq!(result.failed.len(), 2);
+    assert!(!ctx.is_dirty(), "dirty flag should not be set when all ops fail");
+}
+
+#[tokio::test]
+async fn test_detailed_archive_partial_success_is_undoable() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "Card".into(), Default::default())
+        .unwrap();
+    ctx.clear_history();
+    ctx.mark_clean();
+
+    let result = ctx.archive_cards_detailed(vec![card.id, uuid::Uuid::new_v4()]);
+    assert_eq!(result.succeeded.len(), 1);
+    assert_eq!(result.failed.len(), 1);
+    assert!(ctx.is_dirty());
+    assert_eq!(ctx.archived_cards.len(), 1);
+
+    assert!(ctx.undo());
+    assert_eq!(ctx.cards.len(), 1);
+    assert_eq!(ctx.archived_cards.len(), 0);
 }
 
 #[tokio::test]

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -645,6 +645,160 @@ async fn test_detailed_archive_partial_success_is_undoable() {
 }
 
 #[tokio::test]
+async fn test_move_cards_detailed_all_valid_creates_single_undo_entry() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col_a = ctx.create_column(board.id, "A".into(), None).unwrap();
+    let col_b = ctx.create_column(board.id, "B".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col_a.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col_a.id, "Card 2".into(), Default::default())
+        .unwrap();
+    ctx.clear_history();
+    ctx.mark_clean();
+
+    let result = ctx.move_cards_detailed(vec![c1.id, c2.id], col_b.id);
+    assert_eq!(result.succeeded.len(), 2);
+    assert!(result.failed.is_empty());
+    assert!(ctx.is_dirty());
+    assert!(ctx.cards().iter().all(|c| c.column_id == col_b.id));
+
+    assert!(ctx.undo());
+    assert!(ctx.cards().iter().all(|c| c.column_id == col_a.id));
+    assert!(
+        !ctx.can_undo(),
+        "should be a single undo entry for the whole batch"
+    );
+}
+
+#[tokio::test]
+async fn test_move_cards_detailed_all_fail_does_not_set_dirty() {
+    let mut ctx = make_ctx().await;
+    ctx.mark_clean();
+    let result = ctx.move_cards_detailed(
+        vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()],
+        uuid::Uuid::new_v4(),
+    );
+    assert!(result.succeeded.is_empty());
+    assert_eq!(result.failed.len(), 2);
+    assert!(
+        !ctx.is_dirty(),
+        "dirty flag should not be set when all ops fail"
+    );
+    assert!(
+        !ctx.can_undo(),
+        "undo stack should be clean when all ops fail"
+    );
+}
+
+#[tokio::test]
+async fn test_move_cards_detailed_partial_success_is_undoable() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col_a = ctx.create_column(board.id, "A".into(), None).unwrap();
+    let col_b = ctx.create_column(board.id, "B".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col_a.id, "Card".into(), Default::default())
+        .unwrap();
+    ctx.clear_history();
+    ctx.mark_clean();
+
+    let result = ctx.move_cards_detailed(vec![card.id, uuid::Uuid::new_v4()], col_b.id);
+    assert_eq!(result.succeeded.len(), 1);
+    assert_eq!(result.failed.len(), 1);
+    assert!(ctx.is_dirty());
+    assert_eq!(ctx.cards().first().unwrap().column_id, col_b.id);
+
+    assert!(ctx.undo());
+    assert_eq!(ctx.cards().first().unwrap().column_id, col_a.id);
+}
+
+#[tokio::test]
+async fn test_assign_cards_to_sprint_detailed_all_valid_creates_single_undo_entry() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "Card 2".into(), Default::default())
+        .unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+    ctx.clear_history();
+    ctx.mark_clean();
+
+    let result = ctx.assign_cards_to_sprint_detailed(vec![c1.id, c2.id], sprint.id);
+    assert_eq!(result.succeeded.len(), 2);
+    assert!(result.failed.is_empty());
+    assert!(ctx.is_dirty());
+    assert_eq!(
+        ctx.get_card(c1.id).unwrap().unwrap().sprint_id,
+        Some(sprint.id)
+    );
+    assert_eq!(
+        ctx.get_card(c2.id).unwrap().unwrap().sprint_id,
+        Some(sprint.id)
+    );
+
+    assert!(ctx.undo());
+    assert_eq!(ctx.get_card(c1.id).unwrap().unwrap().sprint_id, None);
+    assert_eq!(ctx.get_card(c2.id).unwrap().unwrap().sprint_id, None);
+    assert!(
+        !ctx.can_undo(),
+        "should be a single undo entry for the whole batch"
+    );
+}
+
+#[tokio::test]
+async fn test_assign_cards_to_sprint_detailed_all_fail_does_not_set_dirty() {
+    let mut ctx = make_ctx().await;
+    ctx.mark_clean();
+    let result = ctx.assign_cards_to_sprint_detailed(
+        vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()],
+        uuid::Uuid::new_v4(),
+    );
+    assert!(result.succeeded.is_empty());
+    assert_eq!(result.failed.len(), 2);
+    assert!(
+        !ctx.is_dirty(),
+        "dirty flag should not be set when all ops fail"
+    );
+    assert!(
+        !ctx.can_undo(),
+        "undo stack should be clean when all ops fail"
+    );
+}
+
+#[tokio::test]
+async fn test_assign_cards_to_sprint_detailed_partial_success_is_undoable() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "Card".into(), Default::default())
+        .unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+    ctx.clear_history();
+    ctx.mark_clean();
+
+    let result =
+        ctx.assign_cards_to_sprint_detailed(vec![card.id, uuid::Uuid::new_v4()], sprint.id);
+    assert_eq!(result.succeeded.len(), 1);
+    assert_eq!(result.failed.len(), 1);
+    assert!(ctx.is_dirty());
+    assert_eq!(
+        ctx.get_card(card.id).unwrap().unwrap().sprint_id,
+        Some(sprint.id)
+    );
+
+    assert!(ctx.undo());
+    assert_eq!(ctx.get_card(card.id).unwrap().unwrap().sprint_id, None);
+}
+
+#[tokio::test]
 async fn test_compact_column_positions_is_undoable() {
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -1,5 +1,5 @@
 use kanban_domain::commands::CreateBoard;
-use kanban_domain::{KanbanOperations, Snapshot};
+use kanban_domain::{CardUpdate, KanbanOperations, Snapshot};
 use kanban_service::KanbanContext;
 
 async fn make_ctx() -> KanbanContext {
@@ -97,7 +97,7 @@ async fn test_new_action_after_undo_clears_redo() {
 }
 
 #[tokio::test]
-async fn test_reload_clears_history() {
+async fn test_reload_no_longer_clears_history() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("board.json");
     let store = kanban_service::make_store("json", path.to_str().unwrap()).unwrap();
@@ -118,7 +118,8 @@ async fn test_reload_clears_history() {
     assert!(ctx.can_undo());
 
     ctx.reload().await.unwrap();
-    assert!(!ctx.can_undo());
+    // reload no longer clears history — callers that want it call clear_history() explicitly
+    assert!(ctx.can_undo());
 }
 
 #[tokio::test]
@@ -135,4 +136,113 @@ async fn test_dirty_flag_lifecycle() {
 
     ctx.mark_clean();
     assert!(!ctx.is_dirty());
+}
+
+#[tokio::test]
+async fn test_operations_create_board_captures_history() {
+    let mut ctx = make_ctx().await;
+    ctx.create_board("B".into(), None).unwrap();
+    assert!(ctx.can_undo(), "create_board via KanbanOperations should capture history");
+}
+
+#[tokio::test]
+async fn test_operations_update_card_is_undoable() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "Original".into(), Default::default())
+        .unwrap();
+
+    ctx.update_card(
+        card.id,
+        CardUpdate {
+            title: Some("Updated".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(ctx.get_card(card.id).unwrap().unwrap().title, "Updated");
+
+    ctx.undo();
+    assert_eq!(ctx.get_card(card.id).unwrap().unwrap().title, "Original");
+}
+
+#[tokio::test]
+async fn test_bulk_archive_creates_single_undo_entry() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "Card 2".into(), Default::default())
+        .unwrap();
+    let c3 = ctx
+        .create_card(board.id, col.id, "Card 3".into(), Default::default())
+        .unwrap();
+
+    // Clear history from setup operations
+    ctx.clear_history();
+
+    ctx.bulk_archive_cards(vec![c1.id, c2.id, c3.id]).unwrap();
+    assert_eq!(ctx.cards.len(), 0);
+    assert_eq!(ctx.archived_cards.len(), 3);
+
+    // Single undo should restore all 3 cards
+    assert!(ctx.undo());
+    assert_eq!(ctx.cards.len(), 3);
+    assert_eq!(ctx.archived_cards.len(), 0);
+
+    // No more undo entries (it was a single batch)
+    assert!(!ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_create_sprint_undo_restores_board_counters() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    ctx.clear_history();
+
+    let _sprint = ctx.create_sprint(board.id, None, None).unwrap();
+    assert_eq!(ctx.sprints.len(), 1);
+
+    ctx.undo();
+    assert_eq!(ctx.sprints.len(), 0);
+}
+
+#[tokio::test]
+async fn test_import_board_is_undoable() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("Export".into(), None).unwrap();
+    let _col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let json = ctx.export_board(Some(board.id)).unwrap();
+
+    // Clear and start fresh
+    ctx.clear_history();
+    let boards_before = ctx.boards.len();
+
+    ctx.import_board(&json).unwrap();
+    assert_eq!(ctx.boards.len(), boards_before + 1);
+
+    ctx.undo();
+    assert_eq!(ctx.boards.len(), boards_before);
+}
+
+#[tokio::test]
+async fn test_reload_preserves_history() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("board.json");
+    let store = kanban_service::make_store("json", path.to_str().unwrap()).unwrap();
+    let mut ctx = KanbanContext::empty(store, kanban_core::AppConfig::default());
+
+    ctx.create_board("B".into(), None).unwrap();
+    ctx.save().await.unwrap();
+
+    ctx.create_board("B2".into(), None).unwrap();
+    assert!(ctx.can_undo());
+
+    ctx.reload().await.unwrap();
+    assert!(ctx.can_undo(), "reload should preserve history");
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -316,28 +316,6 @@ async fn test_null_store_context_loads_empty() {
     assert!(ctx.cards.is_empty());
 }
 
-#[tokio::test]
-async fn test_archive_cards_single_undo_entry() {
-    let mut ctx = make_ctx().await;
-    let board = ctx.create_board("B".into(), None).unwrap();
-    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
-    let c1 = ctx
-        .create_card(board.id, col.id, "Card 1".into(), Default::default())
-        .unwrap();
-    let c2 = ctx
-        .create_card(board.id, col.id, "Card 2".into(), Default::default())
-        .unwrap();
-    ctx.clear_history();
-
-    ctx.archive_cards(vec![c1.id, c2.id]).unwrap();
-    assert_eq!(ctx.cards.len(), 0);
-    assert_eq!(ctx.archived_cards.len(), 2);
-
-    assert!(ctx.undo());
-    assert_eq!(ctx.cards.len(), 2);
-    assert_eq!(ctx.archived_cards.len(), 0);
-    assert!(!ctx.can_undo());
-}
 
 #[tokio::test]
 async fn test_move_cards_single_undo_entry() {

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -15,15 +15,15 @@ async fn make_ctx() -> KanbanContext {
 async fn test_snapshot_roundtrip_preserves_all_fields() {
     let mut ctx = make_ctx().await;
     ctx.create_board("B".into(), None).unwrap();
-    let board_id = ctx.boards[0].id;
+    let board_id = ctx.boards()[0].id;
     ctx.create_column(board_id, "C".into(), None).unwrap();
-    let col_id = ctx.columns[0].id;
+    let col_id = ctx.columns()[0].id;
     ctx.create_card(board_id, col_id, "Card".into(), Default::default())
         .unwrap();
 
     let snap = ctx.snapshot();
     ctx.apply_snapshot(Snapshot::new());
-    assert!(ctx.boards.is_empty());
+    assert!(ctx.boards().is_empty());
 
     ctx.apply_snapshot(snap.clone());
     assert_eq!(ctx.snapshot(), snap);
@@ -48,10 +48,10 @@ async fn test_undo_restores_previous_state() {
         card_prefix: None,
     });
     ctx.execute(cmd).unwrap();
-    assert_eq!(ctx.boards.len(), 1);
+    assert_eq!(ctx.boards().len(), 1);
 
     assert!(ctx.undo());
-    assert!(ctx.boards.is_empty());
+    assert!(ctx.boards().is_empty());
 }
 
 #[tokio::test]
@@ -63,10 +63,10 @@ async fn test_redo_restores_undone_state() {
     });
     ctx.execute(cmd).unwrap();
     ctx.undo();
-    assert!(ctx.boards.is_empty());
+    assert!(ctx.boards().is_empty());
 
     assert!(ctx.redo());
-    assert_eq!(ctx.boards.len(), 1);
+    assert_eq!(ctx.boards().len(), 1);
 }
 
 #[tokio::test]
@@ -189,13 +189,13 @@ async fn test_archive_cards_creates_single_undo_entry() {
     ctx.clear_history();
 
     ctx.archive_cards(vec![c1.id, c2.id, c3.id]).unwrap();
-    assert_eq!(ctx.cards.len(), 0);
-    assert_eq!(ctx.archived_cards.len(), 3);
+    assert_eq!(ctx.cards().len(), 0);
+    assert_eq!(ctx.archived_cards().len(), 3);
 
     // Single undo should restore all 3 cards
     assert!(ctx.undo());
-    assert_eq!(ctx.cards.len(), 3);
-    assert_eq!(ctx.archived_cards.len(), 0);
+    assert_eq!(ctx.cards().len(), 3);
+    assert_eq!(ctx.archived_cards().len(), 0);
 
     // No more undo entries (it was a single batch)
     assert!(!ctx.can_undo());
@@ -208,10 +208,10 @@ async fn test_create_sprint_undo_restores_board_counters() {
     ctx.clear_history();
 
     let _sprint = ctx.create_sprint(board.id, None, None).unwrap();
-    assert_eq!(ctx.sprints.len(), 1);
+    assert_eq!(ctx.sprints().len(), 1);
 
     ctx.undo();
-    assert_eq!(ctx.sprints.len(), 0);
+    assert_eq!(ctx.sprints().len(), 0);
 }
 
 #[tokio::test]
@@ -224,11 +224,11 @@ async fn test_import_board_is_undoable() {
     // Import into a fresh context to avoid duplicate UUID errors
     let mut ctx2 = make_ctx().await;
     ctx2.import_board(&json).unwrap();
-    assert_eq!(ctx2.boards.len(), 1);
-    assert_eq!(ctx2.boards[0].name, "Export");
+    assert_eq!(ctx2.boards().len(), 1);
+    assert_eq!(ctx2.boards()[0].name, "Export");
 
     ctx2.undo();
-    assert_eq!(ctx2.boards.len(), 0);
+    assert_eq!(ctx2.boards().len(), 0);
 }
 
 #[tokio::test]
@@ -240,7 +240,7 @@ async fn test_import_board_includes_archived_cards() {
         .create_card(board.id, col.id, "Card".into(), Default::default())
         .unwrap();
     ctx.archive_card(card.id).unwrap();
-    assert_eq!(ctx.archived_cards.len(), 1);
+    assert_eq!(ctx.archived_cards().len(), 1);
 
     let json = ctx.export_board(None).unwrap();
 
@@ -248,13 +248,13 @@ async fn test_import_board_includes_archived_cards() {
     let mut ctx2 = make_ctx().await;
     ctx2.import_board(&json).unwrap();
     assert_eq!(
-        ctx2.archived_cards.len(),
+        ctx2.archived_cards().len(),
         1,
         "imported archived cards should appear"
     );
 
     ctx2.undo();
-    assert_eq!(ctx2.archived_cards.len(), 0);
+    assert_eq!(ctx2.archived_cards().len(), 0);
 }
 
 #[tokio::test]
@@ -287,33 +287,120 @@ async fn test_reload_preserves_history() {
 }
 
 #[tokio::test]
-async fn test_push_before_snapshot_enables_undo() {
+async fn test_undo_pops_before_pushing_to_redo() {
     let mut ctx = make_ctx().await;
-    let board = ctx.create_board("Original".into(), None).unwrap();
+    ctx.execute(Box::new(CreateBoard {
+        name: "B".into(),
+        card_prefix: None,
+    }))
+    .unwrap();
     ctx.clear_history();
 
-    let before = ctx.snapshot();
-    ctx.boards
-        .iter_mut()
-        .find(|b| b.id == board.id)
-        .unwrap()
-        .update_name("Mutated".into());
-    ctx.push_before_snapshot(before);
+    ctx.execute(Box::new(CreateBoard {
+        name: "B2".into(),
+        card_prefix: None,
+    }))
+    .unwrap();
 
-    assert_eq!(ctx.boards[0].name, "Mutated");
-    assert!(ctx.is_dirty());
-    assert!(ctx.can_undo());
+    assert!(ctx.undo());
+    assert_eq!(ctx.redo_depth(), 1);
+    assert_eq!(ctx.undo_depth(), 0);
+}
 
+#[tokio::test]
+async fn test_redo_pops_before_pushing_to_undo() {
+    let mut ctx = make_ctx().await;
+    ctx.execute(Box::new(CreateBoard {
+        name: "B".into(),
+        card_prefix: None,
+    }))
+    .unwrap();
     ctx.undo();
-    assert_eq!(ctx.boards[0].name, "Original");
+
+    assert!(ctx.redo());
+    assert_eq!(ctx.undo_depth(), 1);
+    assert_eq!(ctx.redo_depth(), 0);
+}
+
+#[tokio::test]
+async fn test_undo_on_empty_history_does_not_corrupt() {
+    let mut ctx = make_ctx().await;
+    assert!(!ctx.undo());
+    assert_eq!(ctx.undo_depth(), 0);
+    assert_eq!(ctx.redo_depth(), 0);
+}
+
+#[tokio::test]
+async fn test_execute_batch_partial_failure_rollback_leaves_clean_undo_stack() {
+    let mut ctx = make_ctx().await;
+    ctx.create_board("B1".into(), None).unwrap();
+    ctx.clear_history();
+
+    let batch: Vec<Box<dyn kanban_domain::commands::Command>> = vec![
+        Box::new(CreateBoard {
+            name: "B2".into(),
+            card_prefix: None,
+        }),
+        Box::new(UpdateBoard {
+            board_id: uuid::Uuid::nil(),
+            updates: BoardUpdate {
+                name: Some("Nonexistent".into()),
+                ..Default::default()
+            },
+        }),
+    ];
+    assert!(ctx.execute_batch(batch).is_err());
+    assert_eq!(ctx.boards().len(), 1);
+    assert!(!ctx.can_undo(), "undo stack should be empty after rollback");
+}
+
+#[tokio::test]
+async fn test_move_cards_returns_actual_moved_count() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col_a = ctx.create_column(board.id, "A".into(), None).unwrap();
+    let col_b = ctx.create_column(board.id, "B".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col_a.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col_a.id, "Card 2".into(), Default::default())
+        .unwrap();
+    let c3 = ctx
+        .create_card(board.id, col_b.id, "Card 3".into(), Default::default())
+        .unwrap();
+
+    let count = ctx.move_cards(vec![c1.id, c2.id, c3.id], col_b.id).unwrap();
+    assert_eq!(count, 2, "only 2 cards should have actually moved");
+}
+
+#[tokio::test]
+async fn test_assign_cards_to_sprint_returns_actual_assigned_count() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "Card 2".into(), Default::default())
+        .unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    ctx.assign_card_to_sprint(c1.id, sprint.id).unwrap();
+
+    let count = ctx
+        .assign_cards_to_sprint(vec![c1.id, c2.id], sprint.id)
+        .unwrap();
+    assert_eq!(count, 1, "only 1 card should have been newly assigned");
 }
 
 #[tokio::test]
 async fn test_null_store_context_loads_empty() {
     let ctx = make_ctx().await;
-    assert!(ctx.boards.is_empty());
-    assert!(ctx.columns.is_empty());
-    assert!(ctx.cards.is_empty());
+    assert!(ctx.boards().is_empty());
+    assert!(ctx.columns().is_empty());
+    assert!(ctx.cards().is_empty());
 }
 
 #[tokio::test]
@@ -331,10 +418,10 @@ async fn test_move_cards_single_undo_entry() {
     ctx.clear_history();
 
     ctx.move_cards(vec![c1.id, c2.id], col2.id).unwrap();
-    assert!(ctx.cards.iter().all(|c| c.column_id == col2.id));
+    assert!(ctx.cards().iter().all(|c| c.column_id == col2.id));
 
     assert!(ctx.undo());
-    assert!(ctx.cards.iter().all(|c| c.column_id == col1.id));
+    assert!(ctx.cards().iter().all(|c| c.column_id == col1.id));
     assert!(!ctx.can_undo());
 }
 
@@ -424,8 +511,8 @@ async fn test_execute_batch_partial_failure_rolls_back() {
     assert!(result.is_err());
 
     // Rolled back: B2 should not exist
-    assert_eq!(ctx.boards.len(), 1);
-    assert_eq!(ctx.boards[0].name, "B1");
+    assert_eq!(ctx.boards().len(), 1);
+    assert_eq!(ctx.boards()[0].name, "B1");
 
     // Undo stack should be clean
     assert!(!ctx.can_undo());
@@ -448,10 +535,10 @@ async fn test_execute_batch_success_is_undoable() {
         }),
     ];
     ctx.execute_batch(batch).unwrap();
-    assert_eq!(ctx.boards.len(), 3);
+    assert_eq!(ctx.boards().len(), 3);
 
     assert!(ctx.undo());
-    assert_eq!(ctx.boards.len(), 1);
+    assert_eq!(ctx.boards().len(), 1);
     assert!(!ctx.can_undo());
 }
 
@@ -472,11 +559,11 @@ async fn test_import_entities_is_undoable() {
         graph: None,
     };
     ctx.execute(Box::new(cmd)).unwrap();
-    assert_eq!(ctx.boards.len(), 2);
+    assert_eq!(ctx.boards().len(), 2);
 
     assert!(ctx.undo());
-    assert_eq!(ctx.boards.len(), 1);
-    assert_eq!(ctx.boards[0].name, "B1");
+    assert_eq!(ctx.boards().len(), 1);
+    assert_eq!(ctx.boards()[0].name, "B1");
 }
 
 #[tokio::test]
@@ -507,11 +594,11 @@ async fn test_detailed_archive_partial_success_is_undoable() {
     assert_eq!(result.succeeded.len(), 1);
     assert_eq!(result.failed.len(), 1);
     assert!(ctx.is_dirty());
-    assert_eq!(ctx.archived_cards.len(), 1);
+    assert_eq!(ctx.archived_cards().len(), 1);
 
     assert!(ctx.undo());
-    assert_eq!(ctx.cards.len(), 1);
-    assert_eq!(ctx.archived_cards.len(), 0);
+    assert_eq!(ctx.cards().len(), 1);
+    assert_eq!(ctx.archived_cards().len(), 0);
 }
 
 #[tokio::test]
@@ -527,36 +614,42 @@ async fn test_compact_column_positions_is_undoable() {
         .unwrap();
 
     // Manually set positions to non-sequential values
-    ctx.cards
-        .iter_mut()
-        .find(|c| c.id == c1.id)
-        .unwrap()
-        .position = 0;
-    ctx.cards
-        .iter_mut()
-        .find(|c| c.id == c2.id)
-        .unwrap()
-        .position = 5;
+    ctx.update_card(
+        c1.id,
+        CardUpdate {
+            position: Some(0),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    ctx.update_card(
+        c2.id,
+        CardUpdate {
+            position: Some(5),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     ctx.clear_history();
 
     let cmd = CompactColumnPositions { column_id: col.id };
     ctx.execute(Box::new(cmd)).unwrap();
     assert_eq!(
-        ctx.cards.iter().find(|c| c.id == c1.id).unwrap().position,
+        ctx.cards().iter().find(|c| c.id == c1.id).unwrap().position,
         0
     );
     assert_eq!(
-        ctx.cards.iter().find(|c| c.id == c2.id).unwrap().position,
+        ctx.cards().iter().find(|c| c.id == c2.id).unwrap().position,
         1
     );
 
     assert!(ctx.undo());
     assert_eq!(
-        ctx.cards.iter().find(|c| c.id == c1.id).unwrap().position,
+        ctx.cards().iter().find(|c| c.id == c1.id).unwrap().position,
         0
     );
     assert_eq!(
-        ctx.cards.iter().find(|c| c.id == c2.id).unwrap().position,
+        ctx.cards().iter().find(|c| c.id == c2.id).unwrap().position,
         5
     );
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -1,4 +1,6 @@
-use kanban_domain::commands::{Command, CompactColumnPositions, CreateBoard, ImportEntities, UpdateBoard};
+use kanban_domain::commands::{
+    Command, CompactColumnPositions, CreateBoard, ImportEntities, UpdateBoard,
+};
 use kanban_domain::{BoardUpdate, CardUpdate, KanbanOperations, Snapshot};
 use kanban_persistence::NullStore;
 use kanban_service::KanbanContext;
@@ -83,7 +85,7 @@ async fn test_new_action_after_undo_clears_redo() {
         name: "A".into(),
         card_prefix: None,
     }) as Box<dyn Command>])
-    .unwrap();
+        .unwrap();
     ctx.undo();
     assert!(ctx.can_redo());
 
@@ -91,7 +93,7 @@ async fn test_new_action_after_undo_clears_redo() {
         name: "B".into(),
         card_prefix: None,
     }) as Box<dyn Command>])
-    .unwrap();
+        .unwrap();
     assert!(!ctx.can_redo());
 }
 
@@ -106,14 +108,14 @@ async fn test_reload_no_longer_clears_history() {
         name: "B".into(),
         card_prefix: None,
     }) as Box<dyn Command>])
-    .unwrap();
+        .unwrap();
     ctx.save().await.unwrap();
 
     ctx.execute(vec![Box::new(CreateBoard {
         name: "B2".into(),
         card_prefix: None,
     }) as Box<dyn Command>])
-    .unwrap();
+        .unwrap();
     assert!(ctx.can_undo());
 
     ctx.reload().await.unwrap();
@@ -130,7 +132,7 @@ async fn test_dirty_flag_lifecycle() {
         name: "B".into(),
         card_prefix: None,
     }) as Box<dyn Command>])
-    .unwrap();
+        .unwrap();
     assert!(ctx.is_dirty());
 
     ctx.mark_clean();
@@ -293,14 +295,14 @@ async fn test_undo_pops_before_pushing_to_redo() {
         name: "B".into(),
         card_prefix: None,
     }) as Box<dyn Command>])
-    .unwrap();
+        .unwrap();
     ctx.clear_history();
 
     ctx.execute(vec![Box::new(CreateBoard {
         name: "B2".into(),
         card_prefix: None,
     }) as Box<dyn Command>])
-    .unwrap();
+        .unwrap();
 
     assert!(ctx.undo());
     assert_eq!(ctx.redo_depth(), 1);
@@ -314,7 +316,7 @@ async fn test_redo_pops_before_pushing_to_undo() {
         name: "B".into(),
         card_prefix: None,
     }) as Box<dyn Command>])
-    .unwrap();
+        .unwrap();
     ctx.undo();
 
     assert!(ctx.redo());

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -1,4 +1,4 @@
-use kanban_domain::commands::{CreateBoard, UpdateBoard};
+use kanban_domain::commands::{CompactColumnPositions, CreateBoard, ImportEntities, UpdateBoard};
 use kanban_domain::{BoardUpdate, CardUpdate, KanbanOperations, Snapshot};
 use kanban_persistence::NullStore;
 use kanban_service::KanbanContext;
@@ -451,4 +451,75 @@ async fn test_execute_batch_success_is_undoable() {
     assert!(ctx.undo());
     assert_eq!(ctx.boards.len(), 1);
     assert!(!ctx.can_undo());
+}
+
+#[tokio::test]
+async fn test_import_entities_is_undoable() {
+    let mut ctx = make_ctx().await;
+    ctx.create_board("B1".into(), None).unwrap();
+    ctx.clear_history();
+
+    let b2 = kanban_domain::Board::new("B2".to_string(), None);
+    let col = kanban_domain::Column::new(b2.id, "Todo".to_string(), 0);
+    let cmd = ImportEntities {
+        boards: vec![b2],
+        columns: vec![col],
+        cards: vec![],
+        archived_cards: vec![],
+        sprints: vec![],
+        graph: None,
+    };
+    ctx.execute(Box::new(cmd)).unwrap();
+    assert_eq!(ctx.boards.len(), 2);
+
+    assert!(ctx.undo());
+    assert_eq!(ctx.boards.len(), 1);
+    assert_eq!(ctx.boards[0].name, "B1");
+}
+
+#[tokio::test]
+async fn test_compact_column_positions_is_undoable() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "Card1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "Card2".into(), Default::default())
+        .unwrap();
+
+    // Manually set positions to non-sequential values
+    ctx.cards
+        .iter_mut()
+        .find(|c| c.id == c1.id)
+        .unwrap()
+        .position = 0;
+    ctx.cards
+        .iter_mut()
+        .find(|c| c.id == c2.id)
+        .unwrap()
+        .position = 5;
+    ctx.clear_history();
+
+    let cmd = CompactColumnPositions { column_id: col.id };
+    ctx.execute(Box::new(cmd)).unwrap();
+    assert_eq!(
+        ctx.cards.iter().find(|c| c.id == c1.id).unwrap().position,
+        0
+    );
+    assert_eq!(
+        ctx.cards.iter().find(|c| c.id == c2.id).unwrap().position,
+        1
+    );
+
+    assert!(ctx.undo());
+    assert_eq!(
+        ctx.cards.iter().find(|c| c.id == c1.id).unwrap().position,
+        0
+    );
+    assert_eq!(
+        ctx.cards.iter().find(|c| c.id == c2.id).unwrap().position,
+        5
+    );
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -577,6 +577,35 @@ async fn test_archive_card_not_found_returns_error() {
 }
 
 #[tokio::test]
+async fn test_archive_cards_detailed_all_valid_creates_single_undo_entry() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "Card 2".into(), Default::default())
+        .unwrap();
+    ctx.clear_history();
+    ctx.mark_clean();
+
+    let result = ctx.archive_cards_detailed(vec![c1.id, c2.id]);
+    assert_eq!(result.succeeded.len(), 2);
+    assert!(result.failed.is_empty());
+    assert!(ctx.is_dirty());
+    assert_eq!(ctx.archived_cards().len(), 2);
+
+    assert!(ctx.undo());
+    assert_eq!(ctx.cards().len(), 2);
+    assert_eq!(ctx.archived_cards().len(), 0);
+    assert!(
+        !ctx.can_undo(),
+        "should be a single undo entry for the whole batch"
+    );
+}
+
+#[tokio::test]
 async fn test_archive_cards_detailed_all_fail_does_not_set_dirty() {
     let mut ctx = make_ctx().await;
     ctx.mark_clean();

--- a/crates/kanban-tui/Cargo.toml
+++ b/crates/kanban-tui/Cargo.toml
@@ -30,6 +30,9 @@ arboard = { version = "3.4", features = ["wayland-data-control"] }
 pulldown-cmark = "0.13"
 toml = "0.8"
 
+[features]
+test-helpers = []
+
 [dev-dependencies]
 kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.3" }
 kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.3" }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1418,6 +1418,7 @@ impl App {
                     }
                 };
 
+                let before = self.ctx.inner.snapshot();
                 if let Some(new_content) =
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
@@ -1428,7 +1429,7 @@ impl App {
                             BoardField::Name => {
                                 if !new_content.trim().is_empty() {
                                     board.update_name(new_content.trim().to_string());
-                                    self.ctx.inner.mark_dirty();
+                                    self.ctx.inner.record_undo_snapshot(before);
                                     let snapshot = self.ctx.inner.snapshot();
                                     self.ctx.state_manager.queue_snapshot(snapshot);
                                 }
@@ -1440,7 +1441,7 @@ impl App {
                                     Some(new_content)
                                 };
                                 board.update_description(desc);
-                                self.ctx.inner.mark_dirty();
+                                self.ctx.inner.record_undo_snapshot(before);
                                 let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
@@ -1474,6 +1475,7 @@ impl App {
                     }
                 };
 
+                let before = self.ctx.inner.snapshot();
                 if let Some(new_content) =
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
@@ -1483,7 +1485,7 @@ impl App {
                             CardField::Title => {
                                 if !new_content.trim().is_empty() {
                                     card.update_title(new_content.trim().to_string());
-                                    self.ctx.inner.mark_dirty();
+                                    self.ctx.inner.record_undo_snapshot(before);
                                     let snapshot = self.ctx.inner.snapshot();
                                     self.ctx.state_manager.queue_snapshot(snapshot);
                                 }
@@ -1495,7 +1497,7 @@ impl App {
                                     Some(new_content)
                                 };
                                 card.update_description(desc);
-                                self.ctx.inner.mark_dirty();
+                                self.ctx.inner.record_undo_snapshot(before);
                                 let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1690,6 +1690,7 @@ impl App {
                                                     match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
                                                         Ok(data) => {
                                                             data.apply_to_app(self);
+                                                            self.ctx.clear_history();
                                                             self.ctx.clear_conflict();
                                                             self.refresh_view();
                                                             tracing::info!("Reloaded state from disk");
@@ -1920,6 +1921,7 @@ impl App {
                 match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
                     Ok(data) => {
                         data.apply_to_app(self);
+                        self.ctx.clear_history();
                         self.ctx.mark_clean();
                         self.ctx.clear_conflict();
                         self.refresh_view();

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1280,67 +1280,27 @@ impl App {
 
     /// Undo the last action
     pub fn undo(&mut self) -> KanbanResult<()> {
-        if !self.ctx.state_manager.can_undo() {
-            self.set_error("Nothing to undo".to_string());
-            return Ok(());
-        }
-
-        // Suppress history capture during restore
-        self.ctx.state_manager.history_mut().suppress();
-
-        // Save current state to redo stack
-        let current_snapshot = kanban_domain::Snapshot::from_app(self);
-        self.ctx
-            .state_manager
-            .history_mut()
-            .push_redo(current_snapshot);
-
-        // Restore previous state from undo stack
-        if let Some(snapshot) = self.ctx.state_manager.history_mut().pop_undo() {
-            snapshot.apply_to_app(self);
+        if self.ctx.inner.undo() {
             self.refresh_view();
-
-            // Queue snapshot for persistence
-            let save_snapshot = kanban_domain::Snapshot::from_app(self);
-            self.ctx.state_manager.queue_snapshot(save_snapshot);
+            self.ctx
+                .state_manager
+                .queue_snapshot(self.ctx.inner.snapshot());
+        } else {
+            self.set_error("Nothing to undo".to_string());
         }
-
-        // Re-enable history capture
-        self.ctx.state_manager.history_mut().unsuppress();
-
         Ok(())
     }
 
     /// Redo the last undone action
     pub fn redo(&mut self) -> KanbanResult<()> {
-        if !self.ctx.state_manager.can_redo() {
-            self.set_error("Nothing to redo".to_string());
-            return Ok(());
-        }
-
-        // Suppress history capture during restore
-        self.ctx.state_manager.history_mut().suppress();
-
-        // Save current state to undo stack
-        let current_snapshot = kanban_domain::Snapshot::from_app(self);
-        self.ctx
-            .state_manager
-            .history_mut()
-            .push_undo(current_snapshot);
-
-        // Restore next state from redo stack
-        if let Some(snapshot) = self.ctx.state_manager.history_mut().pop_redo() {
-            snapshot.apply_to_app(self);
+        if self.ctx.inner.redo() {
             self.refresh_view();
-
-            // Queue snapshot for persistence
-            let save_snapshot = kanban_domain::Snapshot::from_app(self);
-            self.ctx.state_manager.queue_snapshot(save_snapshot);
+            self.ctx
+                .state_manager
+                .queue_snapshot(self.ctx.inner.snapshot());
+        } else {
+            self.set_error("Nothing to redo".to_string());
         }
-
-        // Re-enable history capture
-        self.ctx.state_manager.history_mut().unsuppress();
-
         Ok(())
     }
 
@@ -1596,9 +1556,8 @@ impl App {
                         match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
                             Ok(data) => {
                                 data.apply_to_app(self);
-                                self.ctx.state_manager.mark_clean();
-                                // Clear undo/redo history after initial file load (not an undoable action)
-                                self.ctx.state_manager.clear_history();
+                                self.ctx.inner.mark_clean();
+                                self.ctx.inner.clear_history();
                                 tracing::info!("Loaded initial state from store");
                             }
                             Err(e) => {
@@ -1856,7 +1815,7 @@ impl App {
                         }
 
                         // External file change detected - handle smart reload
-                        if !self.ctx.state_manager.is_dirty() {
+                        if !self.ctx.inner.is_dirty() {
                             // No local changes, auto-reload silently
                             tracing::info!("External change detected, auto-reloading");
                             self.auto_reload_from_external_change().await;
@@ -1898,10 +1857,7 @@ impl App {
         let content = std::fs::read_to_string(filename)?;
 
         // Capture snapshot before import for undo history
-        let before_snapshot = self.ctx.inner.snapshot();
-        self.ctx
-            .state_manager
-            .capture_before_command(before_snapshot);
+        self.ctx.inner.capture_before_command();
 
         // Try V2 format first (preserves graph)
         if let Some(snapshot) = BoardImporter::try_load_snapshot(&content) {
@@ -1955,7 +1911,7 @@ impl App {
                     match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
                         Ok(data) => {
                             data.apply_to_app(self);
-                            self.ctx.state_manager.mark_clean();
+                            self.ctx.inner.mark_clean();
                             self.ctx.state_manager.clear_conflict();
                             self.refresh_view();
                             tracing::info!("Auto-reloaded state from external file change");

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -264,7 +264,7 @@ impl App {
             let store = self.ctx.store().clone();
             let instance_id = store.instance_id();
             let file_watcher = self.persistence.file_watcher.clone();
-            let save_completion_tx = self.ctx.state_manager.save_completion_tx().cloned();
+            let save_completion_tx = self.ctx.save_coordinator.save_completion_tx().cloned();
 
             tracing::info!("Spawning save worker to process snapshots");
             let handle = tokio::spawn(async move {
@@ -530,7 +530,7 @@ impl App {
 
         if matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q')) && !is_input_mode {
             // Check for pending saves before quitting
-            if self.ctx.state_manager.has_pending_saves() && !self.quit_with_pending {
+            if self.ctx.save_coordinator.has_pending_saves() && !self.quit_with_pending {
                 // First quit attempt with pending saves - show warning
                 self.set_error(
                     "⏳ Saves pending... press 'q' again to force quit, or wait for completion"
@@ -1261,7 +1261,7 @@ impl App {
                         .map(|dc| dc.card.clone())
                         .collect()
                 } else {
-                    self.ctx.cards().clone()
+                    self.ctx.cards().to_vec()
                 };
 
                 let ctx = ViewRefreshContext {
@@ -1283,7 +1283,9 @@ impl App {
     pub fn undo(&mut self) -> KanbanResult<()> {
         if self.ctx.undo() {
             self.refresh_view();
-            self.ctx.state_manager.queue_snapshot(self.ctx.snapshot());
+            self.ctx
+                .save_coordinator
+                .queue_snapshot(self.ctx.snapshot());
         } else {
             self.set_error("Nothing to undo".to_string());
         }
@@ -1294,7 +1296,9 @@ impl App {
     pub fn redo(&mut self) -> KanbanResult<()> {
         if self.ctx.redo() {
             self.refresh_view();
-            self.ctx.state_manager.queue_snapshot(self.ctx.snapshot());
+            self.ctx
+                .save_coordinator
+                .queue_snapshot(self.ctx.snapshot());
         } else {
             self.set_error("Nothing to redo".to_string());
         }
@@ -1622,7 +1626,7 @@ impl App {
             self.persistence.file_watcher = Some(watcher.clone());
             // Also set it on the state manager (wrapped in Arc) so queue_snapshot can pause it
             let watcher_arc = std::sync::Arc::new(watcher);
-            self.ctx.state_manager.set_file_watcher(watcher_arc);
+            self.ctx.save_coordinator.set_file_watcher(watcher_arc);
         }
 
         // Spawn async save worker if save channel is configured
@@ -1725,11 +1729,6 @@ impl App {
                                     }
                                 }
 
-                                // Auto-refresh view if state manager indicates it's needed
-                                if self.ctx.state_manager.needs_refresh() {
-                                    self.refresh_view();
-                                    self.ctx.state_manager.clear_refresh();
-                                }
                             }
                         }
                     }
@@ -1772,9 +1771,9 @@ impl App {
                     } => {
                         // Save operation completed - update dirty flag
                         tracing::debug!("Save completion signal received");
-                        self.ctx.state_manager.save_completed();
+                        self.ctx.save_coordinator.save_completed();
                         // Reset force quit flag and dirty flag if all saves are now complete
-                        if !self.ctx.state_manager.has_pending_saves() {
+                        if !self.ctx.save_coordinator.has_pending_saves() {
                             self.ctx.mark_clean();
                             self.quit_with_pending = false;
                         }
@@ -1854,7 +1853,7 @@ impl App {
         }
 
         // Graceful shutdown: ensure all queued saves complete before exit
-        self.ctx.state_manager.close_save_channel(); // Close save_tx channel to signal worker to finish
+        self.ctx.save_coordinator.close_save_channel(); // Close save_tx channel to signal worker to finish
 
         // Wait for save worker to finish processing all queued saves
         if let Some(handle) = self.persistence.save_worker_handle.take() {

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1012,7 +1012,7 @@ impl App {
         if had_archives {
             let mut archive_commands: Vec<Box<dyn kanban_domain::commands::Command>> = Vec::new();
             for card_id in archive_cards {
-                let cmd = Box::new(kanban_domain::commands::ArchiveCard { card_id })
+                let cmd = Box::new(kanban_domain::commands::ArchiveCards { ids: vec![card_id] })
                     as Box<dyn kanban_domain::commands::Command>;
                 archive_commands.push(cmd);
             }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1461,13 +1461,13 @@ impl App {
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
                     let board_id = board.id;
-                    if let Some(board) = self.ctx.boards.iter_mut().find(|b| b.id == board_id) {
+                    if let Some(board) = self.ctx.inner.boards.iter_mut().find(|b| b.id == board_id) {
                         match field {
                             BoardField::Name => {
                                 if !new_content.trim().is_empty() {
                                     board.update_name(new_content.trim().to_string());
-                                    self.ctx.state_manager.mark_dirty();
-                                    let snapshot = kanban_domain::Snapshot::from_app(self);
+                                    self.ctx.inner.mark_dirty();
+                                    let snapshot = self.ctx.inner.snapshot();
                                     self.ctx.state_manager.queue_snapshot(snapshot);
                                 }
                             }
@@ -1478,8 +1478,8 @@ impl App {
                                     Some(new_content)
                                 };
                                 board.update_description(desc);
-                                self.ctx.state_manager.mark_dirty();
-                                let snapshot = kanban_domain::Snapshot::from_app(self);
+                                self.ctx.inner.mark_dirty();
+                                let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
                         }
@@ -1516,13 +1516,13 @@ impl App {
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
                     let card_id = card.id;
-                    if let Some(card) = self.ctx.cards.iter_mut().find(|c| c.id == card_id) {
+                    if let Some(card) = self.ctx.inner.cards.iter_mut().find(|c| c.id == card_id) {
                         match field {
                             CardField::Title => {
                                 if !new_content.trim().is_empty() {
                                     card.update_title(new_content.trim().to_string());
-                                    self.ctx.state_manager.mark_dirty();
-                                    let snapshot = kanban_domain::Snapshot::from_app(self);
+                                    self.ctx.inner.mark_dirty();
+                                    let snapshot = self.ctx.inner.snapshot();
                                     self.ctx.state_manager.queue_snapshot(snapshot);
                                 }
                             }
@@ -1533,8 +1533,8 @@ impl App {
                                     Some(new_content)
                                 };
                                 card.update_description(desc);
-                                self.ctx.state_manager.mark_dirty();
-                                let snapshot = kanban_domain::Snapshot::from_app(self);
+                                self.ctx.inner.mark_dirty();
+                                let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
                         }
@@ -1898,49 +1898,51 @@ impl App {
         let content = std::fs::read_to_string(filename)?;
 
         // Capture snapshot before import for undo history
-        let before_snapshot = kanban_domain::Snapshot::from_app(self);
+        let before_snapshot = self.ctx.inner.snapshot();
         self.ctx
             .state_manager
             .capture_before_command(before_snapshot);
 
         // Try V2 format first (preserves graph)
         if let Some(snapshot) = BoardImporter::try_load_snapshot(&content) {
-            let first_new_index = self.ctx.boards.len();
+            let first_new_index = self.ctx.inner.boards.len();
 
-            self.ctx.boards.extend(snapshot.boards);
-            self.ctx.columns.extend(snapshot.columns);
-            self.ctx.cards.extend(snapshot.cards);
-            self.ctx.archived_cards.extend(snapshot.archived_cards);
-            self.ctx.sprints.extend(snapshot.sprints);
-            self.ctx.graph = snapshot.graph;
+            self.ctx.inner.boards.extend(snapshot.boards);
+            self.ctx.inner.columns.extend(snapshot.columns);
+            self.ctx.inner.cards.extend(snapshot.cards);
+            self.ctx.inner.archived_cards.extend(snapshot.archived_cards);
+            self.ctx.inner.sprints.extend(snapshot.sprints);
+            self.ctx.inner.graph = snapshot.graph;
 
             self.selection.board.set(Some(first_new_index));
             self.switch_view_strategy(kanban_domain::TaskListView::GroupedByColumn);
 
             // Queue snapshot for persistence
-            let save_snapshot = kanban_domain::Snapshot::from_app(self);
+            self.ctx.inner.mark_dirty();
+            let save_snapshot = self.ctx.inner.snapshot();
             self.ctx.state_manager.queue_snapshot(save_snapshot);
 
             return Ok(());
         }
 
         // Fall back to V1 format (no graph)
-        let first_new_index = self.ctx.boards.len();
+        let first_new_index = self.ctx.inner.boards.len();
         let import = BoardImporter::import_from_json(&content)?;
         let entities = BoardImporter::extract_entities(import);
 
-        self.ctx.boards.extend(entities.boards);
-        self.ctx.columns.extend(entities.columns);
-        self.ctx.cards.extend(entities.cards);
-        self.ctx.archived_cards.extend(entities.archived_cards);
-        self.ctx.sprints.extend(entities.sprints);
+        self.ctx.inner.boards.extend(entities.boards);
+        self.ctx.inner.columns.extend(entities.columns);
+        self.ctx.inner.cards.extend(entities.cards);
+        self.ctx.inner.archived_cards.extend(entities.archived_cards);
+        self.ctx.inner.sprints.extend(entities.sprints);
 
         self.selection.board.set(Some(first_new_index));
 
         self.switch_view_strategy(kanban_domain::TaskListView::GroupedByColumn);
 
         // Queue snapshot for persistence
-        let save_snapshot = kanban_domain::Snapshot::from_app(self);
+        self.ctx.inner.mark_dirty();
+        let save_snapshot = self.ctx.inner.snapshot();
         self.ctx.state_manager.queue_snapshot(save_snapshot);
 
         Ok(())
@@ -1972,9 +1974,9 @@ impl App {
 
     fn migrate_sprint_logs(&mut self) {
         let count = kanban_domain::card_lifecycle::migrate_sprint_logs(
-            &mut self.ctx.cards,
-            &self.ctx.sprints,
-            &self.ctx.boards,
+            &mut self.ctx.inner.cards,
+            &self.ctx.inner.sprints,
+            &self.ctx.inner.boards,
         );
 
         if count > 0 {

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -260,8 +260,9 @@ impl App {
         use kanban_domain::KanbanError;
         use kanban_persistence::{PersistenceMetadata, StoreSnapshot};
 
-        if let Some(store) = self.ctx.state_manager.store().cloned() {
-            let instance_id = self.ctx.state_manager.instance_id();
+        if self.persistence.save_file.is_some() {
+            let store = self.ctx.inner.store().clone();
+            let instance_id = store.instance_id();
             let file_watcher = self.persistence.file_watcher.clone();
             let save_completion_tx = self.ctx.state_manager.save_completion_tx().cloned();
 
@@ -1549,7 +1550,8 @@ impl App {
 
     #[doc(hidden)]
     pub async fn load_initial_state(&mut self) {
-        if let Some(store) = self.ctx.state_manager.store().cloned() {
+        if self.persistence.save_file.is_some() {
+            let store = self.ctx.inner.store().clone();
             if store.exists().await {
                 match store.load().await {
                     Ok((snapshot, _metadata)) => {
@@ -1563,14 +1565,12 @@ impl App {
                             Err(e) => {
                                 tracing::error!("Failed to deserialize store data: {}", e);
                                 self.persistence.save_file = None;
-                                self.ctx.state_manager.clear_store();
                             }
                         }
                     }
                     Err(e) => {
                         tracing::error!("Failed to load from store: {}", e);
                         self.persistence.save_file = None;
-                        self.ctx.state_manager.clear_store();
                     }
                 }
             }
@@ -1657,8 +1657,8 @@ impl App {
                                         if let Some(ref watcher) = self.persistence.file_watcher {
                                             watcher.pause();
                                         }
-                                        let snapshot = kanban_domain::Snapshot::from_app(self);
-                                        if let Err(e) = self.ctx.state_manager.force_overwrite(&snapshot).await {
+                                        self.ctx.inner.clear_conflict();
+                                        if let Err(e) = self.ctx.inner.save().await {
                                             tracing::error!("Failed to force overwrite: {}", e);
                                         }
                                         // Resume file watcher after save completes
@@ -1669,13 +1669,14 @@ impl App {
                                     Some('t') => {
                                         self.pending_key = None;
                                         // Reload from disk
-                                        if let Some(store) = self.ctx.state_manager.store() {
+                                        {
+                                            let store = self.ctx.inner.store().clone();
                                             match store.load().await {
                                                 Ok((snapshot, _metadata)) => {
                                                     match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
                                                         Ok(data) => {
                                                             data.apply_to_app(self);
-                                                            self.ctx.state_manager.clear_conflict();
+                                                            self.ctx.inner.clear_conflict();
                                                             self.refresh_view();
                                                             tracing::info!("Reloaded state from disk");
                                                         }
@@ -1794,11 +1795,12 @@ impl App {
                         }
                     } => {
                         // Check if this is our own write by comparing instance IDs
-                        if let Some(store) = self.ctx.state_manager.store() {
+                        {
+                            let store = self.ctx.inner.store().clone();
                             match store.load().await {
                                 Ok((_snapshot, metadata)) => {
                                     // Compare instance IDs
-                                    if metadata.instance_id == self.ctx.state_manager.instance_id() {
+                                    if metadata.instance_id == store.instance_id() {
                                         tracing::debug!(
                                             "File change from own instance ({}), ignoring",
                                             metadata.instance_id
@@ -1905,25 +1907,24 @@ impl App {
     }
 
     async fn auto_reload_from_external_change(&mut self) {
-        if let Some(store) = self.ctx.state_manager.store() {
-            match store.load().await {
-                Ok((snapshot, _metadata)) => {
-                    match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
-                        Ok(data) => {
-                            data.apply_to_app(self);
-                            self.ctx.inner.mark_clean();
-                            self.ctx.state_manager.clear_conflict();
-                            self.refresh_view();
-                            tracing::info!("Auto-reloaded state from external file change");
-                        }
-                        Err(e) => {
-                            tracing::error!("Failed to deserialize reloaded state: {}", e);
-                        }
+        let store = self.ctx.inner.store().clone();
+        match store.load().await {
+            Ok((snapshot, _metadata)) => {
+                match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
+                    Ok(data) => {
+                        data.apply_to_app(self);
+                        self.ctx.inner.mark_clean();
+                        self.ctx.inner.clear_conflict();
+                        self.refresh_view();
+                        tracing::info!("Auto-reloaded state from external file change");
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to deserialize reloaded state: {}", e);
                     }
                 }
-                Err(e) => {
-                    tracing::error!("Failed to reload from disk: {}", e);
-                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to reload from disk: {}", e);
             }
         }
     }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -261,7 +261,7 @@ impl App {
         use kanban_persistence::{PersistenceMetadata, StoreSnapshot};
 
         if self.persistence.save_file.is_some() {
-            let store = self.ctx.inner.store().clone();
+            let store = self.ctx.store().clone();
             let instance_id = store.instance_id();
             let file_watcher = self.persistence.file_watcher.clone();
             let save_completion_tx = self.ctx.state_manager.save_completion_tx().cloned();
@@ -988,8 +988,8 @@ impl App {
             self.animation.animating.remove(&card_id);
             match animation_type {
                 AnimationType::Archiving => {
-                    if let Some(card_pos) = self.ctx.cards.iter().position(|c| c.id == card_id) {
-                        let card = self.ctx.cards[card_pos].clone();
+                    if let Some(card_pos) = self.ctx.cards().iter().position(|c| c.id == card_id) {
+                        let card = self.ctx.cards()[card_pos].clone();
                         last_archive_column = Some(card.column_id);
                         last_archive_position = Some(card.position);
                         archive_cards.push(card_id);
@@ -1053,7 +1053,7 @@ impl App {
     fn complete_restore_animation(&mut self, card_id: uuid::Uuid) {
         if let Some(archived_card) = self
             .ctx
-            .archived_cards
+            .archived_cards()
             .iter()
             .find(|dc| dc.card.id == card_id)
             .cloned()
@@ -1063,7 +1063,7 @@ impl App {
     }
 
     pub fn get_board_card_count(&self, board_id: uuid::Uuid) -> usize {
-        let board_filter = BoardFilter::new(board_id, &self.ctx.columns);
+        let board_filter = BoardFilter::new(board_id, self.ctx.columns());
         let sprint_filter = if !self.filter.active_sprint_filters.is_empty() {
             Some(SprintFilter::in_sprints(
                 self.filter.active_sprint_filters.iter().copied(),
@@ -1073,7 +1073,7 @@ impl App {
         };
 
         self.ctx
-            .cards
+            .cards()
             .iter()
             .filter(|c| {
                 if !board_filter.matches(c) {
@@ -1093,8 +1093,8 @@ impl App {
     }
 
     pub fn get_sorted_board_cards(&self, board_id: uuid::Uuid) -> Vec<&Card> {
-        let board = self.ctx.boards.iter().find(|b| b.id == board_id).unwrap();
-        let board_filter = BoardFilter::new(board_id, &self.ctx.columns);
+        let board = self.ctx.boards().iter().find(|b| b.id == board_id).unwrap();
+        let board_filter = BoardFilter::new(board_id, self.ctx.columns());
         let sprint_filter = if !self.filter.active_sprint_filters.is_empty() {
             Some(SprintFilter::in_sprints(
                 self.filter.active_sprint_filters.iter().copied(),
@@ -1105,7 +1105,7 @@ impl App {
 
         let mut cards: Vec<&Card> = self
             .ctx
-            .cards
+            .cards()
             .iter()
             .filter(|c| {
                 if !board_filter.matches(c) {
@@ -1136,12 +1136,12 @@ impl App {
                 if self.mode == AppMode::ArchivedCardsView {
                     return self
                         .ctx
-                        .archived_cards
+                        .archived_cards()
                         .iter()
                         .find(|dc| dc.card.id == card_id)
                         .map(|dc| &dc.card);
                 } else {
-                    return self.ctx.cards.iter().find(|c| c.id == card_id);
+                    return self.ctx.cards().iter().find(|c| c.id == card_id);
                 }
             }
         }
@@ -1164,17 +1164,17 @@ impl App {
     pub fn get_card_by_id(&self, card_id: uuid::Uuid) -> Option<&Card> {
         if self.mode == AppMode::ArchivedCardsView {
             self.ctx
-                .archived_cards
+                .archived_cards()
                 .iter()
                 .find(|dc| dc.card.id == card_id)
                 .map(|dc| &dc.card)
         } else {
-            self.ctx.cards.iter().find(|c| c.id == card_id)
+            self.ctx.cards().iter().find(|c| c.id == card_id)
         }
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
-        let (uncompleted_ids, completed_ids) = partition_sprint_cards(sprint_id, &self.ctx.cards);
+        let (uncompleted_ids, completed_ids) = partition_sprint_cards(sprint_id, self.ctx.cards());
 
         self.sprint_view
             .uncompleted_cards
@@ -1195,13 +1195,13 @@ impl App {
     pub fn apply_sort_to_sprint_lists(&mut self, sort_field: SortField, sort_order: SortOrder) {
         let sorted_uncompleted_ids = sort_card_ids(
             &self.sprint_view.uncompleted_cards.cards,
-            &self.ctx.cards,
+            self.ctx.cards(),
             sort_field,
             sort_order,
         );
         let sorted_completed_ids = sort_card_ids(
             &self.sprint_view.completed_cards.cards,
-            &self.ctx.cards,
+            self.ctx.cards(),
             sort_field,
             sort_order,
         );
@@ -1246,7 +1246,7 @@ impl App {
             .active_board_index
             .or(self.selection.board.get());
         if let Some(idx) = board_idx {
-            if let Some(board) = self.ctx.boards.get(idx) {
+            if let Some(board) = self.ctx.boards().get(idx) {
                 let search_query = if self.filter.search.is_active {
                     Some(self.filter.search.query())
                 } else {
@@ -1256,19 +1256,19 @@ impl App {
                 // When in DeletedCardsView, convert deleted cards to Card objects for display
                 let cards_for_display: Vec<Card> = if self.mode == AppMode::ArchivedCardsView {
                     self.ctx
-                        .archived_cards
+                        .archived_cards()
                         .iter()
                         .map(|dc| dc.card.clone())
                         .collect()
                 } else {
-                    self.ctx.cards.clone()
+                    self.ctx.cards().clone()
                 };
 
                 let ctx = ViewRefreshContext {
                     board,
                     all_cards: &cards_for_display,
-                    all_columns: &self.ctx.columns,
-                    all_sprints: &self.ctx.sprints,
+                    all_columns: self.ctx.columns(),
+                    all_sprints: self.ctx.sprints(),
                     active_sprint_filters: self.filter.active_sprint_filters.clone(),
                     hide_assigned_cards: self.filter.hide_assigned_cards,
                     search_query,
@@ -1281,11 +1281,9 @@ impl App {
 
     /// Undo the last action
     pub fn undo(&mut self) -> KanbanResult<()> {
-        if self.ctx.inner.undo() {
+        if self.ctx.undo() {
             self.refresh_view();
-            self.ctx
-                .state_manager
-                .queue_snapshot(self.ctx.inner.snapshot());
+            self.ctx.state_manager.queue_snapshot(self.ctx.snapshot());
         } else {
             self.set_error("Nothing to undo".to_string());
         }
@@ -1294,11 +1292,9 @@ impl App {
 
     /// Redo the last undone action
     pub fn redo(&mut self) -> KanbanResult<()> {
-        if self.ctx.inner.redo() {
+        if self.ctx.redo() {
             self.refresh_view();
-            self.ctx
-                .state_manager
-                .queue_snapshot(self.ctx.inner.snapshot());
+            self.ctx.state_manager.queue_snapshot(self.ctx.snapshot());
         } else {
             self.set_error("Nothing to redo".to_string());
         }
@@ -1328,13 +1324,13 @@ impl App {
 
     pub fn export_board_with_filename(&self) -> io::Result<()> {
         if let Some(board_idx) = self.selection.board.get() {
-            if let Some(board) = self.ctx.boards.get(board_idx) {
+            if let Some(board) = self.ctx.boards().get(board_idx) {
                 let board_export = BoardExporter::export_board(
                     board,
-                    &self.ctx.columns,
-                    &self.ctx.cards,
-                    &self.ctx.archived_cards,
-                    &self.ctx.sprints,
+                    self.ctx.columns(),
+                    self.ctx.cards(),
+                    self.ctx.archived_cards(),
+                    self.ctx.sprints(),
                 );
 
                 let export = AllBoardsExport {
@@ -1349,11 +1345,11 @@ impl App {
 
     pub fn export_all_boards_with_filename(&self) -> io::Result<()> {
         let export = BoardExporter::export_all_boards(
-            &self.ctx.boards,
-            &self.ctx.columns,
-            &self.ctx.cards,
-            &self.ctx.archived_cards,
-            &self.ctx.sprints,
+            self.ctx.boards(),
+            self.ctx.columns(),
+            self.ctx.cards(),
+            self.ctx.archived_cards(),
+            self.ctx.sprints(),
         );
         BoardExporter::export_to_file(&export, self.input.as_str())?;
         Ok(())
@@ -1362,11 +1358,11 @@ impl App {
     pub fn auto_save(&self) -> io::Result<()> {
         if let Some(ref filename) = self.persistence.save_file {
             let export = BoardExporter::export_all_boards(
-                &self.ctx.boards,
-                &self.ctx.columns,
-                &self.ctx.cards,
-                &self.ctx.archived_cards,
-                &self.ctx.sprints,
+                self.ctx.boards(),
+                self.ctx.columns(),
+                self.ctx.cards(),
+                self.ctx.archived_cards(),
+                self.ctx.sprints(),
             );
             BoardExporter::export_to_file(&export, filename)?;
         }
@@ -1374,7 +1370,7 @@ impl App {
     }
 
     fn check_ended_sprints(&self) {
-        let ended_sprints: Vec<_> = self.ctx.sprints.iter().filter(|s| s.is_ended()).collect();
+        let ended_sprints: Vec<_> = self.ctx.sprints().iter().filter(|s| s.is_ended()).collect();
 
         if !ended_sprints.is_empty() {
             tracing::warn!(
@@ -1382,7 +1378,7 @@ impl App {
                 ended_sprints.len()
             );
             for sprint in &ended_sprints {
-                if let Some(board) = self.ctx.boards.iter().find(|b| b.id == sprint.board_id) {
+                if let Some(board) = self.ctx.boards().iter().find(|b| b.id == sprint.board_id) {
                     tracing::warn!(
                         "  - {} (ended: {})",
                         sprint.formatted_name(board, "sprint"),
@@ -1403,7 +1399,7 @@ impl App {
         field: BoardField,
     ) -> io::Result<()> {
         if let Some(board_idx) = self.selection.board.get() {
-            if let Some(board) = self.ctx.boards.get(board_idx) {
+            if let Some(board) = self.ctx.boards().get(board_idx) {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {
                     BoardField::Name => {
@@ -1418,19 +1414,19 @@ impl App {
                     }
                 };
 
-                let before = self.ctx.inner.snapshot();
+                let before = self.ctx.snapshot();
                 if let Some(new_content) =
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
                     let board_id = board.id;
-                    if let Some(board) = self.ctx.inner.boards.iter_mut().find(|b| b.id == board_id)
+                    if let Some(board) = self.ctx.boards_mut().iter_mut().find(|b| b.id == board_id)
                     {
                         match field {
                             BoardField::Name => {
                                 if !new_content.trim().is_empty() {
                                     board.update_name(new_content.trim().to_string());
-                                    self.ctx.inner.push_before_snapshot(before);
-                                    let snapshot = self.ctx.inner.snapshot();
+                                    self.ctx.push_before_snapshot(before);
+                                    let snapshot = self.ctx.snapshot();
                                     self.ctx.state_manager.queue_snapshot(snapshot);
                                 }
                             }
@@ -1441,8 +1437,8 @@ impl App {
                                     Some(new_content)
                                 };
                                 board.update_description(desc);
-                                self.ctx.inner.push_before_snapshot(before);
-                                let snapshot = self.ctx.inner.snapshot();
+                                self.ctx.push_before_snapshot(before);
+                                let snapshot = self.ctx.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
                         }
@@ -1460,7 +1456,7 @@ impl App {
         field: CardField,
     ) -> io::Result<()> {
         if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.ctx.cards.get(card_idx) {
+            if let Some(card) = self.ctx.cards().get(card_idx) {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {
                     CardField::Title => {
@@ -1475,18 +1471,18 @@ impl App {
                     }
                 };
 
-                let before = self.ctx.inner.snapshot();
+                let before = self.ctx.snapshot();
                 if let Some(new_content) =
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
                     let card_id = card.id;
-                    if let Some(card) = self.ctx.inner.cards.iter_mut().find(|c| c.id == card_id) {
+                    if let Some(card) = self.ctx.cards_mut().iter_mut().find(|c| c.id == card_id) {
                         match field {
                             CardField::Title => {
                                 if !new_content.trim().is_empty() {
                                     card.update_title(new_content.trim().to_string());
-                                    self.ctx.inner.push_before_snapshot(before);
-                                    let snapshot = self.ctx.inner.snapshot();
+                                    self.ctx.push_before_snapshot(before);
+                                    let snapshot = self.ctx.snapshot();
                                     self.ctx.state_manager.queue_snapshot(snapshot);
                                 }
                             }
@@ -1497,8 +1493,8 @@ impl App {
                                     Some(new_content)
                                 };
                                 card.update_description(desc);
-                                self.ctx.inner.push_before_snapshot(before);
-                                let snapshot = self.ctx.inner.snapshot();
+                                self.ctx.push_before_snapshot(before);
+                                let snapshot = self.ctx.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
                         }
@@ -1554,15 +1550,15 @@ impl App {
     #[doc(hidden)]
     pub async fn load_initial_state(&mut self) {
         if self.persistence.save_file.is_some() {
-            let store = self.ctx.inner.store().clone();
+            let store = self.ctx.store().clone();
             if store.exists().await {
                 match store.load().await {
                     Ok((snapshot, _metadata)) => {
                         match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
                             Ok(data) => {
                                 data.apply_to_app(self);
-                                self.ctx.inner.mark_clean();
-                                self.ctx.inner.clear_history();
+                                self.ctx.mark_clean();
+                                self.ctx.clear_history();
                                 tracing::info!("Loaded initial state from store");
                             }
                             Err(e) => {
@@ -1660,8 +1656,8 @@ impl App {
                                         if let Some(ref watcher) = self.persistence.file_watcher {
                                             watcher.pause();
                                         }
-                                        self.ctx.inner.clear_conflict();
-                                        if let Err(e) = self.ctx.inner.save().await {
+                                        self.ctx.clear_conflict();
+                                        if let Err(e) = self.ctx.save().await {
                                             tracing::error!("Failed to force overwrite: {}", e);
                                         }
                                         // Resume file watcher after save completes
@@ -1673,13 +1669,13 @@ impl App {
                                         self.pending_key = None;
                                         // Reload from disk
                                         {
-                                            let store = self.ctx.inner.store().clone();
+                                            let store = self.ctx.store().clone();
                                             match store.load().await {
                                                 Ok((snapshot, _metadata)) => {
                                                     match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
                                                         Ok(data) => {
                                                             data.apply_to_app(self);
-                                                            self.ctx.inner.clear_conflict();
+                                                            self.ctx.clear_conflict();
                                                             self.refresh_view();
                                                             tracing::info!("Reloaded state from disk");
                                                         }
@@ -1768,7 +1764,7 @@ impl App {
                         self.ctx.state_manager.save_completed();
                         // Reset force quit flag and dirty flag if all saves are now complete
                         if !self.ctx.state_manager.has_pending_saves() {
-                            self.ctx.inner.mark_clean();
+                            self.ctx.mark_clean();
                             self.quit_with_pending = false;
                         }
                     }
@@ -1800,7 +1796,7 @@ impl App {
                     } => {
                         // Check if this is our own write by comparing instance IDs
                         {
-                            let store = self.ctx.inner.store().clone();
+                            let store = self.ctx.store().clone();
                             match store.load().await {
                                 Ok((_snapshot, metadata)) => {
                                     // Compare instance IDs
@@ -1821,7 +1817,7 @@ impl App {
                         }
 
                         // External file change detected - handle smart reload
-                        if !self.ctx.inner.is_dirty() {
+                        if !self.ctx.is_dirty() {
                             // No local changes, auto-reload silently
                             tracing::info!("External change detected, auto-reloading");
                             self.auto_reload_from_external_change().await;
@@ -1863,68 +1859,66 @@ impl App {
         let content = std::fs::read_to_string(filename)?;
 
         // Capture snapshot before import for undo history
-        self.ctx.inner.capture_before_command();
+        self.ctx.capture_before_command();
 
         // Try V2 format first (preserves graph)
         if let Some(snapshot) = BoardImporter::try_load_snapshot(&content) {
-            let first_new_index = self.ctx.inner.boards.len();
+            let first_new_index = self.ctx.boards().len();
 
-            self.ctx.inner.boards.extend(snapshot.boards);
-            self.ctx.inner.columns.extend(snapshot.columns);
-            self.ctx.inner.cards.extend(snapshot.cards);
+            self.ctx.boards_mut().extend(snapshot.boards);
+            self.ctx.columns_mut().extend(snapshot.columns);
+            self.ctx.cards_mut().extend(snapshot.cards);
             self.ctx
-                .inner
-                .archived_cards
+                .archived_cards_mut()
                 .extend(snapshot.archived_cards);
-            self.ctx.inner.sprints.extend(snapshot.sprints);
-            self.ctx.inner.graph = snapshot.graph;
+            self.ctx.sprints_mut().extend(snapshot.sprints);
+            *self.ctx.graph_mut() = snapshot.graph;
 
             self.selection.board.set(Some(first_new_index));
             self.switch_view_strategy(kanban_domain::TaskListView::GroupedByColumn);
 
             // Queue snapshot for persistence
-            self.ctx.inner.mark_dirty();
-            let save_snapshot = self.ctx.inner.snapshot();
+            self.ctx.mark_dirty();
+            let save_snapshot = self.ctx.snapshot();
             self.ctx.state_manager.queue_snapshot(save_snapshot);
 
             return Ok(());
         }
 
         // Fall back to V1 format (no graph)
-        let first_new_index = self.ctx.inner.boards.len();
+        let first_new_index = self.ctx.boards().len();
         let import = BoardImporter::import_from_json(&content)?;
         let entities = BoardImporter::extract_entities(import);
 
-        self.ctx.inner.boards.extend(entities.boards);
-        self.ctx.inner.columns.extend(entities.columns);
-        self.ctx.inner.cards.extend(entities.cards);
+        self.ctx.boards_mut().extend(entities.boards);
+        self.ctx.columns_mut().extend(entities.columns);
+        self.ctx.cards_mut().extend(entities.cards);
         self.ctx
-            .inner
-            .archived_cards
+            .archived_cards_mut()
             .extend(entities.archived_cards);
-        self.ctx.inner.sprints.extend(entities.sprints);
+        self.ctx.sprints_mut().extend(entities.sprints);
 
         self.selection.board.set(Some(first_new_index));
 
         self.switch_view_strategy(kanban_domain::TaskListView::GroupedByColumn);
 
         // Queue snapshot for persistence
-        self.ctx.inner.mark_dirty();
-        let save_snapshot = self.ctx.inner.snapshot();
+        self.ctx.mark_dirty();
+        let save_snapshot = self.ctx.snapshot();
         self.ctx.state_manager.queue_snapshot(save_snapshot);
 
         Ok(())
     }
 
     async fn auto_reload_from_external_change(&mut self) {
-        let store = self.ctx.inner.store().clone();
+        let store = self.ctx.store().clone();
         match store.load().await {
             Ok((snapshot, _metadata)) => {
                 match serde_json::from_slice::<kanban_domain::Snapshot>(&snapshot.data) {
                     Ok(data) => {
                         data.apply_to_app(self);
-                        self.ctx.inner.mark_clean();
-                        self.ctx.inner.clear_conflict();
+                        self.ctx.mark_clean();
+                        self.ctx.clear_conflict();
                         self.refresh_view();
                         tracing::info!("Auto-reloaded state from external file change");
                     }
@@ -1940,10 +1934,12 @@ impl App {
     }
 
     fn migrate_sprint_logs(&mut self) {
+        let sprints = self.ctx.sprints().clone();
+        let boards = self.ctx.boards().clone();
         let count = kanban_domain::card_lifecycle::migrate_sprint_logs(
-            &mut self.ctx.inner.cards,
-            &self.ctx.inner.sprints,
-            &self.ctx.inner.boards,
+            self.ctx.cards_mut(),
+            &sprints,
+            &boards,
         );
 
         if count > 0 {
@@ -1958,12 +1954,12 @@ impl App {
     {
         if let Some(card_idx) = self.selection.active_card_index {
             if let Some(board_idx) = self.selection.active_board_index {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
-                    if let Some(card) = self.ctx.cards.get(card_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
+                    if let Some(card) = self.ctx.cards().get(card_idx) {
                         let output = get_output(
                             card,
                             board,
-                            &self.ctx.sprints,
+                            self.ctx.sprints(),
                             self.app_config.effective_default_card_prefix(),
                         );
                         if let Err(e) = clipboard::copy_to_clipboard(&output) {
@@ -1991,7 +1987,7 @@ impl App {
 
     pub fn get_current_priority_selection_index(&self) -> usize {
         if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.ctx.cards.get(card_idx) {
+            if let Some(card) = self.ctx.cards().get(card_idx) {
                 use kanban_domain::CardPriority;
                 return match card.priority {
                     CardPriority::Low => 0,
@@ -2006,11 +2002,11 @@ impl App {
 
     pub fn get_current_sprint_selection_index(&self) -> usize {
         if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.ctx.cards.get(card_idx) {
+            if let Some(card) = self.ctx.cards().get(card_idx) {
                 if let Some(card_sprint_id) = card.sprint_id {
                     if let Some(board_idx) = self.selection.active_board_index {
-                        if let Some(board) = self.ctx.boards.get(board_idx) {
-                            let board_sprints = Sprint::assignable(&self.ctx.sprints, board.id);
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
+                            let board_sprints = Sprint::assignable(self.ctx.sprints(), board.id);
                             for (idx, sprint) in board_sprints.iter().enumerate() {
                                 if sprint.id == card_sprint_id {
                                     return idx + 1;

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1010,10 +1010,12 @@ impl App {
 
         // Execute batch archive commands
         if had_archives {
-            if let Err(e) = self.execute_commands_batch(vec![
-                Box::new(kanban_domain::commands::ArchiveCards { ids: archive_cards })
-                    as Box<dyn kanban_domain::commands::Command>,
-            ]) {
+            if let Err(e) =
+                self.execute_commands_batch(vec![Box::new(kanban_domain::commands::ArchiveCards {
+                    ids: archive_cards,
+                })
+                    as Box<dyn kanban_domain::commands::Command>])
+            {
                 tracing::error!("Failed to archive cards: {}", e);
             } else if let (Some(column_id), Some(position)) =
                 (last_archive_column, last_archive_position)

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1422,7 +1422,8 @@ impl App {
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
                     let board_id = board.id;
-                    if let Some(board) = self.ctx.inner.boards.iter_mut().find(|b| b.id == board_id) {
+                    if let Some(board) = self.ctx.inner.boards.iter_mut().find(|b| b.id == board_id)
+                    {
                         match field {
                             BoardField::Name => {
                                 if !new_content.trim().is_empty() {
@@ -1868,7 +1869,10 @@ impl App {
             self.ctx.inner.boards.extend(snapshot.boards);
             self.ctx.inner.columns.extend(snapshot.columns);
             self.ctx.inner.cards.extend(snapshot.cards);
-            self.ctx.inner.archived_cards.extend(snapshot.archived_cards);
+            self.ctx
+                .inner
+                .archived_cards
+                .extend(snapshot.archived_cards);
             self.ctx.inner.sprints.extend(snapshot.sprints);
             self.ctx.inner.graph = snapshot.graph;
 
@@ -1891,7 +1895,10 @@ impl App {
         self.ctx.inner.boards.extend(entities.boards);
         self.ctx.inner.columns.extend(entities.columns);
         self.ctx.inner.cards.extend(entities.cards);
-        self.ctx.inner.archived_cards.extend(entities.archived_cards);
+        self.ctx
+            .inner
+            .archived_cards
+            .extend(entities.archived_cards);
         self.ctx.inner.sprints.extend(entities.sprints);
 
         self.selection.board.set(Some(first_new_index));

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1010,13 +1010,10 @@ impl App {
 
         // Execute batch archive commands
         if had_archives {
-            let mut archive_commands: Vec<Box<dyn kanban_domain::commands::Command>> = Vec::new();
-            for card_id in archive_cards {
-                let cmd = Box::new(kanban_domain::commands::ArchiveCards { ids: vec![card_id] })
-                    as Box<dyn kanban_domain::commands::Command>;
-                archive_commands.push(cmd);
-            }
-            if let Err(e) = self.execute_commands_batch(archive_commands) {
+            if let Err(e) = self.execute_commands_batch(vec![
+                Box::new(kanban_domain::commands::ArchiveCards { ids: archive_cards })
+                    as Box<dyn kanban_domain::commands::Command>,
+            ]) {
                 tracing::error!("Failed to archive cards: {}", e);
             } else if let (Some(column_id), Some(position)) =
                 (last_archive_column, last_archive_position)
@@ -1876,6 +1873,7 @@ impl App {
                 graph: Some(snapshot.graph),
             });
             if let Err(e) = self.ctx.execute_command(cmd) {
+                self.set_error(e.to_string());
                 tracing::error!("Failed to import V2 board: {}", e);
                 return Ok(());
             }
@@ -1898,6 +1896,7 @@ impl App {
             graph: None,
         });
         if let Err(e) = self.ctx.execute_command(cmd) {
+            self.set_error(e.to_string());
             tracing::error!("Failed to import V1 board: {}", e);
             return Ok(());
         }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1766,8 +1766,9 @@ impl App {
                         // Save operation completed - update dirty flag
                         tracing::debug!("Save completion signal received");
                         self.ctx.state_manager.save_completed();
-                        // Reset force quit flag if all saves are now complete
+                        // Reset force quit flag and dirty flag if all saves are now complete
                         if !self.ctx.state_manager.has_pending_saves() {
+                            self.ctx.inner.mark_clean();
                             self.quit_with_pending = false;
                         }
                     }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1283,9 +1283,6 @@ impl App {
     pub fn undo(&mut self) -> KanbanResult<()> {
         if self.ctx.undo() {
             self.refresh_view();
-            self.ctx
-                .save_coordinator
-                .queue_snapshot(self.ctx.snapshot());
         } else {
             self.set_error("Nothing to undo".to_string());
         }
@@ -1296,9 +1293,6 @@ impl App {
     pub fn redo(&mut self) -> KanbanResult<()> {
         if self.ctx.redo() {
             self.refresh_view();
-            self.ctx
-                .save_coordinator
-                .queue_snapshot(self.ctx.snapshot());
         } else {
             self.set_error("Nothing to redo".to_string());
         }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1414,33 +1414,38 @@ impl App {
                     }
                 };
 
-                let before = self.ctx.snapshot();
+                let board_id = board.id;
                 if let Some(new_content) =
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
-                    let board_id = board.id;
-                    if let Some(board) = self.ctx.boards_mut().iter_mut().find(|b| b.id == board_id)
-                    {
-                        match field {
-                            BoardField::Name => {
-                                if !new_content.trim().is_empty() {
-                                    board.update_name(new_content.trim().to_string());
-                                    self.ctx.push_before_snapshot(before);
-                                    let snapshot = self.ctx.snapshot();
-                                    self.ctx.state_manager.queue_snapshot(snapshot);
-                                }
+                    let updates = match field {
+                        BoardField::Name => {
+                            if new_content.trim().is_empty() {
+                                None
+                            } else {
+                                Some(kanban_domain::BoardUpdate {
+                                    name: Some(new_content.trim().to_string()),
+                                    ..Default::default()
+                                })
                             }
-                            BoardField::Description => {
-                                let desc = if new_content.trim().is_empty() {
-                                    None
-                                } else {
-                                    Some(new_content)
-                                };
-                                board.update_description(desc);
-                                self.ctx.push_before_snapshot(before);
-                                let snapshot = self.ctx.snapshot();
-                                self.ctx.state_manager.queue_snapshot(snapshot);
-                            }
+                        }
+                        BoardField::Description => {
+                            let desc = if new_content.trim().is_empty() {
+                                kanban_domain::FieldUpdate::Clear
+                            } else {
+                                kanban_domain::FieldUpdate::Set(new_content)
+                            };
+                            Some(kanban_domain::BoardUpdate {
+                                description: desc,
+                                ..Default::default()
+                            })
+                        }
+                    };
+                    if let Some(updates) = updates {
+                        let cmd =
+                            Box::new(kanban_domain::commands::UpdateBoard { board_id, updates });
+                        if let Err(e) = self.ctx.execute_command(cmd) {
+                            tracing::error!("Failed to update board: {}", e);
                         }
                     }
                 }
@@ -1471,32 +1476,38 @@ impl App {
                     }
                 };
 
-                let before = self.ctx.snapshot();
+                let card_id = card.id;
                 if let Some(new_content) =
                     edit_in_external_editor(terminal, event_handler, temp_file, &current_content)?
                 {
-                    let card_id = card.id;
-                    if let Some(card) = self.ctx.cards_mut().iter_mut().find(|c| c.id == card_id) {
-                        match field {
-                            CardField::Title => {
-                                if !new_content.trim().is_empty() {
-                                    card.update_title(new_content.trim().to_string());
-                                    self.ctx.push_before_snapshot(before);
-                                    let snapshot = self.ctx.snapshot();
-                                    self.ctx.state_manager.queue_snapshot(snapshot);
-                                }
+                    let updates = match field {
+                        CardField::Title => {
+                            if new_content.trim().is_empty() {
+                                None
+                            } else {
+                                Some(kanban_domain::CardUpdate {
+                                    title: Some(new_content.trim().to_string()),
+                                    ..Default::default()
+                                })
                             }
-                            CardField::Description => {
-                                let desc = if new_content.trim().is_empty() {
-                                    None
-                                } else {
-                                    Some(new_content)
-                                };
-                                card.update_description(desc);
-                                self.ctx.push_before_snapshot(before);
-                                let snapshot = self.ctx.snapshot();
-                                self.ctx.state_manager.queue_snapshot(snapshot);
-                            }
+                        }
+                        CardField::Description => {
+                            let desc = if new_content.trim().is_empty() {
+                                kanban_domain::FieldUpdate::Clear
+                            } else {
+                                kanban_domain::FieldUpdate::Set(new_content)
+                            };
+                            Some(kanban_domain::CardUpdate {
+                                description: desc,
+                                ..Default::default()
+                            })
+                        }
+                    };
+                    if let Some(updates) = updates {
+                        let cmd =
+                            Box::new(kanban_domain::commands::UpdateCard { card_id, updates });
+                        if let Err(e) = self.ctx.execute_command(cmd) {
+                            tracing::error!("Failed to update card: {}", e);
                         }
                     }
                 }
@@ -1858,54 +1869,47 @@ impl App {
     pub fn import_board_from_file(&mut self, filename: &str) -> io::Result<()> {
         let content = std::fs::read_to_string(filename)?;
 
-        // Capture snapshot before import for undo history
-        self.ctx.capture_before_command();
+        let first_new_index = self.ctx.boards().len();
 
         // Try V2 format first (preserves graph)
         if let Some(snapshot) = BoardImporter::try_load_snapshot(&content) {
-            let first_new_index = self.ctx.boards().len();
-
-            self.ctx.boards_mut().extend(snapshot.boards);
-            self.ctx.columns_mut().extend(snapshot.columns);
-            self.ctx.cards_mut().extend(snapshot.cards);
-            self.ctx
-                .archived_cards_mut()
-                .extend(snapshot.archived_cards);
-            self.ctx.sprints_mut().extend(snapshot.sprints);
-            *self.ctx.graph_mut() = snapshot.graph;
+            let cmd = Box::new(kanban_domain::commands::ImportEntities {
+                boards: snapshot.boards,
+                columns: snapshot.columns,
+                cards: snapshot.cards,
+                archived_cards: snapshot.archived_cards,
+                sprints: snapshot.sprints,
+                graph: Some(snapshot.graph),
+            });
+            if let Err(e) = self.ctx.execute_command(cmd) {
+                tracing::error!("Failed to import V2 board: {}", e);
+                return Ok(());
+            }
 
             self.selection.board.set(Some(first_new_index));
             self.switch_view_strategy(kanban_domain::TaskListView::GroupedByColumn);
-
-            // Queue snapshot for persistence
-            self.ctx.mark_dirty();
-            let save_snapshot = self.ctx.snapshot();
-            self.ctx.state_manager.queue_snapshot(save_snapshot);
-
             return Ok(());
         }
 
         // Fall back to V1 format (no graph)
-        let first_new_index = self.ctx.boards().len();
         let import = BoardImporter::import_from_json(&content)?;
         let entities = BoardImporter::extract_entities(import);
 
-        self.ctx.boards_mut().extend(entities.boards);
-        self.ctx.columns_mut().extend(entities.columns);
-        self.ctx.cards_mut().extend(entities.cards);
-        self.ctx
-            .archived_cards_mut()
-            .extend(entities.archived_cards);
-        self.ctx.sprints_mut().extend(entities.sprints);
+        let cmd = Box::new(kanban_domain::commands::ImportEntities {
+            boards: entities.boards,
+            columns: entities.columns,
+            cards: entities.cards,
+            archived_cards: entities.archived_cards,
+            sprints: entities.sprints,
+            graph: None,
+        });
+        if let Err(e) = self.ctx.execute_command(cmd) {
+            tracing::error!("Failed to import V1 board: {}", e);
+            return Ok(());
+        }
 
         self.selection.board.set(Some(first_new_index));
-
         self.switch_view_strategy(kanban_domain::TaskListView::GroupedByColumn);
-
-        // Queue snapshot for persistence
-        self.ctx.mark_dirty();
-        let save_snapshot = self.ctx.snapshot();
-        self.ctx.state_manager.queue_snapshot(save_snapshot);
 
         Ok(())
     }
@@ -1934,16 +1938,9 @@ impl App {
     }
 
     fn migrate_sprint_logs(&mut self) {
-        let sprints = self.ctx.sprints().clone();
-        let boards = self.ctx.boards().clone();
-        let count = kanban_domain::card_lifecycle::migrate_sprint_logs(
-            self.ctx.cards_mut(),
-            &sprints,
-            &boards,
-        );
-
-        if count > 0 {
-            tracing::info!("Migrated sprint logs for {} cards", count);
+        let cmd = Box::new(kanban_domain::commands::MigrateSprintLogs);
+        if let Err(e) = self.ctx.execute_command(cmd) {
+            tracing::error!("Failed to migrate sprint logs: {}", e);
         }
     }
 

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1429,7 +1429,7 @@ impl App {
                             BoardField::Name => {
                                 if !new_content.trim().is_empty() {
                                     board.update_name(new_content.trim().to_string());
-                                    self.ctx.inner.record_undo_snapshot(before);
+                                    self.ctx.inner.push_before_snapshot(before);
                                     let snapshot = self.ctx.inner.snapshot();
                                     self.ctx.state_manager.queue_snapshot(snapshot);
                                 }
@@ -1441,7 +1441,7 @@ impl App {
                                     Some(new_content)
                                 };
                                 board.update_description(desc);
-                                self.ctx.inner.record_undo_snapshot(before);
+                                self.ctx.inner.push_before_snapshot(before);
                                 let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
@@ -1485,7 +1485,7 @@ impl App {
                             CardField::Title => {
                                 if !new_content.trim().is_empty() {
                                     card.update_title(new_content.trim().to_string());
-                                    self.ctx.inner.record_undo_snapshot(before);
+                                    self.ctx.inner.push_before_snapshot(before);
                                     let snapshot = self.ctx.inner.snapshot();
                                     self.ctx.state_manager.queue_snapshot(snapshot);
                                 }
@@ -1497,7 +1497,7 @@ impl App {
                                     Some(new_content)
                                 };
                                 card.update_description(desc);
-                                self.ctx.inner.record_undo_snapshot(before);
+                                self.ctx.inner.push_before_snapshot(before);
                                 let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }

--- a/crates/kanban-tui/src/components/filter_popup.rs
+++ b/crates/kanban-tui/src/components/filter_popup.rs
@@ -82,10 +82,10 @@ fn render_filter_sprints_section(
     )));
 
     if let Some(board_idx) = app.selection.active_board_index {
-        if let Some(board) = app.ctx.boards.get(board_idx) {
+        if let Some(board) = app.ctx.boards().get(board_idx) {
             let board_sprints: Vec<_> = app
                 .ctx
-                .sprints
+                .sprints()
                 .iter()
                 .filter(|s| s.board_id == board.id)
                 .collect();

--- a/crates/kanban-tui/src/components/relationship_popup.rs
+++ b/crates/kanban-tui/src/components/relationship_popup.rs
@@ -85,7 +85,7 @@ fn render_relationship_card_list(app: &App, frame: &mut Frame, area: ratatui::la
             .iter()
             .filter(|card_id| {
                 app.ctx
-                    .cards
+                    .cards()
                     .iter()
                     .find(|c| c.id == **card_id)
                     .map(|c| c.title.to_lowercase().contains(&search_lower))
@@ -97,7 +97,7 @@ fn render_relationship_card_list(app: &App, frame: &mut Frame, area: ratatui::la
 
     let mut lines = vec![];
     for (idx, card_id) in filtered_cards.iter().enumerate() {
-        if let Some(card) = app.ctx.cards.iter().find(|c| c.id == *card_id) {
+        if let Some(card) = app.ctx.cards().iter().find(|c| c.id == *card_id) {
             let is_selected = app.relationship.selection.get() == Some(idx);
             let is_checked = app.relationship.selected.contains(card_id);
 

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -193,9 +193,9 @@ impl SelectionDialog for CarryOverSprintDialog {
 
     fn options_count(&self, app: &App) -> usize {
         if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.ctx.boards.get(board_idx) {
+            if let Some(board) = app.ctx.boards().get(board_idx) {
                 app.ctx
-                    .sprints
+                    .sprints()
                     .iter()
                     .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
                     .count()
@@ -241,10 +241,10 @@ impl SelectionDialog for CarryOverSprintDialog {
         let mut lines = vec![];
 
         if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.ctx.boards.get(board_idx) {
+            if let Some(board) = app.ctx.boards().get(board_idx) {
                 let planning_sprints: Vec<_> = app
                     .ctx
-                    .sprints
+                    .sprints()
                     .iter()
                     .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
                     .collect();
@@ -288,8 +288,8 @@ impl SelectionDialog for SprintAssignDialog {
 
     fn options_count(&self, app: &App) -> usize {
         if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.ctx.boards.get(board_idx) {
-                let sprint_count = Sprint::assignable(&app.ctx.sprints, board.id).len();
+            if let Some(board) = app.ctx.boards().get(board_idx) {
+                let sprint_count = Sprint::assignable(app.ctx.sprints(), board.id).len();
                 sprint_count + 1 // +1 for None option
             } else {
                 1
@@ -331,11 +331,11 @@ impl SelectionDialog for SprintAssignDialog {
         let mut lines = vec![];
 
         if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.ctx.boards.get(board_idx) {
-                let board_sprints = Sprint::assignable(&app.ctx.sprints, board.id);
+            if let Some(board) = app.ctx.boards().get(board_idx) {
+                let board_sprints = Sprint::assignable(app.ctx.sprints(), board.id);
 
                 let current_sprint_id = if let Some(card_idx) = app.selection.active_card_index {
-                    app.ctx.cards.get(card_idx).and_then(|c| c.sprint_id)
+                    app.ctx.cards().get(card_idx).and_then(|c| c.sprint_id)
                 } else {
                     None
                 };

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -76,6 +76,7 @@ impl App {
 
         if let Err(e) = self.execute_command(create_board_cmd) {
             tracing::error!("Failed to create board: {}", e);
+            self.set_error(format!("Failed to create board: {}", e));
             return;
         }
 
@@ -102,6 +103,7 @@ impl App {
         // Execute all column creation commands as a batch (single pause/resume cycle)
         if let Err(e) = self.execute_commands_batch(column_commands) {
             tracing::error!("Failed to create default columns: {}", e);
+            self.set_error(format!("Failed to create default columns: {}", e));
             return;
         }
 
@@ -132,6 +134,7 @@ impl App {
 
                 if let Err(e) = self.execute_command(cmd) {
                     tracing::error!("Failed to rename board: {}", e);
+                    self.set_error(format!("Failed to rename board: {}", e));
                     return;
                 }
 

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -13,7 +13,7 @@ impl App {
     pub fn handle_rename_board_key(&mut self) {
         if self.focus.active == Focus::Boards && self.selection.board.get().is_some() {
             if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     self.input.set(board.name.clone());
                     self.open_dialog(DialogMode::RenameBoard);
                 }
@@ -31,7 +31,7 @@ impl App {
     pub fn handle_export_board_key(&mut self) {
         if self.focus.active == Focus::Boards && self.selection.board.get().is_some() {
             if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     let filename = format!(
                         "{}-{}.json",
                         board.name.replace(" ", "-").to_lowercase(),
@@ -45,7 +45,7 @@ impl App {
     }
 
     pub fn handle_export_all_key(&mut self) {
-        if self.focus.active == Focus::Boards && !self.ctx.boards.is_empty() {
+        if self.focus.active == Focus::Boards && !self.ctx.boards().is_empty() {
             let filename = format!(
                 "kanban-all-{}.json",
                 chrono::Utc::now().format("%Y%m%d-%H%M%S")
@@ -80,7 +80,7 @@ impl App {
         }
 
         // Get the board ID from the newly created board
-        let board_id = if let Some(board) = self.ctx.boards.last() {
+        let board_id = if let Some(board) = self.ctx.boards().last() {
             board.id
         } else {
             return;
@@ -110,14 +110,14 @@ impl App {
         tracing::info!("Created board: {} (id: {})", board_name, board_id);
         tracing::info!("Created default columns: TODO, Doing, Complete");
 
-        let new_index = self.ctx.boards.len() - 1;
+        let new_index = self.ctx.boards().len() - 1;
         self.selection.board.set(Some(new_index));
         self.switch_view_strategy(task_list_view);
     }
 
     pub fn rename_board(&mut self) {
         if let Some(idx) = self.selection.board.get() {
-            if let Some(board) = self.ctx.boards.get(idx) {
+            if let Some(board) = self.ctx.boards().get(idx) {
                 let board_id = board.id;
                 let new_name = self.input.as_str().to_string();
 

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -346,7 +346,7 @@ impl App {
                     Some(col) => col,
                     None => {
                         let new_column = Column::new(bid, "Todo".to_string(), 0);
-                        self.ctx.columns.push(new_column.clone());
+                        self.ctx.inner.columns.push(new_column.clone());
                         new_column
                     }
                 };
@@ -638,7 +638,7 @@ impl App {
     }
 
     pub fn compact_column_positions(&mut self, column_id: uuid::Uuid) {
-        kanban_domain::card_lifecycle::compact_column_positions(&mut self.ctx.cards, column_id);
+        kanban_domain::card_lifecycle::compact_column_positions(&mut self.ctx.inner.cards, column_id);
     }
 
     pub fn select_card_after_deletion(

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -88,12 +88,12 @@ impl App {
             self.open_dialog(DialogMode::AssignMultipleCardsToSprint);
         } else if self.get_selected_card_id().is_some() {
             if let Some(board_idx) = self.selection.active_board_index {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
-                    let sprint_count = Sprint::assignable(&self.ctx.sprints, board.id).len();
+                if let Some(board) = self.ctx.boards().get(board_idx) {
+                    let sprint_count = Sprint::assignable(self.ctx.sprints(), board.id).len();
                     if sprint_count > 0 {
                         if let Some(selected_card) = self.get_selected_card_in_context() {
                             let card_id = selected_card.id;
-                            let actual_idx = self.ctx.cards.iter().position(|c| c.id == card_id);
+                            let actual_idx = self.ctx.cards().iter().position(|c| c.id == card_id);
                             self.selection.active_card_index = actual_idx;
                         }
                         let selection_idx = self.get_current_sprint_selection_index();
@@ -125,7 +125,7 @@ impl App {
                 self.filter.current_sort_order = Some(new_order);
 
                 if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.ctx.boards.get(board_idx) {
+                    if let Some(board) = self.ctx.boards().get(board_idx) {
                         if let Some(field) = self.filter.current_sort_field {
                             let cmd = Box::new(SetBoardTaskSort {
                                 board_id: board.id,
@@ -164,7 +164,7 @@ impl App {
     pub fn handle_toggle_sprint_filter(&mut self) {
         if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
             if let Some(board_idx) = self.selection.active_board_index {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     if let Some(active_sprint_id) = board.active_sprint_id {
                         if self
                             .filter
@@ -197,7 +197,7 @@ impl App {
         if self.focus.active == Focus::Cards {
             if let Some(selected_card) = self.get_selected_card_in_context() {
                 let card_id = selected_card.id;
-                let actual_idx = self.ctx.cards.iter().position(|c| c.id == card_id);
+                let actual_idx = self.ctx.cards().iter().position(|c| c.id == card_id);
                 self.selection.active_card_index = actual_idx;
 
                 if let Err(e) =
@@ -221,12 +221,12 @@ impl App {
             };
 
             let toggle_result = self.selection.active_board_index.and_then(|idx| {
-                self.ctx.boards.get(idx).and_then(|board| {
+                self.ctx.boards().get(idx).and_then(|board| {
                     kanban_domain::card_lifecycle::compute_completion_toggle(
                         card,
                         board,
-                        &self.ctx.columns,
-                        &self.ctx.cards,
+                        self.ctx.columns(),
+                        self.ctx.cards(),
                     )
                 })
             });
@@ -261,7 +261,7 @@ impl App {
         let mut update_commands: Vec<Box<dyn kanban_domain::commands::Command>> = Vec::new();
 
         for card_id in card_ids {
-            let card = match self.ctx.cards.iter().find(|c| c.id == card_id) {
+            let card = match self.ctx.cards().iter().find(|c| c.id == card_id) {
                 Some(c) => c.clone(),
                 None => continue,
             };
@@ -273,12 +273,12 @@ impl App {
             };
 
             let toggle_result = self.selection.active_board_index.and_then(|idx| {
-                self.ctx.boards.get(idx).and_then(|board| {
+                self.ctx.boards().get(idx).and_then(|board| {
                     kanban_domain::card_lifecycle::compute_completion_toggle(
                         &card,
                         board,
-                        &self.ctx.columns,
-                        &self.ctx.cards,
+                        self.ctx.columns(),
+                        self.ctx.cards(),
                     )
                 })
             });
@@ -319,14 +319,14 @@ impl App {
     pub fn create_card(&mut self) {
         if let Some(idx) = self.selection.active_board_index {
             let focused_col_id = self.get_focused_column_id();
-            let board_id = self.ctx.boards.get(idx).map(|b| b.id);
+            let board_id = self.ctx.boards().get(idx).map(|b| b.id);
 
             if let Some(bid) = board_id {
                 let target_column_id = if let Some(focused_col_id) = focused_col_id {
                     Some(focused_col_id)
                 } else {
                     self.ctx
-                        .columns
+                        .columns()
                         .iter()
                         .find(|col| col.board_id == bid)
                         .map(|col| col.id)
@@ -334,7 +334,7 @@ impl App {
 
                 let column = if let Some(col_id) = target_column_id {
                     self.ctx
-                        .columns
+                        .columns()
                         .iter()
                         .find(|col| col.id == col_id)
                         .cloned()
@@ -354,19 +354,19 @@ impl App {
                 };
 
                 let position = kanban_domain::card_lifecycle::next_position_in_column(
-                    &self.ctx.cards,
+                    self.ctx.cards(),
                     column.id,
                 );
 
                 let mark_as_complete = self
                     .ctx
-                    .boards
+                    .boards()
                     .get(idx)
                     .map(|board| {
                         kanban_domain::card_lifecycle::should_auto_complete_new_card(
                             column.id,
                             board,
-                            &self.ctx.columns,
+                            self.ctx.columns(),
                         )
                     })
                     .unwrap_or(false);
@@ -387,7 +387,7 @@ impl App {
                 if mark_as_complete {
                     if let Some(card) = self
                         .ctx
-                        .cards
+                        .cards()
                         .iter()
                         .rev()
                         .find(|c| c.column_id == column.id)
@@ -411,7 +411,7 @@ impl App {
                 // Select the most recently created card
                 if let Some(card) = self
                     .ctx
-                    .cards
+                    .cards()
                     .iter()
                     .rev()
                     .find(|c| c.column_id == column.id)
@@ -444,7 +444,7 @@ impl App {
             let board = self
                 .selection
                 .active_board_index
-                .and_then(|idx| self.ctx.boards.get(idx));
+                .and_then(|idx| self.ctx.boards().get(idx));
             let board = match board {
                 Some(b) => b,
                 None => return,
@@ -453,8 +453,8 @@ impl App {
             let move_result = kanban_domain::card_lifecycle::compute_card_column_move(
                 card,
                 board,
-                &self.ctx.columns,
-                &self.ctx.cards,
+                self.ctx.columns(),
+                self.ctx.cards(),
                 direction,
             );
 
@@ -505,10 +505,10 @@ impl App {
                             let num_cols = self
                                 .selection
                                 .active_board_index
-                                .and_then(|idx| self.ctx.boards.get(idx))
+                                .and_then(|idx| self.ctx.boards().get(idx))
                                 .map(|b| {
                                     self.ctx
-                                        .columns
+                                        .columns()
                                         .iter()
                                         .filter(|c| c.board_id == b.id)
                                         .count()
@@ -533,7 +533,7 @@ impl App {
         let board = self
             .selection
             .active_board_index
-            .and_then(|idx| self.ctx.boards.get(idx));
+            .and_then(|idx| self.ctx.boards().get(idx));
         let board = match board {
             Some(b) => b,
             None => return,
@@ -545,7 +545,7 @@ impl App {
         let mut moved_count = 0;
 
         for card_id in &card_ids {
-            let card = match self.ctx.cards.iter().find(|c| c.id == *card_id) {
+            let card = match self.ctx.cards().iter().find(|c| c.id == *card_id) {
                 Some(c) => c,
                 None => continue,
             };
@@ -553,8 +553,8 @@ impl App {
             let move_result = kanban_domain::card_lifecycle::compute_card_column_move(
                 card,
                 board,
-                &self.ctx.columns,
-                &self.ctx.cards,
+                self.ctx.columns(),
+                self.ctx.cards(),
                 direction,
             );
 
@@ -628,7 +628,7 @@ impl App {
         use kanban_domain::AnimationType;
         use std::time::Instant;
 
-        if self.ctx.cards.iter().any(|c| c.id == card_id) {
+        if self.ctx.cards().iter().any(|c| c.id == card_id) {
             self.animation.animating.insert(
                 card_id,
                 CardAnimation {
@@ -640,10 +640,7 @@ impl App {
     }
 
     pub fn compact_column_positions(&mut self, column_id: uuid::Uuid) {
-        kanban_domain::card_lifecycle::compact_column_positions(
-            &mut self.ctx.inner.cards,
-            column_id,
-        );
+        kanban_domain::card_lifecycle::compact_column_positions(self.ctx.cards_mut(), column_id);
     }
 
     pub fn select_card_after_deletion(
@@ -654,14 +651,14 @@ impl App {
         // Try to find a card in the same column at or after the deleted position
         if let Some(next_card) = self
             .ctx
-            .cards
+            .cards()
             .iter()
             .find(|c| c.column_id == deleted_column_id && c.position >= deleted_position)
         {
             self.select_card_by_id(next_card.id);
         } else if let Some(prev_card) = self
             .ctx
-            .cards
+            .cards()
             .iter()
             .rev()
             .find(|c| c.column_id == deleted_column_id)
@@ -700,7 +697,7 @@ impl App {
 
         if self
             .ctx
-            .archived_cards
+            .archived_cards()
             .iter()
             .any(|dc| dc.card.id == card_id)
         {
@@ -723,7 +720,7 @@ impl App {
         let board_id = self
             .selection
             .active_board_index
-            .and_then(|idx| self.ctx.boards.get(idx))
+            .and_then(|idx| self.ctx.boards().get(idx))
             .map(|b| b.id);
 
         let target_column_id = board_id
@@ -731,7 +728,7 @@ impl App {
                 kanban_domain::card_lifecycle::resolve_restore_column(
                     original_column_id,
                     bid,
-                    &self.ctx.columns,
+                    self.ctx.columns(),
                 )
             })
             .unwrap_or(original_column_id);
@@ -778,7 +775,7 @@ impl App {
 
         if self
             .ctx
-            .archived_cards
+            .archived_cards()
             .iter()
             .any(|dc| dc.card.id == card_id)
         {
@@ -835,7 +832,7 @@ impl App {
 
         // Get the board ID for filtering
         let board_id = match self.selection.active_board_index {
-            Some(idx) => match self.ctx.boards.get(idx) {
+            Some(idx) => match self.ctx.boards().get(idx) {
                 Some(board) => board.id,
                 None => return,
             },
@@ -843,12 +840,12 @@ impl App {
         };
 
         // Get ancestors to exclude (would create cycle)
-        let ancestors = self.ctx.graph.cards.ancestors(card_id);
+        let ancestors = self.ctx.graph().cards.ancestors(card_id);
 
         // Get cards from current board, excluding self and ancestors
         let column_ids: std::collections::HashSet<_> = self
             .ctx
-            .columns
+            .columns()
             .iter()
             .filter(|c| c.board_id == board_id)
             .map(|c| c.id)
@@ -856,7 +853,7 @@ impl App {
 
         let eligible_cards: Vec<_> = self
             .ctx
-            .cards
+            .cards()
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))
             .filter(|c| c.id != card_id)
@@ -865,11 +862,16 @@ impl App {
             .collect();
 
         // Get current children (for checkbox display)
-        let current_children: std::collections::HashSet<_> =
-            self.ctx.graph.cards.children(card_id).into_iter().collect();
+        let current_children: std::collections::HashSet<_> = self
+            .ctx
+            .graph()
+            .cards
+            .children(card_id)
+            .into_iter()
+            .collect();
 
         // Store the card index so the popup knows which card we're managing
-        self.selection.active_card_index = self.ctx.cards.iter().position(|c| c.id == card_id);
+        self.selection.active_card_index = self.ctx.cards().iter().position(|c| c.id == card_id);
 
         // Set up dialog state
         self.relationship.card_ids = eligible_cards;

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -640,7 +640,10 @@ impl App {
     }
 
     pub fn compact_column_positions(&mut self, column_id: uuid::Uuid) {
-        kanban_domain::card_lifecycle::compact_column_positions(self.ctx.cards_mut(), column_id);
+        let cmd = Box::new(kanban_domain::commands::CompactColumnPositions { column_id });
+        if let Err(e) = self.ctx.execute_command(cmd) {
+            tracing::error!("Failed to compact column positions: {}", e);
+        }
     }
 
     pub fn select_card_after_deletion(

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -638,7 +638,10 @@ impl App {
     }
 
     pub fn compact_column_positions(&mut self, column_id: uuid::Uuid) {
-        kanban_domain::card_lifecycle::compact_column_positions(&mut self.ctx.inner.cards, column_id);
+        kanban_domain::card_lifecycle::compact_column_positions(
+            &mut self.ctx.inner.cards,
+            column_id,
+        );
     }
 
     pub fn select_card_after_deletion(

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -2,7 +2,7 @@ use crate::app::{App, AppMode, CardField, DialogMode, Focus};
 use crate::card_list::CardListId;
 use crate::events::EventHandler;
 use kanban_domain::commands::{CreateCard, MoveCard, RestoreCard, SetBoardTaskSort, UpdateCard};
-use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, Column, SortOrder, Sprint};
+use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations, SortOrder, Sprint};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -344,11 +344,13 @@ impl App {
 
                 let column = match column {
                     Some(col) => col,
-                    None => {
-                        let new_column = Column::new(bid, "Todo".to_string(), 0);
-                        self.ctx.inner.columns.push(new_column.clone());
-                        new_column
-                    }
+                    None => match self.ctx.create_column(bid, "Todo".to_string(), Some(0)) {
+                        Ok(col) => col,
+                        Err(e) => {
+                            tracing::error!("Failed to create column: {}", e);
+                            return;
+                        }
+                    },
                 };
 
                 let position = kanban_domain::card_lifecycle::next_position_in_column(

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -135,6 +135,7 @@ impl App {
 
                             if let Err(e) = self.execute_command(cmd) {
                                 tracing::error!("Failed to set board task sort: {}", e);
+                                self.set_error(format!("Failed to set board task sort: {}", e));
                                 return;
                             }
                         }
@@ -204,6 +205,7 @@ impl App {
                     self.edit_card_field(terminal, event_handler, CardField::Description)
                 {
                     tracing::error!("Failed to edit card description: {}", e);
+                    self.set_error(format!("Failed to edit card description: {}", e));
                 }
                 should_restart = true;
             }
@@ -245,6 +247,7 @@ impl App {
             let cmd = Box::new(UpdateCard { card_id, updates });
             if let Err(e) = self.execute_command(cmd) {
                 tracing::error!("Failed to toggle card completion: {}", e);
+                self.set_error(format!("Failed to toggle card completion: {}", e));
                 return;
             }
 
@@ -303,6 +306,7 @@ impl App {
         if !update_commands.is_empty() {
             if let Err(e) = self.execute_commands_batch(update_commands) {
                 tracing::error!("Failed to toggle card completion: {}", e);
+                self.set_error(format!("Failed to toggle card completion: {}", e));
                 return;
             }
         }
@@ -348,6 +352,7 @@ impl App {
                         Ok(col) => col,
                         Err(e) => {
                             tracing::error!("Failed to create column: {}", e);
+                            self.set_error(format!("Failed to create column: {}", e));
                             return;
                         }
                     },
@@ -381,6 +386,7 @@ impl App {
 
                 if let Err(e) = self.execute_command(create_cmd) {
                     tracing::error!("Failed to create card: {}", e);
+                    self.set_error(format!("Failed to create card: {}", e));
                     return;
                 }
 
@@ -403,6 +409,7 @@ impl App {
 
                         if let Err(e) = self.execute_command(update_cmd) {
                             tracing::error!("Failed to update card status: {}", e);
+                            self.set_error(format!("Failed to update card status: {}", e));
                         }
                     }
                 }
@@ -488,6 +495,7 @@ impl App {
                     kanban_domain::card_lifecycle::MoveDirection::Right => "right",
                 };
                 tracing::error!("Failed to move card {}: {}", dir, e);
+                self.set_error(format!("Failed to move card {}: {}", dir, e));
                 return;
             }
 
@@ -589,6 +597,7 @@ impl App {
                     kanban_domain::card_lifecycle::MoveDirection::Right => "right",
                 };
                 tracing::error!("Failed to move cards {}: {}", dir, e);
+                self.set_error(format!("Failed to move cards {}: {}", dir, e));
                 return;
             }
         }
@@ -643,6 +652,7 @@ impl App {
         let cmd = Box::new(kanban_domain::commands::CompactColumnPositions { column_id });
         if let Err(e) = self.ctx.execute_command(cmd) {
             tracing::error!("Failed to compact column positions: {}", e);
+            self.set_error(format!("Failed to compact column positions: {}", e));
         }
     }
 
@@ -744,6 +754,7 @@ impl App {
 
         if let Err(e) = self.execute_command(cmd) {
             tracing::error!("Failed to restore card: {}", e);
+            self.set_error(format!("Failed to restore card: {}", e));
             return;
         }
 

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -9,7 +9,7 @@ impl App {
     pub fn handle_create_column_key(&mut self) {
         if self.focus.board_focus == BoardFocus::Columns {
             if let Some(board_idx) = self.selection.board.get() {
-                if self.ctx.boards.get(board_idx).is_some() {
+                if self.ctx.boards().get(board_idx).is_some() {
                     self.open_dialog(DialogMode::CreateColumn);
                     self.input.clear();
                 }
@@ -22,10 +22,10 @@ impl App {
             && self.dialog_input.column_selection.get().is_some()
         {
             if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     let board_columns: Vec<_> = self
                         .ctx
-                        .columns
+                        .columns()
                         .iter()
                         .filter(|col| col.board_id == board.id)
                         .collect();
@@ -46,10 +46,10 @@ impl App {
             && self.dialog_input.column_selection.get().is_some()
         {
             if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     let column_count = self
                         .ctx
-                        .columns
+                        .columns()
                         .iter()
                         .filter(|col| col.board_id == board.id)
                         .count();
@@ -69,11 +69,11 @@ impl App {
             && self.dialog_input.column_selection.get().is_some()
         {
             if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     // Collect and sort column data before mutating
                     let mut board_columns: Vec<_> = self
                         .ctx
-                        .columns
+                        .columns()
                         .iter()
                         .filter(|col| col.board_id == board.id)
                         .map(|col| (col.id, col.position))
@@ -126,11 +126,11 @@ impl App {
             && self.dialog_input.column_selection.get().is_some()
         {
             if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     // Collect and sort column data before mutating
                     let mut board_columns: Vec<_> = self
                         .ctx
-                        .columns
+                        .columns()
                         .iter()
                         .filter(|col| col.board_id == board.id)
                         .map(|col| (col.id, col.position))
@@ -185,7 +185,7 @@ impl App {
         }
 
         if let Some(board_idx) = self.selection.active_board_index {
-            if let Some(board) = self.ctx.boards.get(board_idx) {
+            if let Some(board) = self.ctx.boards().get(board_idx) {
                 let current_view_idx = match board.task_list_view {
                     TaskListView::Flat => 0,
                     TaskListView::GroupedByColumn => 1,
@@ -202,7 +202,7 @@ impl App {
     pub fn create_column(&mut self) {
         if let Some(board_idx) = self.selection.board.get() {
             // Collect board_id before command execution
-            let board_id = self.ctx.boards.get(board_idx).map(|board| board.id);
+            let board_id = self.ctx.boards().get(board_idx).map(|board| board.id);
 
             if let Some(board_id) = board_id {
                 let column_name = self.input.as_str().trim().to_string();
@@ -214,7 +214,7 @@ impl App {
 
                 let position = self
                     .ctx
-                    .columns
+                    .columns()
                     .iter()
                     .filter(|col| col.board_id == board_id)
                     .map(|col| col.position)
@@ -237,7 +237,7 @@ impl App {
 
                 let board_column_count = self
                     .ctx
-                    .columns
+                    .columns()
                     .iter()
                     .filter(|col| col.board_id == board_id)
                     .count();
@@ -253,11 +253,11 @@ impl App {
         if let Some(board_idx) = self.selection.board.get() {
             // Collect column ID before mutable borrow
             let column_info = {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     if let Some(column_idx) = self.dialog_input.column_selection.get() {
                         let board_columns: Vec<_> = self
                             .ctx
-                            .columns
+                            .columns()
                             .iter()
                             .filter(|col| col.board_id == board.id)
                             .collect();
@@ -301,11 +301,11 @@ impl App {
         if let Some(board_idx) = self.selection.board.get() {
             // Collect all necessary data before mutating
             let delete_info = {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     if let Some(column_idx) = self.dialog_input.column_selection.get() {
                         let board_columns: Vec<_> = self
                             .ctx
-                            .columns
+                            .columns()
                             .iter()
                             .filter(|col| col.board_id == board.id)
                             .map(|col| (col.id, col.name.clone()))
@@ -321,7 +321,7 @@ impl App {
                         if let Some((column_id, column_name)) = column_to_delete {
                             let cards_to_move: Vec<(uuid::Uuid, i32)> = self
                                 .ctx
-                                .cards
+                                .cards()
                                 .iter()
                                 .filter(|card| card.column_id == column_id)
                                 .map(|card| (card.id, card.position))
@@ -386,10 +386,10 @@ impl App {
 
                 let remaining_columns = self
                     .ctx
-                    .columns
+                    .columns()
                     .iter()
                     .filter(|col| {
-                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
                             col.board_id == board.id
                         } else {
                             false
@@ -513,7 +513,7 @@ impl App {
                     let selected_card_id = self.get_selected_card_id();
 
                     if let Some(board_idx) = self.selection.active_board_index {
-                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
                             let cmd = Box::new(SetBoardTaskListView {
                                 board_id: board.id,
                                 view,

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -109,6 +109,7 @@ impl App {
 
                             if let Err(e) = self.execute_commands_batch(vec![cmd1, cmd2]) {
                                 tracing::error!("Failed to move column: {}", e);
+                                self.set_error(format!("Failed to move column: {}", e));
                                 return;
                             }
 
@@ -166,6 +167,7 @@ impl App {
 
                             if let Err(e) = self.execute_commands_batch(vec![cmd1, cmd2]) {
                                 tracing::error!("Failed to move column: {}", e);
+                                self.set_error(format!("Failed to move column: {}", e));
                                 return;
                             }
 
@@ -230,6 +232,7 @@ impl App {
 
                 if let Err(e) = self.execute_command(cmd) {
                     tracing::error!("Failed to create column: {}", e);
+                    self.set_error(format!("Failed to create column: {}", e));
                     return;
                 }
 
@@ -289,6 +292,7 @@ impl App {
 
                 if let Err(e) = self.execute_command(cmd) {
                     tracing::error!("Failed to rename column: {}", e);
+                    self.set_error(format!("Failed to rename column: {}", e));
                     return;
                 }
 
@@ -369,6 +373,7 @@ impl App {
 
                         if let Err(e) = self.execute_commands_batch(move_commands) {
                             tracing::error!("Failed to move cards: {}", e);
+                            self.set_error(format!("Failed to move cards: {}", e));
                             return;
                         }
 
@@ -379,6 +384,7 @@ impl App {
                 let cmd = Box::new(DeleteColumn { column_id });
                 if let Err(e) = self.execute_command(cmd) {
                     tracing::error!("Failed to delete column: {}", e);
+                    self.set_error(format!("Failed to delete column: {}", e));
                     return;
                 }
 
@@ -521,6 +527,7 @@ impl App {
 
                             if let Err(e) = self.execute_command(cmd) {
                                 tracing::error!("Failed to set task list view: {}", e);
+                                self.set_error(format!("Failed to set task list view: {}", e));
                                 self.pop_mode();
                                 self.dialog_input.task_list_view_selection.clear();
                                 return;

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -237,7 +237,7 @@ impl App {
                             ) {
                                 tracing::error!("Failed to edit metadata: {}", e);
                             } else {
-                                self.ctx.inner.record_undo_snapshot(before);
+                                self.ctx.inner.push_before_snapshot(before);
                                 let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
@@ -388,7 +388,7 @@ impl App {
                             ) {
                                 tracing::error!("Failed to edit board settings: {}", e);
                             } else {
-                                self.ctx.inner.record_undo_snapshot(before);
+                                self.ctx.inner.push_before_snapshot(before);
                                 let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1,8 +1,10 @@
 use crate::app::{
     App, AppMode, BoardField, BoardFocus, CardField, CardFocus, DialogMode, SprintTaskPanel,
 };
+use crate::editor::edit_in_external_editor;
 use crate::events::EventHandler;
 use crossterm::event::KeyCode;
+use kanban_core::Editable;
 use kanban_domain::{dependencies::CardGraphExt, BoardSettingsDto, CardMetadataDto};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
@@ -224,22 +226,37 @@ impl App {
                 }
                 CardFocus::Metadata => {
                     if let Some(card_idx) = self.selection.active_card_index {
-                        let before = self.ctx.snapshot();
-                        if let Some(card) = self.ctx.cards_mut().get_mut(card_idx) {
+                        if let Some(card) = self.ctx.cards().get(card_idx) {
                             let card_id = card.id;
+                            let dto = CardMetadataDto::from_entity(card);
+                            let json = serde_json::to_string_pretty(&dto)
+                                .unwrap_or_else(|_| "{}".to_string());
                             let temp_file = std::env::temp_dir()
                                 .join(format!("kanban-card-{}-metadata.json", card_id));
-                            if let Err(e) = App::edit_entity_json_impl::<CardMetadataDto, _>(
-                                card,
-                                terminal,
-                                event_handler,
-                                temp_file,
-                            ) {
-                                tracing::error!("Failed to edit metadata: {}", e);
-                            } else {
-                                self.ctx.push_before_snapshot(before);
-                                let snapshot = self.ctx.snapshot();
-                                self.ctx.state_manager.queue_snapshot(snapshot);
+                            match edit_in_external_editor(terminal, event_handler, temp_file, &json)
+                            {
+                                Ok(Some(new_content)) => {
+                                    match serde_json::from_str::<CardMetadataDto>(&new_content) {
+                                        Ok(new_dto) => {
+                                            let cmd = Box::new(
+                                                kanban_domain::commands::ApplyCardMetadata {
+                                                    card_id,
+                                                    dto: new_dto,
+                                                },
+                                            );
+                                            if let Err(e) = self.ctx.execute_command(cmd) {
+                                                tracing::error!("Failed to apply metadata: {}", e);
+                                            }
+                                        }
+                                        Err(e) => {
+                                            tracing::error!("Failed to parse metadata JSON: {}", e);
+                                        }
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(e) => {
+                                    tracing::error!("Failed to edit metadata: {}", e);
+                                }
                             }
                             should_restart = true;
                         }
@@ -375,22 +392,43 @@ impl App {
                 }
                 BoardFocus::Settings => {
                     if let Some(board_idx) = self.selection.board.get() {
-                        let before = self.ctx.snapshot();
-                        if let Some(board) = self.ctx.boards_mut().get_mut(board_idx) {
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
                             let board_id = board.id;
+                            let dto = BoardSettingsDto::from_entity(board);
+                            let json = serde_json::to_string_pretty(&dto)
+                                .unwrap_or_else(|_| "{}".to_string());
                             let temp_file = std::env::temp_dir()
                                 .join(format!("kanban-board-{}-settings.json", board_id));
-                            if let Err(e) = App::edit_entity_json_impl::<BoardSettingsDto, _>(
-                                board,
-                                terminal,
-                                event_handler,
-                                temp_file,
-                            ) {
-                                tracing::error!("Failed to edit board settings: {}", e);
-                            } else {
-                                self.ctx.push_before_snapshot(before);
-                                let snapshot = self.ctx.snapshot();
-                                self.ctx.state_manager.queue_snapshot(snapshot);
+                            match edit_in_external_editor(terminal, event_handler, temp_file, &json)
+                            {
+                                Ok(Some(new_content)) => {
+                                    match serde_json::from_str::<BoardSettingsDto>(&new_content) {
+                                        Ok(new_dto) => {
+                                            let cmd = Box::new(
+                                                kanban_domain::commands::ApplyBoardSettings {
+                                                    board_id,
+                                                    dto: new_dto,
+                                                },
+                                            );
+                                            if let Err(e) = self.ctx.execute_command(cmd) {
+                                                tracing::error!(
+                                                    "Failed to apply board settings: {}",
+                                                    e
+                                                );
+                                            }
+                                        }
+                                        Err(e) => {
+                                            tracing::error!(
+                                                "Failed to parse board settings JSON: {}",
+                                                e
+                                            );
+                                        }
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(e) => {
+                                    tracing::error!("Failed to edit board settings: {}", e);
+                                }
                             }
                             should_restart = true;
                         }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -213,6 +213,7 @@ impl App {
                     if let Err(e) = self.edit_card_field(terminal, event_handler, CardField::Title)
                     {
                         tracing::error!("Failed to edit title: {}", e);
+                        self.set_error(format!("Failed to edit title: {}", e));
                     }
                     should_restart = true;
                 }
@@ -221,6 +222,7 @@ impl App {
                         self.edit_card_field(terminal, event_handler, CardField::Description)
                     {
                         tracing::error!("Failed to edit description: {}", e);
+                        self.set_error(format!("Failed to edit description: {}", e));
                     }
                     should_restart = true;
                 }
@@ -246,16 +248,25 @@ impl App {
                                             );
                                             if let Err(e) = self.ctx.execute_command(cmd) {
                                                 tracing::error!("Failed to apply metadata: {}", e);
+                                                self.set_error(format!(
+                                                    "Failed to apply metadata: {}",
+                                                    e
+                                                ));
                                             }
                                         }
                                         Err(e) => {
                                             tracing::error!("Failed to parse metadata JSON: {}", e);
+                                            self.set_error(format!(
+                                                "Failed to parse metadata JSON: {}",
+                                                e
+                                            ));
                                         }
                                     }
                                 }
                                 Ok(None) => {}
                                 Err(e) => {
                                     tracing::error!("Failed to edit metadata: {}", e);
+                                    self.set_error(format!("Failed to edit metadata: {}", e));
                                 }
                             }
                             should_restart = true;
@@ -379,6 +390,7 @@ impl App {
                     if let Err(e) = self.edit_board_field(terminal, event_handler, BoardField::Name)
                     {
                         tracing::error!("Failed to edit board name: {}", e);
+                        self.set_error(format!("Failed to edit board name: {}", e));
                     }
                     should_restart = true;
                 }
@@ -387,6 +399,7 @@ impl App {
                         self.edit_board_field(terminal, event_handler, BoardField::Description)
                     {
                         tracing::error!("Failed to edit board description: {}", e);
+                        self.set_error(format!("Failed to edit board description: {}", e));
                     }
                     should_restart = true;
                 }
@@ -415,6 +428,10 @@ impl App {
                                                     "Failed to apply board settings: {}",
                                                     e
                                                 );
+                                                self.set_error(format!(
+                                                    "Failed to apply board settings: {}",
+                                                    e
+                                                ));
                                             }
                                         }
                                         Err(e) => {
@@ -422,12 +439,17 @@ impl App {
                                                 "Failed to parse board settings JSON: {}",
                                                 e
                                             );
+                                            self.set_error(format!(
+                                                "Failed to parse board settings JSON: {}",
+                                                e
+                                            ));
                                         }
                                     }
                                 }
                                 Ok(None) => {}
                                 Err(e) => {
                                     tracing::error!("Failed to edit board settings: {}", e);
+                                    self.set_error(format!("Failed to edit board settings: {}", e));
                                 }
                             }
                             should_restart = true;
@@ -797,6 +819,10 @@ impl App {
                                 });
                                 if let Err(e) = self.execute_command(cmd) {
                                     tracing::error!("Failed to toggle card completion: {}", e);
+                                    self.set_error(format!(
+                                        "Failed to toggle card completion: {}",
+                                        e
+                                    ));
                                 }
                             }
                         }
@@ -914,6 +940,7 @@ impl App {
                                     });
                                     if let Err(e) = self.execute_command(move_cmd) {
                                         tracing::error!("Failed to move card: {}", e);
+                                        self.set_error(format!("Failed to move card: {}", e));
                                         return;
                                     }
 
@@ -928,6 +955,10 @@ impl App {
                                             });
                                         if let Err(e) = self.execute_command(status_cmd) {
                                             tracing::error!("Failed to update card status: {}", e);
+                                            self.set_error(format!(
+                                                "Failed to update card status: {}",
+                                                e
+                                            ));
                                         }
                                     }
                                 }
@@ -1272,6 +1303,7 @@ impl App {
         if !update_commands.is_empty() {
             if let Err(e) = self.execute_commands_batch(update_commands) {
                 tracing::error!("Failed to toggle card completion: {}", e);
+                self.set_error(format!("Failed to toggle card completion: {}", e));
                 return;
             }
         }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2,9 +2,8 @@ use crate::app::{
     App, AppMode, BoardField, BoardFocus, CardField, CardFocus, DialogMode, SprintTaskPanel,
 };
 use crate::events::EventHandler;
-use crate::state::TuiSnapshot;
 use crossterm::event::KeyCode;
-use kanban_domain::{dependencies::CardGraphExt, BoardSettingsDto, CardMetadataDto, Snapshot};
+use kanban_domain::{dependencies::CardGraphExt, BoardSettingsDto, CardMetadataDto};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -225,7 +224,7 @@ impl App {
                 }
                 CardFocus::Metadata => {
                     if let Some(card_idx) = self.selection.active_card_index {
-                        if let Some(card) = self.ctx.cards.get_mut(card_idx) {
+                        if let Some(card) = self.ctx.inner.cards.get_mut(card_idx) {
                             let card_id = card.id;
                             let temp_file = std::env::temp_dir()
                                 .join(format!("kanban-card-{}-metadata.json", card_id));
@@ -237,8 +236,8 @@ impl App {
                             ) {
                                 tracing::error!("Failed to edit metadata: {}", e);
                             } else {
-                                self.ctx.state_manager.mark_dirty();
-                                let snapshot = Snapshot::from_app(self);
+                                self.ctx.inner.mark_dirty();
+                                let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
                             should_restart = true;
@@ -375,7 +374,7 @@ impl App {
                 }
                 BoardFocus::Settings => {
                     if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.ctx.boards.get_mut(board_idx) {
+                        if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
                             let board_id = board.id;
                             let temp_file = std::env::temp_dir()
                                 .join(format!("kanban-board-{}-settings.json", board_id));
@@ -387,8 +386,8 @@ impl App {
                             ) {
                                 tracing::error!("Failed to edit board settings: {}", e);
                             } else {
-                                self.ctx.state_manager.mark_dirty();
-                                let snapshot = Snapshot::from_app(self);
+                                self.ctx.inner.mark_dirty();
+                                let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
                             should_restart = true;

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -224,8 +224,8 @@ impl App {
                 }
                 CardFocus::Metadata => {
                     if let Some(card_idx) = self.selection.active_card_index {
-                        let before = self.ctx.inner.snapshot();
-                        if let Some(card) = self.ctx.inner.cards.get_mut(card_idx) {
+                        let before = self.ctx.snapshot();
+                        if let Some(card) = self.ctx.cards_mut().get_mut(card_idx) {
                             let card_id = card.id;
                             let temp_file = std::env::temp_dir()
                                 .join(format!("kanban-card-{}-metadata.json", card_id));
@@ -237,8 +237,8 @@ impl App {
                             ) {
                                 tracing::error!("Failed to edit metadata: {}", e);
                             } else {
-                                self.ctx.inner.push_before_snapshot(before);
-                                let snapshot = self.ctx.inner.snapshot();
+                                self.ctx.push_before_snapshot(before);
+                                let snapshot = self.ctx.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
                             should_restart = true;
@@ -261,10 +261,10 @@ impl App {
             }
             KeyCode::Char('a') => {
                 if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.ctx.boards.get(board_idx) {
+                    if let Some(board) = self.ctx.boards().get(board_idx) {
                         let sprint_count = self
                             .ctx
-                            .sprints
+                            .sprints()
                             .iter()
                             .filter(|s| s.board_id == board.id)
                             .count();
@@ -375,8 +375,8 @@ impl App {
                 }
                 BoardFocus::Settings => {
                     if let Some(board_idx) = self.selection.board.get() {
-                        let before = self.ctx.inner.snapshot();
-                        if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
+                        let before = self.ctx.snapshot();
+                        if let Some(board) = self.ctx.boards_mut().get_mut(board_idx) {
                             let board_id = board.id;
                             let temp_file = std::env::temp_dir()
                                 .join(format!("kanban-board-{}-settings.json", board_id));
@@ -388,8 +388,8 @@ impl App {
                             ) {
                                 tracing::error!("Failed to edit board settings: {}", e);
                             } else {
-                                self.ctx.inner.push_before_snapshot(before);
-                                let snapshot = self.ctx.inner.snapshot();
+                                self.ctx.push_before_snapshot(before);
+                                let snapshot = self.ctx.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
                             should_restart = true;
@@ -429,10 +429,10 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => match self.focus.board_focus {
                 BoardFocus::Sprints => {
                     if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
                             let sprint_count = self
                                 .ctx
-                                .sprints
+                                .sprints()
                                 .iter()
                                 .filter(|s| s.board_id == board.id)
                                 .count();
@@ -448,10 +448,10 @@ impl App {
                 }
                 BoardFocus::Columns => {
                     if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
                             let column_count = self
                                 .ctx
-                                .columns
+                                .columns()
                                 .iter()
                                 .filter(|col| col.board_id == board.id)
                                 .count();
@@ -496,10 +496,10 @@ impl App {
                             .selection
                             .board
                             .get()
-                            .and_then(|idx| self.ctx.boards.get(idx))
+                            .and_then(|idx| self.ctx.boards().get(idx))
                             .map(|board| {
                                 self.ctx
-                                    .sprints
+                                    .sprints()
                                     .iter()
                                     .filter(|s| s.board_id == board.id)
                                     .count()
@@ -532,10 +532,10 @@ impl App {
                 if self.focus.board_focus == BoardFocus::Sprints {
                     if let Some(sprint_idx) = self.selection.sprint.get() {
                         if let Some(board_idx) = self.selection.board.get() {
-                            if let Some(board) = self.ctx.boards.get(board_idx) {
+                            if let Some(board) = self.ctx.boards().get(board_idx) {
                                 let board_sprints: Vec<_> = self
                                     .ctx
-                                    .sprints
+                                    .sprints()
                                     .iter()
                                     .enumerate()
                                     .filter(|(_, s)| s.board_id == board.id)
@@ -543,7 +543,7 @@ impl App {
                                 if let Some((actual_idx, _)) = board_sprints.get(sprint_idx) {
                                     self.selection.active_sprint_index = Some(*actual_idx);
                                     self.selection.active_board_index = Some(board_idx);
-                                    if let Some(sprint) = self.ctx.sprints.get(*actual_idx) {
+                                    if let Some(sprint) = self.ctx.sprints().get(*actual_idx) {
                                         self.populate_sprint_task_lists(sprint.id);
                                     }
                                     self.push_mode(AppMode::SprintDetail);
@@ -556,7 +556,7 @@ impl App {
             KeyCode::Char('p') => {
                 if self.focus.board_focus == BoardFocus::Settings {
                     if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
                             let current_prefix =
                                 board.sprint_prefix.clone().unwrap_or_else(String::new);
                             self.input.set(current_prefix);
@@ -606,7 +606,7 @@ impl App {
             }
             KeyCode::Char('p') => {
                 if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
+                    if let Some(sprint) = self.ctx.sprints().get(sprint_idx) {
                         let current_prefix = sprint.prefix.clone().unwrap_or_else(String::new);
                         self.input.set(current_prefix);
                         self.open_dialog(DialogMode::SetSprintPrefix);
@@ -615,7 +615,7 @@ impl App {
             }
             KeyCode::Char('C') => {
                 if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
+                    if let Some(sprint) = self.ctx.sprints().get(sprint_idx) {
                         let current_prefix = sprint.card_prefix.clone().unwrap_or_else(String::new);
                         self.input.set(current_prefix);
                         self.open_dialog(DialogMode::SetSprintCardPrefix);
@@ -643,7 +643,7 @@ impl App {
             }
             KeyCode::Char('M') => {
                 if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
+                    if let Some(sprint) = self.ctx.sprints().get(sprint_idx) {
                         use kanban_domain::SprintStatus;
                         if sprint.status == SprintStatus::Completed
                             || sprint.status == SprintStatus::Cancelled
@@ -656,7 +656,7 @@ impl App {
             }
             KeyCode::Char('h') | KeyCode::Left => {
                 if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
+                    if let Some(sprint) = self.ctx.sprints().get(sprint_idx) {
                         if sprint.status == kanban_domain::SprintStatus::Completed {
                             self.sprint_view.panel = SprintTaskPanel::Uncompleted;
                         }
@@ -665,7 +665,7 @@ impl App {
             }
             KeyCode::Char('l') | KeyCode::Right => {
                 if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
+                    if let Some(sprint) = self.ctx.sprints().get(sprint_idx) {
                         if sprint.status == kanban_domain::SprintStatus::Completed {
                             self.sprint_view.panel = SprintTaskPanel::Completed;
                         }
@@ -687,7 +687,7 @@ impl App {
                     match action {
                         CardListAction::Select(card_id) => {
                             if let Some(card_idx) =
-                                self.ctx.cards.iter().position(|c| c.id == card_id)
+                                self.ctx.cards().iter().position(|c| c.id == card_id)
                             {
                                 self.selection.active_card_index = Some(card_idx);
                                 // Initialize list components with item counts
@@ -705,7 +705,7 @@ impl App {
                         }
                         CardListAction::Edit(card_id) => {
                             if let Some(card_idx) =
-                                self.ctx.cards.iter().position(|c| c.id == card_id)
+                                self.ctx.cards().iter().position(|c| c.id == card_id)
                             {
                                 self.selection.active_card_index = Some(card_idx);
                                 // Initialize list components with item counts
@@ -722,7 +722,7 @@ impl App {
                             }
                         }
                         CardListAction::Complete(card_id) => {
-                            if let Some(card) = self.ctx.cards.iter().find(|c| c.id == card_id) {
+                            if let Some(card) = self.ctx.cards().iter().find(|c| c.id == card_id) {
                                 use kanban_domain::{CardStatus, CardUpdate};
                                 let new_status = if card.status == CardStatus::Done {
                                     CardStatus::Todo
@@ -732,12 +732,12 @@ impl App {
 
                                 let toggle_result =
                                     self.selection.active_board_index.and_then(|idx| {
-                                        self.ctx.boards.get(idx).and_then(|board| {
+                                        self.ctx.boards().get(idx).and_then(|board| {
                                         kanban_domain::card_lifecycle::compute_completion_toggle(
                                             card,
                                             board,
-                                            &self.ctx.columns,
-                                            &self.ctx.cards,
+                                            self.ctx.columns(),
+                                            self.ctx.cards(),
                                         )
                                     })
                                     });
@@ -764,7 +764,7 @@ impl App {
                         }
                         CardListAction::TogglePriority(card_id) => {
                             if let Some(card_idx) =
-                                self.ctx.cards.iter().position(|c| c.id == card_id)
+                                self.ctx.cards().iter().position(|c| c.id == card_id)
                             {
                                 self.selection.active_card_index = Some(card_idx);
                                 let priority_idx = self.get_current_priority_selection_index();
@@ -774,14 +774,14 @@ impl App {
                         }
                         CardListAction::AssignSprint(card_id) => {
                             if let Some(card_idx) =
-                                self.ctx.cards.iter().position(|c| c.id == card_id)
+                                self.ctx.cards().iter().position(|c| c.id == card_id)
                             {
                                 self.selection.active_card_index = Some(card_idx);
                                 if let Some(board_idx) = self.selection.active_board_index {
-                                    if let Some(board) = self.ctx.boards.get(board_idx) {
+                                    if let Some(board) = self.ctx.boards().get(board_idx) {
                                         let sprint_count = self
                                             .ctx
-                                            .sprints
+                                            .sprints()
                                             .iter()
                                             .filter(|s| s.board_id == board.id)
                                             .count();
@@ -799,14 +799,14 @@ impl App {
                         }
                         CardListAction::ReassignSprint(card_id) => {
                             if let Some(card_idx) =
-                                self.ctx.cards.iter().position(|c| c.id == card_id)
+                                self.ctx.cards().iter().position(|c| c.id == card_id)
                             {
                                 self.selection.active_card_index = Some(card_idx);
                                 if let Some(board_idx) = self.selection.active_board_index {
-                                    if let Some(board) = self.ctx.boards.get(board_idx) {
+                                    if let Some(board) = self.ctx.boards().get(board_idx) {
                                         let sprint_count = self
                                             .ctx
-                                            .sprints
+                                            .sprints()
                                             .iter()
                                             .filter(|s| s.board_id == board.id)
                                             .count();
@@ -847,7 +847,7 @@ impl App {
                         }
                         CardListAction::MoveColumn(card_id, is_right) => {
                             if let Some(card) =
-                                self.ctx.cards.iter().find(|c| c.id == card_id).cloned()
+                                self.ctx.cards().iter().find(|c| c.id == card_id).cloned()
                             {
                                 let direction = if is_right {
                                     kanban_domain::card_lifecycle::MoveDirection::Right
@@ -857,12 +857,12 @@ impl App {
 
                                 let move_result =
                                     self.selection.active_board_index.and_then(|idx| {
-                                        self.ctx.boards.get(idx).and_then(|board| {
+                                        self.ctx.boards().get(idx).and_then(|board| {
                                             kanban_domain::card_lifecycle::compute_card_column_move(
                                                 &card,
                                                 board,
-                                                &self.ctx.columns,
-                                                &self.ctx.cards,
+                                                self.ctx.columns(),
+                                                self.ctx.cards(),
                                                 direction,
                                             )
                                         })
@@ -953,26 +953,26 @@ impl App {
 
     pub(crate) fn handle_manage_parents(&mut self) {
         if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.ctx.cards.get(card_idx) {
+            if let Some(card) = self.ctx.cards().get(card_idx) {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
                 // Get the board for this card's column
                 let board_id = self
                     .ctx
-                    .columns
+                    .columns()
                     .iter()
                     .find(|c| c.id == card_column_id)
                     .map(|c| c.board_id);
 
                 if let Some(board_id) = board_id {
                     // Get all descendants to exclude (to prevent cycles)
-                    let descendants = self.ctx.graph.cards.descendants(card_id);
+                    let descendants = self.ctx.graph().cards.descendants(card_id);
 
                     // Get cards from current board, excluding self and descendants
                     let column_ids: std::collections::HashSet<_> = self
                         .ctx
-                        .columns
+                        .columns()
                         .iter()
                         .filter(|c| c.board_id == board_id)
                         .map(|c| c.id)
@@ -980,7 +980,7 @@ impl App {
 
                     let eligible_cards: Vec<_> = self
                         .ctx
-                        .cards
+                        .cards()
                         .iter()
                         .filter(|c| column_ids.contains(&c.column_id))
                         .filter(|c| c.id != card_id)
@@ -989,8 +989,13 @@ impl App {
                         .collect();
 
                     // Get current parents (for checkbox display)
-                    let current_parents: std::collections::HashSet<_> =
-                        self.ctx.graph.cards.parents(card_id).into_iter().collect();
+                    let current_parents: std::collections::HashSet<_> = self
+                        .ctx
+                        .graph()
+                        .cards
+                        .parents(card_id)
+                        .into_iter()
+                        .collect();
 
                     // Set up dialog state
                     self.relationship.card_ids = eligible_cards;
@@ -1006,26 +1011,26 @@ impl App {
 
     pub(crate) fn handle_manage_children(&mut self) {
         if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.ctx.cards.get(card_idx) {
+            if let Some(card) = self.ctx.cards().get(card_idx) {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
                 // Get the board for this card's column
                 let board_id = self
                     .ctx
-                    .columns
+                    .columns()
                     .iter()
                     .find(|c| c.id == card_column_id)
                     .map(|c| c.board_id);
 
                 if let Some(board_id) = board_id {
                     // Get all ancestors to exclude (to prevent cycles)
-                    let ancestors = self.ctx.graph.cards.ancestors(card_id);
+                    let ancestors = self.ctx.graph().cards.ancestors(card_id);
 
                     // Get cards from current board, excluding self and ancestors
                     let column_ids: std::collections::HashSet<_> = self
                         .ctx
-                        .columns
+                        .columns()
                         .iter()
                         .filter(|c| c.board_id == board_id)
                         .map(|c| c.id)
@@ -1033,7 +1038,7 @@ impl App {
 
                     let eligible_cards: Vec<_> = self
                         .ctx
-                        .cards
+                        .cards()
                         .iter()
                         .filter(|c| column_ids.contains(&c.column_id))
                         .filter(|c| c.id != card_id)
@@ -1042,8 +1047,13 @@ impl App {
                         .collect();
 
                     // Get current children (for checkbox display)
-                    let current_children: std::collections::HashSet<_> =
-                        self.ctx.graph.cards.children(card_id).into_iter().collect();
+                    let current_children: std::collections::HashSet<_> = self
+                        .ctx
+                        .graph()
+                        .cards
+                        .children(card_id)
+                        .into_iter()
+                        .collect();
 
                     // Set up dialog state
                     self.relationship.card_ids = eligible_cards;
@@ -1059,8 +1069,8 @@ impl App {
 
     pub fn get_current_card_parents(&self) -> Vec<uuid::Uuid> {
         if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.ctx.cards.get(card_idx) {
-                return self.ctx.graph.cards.parents(card.id);
+            if let Some(card) = self.ctx.cards().get(card_idx) {
+                return self.ctx.graph().cards.parents(card.id);
             }
         }
         Vec::new()
@@ -1068,8 +1078,8 @@ impl App {
 
     pub fn get_current_card_children(&self) -> Vec<uuid::Uuid> {
         if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.ctx.cards.get(card_idx) {
-                return self.ctx.graph.cards.children(card.id);
+            if let Some(card) = self.ctx.cards().get(card_idx) {
+                return self.ctx.graph().cards.children(card.id);
             }
         }
         Vec::new()
@@ -1079,7 +1089,7 @@ impl App {
         let parents = self.get_current_card_parents();
         if let Some(selected_idx) = self.relationship.parents_list.selection.get() {
             if let Some(&parent_id) = parents.get(selected_idx) {
-                if let Some(parent_idx) = self.ctx.cards.iter().position(|c| c.id == parent_id) {
+                if let Some(parent_idx) = self.ctx.cards().iter().position(|c| c.id == parent_id) {
                     // Push current card to history
                     self.selection
                         .card_navigation_history
@@ -1102,7 +1112,7 @@ impl App {
         }
         // If no valid selection, navigate to first parent if available
         if !parents.is_empty() {
-            if let Some(parent_idx) = self.ctx.cards.iter().position(|c| c.id == parents[0]) {
+            if let Some(parent_idx) = self.ctx.cards().iter().position(|c| c.id == parents[0]) {
                 self.selection
                     .card_navigation_history
                     .push(current_card_idx);
@@ -1125,7 +1135,7 @@ impl App {
         let children = self.get_current_card_children();
         if let Some(selected_idx) = self.relationship.children_list.selection.get() {
             if let Some(&child_id) = children.get(selected_idx) {
-                if let Some(child_idx) = self.ctx.cards.iter().position(|c| c.id == child_id) {
+                if let Some(child_idx) = self.ctx.cards().iter().position(|c| c.id == child_id) {
                     // Push current card to history
                     self.selection
                         .card_navigation_history
@@ -1148,7 +1158,7 @@ impl App {
         }
         // If no valid selection, navigate to first child if available
         if !children.is_empty() {
-            if let Some(child_idx) = self.ctx.cards.iter().position(|c| c.id == children[0]) {
+            if let Some(child_idx) = self.ctx.cards().iter().position(|c| c.id == children[0]) {
                 self.selection
                     .card_navigation_history
                     .push(current_card_idx);
@@ -1180,18 +1190,18 @@ impl App {
         let mut update_commands: Vec<Box<dyn kanban_domain::commands::Command>> = Vec::new();
 
         for card_id in &ids {
-            let card = match self.ctx.cards.iter().find(|c| c.id == *card_id) {
+            let card = match self.ctx.cards().iter().find(|c| c.id == *card_id) {
                 Some(c) => c.clone(),
                 None => continue,
             };
 
             let toggle_result = self.selection.active_board_index.and_then(|idx| {
-                self.ctx.boards.get(idx).and_then(|board| {
+                self.ctx.boards().get(idx).and_then(|board| {
                     kanban_domain::card_lifecycle::compute_completion_toggle(
                         &card,
                         board,
-                        &self.ctx.columns,
-                        &self.ctx.cards,
+                        self.ctx.columns(),
+                        self.ctx.cards(),
                     )
                 })
             });

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -224,6 +224,7 @@ impl App {
                 }
                 CardFocus::Metadata => {
                     if let Some(card_idx) = self.selection.active_card_index {
+                        let before = self.ctx.inner.snapshot();
                         if let Some(card) = self.ctx.inner.cards.get_mut(card_idx) {
                             let card_id = card.id;
                             let temp_file = std::env::temp_dir()
@@ -236,7 +237,7 @@ impl App {
                             ) {
                                 tracing::error!("Failed to edit metadata: {}", e);
                             } else {
-                                self.ctx.inner.mark_dirty();
+                                self.ctx.inner.record_undo_snapshot(before);
                                 let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }
@@ -374,6 +375,7 @@ impl App {
                 }
                 BoardFocus::Settings => {
                     if let Some(board_idx) = self.selection.board.get() {
+                        let before = self.ctx.inner.snapshot();
                         if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
                             let board_id = board.id;
                             let temp_file = std::env::temp_dir()
@@ -386,7 +388,7 @@ impl App {
                             ) {
                                 tracing::error!("Failed to edit board settings: {}", e);
                             } else {
-                                self.ctx.inner.mark_dirty();
+                                self.ctx.inner.record_undo_snapshot(before);
                                 let snapshot = self.ctx.inner.snapshot();
                                 self.ctx.state_manager.queue_snapshot(snapshot);
                             }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -81,6 +81,7 @@ impl App {
             DialogAction::Confirm => {
                 if let Err(e) = self.export_board_with_filename() {
                     tracing::error!("Failed to export board: {}", e);
+                    self.set_error(format!("Failed to export board: {}", e));
                 }
                 self.pop_mode();
                 self.input.clear();
@@ -98,6 +99,7 @@ impl App {
             DialogAction::Confirm => {
                 if let Err(e) = self.export_all_boards_with_filename() {
                     tracing::error!("Failed to export all boards: {}", e);
+                    self.set_error(format!("Failed to export all boards: {}", e));
                 }
                 self.pop_mode();
                 self.input.clear();
@@ -149,6 +151,7 @@ impl App {
                     });
                     if let Err(e) = self.execute_command(cmd) {
                         tracing::error!("Failed to set card points: {}", e);
+                        self.set_error(format!("Failed to set card points: {}", e));
                     } else {
                         tracing::info!("Set points to: {:?}", points);
                     }
@@ -188,6 +191,10 @@ impl App {
                                     });
                                     if let Err(e) = self.execute_command(cmd) {
                                         tracing::error!("Failed to clear sprint prefix: {}", e);
+                                        self.set_error(format!(
+                                            "Failed to clear sprint prefix: {}",
+                                            e
+                                        ));
                                     } else {
                                         tracing::info!("Cleared sprint prefix");
                                     }
@@ -208,6 +215,10 @@ impl App {
                                     });
                                     if let Err(e) = self.execute_command(cmd) {
                                         tracing::error!("Failed to clear sprint prefix: {}", e);
+                                        self.set_error(format!(
+                                            "Failed to clear sprint prefix: {}",
+                                            e
+                                        ));
                                     } else {
                                         tracing::info!("Cleared sprint prefix");
                                     }
@@ -231,6 +242,10 @@ impl App {
                                             "Failed to clear sprint card prefix override: {}",
                                             e
                                         );
+                                        self.set_error(format!(
+                                            "Failed to clear sprint card prefix override: {}",
+                                            e
+                                        ));
                                     } else {
                                         tracing::info!("Cleared sprint card prefix override");
                                     }
@@ -254,6 +269,10 @@ impl App {
                                     });
                                     if let Err(e) = self.execute_command(cmd) {
                                         tracing::error!("Failed to set sprint prefix: {}", e);
+                                        self.set_error(format!(
+                                            "Failed to set sprint prefix: {}",
+                                            e
+                                        ));
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
                                     }
@@ -274,6 +293,10 @@ impl App {
                                     });
                                     if let Err(e) = self.execute_command(cmd) {
                                         tracing::error!("Failed to set sprint prefix: {}", e);
+                                        self.set_error(format!(
+                                            "Failed to set sprint prefix: {}",
+                                            e
+                                        ));
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
                                     }
@@ -297,6 +320,10 @@ impl App {
                                             "Failed to set sprint card prefix override: {}",
                                             e
                                         );
+                                        self.set_error(format!(
+                                            "Failed to set sprint card prefix override: {}",
+                                            e
+                                        ));
                                     } else {
                                         tracing::info!(
                                             "Set sprint card prefix override to: {}",

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -386,7 +386,7 @@ impl App {
             }
             KeyCode::Esc => {
                 // Retry later - just go back to previous mode
-                self.ctx.state_manager.clear_conflict();
+                self.ctx.inner.clear_conflict();
                 self.pop_mode();
             }
             _ => {}

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -254,10 +254,10 @@ impl App {
                                         tracing::error!("Failed to set sprint prefix: {}", e);
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
-                                        if let Some(board) = self.ctx.boards.get_mut(board_idx) {
+                                        if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
                                             board.ensure_sprint_counter_initialized(
                                                 &prefix_str,
-                                                &self.ctx.sprints,
+                                                &self.ctx.inner.sprints,
                                             );
                                         }
                                     }
@@ -288,10 +288,10 @@ impl App {
                                 .active_board_index
                                 .or(self.selection.board.get());
                             if let Some(board_idx) = board_idx {
-                                if let Some(board) = self.ctx.boards.get_mut(board_idx) {
+                                if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
                                     board.ensure_sprint_counter_initialized(
                                         &prefix_str,
-                                        &self.ctx.sprints,
+                                        &self.ctx.inner.sprints,
                                     );
                                 }
                             }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -135,7 +135,7 @@ impl App {
                 let card_id = self
                     .selection
                     .active_card_index
-                    .and_then(|idx| self.ctx.cards.get(idx))
+                    .and_then(|idx| self.ctx.cards().get(idx))
                     .map(|c| c.id)
                     .or_else(|| self.get_selected_card_in_context().map(|c| c.id));
 
@@ -176,7 +176,8 @@ impl App {
                     match context {
                         PrefixDialogContext::BoardSprint => {
                             if let Some(board_idx) = self.selection.board.get() {
-                                if let Some(board_id) = self.ctx.boards.get(board_idx).map(|b| b.id)
+                                if let Some(board_id) =
+                                    self.ctx.boards().get(board_idx).map(|b| b.id)
                                 {
                                     let cmd = Box::new(kanban_domain::commands::UpdateBoard {
                                         board_id,
@@ -196,7 +197,7 @@ impl App {
                         PrefixDialogContext::Sprint => {
                             if let Some(sprint_idx) = self.selection.active_sprint_index {
                                 if let Some(sprint_id) =
-                                    self.ctx.sprints.get(sprint_idx).map(|s| s.id)
+                                    self.ctx.sprints().get(sprint_idx).map(|s| s.id)
                                 {
                                     let cmd = Box::new(kanban_domain::commands::UpdateSprint {
                                         sprint_id,
@@ -216,7 +217,7 @@ impl App {
                         PrefixDialogContext::SprintCard => {
                             if let Some(sprint_idx) = self.selection.active_sprint_index {
                                 if let Some(sprint_id) =
-                                    self.ctx.sprints.get(sprint_idx).map(|s| s.id)
+                                    self.ctx.sprints().get(sprint_idx).map(|s| s.id)
                                 {
                                     let cmd = Box::new(kanban_domain::commands::UpdateSprint {
                                         sprint_id,
@@ -241,7 +242,8 @@ impl App {
                     match context {
                         PrefixDialogContext::BoardSprint => {
                             if let Some(board_idx) = self.selection.board.get() {
-                                if let Some(board_id) = self.ctx.boards.get(board_idx).map(|b| b.id)
+                                if let Some(board_id) =
+                                    self.ctx.boards().get(board_idx).map(|b| b.id)
                                 {
                                     let cmd = Box::new(kanban_domain::commands::UpdateBoard {
                                         board_id,
@@ -254,12 +256,13 @@ impl App {
                                         tracing::error!("Failed to set sprint prefix: {}", e);
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
+                                        let sprints_ref = self.ctx.sprints().clone();
                                         if let Some(board) =
-                                            self.ctx.inner.boards.get_mut(board_idx)
+                                            self.ctx.boards_mut().get_mut(board_idx)
                                         {
                                             board.ensure_sprint_counter_initialized(
                                                 &prefix_str,
-                                                &self.ctx.inner.sprints,
+                                                &sprints_ref,
                                             );
                                         }
                                     }
@@ -269,7 +272,7 @@ impl App {
                         PrefixDialogContext::Sprint => {
                             if let Some(sprint_idx) = self.selection.active_sprint_index {
                                 if let Some(sprint_id) =
-                                    self.ctx.sprints.get(sprint_idx).map(|s| s.id)
+                                    self.ctx.sprints().get(sprint_idx).map(|s| s.id)
                                 {
                                     let cmd = Box::new(kanban_domain::commands::UpdateSprint {
                                         sprint_id,
@@ -290,10 +293,11 @@ impl App {
                                 .active_board_index
                                 .or(self.selection.board.get());
                             if let Some(board_idx) = board_idx {
-                                if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
+                                let sprints_ref = self.ctx.sprints().clone();
+                                if let Some(board) = self.ctx.boards_mut().get_mut(board_idx) {
                                     board.ensure_sprint_counter_initialized(
                                         &prefix_str,
-                                        &self.ctx.inner.sprints,
+                                        &sprints_ref,
                                     );
                                 }
                             }
@@ -301,7 +305,7 @@ impl App {
                         PrefixDialogContext::SprintCard => {
                             if let Some(sprint_idx) = self.selection.active_sprint_index {
                                 if let Some(sprint_id) =
-                                    self.ctx.sprints.get(sprint_idx).map(|s| s.id)
+                                    self.ctx.sprints().get(sprint_idx).map(|s| s.id)
                                 {
                                     let cmd = Box::new(kanban_domain::commands::UpdateSprint {
                                         sprint_id,
@@ -388,7 +392,7 @@ impl App {
             }
             KeyCode::Esc => {
                 // Retry later - just go back to previous mode
-                self.ctx.inner.clear_conflict();
+                self.ctx.clear_conflict();
                 self.pop_mode();
             }
             _ => {}

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -254,7 +254,9 @@ impl App {
                                         tracing::error!("Failed to set sprint prefix: {}", e);
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
-                                        if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
+                                        if let Some(board) =
+                                            self.ctx.inner.boards.get_mut(board_idx)
+                                        {
                                             board.ensure_sprint_counter_initialized(
                                                 &prefix_str,
                                                 &self.ctx.inner.sprints,

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -256,15 +256,6 @@ impl App {
                                         tracing::error!("Failed to set sprint prefix: {}", e);
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
-                                        let sprints_ref = self.ctx.sprints().clone();
-                                        if let Some(board) =
-                                            self.ctx.boards_mut().get_mut(board_idx)
-                                        {
-                                            board.ensure_sprint_counter_initialized(
-                                                &prefix_str,
-                                                &sprints_ref,
-                                            );
-                                        }
                                     }
                                 }
                             }
@@ -286,19 +277,6 @@ impl App {
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
                                     }
-                                }
-                            }
-                            let board_idx = self
-                                .selection
-                                .active_board_index
-                                .or(self.selection.board.get());
-                            if let Some(board_idx) = board_idx {
-                                let sprints_ref = self.ctx.sprints().clone();
-                                if let Some(board) = self.ctx.boards_mut().get_mut(board_idx) {
-                                    board.ensure_sprint_counter_initialized(
-                                        &prefix_str,
-                                        &sprints_ref,
-                                    );
                                 }
                             }
                         }

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -33,10 +33,10 @@ impl App {
                 KeyCode::Char('j') | KeyCode::Down => match dialog_state.current_section {
                     FilterDialogSection::Sprints => {
                         if let Some(board_idx) = self.selection.active_board_index {
-                            if let Some(board) = self.ctx.boards.get(board_idx) {
+                            if let Some(board) = self.ctx.boards().get(board_idx) {
                                 let sprint_count = self
                                     .ctx
-                                    .sprints
+                                    .sprints()
                                     .iter()
                                     .filter(|s| s.board_id == board.id)
                                     .count();
@@ -76,10 +76,10 @@ impl App {
                             );
                             self.apply_filters();
                         } else if let Some(board_idx) = self.selection.active_board_index {
-                            if let Some(board) = self.ctx.boards.get(board_idx) {
+                            if let Some(board) = self.ctx.boards().get(board_idx) {
                                 let board_sprints: Vec<_> = self
                                     .ctx
-                                    .sprints
+                                    .sprints()
                                     .iter()
                                     .filter(|s| s.board_id == board.id)
                                     .collect();

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -306,7 +306,7 @@ impl App {
             .active_board_index
             .or(self.selection.board.get())
         {
-            if let Some(board) = self.ctx.boards.get(board_idx) {
+            if let Some(board) = self.ctx.boards().get(board_idx) {
                 if board.task_list_view == TaskListView::GroupedByColumn {
                     // Try to get column boundaries for header-aware pagination
                     if let Some(unified) = self
@@ -359,7 +359,7 @@ impl App {
     pub fn handle_navigation_down(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                self.selection.board.next(self.ctx.boards.len());
+                self.selection.board.next(self.ctx.boards().len());
                 self.switch_view_strategy(TaskListView::GroupedByColumn);
             }
             Focus::Cards => {
@@ -455,7 +455,7 @@ impl App {
 
                     if let Some(board_idx) = self.selection.active_board_index {
                         let (task_list_view, task_sort_field, task_sort_order) = {
-                            if let Some(board) = self.ctx.boards.get(board_idx) {
+                            if let Some(board) = self.ctx.boards().get(board_idx) {
                                 (
                                     board.task_list_view,
                                     board.task_sort_field,
@@ -488,7 +488,7 @@ impl App {
             Focus::Cards => {
                 if let Some(selected_card) = self.get_selected_card_in_context() {
                     let card_id = selected_card.id;
-                    let actual_idx = self.ctx.cards.iter().position(|c| c.id == card_id);
+                    let actual_idx = self.ctx.cards().iter().position(|c| c.id == card_id);
                     self.selection.active_card_index = actual_idx;
                     // Initialize list components with item counts
                     let parents = self.get_current_card_parents();
@@ -533,7 +533,7 @@ impl App {
             .active_board_index
             .or(self.selection.board.get())
         {
-            if let Some(board) = self.ctx.boards.get(board_idx) {
+            if let Some(board) = self.ctx.boards().get(board_idx) {
                 return board.task_list_view == TaskListView::ColumnView;
             }
         }
@@ -609,7 +609,7 @@ impl App {
     pub fn handle_jump_to_bottom(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                self.selection.board.jump_to_last(self.ctx.boards.len());
+                self.selection.board.jump_to_last(self.ctx.boards().len());
                 self.switch_view_strategy(TaskListView::GroupedByColumn);
             }
             Focus::Cards => {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,8 +1,6 @@
 use crate::app::App;
 use crossterm::event::KeyCode;
-use kanban_domain::{
-    dependencies::CardGraphExt, FieldUpdate, KanbanOperations, SortField, SortOrder, Sprint,
-};
+use kanban_domain::{FieldUpdate, KanbanOperations, SortField, SortOrder, Sprint};
 
 const PRIORITY_COUNT: usize = 4;
 
@@ -261,10 +259,6 @@ impl App {
                             if let Err(e) = self.execute_command(cmd) {
                                 tracing::error!("Failed to unassign card from sprint: {}", e);
                             } else {
-                                // Clear sprint log via direct mutation (domain operation)
-                                if let Some(card) = self.ctx.inner.cards.get_mut(card_idx) {
-                                    card.end_current_sprint_log();
-                                }
                                 tracing::info!("Unassigned card from sprint");
                             }
                         } else if let Some(board_idx) = self.selection.active_board_index {
@@ -639,51 +633,32 @@ impl App {
 
                                 if self.relationship.selected.contains(&selected_card_id) {
                                     // Remove relationship
-                                    let result = if is_parent_mode {
-                                        // Current card is child, selected card is parent
-                                        self.ctx
-                                            .inner
-                                            .graph
-                                            .cards
-                                            .remove_parent(current_card_id, selected_card_id)
+                                    let (child_id, parent_id) = if is_parent_mode {
+                                        (current_card_id, selected_card_id)
                                     } else {
-                                        // Current card is parent, selected card is child
-                                        self.ctx
-                                            .inner
-                                            .graph
-                                            .cards
-                                            .remove_parent(selected_card_id, current_card_id)
+                                        (selected_card_id, current_card_id)
                                     };
-
-                                    if result.is_ok() {
+                                    let cmd =
+                                        Box::new(kanban_domain::commands::RemoveParentCommand {
+                                            child_id,
+                                            parent_id,
+                                        });
+                                    if self.execute_command(cmd).is_ok() {
                                         self.relationship.selected.remove(&selected_card_id);
-                                        self.ctx.inner.mark_dirty();
-                                        let snapshot = self.ctx.inner.snapshot();
-                                        self.ctx.state_manager.queue_snapshot(snapshot);
                                     }
                                 } else {
                                     // Add relationship
-                                    let result = if is_parent_mode {
-                                        // Current card is child, selected card is parent
-                                        self.ctx
-                                            .inner
-                                            .graph
-                                            .cards
-                                            .set_parent(current_card_id, selected_card_id)
+                                    let (child_id, parent_id) = if is_parent_mode {
+                                        (current_card_id, selected_card_id)
                                     } else {
-                                        // Current card is parent, selected card is child
-                                        self.ctx
-                                            .inner
-                                            .graph
-                                            .cards
-                                            .set_parent(selected_card_id, current_card_id)
+                                        (selected_card_id, current_card_id)
                                     };
-
-                                    if result.is_ok() {
+                                    let cmd = Box::new(kanban_domain::commands::SetParentCommand {
+                                        child_id,
+                                        parent_id,
+                                    });
+                                    if self.execute_command(cmd).is_ok() {
                                         self.relationship.selected.insert(selected_card_id);
-                                        self.ctx.inner.mark_dirty();
-                                        let snapshot = self.ctx.inner.snapshot();
-                                        self.ctx.state_manager.queue_snapshot(snapshot);
                                     }
                                 }
                             }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -48,7 +48,7 @@ impl App {
             KeyCode::Enter => {
                 if let Some(priority_idx) = self.dialog_input.priority_selection.get() {
                     if let Some(card_idx) = self.selection.active_card_index {
-                        if let Some(card) = self.ctx.cards.get(card_idx) {
+                        if let Some(card) = self.ctx.cards().get(card_idx) {
                             use kanban_domain::{CardPriority, CardUpdate};
                             let priority = match priority_idx {
                                 0 => CardPriority::Low,
@@ -185,7 +185,7 @@ impl App {
                     self.filter.current_sort_order = Some(order);
 
                     if let Some(board_idx) = self.selection.active_board_index {
-                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
                             let board_id = board.id;
                             let cmd = Box::new(kanban_domain::commands::SetBoardTaskSort {
                                 board_id,
@@ -224,8 +224,8 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.ctx.boards.get(board_idx) {
-                        let sprint_count = Sprint::assignable(&self.ctx.sprints, board.id).len();
+                    if let Some(board) = self.ctx.boards().get(board_idx) {
+                        let sprint_count = Sprint::assignable(self.ctx.sprints(), board.id).len();
                         self.dialog_input
                             .sprint_assign_selection
                             .next(sprint_count + 1);
@@ -239,7 +239,7 @@ impl App {
                 if let Some(selection_idx) = self.dialog_input.sprint_assign_selection.get() {
                     if let Some(card_idx) = self.selection.active_card_index {
                         let card_id = {
-                            if let Some(card) = self.ctx.cards.get(card_idx) {
+                            if let Some(card) = self.ctx.cards().get(card_idx) {
                                 card.id
                             } else {
                                 return;
@@ -262,8 +262,9 @@ impl App {
                                 tracing::info!("Unassigned card from sprint");
                             }
                         } else if let Some(board_idx) = self.selection.active_board_index {
-                            if let Some(board_id) = self.ctx.boards.get(board_idx).map(|b| b.id) {
-                                let board_sprints = Sprint::assignable(&self.ctx.sprints, board_id);
+                            if let Some(board_id) = self.ctx.boards().get(board_idx).map(|b| b.id) {
+                                let board_sprints =
+                                    Sprint::assignable(self.ctx.sprints(), board_id);
                                 if let Some(sprint) = board_sprints.get(selection_idx - 1) {
                                     let sprint_id = sprint.id;
                                     let sprint_number = sprint.sprint_number;
@@ -271,7 +272,7 @@ impl App {
 
                                     // Get effective prefix and sprint info before calling execute_command
                                     let effective_prefix = {
-                                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                                        if let Some(board) = self.ctx.boards().get(board_idx) {
                                             sprint.effective_prefix(board, "task").to_string()
                                         } else {
                                             "task".to_string()
@@ -279,7 +280,7 @@ impl App {
                                     };
 
                                     let sprint_name = {
-                                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                                        if let Some(board) = self.ctx.boards().get(board_idx) {
                                             sprint.get_name(board).map(|s| s.to_string())
                                         } else {
                                             None
@@ -347,8 +348,8 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.ctx.boards.get(board_idx) {
-                        let sprint_count = Sprint::assignable(&self.ctx.sprints, board.id).len();
+                    if let Some(board) = self.ctx.boards().get(board_idx) {
+                        let sprint_count = Sprint::assignable(self.ctx.sprints(), board.id).len();
                         self.dialog_input
                             .sprint_assign_selection
                             .next(sprint_count + 1);
@@ -384,8 +385,8 @@ impl App {
                             );
                         }
                     } else if let Some(board_idx) = self.selection.active_board_index {
-                        if let Some(board_id) = self.ctx.boards.get(board_idx).map(|b| b.id) {
-                            let board_sprints = Sprint::assignable(&self.ctx.sprints, board_id);
+                        if let Some(board_id) = self.ctx.boards().get(board_idx).map(|b| b.id) {
+                            let board_sprints = Sprint::assignable(self.ctx.sprints(), board_id);
                             if let Some(sprint) = board_sprints.get(selection_idx - 1) {
                                 let sprint_id = sprint.id;
                                 let sprint_number = sprint.sprint_number;
@@ -393,7 +394,7 @@ impl App {
 
                                 // Get effective prefix and sprint info before the loop
                                 let effective_prefix = {
-                                    if let Some(board) = self.ctx.boards.get(board_idx) {
+                                    if let Some(board) = self.ctx.boards().get(board_idx) {
                                         sprint.effective_prefix(board, "task").to_string()
                                     } else {
                                         "task".to_string()
@@ -401,7 +402,7 @@ impl App {
                                 };
 
                                 let sprint_name = {
-                                    if let Some(board) = self.ctx.boards.get(board_idx) {
+                                    if let Some(board) = self.ctx.boards().get(board_idx) {
                                         sprint.get_name(board).map(|s| s.to_string())
                                     } else {
                                         None
@@ -478,11 +479,11 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(source_id) = self.dialog_input.carry_over_source_sprint_id {
-                    if let Some(sprint) = self.ctx.sprints.iter().find(|s| s.id == source_id) {
+                    if let Some(sprint) = self.ctx.sprints().iter().find(|s| s.id == source_id) {
                         let board_id = sprint.board_id;
                         let count = self
                             .ctx
-                            .sprints
+                            .sprints()
                             .iter()
                             .filter(|s| {
                                 s.board_id == board_id
@@ -499,11 +500,12 @@ impl App {
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if let Some(idx) = self.dialog_input.carry_over_sprint_selection.get() {
                     if let Some(source_id) = self.dialog_input.carry_over_source_sprint_id {
-                        if let Some(sprint) = self.ctx.sprints.iter().find(|s| s.id == source_id) {
+                        if let Some(sprint) = self.ctx.sprints().iter().find(|s| s.id == source_id)
+                        {
                             let board_id = sprint.board_id;
                             let planning_sprint_ids: Vec<uuid::Uuid> = self
                                 .ctx
-                                .sprints
+                                .sprints()
                                 .iter()
                                 .filter(|s| {
                                     s.board_id == board_id
@@ -515,12 +517,12 @@ impl App {
                             if let Some(&to_sprint_id) = planning_sprint_ids.get(idx) {
                                 let sprint_label = self
                                     .ctx
-                                    .sprints
+                                    .sprints()
                                     .iter()
                                     .find(|s| s.id == to_sprint_id)
                                     .map(|s| {
                                         self.ctx
-                                            .boards
+                                            .boards()
                                             .iter()
                                             .find(|b| b.id == board_id)
                                             .and_then(|b| s.get_name(b))
@@ -567,7 +569,7 @@ impl App {
                 .iter()
                 .filter(|card_id| {
                     self.ctx
-                        .cards
+                        .cards()
                         .iter()
                         .find(|c| c.id == **card_id)
                         .map(|c| c.title.to_lowercase().contains(&search_lower))
@@ -628,7 +630,7 @@ impl App {
                 if let Some(idx) = self.relationship.selection.get() {
                     if let Some(selected_card_id) = filtered_cards.get(idx).copied() {
                         if let Some(card_idx) = self.selection.active_card_index {
-                            if let Some(current_card) = self.ctx.cards.get(card_idx) {
+                            if let Some(current_card) = self.ctx.cards().get(card_idx) {
                                 let current_card_id = current_card.id;
 
                                 if self.relationship.selected.contains(&selected_card_id) {
@@ -680,7 +682,7 @@ impl App {
                 .iter()
                 .filter(|card_id| {
                     self.ctx
-                        .cards
+                        .cards()
                         .iter()
                         .find(|c| c.id == **card_id)
                         .map(|c| c.title.to_lowercase().contains(&search_lower))

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -280,10 +280,7 @@ impl App {
                                     Sprint::assignable(self.ctx.sprints(), board_id);
                                 if let Some(sprint) = board_sprints.get(selection_idx - 1) {
                                     let sprint_id = sprint.id;
-                                    let sprint_number = sprint.sprint_number;
-                                    let sprint_status = format!("{:?}", sprint.status);
 
-                                    // Get effective prefix and sprint info before calling execute_command
                                     let effective_prefix = {
                                         if let Some(board) = self.ctx.boards().get(board_idx) {
                                             sprint.effective_prefix(board, "task").to_string()
@@ -292,32 +289,18 @@ impl App {
                                         }
                                     };
 
-                                    let sprint_name = {
-                                        if let Some(board) = self.ctx.boards().get(board_idx) {
-                                            sprint.get_name(board).map(|s| s.to_string())
-                                        } else {
-                                            None
-                                        }
-                                    };
-
-                                    // Build batch of commands
                                     let mut commands: Vec<
                                         Box<dyn kanban_domain::commands::Command>,
                                     > = Vec::new();
 
-                                    // First, assign to sprint
                                     let assign_cmd =
-                                        Box::new(kanban_domain::commands::AssignCardToSprint {
-                                            card_id,
+                                        Box::new(kanban_domain::commands::AssignCardsToSprint {
+                                            ids: vec![card_id],
                                             sprint_id,
-                                            sprint_number,
-                                            sprint_name,
-                                            sprint_status,
                                         })
                                             as Box<dyn kanban_domain::commands::Command>;
                                     commands.push(assign_cmd);
 
-                                    // Then, update the assigned prefix
                                     let update_cmd = Box::new(kanban_domain::commands::UpdateCard {
                                         card_id,
                                         updates: kanban_domain::CardUpdate {
@@ -330,7 +313,6 @@ impl App {
                                         as Box<dyn kanban_domain::commands::Command>;
                                     commands.push(update_cmd);
 
-                                    // Execute all commands as a batch
                                     if let Err(e) = self.execute_commands_batch(commands) {
                                         tracing::error!("Failed to assign card to sprint: {}", e);
                                         self.set_error(format!(
@@ -407,10 +389,7 @@ impl App {
                             let board_sprints = Sprint::assignable(self.ctx.sprints(), board_id);
                             if let Some(sprint) = board_sprints.get(selection_idx - 1) {
                                 let sprint_id = sprint.id;
-                                let sprint_number = sprint.sprint_number;
-                                let sprint_status = format!("{:?}", sprint.status);
 
-                                // Get effective prefix and sprint info before the loop
                                 let effective_prefix = {
                                     if let Some(board) = self.ctx.boards().get(board_idx) {
                                         sprint.effective_prefix(board, "task").to_string()
@@ -419,31 +398,18 @@ impl App {
                                     }
                                 };
 
-                                let sprint_name = {
-                                    if let Some(board) = self.ctx.boards().get(board_idx) {
-                                        sprint.get_name(board).map(|s| s.to_string())
-                                    } else {
-                                        None
-                                    }
-                                };
-
-                                // Build batch of commands for all cards
                                 let mut commands: Vec<Box<dyn kanban_domain::commands::Command>> =
                                     Vec::new();
-                                for card_id in &card_ids {
-                                    // First, assign to sprint
-                                    let assign_cmd =
-                                        Box::new(kanban_domain::commands::AssignCardToSprint {
-                                            card_id: *card_id,
-                                            sprint_id,
-                                            sprint_number,
-                                            sprint_name: sprint_name.clone(),
-                                            sprint_status: sprint_status.clone(),
-                                        })
-                                            as Box<dyn kanban_domain::commands::Command>;
-                                    commands.push(assign_cmd);
 
-                                    // Then, update the assigned prefix
+                                commands.push(
+                                    Box::new(kanban_domain::commands::AssignCardsToSprint {
+                                        ids: card_ids.clone(),
+                                        sprint_id,
+                                    })
+                                        as Box<dyn kanban_domain::commands::Command>,
+                                );
+
+                                for card_id in &card_ids {
                                     let update_cmd = Box::new(kanban_domain::commands::UpdateCard {
                                         card_id: *card_id,
                                         updates: kanban_domain::CardUpdate {
@@ -457,7 +423,6 @@ impl App {
                                     commands.push(update_cmd);
                                 }
 
-                                // Execute all commands as a batch (single pause/resume cycle)
                                 if let Err(e) = self.execute_commands_batch(commands) {
                                     tracing::error!("Failed to assign cards to sprint: {}", e);
                                     self.set_error(format!(

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -401,13 +401,13 @@ impl App {
                                 let mut commands: Vec<Box<dyn kanban_domain::commands::Command>> =
                                     Vec::new();
 
-                                commands.push(
-                                    Box::new(kanban_domain::commands::AssignCardsToSprint {
+                                commands.push(Box::new(
+                                    kanban_domain::commands::AssignCardsToSprint {
                                         ids: card_ids.clone(),
                                         sprint_id,
-                                    })
-                                        as Box<dyn kanban_domain::commands::Command>,
-                                );
+                                    },
+                                )
+                                    as Box<dyn kanban_domain::commands::Command>);
 
                                 for card_id in &card_ids {
                                     let update_cmd = Box::new(kanban_domain::commands::UpdateCard {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,9 +1,7 @@
 use crate::app::App;
-use crate::state::TuiSnapshot;
 use crossterm::event::KeyCode;
 use kanban_domain::{
-    dependencies::CardGraphExt, FieldUpdate, KanbanOperations, Snapshot, SortField, SortOrder,
-    Sprint,
+    dependencies::CardGraphExt, FieldUpdate, KanbanOperations, SortField, SortOrder, Sprint,
 };
 
 const PRIORITY_COUNT: usize = 4;
@@ -264,7 +262,7 @@ impl App {
                                 tracing::error!("Failed to unassign card from sprint: {}", e);
                             } else {
                                 // Clear sprint log via direct mutation (domain operation)
-                                if let Some(card) = self.ctx.cards.get_mut(card_idx) {
+                                if let Some(card) = self.ctx.inner.cards.get_mut(card_idx) {
                                     card.end_current_sprint_log();
                                 }
                                 tracing::info!("Unassigned card from sprint");
@@ -644,12 +642,14 @@ impl App {
                                     let result = if is_parent_mode {
                                         // Current card is child, selected card is parent
                                         self.ctx
+                                            .inner
                                             .graph
                                             .cards
                                             .remove_parent(current_card_id, selected_card_id)
                                     } else {
                                         // Current card is parent, selected card is child
                                         self.ctx
+                                            .inner
                                             .graph
                                             .cards
                                             .remove_parent(selected_card_id, current_card_id)
@@ -657,8 +657,8 @@ impl App {
 
                                     if result.is_ok() {
                                         self.relationship.selected.remove(&selected_card_id);
-                                        self.ctx.state_manager.mark_dirty();
-                                        let snapshot = Snapshot::from_app(self);
+                                        self.ctx.inner.mark_dirty();
+                                        let snapshot = self.ctx.inner.snapshot();
                                         self.ctx.state_manager.queue_snapshot(snapshot);
                                     }
                                 } else {
@@ -666,12 +666,14 @@ impl App {
                                     let result = if is_parent_mode {
                                         // Current card is child, selected card is parent
                                         self.ctx
+                                            .inner
                                             .graph
                                             .cards
                                             .set_parent(current_card_id, selected_card_id)
                                     } else {
                                         // Current card is parent, selected card is child
                                         self.ctx
+                                            .inner
                                             .graph
                                             .cards
                                             .set_parent(selected_card_id, current_card_id)
@@ -679,8 +681,8 @@ impl App {
 
                                     if result.is_ok() {
                                         self.relationship.selected.insert(selected_card_id);
-                                        self.ctx.state_manager.mark_dirty();
-                                        let snapshot = Snapshot::from_app(self);
+                                        self.ctx.inner.mark_dirty();
+                                        let snapshot = self.ctx.inner.snapshot();
                                         self.ctx.state_manager.queue_snapshot(snapshot);
                                     }
                                 }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -24,6 +24,7 @@ impl App {
                     if let Some(filename) = self.dialog_input.import_files.get(idx).cloned() {
                         if let Err(e) = self.import_board_from_file(&filename) {
                             tracing::error!("Failed to import board: {}", e);
+                            self.set_error(format!("Failed to import board: {}", e));
                         }
                     }
                 }
@@ -67,6 +68,7 @@ impl App {
                             });
                             if let Err(e) = self.execute_command(cmd) {
                                 tracing::error!("Failed to update card priority: {}", e);
+                                self.set_error(format!("Failed to update card priority: {}", e));
                             }
                         }
                     }
@@ -119,6 +121,7 @@ impl App {
                     if !commands.is_empty() {
                         if let Err(e) = self.execute_commands_batch(commands) {
                             tracing::error!("Failed to update cards priority: {}", e);
+                            self.set_error(format!("Failed to update cards priority: {}", e));
                         } else {
                             tracing::info!(
                                 "Set priority to {:?} for {} cards",
@@ -194,6 +197,7 @@ impl App {
                             });
                             if let Err(e) = self.execute_command(cmd) {
                                 tracing::error!("Failed to set board task sort: {}", e);
+                                self.set_error(format!("Failed to set board task sort: {}", e));
                             }
                         }
                     }
@@ -248,16 +252,25 @@ impl App {
 
                         if selection_idx == 0 {
                             // Unassign from sprint
-                            let cmd = Box::new(kanban_domain::commands::UpdateCard {
+                            let unassign_cmd =
+                                Box::new(kanban_domain::commands::UnassignCardFromSprint {
+                                    card_id,
+                                });
+                            let clear_prefix_cmd = Box::new(kanban_domain::commands::UpdateCard {
                                 card_id,
                                 updates: kanban_domain::CardUpdate {
-                                    sprint_id: FieldUpdate::Clear,
                                     assigned_prefix: FieldUpdate::Clear,
                                     ..Default::default()
                                 },
                             });
-                            if let Err(e) = self.execute_command(cmd) {
+                            if let Err(e) =
+                                self.execute_commands_batch(vec![unassign_cmd, clear_prefix_cmd])
+                            {
                                 tracing::error!("Failed to unassign card from sprint: {}", e);
+                                self.set_error(format!(
+                                    "Failed to unassign card from sprint: {}",
+                                    e
+                                ));
                             } else {
                                 tracing::info!("Unassigned card from sprint");
                             }
@@ -320,6 +333,10 @@ impl App {
                                     // Execute all commands as a batch
                                     if let Err(e) = self.execute_commands_batch(commands) {
                                         tracing::error!("Failed to assign card to sprint: {}", e);
+                                        self.set_error(format!(
+                                            "Failed to assign card to sprint: {}",
+                                            e
+                                        ));
                                     } else {
                                         tracing::info!(
                                             "Assigned card to sprint with id: {}",
@@ -378,6 +395,7 @@ impl App {
 
                         if let Err(e) = self.execute_commands_batch(unassign_commands) {
                             tracing::error!("Failed to unassign cards from sprint: {}", e);
+                            self.set_error(format!("Failed to unassign cards from sprint: {}", e));
                         } else {
                             tracing::info!(
                                 "Unassigned {} cards from sprint",
@@ -442,6 +460,10 @@ impl App {
                                 // Execute all commands as a batch (single pause/resume cycle)
                                 if let Err(e) = self.execute_commands_batch(commands) {
                                     tracing::error!("Failed to assign cards to sprint: {}", e);
+                                    self.set_error(format!(
+                                        "Failed to assign cards to sprint: {}",
+                                        e
+                                    ));
                                 }
 
                                 tracing::info!(

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -241,7 +241,7 @@ impl App {
         match kanban_service::make_store(&new_backend, &new_storage_location) {
             Ok(new_store) => {
                 self.ctx.replace_store(new_store);
-                let (save_rx, completion_rx) = self.ctx.state_manager.reset_save_channels();
+                let (save_rx, completion_rx) = self.ctx.save_coordinator.reset_save_channels();
                 use crate::state::snapshot::TuiSnapshot;
                 snapshot.apply_to_app(self);
                 self.ctx.mark_clean();

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -246,8 +246,8 @@ impl App {
             Ok((save_rx, completion_rx)) => {
                 use crate::state::snapshot::TuiSnapshot;
                 snapshot.apply_to_app(self);
-                self.ctx.state_manager.mark_clean();
-                self.ctx.state_manager.clear_history();
+                self.ctx.inner.mark_clean();
+                self.ctx.inner.clear_history();
 
                 self.selection.active_board_index = if self.ctx.boards.is_empty() {
                     None

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -240,19 +240,19 @@ impl App {
 
         match kanban_service::make_store(&new_backend, &new_storage_location) {
             Ok(new_store) => {
-                self.ctx.inner.replace_store(new_store);
+                self.ctx.replace_store(new_store);
                 let (save_rx, completion_rx) = self.ctx.state_manager.reset_save_channels();
                 use crate::state::snapshot::TuiSnapshot;
                 snapshot.apply_to_app(self);
-                self.ctx.inner.mark_clean();
-                self.ctx.inner.clear_history();
+                self.ctx.mark_clean();
+                self.ctx.clear_history();
 
-                self.selection.active_board_index = if self.ctx.boards.is_empty() {
+                self.selection.active_board_index = if self.ctx.boards().is_empty() {
                     None
                 } else {
                     Some(0)
                 };
-                self.selection.board.set(if self.ctx.boards.is_empty() {
+                self.selection.board.set(if self.ctx.boards().is_empty() {
                     None
                 } else {
                     Some(0)
@@ -362,7 +362,7 @@ impl App {
             | KeyCode::Enter => self.handle_settings_key_nav(key),
             KeyCode::Char('e') => self.open_config_editor(terminal, event_handler),
             KeyCode::Char('x') => {
-                let board_count = self.ctx.boards.len();
+                let board_count = self.ctx.boards().len();
                 if board_count == 0 {
                     self.set_error("No boards to export".to_string());
                     return false;
@@ -513,7 +513,7 @@ impl App {
     }
 
     fn trigger_export(&mut self) -> bool {
-        let board_count = self.ctx.boards.len();
+        let board_count = self.ctx.boards().len();
         if board_count == 0 {
             self.set_error("No boards to export".to_string());
             return false;
@@ -619,14 +619,14 @@ impl App {
 
         let board_exports: Vec<_> = selected_indices
             .iter()
-            .filter_map(|&i| self.ctx.boards.get(i))
+            .filter_map(|&i| self.ctx.boards().get(i))
             .map(|board| {
                 BoardExporter::export_board(
                     board,
-                    &self.ctx.columns,
-                    &self.ctx.cards,
-                    &self.ctx.archived_cards,
-                    &self.ctx.sprints,
+                    self.ctx.columns(),
+                    self.ctx.cards(),
+                    self.ctx.archived_cards(),
+                    self.ctx.sprints(),
                 )
             })
             .collect();

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -238,12 +238,10 @@ impl App {
             kanban_service::config::resolve_storage_location(&self.app_config);
         let new_backend = self.app_config.effective_storage_backend().to_string();
 
-        match self
-            .ctx
-            .state_manager
-            .replace_store(&new_backend, &new_storage_location)
-        {
-            Ok((save_rx, completion_rx)) => {
+        match kanban_service::make_store(&new_backend, &new_storage_location) {
+            Ok(new_store) => {
+                self.ctx.inner.replace_store(new_store);
+                let (save_rx, completion_rx) = self.ctx.state_manager.reset_save_channels();
                 use crate::state::snapshot::TuiSnapshot;
                 snapshot.apply_to_app(self);
                 self.ctx.inner.mark_clean();

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -15,12 +15,12 @@ impl App {
         if let Some(sprint_idx) = self.selection.active_sprint_index {
             // Collect sprint info before mutations
             let sprint_info = {
-                if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
+                if let Some(sprint) = self.ctx.sprints().get(sprint_idx) {
                     if sprint.status == SprintStatus::Planning {
                         Some((
                             sprint.id,
                             sprint.formatted_name(
-                                &self.ctx.boards[self.selection.board.get().unwrap_or(0)],
+                                &self.ctx.boards()[self.selection.board.get().unwrap_or(0)],
                                 "sprint",
                             ),
                         ))
@@ -38,7 +38,7 @@ impl App {
                     .active_board_index
                     .or(self.selection.board.get());
                 if let Some(board_idx) = board_idx {
-                    if let Some(board) = self.ctx.boards.get(board_idx) {
+                    if let Some(board) = self.ctx.boards().get(board_idx) {
                         let duration = board.sprint_duration_days.unwrap_or(14);
                         let board_id = board.id;
 
@@ -63,11 +63,11 @@ impl App {
                             return;
                         }
 
-                        if let Some(board) = self.ctx.boards.get(board_idx) {
+                        if let Some(board) = self.ctx.boards().get(board_idx) {
                             tracing::info!(
                                 "Activated sprint: {}",
                                 self.ctx
-                                    .sprints
+                                    .sprints()
                                     .get(sprint_idx)
                                     .map(|s| s.formatted_name(board, "sprint"))
                                     .unwrap_or_default()
@@ -83,7 +83,7 @@ impl App {
         if let Some(sprint_idx) = self.selection.active_sprint_index {
             // Collect sprint and board info before mutations
             let sprint_info = {
-                if let Some(sprint) = self.ctx.sprints.get(sprint_idx) {
+                if let Some(sprint) = self.ctx.sprints().get(sprint_idx) {
                     if sprint.status == SprintStatus::Active
                         || sprint.status == SprintStatus::Planning
                     {
@@ -92,7 +92,7 @@ impl App {
                             .active_board_index
                             .or(self.selection.board.get());
                         board_idx.and_then(|board_idx| {
-                            self.ctx.boards.get(board_idx).map(|board| {
+                            self.ctx.boards().get(board_idx).map(|board| {
                                 (sprint.id, board.id, sprint.formatted_name(board, "sprint"))
                             })
                         })
@@ -134,12 +134,12 @@ impl App {
                     use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
                     let has_planning = self
                         .ctx
-                        .sprints
+                        .sprints()
                         .iter()
                         .any(|s| s.board_id == board_id && s.status == SprintStatus::Planning);
 
                     if has_planning
-                        && !get_sprint_uncompleted_cards(sprint_id, &self.ctx.cards).is_empty()
+                        && !get_sprint_uncompleted_cards(sprint_id, self.ctx.cards()).is_empty()
                     {
                         self.dialog_input.carry_over_source_sprint_id = Some(sprint_id);
                         self.dialog_input.carry_over_sprint_selection.set(Some(0));
@@ -151,14 +151,14 @@ impl App {
     }
 
     pub fn handle_carry_over_for_sprint(&mut self, from_sprint_id: Uuid) {
-        let board_id = match self.ctx.sprints.iter().find(|s| s.id == from_sprint_id) {
+        let board_id = match self.ctx.sprints().iter().find(|s| s.id == from_sprint_id) {
             Some(sprint) => sprint.board_id,
             None => return,
         };
 
         let has_planning_sprint = self
             .ctx
-            .sprints
+            .sprints()
             .iter()
             .any(|s| s.board_id == board_id && s.status == SprintStatus::Planning);
 
@@ -178,17 +178,15 @@ impl App {
             .or(self.selection.board.get());
         if let Some(board_idx) = board_idx {
             let (sprint_number, name_index, board_id, effective_sprint_prefix) = {
-                if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
+                let sprints_ref = self.ctx.sprints().clone();
+                if let Some(board) = self.ctx.boards_mut().get_mut(board_idx) {
                     let effective_sprint_prefix = board
                         .sprint_prefix
                         .as_deref()
                         .unwrap_or(self.app_config.effective_default_sprint_prefix())
                         .to_string();
                     // Ensure the counter for this prefix is initialized based on existing sprints
-                    board.ensure_sprint_counter_initialized(
-                        &effective_sprint_prefix,
-                        &self.ctx.inner.sprints,
-                    );
+                    board.ensure_sprint_counter_initialized(&effective_sprint_prefix, &sprints_ref);
                     let sprint_number = board.get_next_sprint_number(&effective_sprint_prefix);
                     let input_text = self.input.as_str().trim();
                     let name_index = if input_text.is_empty() {
@@ -218,13 +216,13 @@ impl App {
             // Log the newly created sprint
             let board_sprints: Vec<_> = self
                 .ctx
-                .sprints
+                .sprints()
                 .iter()
                 .filter(|s| s.board_id == board_id)
                 .collect();
 
             if let Some(new_sprint) = board_sprints.last() {
-                if let Some(board) = self.ctx.boards.get(board_idx) {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     tracing::info!(
                         "Creating sprint: {} (id: {})",
                         new_sprint.formatted_name(board, &effective_sprint_prefix),

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -60,6 +60,7 @@ impl App {
 
                         if let Err(e) = self.execute_commands_batch(vec![activate_cmd, board_cmd]) {
                             tracing::error!("Failed to activate sprint: {}", e);
+                            self.set_error(format!("Failed to activate sprint: {}", e));
                             return;
                         }
 
@@ -119,6 +120,7 @@ impl App {
 
                 if let Err(e) = self.execute_commands_batch(vec![complete_cmd, board_cmd]) {
                     tracing::error!("Failed to complete sprint: {}", e);
+                    self.set_error(format!("Failed to complete sprint: {}", e));
                     return;
                 }
 
@@ -206,6 +208,7 @@ impl App {
 
             if let Err(e) = self.execute_command(cmd) {
                 tracing::error!("Failed to create sprint: {}", e);
+                self.set_error(format!("Failed to create sprint: {}", e));
                 return;
             }
 

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -177,35 +177,31 @@ impl App {
             .active_board_index
             .or(self.selection.board.get());
         if let Some(board_idx) = board_idx {
-            let (sprint_number, name_index, board_id, effective_sprint_prefix) = {
-                let sprints_ref = self.ctx.sprints().clone();
-                if let Some(board) = self.ctx.boards_mut().get_mut(board_idx) {
-                    let effective_sprint_prefix = board
-                        .sprint_prefix
-                        .as_deref()
-                        .unwrap_or(self.app_config.effective_default_sprint_prefix())
-                        .to_string();
-                    // Ensure the counter for this prefix is initialized based on existing sprints
-                    board.ensure_sprint_counter_initialized(&effective_sprint_prefix, &sprints_ref);
-                    let sprint_number = board.get_next_sprint_number(&effective_sprint_prefix);
+            let (board_id, name) = {
+                if let Some(board) = self.ctx.boards().get(board_idx) {
                     let input_text = self.input.as_str().trim();
-                    let name_index = if input_text.is_empty() {
-                        board.consume_sprint_name()
+                    let name = if input_text.is_empty() {
+                        None
                     } else {
-                        Some(board.add_sprint_name_at_used_index(input_text.to_string()))
+                        Some(input_text.to_string())
                     };
-                    (sprint_number, name_index, board.id, effective_sprint_prefix)
+                    (board.id, name)
                 } else {
                     return;
                 }
             };
 
-            // Execute CreateSprint command
+            let default_sprint_prefix = self
+                .app_config
+                .effective_default_sprint_prefix()
+                .to_string();
+
             let cmd = Box::new(CreateSprint {
                 board_id,
-                sprint_number,
-                name_index,
-                prefix: Some(effective_sprint_prefix.clone()),
+                name,
+                default_sprint_prefix: default_sprint_prefix.clone(),
+                explicit_prefix: None,
+                auto_consume_name: true,
             });
 
             if let Err(e) = self.execute_command(cmd) {
@@ -223,9 +219,13 @@ impl App {
 
             if let Some(new_sprint) = board_sprints.last() {
                 if let Some(board) = self.ctx.boards().get(board_idx) {
+                    let effective_prefix = board
+                        .sprint_prefix
+                        .as_deref()
+                        .unwrap_or(&default_sprint_prefix);
                     tracing::info!(
                         "Creating sprint: {} (id: {})",
-                        new_sprint.formatted_name(board, &effective_sprint_prefix),
+                        new_sprint.formatted_name(board, effective_prefix),
                         new_sprint.id
                     );
                 }

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -178,7 +178,7 @@ impl App {
             .or(self.selection.board.get());
         if let Some(board_idx) = board_idx {
             let (sprint_number, name_index, board_id, effective_sprint_prefix) = {
-                if let Some(board) = self.ctx.boards.get_mut(board_idx) {
+                if let Some(board) = self.ctx.inner.boards.get_mut(board_idx) {
                     let effective_sprint_prefix = board
                         .sprint_prefix
                         .as_deref()
@@ -187,7 +187,7 @@ impl App {
                     // Ensure the counter for this prefix is initialized based on existing sprints
                     board.ensure_sprint_counter_initialized(
                         &effective_sprint_prefix,
-                        &self.ctx.sprints,
+                        &self.ctx.inner.sprints,
                     );
                     let sprint_number = board.get_next_sprint_number(&effective_sprint_prefix);
                     let input_text = self.input.as_str().trim();

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -67,7 +67,7 @@ impl RenderStrategy for SinglePanelRenderer {
         let mut lines = vec![];
 
         if let Some(idx) = board_idx {
-            if let Some(board) = app.ctx.boards.get(idx) {
+            if let Some(board) = app.ctx.boards().get(idx) {
                 let active_task_list = app.view.strategy.get_active_task_list();
 
                 if self.show_column_headers {
@@ -186,7 +186,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                         let line = render_card_list_item(CardListItemConfig {
                                             card,
                                             board,
-                                            sprints: &app.ctx.sprints,
+                                            sprints: app.ctx.sprints(),
                                             is_selected,
                                             is_focused: app.focus.active
                                                 == crate::app::Focus::Cards,
@@ -213,10 +213,10 @@ impl RenderStrategy for SinglePanelRenderer {
                                 "Task",
                             ));
                         }
-                    } else if let Some(board) = app.ctx.boards.get(board_idx.unwrap()) {
+                    } else if let Some(board) = app.ctx.boards().get(board_idx.unwrap()) {
                         let mut board_columns: Vec<_> = app
                             .ctx
-                            .columns
+                            .columns()
                             .iter()
                             .filter(|col| col.board_id == board.id)
                             .collect();
@@ -279,7 +279,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                     let line = render_card_list_item(CardListItemConfig {
                                         card,
                                         board,
-                                        sprints: &app.ctx.sprints,
+                                        sprints: app.ctx.sprints(),
                                         is_selected: task_list.get_selected_index()
                                             == Some(*card_idx),
                                         is_focused: app.focus.active == crate::app::Focus::Cards,
@@ -341,7 +341,7 @@ impl RenderStrategy for MultiPanelRenderer {
             .or(app.selection.board.get());
 
         if let Some(idx) = board_idx {
-            if let Some(board) = app.ctx.boards.get(idx) {
+            if let Some(board) = app.ctx.boards().get(idx) {
                 let task_lists = app.view.strategy.get_all_task_lists();
 
                 if task_lists.is_empty() {
@@ -428,7 +428,7 @@ impl RenderStrategy for MultiPanelRenderer {
                                     let line = render_card_list_item(CardListItemConfig {
                                         card,
                                         board,
-                                        sprints: &app.ctx.sprints,
+                                        sprints: app.ctx.sprints(),
                                         is_selected,
                                         is_focused: app.focus.active == crate::app::Focus::Cards
                                             && is_focused_column,
@@ -458,7 +458,7 @@ impl RenderStrategy for MultiPanelRenderer {
                     let column_name =
                         if let crate::card_list::CardListId::Column(column_id) = task_list.id {
                             app.ctx
-                                .columns
+                                .columns()
                                 .iter()
                                 .find(|c| c.id == column_id)
                                 .map(|c| c.name.clone())

--- a/crates/kanban-tui/src/state/mod.rs
+++ b/crates/kanban-tui/src/state/mod.rs
@@ -1,16 +1,13 @@
 pub mod snapshot;
 
 use crate::app::App;
-use kanban_domain::commands::Command;
-use kanban_domain::commands::CommandContext;
 use kanban_domain::KanbanResult;
-use kanban_domain::{ArchivedCard, Board, Card, Column, HistoryManager, Snapshot, Sprint};
+use kanban_domain::Snapshot;
 use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-pub use kanban_domain::commands;
 pub use snapshot::TuiSnapshot;
 
 type DynStore = Arc<dyn PersistenceStore + Send + Sync>;
@@ -32,14 +29,12 @@ const SAVE_QUEUE_CAPACITY: usize = 100;
 ///
 /// # Example
 /// ```ignore
-/// // Execute command - automatically saves afterward
-/// state_manager.execute(app, command)?;
-/// state_manager.save(&snapshot).await?;
+/// // Execute command via TuiContext, then queue snapshot
+/// ctx.execute_commands_batch(commands)?;
 /// ```
 pub struct StateManager {
     store: Option<DynStore>,
     command_queue: VecDeque<String>,
-    dirty: bool,
     instance_id: uuid::Uuid,
     conflict_pending: bool,
     needs_refresh: bool,
@@ -47,7 +42,6 @@ pub struct StateManager {
     save_completion_tx: Option<mpsc::UnboundedSender<()>>,
     pending_saves: usize,
     file_watcher: Option<Arc<kanban_persistence::FileWatcher>>,
-    history: HistoryManager,
 }
 
 impl StateManager {
@@ -103,7 +97,6 @@ impl StateManager {
         let manager = Self {
             store,
             command_queue: VecDeque::new(),
-            dirty: false,
             instance_id,
             conflict_pending: false,
             needs_refresh: false,
@@ -111,7 +104,6 @@ impl StateManager {
             save_completion_tx: Some(save_completion_tx),
             pending_saves: 0,
             file_watcher: None,
-            history: HistoryManager::new(),
         };
 
         (manager, save_rx, Some(save_completion_rx))
@@ -124,107 +116,6 @@ impl StateManager {
         let store = kanban_service::make_store(backend, path)?;
         let id = store.instance_id();
         Ok((store, id))
-    }
-
-    /// Execute a command and mark state as dirty
-    /// Takes individual mutable references to avoid borrow checker issues when called from App methods
-    #[allow(clippy::too_many_arguments)]
-    pub fn execute_with_context(
-        &mut self,
-        boards: &mut Vec<Board>,
-        columns: &mut Vec<Column>,
-        cards: &mut Vec<Card>,
-        sprints: &mut Vec<Sprint>,
-        archived_cards: &mut Vec<ArchivedCard>,
-        graph: &mut kanban_domain::DependencyGraph,
-        command: Box<dyn Command>,
-    ) -> KanbanResult<()> {
-        let description = command.description();
-        tracing::debug!("Executing: {}", description);
-
-        // Create context from data
-        let mut context = CommandContext {
-            boards,
-            columns,
-            cards,
-            sprints,
-            archived_cards,
-            graph,
-        };
-
-        // Execute business logic
-        command.execute(&mut context)?;
-
-        // Mark dirty and queue command
-        self.dirty = true;
-        self.needs_refresh = true;
-        self.command_queue.push_back(description);
-
-        Ok(())
-    }
-
-    /// Execute a command and mark state as dirty (app-based convenience method)
-    ///
-    /// After execution, queues a snapshot for async saving if a save channel is configured.
-    pub fn execute(&mut self, app: &mut App, command: Box<dyn Command>) -> KanbanResult<()> {
-        // Execute command
-        self.execute_with_context(
-            &mut app.ctx.inner.boards,
-            &mut app.ctx.inner.columns,
-            &mut app.ctx.inner.cards,
-            &mut app.ctx.inner.sprints,
-            &mut app.ctx.inner.archived_cards,
-            &mut app.ctx.inner.graph,
-            command,
-        )?;
-
-        // Queue snapshot for async save if channel is available
-        if let Some(ref tx) = self.save_tx {
-            let snapshot = Snapshot::from_app(app);
-            tracing::debug!("Queueing snapshot for async save");
-            // Use try_send (non-blocking) since we're in a synchronous context
-            // Backpressure is handled by queue_snapshot method
-            match tx.try_send(snapshot) {
-                Ok(_) => {
-                    self.pending_saves += 1;
-                    tracing::debug!(
-                        "Snapshot queued successfully (pending: {})",
-                        self.pending_saves
-                    );
-                }
-                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                    tracing::warn!(
-                        "Save queue is full ({} pending), skipping this save. \
-                        This may indicate the disk is slow or the save worker is overloaded.",
-                        self.pending_saves
-                    );
-                }
-                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                    tracing::error!("Failed to queue save: channel closed");
-                }
-            }
-        } else {
-            tracing::debug!("No save channel available - skipping save");
-        }
-
-        Ok(())
-    }
-
-    /// Execute multiple commands in a batch
-    pub fn execute_batch(
-        &mut self,
-        app: &mut App,
-        commands: Vec<Box<dyn Command>>,
-    ) -> KanbanResult<()> {
-        for command in commands {
-            self.execute(app, command)?;
-        }
-        Ok(())
-    }
-
-    /// Check if state is dirty
-    pub fn is_dirty(&self) -> bool {
-        self.dirty
     }
 
     /// Get the instance ID for this manager
@@ -262,12 +153,6 @@ impl StateManager {
         self.needs_refresh = false;
     }
 
-    /// Mark state as dirty and needing refresh (for direct mutations that bypass execute_command)
-    pub fn mark_dirty(&mut self) {
-        self.dirty = true;
-        self.needs_refresh = true;
-    }
-
     /// Force overwrite external changes (user chose to keep their changes)
     pub async fn force_overwrite(&mut self, snapshot: &Snapshot) -> KanbanResult<()> {
         self.conflict_pending = false;
@@ -280,7 +165,6 @@ impl StateManager {
             };
 
             store.save(persistence_snapshot).await?;
-            self.dirty = false;
             self.command_queue.clear();
 
             tracing::info!("Force overwrote external changes");
@@ -301,21 +185,14 @@ impl StateManager {
 
             data.apply_to_app(app);
 
-            self.dirty = false;
+            app.ctx.inner.mark_clean();
+            app.ctx.inner.clear_history();
             self.command_queue.clear();
-            self.history.clear();
 
             tracing::info!("Reloaded state from disk - undo history cleared");
         }
 
         Ok(())
-    }
-
-    /// Mark state as clean, clearing dirty flag and command queue
-    /// Used after successful external reload to prevent re-save
-    pub fn mark_clean(&mut self) {
-        self.dirty = false;
-        self.command_queue.clear();
     }
 
     /// Close the save channel to signal the worker to finish processing and exit
@@ -401,43 +278,12 @@ impl StateManager {
                 self.pending_saves + 1,
                 self.pending_saves
             );
-
-            // If no more pending saves, clear the dirty flag
-            if self.pending_saves == 0 {
-                self.dirty = false;
-                tracing::debug!("All saves complete - clearing dirty flag");
-            }
         }
     }
 
     /// Get the save completion sender for the worker to use
     pub fn save_completion_tx(&self) -> Option<&mpsc::UnboundedSender<()>> {
         self.save_completion_tx.as_ref()
-    }
-
-    /// Capture snapshot before command execution (for undo history)
-    pub fn capture_before_command(&mut self, snapshot: Snapshot) {
-        self.history.capture_before_command(snapshot);
-    }
-
-    /// Check if undo is available
-    pub fn can_undo(&self) -> bool {
-        self.history.can_undo()
-    }
-
-    /// Check if redo is available
-    pub fn can_redo(&self) -> bool {
-        self.history.can_redo()
-    }
-
-    /// Access to history manager for undo/redo operations
-    pub fn history_mut(&mut self) -> &mut HistoryManager {
-        &mut self.history
-    }
-
-    /// Clear undo/redo history (called after initial file load)
-    pub fn clear_history(&mut self) {
-        self.history.clear();
     }
 
     /// Set the file watcher for coordinating pause/resume with saves
@@ -462,7 +308,6 @@ impl StateManager {
         self.store = Some(store);
         self.instance_id = instance_id;
         self.file_watcher = None;
-        self.dirty = false;
         self.pending_saves = 0;
 
         let (tx, rx) = mpsc::channel(SAVE_QUEUE_CAPACITY);
@@ -483,7 +328,7 @@ mod tests {
     #[test]
     fn test_state_manager_creation() {
         let (manager, _rx, _completion_rx) = StateManager::new("json", None).unwrap();
-        assert!(!manager.is_dirty());
+        assert!(!manager.has_pending_saves());
     }
 
     #[test]
@@ -510,38 +355,13 @@ mod tests {
         std::fs::write(&path1, "{}").unwrap();
         let (mut manager, _rx, _crx) =
             StateManager::new("json", Some(path1.to_str().unwrap().to_string())).unwrap();
-        manager.mark_dirty();
-        assert!(manager.is_dirty());
 
         let path2 = dir.path().join("b.json");
         std::fs::write(&path2, "{}").unwrap();
         let (_rx, _crx) = manager
             .replace_store("json", path2.to_str().unwrap())
             .unwrap();
-        assert!(!manager.is_dirty());
         assert!(!manager.has_pending_saves());
         assert!(manager.has_save_channel());
-    }
-
-    #[test]
-    fn test_dirty_flag_after_execute() {
-        let (mut manager, _rx, _completion_rx) = StateManager::new("json", None).unwrap();
-
-        struct DummyCommand;
-        impl Command for DummyCommand {
-            fn execute(&self, _context: &mut CommandContext) -> KanbanResult<()> {
-                Ok(())
-            }
-
-            fn description(&self) -> String {
-                "dummy".to_string()
-            }
-        }
-
-        let command = Box::new(DummyCommand);
-        let (mut app, _app_rx) = App::new(None).unwrap();
-        manager.execute(&mut app, command).unwrap();
-
-        assert!(manager.is_dirty());
     }
 }

--- a/crates/kanban-tui/src/state/mod.rs
+++ b/crates/kanban-tui/src/state/mod.rs
@@ -1,16 +1,10 @@
 pub mod snapshot;
 
-use crate::app::App;
-use kanban_domain::KanbanResult;
 use kanban_domain::Snapshot;
-use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
-use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
 pub use snapshot::TuiSnapshot;
-
-type DynStore = Arc<dyn PersistenceStore + Send + Sync>;
 const SAVE_QUEUE_CAPACITY: usize = 100;
 
 /// Manages state mutations and persistence with immediate auto-saving
@@ -33,10 +27,6 @@ const SAVE_QUEUE_CAPACITY: usize = 100;
 /// ctx.execute_commands_batch(commands)?;
 /// ```
 pub struct StateManager {
-    store: Option<DynStore>,
-    command_queue: VecDeque<String>,
-    instance_id: uuid::Uuid,
-    conflict_pending: bool,
     needs_refresh: bool,
     save_tx: Option<mpsc::Sender<Snapshot>>,
     save_completion_tx: Option<mpsc::UnboundedSender<()>>,
@@ -54,38 +44,13 @@ impl StateManager {
     ///
     #[allow(clippy::type_complexity)]
     pub fn new(
-        backend: &str,
-        save_file: Option<String>,
-    ) -> kanban_domain::KanbanResult<(
-        Self,
-        Option<mpsc::Receiver<Snapshot>>,
-        Option<mpsc::UnboundedReceiver<()>>,
-    )> {
-        let store: Option<DynStore> = if let Some(ref path) = save_file {
-            let (store, _id) = Self::create_store(backend, path)?;
-            Some(store)
-        } else {
-            None
-        };
-
-        Ok(Self::with_store(store))
-    }
-
-    /// Create a state manager with a pre-built store
-    #[allow(clippy::type_complexity)]
-    pub fn with_store(
-        store: Option<DynStore>,
+        has_persistence: bool,
     ) -> (
         Self,
         Option<mpsc::Receiver<Snapshot>>,
         Option<mpsc::UnboundedReceiver<()>>,
     ) {
-        let instance_id = store
-            .as_ref()
-            .map(|s| s.instance_id())
-            .unwrap_or_else(uuid::Uuid::new_v4);
-
-        let (save_tx, save_rx) = if store.is_some() {
+        let (save_tx, save_rx) = if has_persistence {
             let (tx, rx) = mpsc::channel(SAVE_QUEUE_CAPACITY);
             (Some(tx), Some(rx))
         } else {
@@ -95,10 +60,6 @@ impl StateManager {
         let (save_completion_tx, save_completion_rx) = mpsc::unbounded_channel();
 
         let manager = Self {
-            store,
-            command_queue: VecDeque::new(),
-            instance_id,
-            conflict_pending: false,
             needs_refresh: false,
             save_tx,
             save_completion_tx: Some(save_completion_tx),
@@ -109,40 +70,6 @@ impl StateManager {
         (manager, save_rx, Some(save_completion_rx))
     }
 
-    fn create_store(
-        backend: &str,
-        path: &str,
-    ) -> kanban_domain::KanbanResult<(DynStore, uuid::Uuid)> {
-        let store = kanban_service::make_store(backend, path)?;
-        let id = store.instance_id();
-        Ok((store, id))
-    }
-
-    /// Get the instance ID for this manager
-    pub fn instance_id(&self) -> uuid::Uuid {
-        self.instance_id
-    }
-
-    /// Get the store reference
-    pub fn store(&self) -> Option<&DynStore> {
-        self.store.as_ref()
-    }
-
-    /// Check if there's a pending conflict
-    pub fn has_conflict(&self) -> bool {
-        self.conflict_pending
-    }
-
-    /// Clear the conflict flag (called after user resolves conflict)
-    pub fn clear_conflict(&mut self) {
-        self.conflict_pending = false;
-    }
-
-    /// Clear the store reference (called when import fails to prevent accidental saves)
-    pub fn clear_store(&mut self) {
-        self.store = None;
-    }
-
     /// Check if view needs to be refreshed
     pub fn needs_refresh(&self) -> bool {
         self.needs_refresh
@@ -151,48 +78,6 @@ impl StateManager {
     /// Clear the refresh flag (called after view is refreshed)
     pub fn clear_refresh(&mut self) {
         self.needs_refresh = false;
-    }
-
-    /// Force overwrite external changes (user chose to keep their changes)
-    pub async fn force_overwrite(&mut self, snapshot: &Snapshot) -> KanbanResult<()> {
-        self.conflict_pending = false;
-
-        if let Some(ref store) = self.store {
-            let data = kanban_persistence::snapshot_to_json_bytes(snapshot)?;
-            let persistence_snapshot = StoreSnapshot {
-                data,
-                metadata: PersistenceMetadata::new(self.instance_id),
-            };
-
-            store.save(persistence_snapshot).await?;
-            self.command_queue.clear();
-
-            tracing::info!("Force overwrote external changes");
-        }
-
-        Ok(())
-    }
-
-    /// Reload from disk (user chose to discard their changes)
-    pub async fn reload_from_disk(&mut self, app: &mut App) -> KanbanResult<()> {
-        self.conflict_pending = false;
-
-        if let Some(ref store) = self.store {
-            let (snapshot, _metadata) = store.load().await?;
-
-            // Deserialize and apply loaded data to app
-            let data: Snapshot = kanban_persistence::snapshot_from_json_bytes(&snapshot.data)?;
-
-            data.apply_to_app(app);
-
-            app.ctx.inner.mark_clean();
-            app.ctx.inner.clear_history();
-            self.command_queue.clear();
-
-            tracing::info!("Reloaded state from disk - undo history cleared");
-        }
-
-        Ok(())
     }
 
     /// Close the save channel to signal the worker to finish processing and exit
@@ -293,20 +178,15 @@ impl StateManager {
         tracing::debug!("File watcher set on StateManager");
     }
 
-    /// Replace the persistence store after a backend migration.
+    /// Reset save channels after a backend migration.
     ///
     /// Drops the old save channel (causing the old save worker to exit),
-    /// creates a new store and channels. Returns receivers so the caller
-    /// can spawn a new save worker.
+    /// creates new channels. Returns receivers so the caller can spawn a new save worker.
+    /// The store itself lives on KanbanContext.
     #[allow(clippy::type_complexity)]
-    pub fn replace_store(
+    pub fn reset_save_channels(
         &mut self,
-        backend: &str,
-        path: &str,
-    ) -> KanbanResult<(mpsc::Receiver<Snapshot>, mpsc::UnboundedReceiver<()>)> {
-        let (store, instance_id) = Self::create_store(backend, path)?;
-        self.store = Some(store);
-        self.instance_id = instance_id;
+    ) -> (mpsc::Receiver<Snapshot>, mpsc::UnboundedReceiver<()>) {
         self.file_watcher = None;
         self.pending_saves = 0;
 
@@ -316,8 +196,7 @@ impl StateManager {
         let (completion_tx, completion_rx) = mpsc::unbounded_channel();
         self.save_completion_tx = Some(completion_tx);
 
-        tracing::info!("Store replaced with new backend at: {}", path);
-        Ok((rx, completion_rx))
+        (rx, completion_rx)
     }
 }
 
@@ -326,41 +205,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_state_manager_creation() {
-        let (manager, _rx, _completion_rx) = StateManager::new("json", None).unwrap();
+    fn test_state_manager_creation_no_persistence() {
+        let (manager, save_rx, _completion_rx) = StateManager::new(false);
         assert!(!manager.has_pending_saves());
+        assert!(save_rx.is_none());
     }
 
     #[test]
-    fn test_replace_store_swaps_backend() {
-        let dir = tempfile::tempdir().unwrap();
-        let initial_path = dir.path().join("test.json");
-        std::fs::write(&initial_path, "{}").unwrap();
-        let (mut manager, _rx, _crx) =
-            StateManager::new("json", Some(initial_path.to_str().unwrap().to_string())).unwrap();
-
-        let new_path = dir.path().join("test2.json");
-        std::fs::write(&new_path, "{}").unwrap();
-        let result = manager.replace_store("json", new_path.to_str().unwrap());
-        assert!(result.is_ok());
-
-        let store = manager.store().unwrap();
-        assert_eq!(store.path(), new_path.as_path());
+    fn test_state_manager_creation_with_persistence() {
+        let (manager, save_rx, _completion_rx) = StateManager::new(true);
+        assert!(!manager.has_pending_saves());
+        assert!(save_rx.is_some());
+        assert!(manager.has_save_channel());
     }
 
     #[test]
-    fn test_replace_store_resets_state() {
-        let dir = tempfile::tempdir().unwrap();
-        let path1 = dir.path().join("a.json");
-        std::fs::write(&path1, "{}").unwrap();
-        let (mut manager, _rx, _crx) =
-            StateManager::new("json", Some(path1.to_str().unwrap().to_string())).unwrap();
-
-        let path2 = dir.path().join("b.json");
-        std::fs::write(&path2, "{}").unwrap();
-        let (_rx, _crx) = manager
-            .replace_store("json", path2.to_str().unwrap())
-            .unwrap();
+    fn test_reset_save_channels() {
+        let (mut manager, _rx, _crx) = StateManager::new(true);
+        let (_rx, _crx) = manager.reset_save_channels();
         assert!(!manager.has_pending_saves());
         assert!(manager.has_save_channel());
     }

--- a/crates/kanban-tui/src/state/mod.rs
+++ b/crates/kanban-tui/src/state/mod.rs
@@ -14,8 +14,6 @@ pub use kanban_domain::commands;
 pub use snapshot::TuiSnapshot;
 
 type DynStore = Arc<dyn PersistenceStore + Send + Sync>;
-type SaveChannel = (mpsc::Sender<Snapshot>, mpsc::Receiver<Snapshot>);
-
 const SAVE_QUEUE_CAPACITY: usize = 100;
 
 /// Manages state mutations and persistence with immediate auto-saving
@@ -69,21 +67,32 @@ impl StateManager {
         Option<mpsc::Receiver<Snapshot>>,
         Option<mpsc::UnboundedReceiver<()>>,
     )> {
-        // Use bounded channel to prevent unbounded memory growth.
-        // If queue is full, save_if_needed() will log a warning instead of blocking.
-        let (store, instance_id, save_channel): (
-            Option<DynStore>,
-            uuid::Uuid,
-            Option<SaveChannel>,
-        ) = if let Some(ref path) = save_file {
-            let (store, id) = Self::create_store(backend, path)?;
-            let (tx, rx) = mpsc::channel(SAVE_QUEUE_CAPACITY);
-            (Some(store), id, Some((tx, rx)))
+        let store: Option<DynStore> = if let Some(ref path) = save_file {
+            let (store, _id) = Self::create_store(backend, path)?;
+            Some(store)
         } else {
-            (None, uuid::Uuid::new_v4(), None)
+            None
         };
 
-        let (save_tx, save_rx) = if let Some((tx, rx)) = save_channel {
+        Ok(Self::with_store(store))
+    }
+
+    /// Create a state manager with a pre-built store
+    #[allow(clippy::type_complexity)]
+    pub fn with_store(
+        store: Option<DynStore>,
+    ) -> (
+        Self,
+        Option<mpsc::Receiver<Snapshot>>,
+        Option<mpsc::UnboundedReceiver<()>>,
+    ) {
+        let instance_id = store
+            .as_ref()
+            .map(|s| s.instance_id())
+            .unwrap_or_else(uuid::Uuid::new_v4);
+
+        let (save_tx, save_rx) = if store.is_some() {
+            let (tx, rx) = mpsc::channel(SAVE_QUEUE_CAPACITY);
             (Some(tx), Some(rx))
         } else {
             (None, None)
@@ -105,7 +114,7 @@ impl StateManager {
             history: HistoryManager::new(),
         };
 
-        Ok((manager, save_rx, Some(save_completion_rx)))
+        (manager, save_rx, Some(save_completion_rx))
     }
 
     fn create_store(
@@ -160,12 +169,12 @@ impl StateManager {
     pub fn execute(&mut self, app: &mut App, command: Box<dyn Command>) -> KanbanResult<()> {
         // Execute command
         self.execute_with_context(
-            &mut app.ctx.boards,
-            &mut app.ctx.columns,
-            &mut app.ctx.cards,
-            &mut app.ctx.sprints,
-            &mut app.ctx.archived_cards,
-            &mut app.ctx.graph,
+            &mut app.ctx.inner.boards,
+            &mut app.ctx.inner.columns,
+            &mut app.ctx.inner.cards,
+            &mut app.ctx.inner.sprints,
+            &mut app.ctx.inner.archived_cards,
+            &mut app.ctx.inner.graph,
             command,
         )?;
 

--- a/crates/kanban-tui/src/state/mod.rs
+++ b/crates/kanban-tui/src/state/mod.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 pub use snapshot::TuiSnapshot;
 const SAVE_QUEUE_CAPACITY: usize = 100;
 
-/// Manages state mutations and persistence with immediate auto-saving
+/// Coordinates persistence with immediate auto-saving
 ///
 /// # Save Behavior
 ///
@@ -26,19 +26,18 @@ const SAVE_QUEUE_CAPACITY: usize = 100;
 /// // Execute command via TuiContext, then queue snapshot
 /// ctx.execute_commands_batch(commands)?;
 /// ```
-pub struct StateManager {
-    needs_refresh: bool,
+pub struct SaveCoordinator {
     save_tx: Option<mpsc::Sender<Snapshot>>,
     save_completion_tx: Option<mpsc::UnboundedSender<()>>,
     pending_saves: usize,
     file_watcher: Option<Arc<kanban_persistence::FileWatcher>>,
 }
 
-impl StateManager {
-    /// Create a new state manager with optional persistence store
+impl SaveCoordinator {
+    /// Create a new save coordinator with optional persistence store
     ///
     /// Returns a tuple of:
-    /// - StateManager instance
+    /// - SaveCoordinator instance
     /// - Optional receiver for async save processing (snapshots to save)
     /// - Optional receiver for save completion notifications
     ///
@@ -59,25 +58,14 @@ impl StateManager {
 
         let (save_completion_tx, save_completion_rx) = mpsc::unbounded_channel();
 
-        let manager = Self {
-            needs_refresh: false,
+        let coordinator = Self {
             save_tx,
             save_completion_tx: Some(save_completion_tx),
             pending_saves: 0,
             file_watcher: None,
         };
 
-        (manager, save_rx, Some(save_completion_rx))
-    }
-
-    /// Check if view needs to be refreshed
-    pub fn needs_refresh(&self) -> bool {
-        self.needs_refresh
-    }
-
-    /// Clear the refresh flag (called after view is refreshed)
-    pub fn clear_refresh(&mut self) {
-        self.needs_refresh = false;
+        (coordinator, save_rx, Some(save_completion_rx))
     }
 
     /// Close the save channel to signal the worker to finish processing and exit
@@ -175,7 +163,7 @@ impl StateManager {
     /// Called after the file watcher is initialized in App::run()
     pub fn set_file_watcher(&mut self, watcher: Arc<kanban_persistence::FileWatcher>) {
         self.file_watcher = Some(watcher);
-        tracing::debug!("File watcher set on StateManager");
+        tracing::debug!("File watcher set on SaveCoordinator");
     }
 
     /// Reset save channels after a backend migration.
@@ -205,25 +193,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_state_manager_creation_no_persistence() {
-        let (manager, save_rx, _completion_rx) = StateManager::new(false);
-        assert!(!manager.has_pending_saves());
+    fn test_save_coordinator_creation_no_persistence() {
+        let (coordinator, save_rx, _completion_rx) = SaveCoordinator::new(false);
+        assert!(!coordinator.has_pending_saves());
         assert!(save_rx.is_none());
     }
 
     #[test]
-    fn test_state_manager_creation_with_persistence() {
-        let (manager, save_rx, _completion_rx) = StateManager::new(true);
-        assert!(!manager.has_pending_saves());
+    fn test_save_coordinator_creation_with_persistence() {
+        let (coordinator, save_rx, _completion_rx) = SaveCoordinator::new(true);
+        assert!(!coordinator.has_pending_saves());
         assert!(save_rx.is_some());
-        assert!(manager.has_save_channel());
+        assert!(coordinator.has_save_channel());
     }
 
     #[test]
     fn test_reset_save_channels() {
-        let (mut manager, _rx, _crx) = StateManager::new(true);
-        let (_rx, _crx) = manager.reset_save_channels();
-        assert!(!manager.has_pending_saves());
-        assert!(manager.has_save_channel());
+        let (mut coordinator, _rx, _crx) = SaveCoordinator::new(true);
+        let (_rx, _crx) = coordinator.reset_save_channels();
+        assert!(!coordinator.has_pending_saves());
+        assert!(coordinator.has_save_channel());
     }
 }

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -21,23 +21,11 @@ pub trait TuiSnapshot {
 
 impl TuiSnapshot for Snapshot {
     fn from_app(app: &App) -> Self {
-        Self {
-            boards: app.ctx.boards.clone(),
-            columns: app.ctx.columns.clone(),
-            cards: app.ctx.cards.clone(),
-            archived_cards: app.ctx.archived_cards.clone(),
-            sprints: app.ctx.sprints.clone(),
-            graph: app.ctx.graph.clone(),
-        }
+        app.ctx.inner.snapshot()
     }
 
     fn apply_to_app(&self, app: &mut App) {
-        app.ctx.boards = self.boards.clone();
-        app.ctx.columns = self.columns.clone();
-        app.ctx.cards = self.cards.clone();
-        app.ctx.archived_cards = self.archived_cards.clone();
-        app.ctx.sprints = self.sprints.clone();
-        app.ctx.graph = self.graph.clone();
+        app.ctx.inner.apply_snapshot(self.clone());
 
         // Sync sort field/order from active board to preserve user's selection after reload
         if let Some(board_idx) = app.selection.active_board_index {

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -21,15 +21,15 @@ pub trait TuiSnapshot {
 
 impl TuiSnapshot for Snapshot {
     fn from_app(app: &App) -> Self {
-        app.ctx.inner.snapshot()
+        app.ctx.snapshot()
     }
 
     fn apply_to_app(&self, app: &mut App) {
-        app.ctx.inner.apply_snapshot(self.clone());
+        app.ctx.apply_snapshot(self.clone());
 
         // Sync sort field/order from active board to preserve user's selection after reload
         if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.ctx.boards.get(board_idx) {
+            if let Some(board) = app.ctx.boards().get(board_idx) {
                 app.filter.current_sort_field = Some(board.task_sort_field);
                 app.filter.current_sort_order = Some(board.task_sort_order);
             }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -1,11 +1,11 @@
 use crate::state::StateManager;
 use kanban_domain::commands::Command;
+use kanban_domain::KanbanResult;
 use kanban_domain::Snapshot;
 use kanban_domain::{
     ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
     ColumnUpdate, CreateCardOptions, KanbanOperations, Sprint, SprintUpdate,
 };
-use kanban_domain::KanbanResult;
 use kanban_service::KanbanContext;
 use std::ops::Deref;
 use std::sync::Arc;

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -57,7 +57,7 @@ impl TuiContext {
     }
 
     pub fn execute_commands_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
-        self.inner.execute_batch(commands)?;
+        self.inner.execute(commands)?;
         let snapshot = self.inner.snapshot();
         self.save_coordinator.queue_snapshot(snapshot);
         Ok(())

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -63,7 +63,7 @@ impl TuiContext {
     }
 
     pub fn execute_commands_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
-        self.inner.execute_batch_with_history(commands)?;
+        self.inner.execute_batch(commands)?;
         let snapshot = self.inner.snapshot();
         self.state_manager.queue_snapshot(snapshot);
         Ok(())

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -1,27 +1,27 @@
 use crate::state::StateManager;
-use kanban_domain::commands::{
-    ActivateSprint, ArchiveCard, AssignCardToSprint, CancelSprint, Command, CompleteSprint,
-    CreateBoard, CreateCard, CreateColumn, CreateSprint, DeleteBoard, DeleteCard, DeleteColumn,
-    DeleteSprint, MoveCard, RestoreCard, UnassignCardFromSprint, UpdateBoard, UpdateCard,
-    UpdateColumn, UpdateSprint,
-};
+use kanban_domain::commands::Command;
 use kanban_domain::Snapshot;
 use kanban_domain::{
     ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
-    ColumnUpdate, DependencyGraph, FieldUpdate, KanbanOperations, Sprint, SprintUpdate,
+    ColumnUpdate, CreateCardOptions, KanbanOperations, Sprint, SprintUpdate,
 };
-use kanban_domain::{KanbanError, KanbanResult};
+use kanban_domain::KanbanResult;
+use kanban_service::KanbanContext;
+use std::ops::Deref;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 pub struct TuiContext {
-    pub boards: Vec<Board>,
-    pub columns: Vec<Column>,
-    pub cards: Vec<Card>,
-    pub archived_cards: Vec<ArchivedCard>,
-    pub sprints: Vec<Sprint>,
-    pub graph: DependencyGraph,
+    pub inner: KanbanContext,
     pub state_manager: StateManager,
+}
+
+impl Deref for TuiContext {
+    type Target = KanbanContext;
+    fn deref(&self) -> &KanbanContext {
+        &self.inner
+    }
 }
 
 impl TuiContext {
@@ -34,15 +34,24 @@ impl TuiContext {
         Option<mpsc::Receiver<Snapshot>>,
         Option<mpsc::UnboundedReceiver<()>>,
     )> {
-        let (state_manager, save_rx, completion_rx) = StateManager::new(backend, save_file)?;
+        let store: Option<Arc<dyn kanban_persistence::PersistenceStore + Send + Sync>> =
+            if let Some(ref path) = save_file {
+                Some(kanban_service::make_store(backend, path)?)
+            } else {
+                None
+            };
+
+        let inner = KanbanContext::empty(
+            store
+                .clone()
+                .unwrap_or_else(|| kanban_service::make_store("json", "/dev/null").unwrap()),
+            kanban_core::AppConfig::default(),
+        );
+
+        let (state_manager, save_rx, completion_rx) = StateManager::with_store(store);
 
         let ctx = Self {
-            boards: Vec::new(),
-            columns: Vec::new(),
-            cards: Vec::new(),
-            archived_cards: Vec::new(),
-            sprints: Vec::new(),
-            graph: DependencyGraph::new(),
+            inner,
             state_manager,
         };
 
@@ -54,71 +63,32 @@ impl TuiContext {
     }
 
     pub fn execute_commands_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
-        // Capture snapshot BEFORE execution for undo history
-        let before_snapshot = Snapshot {
-            boards: self.boards.clone(),
-            columns: self.columns.clone(),
-            cards: self.cards.clone(),
-            archived_cards: self.archived_cards.clone(),
-            sprints: self.sprints.clone(),
-            graph: self.graph.clone(),
-        };
-        self.state_manager.capture_before_command(before_snapshot);
-
-        for command in commands {
-            self.state_manager.execute_with_context(
-                &mut self.boards,
-                &mut self.columns,
-                &mut self.cards,
-                &mut self.sprints,
-                &mut self.archived_cards,
-                &mut self.graph,
-                command,
-            )?;
-        }
-
-        let snapshot = Snapshot {
-            boards: self.boards.clone(),
-            columns: self.columns.clone(),
-            cards: self.cards.clone(),
-            archived_cards: self.archived_cards.clone(),
-            sprints: self.sprints.clone(),
-            graph: self.graph.clone(),
-        };
+        self.inner.execute_batch_with_history(commands)?;
+        let snapshot = self.inner.snapshot();
         self.state_manager.queue_snapshot(snapshot);
-
         Ok(())
     }
 }
 
 impl KanbanOperations for TuiContext {
     fn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {
-        let cmd = Box::new(CreateBoard { name, card_prefix });
-        self.execute_command(cmd)?;
-        Ok(self.boards.last().unwrap().clone())
+        self.inner.create_board(name, card_prefix)
     }
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
-        Ok(self.boards.clone())
+        self.inner.list_boards()
     }
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
-        Ok(self.boards.iter().find(|b| b.id == id).cloned())
+        self.inner.get_board(id)
     }
 
     fn update_board(&mut self, id: Uuid, updates: BoardUpdate) -> KanbanResult<Board> {
-        let cmd = Box::new(UpdateBoard {
-            board_id: id,
-            updates,
-        });
-        self.execute_command(cmd)?;
-        self.get_board(id)?
-            .ok_or_else(|| KanbanError::not_found("board", id))
+        self.inner.update_board(id, updates)
     }
 
     fn delete_board(&mut self, id: Uuid) -> KanbanResult<()> {
-        let cmd = Box::new(DeleteBoard { board_id: id });
-        self.execute_command(cmd)
+        self.inner.delete_board(id)
     }
 
     fn create_column(
@@ -127,56 +97,27 @@ impl KanbanOperations for TuiContext {
         name: String,
         position: Option<i32>,
     ) -> KanbanResult<Column> {
-        let position = position.unwrap_or_else(|| {
-            self.columns
-                .iter()
-                .filter(|c| c.board_id == board_id)
-                .count() as i32
-        });
-        let cmd = Box::new(CreateColumn {
-            board_id,
-            name,
-            position,
-        });
-        self.execute_command(cmd)?;
-        Ok(self.columns.last().unwrap().clone())
+        self.inner.create_column(board_id, name, position)
     }
 
     fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
-        Ok(self
-            .columns
-            .iter()
-            .filter(|c| c.board_id == board_id)
-            .cloned()
-            .collect())
+        self.inner.list_columns(board_id)
     }
 
     fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
-        Ok(self.columns.iter().find(|c| c.id == id).cloned())
+        self.inner.get_column(id)
     }
 
     fn update_column(&mut self, id: Uuid, updates: ColumnUpdate) -> KanbanResult<Column> {
-        let cmd = Box::new(UpdateColumn {
-            column_id: id,
-            updates,
-        });
-        self.execute_command(cmd)?;
-        self.get_column(id)?
-            .ok_or_else(|| KanbanError::not_found("column", id))
+        self.inner.update_column(id, updates)
     }
 
     fn delete_column(&mut self, id: Uuid) -> KanbanResult<()> {
-        let cmd = Box::new(DeleteColumn { column_id: id });
-        self.execute_command(cmd)
+        self.inner.delete_column(id)
     }
 
     fn reorder_column(&mut self, id: Uuid, new_position: i32) -> KanbanResult<Column> {
-        let updates = ColumnUpdate {
-            name: None,
-            position: Some(new_position),
-            wip_limit: FieldUpdate::NoChange,
-        };
-        self.update_column(id, updates)
+        self.inner.reorder_column(id, new_position)
     }
 
     fn create_card(
@@ -184,75 +125,25 @@ impl KanbanOperations for TuiContext {
         board_id: Uuid,
         column_id: Uuid,
         title: String,
-        options: kanban_domain::CreateCardOptions,
+        options: CreateCardOptions,
     ) -> KanbanResult<Card> {
-        let position =
-            kanban_domain::card_lifecycle::next_position_in_column(&self.cards, column_id);
-        let cmd = Box::new(CreateCard {
-            board_id,
-            column_id,
-            title,
-            position,
-            options,
-        });
-        self.execute_command(cmd)?;
-        Ok(self.cards.last().unwrap().clone())
+        self.inner.create_card(board_id, column_id, title, options)
     }
 
     fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
-        let mut cards: Vec<_> = self.cards.clone();
-
-        if let Some(board_id) = filter.board_id {
-            let board_columns: Vec<_> = self
-                .columns
-                .iter()
-                .filter(|c| c.board_id == board_id)
-                .map(|c| c.id)
-                .collect();
-            cards.retain(|c| board_columns.contains(&c.column_id));
-        }
-
-        if let Some(column_id) = filter.column_id {
-            cards.retain(|c| c.column_id == column_id);
-        }
-
-        if let Some(sprint_id) = filter.sprint_id {
-            cards.retain(|c| c.sprint_id == Some(sprint_id));
-        }
-
-        if let Some(status) = filter.status {
-            cards.retain(|c| c.status == status);
-        }
-
-        Ok(cards.iter().map(CardSummary::from).collect())
+        self.inner.list_cards(filter)
     }
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
-        Ok(self.cards.iter().find(|c| c.id == id).cloned())
+        self.inner.get_card(id)
     }
 
     fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
-        use kanban_domain::search::find_cards_by_identifier as search;
-        Ok(search(
-            identifier,
-            &self.cards,
-            &self.columns,
-            &self.boards,
-            &self.sprints,
-        )
-        .into_iter()
-        .cloned()
-        .collect())
+        self.inner.find_cards_by_identifier(identifier)
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
-        let cmd = Box::new(UpdateCard {
-            card_id: id,
-            updates,
-        });
-        self.execute_command(cmd)?;
-        self.get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))
+        self.inner.update_card(id, updates)
     }
 
     fn move_card(
@@ -261,210 +152,51 @@ impl KanbanOperations for TuiContext {
         column_id: Uuid,
         position: Option<i32>,
     ) -> KanbanResult<Card> {
-        let position = position.unwrap_or_else(|| {
-            kanban_domain::card_lifecycle::next_position_in_column(&self.cards, column_id)
-        });
-        let cmd = Box::new(MoveCard {
-            card_id: id,
-            new_column_id: column_id,
-            new_position: position,
-        });
-        self.execute_command(cmd)?;
-        self.get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))
+        self.inner.move_card(id, column_id, position)
     }
 
     fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        let cmd = Box::new(ArchiveCard { card_id: id });
-        self.execute_command(cmd)
+        self.inner.archive_card(id)
     }
 
     fn restore_card(&mut self, id: Uuid, column_id: Option<Uuid>) -> KanbanResult<Card> {
-        let archived = self
-            .archived_cards
-            .iter()
-            .find(|ac| ac.card.id == id)
-            .ok_or_else(|| KanbanError::not_found("archived card", id))?;
-        let original_column_id = archived.original_column_id;
-        let position = archived.original_position;
-
-        let target_column = if let Some(col_id) = column_id {
-            col_id
-        } else {
-            // Derive board_id from the original column
-            let board_id = self
-                .columns
-                .iter()
-                .find(|c| c.id == original_column_id)
-                .map(|c| c.board_id);
-
-            if let Some(bid) = board_id {
-                kanban_domain::card_lifecycle::resolve_restore_column(
-                    original_column_id,
-                    bid,
-                    &self.columns,
-                )
-                .unwrap_or(original_column_id)
-            } else {
-                // Column was deleted; try first board's first column as fallback
-                self.columns
-                    .first()
-                    .map(|c| c.id)
-                    .unwrap_or(original_column_id)
-            }
-        };
-
-        let cmd = Box::new(RestoreCard {
-            card_id: id,
-            column_id: target_column,
-            position,
-        });
-        self.execute_command(cmd)?;
-        self.get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))
+        self.inner.restore_card(id, column_id)
     }
 
     fn delete_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        let cmd = Box::new(DeleteCard { card_id: id });
-        self.execute_command(cmd)
+        self.inner.delete_card(id)
     }
 
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
-        Ok(self.archived_cards.clone())
+        self.inner.list_archived_cards()
     }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
-        let sprint = self
-            .get_sprint(sprint_id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", sprint_id))?;
-        let board = self
-            .boards
-            .iter()
-            .find(|b| b.id == sprint.board_id)
-            .ok_or_else(|| KanbanError::not_found("board", sprint.board_id))?;
-        let sprint_name = sprint.get_name(board).map(|s| s.to_string());
-        let cmd = Box::new(AssignCardToSprint {
-            card_id,
-            sprint_id,
-            sprint_number: sprint.sprint_number,
-            sprint_name,
-            sprint_status: format!("{:?}", sprint.status),
-        });
-        self.execute_command(cmd)?;
-        self.get_card(card_id)?
-            .ok_or_else(|| KanbanError::not_found("card", card_id))
+        self.inner.assign_card_to_sprint(card_id, sprint_id)
     }
 
     fn unassign_card_from_sprint(&mut self, card_id: Uuid) -> KanbanResult<Card> {
-        let cmd = Box::new(UnassignCardFromSprint { card_id });
-        self.execute_command(cmd)?;
-        self.get_card(card_id)?
-            .ok_or_else(|| KanbanError::not_found("card", card_id))
+        self.inner.unassign_card_from_sprint(card_id)
     }
 
     fn get_card_branch_name(&self, id: Uuid) -> KanbanResult<String> {
-        let card = self
-            .get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))?;
-        let column = self
-            .columns
-            .iter()
-            .find(|c| c.id == card.column_id)
-            .ok_or_else(|| KanbanError::not_found("column", card.column_id))?;
-        let board = self
-            .boards
-            .iter()
-            .find(|b| b.id == column.board_id)
-            .ok_or_else(|| KanbanError::not_found("board", column.board_id))?;
-        Ok(card.branch_name(board, &self.sprints, "task"))
+        self.inner.get_card_branch_name(id)
     }
 
     fn get_card_git_checkout(&self, id: Uuid) -> KanbanResult<String> {
-        let card = self
-            .get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))?;
-        let column = self
-            .columns
-            .iter()
-            .find(|c| c.id == card.column_id)
-            .ok_or_else(|| KanbanError::not_found("column", card.column_id))?;
-        let board = self
-            .boards
-            .iter()
-            .find(|b| b.id == column.board_id)
-            .ok_or_else(|| KanbanError::not_found("board", column.board_id))?;
-        Ok(card.git_checkout_command(board, &self.sprints, "task"))
+        self.inner.get_card_git_checkout(id)
     }
 
     fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        let commands: Vec<Box<dyn Command>> = ids
-            .iter()
-            .filter(|id| self.cards.iter().any(|c| c.id == **id))
-            .map(|&card_id| Box::new(ArchiveCard { card_id }) as Box<dyn Command>)
-            .collect();
-        let count = commands.len();
-        if !commands.is_empty() {
-            self.execute_commands_batch(commands)?;
-        }
-        Ok(count)
+        self.inner.bulk_archive_cards(ids)
     }
 
     fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        let valid_ids: Vec<Uuid> = ids
-            .into_iter()
-            .filter(|id| self.cards.iter().any(|c| c.id == *id))
-            .collect();
-        let count = valid_ids.len();
-        if count == 0 {
-            return Ok(0);
-        }
-        let base_position =
-            kanban_domain::card_lifecycle::next_position_in_column(&self.cards, column_id);
-        let commands: Vec<Box<dyn Command>> = valid_ids
-            .into_iter()
-            .enumerate()
-            .map(|(i, card_id)| {
-                Box::new(MoveCard {
-                    card_id,
-                    new_column_id: column_id,
-                    new_position: base_position + i as i32,
-                }) as Box<dyn Command>
-            })
-            .collect();
-        self.execute_commands_batch(commands)?;
-        Ok(count)
+        self.inner.bulk_move_cards(ids, column_id)
     }
 
     fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        let sprint = self
-            .get_sprint(sprint_id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", sprint_id))?;
-        let board = self
-            .boards
-            .iter()
-            .find(|b| b.id == sprint.board_id)
-            .ok_or_else(|| KanbanError::not_found("board", sprint.board_id))?;
-        let sprint_name = sprint.get_name(board).map(|s| s.to_string());
-        let sprint_number = sprint.sprint_number;
-        let sprint_status = format!("{:?}", sprint.status);
-        let commands: Vec<Box<dyn Command>> = ids
-            .into_iter()
-            .filter(|id| self.cards.iter().any(|c| c.id == *id))
-            .map(|card_id| {
-                Box::new(AssignCardToSprint {
-                    card_id,
-                    sprint_id,
-                    sprint_number,
-                    sprint_name: sprint_name.clone(),
-                    sprint_status: sprint_status.clone(),
-                }) as Box<dyn Command>
-            })
-            .collect();
-        let count = commands.len();
-        if !commands.is_empty() {
-            self.execute_commands_batch(commands)?;
-        }
-        Ok(count)
+        self.inner.bulk_assign_sprint(ids, sprint_id)
     }
 
     fn carry_over_sprint_cards(
@@ -472,34 +204,8 @@ impl KanbanOperations for TuiContext {
         from_sprint_id: Uuid,
         to_sprint_id: Uuid,
     ) -> KanbanResult<usize> {
-        use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-
-        let from_sprint = self
-            .get_sprint(from_sprint_id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", from_sprint_id))?;
-        if from_sprint.status != kanban_domain::SprintStatus::Completed
-            && from_sprint.status != kanban_domain::SprintStatus::Cancelled
-        {
-            return Err(KanbanError::validation(format!(
-                "Source sprint must be Completed or Cancelled, got {:?}",
-                from_sprint.status
-            )));
-        }
-        let to_sprint = self
-            .get_sprint(to_sprint_id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", to_sprint_id))?;
-        if to_sprint.status != kanban_domain::SprintStatus::Planning {
-            return Err(KanbanError::validation(format!(
-                "Target sprint must be Planning, got {:?}",
-                to_sprint.status
-            )));
-        }
-
-        let ids: Vec<Uuid> = get_sprint_uncompleted_cards(from_sprint_id, &self.cards)
-            .iter()
-            .map(|c| c.id)
-            .collect();
-        self.bulk_assign_sprint(ids, to_sprint_id)
+        self.inner
+            .carry_over_sprint_cards(from_sprint_id, to_sprint_id)
     }
 
     fn create_sprint(
@@ -508,147 +214,42 @@ impl KanbanOperations for TuiContext {
         prefix: Option<String>,
         name: Option<String>,
     ) -> KanbanResult<Sprint> {
-        let (sprint_number, name_index, effective_prefix) = {
-            let board = self
-                .boards
-                .iter_mut()
-                .find(|b| b.id == board_id)
-                .ok_or_else(|| KanbanError::not_found("board", board_id))?;
-
-            let effective_prefix = prefix
-                .or_else(|| board.sprint_prefix.clone())
-                .unwrap_or_else(|| "sprint".to_string());
-
-            board.ensure_sprint_counter_initialized(&effective_prefix, &self.sprints);
-            let sprint_number = board.get_next_sprint_number(&effective_prefix);
-            let name_index = name.map(|n| board.add_sprint_name_at_used_index(n));
-
-            (sprint_number, name_index, effective_prefix)
-        };
-
-        let cmd = Box::new(CreateSprint {
-            board_id,
-            sprint_number,
-            name_index,
-            prefix: Some(effective_prefix),
-        });
-        self.execute_command(cmd)?;
-        Ok(self.sprints.last().unwrap().clone())
+        self.inner.create_sprint(board_id, prefix, name)
     }
 
     fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
-        Ok(self
-            .sprints
-            .iter()
-            .filter(|s| s.board_id == board_id)
-            .cloned()
-            .collect())
+        self.inner.list_sprints(board_id)
     }
 
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
-        Ok(self.sprints.iter().find(|s| s.id == id).cloned())
+        self.inner.get_sprint(id)
     }
 
     fn update_sprint(&mut self, id: Uuid, updates: SprintUpdate) -> KanbanResult<Sprint> {
-        let cmd = Box::new(UpdateSprint {
-            sprint_id: id,
-            updates,
-        });
-        self.execute_command(cmd)?;
-        self.get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+        self.inner.update_sprint(id, updates)
     }
 
     fn activate_sprint(&mut self, id: Uuid, duration_days: Option<i32>) -> KanbanResult<Sprint> {
-        let duration = duration_days.unwrap_or(14) as u32;
-        let cmd = Box::new(ActivateSprint {
-            sprint_id: id,
-            duration_days: duration,
-        });
-        self.execute_command(cmd)?;
-        self.get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+        self.inner.activate_sprint(id, duration_days)
     }
 
     fn complete_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
-        let cmd = Box::new(CompleteSprint { sprint_id: id });
-        self.execute_command(cmd)?;
-        self.get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+        self.inner.complete_sprint(id)
     }
 
     fn cancel_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
-        let cmd = Box::new(CancelSprint { sprint_id: id });
-        self.execute_command(cmd)?;
-        self.get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+        self.inner.cancel_sprint(id)
     }
 
     fn delete_sprint(&mut self, id: Uuid) -> KanbanResult<()> {
-        let cmd = Box::new(DeleteSprint { sprint_id: id });
-        self.execute_command(cmd)
+        self.inner.delete_sprint(id)
     }
 
     fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String> {
-        let snapshot = if let Some(id) = board_id {
-            let boards: Vec<_> = self.boards.iter().filter(|b| b.id == id).cloned().collect();
-            let columns: Vec<_> = self
-                .columns
-                .iter()
-                .filter(|c| c.board_id == id)
-                .cloned()
-                .collect();
-            let column_ids: Vec<_> = columns.iter().map(|c| c.id).collect();
-            let cards: Vec<_> = self
-                .cards
-                .iter()
-                .filter(|c| column_ids.contains(&c.column_id))
-                .cloned()
-                .collect();
-            let sprints: Vec<_> = self
-                .sprints
-                .iter()
-                .filter(|s| s.board_id == id)
-                .cloned()
-                .collect();
-            Snapshot {
-                boards,
-                columns,
-                cards,
-                archived_cards: vec![],
-                sprints,
-                graph: self.graph.clone(),
-            }
-        } else {
-            Snapshot {
-                boards: self.boards.clone(),
-                columns: self.columns.clone(),
-                cards: self.cards.clone(),
-                archived_cards: self.archived_cards.clone(),
-                sprints: self.sprints.clone(),
-                graph: self.graph.clone(),
-            }
-        };
-
-        serde_json::to_string_pretty(&snapshot)
-            .map_err(|e| KanbanError::serialization(e.to_string()))
+        self.inner.export_board(board_id)
     }
 
     fn import_board(&mut self, data: &str) -> KanbanResult<Board> {
-        let imported: Snapshot =
-            serde_json::from_str(data).map_err(|e| KanbanError::serialization(e.to_string()))?;
-
-        let board = imported
-            .boards
-            .first()
-            .cloned()
-            .ok_or_else(|| KanbanError::validation("No board in import data"))?;
-
-        self.boards.extend(imported.boards);
-        self.columns.extend(imported.columns);
-        self.cards.extend(imported.cards);
-        self.sprints.extend(imported.sprints);
-
-        Ok(board)
+        self.inner.import_board(data)
     }
 }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -66,11 +66,21 @@ impl TuiContext {
     // --- Delegation: state methods ---
 
     pub fn undo(&mut self) -> bool {
-        self.inner.undo()
+        let result = self.inner.undo();
+        if result {
+            let snapshot = self.inner.snapshot();
+            self.save_coordinator.queue_snapshot(snapshot);
+        }
+        result
     }
 
     pub fn redo(&mut self) -> bool {
-        self.inner.redo()
+        let result = self.inner.redo();
+        if result {
+            let snapshot = self.inner.snapshot();
+            self.save_coordinator.queue_snapshot(snapshot);
+        }
+        result
     }
 
     pub fn can_undo(&self) -> bool {

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -89,14 +89,6 @@ impl TuiContext {
         self.inner.apply_snapshot(s)
     }
 
-    pub fn push_before_snapshot(&mut self, s: Snapshot) {
-        self.inner.push_before_snapshot(s)
-    }
-
-    pub fn capture_before_command(&mut self) {
-        self.inner.capture_before_command()
-    }
-
     pub fn mark_clean(&mut self) {
         self.inner.mark_clean()
     }
@@ -139,48 +131,29 @@ impl TuiContext {
         &self.inner.boards
     }
 
-    pub fn boards_mut(&mut self) -> &mut Vec<Board> {
-        &mut self.inner.boards
-    }
-
     pub fn columns(&self) -> &Vec<Column> {
         &self.inner.columns
-    }
-
-    pub fn columns_mut(&mut self) -> &mut Vec<Column> {
-        &mut self.inner.columns
     }
 
     pub fn cards(&self) -> &Vec<Card> {
         &self.inner.cards
     }
 
-    pub fn cards_mut(&mut self) -> &mut Vec<Card> {
-        &mut self.inner.cards
-    }
-
     pub fn sprints(&self) -> &Vec<Sprint> {
         &self.inner.sprints
-    }
-
-    pub fn sprints_mut(&mut self) -> &mut Vec<Sprint> {
-        &mut self.inner.sprints
     }
 
     pub fn archived_cards(&self) -> &Vec<ArchivedCard> {
         &self.inner.archived_cards
     }
 
-    pub fn archived_cards_mut(&mut self) -> &mut Vec<ArchivedCard> {
-        &mut self.inner.archived_cards
-    }
-
     pub fn graph(&self) -> &DependencyGraph {
         &self.inner.graph
     }
 
-    pub fn graph_mut(&mut self) -> &mut DependencyGraph {
-        &mut self.inner.graph
+    #[doc(hidden)]
+    pub fn inner_mut(&mut self) -> &mut KanbanContext {
+        &mut self.inner
     }
 }
 

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -187,16 +187,16 @@ impl KanbanOperations for TuiContext {
         self.inner.get_card_git_checkout(id)
     }
 
-    fn bulk_archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        self.inner.bulk_archive_cards(ids)
+    fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
+        self.inner.archive_cards(ids)
     }
 
-    fn bulk_move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        self.inner.bulk_move_cards(ids, column_id)
+    fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
+        self.inner.move_cards(ids, column_id)
     }
 
-    fn bulk_assign_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        self.inner.bulk_assign_sprint(ids, sprint_id)
+    fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
+        self.inner.assign_cards_to_sprint(ids, sprint_id)
     }
 
     fn carry_over_sprint_cards(

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -1,4 +1,4 @@
-use crate::state::StateManager;
+use crate::state::SaveCoordinator;
 use kanban_domain::commands::Command;
 use kanban_domain::DependencyGraph;
 use kanban_domain::KanbanResult;
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 pub struct TuiContext {
     inner: KanbanContext,
-    pub state_manager: StateManager,
+    pub save_coordinator: SaveCoordinator,
 }
 
 impl TuiContext {
@@ -42,11 +42,11 @@ impl TuiContext {
             kanban_core::AppConfig::default(),
         );
 
-        let (state_manager, save_rx, completion_rx) = StateManager::new(store.is_some());
+        let (save_coordinator, save_rx, completion_rx) = SaveCoordinator::new(store.is_some());
 
         let ctx = Self {
             inner,
-            state_manager,
+            save_coordinator,
         };
 
         Ok((ctx, save_rx, completion_rx))
@@ -59,7 +59,7 @@ impl TuiContext {
     pub fn execute_commands_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {
         self.inner.execute_batch(commands)?;
         let snapshot = self.inner.snapshot();
-        self.state_manager.queue_snapshot(snapshot);
+        self.save_coordinator.queue_snapshot(snapshot);
         Ok(())
     }
 
@@ -127,28 +127,28 @@ impl TuiContext {
 
     // --- Delegation: field accessors ---
 
-    pub fn boards(&self) -> &Vec<Board> {
-        &self.inner.boards
+    pub fn boards(&self) -> &[Board] {
+        self.inner.boards()
     }
 
-    pub fn columns(&self) -> &Vec<Column> {
-        &self.inner.columns
+    pub fn columns(&self) -> &[Column] {
+        self.inner.columns()
     }
 
-    pub fn cards(&self) -> &Vec<Card> {
-        &self.inner.cards
+    pub fn cards(&self) -> &[Card] {
+        self.inner.cards()
     }
 
-    pub fn sprints(&self) -> &Vec<Sprint> {
-        &self.inner.sprints
+    pub fn sprints(&self) -> &[Sprint] {
+        self.inner.sprints()
     }
 
-    pub fn archived_cards(&self) -> &Vec<ArchivedCard> {
-        &self.inner.archived_cards
+    pub fn archived_cards(&self) -> &[ArchivedCard] {
+        self.inner.archived_cards()
     }
 
     pub fn graph(&self) -> &DependencyGraph {
-        &self.inner.graph
+        self.inner.graph()
     }
 
     #[doc(hidden)]
@@ -159,7 +159,7 @@ impl TuiContext {
     fn with_snapshot<T>(&mut self, result: KanbanResult<T>) -> KanbanResult<T> {
         if result.is_ok() {
             let snapshot = self.inner.snapshot();
-            self.state_manager.queue_snapshot(snapshot);
+            self.save_coordinator.queue_snapshot(snapshot);
         }
         result
     }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -1,27 +1,21 @@
 use crate::state::StateManager;
 use kanban_domain::commands::Command;
+use kanban_domain::DependencyGraph;
 use kanban_domain::KanbanResult;
 use kanban_domain::Snapshot;
 use kanban_domain::{
     ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
     ColumnUpdate, CreateCardOptions, KanbanOperations, Sprint, SprintUpdate,
 };
+use kanban_persistence::PersistenceStore;
 use kanban_service::KanbanContext;
-use std::ops::Deref;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 pub struct TuiContext {
-    pub inner: KanbanContext,
+    inner: KanbanContext,
     pub state_manager: StateManager,
-}
-
-impl Deref for TuiContext {
-    type Target = KanbanContext;
-    fn deref(&self) -> &KanbanContext {
-        &self.inner
-    }
 }
 
 impl TuiContext {
@@ -67,6 +61,126 @@ impl TuiContext {
         let snapshot = self.inner.snapshot();
         self.state_manager.queue_snapshot(snapshot);
         Ok(())
+    }
+
+    // --- Delegation: state methods ---
+
+    pub fn undo(&mut self) -> bool {
+        self.inner.undo()
+    }
+
+    pub fn redo(&mut self) -> bool {
+        self.inner.redo()
+    }
+
+    pub fn can_undo(&self) -> bool {
+        self.inner.can_undo()
+    }
+
+    pub fn can_redo(&self) -> bool {
+        self.inner.can_redo()
+    }
+
+    pub fn snapshot(&self) -> Snapshot {
+        self.inner.snapshot()
+    }
+
+    pub fn apply_snapshot(&mut self, s: Snapshot) {
+        self.inner.apply_snapshot(s)
+    }
+
+    pub fn push_before_snapshot(&mut self, s: Snapshot) {
+        self.inner.push_before_snapshot(s)
+    }
+
+    pub fn capture_before_command(&mut self) {
+        self.inner.capture_before_command()
+    }
+
+    pub fn mark_clean(&mut self) {
+        self.inner.mark_clean()
+    }
+
+    pub fn mark_dirty(&mut self) {
+        self.inner.mark_dirty()
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.inner.is_dirty()
+    }
+
+    pub fn clear_history(&mut self) {
+        self.inner.clear_history()
+    }
+
+    pub fn clear_conflict(&mut self) {
+        self.inner.clear_conflict()
+    }
+
+    pub fn has_conflict(&self) -> bool {
+        self.inner.has_conflict()
+    }
+
+    pub fn store(&self) -> Arc<dyn PersistenceStore + Send + Sync> {
+        self.inner.store().clone()
+    }
+
+    pub fn replace_store(&mut self, s: Arc<dyn PersistenceStore + Send + Sync>) {
+        self.inner.replace_store(s)
+    }
+
+    pub async fn save(&self) -> KanbanResult<()> {
+        self.inner.save().await
+    }
+
+    // --- Delegation: field accessors ---
+
+    pub fn boards(&self) -> &Vec<Board> {
+        &self.inner.boards
+    }
+
+    pub fn boards_mut(&mut self) -> &mut Vec<Board> {
+        &mut self.inner.boards
+    }
+
+    pub fn columns(&self) -> &Vec<Column> {
+        &self.inner.columns
+    }
+
+    pub fn columns_mut(&mut self) -> &mut Vec<Column> {
+        &mut self.inner.columns
+    }
+
+    pub fn cards(&self) -> &Vec<Card> {
+        &self.inner.cards
+    }
+
+    pub fn cards_mut(&mut self) -> &mut Vec<Card> {
+        &mut self.inner.cards
+    }
+
+    pub fn sprints(&self) -> &Vec<Sprint> {
+        &self.inner.sprints
+    }
+
+    pub fn sprints_mut(&mut self) -> &mut Vec<Sprint> {
+        &mut self.inner.sprints
+    }
+
+    pub fn archived_cards(&self) -> &Vec<ArchivedCard> {
+        &self.inner.archived_cards
+    }
+
+    pub fn archived_cards_mut(&mut self) -> &mut Vec<ArchivedCard> {
+        &mut self.inner.archived_cards
+    }
+
+    pub fn graph(&self) -> &DependencyGraph {
+        &self.inner.graph
+    }
+
+    pub fn graph_mut(&mut self) -> &mut DependencyGraph {
+        &mut self.inner.graph
     }
 }
 

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -161,7 +161,7 @@ impl TuiContext {
         self.inner.graph()
     }
 
-    #[doc(hidden)]
+    #[cfg(any(test, feature = "test-helpers"))]
     pub fn inner_mut(&mut self) -> &mut KanbanContext {
         &mut self.inner
     }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -48,7 +48,7 @@ impl TuiContext {
             kanban_core::AppConfig::default(),
         );
 
-        let (state_manager, save_rx, completion_rx) = StateManager::with_store(store);
+        let (state_manager, save_rx, completion_rx) = StateManager::new(store.is_some());
 
         let ctx = Self {
             inner,

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -44,7 +44,7 @@ impl TuiContext {
         let inner = KanbanContext::empty(
             store
                 .clone()
-                .unwrap_or_else(|| kanban_service::make_store("json", "/dev/null").unwrap()),
+                .unwrap_or_else(|| Arc::new(kanban_persistence::NullStore::new())),
             kanban_core::AppConfig::default(),
         );
 

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -155,11 +155,20 @@ impl TuiContext {
     pub fn inner_mut(&mut self) -> &mut KanbanContext {
         &mut self.inner
     }
+
+    fn with_snapshot<T>(&mut self, result: KanbanResult<T>) -> KanbanResult<T> {
+        if result.is_ok() {
+            let snapshot = self.inner.snapshot();
+            self.state_manager.queue_snapshot(snapshot);
+        }
+        result
+    }
 }
 
 impl KanbanOperations for TuiContext {
     fn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {
-        self.inner.create_board(name, card_prefix)
+        let r = self.inner.create_board(name, card_prefix);
+        self.with_snapshot(r)
     }
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
@@ -171,11 +180,13 @@ impl KanbanOperations for TuiContext {
     }
 
     fn update_board(&mut self, id: Uuid, updates: BoardUpdate) -> KanbanResult<Board> {
-        self.inner.update_board(id, updates)
+        let r = self.inner.update_board(id, updates);
+        self.with_snapshot(r)
     }
 
     fn delete_board(&mut self, id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_board(id)
+        let r = self.inner.delete_board(id);
+        self.with_snapshot(r)
     }
 
     fn create_column(
@@ -184,7 +195,8 @@ impl KanbanOperations for TuiContext {
         name: String,
         position: Option<i32>,
     ) -> KanbanResult<Column> {
-        self.inner.create_column(board_id, name, position)
+        let r = self.inner.create_column(board_id, name, position);
+        self.with_snapshot(r)
     }
 
     fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
@@ -196,15 +208,18 @@ impl KanbanOperations for TuiContext {
     }
 
     fn update_column(&mut self, id: Uuid, updates: ColumnUpdate) -> KanbanResult<Column> {
-        self.inner.update_column(id, updates)
+        let r = self.inner.update_column(id, updates);
+        self.with_snapshot(r)
     }
 
     fn delete_column(&mut self, id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_column(id)
+        let r = self.inner.delete_column(id);
+        self.with_snapshot(r)
     }
 
     fn reorder_column(&mut self, id: Uuid, new_position: i32) -> KanbanResult<Column> {
-        self.inner.reorder_column(id, new_position)
+        let r = self.inner.reorder_column(id, new_position);
+        self.with_snapshot(r)
     }
 
     fn create_card(
@@ -214,7 +229,8 @@ impl KanbanOperations for TuiContext {
         title: String,
         options: CreateCardOptions,
     ) -> KanbanResult<Card> {
-        self.inner.create_card(board_id, column_id, title, options)
+        let r = self.inner.create_card(board_id, column_id, title, options);
+        self.with_snapshot(r)
     }
 
     fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
@@ -230,7 +246,8 @@ impl KanbanOperations for TuiContext {
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
-        self.inner.update_card(id, updates)
+        let r = self.inner.update_card(id, updates);
+        self.with_snapshot(r)
     }
 
     fn move_card(
@@ -239,19 +256,23 @@ impl KanbanOperations for TuiContext {
         column_id: Uuid,
         position: Option<i32>,
     ) -> KanbanResult<Card> {
-        self.inner.move_card(id, column_id, position)
+        let r = self.inner.move_card(id, column_id, position);
+        self.with_snapshot(r)
     }
 
     fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        self.inner.archive_card(id)
+        let r = self.inner.archive_card(id);
+        self.with_snapshot(r)
     }
 
     fn restore_card(&mut self, id: Uuid, column_id: Option<Uuid>) -> KanbanResult<Card> {
-        self.inner.restore_card(id, column_id)
+        let r = self.inner.restore_card(id, column_id);
+        self.with_snapshot(r)
     }
 
     fn delete_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_card(id)
+        let r = self.inner.delete_card(id);
+        self.with_snapshot(r)
     }
 
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
@@ -259,11 +280,13 @@ impl KanbanOperations for TuiContext {
     }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
-        self.inner.assign_card_to_sprint(card_id, sprint_id)
+        let r = self.inner.assign_card_to_sprint(card_id, sprint_id);
+        self.with_snapshot(r)
     }
 
     fn unassign_card_from_sprint(&mut self, card_id: Uuid) -> KanbanResult<Card> {
-        self.inner.unassign_card_from_sprint(card_id)
+        let r = self.inner.unassign_card_from_sprint(card_id);
+        self.with_snapshot(r)
     }
 
     fn get_card_branch_name(&self, id: Uuid) -> KanbanResult<String> {
@@ -275,15 +298,18 @@ impl KanbanOperations for TuiContext {
     }
 
     fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        self.inner.archive_cards(ids)
+        let r = self.inner.archive_cards(ids);
+        self.with_snapshot(r)
     }
 
     fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        self.inner.move_cards(ids, column_id)
+        let r = self.inner.move_cards(ids, column_id);
+        self.with_snapshot(r)
     }
 
     fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        self.inner.assign_cards_to_sprint(ids, sprint_id)
+        let r = self.inner.assign_cards_to_sprint(ids, sprint_id);
+        self.with_snapshot(r)
     }
 
     fn carry_over_sprint_cards(
@@ -291,8 +317,10 @@ impl KanbanOperations for TuiContext {
         from_sprint_id: Uuid,
         to_sprint_id: Uuid,
     ) -> KanbanResult<usize> {
-        self.inner
-            .carry_over_sprint_cards(from_sprint_id, to_sprint_id)
+        let r = self
+            .inner
+            .carry_over_sprint_cards(from_sprint_id, to_sprint_id);
+        self.with_snapshot(r)
     }
 
     fn create_sprint(
@@ -301,7 +329,8 @@ impl KanbanOperations for TuiContext {
         prefix: Option<String>,
         name: Option<String>,
     ) -> KanbanResult<Sprint> {
-        self.inner.create_sprint(board_id, prefix, name)
+        let r = self.inner.create_sprint(board_id, prefix, name);
+        self.with_snapshot(r)
     }
 
     fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
@@ -313,23 +342,28 @@ impl KanbanOperations for TuiContext {
     }
 
     fn update_sprint(&mut self, id: Uuid, updates: SprintUpdate) -> KanbanResult<Sprint> {
-        self.inner.update_sprint(id, updates)
+        let r = self.inner.update_sprint(id, updates);
+        self.with_snapshot(r)
     }
 
     fn activate_sprint(&mut self, id: Uuid, duration_days: Option<i32>) -> KanbanResult<Sprint> {
-        self.inner.activate_sprint(id, duration_days)
+        let r = self.inner.activate_sprint(id, duration_days);
+        self.with_snapshot(r)
     }
 
     fn complete_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
-        self.inner.complete_sprint(id)
+        let r = self.inner.complete_sprint(id);
+        self.with_snapshot(r)
     }
 
     fn cancel_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
-        self.inner.cancel_sprint(id)
+        let r = self.inner.cancel_sprint(id);
+        self.with_snapshot(r)
     }
 
     fn delete_sprint(&mut self, id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_sprint(id)
+        let r = self.inner.delete_sprint(id);
+        self.with_snapshot(r)
     }
 
     fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String> {
@@ -337,6 +371,7 @@ impl KanbanOperations for TuiContext {
     }
 
     fn import_board(&mut self, data: &str) -> KanbanResult<Board> {
-        self.inner.import_board(data)
+        let r = self.inner.import_board(data);
+        self.with_snapshot(r)
     }
 }

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -12,7 +12,7 @@ use ratatui::{
 
 pub(super) fn render_board_detail_view(app: &App, frame: &mut Frame, area: Rect) {
     if let Some(board_idx) = app.selection.board.get() {
-        if let Some(board) = app.ctx.boards.get(board_idx) {
+        if let Some(board) = app.ctx.boards().get(board_idx) {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
@@ -99,7 +99,7 @@ fn render_board_settings_section(
     ];
 
     if let Some(sprint_prefix) =
-        kanban_domain::get_active_sprint_card_prefix_override(board, &app.ctx.sprints)
+        kanban_domain::get_active_sprint_card_prefix_override(board, app.ctx.sprints())
     {
         settings_lines.push(metadata_line_styled(
             "Active Sprint Card Prefix",
@@ -146,7 +146,7 @@ fn render_board_sprints_list(
 
     let board_sprints: Vec<&Sprint> = app
         .ctx
-        .sprints
+        .sprints()
         .iter()
         .filter(|s| s.board_id == board.id)
         .collect();
@@ -174,7 +174,7 @@ fn render_board_sprints_list(
 
             let card_count = app
                 .ctx
-                .cards
+                .cards()
                 .iter()
                 .filter(|c| c.sprint_id == Some(sprint.id))
                 .count();
@@ -234,7 +234,7 @@ fn render_board_columns_list(
 
     let mut board_columns: Vec<_> = app
         .ctx
-        .columns
+        .columns()
         .iter()
         .filter(|col| col.board_id == board.id)
         .collect();
@@ -254,7 +254,7 @@ fn render_board_columns_list(
 
             let card_count = app
                 .ctx
-                .cards
+                .cards()
                 .iter()
                 .filter(|c| c.column_id == column.id)
                 .count();

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -34,7 +34,7 @@ pub(super) fn render_relationship_boxes(
         .focused(app.focus.card_focus == CardFocus::Parents);
     let parents_lines = render_relationship_section(
         parents,
-        &app.ctx.cards,
+        app.ctx.cards(),
         "Parents",
         app.focus.card_focus == CardFocus::Parents,
         &app.relationship.parents_list,
@@ -51,7 +51,7 @@ pub(super) fn render_relationship_boxes(
         .focused(app.focus.card_focus == CardFocus::Children);
     let children_lines = render_relationship_section(
         children,
-        &app.ctx.cards,
+        app.ctx.cards(),
         "Children",
         app.focus.card_focus == CardFocus::Children,
         &app.relationship.children_list,
@@ -65,15 +65,15 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
     use kanban_domain::dependencies::CardGraphExt;
 
     if let Some(card_idx) = app.selection.active_card_index {
-        if let Some(card) = app.ctx.cards.get(card_idx) {
+        if let Some(card) = app.ctx.cards().get(card_idx) {
             if let Some(board_idx) = app.selection.active_board_index {
-                if let Some(board) = app.ctx.boards.get(board_idx) {
+                if let Some(board) = app.ctx.boards().get(board_idx) {
                     let has_sprint_logs = card.sprint_logs.len() > 1;
                     let card_id = card.id;
 
                     // Get parent and child information
-                    let parents = app.ctx.graph.cards.parents(card_id);
-                    let children = app.ctx.graph.cards.children(card_id);
+                    let parents = app.ctx.graph().cards.parents(card_id);
+                    let children = app.ctx.graph().cards.children(card_id);
                     let child_count = children.len();
 
                     let constraints = vec![
@@ -108,7 +108,7 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                             .with_focus_indicator("Metadata [2]")
                             .focused(app.focus.card_focus == CardFocus::Metadata);
                         let meta_lines =
-                            build_metadata_lines(card, board, &app.ctx.sprints, &app.app_config);
+                            build_metadata_lines(card, board, app.ctx.sprints(), &app.app_config);
                         let meta = Paragraph::new(meta_lines).block(meta_config.block());
                         frame.render_widget(meta, meta_chunks[0]);
 
@@ -142,7 +142,7 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                             .with_focus_indicator("Metadata [2]")
                             .focused(app.focus.card_focus == CardFocus::Metadata);
                         let meta_lines =
-                            build_metadata_lines(card, board, &app.ctx.sprints, &app.app_config);
+                            build_metadata_lines(card, board, app.ctx.sprints(), &app.app_config);
                         let meta = Paragraph::new(meta_lines).block(meta_config.block());
                         frame.render_widget(meta, chunks[1]);
 

--- a/crates/kanban-tui/src/ui/dialogs/boards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/boards.rs
@@ -28,7 +28,7 @@ pub(crate) fn render_export_boards_popup(app: &App, frame: &mut Frame) {
 
             let items: Vec<Line> = app
                 .ctx
-                .boards
+                .boards()
                 .iter()
                 .enumerate()
                 .map(|(i, board)| {

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -84,8 +84,8 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     let mut lines = vec![];
 
     if let Some(board_idx) = app.selection.active_board_index {
-        if let Some(board) = app.ctx.boards.get(board_idx) {
-            let board_sprints = Sprint::assignable(&app.ctx.sprints, board.id);
+        if let Some(board) = app.ctx.boards().get(board_idx) {
+            let board_sprints = Sprint::assignable(app.ctx.sprints(), board.id);
 
             for (idx, sprint_option) in std::iter::once(None)
                 .chain(board_sprints.iter().map(|s| Some(*s)))

--- a/crates/kanban-tui/src/ui/dialogs/columns.rs
+++ b/crates/kanban-tui/src/ui/dialogs/columns.rs
@@ -69,7 +69,7 @@ pub(crate) fn render_select_task_list_view_popup(app: &App, frame: &mut Frame) {
     let current_view = app
         .selection
         .active_board_index
-        .and_then(|idx| app.ctx.boards.get(idx))
+        .and_then(|idx| app.ctx.boards().get(idx))
         .map(|board| board.task_list_view);
 
     let items: Vec<ListItem> = views

--- a/crates/kanban-tui/src/ui/dialogs/sprints.rs
+++ b/crates/kanban-tui/src/ui/dialogs/sprints.rs
@@ -40,7 +40,7 @@ pub(crate) fn render_carry_over_sprint_popup(app: &App, frame: &mut Frame) {
         .carry_over_source_sprint_id
         .map(|id| {
             use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-            get_sprint_uncompleted_cards(id, &app.ctx.cards).len()
+            get_sprint_uncompleted_cards(id, app.ctx.cards()).len()
         })
         .unwrap_or(0);
     CarryOverSprintDialog { card_count }.render(app, frame);

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -153,8 +153,8 @@ mod tests {
         let board = kanban_domain::Board::new("Test Board".to_string(), None);
         let sprint = kanban_domain::Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
         let sprint_id = sprint.id;
-        app.ctx.sprints_mut().push(sprint);
-        app.ctx.boards_mut().push(board);
+        app.ctx.inner_mut().sprints.push(sprint);
+        app.ctx.inner_mut().boards.push(board);
         app.selection.active_board_index = Some(0);
         app.filter.active_sprint_filters.insert(sprint_id);
         let suffix = build_filter_title_suffix(&app);

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -153,8 +153,8 @@ mod tests {
         let board = kanban_domain::Board::new("Test Board".to_string(), None);
         let sprint = kanban_domain::Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
         let sprint_id = sprint.id;
-        app.ctx.sprints.push(sprint);
-        app.ctx.boards.push(board);
+        app.ctx.inner.sprints.push(sprint);
+        app.ctx.inner.boards.push(board);
         app.selection.active_board_index = Some(0);
         app.filter.active_sprint_filters.insert(sprint_id);
         let suffix = build_filter_title_suffix(&app);

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -11,7 +11,7 @@ use ratatui::{
 
 pub(super) fn render_main(app: &mut App, frame: &mut Frame, area: Rect) {
     let is_kanban_view = if let Some(idx) = app.selection.active_board_index {
-        if let Some(board) = app.ctx.boards.get(idx) {
+        if let Some(board) = app.ctx.boards().get(idx) {
             board.task_list_view == kanban_domain::TaskListView::ColumnView
         } else {
             false
@@ -38,13 +38,13 @@ pub(super) fn render_main(app: &mut App, frame: &mut Frame, area: Rect) {
 pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
     let mut lines = vec![];
 
-    if app.ctx.boards.is_empty() {
+    if app.ctx.boards().is_empty() {
         lines.push(Line::from(Span::styled(
             "No projects yet. Press 'n' to create one!",
             label_text(),
         )));
     } else {
-        for (idx, board) in app.ctx.boards.iter().enumerate() {
+        for (idx, board) in app.ctx.boards().iter().enumerate() {
             let config = ListItemConfig::new()
                 .selected(app.selection.board.get() == Some(idx))
                 .focused(app.focus.active == Focus::Boards)
@@ -75,10 +75,10 @@ pub fn build_filter_title_suffix(app: &App) -> Option<String> {
             .active_board_index
             .or(app.selection.board.get())
         {
-            if let Some(board) = app.ctx.boards.get(board_idx) {
+            if let Some(board) = app.ctx.boards().get(board_idx) {
                 let mut sprint_names: Vec<String> = app
                     .ctx
-                    .sprints
+                    .sprints()
                     .iter()
                     .filter(|s| app.filter.active_sprint_filters.contains(&s.id))
                     .map(|s| s.formatted_name(board, "sprint"))
@@ -153,8 +153,8 @@ mod tests {
         let board = kanban_domain::Board::new("Test Board".to_string(), None);
         let sprint = kanban_domain::Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
         let sprint_id = sprint.id;
-        app.ctx.inner.sprints.push(sprint);
-        app.ctx.inner.boards.push(board);
+        app.ctx.sprints_mut().push(sprint);
+        app.ctx.boards_mut().push(board);
         app.selection.active_board_index = Some(0);
         app.filter.active_sprint_filters.insert(sprint_id);
         let suffix = build_filter_title_suffix(&app);

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -149,12 +149,19 @@ mod tests {
 
     #[test]
     fn test_build_filter_title_suffix_sprint_filter_formats_sprint_name() {
+        use kanban_domain::KanbanOperations;
         let (mut app, _rx) = App::new(None).unwrap();
-        let board = kanban_domain::Board::new("Test Board".to_string(), None);
-        let sprint = kanban_domain::Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
+        let board = app
+            .ctx
+            .inner_mut()
+            .create_board("Test Board".to_string(), None)
+            .unwrap();
+        let sprint = app
+            .ctx
+            .inner_mut()
+            .create_sprint(board.id, None, Some("Sprint".to_string()))
+            .unwrap();
         let sprint_id = sprint.id;
-        app.ctx.inner_mut().sprints.push(sprint);
-        app.ctx.inner_mut().boards.push(board);
         app.selection.active_board_index = Some(0);
         app.filter.active_sprint_filters.insert(sprint_id);
         let suffix = build_filter_title_suffix(&app);

--- a/crates/kanban-tui/src/ui/settings_view.rs
+++ b/crates/kanban-tui/src/ui/settings_view.rs
@@ -164,7 +164,7 @@ fn render_settings_storage(app: &App, frame: &mut Frame, area: Rect) {
     } else {
         "(none)"
     };
-    let instance_id = app.ctx.state_manager.instance_id().to_string();
+    let instance_id = app.ctx.inner.store().instance_id().to_string();
     let export_selected = is_storage_selected(3);
     let export_checkbox_style = if export_selected {
         Style::default().fg(Color::Yellow).bg(SELECTED_BG)

--- a/crates/kanban-tui/src/ui/settings_view.rs
+++ b/crates/kanban-tui/src/ui/settings_view.rs
@@ -164,7 +164,7 @@ fn render_settings_storage(app: &App, frame: &mut Frame, area: Rect) {
     } else {
         "(none)"
     };
-    let instance_id = app.ctx.inner.store().instance_id().to_string();
+    let instance_id = app.ctx.store().instance_id().to_string();
     let export_selected = is_storage_selected(3);
     let export_checkbox_style = if export_selected {
         Style::default().fg(Color::Yellow).bg(SELECTED_BG)

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -12,9 +12,9 @@ use ratatui::{
 
 pub(super) fn render_sprint_detail_view(app: &App, frame: &mut Frame, area: Rect) {
     if let Some(sprint_idx) = app.selection.active_sprint_index {
-        if let Some(sprint) = app.ctx.sprints.get(sprint_idx) {
+        if let Some(sprint) = app.ctx.sprints().get(sprint_idx) {
             if let Some(board_idx) = app.selection.active_board_index {
-                if let Some(board) = app.ctx.boards.get(board_idx) {
+                if let Some(board) = app.ctx.boards().get(board_idx) {
                     let is_completed = sprint.status == SprintStatus::Completed;
 
                     if is_completed {
@@ -101,7 +101,7 @@ fn sprint_card_assignment_lines(
 ) -> Vec<Line<'static>> {
     let card_count = app
         .ctx
-        .cards
+        .cards()
         .iter()
         .filter(|c| c.sprint_id == Some(sprint.id))
         .count();
@@ -230,7 +230,7 @@ pub(super) fn render_sprint_task_panel_with_selection(
 
         for card_idx in &render_info.visible_card_indices {
             if let Some(card_id) = task_list.cards.get(*card_idx) {
-                if let Some(card) = app.ctx.cards.iter().find(|c| c.id == *card_id) {
+                if let Some(card) = app.ctx.cards().iter().find(|c| c.id == *card_id) {
                     let is_selected = selected_idx == Some(*card_idx) && is_focused;
                     let animation_type = app
                         .animation
@@ -240,7 +240,7 @@ pub(super) fn render_sprint_task_panel_with_selection(
                     let line = render_card_list_item(CardListItemConfig {
                         card,
                         board,
-                        sprints: &app.ctx.sprints,
+                        sprints: app.ctx.sprints(),
                         is_selected,
                         is_focused,
                         is_multi_selected: false,
@@ -260,7 +260,7 @@ pub(super) fn render_sprint_task_panel_with_selection(
         ));
     }
 
-    let points = calculate_task_panel_points(task_list, &app.ctx.cards);
+    let points = calculate_task_panel_points(task_list, app.ctx.cards());
 
     lines.push(Line::from(Span::styled(
         format!("Points: {}", points),

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -167,7 +167,7 @@ fn test_delete_column_with_archived_cards_fails() {
     };
 
     {
-        let cmd = ArchiveCard { card_id };
+        let cmd = ArchiveCards { ids: vec![card_id] };
         let mut ctx = CommandContext {
             boards: &mut boards,
             columns: &mut columns,
@@ -406,7 +406,7 @@ fn test_archive_card_preserves_edges() {
     }
 
     {
-        let cmd = ArchiveCard { card_id: card_a };
+        let cmd = ArchiveCards { ids: vec![card_a] };
         let mut ctx = CommandContext {
             boards: &mut boards,
             columns: &mut columns,

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -253,31 +253,9 @@ fn test_delete_sprint_unassigns_cards() {
     };
 
     {
-        let cmd = AssignCardToSprint {
-            card_id: card_a,
+        let cmd = AssignCardsToSprint {
+            ids: vec![card_a, card_b],
             sprint_id,
-            sprint_number: 1,
-            sprint_name: Some("Sprint 1".to_string()),
-            sprint_status: "Active".to_string(),
-        };
-        let mut ctx = CommandContext {
-            boards: &mut boards,
-            columns: &mut columns,
-            cards: &mut cards,
-            sprints: &mut sprints,
-            archived_cards: &mut archived_cards,
-            graph: &mut graph,
-        };
-        cmd.execute(&mut ctx).unwrap();
-    }
-
-    {
-        let cmd = AssignCardToSprint {
-            card_id: card_b,
-            sprint_id,
-            sprint_number: 1,
-            sprint_name: Some("Sprint 1".to_string()),
-            sprint_status: "Active".to_string(),
         };
         let mut ctx = CommandContext {
             boards: &mut boards,

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -14,9 +14,9 @@ fn test_export_single_board() {
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0, "task");
 
-    app.ctx.boards.push(board.clone());
-    app.ctx.columns.push(column.clone());
-    app.ctx.cards.push(card.clone());
+    app.ctx.inner.boards.push(board.clone());
+    app.ctx.inner.columns.push(column.clone());
+    app.ctx.inner.cards.push(card.clone());
     app.selection.board.set(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
 
@@ -49,12 +49,12 @@ fn test_export_all_boards() {
     let column2 = Column::new(board2.id, "Todo".to_string(), 0);
     let card2 = Card::new(&mut board2, column2.id, "Task 2".to_string(), 0, "task");
 
-    app.ctx.boards.push(board1);
-    app.ctx.boards.push(board2);
-    app.ctx.columns.push(column1);
-    app.ctx.columns.push(column2);
-    app.ctx.cards.push(card1);
-    app.ctx.cards.push(card2);
+    app.ctx.inner.boards.push(board1);
+    app.ctx.inner.boards.push(board2);
+    app.ctx.inner.columns.push(column1);
+    app.ctx.inner.columns.push(column2);
+    app.ctx.inner.cards.push(card1);
+    app.ctx.inner.cards.push(card2);
     app.input.set(file_path.to_str().unwrap().to_string());
 
     app.export_all_boards_with_filename().unwrap();
@@ -164,8 +164,8 @@ fn test_auto_save() {
 
     let board = Board::new("Auto Save Board".to_string(), None);
     let column = Column::new(board.id, "Todo".to_string(), 0);
-    app.ctx.boards.push(board);
-    app.ctx.columns.push(column);
+    app.ctx.inner.boards.push(board);
+    app.ctx.inner.columns.push(column);
 
     app.auto_save().unwrap();
 
@@ -250,10 +250,10 @@ fn test_export_import_sprint_and_card_prefixes() {
     let mut sprint = Sprint::new(board.id, 1, None, None);
     sprint.update_card_prefix(Some("hotfix".to_string()));
 
-    app.ctx.boards.push(board.clone());
-    app.ctx.columns.push(column);
-    app.ctx.cards.push(card);
-    app.ctx.sprints.push(sprint.clone());
+    app.ctx.inner.boards.push(board.clone());
+    app.ctx.inner.columns.push(column);
+    app.ctx.inner.cards.push(card);
+    app.ctx.inner.sprints.push(sprint.clone());
     app.selection.board.set(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
 

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -12,16 +12,13 @@ fn test_export_single_board() {
 
     let board = app
         .ctx
-        .inner_mut()
         .create_board("Test Board".to_string(), None)
         .unwrap();
     let column = app
         .ctx
-        .inner_mut()
         .create_column(board.id, "Todo".to_string(), None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .create_card(
             board.id,
             column.id,
@@ -55,16 +52,13 @@ fn test_export_all_boards() {
 
     let board1 = app
         .ctx
-        .inner_mut()
         .create_board("Board 1".to_string(), None)
         .unwrap();
     let column1 = app
         .ctx
-        .inner_mut()
         .create_column(board1.id, "Todo".to_string(), None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .create_card(
             board1.id,
             column1.id,
@@ -75,16 +69,13 @@ fn test_export_all_boards() {
 
     let board2 = app
         .ctx
-        .inner_mut()
         .create_board("Board 2".to_string(), None)
         .unwrap();
     let column2 = app
         .ctx
-        .inner_mut()
         .create_column(board2.id, "Todo".to_string(), None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .create_card(
             board2.id,
             column2.id,
@@ -202,11 +193,9 @@ fn test_auto_save() {
 
     let board = app
         .ctx
-        .inner_mut()
         .create_board("Auto Save Board".to_string(), None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .create_column(board.id, "Todo".to_string(), None)
         .unwrap();
 
@@ -285,11 +274,9 @@ fn test_export_import_sprint_and_card_prefixes() {
     use kanban_domain::{BoardUpdate, FieldUpdate, SprintUpdate};
     let board = app
         .ctx
-        .inner_mut()
         .create_board("Prefix Board".to_string(), None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .update_board(
             board.id,
             BoardUpdate {
@@ -302,11 +289,9 @@ fn test_export_import_sprint_and_card_prefixes() {
 
     let column = app
         .ctx
-        .inner_mut()
         .create_column(board.id, "Todo".to_string(), None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .create_card(
             board.id,
             column.id,
@@ -318,11 +303,9 @@ fn test_export_import_sprint_and_card_prefixes() {
     // Create sprint with card_prefix override
     let sprint = app
         .ctx
-        .inner_mut()
         .create_sprint(board.id, None, None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .update_sprint(
             sprint.id,
             SprintUpdate {

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -1,4 +1,4 @@
-use kanban_domain::{Board, Card, Column, Sprint};
+use kanban_domain::KanbanOperations;
 use kanban_tui::App;
 use std::fs;
 use tempfile::tempdir;
@@ -10,13 +10,25 @@ fn test_export_single_board() {
 
     let (mut app, _rx) = App::new(None).unwrap();
 
-    let mut board = Board::new("Test Board".to_string(), None);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0, "task");
-
-    app.ctx.inner_mut().boards.push(board.clone());
-    app.ctx.inner_mut().columns.push(column.clone());
-    app.ctx.inner_mut().cards.push(card.clone());
+    let board = app
+        .ctx
+        .inner_mut()
+        .create_board("Test Board".to_string(), None)
+        .unwrap();
+    let column = app
+        .ctx
+        .inner_mut()
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .create_card(
+            board.id,
+            column.id,
+            "Test Task".to_string(),
+            Default::default(),
+        )
+        .unwrap();
     app.selection.board.set(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
 
@@ -41,20 +53,46 @@ fn test_export_all_boards() {
 
     let (mut app, _rx) = App::new(None).unwrap();
 
-    let mut board1 = Board::new("Board 1".to_string(), None);
-    let column1 = Column::new(board1.id, "Todo".to_string(), 0);
-    let card1 = Card::new(&mut board1, column1.id, "Task 1".to_string(), 0, "task");
+    let board1 = app
+        .ctx
+        .inner_mut()
+        .create_board("Board 1".to_string(), None)
+        .unwrap();
+    let column1 = app
+        .ctx
+        .inner_mut()
+        .create_column(board1.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .create_card(
+            board1.id,
+            column1.id,
+            "Task 1".to_string(),
+            Default::default(),
+        )
+        .unwrap();
 
-    let mut board2 = Board::new("Board 2".to_string(), None);
-    let column2 = Column::new(board2.id, "Todo".to_string(), 0);
-    let card2 = Card::new(&mut board2, column2.id, "Task 2".to_string(), 0, "task");
+    let board2 = app
+        .ctx
+        .inner_mut()
+        .create_board("Board 2".to_string(), None)
+        .unwrap();
+    let column2 = app
+        .ctx
+        .inner_mut()
+        .create_column(board2.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .create_card(
+            board2.id,
+            column2.id,
+            "Task 2".to_string(),
+            Default::default(),
+        )
+        .unwrap();
 
-    app.ctx.inner_mut().boards.push(board1);
-    app.ctx.inner_mut().boards.push(board2);
-    app.ctx.inner_mut().columns.push(column1);
-    app.ctx.inner_mut().columns.push(column2);
-    app.ctx.inner_mut().cards.push(card1);
-    app.ctx.inner_mut().cards.push(card2);
     app.input.set(file_path.to_str().unwrap().to_string());
 
     app.export_all_boards_with_filename().unwrap();
@@ -162,10 +200,15 @@ fn test_auto_save() {
 
     let (mut app, _rx) = App::new(Some(file_path.to_str().unwrap().to_string())).unwrap();
 
-    let board = Board::new("Auto Save Board".to_string(), None);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    app.ctx.inner_mut().boards.push(board);
-    app.ctx.inner_mut().columns.push(column);
+    let board = app
+        .ctx
+        .inner_mut()
+        .create_board("Auto Save Board".to_string(), None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
 
     app.auto_save().unwrap();
 
@@ -239,21 +282,56 @@ fn test_export_import_sprint_and_card_prefixes() {
 
     // Create board with both sprint_prefix and card_prefix
     let (mut app, _rx) = App::new(None).unwrap();
-    let mut board = Board::new("Prefix Board".to_string(), None);
-    board.update_sprint_prefix(Some("sprint".to_string()));
-    board.update_card_prefix(Some("task".to_string()));
+    use kanban_domain::{BoardUpdate, FieldUpdate, SprintUpdate};
+    let board = app
+        .ctx
+        .inner_mut()
+        .create_board("Prefix Board".to_string(), None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .update_board(
+            board.id,
+            BoardUpdate {
+                sprint_prefix: FieldUpdate::Set("sprint".to_string()),
+                card_prefix: FieldUpdate::Set("task".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    let card = Card::new(&mut board, column.id, "Test Card".to_string(), 0, "task");
+    let column = app
+        .ctx
+        .inner_mut()
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .create_card(
+            board.id,
+            column.id,
+            "Test Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
 
     // Create sprint with card_prefix override
-    let mut sprint = Sprint::new(board.id, 1, None, None);
-    sprint.update_card_prefix(Some("hotfix".to_string()));
+    let sprint = app
+        .ctx
+        .inner_mut()
+        .create_sprint(board.id, None, None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .update_sprint(
+            sprint.id,
+            SprintUpdate {
+                card_prefix: FieldUpdate::Set("hotfix".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
-    app.ctx.inner_mut().boards.push(board.clone());
-    app.ctx.inner_mut().columns.push(column);
-    app.ctx.inner_mut().cards.push(card);
-    app.ctx.inner_mut().sprints.push(sprint.clone());
     app.selection.board.set(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
 

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -50,10 +50,7 @@ fn test_export_all_boards() {
 
     let (mut app, _rx) = App::new(None).unwrap();
 
-    let board1 = app
-        .ctx
-        .create_board("Board 1".to_string(), None)
-        .unwrap();
+    let board1 = app.ctx.create_board("Board 1".to_string(), None).unwrap();
     let column1 = app
         .ctx
         .create_column(board1.id, "Todo".to_string(), None)
@@ -67,10 +64,7 @@ fn test_export_all_boards() {
         )
         .unwrap();
 
-    let board2 = app
-        .ctx
-        .create_board("Board 2".to_string(), None)
-        .unwrap();
+    let board2 = app.ctx.create_board("Board 2".to_string(), None).unwrap();
     let column2 = app
         .ctx
         .create_column(board2.id, "Todo".to_string(), None)
@@ -301,10 +295,7 @@ fn test_export_import_sprint_and_card_prefixes() {
         .unwrap();
 
     // Create sprint with card_prefix override
-    let sprint = app
-        .ctx
-        .create_sprint(board.id, None, None)
-        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
     app.ctx
         .update_sprint(
             sprint.id,

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -14,9 +14,9 @@ fn test_export_single_board() {
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0, "task");
 
-    app.ctx.boards_mut().push(board.clone());
-    app.ctx.columns_mut().push(column.clone());
-    app.ctx.cards_mut().push(card.clone());
+    app.ctx.inner_mut().boards.push(board.clone());
+    app.ctx.inner_mut().columns.push(column.clone());
+    app.ctx.inner_mut().cards.push(card.clone());
     app.selection.board.set(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
 
@@ -49,12 +49,12 @@ fn test_export_all_boards() {
     let column2 = Column::new(board2.id, "Todo".to_string(), 0);
     let card2 = Card::new(&mut board2, column2.id, "Task 2".to_string(), 0, "task");
 
-    app.ctx.boards_mut().push(board1);
-    app.ctx.boards_mut().push(board2);
-    app.ctx.columns_mut().push(column1);
-    app.ctx.columns_mut().push(column2);
-    app.ctx.cards_mut().push(card1);
-    app.ctx.cards_mut().push(card2);
+    app.ctx.inner_mut().boards.push(board1);
+    app.ctx.inner_mut().boards.push(board2);
+    app.ctx.inner_mut().columns.push(column1);
+    app.ctx.inner_mut().columns.push(column2);
+    app.ctx.inner_mut().cards.push(card1);
+    app.ctx.inner_mut().cards.push(card2);
     app.input.set(file_path.to_str().unwrap().to_string());
 
     app.export_all_boards_with_filename().unwrap();
@@ -164,8 +164,8 @@ fn test_auto_save() {
 
     let board = Board::new("Auto Save Board".to_string(), None);
     let column = Column::new(board.id, "Todo".to_string(), 0);
-    app.ctx.boards_mut().push(board);
-    app.ctx.columns_mut().push(column);
+    app.ctx.inner_mut().boards.push(board);
+    app.ctx.inner_mut().columns.push(column);
 
     app.auto_save().unwrap();
 
@@ -250,10 +250,10 @@ fn test_export_import_sprint_and_card_prefixes() {
     let mut sprint = Sprint::new(board.id, 1, None, None);
     sprint.update_card_prefix(Some("hotfix".to_string()));
 
-    app.ctx.boards_mut().push(board.clone());
-    app.ctx.columns_mut().push(column);
-    app.ctx.cards_mut().push(card);
-    app.ctx.sprints_mut().push(sprint.clone());
+    app.ctx.inner_mut().boards.push(board.clone());
+    app.ctx.inner_mut().columns.push(column);
+    app.ctx.inner_mut().cards.push(card);
+    app.ctx.inner_mut().sprints.push(sprint.clone());
     app.selection.board.set(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
 

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -14,9 +14,9 @@ fn test_export_single_board() {
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0, "task");
 
-    app.ctx.inner.boards.push(board.clone());
-    app.ctx.inner.columns.push(column.clone());
-    app.ctx.inner.cards.push(card.clone());
+    app.ctx.boards_mut().push(board.clone());
+    app.ctx.columns_mut().push(column.clone());
+    app.ctx.cards_mut().push(card.clone());
     app.selection.board.set(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
 
@@ -49,12 +49,12 @@ fn test_export_all_boards() {
     let column2 = Column::new(board2.id, "Todo".to_string(), 0);
     let card2 = Card::new(&mut board2, column2.id, "Task 2".to_string(), 0, "task");
 
-    app.ctx.inner.boards.push(board1);
-    app.ctx.inner.boards.push(board2);
-    app.ctx.inner.columns.push(column1);
-    app.ctx.inner.columns.push(column2);
-    app.ctx.inner.cards.push(card1);
-    app.ctx.inner.cards.push(card2);
+    app.ctx.boards_mut().push(board1);
+    app.ctx.boards_mut().push(board2);
+    app.ctx.columns_mut().push(column1);
+    app.ctx.columns_mut().push(column2);
+    app.ctx.cards_mut().push(card1);
+    app.ctx.cards_mut().push(card2);
     app.input.set(file_path.to_str().unwrap().to_string());
 
     app.export_all_boards_with_filename().unwrap();
@@ -134,11 +134,11 @@ fn test_import_valid_format() {
     app.import_board_from_file(file_path.to_str().unwrap())
         .unwrap();
 
-    assert_eq!(app.ctx.boards.len(), 1);
-    assert_eq!(app.ctx.boards[0].name, "Imported Board");
-    assert_eq!(app.ctx.columns.len(), 1);
-    assert_eq!(app.ctx.cards.len(), 1);
-    assert_eq!(app.ctx.cards[0].title, "Imported Task");
+    assert_eq!(app.ctx.boards().len(), 1);
+    assert_eq!(app.ctx.boards()[0].name, "Imported Board");
+    assert_eq!(app.ctx.columns().len(), 1);
+    assert_eq!(app.ctx.cards().len(), 1);
+    assert_eq!(app.ctx.cards()[0].title, "Imported Task");
 }
 
 #[test]
@@ -164,8 +164,8 @@ fn test_auto_save() {
 
     let board = Board::new("Auto Save Board".to_string(), None);
     let column = Column::new(board.id, "Todo".to_string(), 0);
-    app.ctx.inner.boards.push(board);
-    app.ctx.inner.columns.push(column);
+    app.ctx.boards_mut().push(board);
+    app.ctx.columns_mut().push(column);
 
     app.auto_save().unwrap();
 
@@ -226,10 +226,10 @@ async fn test_async_load_initial_state_sqlite() {
     let (mut app, _rx) = App::new(Some(db_path.to_str().unwrap().to_string())).unwrap();
     app.load_initial_state().await;
 
-    assert_eq!(app.ctx.boards.len(), 1);
-    assert_eq!(app.ctx.boards[0].name, "SQLite Board");
-    assert_eq!(app.ctx.columns.len(), 1);
-    assert_eq!(app.ctx.columns[0].name, "Backlog");
+    assert_eq!(app.ctx.boards().len(), 1);
+    assert_eq!(app.ctx.boards()[0].name, "SQLite Board");
+    assert_eq!(app.ctx.columns().len(), 1);
+    assert_eq!(app.ctx.columns()[0].name, "Backlog");
 }
 
 #[test]
@@ -250,10 +250,10 @@ fn test_export_import_sprint_and_card_prefixes() {
     let mut sprint = Sprint::new(board.id, 1, None, None);
     sprint.update_card_prefix(Some("hotfix".to_string()));
 
-    app.ctx.inner.boards.push(board.clone());
-    app.ctx.inner.columns.push(column);
-    app.ctx.inner.cards.push(card);
-    app.ctx.inner.sprints.push(sprint.clone());
+    app.ctx.boards_mut().push(board.clone());
+    app.ctx.columns_mut().push(column);
+    app.ctx.cards_mut().push(card);
+    app.ctx.sprints_mut().push(sprint.clone());
     app.selection.board.set(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
 
@@ -273,11 +273,17 @@ fn test_export_import_sprint_and_card_prefixes() {
         .unwrap();
 
     // Verify prefixes preserved after import
-    assert_eq!(app2.ctx.boards.len(), 1);
-    assert_eq!(app2.ctx.boards[0].sprint_prefix, Some("sprint".to_string()));
-    assert_eq!(app2.ctx.boards[0].card_prefix, Some("task".to_string()));
-    assert_eq!(app2.ctx.sprints.len(), 1);
-    assert_eq!(app2.ctx.sprints[0].card_prefix, Some("hotfix".to_string()));
+    assert_eq!(app2.ctx.boards().len(), 1);
+    assert_eq!(
+        app2.ctx.boards()[0].sprint_prefix,
+        Some("sprint".to_string())
+    );
+    assert_eq!(app2.ctx.boards()[0].card_prefix, Some("task".to_string()));
+    assert_eq!(app2.ctx.sprints().len(), 1);
+    assert_eq!(
+        app2.ctx.sprints()[0].card_prefix,
+        Some("hotfix".to_string())
+    );
 }
 
 #[test]
@@ -347,14 +353,14 @@ fn test_backward_compat_old_export_format() {
         .unwrap();
 
     // Verify board imported and old branch_prefix is mapped to sprint_prefix
-    assert_eq!(app.ctx.boards.len(), 1);
-    assert_eq!(app.ctx.boards[0].name, "Old Board");
-    assert_eq!(app.ctx.boards[0].sprint_prefix, Some("FEAT".to_string()));
+    assert_eq!(app.ctx.boards().len(), 1);
+    assert_eq!(app.ctx.boards()[0].name, "Old Board");
+    assert_eq!(app.ctx.boards()[0].sprint_prefix, Some("FEAT".to_string()));
     // card_prefix should be None since old format didn't have it
-    assert_eq!(app.ctx.boards[0].card_prefix, None);
+    assert_eq!(app.ctx.boards()[0].card_prefix, None);
 
     // Verify cards still work
-    assert_eq!(app.ctx.cards.len(), 1);
-    assert_eq!(app.ctx.cards[0].title, "Old Card");
-    assert_eq!(app.ctx.cards[0].card_prefix, None);
+    assert_eq!(app.ctx.cards().len(), 1);
+    assert_eq!(app.ctx.cards()[0].title, "Old Card");
+    assert_eq!(app.ctx.cards()[0].card_prefix, None);
 }

--- a/crates/kanban-tui/tests/filter_popup_tests.rs
+++ b/crates/kanban-tui/tests/filter_popup_tests.rs
@@ -60,8 +60,8 @@ fn test_render_filter_popup_with_sprint_shows_sprint_name() {
     let (mut app, _rx) = App::new(None).unwrap();
     let board = Board::new("Test Board".to_string(), None);
     let sprint = Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
-    app.ctx.sprints_mut().push(sprint);
-    app.ctx.boards_mut().push(board);
+    app.ctx.inner_mut().sprints.push(sprint);
+    app.ctx.inner_mut().boards.push(board);
     app.selection.active_board_index = Some(0);
     app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
     app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));

--- a/crates/kanban-tui/tests/filter_popup_tests.rs
+++ b/crates/kanban-tui/tests/filter_popup_tests.rs
@@ -60,8 +60,8 @@ fn test_render_filter_popup_with_sprint_shows_sprint_name() {
     let (mut app, _rx) = App::new(None).unwrap();
     let board = Board::new("Test Board".to_string(), None);
     let sprint = Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
-    app.ctx.sprints.push(sprint);
-    app.ctx.boards.push(board);
+    app.ctx.inner.sprints.push(sprint);
+    app.ctx.inner.boards.push(board);
     app.selection.active_board_index = Some(0);
     app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
     app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));

--- a/crates/kanban-tui/tests/filter_popup_tests.rs
+++ b/crates/kanban-tui/tests/filter_popup_tests.rs
@@ -55,13 +55,18 @@ fn test_render_filter_options_popup_shows_tags_section() {
 #[test]
 fn test_render_filter_popup_with_sprint_shows_sprint_name() {
     use kanban_domain::CardFilters;
-    use kanban_domain::{Board, Sprint};
     use kanban_tui::filters::FilterDialogState;
     let (mut app, _rx) = App::new(None).unwrap();
-    let board = Board::new("Test Board".to_string(), None);
-    let sprint = Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
-    app.ctx.inner_mut().sprints.push(sprint);
-    app.ctx.inner_mut().boards.push(board);
+    use kanban_domain::KanbanOperations;
+    let board = app
+        .ctx
+        .inner_mut()
+        .create_board("Test Board".to_string(), None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .create_sprint(board.id, None, Some("Sprint".to_string()))
+        .unwrap();
     app.selection.active_board_index = Some(0);
     app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
     app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));

--- a/crates/kanban-tui/tests/filter_popup_tests.rs
+++ b/crates/kanban-tui/tests/filter_popup_tests.rs
@@ -60,11 +60,9 @@ fn test_render_filter_popup_with_sprint_shows_sprint_name() {
     use kanban_domain::KanbanOperations;
     let board = app
         .ctx
-        .inner_mut()
         .create_board("Test Board".to_string(), None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .create_sprint(board.id, None, Some("Sprint".to_string()))
         .unwrap();
     app.selection.active_board_index = Some(0);

--- a/crates/kanban-tui/tests/filter_popup_tests.rs
+++ b/crates/kanban-tui/tests/filter_popup_tests.rs
@@ -60,8 +60,8 @@ fn test_render_filter_popup_with_sprint_shows_sprint_name() {
     let (mut app, _rx) = App::new(None).unwrap();
     let board = Board::new("Test Board".to_string(), None);
     let sprint = Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
-    app.ctx.inner.sprints.push(sprint);
-    app.ctx.inner.boards.push(board);
+    app.ctx.sprints_mut().push(sprint);
+    app.ctx.boards_mut().push(board);
     app.selection.active_board_index = Some(0);
     app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
     app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -76,14 +76,15 @@ pub fn setup_settings_app() -> App {
 }
 
 pub fn setup_app_with_export_dialog(board_count: usize) -> App {
+    use kanban_domain::KanbanOperations;
     let (mut app, _rx) = App::new(None).unwrap();
     app.focus.active = Focus::Boards;
     app.push_mode(AppMode::Settings);
     for i in 0..board_count {
         app.ctx
             .inner_mut()
-            .boards
-            .push(kanban_domain::Board::new(format!("Board{}", i + 1), None));
+            .create_board(format!("Board{}", i + 1), None)
+            .unwrap();
     }
     app.export_dialog = Some(ExportDialogState::new(board_count));
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -81,8 +81,7 @@ pub fn setup_app_with_export_dialog(board_count: usize) -> App {
     app.push_mode(AppMode::Settings);
     for i in 0..board_count {
         app.ctx
-            .inner
-            .boards
+            .boards_mut()
             .push(kanban_domain::Board::new(format!("Board{}", i + 1), None));
     }
     app.export_dialog = Some(ExportDialogState::new(board_count));

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -81,6 +81,7 @@ pub fn setup_app_with_export_dialog(board_count: usize) -> App {
     app.push_mode(AppMode::Settings);
     for i in 0..board_count {
         app.ctx
+            .inner
             .boards
             .push(kanban_domain::Board::new(format!("Board{}", i + 1), None));
     }

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -82,7 +82,6 @@ pub fn setup_app_with_export_dialog(board_count: usize) -> App {
     app.push_mode(AppMode::Settings);
     for i in 0..board_count {
         app.ctx
-            .inner_mut()
             .create_board(format!("Board{}", i + 1), None)
             .unwrap();
     }

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -81,7 +81,8 @@ pub fn setup_app_with_export_dialog(board_count: usize) -> App {
     app.push_mode(AppMode::Settings);
     for i in 0..board_count {
         app.ctx
-            .boards_mut()
+            .inner_mut()
+            .boards
             .push(kanban_domain::Board::new(format!("Board{}", i + 1), None));
     }
     app.export_dialog = Some(ExportDialogState::new(board_count));

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -45,11 +45,11 @@ async fn test_import_failure_prevents_empty_state_save() {
 
     // App should load the board from V2 format
     assert_eq!(
-        app.ctx.boards.len(),
+        app.ctx.boards().len(),
         1,
         "V2 format should be imported successfully"
     );
-    assert_eq!(app.ctx.boards[0].name, "Test Board");
+    assert_eq!(app.ctx.boards()[0].name, "Test Board");
     assert!(
         app.persistence.save_file.is_some(),
         "save_file should still be enabled after successful V2 import"
@@ -75,7 +75,7 @@ async fn test_import_failure_disables_save_file() {
     );
 
     // App should have empty state
-    assert_eq!(app.ctx.boards.len(), 0);
+    assert_eq!(app.ctx.boards().len(), 0);
 }
 
 #[tokio::test]
@@ -127,11 +127,11 @@ async fn test_v2_format_is_imported_correctly() {
     app.load_initial_state().await;
 
     // Should successfully import the board with its column and card
-    assert_eq!(app.ctx.boards.len(), 1);
-    assert_eq!(app.ctx.boards[0].name, "My Project");
-    assert_eq!(app.ctx.columns.len(), 1);
-    assert_eq!(app.ctx.cards.len(), 1);
-    assert_eq!(app.ctx.cards[0].title, "Important Task");
+    assert_eq!(app.ctx.boards().len(), 1);
+    assert_eq!(app.ctx.boards()[0].name, "My Project");
+    assert_eq!(app.ctx.columns().len(), 1);
+    assert_eq!(app.ctx.cards().len(), 1);
+    assert_eq!(app.ctx.cards()[0].title, "Important Task");
     assert!(
         app.persistence.save_file.is_some(),
         "save_file should remain enabled after successful V2 import"

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -120,9 +120,7 @@ fn test_render_export_boards_select_step_shows_board_names() {
     use ratatui::Terminal;
 
     let (mut app, _rx) = App::new(None).unwrap();
-    app.ctx
-        .create_board("MyTestBoard".into(), None)
-        .unwrap();
+    app.ctx.create_board("MyTestBoard".into(), None).unwrap();
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Settings);
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
@@ -154,9 +152,7 @@ fn test_render_export_boards_options_step_shows_filename() {
     use ratatui::Terminal;
 
     let (mut app, _rx) = App::new(None).unwrap();
-    app.ctx
-        .create_board("Board1".into(), None)
-        .unwrap();
+    app.ctx.create_board("Board1".into(), None).unwrap();
     let mut dialog = ExportDialogState::new(1);
     dialog.step = ExportStep::ExportOptions;
     dialog.board_selections[0] = true;
@@ -196,10 +192,7 @@ fn test_export_boards_json_creates_file() {
     app.focus.active = Focus::Boards;
     app.push_mode(AppMode::Settings);
 
-    let board = app
-        .ctx
-        .create_board("ExportTest".into(), None)
-        .unwrap();
+    let board = app.ctx.create_board("ExportTest".into(), None).unwrap();
     app.ctx
         .create_column(board.id, "Todo".into(), None)
         .unwrap();

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -1,5 +1,6 @@
 mod helpers;
 
+use kanban_domain::KanbanOperations;
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::app::{ExportDialogState, ExportFormat, ExportStep};
@@ -121,8 +122,8 @@ fn test_render_export_boards_select_step_shows_board_names() {
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
         .inner_mut()
-        .boards
-        .push(kanban_domain::Board::new("MyTestBoard".into(), None));
+        .create_board("MyTestBoard".into(), None)
+        .unwrap();
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Settings);
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
@@ -156,8 +157,8 @@ fn test_render_export_boards_options_step_shows_filename() {
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
         .inner_mut()
-        .boards
-        .push(kanban_domain::Board::new("Board1".into(), None));
+        .create_board("Board1".into(), None)
+        .unwrap();
     let mut dialog = ExportDialogState::new(1);
     dialog.step = ExportStep::ExportOptions;
     dialog.board_selections[0] = true;
@@ -197,10 +198,15 @@ fn test_export_boards_json_creates_file() {
     app.focus.active = Focus::Boards;
     app.push_mode(AppMode::Settings);
 
-    let board = kanban_domain::Board::new("ExportTest".into(), None);
-    let col = kanban_domain::Column::new(board.id, "Todo".into(), 0);
-    app.ctx.inner_mut().boards.push(board);
-    app.ctx.inner_mut().columns.push(col);
+    let board = app
+        .ctx
+        .inner_mut()
+        .create_board("ExportTest".into(), None)
+        .unwrap();
+    app.ctx
+        .inner_mut()
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
 
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -120,7 +120,8 @@ fn test_render_export_boards_select_step_shows_board_names() {
 
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
-        .boards_mut()
+        .inner_mut()
+        .boards
         .push(kanban_domain::Board::new("MyTestBoard".into(), None));
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Settings);
@@ -154,7 +155,8 @@ fn test_render_export_boards_options_step_shows_filename() {
 
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
-        .boards_mut()
+        .inner_mut()
+        .boards
         .push(kanban_domain::Board::new("Board1".into(), None));
     let mut dialog = ExportDialogState::new(1);
     dialog.step = ExportStep::ExportOptions;
@@ -197,8 +199,8 @@ fn test_export_boards_json_creates_file() {
 
     let board = kanban_domain::Board::new("ExportTest".into(), None);
     let col = kanban_domain::Column::new(board.id, "Todo".into(), 0);
-    app.ctx.boards_mut().push(board);
-    app.ctx.columns_mut().push(col);
+    app.ctx.inner_mut().boards.push(board);
+    app.ctx.inner_mut().columns.push(col);
 
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -120,6 +120,7 @@ fn test_render_export_boards_select_step_shows_board_names() {
 
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
+        .inner
         .boards
         .push(kanban_domain::Board::new("MyTestBoard".into(), None));
     app.export_dialog = Some(ExportDialogState::new(1));
@@ -154,6 +155,7 @@ fn test_render_export_boards_options_step_shows_filename() {
 
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
+        .inner
         .boards
         .push(kanban_domain::Board::new("Board1".into(), None));
     let mut dialog = ExportDialogState::new(1);
@@ -197,8 +199,8 @@ fn test_export_boards_json_creates_file() {
 
     let board = kanban_domain::Board::new("ExportTest".into(), None);
     let col = kanban_domain::Column::new(board.id, "Todo".into(), 0);
-    app.ctx.boards.push(board);
-    app.ctx.columns.push(col);
+    app.ctx.inner.boards.push(board);
+    app.ctx.inner.columns.push(col);
 
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -121,7 +121,6 @@ fn test_render_export_boards_select_step_shows_board_names() {
 
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
-        .inner_mut()
         .create_board("MyTestBoard".into(), None)
         .unwrap();
     app.export_dialog = Some(ExportDialogState::new(1));
@@ -156,7 +155,6 @@ fn test_render_export_boards_options_step_shows_filename() {
 
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
-        .inner_mut()
         .create_board("Board1".into(), None)
         .unwrap();
     let mut dialog = ExportDialogState::new(1);
@@ -200,11 +198,9 @@ fn test_export_boards_json_creates_file() {
 
     let board = app
         .ctx
-        .inner_mut()
         .create_board("ExportTest".into(), None)
         .unwrap();
     app.ctx
-        .inner_mut()
         .create_column(board.id, "Todo".into(), None)
         .unwrap();
 

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -120,8 +120,7 @@ fn test_render_export_boards_select_step_shows_board_names() {
 
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
-        .inner
-        .boards
+        .boards_mut()
         .push(kanban_domain::Board::new("MyTestBoard".into(), None));
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Settings);
@@ -155,8 +154,7 @@ fn test_render_export_boards_options_step_shows_filename() {
 
     let (mut app, _rx) = App::new(None).unwrap();
     app.ctx
-        .inner
-        .boards
+        .boards_mut()
         .push(kanban_domain::Board::new("Board1".into(), None));
     let mut dialog = ExportDialogState::new(1);
     dialog.step = ExportStep::ExportOptions;
@@ -199,8 +197,8 @@ fn test_export_boards_json_creates_file() {
 
     let board = kanban_domain::Board::new("ExportTest".into(), None);
     let col = kanban_domain::Column::new(board.id, "Todo".into(), 0);
-    app.ctx.inner.boards.push(board);
-    app.ctx.inner.columns.push(col);
+    app.ctx.boards_mut().push(board);
+    app.ctx.columns_mut().push(col);
 
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));

--- a/crates/kanban-tui/tests/settings_navigation_tests.rs
+++ b/crates/kanban-tui/tests/settings_navigation_tests.rs
@@ -146,10 +146,8 @@ fn test_settings_enter_on_export_triggers_dialog() {
     use crossterm::event::KeyCode;
 
     let mut app = helpers::setup_settings_app();
-    app.ctx
-        .inner_mut()
-        .boards
-        .push(kanban_domain::Board::new("B1".into(), None));
+    use kanban_domain::KanbanOperations;
+    app.ctx.inner_mut().create_board("B1".into(), None).unwrap();
     app.focus.settings_focus = SettingsFocus::Storage;
     app.selection.settings_storage.set(Some(3));
 

--- a/crates/kanban-tui/tests/settings_navigation_tests.rs
+++ b/crates/kanban-tui/tests/settings_navigation_tests.rs
@@ -147,6 +147,7 @@ fn test_settings_enter_on_export_triggers_dialog() {
 
     let mut app = helpers::setup_settings_app();
     app.ctx
+        .inner
         .boards
         .push(kanban_domain::Board::new("B1".into(), None));
     app.focus.settings_focus = SettingsFocus::Storage;

--- a/crates/kanban-tui/tests/settings_navigation_tests.rs
+++ b/crates/kanban-tui/tests/settings_navigation_tests.rs
@@ -147,8 +147,7 @@ fn test_settings_enter_on_export_triggers_dialog() {
 
     let mut app = helpers::setup_settings_app();
     app.ctx
-        .inner
-        .boards
+        .boards_mut()
         .push(kanban_domain::Board::new("B1".into(), None));
     app.focus.settings_focus = SettingsFocus::Storage;
     app.selection.settings_storage.set(Some(3));

--- a/crates/kanban-tui/tests/settings_navigation_tests.rs
+++ b/crates/kanban-tui/tests/settings_navigation_tests.rs
@@ -147,7 +147,7 @@ fn test_settings_enter_on_export_triggers_dialog() {
 
     let mut app = helpers::setup_settings_app();
     use kanban_domain::KanbanOperations;
-    app.ctx.inner_mut().create_board("B1".into(), None).unwrap();
+    app.ctx.create_board("B1".into(), None).unwrap();
     app.focus.settings_focus = SettingsFocus::Storage;
     app.selection.settings_storage.set(Some(3));
 

--- a/crates/kanban-tui/tests/settings_navigation_tests.rs
+++ b/crates/kanban-tui/tests/settings_navigation_tests.rs
@@ -147,7 +147,8 @@ fn test_settings_enter_on_export_triggers_dialog() {
 
     let mut app = helpers::setup_settings_app();
     app.ctx
-        .boards_mut()
+        .inner_mut()
+        .boards
         .push(kanban_domain::Board::new("B1".into(), None));
     app.focus.settings_focus = SettingsFocus::Storage;
     app.selection.settings_storage.set(Some(3));

--- a/crates/kanban-tui/tests/settings_storage_tests.rs
+++ b/crates/kanban-tui/tests/settings_storage_tests.rs
@@ -37,8 +37,8 @@ async fn test_file_arg_new_file_defaults_to_json() {
 async fn test_migrate_json_to_sqlite_creates_file() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    assert_eq!(app.ctx.boards.len(), 1);
-    assert_eq!(app.ctx.boards[0].name, "OriginalBoard");
+    assert_eq!(app.ctx.boards().len(), 1);
+    assert_eq!(app.ctx.boards()[0].name, "OriginalBoard");
 
     let old_config = app.app_config.clone();
     let old_storage_location = app.app_config.effective_storage_location();
@@ -48,8 +48,8 @@ async fn test_migrate_json_to_sqlite_creates_file() {
     app.apply_storage_location_change(old_config, &old_storage_location);
     app.await_migration().await;
     assert!(sqlite_path.exists(), "SQLite file should be created");
-    assert_eq!(app.ctx.boards.len(), 1);
-    assert_eq!(app.ctx.boards[0].name, "OriginalBoard");
+    assert_eq!(app.ctx.boards().len(), 1);
+    assert_eq!(app.ctx.boards()[0].name, "OriginalBoard");
     assert_eq!(
         app.persistence.save_file.as_deref(),
         Some(sqlite_path.to_str().unwrap())
@@ -60,7 +60,7 @@ async fn test_migrate_json_to_sqlite_creates_file() {
 async fn test_switch_to_existing_sqlite_reloads_data() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    assert_eq!(app.ctx.boards[0].name, "OriginalBoard");
+    assert_eq!(app.ctx.boards()[0].name, "OriginalBoard");
 
     let sqlite_path =
         helpers::create_test_sqlite_file(dir.path(), "other.db", &["SqliteBoard"]).await;
@@ -71,8 +71,8 @@ async fn test_switch_to_existing_sqlite_reloads_data() {
 
     app.apply_storage_location_change(old_config, &old_storage_location);
     app.await_migration().await;
-    assert_eq!(app.ctx.boards.len(), 1);
-    assert_eq!(app.ctx.boards[0].name, "SqliteBoard");
+    assert_eq!(app.ctx.boards().len(), 1);
+    assert_eq!(app.ctx.boards()[0].name, "SqliteBoard");
     assert_eq!(
         app.persistence.save_file.as_deref(),
         Some(sqlite_path.as_str())
@@ -83,7 +83,7 @@ async fn test_switch_to_existing_sqlite_reloads_data() {
 async fn test_switch_to_existing_json_reloads_data() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    assert_eq!(app.ctx.boards[0].name, "OriginalBoard");
+    assert_eq!(app.ctx.boards()[0].name, "OriginalBoard");
 
     let second_json =
         helpers::create_test_json_file(dir.path(), "other.json", &["SecondBoard"]).await;
@@ -94,8 +94,8 @@ async fn test_switch_to_existing_json_reloads_data() {
 
     app.apply_storage_location_change(old_config, &old_storage_location);
     app.await_migration().await;
-    assert_eq!(app.ctx.boards.len(), 1);
-    assert_eq!(app.ctx.boards[0].name, "SecondBoard");
+    assert_eq!(app.ctx.boards().len(), 1);
+    assert_eq!(app.ctx.boards()[0].name, "SecondBoard");
     assert_eq!(
         app.persistence.save_file.as_deref(),
         Some(second_json.as_str())

--- a/crates/kanban-tui/tests/undo_redo_tests.rs
+++ b/crates/kanban-tui/tests/undo_redo_tests.rs
@@ -1,0 +1,64 @@
+use kanban_domain::KanbanOperations;
+use kanban_tui::tui_context::TuiContext;
+use tempfile::TempDir;
+
+fn make_ctx_with_persistence() -> (
+    TuiContext,
+    tokio::sync::mpsc::Receiver<kanban_domain::Snapshot>,
+) {
+    let dir = TempDir::new().unwrap();
+    // leak dir so the temp file lives for the test
+    let path = dir.keep().join("test.json");
+    let (ctx, save_rx, _) =
+        TuiContext::new("json", Some(path.to_str().unwrap().to_string())).unwrap();
+    (ctx, save_rx.unwrap())
+}
+
+#[test]
+fn test_undo_queues_snapshot_to_save_coordinator() {
+    let (mut ctx, mut save_rx) = make_ctx_with_persistence();
+
+    ctx.create_board("Board".into(), None).unwrap();
+    // drain the post-create snapshot
+    save_rx.try_recv().ok();
+
+    assert!(ctx.undo());
+    let snapshot = save_rx
+        .try_recv()
+        .expect("undo should queue a snapshot to the save coordinator");
+    assert!(
+        snapshot.boards.is_empty(),
+        "snapshot after undo should reflect the rolled-back state"
+    );
+}
+
+#[test]
+fn test_redo_queues_snapshot_to_save_coordinator() {
+    let (mut ctx, mut save_rx) = make_ctx_with_persistence();
+
+    ctx.create_board("Board".into(), None).unwrap();
+    assert!(ctx.undo());
+    // drain setup snapshots (create + undo)
+    while save_rx.try_recv().is_ok() {}
+
+    assert!(ctx.redo());
+    let snapshot = save_rx
+        .try_recv()
+        .expect("redo should queue a snapshot to the save coordinator");
+    assert_eq!(
+        snapshot.boards.len(),
+        1,
+        "snapshot after redo should reflect the re-applied state"
+    );
+}
+
+#[test]
+fn test_undo_when_nothing_to_undo_does_not_queue_snapshot() {
+    let (mut ctx, mut save_rx) = make_ctx_with_persistence();
+
+    assert!(!ctx.undo());
+    assert!(
+        save_rx.try_recv().is_err(),
+        "failed undo should not queue a snapshot"
+    );
+}

--- a/crates/kanban-tui/tests/undo_redo_tests.rs
+++ b/crates/kanban-tui/tests/undo_redo_tests.rs
@@ -5,18 +5,18 @@ use tempfile::TempDir;
 fn make_ctx_with_persistence() -> (
     TuiContext,
     tokio::sync::mpsc::Receiver<kanban_domain::Snapshot>,
+    TempDir,
 ) {
     let dir = TempDir::new().unwrap();
-    // leak dir so the temp file lives for the test
-    let path = dir.keep().join("test.json");
+    let path = dir.path().join("test.json");
     let (ctx, save_rx, _) =
         TuiContext::new("json", Some(path.to_str().unwrap().to_string())).unwrap();
-    (ctx, save_rx.unwrap())
+    (ctx, save_rx.unwrap(), dir)
 }
 
 #[test]
 fn test_undo_queues_snapshot_to_save_coordinator() {
-    let (mut ctx, mut save_rx) = make_ctx_with_persistence();
+    let (mut ctx, mut save_rx, _dir) = make_ctx_with_persistence();
 
     ctx.create_board("Board".into(), None).unwrap();
     // drain the post-create snapshot
@@ -34,7 +34,7 @@ fn test_undo_queues_snapshot_to_save_coordinator() {
 
 #[test]
 fn test_redo_queues_snapshot_to_save_coordinator() {
-    let (mut ctx, mut save_rx) = make_ctx_with_persistence();
+    let (mut ctx, mut save_rx, _dir) = make_ctx_with_persistence();
 
     ctx.create_board("Board".into(), None).unwrap();
     assert!(ctx.undo());
@@ -54,7 +54,7 @@ fn test_redo_queues_snapshot_to_save_coordinator() {
 
 #[test]
 fn test_undo_when_nothing_to_undo_does_not_queue_snapshot() {
-    let (mut ctx, mut save_rx) = make_ctx_with_persistence();
+    let (mut ctx, mut save_rx, _dir) = make_ctx_with_persistence();
 
     assert!(!ctx.undo());
     assert!(


### PR DESCRIPTION
Completes KAN-264 and KAN-265: history-aware execute, StateManager slimming, TuiContext encapsulation, and MCP undo/redo.

## What

- Makes `execute()` capture undo history by default so all consumers (TUI, MCP, CLI) get undo/redo for free
- Adds native batch commands (`ArchiveCards`, `MoveCards`, `AssignCardsToSprint`) — single undo entry per bulk op
- Moves conflict detection to `KanbanContext`, slims `StateManager` to a pure save coordinator
- Exposes undo/redo via MCP tools
- Encapsulates `TuiContext` — removes `Deref`, makes `inner` private, removes all `_mut()` accessors
- Routes every TUI mutation through domain commands, making all operations automatically undoable

## Why

After KAN-264 lifted `HistoryManager` into `KanbanContext`, only TUI had undo/redo (via `execute_with_history`). CLI and MCP consumers called `execute()` directly — no history. Bulk operations created N separate undo entries instead of one. `StateManager` still owned store, instance_id, and conflict detection that belong on `KanbanContext`.

The `_mut()` accessors on `TuiContext` (and previously `Deref`) let callers bypass the command system — the same footgun that caused mutations to skip undo history. CLI and MCP already route everything through `KanbanOperations` trait methods; TUI was the only path that bypassed commands.

## How

### Phase 1: History-aware execute & StateManager slimming
- Rename `execute()` → `execute_raw()` (private); new `execute()` captures history automatically
- Add `ArchiveCards`, `MoveCards`, `AssignCardsToSprint` native batch commands
- Remove `history.clear()` from `reload()` — callers call `clear_history()` explicitly
- Move `conflict_pending` / `has_conflict()` / `set_conflict()` / `clear_conflict()` to `KanbanContext`
- Add `replace_store()` to `KanbanContext` for backend migration
- Strip `store`, `instance_id`, `conflict_pending`, `command_queue` from `StateManager`
- Add `tool_undo` and `tool_redo` MCP tool handlers

### Phase 2: TuiContext encapsulation
- Remove `Deref<Target = KanbanContext>` from `TuiContext`, make `inner` private
- Add delegation methods for all read-only accessors and state operations
- Rewrite all call sites to use delegation methods

### Phase 3: Remove _mut() accessors
- Add 5 new domain commands: `ImportEntities`, `ApplyBoardSettings`, `ApplyCardMetadata`, `CompactColumnPositions`, `MigrateSprintLogs`
- Lift sprint counter initialization, number generation, and name assignment into `CreateSprint` command
- Rewrite all 13 production `_mut()` call sites to use `execute_command()`:
  - External editor (board name/desc, card title/desc) → `UpdateBoard`/`UpdateCard`
  - JSON editor (card metadata, board settings) → `ApplyCardMetadata`/`ApplyBoardSettings`
  - Board import (V1 and V2) → `ImportEntities`
  - Sprint creation → new `CreateSprint` with internal counter/name logic
  - Column compaction → `CompactColumnPositions`
  - Sprint log migration → `MigrateSprintLogs`
  - Sprint counter initialization after prefix change → removed (handled inside `CreateSprint`)
- Delete all 6 `_mut()` methods and `push_before_snapshot`/`capture_before_command` from `TuiContext`
- Add `#[doc(hidden)] inner_mut()` for test access

### Phase 4: Code review fixes
Addresses 12 actionable issues from code review:

**Undo/redo safety (Issues 3, 4, 14)**
- Restructure `undo()`/`redo()` to pop-before-push — pop the snapshot first, then push current state to the opposite stack
- Remove redundant `before` clone in `execute_batch()` — on failure, pop from undo stack directly
- Remove `push_before_snapshot()` footgun method entirely

**Correctness (Issues 1, 2, 6)**
- `assign_cards_to_sprint_detailed()` uses `AssignCardToSprint` (singular) with sprint metadata lookup, ensuring `end_current_sprint_log()` is called per card
- `move_cards()`/`assign_cards_to_sprint()` return actual counts via before/after state diff instead of counting valid IDs
- Sprint popup unassign uses `UnassignCardFromSprint` command + `UpdateCard` (clear prefix only) in a batch for proper sprint log termination

**Encapsulation (Issues 7, 8, 12)**
- Make all 6 `KanbanContext` data fields private with `&[T]` read accessors
- Add `#[cfg(any(test, feature = "test-helpers"))]` mutable accessors for test setup
- `TuiContext` accessors delegate and return `&[T]` instead of `&Vec<T>`
- Keep `inner_mut()` as `#[doc(hidden)]` (needed by integration tests)

**UX (Issue 11)**
- Add `self.set_error(...)` after every `tracing::error!` in user-initiated command failures across all 7 handler files (~56 sites) — errors are now shown to the user via the banner system

**Rename & dead code (Issues 9, 13)**
- Rename `StateManager` → `SaveCoordinator` (struct, field, all references)
- Remove `needs_refresh` field, accessor methods, and dead check in event loop

**Confirmed no-ops**: Issue 5 (sprint counter init already handled by `CreateSprint`), Issue 10 (two code paths through command system is architecturally intentional)

## Testing

- `cargo test --workspace` — all pass (630+)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — formatted
- Grep verifications: no `pub` fields on `KanbanContext`, no `push_before_snapshot`, no `needs_refresh`, no `StateManager`, no `&Vec<` in `tui_context.rs`

**Note**: CLI processes exit after one command so in-memory history is lost. CLI undo would require persisting the undo stack to disk — separate card.