### PR TITLE
KAN-365 feat(tui): block quit during migration with double-q UI

### DIFF
--- a/.changeset/kan-365-block-quit-during-migration-with-double-q-ui.md
+++ b/.changeset/kan-365-block-quit-during-migration-with-double-q-ui.md
@@ -1,0 +1,17 @@
+---
+bump: patch
+---
+
+Pressing `q` while a storage migration is in progress no longer silently
+abandons the migration. The app now shows a warning banner and requires a
+second `q` to confirm the abort. If the migration completes before the
+second `q` is pressed, the confirmation clears automatically and the next
+`q` exits cleanly with no data loss.
+
+This fixes a data loss scenario where triggering a JSON→SQLite migration
+via the config editor and immediately pressing `q` would leave the
+destination file unwritten.
+
+Also fixes a startup regression where supplying an explicit file argument
+(e.g. `kanban myboard.json`) was incorrectly treated as a SQLite file when
+the config had `storage_backend = "sqlite"` set, causing a load error.

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -277,3 +277,51 @@ impl CliApp {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_core::AppConfig;
+
+    fn default_store_manager() -> kanban_service::StoreManager {
+        kanban_service::StoreManager::new(kanban_service::default_registry())
+    }
+
+    #[test]
+    fn test_resolve_is_sqlite_explicit_json_file_ignores_config_backend() {
+        let sm = default_store_manager();
+        let config = AppConfig {
+            storage_backend: Some("sqlite".to_string()),
+            ..Default::default()
+        };
+        let result = resolve_is_sqlite(&sm, Some("myboard.json"), &config);
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_resolve_is_sqlite_no_explicit_file_uses_config_backend() {
+        let sm = default_store_manager();
+        let config = AppConfig {
+            storage_backend: Some("sqlite".to_string()),
+            ..Default::default()
+        };
+        let result = resolve_is_sqlite(&sm, None, &config);
+        assert!(result);
+    }
+
+    #[test]
+    fn test_resolve_is_sqlite_explicit_sqlite_extension_is_sqlite() {
+        let sm = default_store_manager();
+        let config = AppConfig::default();
+        let result = resolve_is_sqlite(&sm, Some("myboard.sqlite"), &config);
+        assert!(result);
+    }
+
+    #[test]
+    fn test_resolve_is_sqlite_no_file_default_config_is_not_sqlite() {
+        let sm = default_store_manager();
+        let config = AppConfig::default();
+        let result = resolve_is_sqlite(&sm, None, &config);
+        assert!(!result);
+    }
+}

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -226,7 +226,7 @@ impl CliApp {
             .clone()
             .unwrap_or_else(|| kanban_service::config::resolve_storage_location(&config));
         let is_sqlite = store_manager.is_sqlite(&effective_file)
-            || config.effective_storage_backend() == "sqlite";
+            || (validated_file.is_none() && config.effective_storage_backend() == "sqlite");
 
         match command {
             None => {

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -8,6 +8,18 @@ use kanban_service::StoreManager;
 #[cfg(feature = "tui")]
 use kanban_tui::App;
 
+pub(crate) fn resolve_is_sqlite(
+    store_manager: &kanban_service::StoreManager,
+    validated_file: Option<&str>,
+    config: &kanban_core::AppConfig,
+) -> bool {
+    let effective_file = validated_file
+        .map(str::to_owned)
+        .unwrap_or_else(|| kanban_service::config::resolve_storage_location(config));
+    store_manager.is_sqlite(&effective_file)
+        || (validated_file.is_none() && config.effective_storage_backend() == "sqlite")
+}
+
 fn init_tracing() {
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
@@ -225,8 +237,7 @@ impl CliApp {
         let effective_file = validated_file
             .clone()
             .unwrap_or_else(|| kanban_service::config::resolve_storage_location(&config));
-        let is_sqlite = store_manager.is_sqlite(&effective_file)
-            || (validated_file.is_none() && config.effective_storage_backend() == "sqlite");
+        let is_sqlite = resolve_is_sqlite(&store_manager, validated_file.as_deref(), &config);
 
         match command {
             None => {

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -354,22 +354,30 @@ impl App {
     }
 
     pub fn handle_quit_key(&mut self) {
-        if self.ctx.save_coordinator.has_pending_saves() && !self.quit_with_pending {
-            self.set_error(
-                "⏳ Saves pending... press 'q' again to force quit, or wait for completion"
-                    .to_string(),
-            );
-            self.quit_with_pending = true;
-            tracing::warn!("Quit attempted with pending saves, requiring confirmation");
-            return;
-        }
+        let needs_pending_confirm =
+            self.ctx.save_coordinator.has_pending_saves() && !self.quit_with_pending;
+        let needs_migration_confirm =
+            matches!(self.migration_state, MigrationState::Migrating { .. })
+                && !self.quit_with_migration;
 
-        if matches!(self.migration_state, MigrationState::Migrating { .. })
-            && !self.quit_with_migration
-        {
-            self.set_error(
-                "Migration in progress... press 'q' again to abort and quit".to_string(),
-            );
+        if needs_pending_confirm || needs_migration_confirm {
+            if needs_pending_confirm && needs_migration_confirm {
+                self.set_error(
+                    "⏳ Saves pending and migration in progress... press 'q' again to force quit"
+                        .to_string(),
+                );
+            } else if needs_pending_confirm {
+                self.set_error(
+                    "⏳ Saves pending... press 'q' again to force quit, or wait for completion"
+                        .to_string(),
+                );
+                tracing::warn!("Quit attempted with pending saves, requiring confirmation");
+            } else {
+                self.set_error(
+                    "Migration in progress... press 'q' again to abort and quit".to_string(),
+                );
+            }
+            self.quit_with_pending = true;
             self.quit_with_migration = true;
             return;
         }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -76,6 +76,7 @@ pub struct App {
     pub store_manager: Arc<StoreManager>,
     pub should_quit: bool,
     pub quit_with_pending: bool, // Force quit even if saves are pending (second 'q' press)
+    pub quit_with_migration: bool, // Force quit even if migration is in progress (second 'q' press)
     pub mode: AppMode,
     pub mode_stack: Vec<AppMode>,
     pub input: InputState,
@@ -242,6 +243,7 @@ impl App {
             store_manager,
             should_quit: false,
             quit_with_pending: false,
+            quit_with_migration: false,
             mode: AppMode::Normal,
             mode_stack: Vec::new(),
             input: InputState::new(),
@@ -315,6 +317,7 @@ impl App {
             store_manager,
             should_quit: false,
             quit_with_pending: false,
+            quit_with_migration: false,
             mode: AppMode::Normal,
             mode_stack: Vec::new(),
             input: kanban_core::InputState::new(),
@@ -348,6 +351,30 @@ impl App {
 
     pub fn quit(&mut self) {
         self.should_quit = true;
+    }
+
+    pub fn handle_quit_key(&mut self) {
+        if self.ctx.save_coordinator.has_pending_saves() && !self.quit_with_pending {
+            self.set_error(
+                "⏳ Saves pending... press 'q' again to force quit, or wait for completion"
+                    .to_string(),
+            );
+            self.quit_with_pending = true;
+            tracing::warn!("Quit attempted with pending saves, requiring confirmation");
+            return;
+        }
+
+        if matches!(self.migration_state, MigrationState::Migrating { .. })
+            && !self.quit_with_migration
+        {
+            self.set_error(
+                "Migration in progress... press 'q' again to abort and quit".to_string(),
+            );
+            self.quit_with_migration = true;
+            return;
+        }
+
+        self.quit();
     }
 
     pub fn spawn_save_worker(
@@ -647,20 +674,7 @@ impl App {
         );
 
         if matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q')) && !is_input_mode {
-            // Check for pending saves before quitting
-            if self.ctx.save_coordinator.has_pending_saves() && !self.quit_with_pending {
-                // First quit attempt with pending saves - show warning
-                self.set_error(
-                    "⏳ Saves pending... press 'q' again to force quit, or wait for completion"
-                        .to_string(),
-                );
-                self.quit_with_pending = true;
-                tracing::warn!("Quit attempted with pending saves, requiring confirmation");
-                return false;
-            }
-
-            // Either no pending saves, or user confirmed force quit
-            self.quit();
+            self.handle_quit_key();
             return false;
         }
 
@@ -2048,6 +2062,9 @@ impl App {
             }
         }
 
+        // If a migration completed at the same instant as quit, apply it before tearing down.
+        self.await_migration().await;
+
         // Graceful shutdown: ensure all queued saves complete before exit
         self.ctx.save_coordinator.close_save_channel(); // Close save_tx channel to signal worker to finish
 
@@ -2289,6 +2306,7 @@ impl App {
             store_manager: Arc::new(default_store_manager()),
             should_quit: false,
             quit_with_pending: false,
+            quit_with_migration: false,
             mode: AppMode::Normal,
             mode_stack: Vec::new(),
             input: InputState::new(),

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -229,6 +229,7 @@ impl App {
         result: Result<(kanban_domain::Snapshot, bool), String>,
     ) {
         self.migration_state = crate::app::MigrationState::Idle;
+        self.quit_with_migration = false;
 
         let (snapshot, file_existed) = match result {
             Ok(s) => s,

--- a/crates/kanban-tui/src/state/mod.rs
+++ b/crates/kanban-tui/src/state/mod.rs
@@ -159,6 +159,11 @@ impl SaveCoordinator {
         self.save_completion_tx.as_ref()
     }
 
+    #[doc(hidden)]
+    pub fn set_pending_for_test(&mut self, n: usize) {
+        self.pending_saves = n;
+    }
+
     /// Set the file watcher for coordinating pause/resume with saves
     /// Called after the file watcher is initialized in App::run()
     pub fn set_file_watcher(&mut self, watcher: Arc<kanban_persistence::FileWatcher>) {

--- a/crates/kanban-tui/tests/settings_config_edit_tests.rs
+++ b/crates/kanban-tui/tests/settings_config_edit_tests.rs
@@ -350,6 +350,54 @@ fn test_migration_complete_resets_quit_with_migration_flag() {
 }
 
 #[test]
+fn test_quit_with_both_pending_saves_and_migration_sets_both_flags_on_first_press() {
+    use kanban_core::AppConfig;
+    let mut app = App::test_default();
+    app.ctx.save_coordinator.set_pending_for_test(1);
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    app.migration_state = MigrationState::Migrating {
+        old_config: AppConfig::default(),
+        old_storage_location: "old.json".to_string(),
+        result_rx: rx,
+    };
+
+    app.handle_quit_key();
+
+    assert!(!app.should_quit, "should not quit on first q");
+    assert!(app.quit_with_pending, "quit_with_pending must be set");
+    assert!(app.quit_with_migration, "quit_with_migration must be set");
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("banner must be set");
+    assert!(
+        banner.message.contains("pending") || banner.message.contains("migration"),
+        "banner must mention pending saves or migration, got: {}",
+        banner.message
+    );
+}
+
+#[test]
+fn test_quit_twice_with_both_pending_saves_and_migration_quits() {
+    use kanban_core::AppConfig;
+    let mut app = App::test_default();
+    app.ctx.save_coordinator.set_pending_for_test(1);
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    app.migration_state = MigrationState::Migrating {
+        old_config: AppConfig::default(),
+        old_storage_location: "old.json".to_string(),
+        result_rx: rx,
+    };
+
+    app.handle_quit_key();
+    assert!(!app.should_quit, "should not quit after first q");
+
+    app.handle_quit_key();
+    assert!(app.should_quit, "should quit after second q");
+}
+
+#[test]
 fn test_apply_config_edit_syncs_prefixes() {
     let mut app = App::test_default();
     let format = kanban_tui::edit_format::EditFormat::Json;

--- a/crates/kanban-tui/tests/settings_config_edit_tests.rs
+++ b/crates/kanban-tui/tests/settings_config_edit_tests.rs
@@ -284,6 +284,72 @@ fn test_apply_config_edit_with_cli_override_unloads_when_storage_explicitly_prov
 }
 
 #[test]
+fn test_quit_while_migrating_shows_warning_and_does_not_quit() {
+    use kanban_core::AppConfig;
+    let mut app = App::test_default();
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    app.migration_state = MigrationState::Migrating {
+        old_config: AppConfig::default(),
+        old_storage_location: "old.json".to_string(),
+        result_rx: rx,
+    };
+
+    app.handle_quit_key();
+
+    assert!(
+        !app.should_quit,
+        "should not quit on first q during migration"
+    );
+    assert!(
+        app.quit_with_migration,
+        "quit_with_migration must be set on first q"
+    );
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("banner must be set with migration warning");
+    assert!(
+        banner.message.contains("Migration") || banner.message.contains("migration"),
+        "banner must mention migration, got: {}",
+        banner.message
+    );
+}
+
+#[test]
+fn test_quit_twice_while_migrating_quits() {
+    use kanban_core::AppConfig;
+    let mut app = App::test_default();
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    app.migration_state = MigrationState::Migrating {
+        old_config: AppConfig::default(),
+        old_storage_location: "old.json".to_string(),
+        result_rx: rx,
+    };
+    app.quit_with_migration = true;
+
+    app.handle_quit_key();
+
+    assert!(app.should_quit, "second q during migration must quit");
+}
+
+#[test]
+fn test_migration_complete_resets_quit_with_migration_flag() {
+    let mut app = App::test_default();
+    app.quit_with_migration = true;
+
+    app.handle_migration_complete(
+        kanban_core::AppConfig::default(),
+        Err("simulated error".to_string()),
+    );
+
+    assert!(
+        !app.quit_with_migration,
+        "quit_with_migration must be reset when migration completes"
+    );
+}
+
+#[test]
 fn test_apply_config_edit_syncs_prefixes() {
     let mut app = App::test_default();
     let format = kanban_tui::edit_format::EditFormat::Json;

--- a/crates/kanban-tui/tests/settings_config_edit_tests.rs
+++ b/crates/kanban-tui/tests/settings_config_edit_tests.rs
@@ -366,11 +366,7 @@ fn test_quit_with_both_pending_saves_and_migration_sets_both_flags_on_first_pres
     assert!(!app.should_quit, "should not quit on first q");
     assert!(app.quit_with_pending, "quit_with_pending must be set");
     assert!(app.quit_with_migration, "quit_with_migration must be set");
-    let banner = app
-        .ui_state
-        .banner
-        .as_ref()
-        .expect("banner must be set");
+    let banner = app.ui_state.banner.as_ref().expect("banner must be set");
     assert!(
         banner.message.contains("pending") || banner.message.contains("migration"),
         "banner must mention pending saves or migration, got: {}",


### PR DESCRIPTION
Guards the quit key against silently aborting an in-progress storage migration:

- Add `quit_with_migration: bool` field to `App` to track the confirmation state
- Extract quit guard logic into `pub fn handle_quit_key(&mut self)`, covering both pending-save and migration guards
- First `q` during migration shows a warning banner and sets the flag; second `q` aborts and quits
- Reset `quit_with_migration` in `handle_migration_complete` so a migration that finishes before the second `q` clears the confirmation automatically
- Call `await_migration().await` in the graceful shutdown path to apply a migration that completes at the same instant as quit
- Fix CLI startup: explicit file argument (e.g. `kanban myboard.json`) was incorrectly sniffed as SQLite when `storage_backend = "sqlite"` was set in config

**What**: Pressing `q` during a JSON→SQLite migration no longer silently drops the destination file. The app warns on the first `q` and requires a second to confirm abort.

**Why**: The migration runs as a detached `tokio::spawn` task. Quitting before the task completes caused the spawned future to be dropped with the runtime, leaving the destination file unwritten and data effectively lost. The existing double-`q` guard for pending saves did not cover migrations.

**How**: Extracted the quit guard into `handle_quit_key()` (testable without a terminal), added a migration arm parallel to the existing save-pending arm, and ensured `await_migration()` runs in the graceful shutdown path to handle the race between migration completion and quit.

**Testing**: `cargo test -p kanban-tui --test settings_config_edit_tests` (3 new regression tests: warning on first `q`, quit on second `q`, flag reset on completion), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean).