### PR TITLE
KAN-326/hide-grayed-config-storage-rows-when-storage-is-not-set-in-config

### DIFF
--- a/.changeset/kan-326-hide-grayed-config-storage-rows-when-storage-is-not-set-in-config.md
+++ b/.changeset/kan-326-hide-grayed-config-storage-rows-when-storage-is-not-set-in-config.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- KAN-326: test grayed config storage rows hidden when storage not in config
+- KAN-326: hide grayed config storage rows when storage not set in config

--- a/.changeset/kan-326-hide-grayed-config-storage-rows-when-storage-is-not-set-in-config.md
+++ b/.changeset/kan-326-hide-grayed-config-storage-rows-when-storage-is-not-set-in-config.md
@@ -2,5 +2,7 @@
 bump: patch
 ---
 
-- KAN-326: test grayed config storage rows hidden when storage not in config
-- KAN-326: hide grayed config storage rows when storage not set in config
+Hide grayed config storage rows when storage not set in config
+
+- Only show grayed 'Storage Backend' / 'Storage Location' rows in the Configuration panel when storage is explicitly configured (original_storage_backend or original_storage_location is Some)
+- When config defines no storage and a CLI file overrides the default, only Active Storage rows are shown, avoiding the misleading implication that CWD-resolved defaults are configured values

--- a/crates/kanban-tui/src/ui/settings_view.rs
+++ b/crates/kanban-tui/src/ui/settings_view.rs
@@ -69,16 +69,20 @@ fn render_settings_configuration(app: &App, frame: &mut Frame, area: Rect, confi
         let active_storage_location =
             kanban_service::config::resolve_storage_location(&app.app_config);
         if app.cli_file_override {
-            config_lines.push(metadata_line_styled(
-                "Storage Backend",
-                &app.config_storage_backend,
-                Style::default().fg(Color::DarkGray),
-            ));
-            config_lines.push(metadata_line_styled(
-                "Storage Location",
-                &app.config_storage_location,
-                Style::default().fg(Color::DarkGray),
-            ));
+            let storage_configured = app.original_storage_backend.is_some()
+                || app.original_storage_location.is_some();
+            if storage_configured {
+                config_lines.push(metadata_line_styled(
+                    "Storage Backend",
+                    &app.config_storage_backend,
+                    Style::default().fg(Color::DarkGray),
+                ));
+                config_lines.push(metadata_line_styled(
+                    "Storage Location",
+                    &app.config_storage_location,
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
             config_lines.push(metadata_line_selectable(
                 "Active Storage Backend",
                 app.app_config.effective_storage_backend(),

--- a/crates/kanban-tui/src/ui/settings_view.rs
+++ b/crates/kanban-tui/src/ui/settings_view.rs
@@ -69,8 +69,8 @@ fn render_settings_configuration(app: &App, frame: &mut Frame, area: Rect, confi
         let active_storage_location =
             kanban_service::config::resolve_storage_location(&app.app_config);
         if app.cli_file_override {
-            let storage_configured = app.original_storage_backend.is_some()
-                || app.original_storage_location.is_some();
+            let storage_configured =
+                app.original_storage_backend.is_some() || app.original_storage_location.is_some();
             if storage_configured {
                 config_lines.push(metadata_line_styled(
                     "Storage Backend",

--- a/crates/kanban-tui/tests/settings_ui_tests.rs
+++ b/crates/kanban-tui/tests/settings_ui_tests.rs
@@ -213,6 +213,8 @@ fn test_render_settings_storage_fields_greyed_when_cli_file_override() {
     let (mut app, _rx) = App::new(None).unwrap();
     app.cli_file_override = true;
     app.app_config.storage_backend = Some("json".into());
+    // original_storage_backend must be set so grayed rows are shown
+    app.original_storage_backend = Some("json".into());
     app.push_mode(AppMode::Settings);
     let cells = helpers::render_to_string_with_colors(&app);
     let dark_gray_text: String = cells
@@ -313,6 +315,39 @@ fn test_render_settings_active_storage_location_shows_absolute_path_with_cli_ove
         value.starts_with('/'),
         "Active Storage Location must show an absolute path, got: {:?}",
         &value[..value.find(' ').unwrap_or(value.len()).min(60)]
+    );
+}
+
+#[test]
+fn test_render_settings_cli_override_without_config_storage_hides_config_storage_rows() {
+    // When CLI overrides the file but config defines no storage, the grayed-out
+    // "Storage Backend" / "Storage Location" rows must NOT appear — only the
+    // "Active Storage *" rows should be shown.
+    let (mut app, _rx) = App::new(None).unwrap();
+    app.cli_file_provided = true;
+    app.cli_file_override = true;
+    app.original_storage_backend = None;
+    app.original_storage_location = None;
+    app.app_config.storage_location = Some("/tmp/cli_override.json".into());
+    app.has_data_file = true;
+    app.push_mode(AppMode::Settings);
+
+    let output = helpers::render_to_string(&app);
+
+    assert!(
+        output.contains("Active Storage Backend"),
+        "Active Storage Backend must appear when CLI override is active"
+    );
+    assert!(
+        output.contains("Active Storage Location"),
+        "Active Storage Location must appear when CLI override is active"
+    );
+    // Every occurrence of "Storage Backend" must be part of "Active Storage Backend"
+    let plain_count = output.matches("Storage Backend").count();
+    let active_count = output.matches("Active Storage Backend").count();
+    assert_eq!(
+        plain_count, active_count,
+        "Plain 'Storage Backend' rows must not appear when config has no storage configured"
     );
 }
 


### PR DESCRIPTION
**What:** Hide grayed-out 'Storage Backend' / 'Storage Location' rows in the Configuration panel when storage is not explicitly configured in config.

**Why:** When no `storage_backend` or `storage_location` is set in `config.toml` and a CLI file overrides the default, the grayed rows were shown with a CWD-resolved default path (e.g. `/home/user/project/kanban.json`). This implied the value came from config when config had said nothing — a misleading presentation of an implicit default.

**How:** Gate the grayed rows on `original_storage_backend.is_some() || original_storage_location.is_some()`. When neither is set, skip them and show only the Active Storage rows. Updated the existing `test_render_settings_storage_fields_greyed_when_cli_file_override` to correctly set `original_storage_backend` for the scenario where config does define storage.

**Testing:** Added `test_render_settings_cli_override_without_config_storage_hides_config_storage_rows` to `crates/kanban-tui/tests/settings_ui_tests.rs`. All 43 TUI integration tests pass.