### PR TITLE
KAN-364 fix(tui): card detail view shows wrong card due to HashMap ordering

### DIFF
--- a/.changeset/kan-364-fix-tui-card-selection-opens-wrong-details.md
+++ b/.changeset/kan-364-fix-tui-card-selection-opens-wrong-details.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+---
+
+Fixed a bug where opening the card detail view would display the wrong card. The
+detail view was resolving the selected card by indexing into
+`cards_by_id.values()`, but `HashMap` iteration order is non-deterministic and
+does not match the ordered position stored in `active_card_index`. This caused
+the wrong card to be shown whenever the HashMap's internal order diverged from
+the selection order.
+
+The fix stores the selected card's UUID in `SelectionHub.active_card_id` when
+entering the detail view and looks the card up directly by ID via the new
+`App::get_card_for_detail_view` method, eliminating the ordering dependency.

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1274,6 +1274,12 @@ impl App {
         self.view.cards_by_id.get(&card_id).cloned()
     }
 
+    pub fn get_card_for_detail_view(&self) -> Option<Card> {
+        self.selection
+            .active_card_id
+            .and_then(|id| self.view.cards_by_id.get(&id).cloned())
+    }
+
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
         let cards = self.ctx.cards();
         let (uncompleted_ids, completed_ids) = partition_sprint_cards(sprint_id, &cards);

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -5,6 +5,7 @@ pub struct SelectionHub {
     pub board: SelectionState,
     pub active_board_index: Option<usize>,
     pub active_card_index: Option<usize>,
+    pub active_card_id: Option<uuid::Uuid>,
     pub sprint: SelectionState,
     pub active_sprint_index: Option<usize>,
     pub card_navigation_history: Vec<usize>,

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -490,6 +490,7 @@ impl App {
                     let card_id = selected_card.id;
                     let actual_idx = self.ctx.cards().iter().position(|c| c.id == card_id);
                     self.selection.active_card_index = actual_idx;
+                    self.selection.active_card_id = Some(card_id);
                     // Initialize list components with item counts
                     let parents = self.get_current_card_parents();
                     let children = self.get_current_card_children();

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -65,11 +65,10 @@ pub(super) fn render_relationship_boxes(
 pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
     use kanban_domain::dependencies::CardGraphExt;
 
-    if let Some(card_idx) = app.selection.active_card_index {
-        let cards_vec: Vec<_> = app.view.cards_by_id.values().collect();
-        if let Some(card) = cards_vec.get(card_idx) {
-            if let Some(board_idx) = app.selection.active_board_index {
-                if let Some(board) = app.view.boards.get(board_idx) {
+    if let Some(card) = app.get_card_for_detail_view() {
+        let card = &card;
+        if let Some(board_idx) = app.selection.active_board_index {
+            if let Some(board) = app.view.boards.get(board_idx) {
                     let has_sprint_logs = card.sprint_logs.len() > 1;
                     let card_id = card.id;
 
@@ -168,6 +167,5 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                     }
                 }
             }
-        }
     }
 }

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -69,103 +69,103 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
         let card = &card;
         if let Some(board_idx) = app.selection.active_board_index {
             if let Some(board) = app.view.boards.get(board_idx) {
-                    let has_sprint_logs = card.sprint_logs.len() > 1;
-                    let card_id = card.id;
+                let has_sprint_logs = card.sprint_logs.len() > 1;
+                let card_id = card.id;
 
-                    // Get parent and child information
-                    let parents = app.view.graph.cards.parents(card_id);
-                    let children = app.view.graph.cards.children(card_id);
-                    let child_count = children.len();
+                // Get parent and child information
+                let parents = app.view.graph.cards.parents(card_id);
+                let children = app.view.graph.cards.children(card_id);
+                let child_count = children.len();
 
-                    let constraints = vec![
-                        Constraint::Length(5),                       // Title
-                        Constraint::Length(6),                       // Metadata
-                        Constraint::Min(5),                          // Description
-                        Constraint::Length(RELATIONSHIP_BOX_HEIGHT), // Relationships
-                    ];
+                let constraints = vec![
+                    Constraint::Length(5),                       // Title
+                    Constraint::Length(6),                       // Metadata
+                    Constraint::Min(5),                          // Description
+                    Constraint::Length(RELATIONSHIP_BOX_HEIGHT), // Relationships
+                ];
 
-                    let chunks = Layout::default()
-                        .direction(Direction::Vertical)
-                        .constraints(constraints)
-                        .split(area);
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints(constraints)
+                    .split(area);
 
-                    // Render title section
-                    let title_config = FieldSectionConfig::new("Task Title")
-                        .with_focus_indicator("Task Title [1]")
-                        .focused(app.focus.card_focus == CardFocus::Title);
-                    let title = Paragraph::new(build_title_lines(card))
-                        .style(bold_highlight())
-                        .block(title_config.block());
-                    frame.render_widget(title, chunks[0]);
+                // Render title section
+                let title_config = FieldSectionConfig::new("Task Title")
+                    .with_focus_indicator("Task Title [1]")
+                    .focused(app.focus.card_focus == CardFocus::Title);
+                let title = Paragraph::new(build_title_lines(card))
+                    .style(bold_highlight())
+                    .block(title_config.block());
+                frame.render_widget(title, chunks[0]);
 
-                    if has_sprint_logs {
-                        let meta_chunks = Layout::default()
-                            .direction(Direction::Horizontal)
-                            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                            .split(chunks[1]);
+                if has_sprint_logs {
+                    let meta_chunks = Layout::default()
+                        .direction(Direction::Horizontal)
+                        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                        .split(chunks[1]);
 
-                        // Render metadata
-                        let meta_config = FieldSectionConfig::new("Metadata")
-                            .with_focus_indicator("Metadata [2]")
-                            .focused(app.focus.card_focus == CardFocus::Metadata);
-                        let meta_lines =
-                            build_metadata_lines(card, board, &app.view.sprints, &app.app_config);
-                        let meta = Paragraph::new(meta_lines).block(meta_config.block());
-                        frame.render_widget(meta, meta_chunks[0]);
+                    // Render metadata
+                    let meta_config = FieldSectionConfig::new("Metadata")
+                        .with_focus_indicator("Metadata [2]")
+                        .focused(app.focus.card_focus == CardFocus::Metadata);
+                    let meta_lines =
+                        build_metadata_lines(card, board, &app.view.sprints, &app.app_config);
+                    let meta = Paragraph::new(meta_lines).block(meta_config.block());
+                    frame.render_widget(meta, meta_chunks[0]);
 
-                        // Render sprint logs
-                        let sprint_logs_config = FieldSectionConfig::new("Sprint History");
-                        let sprint_log_lines = build_sprint_logs_lines(card);
-                        let sprint_logs =
-                            Paragraph::new(sprint_log_lines).block(sprint_logs_config.block());
-                        frame.render_widget(sprint_logs, meta_chunks[1]);
+                    // Render sprint logs
+                    let sprint_logs_config = FieldSectionConfig::new("Sprint History");
+                    let sprint_log_lines = build_sprint_logs_lines(card);
+                    let sprint_logs =
+                        Paragraph::new(sprint_log_lines).block(sprint_logs_config.block());
+                    frame.render_widget(sprint_logs, meta_chunks[1]);
 
-                        // Render description
-                        let desc_config = FieldSectionConfig::new("Description")
-                            .with_focus_indicator("Description [3]")
-                            .focused(app.focus.card_focus == CardFocus::Description);
-                        let desc_lines = build_description_lines(card);
-                        let desc = Paragraph::new(desc_lines).block(desc_config.block());
-                        frame.render_widget(desc, chunks[2]);
+                    // Render description
+                    let desc_config = FieldSectionConfig::new("Description")
+                        .with_focus_indicator("Description [3]")
+                        .focused(app.focus.card_focus == CardFocus::Description);
+                    let desc_lines = build_description_lines(card);
+                    let desc = Paragraph::new(desc_lines).block(desc_config.block());
+                    frame.render_widget(desc, chunks[2]);
 
-                        // Render relationship boxes
-                        render_relationship_boxes(
-                            app,
-                            frame,
-                            chunks[3],
-                            &parents,
-                            &children,
-                            child_count,
-                        );
-                    } else {
-                        // Render metadata section
-                        let meta_config = FieldSectionConfig::new("Metadata")
-                            .with_focus_indicator("Metadata [2]")
-                            .focused(app.focus.card_focus == CardFocus::Metadata);
-                        let meta_lines =
-                            build_metadata_lines(card, board, &app.view.sprints, &app.app_config);
-                        let meta = Paragraph::new(meta_lines).block(meta_config.block());
-                        frame.render_widget(meta, chunks[1]);
+                    // Render relationship boxes
+                    render_relationship_boxes(
+                        app,
+                        frame,
+                        chunks[3],
+                        &parents,
+                        &children,
+                        child_count,
+                    );
+                } else {
+                    // Render metadata section
+                    let meta_config = FieldSectionConfig::new("Metadata")
+                        .with_focus_indicator("Metadata [2]")
+                        .focused(app.focus.card_focus == CardFocus::Metadata);
+                    let meta_lines =
+                        build_metadata_lines(card, board, &app.view.sprints, &app.app_config);
+                    let meta = Paragraph::new(meta_lines).block(meta_config.block());
+                    frame.render_widget(meta, chunks[1]);
 
-                        // Render description section
-                        let desc_config = FieldSectionConfig::new("Description")
-                            .with_focus_indicator("Description [3]")
-                            .focused(app.focus.card_focus == CardFocus::Description);
-                        let desc_lines = build_description_lines(card);
-                        let desc = Paragraph::new(desc_lines).block(desc_config.block());
-                        frame.render_widget(desc, chunks[2]);
+                    // Render description section
+                    let desc_config = FieldSectionConfig::new("Description")
+                        .with_focus_indicator("Description [3]")
+                        .focused(app.focus.card_focus == CardFocus::Description);
+                    let desc_lines = build_description_lines(card);
+                    let desc = Paragraph::new(desc_lines).block(desc_config.block());
+                    frame.render_widget(desc, chunks[2]);
 
-                        // Render relationship boxes
-                        render_relationship_boxes(
-                            app,
-                            frame,
-                            chunks[3],
-                            &parents,
-                            &children,
-                            child_count,
-                        );
-                    }
+                    // Render relationship boxes
+                    render_relationship_boxes(
+                        app,
+                        frame,
+                        chunks[3],
+                        &parents,
+                        &children,
+                        child_count,
+                    );
                 }
             }
+        }
     }
 }

--- a/crates/kanban-tui/tests/card_detail_tests.rs
+++ b/crates/kanban-tui/tests/card_detail_tests.rs
@@ -1,0 +1,42 @@
+use kanban_domain::{Board, Card, Column};
+
+/// Verify that `get_card_for_detail_view` resolves to the card whose UUID is
+/// stored in `active_card_id`, regardless of HashMap iteration order.
+///
+/// If the detail view were using an index into `cards_by_id.values()`, it
+/// could silently return the wrong card because HashMap order is
+/// non-deterministic.
+#[test]
+fn test_active_card_detail_shows_selected_card() {
+    let mut app = kanban_tui::App::test_default();
+
+    let mut board = Board::new("TestBoard".to_string(), None);
+    let col = Column::new(board.id, "Backlog".to_string(), 0);
+    let card_a = Card::new(&mut board, col.id, "Card Alpha".to_string(), 0);
+    let card_b = Card::new(&mut board, col.id, "Card Beta".to_string(), 1);
+
+    let card_b_id = card_b.id;
+
+    app.view.cards_by_id.insert(card_a.id, card_a);
+    app.view.cards_by_id.insert(card_b.id, card_b);
+
+    // Select the second card by ID — not by index into HashMap values.
+    app.selection.active_card_id = Some(card_b_id);
+
+    let detail_card = app
+        .get_card_for_detail_view()
+        .expect("should return a card when active_card_id is set");
+
+    assert_eq!(
+        detail_card.id, card_b_id,
+        "detail view must show the card whose UUID matches active_card_id, not an arbitrary HashMap entry"
+    );
+}
+
+/// When `active_card_id` is None, `get_card_for_detail_view` returns None.
+#[test]
+fn test_active_card_detail_returns_none_when_no_card_selected() {
+    let app = kanban_tui::App::test_default();
+    assert!(app.selection.active_card_id.is_none());
+    assert!(app.get_card_for_detail_view().is_none());
+}


### PR DESCRIPTION
Fixes wrong card shown when opening the card detail view:

- Add `active_card_id: Option<Uuid>` to `SelectionHub` to track the selected card by UUID
- Set `active_card_id` when entering `CardDetail` mode in the navigation handler
- Add `App::get_card_for_detail_view()` that resolves the card directly by UUID from `cards_by_id`
- Replace the broken index-into-`HashMap::values()` lookup in `render_card_detail_view` with the new method
- Add regression tests in `card_detail_tests.rs` covering correct resolution and the `None` case

**What**: The detail view was looking up the selected card by indexing into `cards_by_id.values()`, but `HashMap` iteration order is non-deterministic. This caused it to show a different card than the one selected.

**Why**: `active_card_index` was set as a position in the ordered `ctx.cards()` list, but `cards_by_id.values()` returns entries in arbitrary order — the two orderings diverge, so the wrong card was shown.

**How**: Store the card's UUID at selection time (`active_card_id`) and look it up directly by key, removing any dependency on collection ordering.

**Testing**: `cargo test -p kanban-tui --test card_detail_tests` (new regression tests), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean).