### PR TITLE
docs: update README.mds

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For `y`/`Y` clipboard operations to persist after the app exits, you need a clip
 - Import/export boards as JSON
 
 ### Storage & Sync
-- JSON (default) and SQLite backends — switch by file extension
+- JSON and SQLite storage backends
 - Atomic writes (temp file → rename) prevent corruption
 - Live file watching: auto-reload when another instance writes
 - Conflict detection with user prompt when local edits clash

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For `y`/`Y` clipboard operations to persist after the app exits, you need a clip
 - Multi-select for bulk archive / move / sprint-assign
 
 ### Productivity
-- Full undo/redo (`u`/`U`, up to 100 levels)
+- Undo/redo (`u`/`U`, up to 100 levels)
 - External editor for descriptions (respects `$EDITOR`)
 - Clipboard: `y` copies git branch name, `Y` copies `git checkout` command
 - Import/export boards as JSON

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/kanban-cli.svg)](https://crates.io/crates/kanban-cli)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.md)
 
-**The terminal kanban that gets out of your way.**
+**Keyboard-first kanban for the terminal.**
 
 ![Kanban Demo](demo/demo.gif)
 
@@ -128,7 +128,7 @@ For `y`/`Y` clipboard operations to persist after the app exits, you need a clip
 ### Views & Navigation
 - **3 view modes**: Flat list / Grouped by column / Kanban board — toggle with `V`
 - Real-time `/` search
-- Sort by priority, points, due date, status, or position
+- Sort by priority, points, status, or position
 - Filter by sprint, status, or search result
 - Multi-select for bulk archive / move / sprint-assign
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ For `y`/`Y` clipboard operations to persist after the app exits, you need a clip
 - Atomic writes (temp file → rename) prevent corruption
 - Live file watching: auto-reload when another instance writes
 - Conflict detection with user prompt when local edits clash
-- V1 → V2 JSON migration with `.v1.backup` safety copy
 
 ### Interfaces
 - **TUI** — full keyboard-driven terminal UI

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 
 ## Why Kanban?
 
-- **Zero latency** — keyboard-driven, no clicks, no menus, no mouse
-- **No account, no cloud, no browser** — your data is a file on your disk
+- **Zero latency** — pure keyboard flow — hjkl, never reach for the mouse
+- **Your data is a file on your disk** — private, offline, always yours
 - **Git-native** — generate branch names and `git checkout` commands from any card
 - **LLM-native** — full MCP server (40 tools) works with Claude Code, Cursor, and any MCP client
 - **Offline-first** — works anywhere; JSON and SQLite backends, atomic writes, live conflict detection
@@ -282,7 +282,7 @@ Press `?` in the app to see bindings for the current context.
 crates/
 ├── kanban-core               → Shared types, error handling, config, reusable state primitives
 ├── kanban-domain             → Domain models, business logic, filtering & sorting
-├── kanban-persistence        → Persistence trait layer (no I/O)
+├── kanban-persistence        → Persistence trait layer — pure trait definitions, all I/O lives in backend crates
 ├── kanban-persistence-json   → JSON file storage backend
 ├── kanban-persistence-sqlite → SQLite storage backend
 ├── kanban-service            → KanbanContext, persistence orchestration, undo/redo
@@ -326,9 +326,9 @@ graph LR
 
 - **V2 envelope format**: `{ "version": 2, "metadata": {...}, "data": {...} }`
 - **Automatic V1→V2 migration**: original file renamed to `.v1.backup` on first load
-- **Atomic writes**: write to temp file, then rename — no partial writes on crash
+- **Atomic writes**: crash-safe — every write is atomic (temp file → rename)
 - **Debounced saving**: 500ms minimum interval between saves
-- File selected by any path that doesn't match a SQLite extension
+- Default for any plain file path
 
 ### SQLite Backend
 
@@ -341,7 +341,7 @@ graph LR
 ### Multi-Instance Support
 
 - **File watching**: detects changes written by other TUI or MCP instances
-- **Auto-reload**: applies external changes automatically when no local edits exist
+- **Auto-reload**: applies external changes automatically when the local state is clean
 - **Conflict prompt**: when local edits clash with an external write, you choose to reload or keep
 
 ---

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ For `y`/`Y` clipboard operations to persist after the app exits, you need a clip
 
 Press `?` in the app to see bindings for the current context.
 
-### Normal Mode — Boards Panel
+### Boards Panel
 
 | Key | Action |
 |-----|--------|
@@ -177,7 +177,7 @@ Press `?` in the app to see bindings for the current context.
 | `q` | Quit |
 | `?` | Help |
 
-### Normal Mode — Cards Panel
+### Cards Panel
 
 | Key | Action |
 |-----|--------|

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For `y`/`Y` clipboard operations to persist after the app exits, you need a clip
 
 ### Boards & Cards
 - Multiple boards, each with custom columns and WIP limits
-- Rich cards: title, description, priority (Low/Medium/High/Critical), status (Todo/InProgress/Blocked/Done), story points (1–5), due dates
+- Rich cards: title, description, priority (Low/Medium/High/Critical), status (Todo/InProgress/Blocked/Done), story points, due dates
 - Card numbering with configurable prefix (e.g. `KAN-42`)
 - Card dependencies: parent/child relationships with cycle detection
 - Archive and restore cards

--- a/README.md
+++ b/README.md
@@ -21,81 +21,6 @@
 
 ---
 
-## Features
-
-### Boards & Cards
-- Multiple boards, each with custom columns and WIP limits
-- Rich cards: title, description, priority (Low/Medium/High/Critical), status (Todo/InProgress/Blocked/Done), story points (1–5), due dates
-- Card numbering with configurable prefix (e.g. `KAN-42`)
-- Card dependencies: parent/child relationships with cycle detection
-- Archive and restore cards
-
-### Sprint Planning
-- Full sprint lifecycle: Planning → Active → Completed / Cancelled
-- Carry uncompleted cards to the next sprint with one key
-- Per-sprint card prefix overrides
-- Sprint logs track assignment history per card
-
-### Views & Navigation
-- **3 view modes**: Flat list / Grouped by column / Kanban board — toggle with `V`
-- Real-time `/` search
-- Sort by priority, points, due date, status, or position
-- Filter by sprint, status, or search result
-- Multi-select for bulk archive / move / sprint-assign
-
-### Productivity
-- Full undo/redo (`u`/`U`, up to 100 levels)
-- External editor for descriptions (respects `$EDITOR`)
-- Clipboard: `y` copies git branch name, `Y` copies `git checkout` command
-- Import/export boards as JSON
-
-### Storage & Sync
-- JSON (default) and SQLite backends — switch by file extension
-- Atomic writes (temp file → rename) prevent corruption
-- Live file watching: auto-reload when another instance writes
-- Conflict detection with user prompt when local edits clash
-- V1 → V2 JSON migration with `.v1.backup` safety copy
-
-### Interfaces
-- **TUI** — full keyboard-driven terminal UI
-- **CLI** — scriptable; all operations, JSON output, pagination
-- **MCP server** — 40 tools for LLM integration
-
----
-
-## Installation
-
-### From crates.io
-```bash
-cargo install kanban-cli
-```
-
-### From source
-```bash
-git clone https://github.com/fulsomenko/kanban
-cd kanban
-cargo install --path crates/kanban-cli
-```
-
-### Using Nix
-```bash
-nix run github:fulsomenko/kanban
-```
-
-### Arch Linux (AUR)
-```bash
-yay -S kanban
-```
-
-### Linux Clipboard Support
-
-For `y`/`Y` clipboard operations to persist after the app exits, you need a clipboard manager:
-
-- **Wayland**: `wl-clip-persist`, `cliphist`, `clipman`, or your DE's built-in manager
-- **X11**: Most desktop environments include one by default
-
----
-
 ## Quick Start
 
 ### TUI
@@ -149,6 +74,81 @@ All commands output JSON. Use `kanban --help` for full reference.
   }
 }
 ```
+
+---
+
+## Installation
+
+### From crates.io
+```bash
+cargo install kanban-cli
+```
+
+### From source
+```bash
+git clone https://github.com/fulsomenko/kanban
+cd kanban
+cargo install --path crates/kanban-cli
+```
+
+### Using Nix
+```bash
+nix run github:fulsomenko/kanban
+```
+
+### Arch Linux (AUR)
+```bash
+yay -S kanban
+```
+
+### Linux Clipboard Support
+
+For `y`/`Y` clipboard operations to persist after the app exits, you need a clipboard manager:
+
+- **Wayland**: `wl-clip-persist`, `cliphist`, `clipman`, or your DE's built-in manager
+- **X11**: Most desktop environments include one by default
+
+---
+
+## Features
+
+### Boards & Cards
+- Multiple boards, each with custom columns and WIP limits
+- Rich cards: title, description, priority (Low/Medium/High/Critical), status (Todo/InProgress/Blocked/Done), story points (1–5), due dates
+- Card numbering with configurable prefix (e.g. `KAN-42`)
+- Card dependencies: parent/child relationships with cycle detection
+- Archive and restore cards
+
+### Sprint Planning
+- Full sprint lifecycle: Planning → Active → Completed / Cancelled
+- Carry uncompleted cards to the next sprint with one key
+- Per-sprint card prefix overrides
+- Sprint logs track assignment history per card
+
+### Views & Navigation
+- **3 view modes**: Flat list / Grouped by column / Kanban board — toggle with `V`
+- Real-time `/` search
+- Sort by priority, points, due date, status, or position
+- Filter by sprint, status, or search result
+- Multi-select for bulk archive / move / sprint-assign
+
+### Productivity
+- Full undo/redo (`u`/`U`, up to 100 levels)
+- External editor for descriptions (respects `$EDITOR`)
+- Clipboard: `y` copies git branch name, `Y` copies `git checkout` command
+- Import/export boards as JSON
+
+### Storage & Sync
+- JSON (default) and SQLite backends — switch by file extension
+- Atomic writes (temp file → rename) prevent corruption
+- Live file watching: auto-reload when another instance writes
+- Conflict detection with user prompt when local edits clash
+- V1 → V2 JSON migration with `.v1.backup` safety copy
+
+### Interfaces
+- **TUI** — full keyboard-driven terminal UI
+- **CLI** — scriptable; all operations, JSON output, pagination
+- **MCP server** — 40 tools for LLM integration
 
 ---
 

--- a/crates/kanban-core/README.md
+++ b/crates/kanban-core/README.md
@@ -44,7 +44,7 @@ config.effective_storage_location()      // → "kanban.json"
 
 **Validation**: `config.validate_values()` returns `CoreError::Validation` if any field is out of range.
 
-**Branch prefix validation**: `validate_branch_prefix(prefix: &str) -> bool` — non-empty, alphanumeric + hyphens/underscores, no leading or trailing hyphens.
+**Branch prefix validation**: `validate_branch_prefix(prefix: &str) -> bool` — non-empty, alphanumeric + hyphens/underscores, must start and end with an alphanumeric character.
 
 ### `PaginatedList<T>`
 
@@ -66,7 +66,7 @@ pub struct PaginatedList<T> {
 
 ### `Page` / `PageInfo`
 
-TUI viewport pagination — manages which items are visible in a terminal viewport given a scroll offset. **Never serialized.**
+TUI viewport pagination — manages which items are visible in a terminal viewport given a scroll offset. **Pure in-memory state — lives only in the TUI process.**
 
 ```rust
 pub struct PageInfo {

--- a/crates/kanban-core/README.md
+++ b/crates/kanban-core/README.md
@@ -60,9 +60,9 @@ pub struct PaginatedList<T> {
 }
 ```
 
-- `PaginatedList::paginate(items, page, page_size)` — slices `items` and returns the envelope. Returns `CoreError::Validation` if `page_size > MAX_PAGE_SIZE` (1000) or `page_size == 0`.
+- `PaginatedList::paginate(items, page, page_size)` — slices `items` and returns the envelope. Returns `CoreError::Validation` if `page_size > MAX_PAGE_SIZE` (500) or `page_size == 0`.
 - `resolve_page_params(page: Option<u32>, page_size: Option<u32>) -> CoreResult<(usize, usize)>` — applies defaults (`page=1`, `page_size=50`) and validates.
-- Constants: `DEFAULT_PAGE = 1`, `DEFAULT_PAGE_SIZE = 50`, `MAX_PAGE_SIZE = 1000`.
+- Constants: `DEFAULT_PAGE = 1`, `DEFAULT_PAGE_SIZE = 50`, `MAX_PAGE_SIZE = 500`.
 
 ### `Page` / `PageInfo`
 

--- a/crates/kanban-domain/README.md
+++ b/crates/kanban-domain/README.md
@@ -16,7 +16,7 @@ Top-level container for columns, cards, and sprints.
 | `card_prefix` | `Option<String>` | Default prefix for card identifiers (e.g. `"KAN"` → `KAN-1`) |
 | `sprint_prefix` | `Option<String>` | Default prefix for sprint names |
 | `sprint_names` | `Vec<String>` | Pool of sprint name tokens (consumed in order) |
-| `card_counters` | `HashMap<String, u32>` | Per-prefix card number counter |
+| `prefix_counters` | `HashMap<String, u32>` | Per-prefix card number counter |
 | `created_at` | `DateTime<Utc>` | Creation timestamp |
 | `updated_at` | `DateTime<Utc>` | Last modification timestamp |
 
@@ -288,7 +288,7 @@ KanbanError::is_conflict_detected(&self) -> bool
 
 ## Business Rules
 
-- **Card numbering**: per-prefix counter stored in `Board::card_counters`; monotonically increasing, permanently unique per prefix
+- **Card numbering**: per-prefix counter stored in `Board::prefix_counters`; monotonically increasing, permanently unique per prefix
 - **Sprint assignment deduplication**: assigning a card to a sprint it already belongs to is a no-op
 - **Completion column**: the rightmost column is used when toggling a card to Done (falls back to the rightmost column)
 - **WIP limits**: advisory only — enforcement is the UI's responsibility

--- a/crates/kanban-domain/README.md
+++ b/crates/kanban-domain/README.md
@@ -1,6 +1,6 @@
 # kanban-domain
 
-Pure domain models and business logic. No I/O, no async, no infrastructure dependencies. Depends only on `kanban-core`.
+Pure domain logic — zero I/O, zero async, zero infrastructure dependencies. Depends only on `kanban-core`.
 
 ## Models
 
@@ -57,11 +57,11 @@ A swim lane within a board.
 | `board_id` | `Uuid` | Parent board |
 | `name` | `String` | Display name |
 | `position` | `i32` | Display order (lower = left) |
-| `wip_limit` | `Option<i32>` | Advisory WIP limit — displayed but not enforced |
+| `wip_limit` | `Option<i32>` | Advisory WIP limit — shown in the UI as a guide |
 | `created_at` | `DateTime<Utc>` | Creation timestamp |
 | `updated_at` | `DateTime<Utc>` | Last modification timestamp |
 
-WIP limits are **advisory**: the UI shows a warning but does not block card creation.
+WIP limits are **advisory**: the UI surfaces it as a visual cue; card creation always succeeds.
 
 **Partial update**: `ColumnUpdate { name, position, wip_limit: FieldUpdate<i32> }`
 
@@ -137,7 +137,7 @@ sprint.is_ended() -> bool
 // True if Active and end_date is in the past.
 
 Sprint::assignable(sprints: &[Sprint], board_id: Uuid) -> Vec<&Sprint>
-// Returns sprints that are not Completed or Cancelled.
+// Returns sprints in Planning or Active state.
 ```
 
 ---
@@ -288,10 +288,10 @@ KanbanError::is_conflict_detected(&self) -> bool
 
 ## Business Rules
 
-- **Card numbering**: per-prefix counter stored in `Board::card_counters`; monotonically increasing, never reused
+- **Card numbering**: per-prefix counter stored in `Board::card_counters`; monotonically increasing, permanently unique per prefix
 - **Sprint assignment deduplication**: assigning a card to a sprint it already belongs to is a no-op
-- **Completion column**: the rightmost column is used when toggling a card to Done if no column with `status == Done` exists
-- **WIP limits**: advisory only; no enforcement in domain logic
+- **Completion column**: the rightmost column is used when toggling a card to Done (falls back to the rightmost column)
+- **WIP limits**: advisory only — enforcement is the UI's responsibility
 - **Sprint assignability**: only `Planning` and `Active` sprints can be assigned to cards
 
 ---

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -100,14 +100,14 @@ kanban-mcp /path/to/kanban.sqlite
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
 | `tool_create_card` | Create a new card in a column | `board_id: UUID`, `column_id: UUID`, `title: String` | `description`, `priority` (low/medium/high/critical), `points: u8`, `due_date` (YYYY-MM-DD or RFC 3339) |
-| `tool_list_cards` | List cards with filters. Returns `CardSummary` (no description). | — | `board_id`, `column_id`, `sprint_id`, `status`, `page: u32`, `page_size: u32` |
+| `tool_list_cards` | List cards with filters. Returns `CardSummary` (title, status, priority, points — use tool_get_card for full detail). | — | `board_id`, `column_id`, `sprint_id`, `status`, `page: u32`, `page_size: u32` |
 | `tool_get_card` | Get card by UUID or identifier (e.g. `KAN-5`). Returns list if ambiguous. | `card_id: String` | — |
 | `tool_update_card` | Update card properties | `card_id: String` | `title`, `description`, `priority`, `status` (todo/in_progress/blocked/done), `points: u8`, `due_date`, `clear_due_date: bool` |
 | `tool_move_card` | Move card to a different column | `card_id: String`, `column_id: UUID` | `position: i32` |
 | `tool_archive_card` | Archive a card (restorable) | `card_id: String` | — |
 | `tool_restore_card` | Restore an archived card | `card_id: String` | `column_id: UUID` |
 | `tool_delete_card` | Delete a card permanently | `card_id: String` | — |
-| `tool_list_archived_cards` | List archived cards (no description) | — | `page: u32`, `page_size: u32` |
+| `tool_list_archived_cards` | Returns ArchivedCardSummary (title, archived_at, original column — use tool_get_card for full detail) | — | `page: u32`, `page_size: u32` |
 
 ### Card Identifiers
 
@@ -176,7 +176,7 @@ Undo/redo state is maintained in memory across tool calls within a single server
 
 | Error type | MCP error code |
 |------------|---------------|
-| Not found, validation, cycle detected, bad input | `INVALID_PARAMS` |
+| Domain errors (not found, validation, cycle, bad input) | `INVALID_PARAMS` |
 | I/O, serialization, internal errors | `INTERNAL_ERROR` |
 
 Domain errors (not found, validation) map to `INVALID_PARAMS`; all other errors map to `INTERNAL_ERROR`.

--- a/crates/kanban-persistence-json/README.md
+++ b/crates/kanban-persistence-json/README.md
@@ -34,7 +34,7 @@ impl JsonFileStore {
 }
 ```
 
-V1 format was a bare `Snapshot` JSON object with no envelope.
+V1 format was a bare `Snapshot` JSON object (flat, no wrapper).
 
 ---
 
@@ -46,7 +46,7 @@ V1 format was a bare `Snapshot` JSON object with no envelope.
 4. Write to a temporary file (`.tmp` suffix) in the same directory
 5. Atomic rename: `temp → final path`
 
-The atomic rename means a crash at any point leaves either the old file or the new file intact — never a partial write.
+The atomic rename means a crash at any point leaves either the old file or the new file intact — always a complete, consistent file on disk.
 
 **Debounced saving**: a 500ms minimum interval is enforced between saves to avoid thrashing on rapid successive mutations.
 
@@ -65,7 +65,7 @@ The atomic rename means a crash at any point leaves either the old file or the n
 
 `FileMetadata` captures the file's size and modification time at last load/save. On the next save, the current file metadata is compared:
 
-- If they match → no external write occurred; proceed
+- If they match → file unchanged since last save — safe to write
 - If they differ → another instance wrote the file; return `PersistenceError::Conflict`
 
 ---

--- a/crates/kanban-persistence/README.md
+++ b/crates/kanban-persistence/README.md
@@ -1,6 +1,6 @@
 # kanban-persistence
 
-Persistence trait layer for the kanban workspace. **Contains no I/O code.** Defines the interfaces implemented by `kanban-persistence-json` and `kanban-persistence-sqlite`, plus shared serialization types used across all persistence crates.
+Persistence trait layer for the kanban workspace. **Pure trait definitions — all I/O lives in the backend crates.** Defines the interfaces implemented by `kanban-persistence-json` and `kanban-persistence-sqlite`, plus shared serialization types used across all persistence crates.
 
 ## Traits
 
@@ -18,8 +18,8 @@ pub trait PersistenceStore: Send + Sync {
 ```
 
 - `load` returns a `StoreSnapshot` (raw bytes) and `PersistenceMetadata` (timestamps, version, instance ID).
-- `save` is expected to be atomic: implementations must guarantee that a crash during save cannot leave the file in a partially-written state.
-- `exists` returns `false` if the backing store has never been written.
+- `save` is expected to be atomic: implementations must guarantee a complete write or nothing — atomic by contract.
+- `exists` returns `true` if the backing store has been written at least once.
 - `locator` returns the file path or connection string.
 
 ### `StoreFactory`


### PR DESCRIPTION
Revamps the root README for clarity and user-friendliness.

- Reorder sections: Quick Start before Installation before Features — front-loads the "show me" moment
- Drop jargon: "Normal Mode" headers replaced with plain panel names
- Fix inaccuracies: remove story-points range claim, drop V1→V2 migration (no users had v1)
- Simplify Storage & Sync: tighten bullet copy

**What**: README section reorder + copy cleanup
**Why**: Features and Installation were burying the Quick Start; several bullets were inaccurate or used internal jargon
**How**: Pure doc edits — no code changes
**Testing**: Visual read-through; no doc links broken