### PR TITLE
CAT-302/starting the tui doesnt select a board

### DIFF
--- a/.changeset/cat-302-starting-the-tui-doesnt-select-a-board.md
+++ b/.changeset/cat-302-starting-the-tui-doesnt-select-a-board.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- feat(tui): preselect first board and refresh card view on startup
+- test(tui): preselect first board and refresh card view on startup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,28 @@ cargo tarpaulin        # Code coverage
 4. **TUI Components**: Build UI in `kanban-tui`
 5. **Integration**: Wire up in `kanban-cli`
 
+## Commit Message Convention
+
+Use conventional commits with the crate name as scope, dropping the `kanban-` prefix:
+
+```
+<type>(<crate>): <description>
+```
+
+**Types:** `feat`, `fix`, `test`, `refactor`, `chore`, `docs`
+
+**Scope:** crate name without the `kanban-` prefix — e.g. `tui`, `domain`, `service`, `persistence`, `cli`, `mcp`, `core`
+
+**Examples:**
+```
+feat(tui): preselect first board and refresh card view on startup
+fix(service): handle empty board list on context init
+test(tui): preselect first board and refresh card view on startup
+refactor(domain): extract card sorting into pure function
+```
+
+Split commits by type — tests and implementation go in separate commits.
+
 ## Guidelines
 
 - **No comments** unless documenting public APIs or complex algorithms

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1584,6 +1584,10 @@ impl App {
         }
         self.migrate_sprint_logs();
         self.check_ended_sprints();
+        if self.selection.board.get().is_none() && !self.ctx.boards().is_empty() {
+            self.selection.board.set(Some(0));
+            self.refresh_view();
+        }
     }
 
     pub async fn run(

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -1,0 +1,78 @@
+mod helpers;
+
+#[tokio::test]
+async fn test_load_initial_state_with_boards_selects_first_board() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = helpers::create_test_json_file(dir.path(), "test.json", &["Alpha", "Beta"]).await;
+    let (mut app, _rx) = kanban_tui::App::new(Some(path)).unwrap();
+    app.load_initial_state().await;
+
+    assert_eq!(
+        app.selection.board.get(),
+        Some(0),
+        "first board should be selected after startup"
+    );
+}
+
+#[tokio::test]
+async fn test_load_initial_state_with_boards_refreshes_card_view() {
+    use kanban_domain::{Board, Card, Column, Snapshot};
+    use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("with_cards.json");
+    let path_str = path.to_str().unwrap().to_string();
+
+    let mut board = Board::new("Alpha".to_string(), None);
+    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let card = Card::new(&mut board, column.id, "Task One".to_string(), 0, "TST");
+    let snapshot = Snapshot {
+        boards: vec![board],
+        columns: vec![column],
+        cards: vec![card],
+        archived_cards: vec![],
+        sprints: vec![],
+        graph: Default::default(),
+    };
+    let store = kanban_persistence_json::JsonFileStore::new(&path_str);
+    let store_snapshot = StoreSnapshot {
+        data: serde_json::to_vec(&snapshot).unwrap(),
+        metadata: PersistenceMetadata::new(store.instance_id()),
+    };
+    store.save(store_snapshot).await.unwrap();
+
+    let (mut app, _rx) = kanban_tui::App::new(Some(path_str)).unwrap();
+    app.load_initial_state().await;
+
+    let task_list = app.view.strategy.get_active_task_list();
+    assert!(
+        task_list.is_some_and(|l| !l.is_empty()),
+        "card view should be populated after startup without user interaction"
+    );
+}
+
+#[tokio::test]
+async fn test_load_initial_state_with_no_boards_leaves_selection_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = helpers::create_test_json_file(dir.path(), "empty.json", &[]).await;
+    let (mut app, _rx) = kanban_tui::App::new(Some(path)).unwrap();
+    app.load_initial_state().await;
+
+    assert_eq!(
+        app.selection.board.get(),
+        None,
+        "selection should remain None when there are no boards"
+    );
+}
+
+#[tokio::test]
+async fn test_load_initial_state_with_no_file_leaves_selection_none() {
+    let (mut app, _rx) = kanban_tui::App::new(None).unwrap();
+    app.load_initial_state().await;
+
+    assert_eq!(
+        app.selection.board.get(),
+        None,
+        "selection should remain None when no file is provided"
+    );
+}

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -1,10 +1,13 @@
 mod helpers;
 
+use kanban_domain::{Board, Card, Column, KanbanError, KanbanResult, Snapshot};
+use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
+
 #[tokio::test]
-async fn test_load_initial_state_with_boards_selects_first_board() {
-    let dir = tempfile::tempdir().unwrap();
+async fn test_load_initial_state_with_boards_selects_first_board() -> KanbanResult<()> {
+    let dir = tempfile::tempdir()?;
     let path = helpers::create_test_json_file(dir.path(), "test.json", &["Alpha", "Beta"]).await;
-    let (mut app, _rx) = kanban_tui::App::new(Some(path)).unwrap();
+    let (mut app, _rx) = kanban_tui::App::new(Some(path))?;
     app.load_initial_state().await;
 
     assert_eq!(
@@ -12,14 +15,12 @@ async fn test_load_initial_state_with_boards_selects_first_board() {
         Some(0),
         "first board should be selected after startup"
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_load_initial_state_with_boards_refreshes_card_view() {
-    use kanban_domain::{Board, Card, Column, Snapshot};
-    use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
-
-    let dir = tempfile::tempdir().unwrap();
+async fn test_load_initial_state_with_boards_refreshes_card_view() -> KanbanResult<()> {
+    let dir = tempfile::tempdir()?;
     let path = dir.path().join("with_cards.json");
     let path_str = path.to_str().unwrap().to_string();
 
@@ -36,12 +37,13 @@ async fn test_load_initial_state_with_boards_refreshes_card_view() {
     };
     let store = kanban_persistence_json::JsonFileStore::new(&path_str);
     let store_snapshot = StoreSnapshot {
-        data: serde_json::to_vec(&snapshot).unwrap(),
+        data: serde_json::to_vec(&snapshot)
+            .map_err(|e| KanbanError::serialization(e.to_string()))?,
         metadata: PersistenceMetadata::new(store.instance_id()),
     };
-    store.save(store_snapshot).await.unwrap();
+    store.save(store_snapshot).await?;
 
-    let (mut app, _rx) = kanban_tui::App::new(Some(path_str)).unwrap();
+    let (mut app, _rx) = kanban_tui::App::new(Some(path_str))?;
     app.load_initial_state().await;
 
     let task_list = app.view.strategy.get_active_task_list();
@@ -49,13 +51,14 @@ async fn test_load_initial_state_with_boards_refreshes_card_view() {
         task_list.is_some_and(|l| !l.is_empty()),
         "card view should be populated after startup without user interaction"
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_load_initial_state_with_no_boards_leaves_selection_none() {
-    let dir = tempfile::tempdir().unwrap();
+async fn test_load_initial_state_with_no_boards_leaves_selection_none() -> KanbanResult<()> {
+    let dir = tempfile::tempdir()?;
     let path = helpers::create_test_json_file(dir.path(), "empty.json", &[]).await;
-    let (mut app, _rx) = kanban_tui::App::new(Some(path)).unwrap();
+    let (mut app, _rx) = kanban_tui::App::new(Some(path))?;
     app.load_initial_state().await;
 
     assert_eq!(
@@ -63,11 +66,12 @@ async fn test_load_initial_state_with_no_boards_leaves_selection_none() {
         None,
         "selection should remain None when there are no boards"
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_load_initial_state_with_no_file_leaves_selection_none() {
-    let (mut app, _rx) = kanban_tui::App::new(None).unwrap();
+async fn test_load_initial_state_with_no_file_leaves_selection_none() -> KanbanResult<()> {
+    let (mut app, _rx) = kanban_tui::App::new(None)?;
     app.load_initial_state().await;
 
     assert_eq!(
@@ -75,4 +79,5 @@ async fn test_load_initial_state_with_no_file_leaves_selection_none() {
         None,
         "selection should remain None when no file is provided"
     );
+    Ok(())
 }

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -81,3 +81,19 @@ async fn test_load_initial_state_with_no_file_leaves_selection_none() -> KanbanR
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn test_load_initial_state_does_not_clobber_existing_board_selection() -> KanbanResult<()> {
+    let dir = tempfile::tempdir()?;
+    let path = helpers::create_test_json_file(dir.path(), "test.json", &["Alpha", "Beta"]).await;
+    let (mut app, _rx) = kanban_tui::App::new(Some(path))?;
+    app.selection.board.set(Some(1));
+    app.load_initial_state().await;
+
+    assert_eq!(
+        app.selection.board.get(),
+        Some(1),
+        "pre-existing board selection should not be overwritten by load_initial_state"
+    );
+    Ok(())
+}


### PR DESCRIPTION
When starting the TUI, no board was pre-selected, leaving the card panel empty until the user manually moved the cursor or pressed Enter.

- Preselect the first board in `load_initial_state` when no selection exists
- Call `refresh_view` after preselection so cards are populated immediately without user interaction

**Why:** The empty card panel on startup felt broken and required an extra keypress (`j` or Enter) before any content was visible.

**How:** At the end of `load_initial_state`, if `selection.board` is `None` and boards are present, set it to `Some(0)` and call `refresh_view()`. This reuses the existing refresh path that `j`/`k` navigation already triggers.

**Testing:** Three integration tests cover the new behaviour — boards present (selection + view populated), no boards (selection stays None), no file (selection stays None).