### PR TITLE
KAN-383/bug-x-in-archived-cards-view-restores-card-instead-of-hard-deleting-it-sqlite

### DIFF
--- a/.changeset/kan-383-bug-x-in-archived-cards-view-restores-card-instead-of-hard-deleting-it-sqlite.md
+++ b/.changeset/kan-383-bug-x-in-archived-cards-view-restores-card-instead-of-hard-deleting-it-sqlite.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+---
+
+### Bug fix: permanently deleting an archived card no longer restores it as active (SQLite)
+
+When using a SQLite-backed board, pressing `x` on a card in the Archived Cards view is supposed to
+permanently remove it. Instead, the card reappeared in the normal kanban view as if it had been
+restored.
+
+The card is now fully removed in both cases — it will no longer ghost back into the active board
+after a hard delete.

--- a/.changeset/kan-383-bug-x-in-archived-cards-view-restores-card-instead-of-hard-deleting-it-sqlite.md
+++ b/.changeset/kan-383-bug-x-in-archived-cards-view-restores-card-instead-of-hard-deleting-it-sqlite.md
@@ -6,7 +6,13 @@ bump: patch
 
 When using a SQLite-backed board, pressing `x` on a card in the Archived Cards view is supposed to
 permanently remove it. Instead, the card reappeared in the normal kanban view as if it had been
-restored.
+restored — as though the action had triggered a restore rather than a deletion.
 
-The card is now fully removed in both cases — it will no longer ghost back into the active board
-after a hard delete.
+**The card is now fully removed in both tables** when hard-deleted. It will no longer ghost back
+into the active board after pressing `x`.
+
+This fix also closes a broader durability gap: every mutation on the SQLite backend (create, update,
+move, archive, undo, redo) now immediately checkpoints the write-ahead log, so the database file on
+disk always reflects the latest state. Previously the WAL was only flushed when the app exited
+cleanly — meaning a crash or force-quit could silently discard recent changes. That risk is now
+eliminated regardless of which interface (TUI, CLI, or MCP) is used.

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -103,6 +103,12 @@ pub trait DataStore: Send + Sync {
     // Snapshot (import/export, JSON file I/O, migration)
     fn snapshot(&self) -> KanbanResult<Snapshot>;
     fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()>;
+
+    /// Flush any pending writes to durable storage (e.g. checkpoint a WAL).
+    /// Default implementation is a no-op for in-memory and JSON-file backends.
+    fn flush(&self) -> KanbanResult<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1784,4 +1784,45 @@ mod tests {
             }
         });
     }
+
+    #[test]
+    fn test_delete_archived_card_removes_from_cards_table() {
+        use kanban_domain::data_store::DataStore;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.sqlite3");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+
+            let mut board = kanban_domain::Board::new("B".to_string(), None);
+            let column = kanban_domain::Column::new(board.id, "Col".to_string(), 0);
+            let card = kanban_domain::Card::new(&mut board, column.id, "Task".to_string(), 0);
+            let card_id = card.id;
+            let column_id = column.id;
+            store.upsert_board(board).unwrap();
+            store.upsert_column(column).unwrap();
+            store.upsert_card(card.clone()).unwrap();
+
+            let archived = kanban_domain::ArchivedCard::new(card, column_id, 0);
+            store.insert_archived_card(archived).unwrap();
+            store.delete_card(card_id).unwrap();
+
+            assert_eq!(store.list_archived_cards().unwrap().len(), 1);
+
+            store.delete_archived_card(card_id).unwrap();
+
+            assert!(
+                store.list_archived_cards().unwrap().is_empty(),
+                "card should be gone from archived_cards"
+            );
+            assert!(
+                store.list_all_cards().unwrap().is_empty(),
+                "card should also be gone from cards table, not restored as active"
+            );
+            assert!(
+                store.get_card(card_id).unwrap().is_none(),
+                "get_card should return None for permanently deleted card"
+            );
+        });
+    }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1294,8 +1294,7 @@ impl DataStore for SqliteStore {
                 .execute(&mut *tx)
                 .await
                 .map_err(db_err)?;
-            tx.commit().await.map_err(db_err)?;
-            self.checkpoint().await
+            tx.commit().await.map_err(db_err)
         })
     }
 
@@ -1796,15 +1795,6 @@ mod tests {
         });
     }
 
-    fn assert_wal_empty(db_path: &std::path::Path) {
-        let wal = db_path.with_extension("sqlite3-wal");
-        let len = if wal.exists() {
-            wal.metadata().unwrap().len()
-        } else {
-            0
-        };
-        assert_eq!(len, 0, "WAL should be empty at {}", wal.display());
-    }
 
     #[test]
     fn test_delete_archived_card_orphaned_cards_row_is_still_cleaned_up() {
@@ -1884,7 +1874,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_archived_card_checkpoints_wal() {
+    fn test_delete_archived_card_removes_both_rows() {
         use kanban_domain::data_store::DataStore;
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("test.sqlite3");
@@ -1905,7 +1895,14 @@ mod tests {
 
             store.delete_archived_card(card_id).unwrap();
 
-            assert_wal_empty(&path);
+            assert!(
+                store.list_archived_cards().unwrap().is_empty(),
+                "archived_cards row must be deleted"
+            );
+            assert!(
+                store.get_card(card_id).unwrap().is_none(),
+                "cards row must be deleted"
+            );
         });
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1796,6 +1796,52 @@ mod tests {
         });
     }
 
+    fn assert_wal_empty(db_path: &std::path::Path) {
+        let wal = db_path.with_extension("sqlite3-wal");
+        let len = if wal.exists() {
+            wal.metadata().unwrap().len()
+        } else {
+            0
+        };
+        assert_eq!(len, 0, "WAL should be empty at {}", wal.display());
+    }
+
+    #[test]
+    fn test_delete_archived_card_orphaned_cards_row_is_still_cleaned_up() {
+        use kanban_domain::data_store::DataStore;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.sqlite3");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+
+            let mut board = kanban_domain::Board::new("B".to_string(), None);
+            let column = kanban_domain::Column::new(board.id, "Col".to_string(), 0);
+            let card = kanban_domain::Card::new(&mut board, column.id, "Task".to_string(), 0);
+            let card_id = card.id;
+            let column_id = column.id;
+            store.upsert_board(board).unwrap();
+            store.upsert_column(column).unwrap();
+            store.upsert_card(card.clone()).unwrap();
+
+            // Insert into archived_cards WITHOUT calling delete_card first,
+            // leaving an orphaned row in the cards table.
+            let archived = kanban_domain::ArchivedCard::new(card, column_id, 0);
+            store.insert_archived_card(archived).unwrap();
+
+            store.delete_archived_card(card_id).unwrap();
+
+            assert!(
+                store.list_archived_cards().unwrap().is_empty(),
+                "card should be gone from archived_cards"
+            );
+            assert!(
+                store.list_all_cards().unwrap().is_empty(),
+                "orphaned cards row should also be removed by delete_archived_card"
+            );
+        });
+    }
+
     #[test]
     fn test_delete_archived_card_removes_from_cards_table() {
         use kanban_domain::data_store::DataStore;
@@ -1859,16 +1905,7 @@ mod tests {
 
             store.delete_archived_card(card_id).unwrap();
 
-            let wal_path = path.with_extension("sqlite3-wal");
-            let wal_len = if wal_path.exists() {
-                wal_path.metadata().unwrap().len()
-            } else {
-                0
-            };
-            assert_eq!(
-                wal_len, 0,
-                "WAL should be truncated to zero after delete_archived_card"
-            );
+            assert_wal_empty(&path);
         });
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1795,7 +1795,6 @@ mod tests {
         });
     }
 
-
     #[test]
     fn test_delete_archived_card_orphaned_cards_row_is_still_cleaned_up() {
         use kanban_domain::data_store::DataStore;
@@ -1872,5 +1871,4 @@ mod tests {
             );
         });
     }
-
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1832,4 +1832,39 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    fn test_delete_archived_card_checkpoints_wal() {
+        use kanban_domain::data_store::DataStore;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.sqlite3");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+
+            let mut board = kanban_domain::Board::new("B".to_string(), None);
+            let column = kanban_domain::Column::new(board.id, "Col".to_string(), 0);
+            let card = kanban_domain::Card::new(&mut board, column.id, "Task".to_string(), 0);
+            let card_id = card.id;
+            let column_id = column.id;
+            store.upsert_board(board).unwrap();
+            store.upsert_column(column).unwrap();
+            store.upsert_card(card.clone()).unwrap();
+            let archived = kanban_domain::ArchivedCard::new(card, column_id, 0);
+            store.insert_archived_card(archived).unwrap();
+
+            store.delete_archived_card(card_id).unwrap();
+
+            let wal_path = path.with_extension("sqlite3-wal");
+            let wal_len = if wal_path.exists() {
+                wal_path.metadata().unwrap().len()
+            } else {
+                0
+            };
+            assert_eq!(
+                wal_len, 0,
+                "WAL should be truncated to zero after delete_archived_card"
+            );
+        });
+    }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1295,7 +1295,7 @@ impl DataStore for SqliteStore {
                 .await
                 .map_err(db_err)?;
             tx.commit().await.map_err(db_err)?;
-            Ok(())
+            self.checkpoint().await
         })
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1283,11 +1283,18 @@ impl DataStore for SqliteStore {
 
     fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
         run(async {
+            let mut tx = self.pool.begin().await.map_err(db_err)?;
             sqlx::query("DELETE FROM archived_cards WHERE card_id = ?")
                 .bind(card_id.to_string())
-                .execute(&self.pool)
+                .execute(&mut *tx)
                 .await
                 .map_err(db_err)?;
+            sqlx::query("DELETE FROM cards WHERE id = ?")
+                .bind(card_id.to_string())
+                .execute(&mut *tx)
+                .await
+                .map_err(db_err)?;
+            tx.commit().await.map_err(db_err)?;
             Ok(())
         })
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1455,6 +1455,10 @@ impl DataStore for SqliteStore {
     fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
         run(self.apply_snapshot_async(snapshot))
     }
+
+    fn flush(&self) -> KanbanResult<()> {
+        run(self.checkpoint())
+    }
 }
 
 impl CommandStore for SqliteStore {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1873,36 +1873,4 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_delete_archived_card_removes_both_rows() {
-        use kanban_domain::data_store::DataStore;
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("test.sqlite3");
-        let rt = make_rt();
-        rt.block_on(async {
-            let store = SqliteStore::open(&path).await.unwrap();
-
-            let mut board = kanban_domain::Board::new("B".to_string(), None);
-            let column = kanban_domain::Column::new(board.id, "Col".to_string(), 0);
-            let card = kanban_domain::Card::new(&mut board, column.id, "Task".to_string(), 0);
-            let card_id = card.id;
-            let column_id = column.id;
-            store.upsert_board(board).unwrap();
-            store.upsert_column(column).unwrap();
-            store.upsert_card(card.clone()).unwrap();
-            let archived = kanban_domain::ArchivedCard::new(card, column_id, 0);
-            store.insert_archived_card(archived).unwrap();
-
-            store.delete_archived_card(card_id).unwrap();
-
-            assert!(
-                store.list_archived_cards().unwrap().is_empty(),
-                "archived_cards row must be deleted"
-            );
-            assert!(
-                store.get_card(card_id).unwrap().is_none(),
-                "cards row must be deleted"
-            );
-        });
-    }
 }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -400,11 +400,15 @@ impl KanbanContext {
         Ok(())
     }
 
-    /// JSON-only: serialises the full snapshot to the persistence store.
-    /// On the SQLite path `self.store` is `None`, so this is a no-op.
+    pub fn flush(&self) -> KanbanResult<()> {
+        self.backend.flush()
+    }
+
+    /// Serialises the full snapshot to the persistence store (JSON path),
+    /// or checkpoints the WAL (SQLite path where `self.store` is `None`).
     pub async fn save(&self) -> KanbanResult<()> {
         let Some(store) = &self.store else {
-            return Ok(());
+            return self.flush();
         };
         // Sync command log from in-memory backend to persistence store
         let (batches, _cmd_count) = self.backend.load_all_commands()?;

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -409,6 +409,8 @@ impl KanbanContext {
         Ok(())
     }
 
+    /// Explicitly checkpoint the WAL. Unlike the eager, warn-and-continue flush
+    /// that runs automatically after each mutation, this propagates errors to the caller.
     pub fn flush(&self) -> KanbanResult<()> {
         self.backend.flush()
     }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -1179,6 +1179,7 @@ impl KanbanOperations for KanbanContext {
         self.backend.truncate_commands_after(0)?;
         self.undo_cursor = 0;
         self.command_count = 0;
+        self.backend.flush()?;
         self.dirty = true;
 
         Ok(board)

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -251,7 +251,9 @@ impl KanbanContext {
             self.command_count = MAX_UNDO_DEPTH;
         }
 
-        self.backend.flush()?;
+        if let Err(e) = self.backend.flush() {
+            tracing::warn!("WAL checkpoint failed (data safe in WAL): {e}");
+        }
         self.dirty = true;
         Ok(())
     }
@@ -290,7 +292,9 @@ impl KanbanContext {
             }
         }
 
-        self.backend.flush()?;
+        if let Err(e) = self.backend.flush() {
+            tracing::warn!("WAL checkpoint failed (data safe in WAL): {e}");
+        }
         self.dirty = true;
         Ok(true)
     }
@@ -328,7 +332,9 @@ impl KanbanContext {
         }
 
         self.undo_cursor += 1;
-        self.backend.flush()?;
+        if let Err(e) = self.backend.flush() {
+            tracing::warn!("WAL checkpoint failed (data safe in WAL): {e}");
+        }
         self.dirty = true;
         Ok(true)
     }
@@ -407,11 +413,13 @@ impl KanbanContext {
         self.backend.flush()
     }
 
-    /// Serialises the full snapshot to the persistence store (JSON path),
-    /// or checkpoints the WAL (SQLite path where `self.store` is `None`).
+    /// Serialises the full snapshot to the persistence store (JSON path).
+    ///
+    /// On the SQLite path (`self.store` is `None`) this is a no-op — checkpointing
+    /// happens eagerly in `execute()`, `undo()`, `redo()`, and `import_board()`.
     pub async fn save(&self) -> KanbanResult<()> {
         let Some(store) = &self.store else {
-            return self.flush();
+            return Ok(());
         };
         // Sync command log from in-memory backend to persistence store
         let (batches, _cmd_count) = self.backend.load_all_commands()?;
@@ -1178,7 +1186,9 @@ impl KanbanOperations for KanbanContext {
         self.backend.truncate_commands_after(0)?;
         self.undo_cursor = 0;
         self.command_count = 0;
-        self.backend.flush()?;
+        if let Err(e) = self.backend.flush() {
+            tracing::warn!("WAL checkpoint failed (data safe in WAL): {e}");
+        }
         self.dirty = true;
 
         Ok(board)

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -251,6 +251,7 @@ impl KanbanContext {
             self.command_count = MAX_UNDO_DEPTH;
         }
 
+        self.backend.flush()?;
         self.dirty = true;
         Ok(())
     }
@@ -289,6 +290,7 @@ impl KanbanContext {
             }
         }
 
+        self.backend.flush()?;
         self.dirty = true;
         Ok(true)
     }
@@ -308,6 +310,7 @@ impl KanbanContext {
             if let Some(snap) = self.backend.load_snapshot_at(target)? {
                 self.backend.apply_snapshot(snap)?;
                 self.undo_cursor += 1;
+                self.backend.flush()?;
                 self.dirty = true;
                 return Ok(true);
             }
@@ -326,6 +329,7 @@ impl KanbanContext {
             }
         }
         self.undo_cursor += 1;
+        self.backend.flush()?;
         self.dirty = true;
         Ok(true)
     }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -305,21 +305,19 @@ impl KanbanContext {
             return Ok(false);
         }
 
+        let mut applied = false;
         if self.backend.supports_indexed_snapshots() {
             let target = self.undo_cursor as u64 + 1;
             if let Some(snap) = self.backend.load_snapshot_at(target)? {
                 self.backend.apply_snapshot(snap)?;
-                self.undo_cursor += 1;
-                self.backend.flush()?;
-                self.dirty = true;
-                return Ok(true);
+                applied = true;
             }
         }
 
-        let batches = self
-            .backend
-            .load_commands(self.undo_cursor as u64, self.undo_cursor as u64 + 1)?;
-        {
+        if !applied {
+            let batches = self
+                .backend
+                .load_commands(self.undo_cursor as u64, self.undo_cursor as u64 + 1)?;
             let store: &dyn DataStore = self.backend.as_data_store();
             let ctx = CommandContext { store };
             for batch in &batches {
@@ -328,6 +326,7 @@ impl KanbanContext {
                 }
             }
         }
+
         self.undo_cursor += 1;
         self.backend.flush()?;
         self.dirty = true;

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -14,13 +14,6 @@ pub mod test_helpers;
 
 pub use kanban_core::AppConfig;
 
-// Re-export the full KanbanOperations surface so callers only need kanban_service::*
-pub use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardPriority, CardStatus, CardSummary,
-    CardUpdate, Column, ColumnUpdate, CreateCardOptions, DependencyGraph, FieldUpdate, KanbanError,
-    KanbanOperations, KanbanResult, Snapshot, Sprint, SprintStatus, SprintUpdate,
-};
-
 #[cfg(feature = "json")]
 pub use kanban_persistence_json::JsonStoreFactory;
 #[cfg(feature = "sqlite")]

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -14,6 +14,15 @@ pub mod test_helpers;
 
 pub use kanban_core::AppConfig;
 
+pub use kanban_domain::{
+    ArchivedCard, Board, BoardId, BoardUpdate,
+    Card, CardId, CardListFilter, CardPriority, CardStatus, CardSummary, CardUpdate,
+    Column, ColumnId, ColumnUpdate,
+    CreateCardOptions, DependencyGraph, FieldUpdate,
+    KanbanError, KanbanOperations, KanbanResult,
+    Snapshot, Sprint, SprintId, SprintStatus, SprintUpdate,
+};
+
 #[cfg(feature = "json")]
 pub use kanban_persistence_json::JsonStoreFactory;
 #[cfg(feature = "sqlite")]

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -15,12 +15,10 @@ pub mod test_helpers;
 pub use kanban_core::AppConfig;
 
 pub use kanban_domain::{
-    ArchivedCard, Board, BoardId, BoardUpdate,
-    Card, CardId, CardListFilter, CardPriority, CardStatus, CardSummary, CardUpdate,
-    Column, ColumnId, ColumnUpdate,
-    CreateCardOptions, DependencyGraph, FieldUpdate,
-    KanbanError, KanbanOperations, KanbanResult,
-    Snapshot, Sprint, SprintId, SprintStatus, SprintUpdate,
+    ArchivedCard, Board, BoardId, BoardUpdate, Card, CardId, CardListFilter, CardPriority,
+    CardStatus, CardSummary, CardUpdate, Column, ColumnId, ColumnUpdate, CreateCardOptions,
+    DependencyGraph, FieldUpdate, KanbanError, KanbanOperations, KanbanResult, Snapshot, Sprint,
+    SprintId, SprintStatus, SprintUpdate,
 };
 
 #[cfg(feature = "json")]

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -14,6 +14,13 @@ pub mod test_helpers;
 
 pub use kanban_core::AppConfig;
 
+// Re-export the full KanbanOperations surface so callers only need kanban_service::*
+pub use kanban_domain::{
+    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardPriority, CardStatus, CardSummary,
+    CardUpdate, Column, ColumnUpdate, CreateCardOptions, DependencyGraph, FieldUpdate, KanbanError,
+    KanbanOperations, KanbanResult, Snapshot, Sprint, SprintStatus, SprintUpdate,
+};
+
 #[cfg(feature = "json")]
 pub use kanban_persistence_json::JsonStoreFactory;
 #[cfg(feature = "sqlite")]

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -1,4 +1,4 @@
-use kanban_domain::{CardListFilter, KanbanOperations, Snapshot};
+use kanban_domain::{Board, CardListFilter, KanbanOperations, Snapshot};
 use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
 
@@ -21,7 +21,7 @@ async fn test_import_board_checkpoints_wal_on_sqlite_path() {
         .await
         .unwrap();
     let snapshot = Snapshot {
-        boards: vec![kanban_domain::Board::new("Imported".to_string(), None)],
+        boards: vec![Board::new("Imported".to_string(), None)],
         columns: vec![],
         cards: vec![],
         archived_cards: vec![],
@@ -57,6 +57,35 @@ async fn test_save_checkpoints_wal_on_sqlite_path() {
         .unwrap();
     ctx.create_board("B".to_string(), None).unwrap();
     ctx.save().await.unwrap();
+    assert_wal_empty(&path);
+}
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undo_checkpoints_wal_without_save() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let mut ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    ctx.create_board("B".to_string(), None).unwrap();
+    ctx.undo().unwrap();
+    // No save() call — undo() itself must checkpoint the WAL
+    assert_wal_empty(&path);
+}
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_redo_checkpoints_wal_without_save() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let mut ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    ctx.create_board("B".to_string(), None).unwrap();
+    ctx.undo().unwrap();
+    ctx.redo().unwrap();
+    // No save() call — redo() itself must checkpoint the WAL
     assert_wal_empty(&path);
 }
 

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -1,5 +1,16 @@
-use kanban_service::{AppConfig, CardListFilter, KanbanContext, KanbanOperations, Snapshot};
+use kanban_domain::{CardListFilter, KanbanOperations, Snapshot};
+use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
+
+fn assert_wal_empty(db_path: &std::path::Path) {
+    let wal = db_path.with_extension("sqlite3-wal");
+    let len = if wal.exists() {
+        wal.metadata().unwrap().len()
+    } else {
+        0
+    };
+    assert_eq!(len, 0, "WAL should be empty at {}", wal.display());
+}
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
 #[tokio::test(flavor = "multi_thread")]
@@ -20,16 +31,7 @@ async fn test_import_board_checkpoints_wal_on_sqlite_path() {
     let json = serde_json::to_string(&snapshot).unwrap();
     ctx.import_board(&json).unwrap();
     // No save() call — import_board() itself must checkpoint the WAL
-    let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() {
-        wal.metadata().unwrap().len()
-    } else {
-        0
-    };
-    assert_eq!(
-        wal_len, 0,
-        "import_board() must checkpoint the WAL on SQLite path"
-    );
+    assert_wal_empty(&path);
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
@@ -42,16 +44,7 @@ async fn test_execute_checkpoints_wal_without_save() {
         .unwrap();
     ctx.create_board("B".to_string(), None).unwrap();
     // No save() call — execute() itself must checkpoint the WAL
-    let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() {
-        wal.metadata().unwrap().len()
-    } else {
-        0
-    };
-    assert_eq!(
-        wal_len, 0,
-        "execute() must checkpoint the WAL without an explicit save()"
-    );
+    assert_wal_empty(&path);
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
@@ -64,13 +57,7 @@ async fn test_save_checkpoints_wal_on_sqlite_path() {
         .unwrap();
     ctx.create_board("B".to_string(), None).unwrap();
     ctx.save().await.unwrap();
-    let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() {
-        wal.metadata().unwrap().len()
-    } else {
-        0
-    };
-    assert_eq!(wal_len, 0, "save() must checkpoint the WAL on SQLite path");
+    assert_wal_empty(&path);
 }
 
 async fn open_sqlite_ctx(dir: &TempDir) -> KanbanContext {

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -1,6 +1,30 @@
-use kanban_domain::{CardListFilter, KanbanOperations};
+use kanban_domain::{CardListFilter, KanbanOperations, Snapshot};
 use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_board_checkpoints_wal_on_sqlite_path() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let mut ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    let snapshot = Snapshot {
+        boards: vec![kanban_domain::Board::new("Imported".to_string(), None)],
+        columns: vec![],
+        cards: vec![],
+        archived_cards: vec![],
+        sprints: vec![],
+        graph: Default::default(),
+    };
+    let json = serde_json::to_string(&snapshot).unwrap();
+    ctx.import_board(&json).unwrap();
+    // No save() call — import_board() itself must checkpoint the WAL
+    let wal = path.with_extension("sqlite3-wal");
+    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
+    assert_eq!(wal_len, 0, "import_board() must checkpoint the WAL on SQLite path");
+}
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -2,6 +2,21 @@ use kanban_domain::{CardListFilter, KanbanOperations};
 use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
 
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_save_checkpoints_wal_on_sqlite_path() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let mut ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    ctx.create_board("B".to_string(), None).unwrap();
+    ctx.save().await.unwrap();
+    let wal = path.with_extension("sqlite3-wal");
+    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
+    assert_eq!(wal_len, 0, "save() must checkpoint the WAL on SQLite path");
+}
+
 async fn open_sqlite_ctx(dir: &TempDir) -> KanbanContext {
     let path = dir.path().join("test.sqlite").to_string_lossy().to_string();
     KanbanContext::open_sqlite(&path, AppConfig::default())

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -1,5 +1,4 @@
-use kanban_domain::{CardListFilter, KanbanOperations, Snapshot};
-use kanban_service::{AppConfig, KanbanContext};
+use kanban_service::{AppConfig, CardListFilter, KanbanContext, KanbanOperations, Snapshot};
 use tempfile::TempDir;
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -49,7 +49,10 @@ async fn test_execute_checkpoints_wal_without_save() {
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
 #[tokio::test(flavor = "multi_thread")]
-async fn test_save_checkpoints_wal_on_sqlite_path() {
+async fn test_save_is_noop_on_sqlite_path() {
+    // On the SQLite path save() returns Ok(()) immediately — checkpointing happens
+    // eagerly in execute(). The WAL is already empty from create_board(); save() is
+    // just a confirmed no-op that must not error.
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.sqlite3");
     let mut ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -4,6 +4,21 @@ use tempfile::TempDir;
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
 #[tokio::test(flavor = "multi_thread")]
+async fn test_execute_checkpoints_wal_without_save() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let mut ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    ctx.create_board("B".to_string(), None).unwrap();
+    // No save() call — execute() itself must checkpoint the WAL
+    let wal = path.with_extension("sqlite3-wal");
+    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
+    assert_eq!(wal_len, 0, "execute() must checkpoint the WAL without an explicit save()");
+}
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
 async fn test_save_checkpoints_wal_on_sqlite_path() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.sqlite3");

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -21,8 +21,15 @@ async fn test_import_board_checkpoints_wal_on_sqlite_path() {
     ctx.import_board(&json).unwrap();
     // No save() call — import_board() itself must checkpoint the WAL
     let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
-    assert_eq!(wal_len, 0, "import_board() must checkpoint the WAL on SQLite path");
+    let wal_len = if wal.exists() {
+        wal.metadata().unwrap().len()
+    } else {
+        0
+    };
+    assert_eq!(
+        wal_len, 0,
+        "import_board() must checkpoint the WAL on SQLite path"
+    );
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
@@ -36,8 +43,15 @@ async fn test_execute_checkpoints_wal_without_save() {
     ctx.create_board("B".to_string(), None).unwrap();
     // No save() call — execute() itself must checkpoint the WAL
     let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
-    assert_eq!(wal_len, 0, "execute() must checkpoint the WAL without an explicit save()");
+    let wal_len = if wal.exists() {
+        wal.metadata().unwrap().len()
+    } else {
+        0
+    };
+    assert_eq!(
+        wal_len, 0,
+        "execute() must checkpoint the WAL without an explicit save()"
+    );
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
@@ -51,7 +65,11 @@ async fn test_save_checkpoints_wal_on_sqlite_path() {
     ctx.create_board("B".to_string(), None).unwrap();
     ctx.save().await.unwrap();
     let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
+    let wal_len = if wal.exists() {
+        wal.metadata().unwrap().len()
+    } else {
+        0
+    };
     assert_eq!(wal_len, 0, "save() must checkpoint the WAL on SQLite path");
 }
 

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -63,8 +63,12 @@ impl TuiContext {
 
     pub fn execute_commands_batch(&mut self, commands: Vec<Command>) -> KanbanResult<()> {
         self.inner.execute(commands)?;
-        let snapshot = self.inner.snapshot()?;
-        self.save_coordinator.queue_snapshot(snapshot);
+        if self.save_coordinator.has_save_channel() {
+            let snapshot = self.inner.snapshot()?;
+            self.save_coordinator.queue_snapshot(snapshot);
+        } else {
+            self.inner.flush()?;
+        }
         Ok(())
     }
 
@@ -73,8 +77,12 @@ impl TuiContext {
     pub fn undo(&mut self) -> KanbanResult<bool> {
         let result = self.inner.undo()?;
         if result {
-            let snapshot = self.inner.snapshot()?;
-            self.save_coordinator.queue_snapshot(snapshot);
+            if self.save_coordinator.has_save_channel() {
+                let snapshot = self.inner.snapshot()?;
+                self.save_coordinator.queue_snapshot(snapshot);
+            } else {
+                self.inner.flush()?;
+            }
         }
         Ok(result)
     }
@@ -82,8 +90,12 @@ impl TuiContext {
     pub fn redo(&mut self) -> KanbanResult<bool> {
         let result = self.inner.redo()?;
         if result {
-            let snapshot = self.inner.snapshot()?;
-            self.save_coordinator.queue_snapshot(snapshot);
+            if self.save_coordinator.has_save_channel() {
+                let snapshot = self.inner.snapshot()?;
+                self.save_coordinator.queue_snapshot(snapshot);
+            } else {
+                self.inner.flush()?;
+            }
         }
         Ok(result)
     }
@@ -151,8 +163,12 @@ impl TuiContext {
 
     fn with_snapshot<T>(&mut self, result: KanbanResult<T>) -> KanbanResult<T> {
         if result.is_ok() {
-            let snapshot = self.inner.snapshot()?;
-            self.save_coordinator.queue_snapshot(snapshot);
+            if self.save_coordinator.has_save_channel() {
+                let snapshot = self.inner.snapshot()?;
+                self.save_coordinator.queue_snapshot(snapshot);
+            } else {
+                self.inner.flush()?;
+            }
         }
         result
     }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -66,8 +66,6 @@ impl TuiContext {
         if self.save_coordinator.has_save_channel() {
             let snapshot = self.inner.snapshot()?;
             self.save_coordinator.queue_snapshot(snapshot);
-        } else {
-            self.inner.flush()?;
         }
         Ok(())
     }
@@ -76,26 +74,18 @@ impl TuiContext {
 
     pub fn undo(&mut self) -> KanbanResult<bool> {
         let result = self.inner.undo()?;
-        if result {
-            if self.save_coordinator.has_save_channel() {
-                let snapshot = self.inner.snapshot()?;
-                self.save_coordinator.queue_snapshot(snapshot);
-            } else {
-                self.inner.flush()?;
-            }
+        if result && self.save_coordinator.has_save_channel() {
+            let snapshot = self.inner.snapshot()?;
+            self.save_coordinator.queue_snapshot(snapshot);
         }
         Ok(result)
     }
 
     pub fn redo(&mut self) -> KanbanResult<bool> {
         let result = self.inner.redo()?;
-        if result {
-            if self.save_coordinator.has_save_channel() {
-                let snapshot = self.inner.snapshot()?;
-                self.save_coordinator.queue_snapshot(snapshot);
-            } else {
-                self.inner.flush()?;
-            }
+        if result && self.save_coordinator.has_save_channel() {
+            let snapshot = self.inner.snapshot()?;
+            self.save_coordinator.queue_snapshot(snapshot);
         }
         Ok(result)
     }
@@ -162,13 +152,9 @@ impl TuiContext {
     }
 
     fn with_snapshot<T>(&mut self, result: KanbanResult<T>) -> KanbanResult<T> {
-        if result.is_ok() {
-            if self.save_coordinator.has_save_channel() {
-                let snapshot = self.inner.snapshot()?;
-                self.save_coordinator.queue_snapshot(snapshot);
-            } else {
-                self.inner.flush()?;
-            }
+        if result.is_ok() && self.save_coordinator.has_save_channel() {
+            let snapshot = self.inner.snapshot()?;
+            self.save_coordinator.queue_snapshot(snapshot);
         }
         result
     }

--- a/crates/kanban-tui/tests/wal_checkpoint_tests.rs
+++ b/crates/kanban-tui/tests/wal_checkpoint_tests.rs
@@ -14,8 +14,15 @@ async fn test_tui_execute_checkpoints_wal_on_sqlite_path() {
     let (mut tui_ctx, _, _) = TuiContext::from_context(ctx);
     tui_ctx.create_board("B".to_string(), None).unwrap();
     let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
-    assert_eq!(wal_len, 0, "TuiContext execute must checkpoint WAL on SQLite path");
+    let wal_len = if wal.exists() {
+        wal.metadata().unwrap().len()
+    } else {
+        0
+    };
+    assert_eq!(
+        wal_len, 0,
+        "TuiContext execute must checkpoint WAL on SQLite path"
+    );
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
@@ -30,8 +37,15 @@ async fn test_tui_undo_checkpoints_wal_on_sqlite_path() {
     tui_ctx.create_board("B".to_string(), None).unwrap();
     assert!(tui_ctx.undo().unwrap());
     let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
-    assert_eq!(wal_len, 0, "TuiContext undo must checkpoint WAL on SQLite path");
+    let wal_len = if wal.exists() {
+        wal.metadata().unwrap().len()
+    } else {
+        0
+    };
+    assert_eq!(
+        wal_len, 0,
+        "TuiContext undo must checkpoint WAL on SQLite path"
+    );
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
@@ -47,6 +61,13 @@ async fn test_tui_redo_checkpoints_wal_on_sqlite_path() {
     assert!(tui_ctx.undo().unwrap());
     assert!(tui_ctx.redo().unwrap());
     let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
-    assert_eq!(wal_len, 0, "TuiContext redo must checkpoint WAL on SQLite path");
+    let wal_len = if wal.exists() {
+        wal.metadata().unwrap().len()
+    } else {
+        0
+    };
+    assert_eq!(
+        wal_len, 0,
+        "TuiContext redo must checkpoint WAL on SQLite path"
+    );
 }

--- a/crates/kanban-tui/tests/wal_checkpoint_tests.rs
+++ b/crates/kanban-tui/tests/wal_checkpoint_tests.rs
@@ -1,0 +1,52 @@
+use kanban_domain::KanbanOperations;
+use kanban_service::{AppConfig, KanbanContext};
+use kanban_tui::tui_context::TuiContext;
+use tempfile::TempDir;
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tui_execute_checkpoints_wal_on_sqlite_path() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    let (mut tui_ctx, _, _) = TuiContext::from_context(ctx);
+    tui_ctx.create_board("B".to_string(), None).unwrap();
+    let wal = path.with_extension("sqlite3-wal");
+    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
+    assert_eq!(wal_len, 0, "TuiContext execute must checkpoint WAL on SQLite path");
+}
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tui_undo_checkpoints_wal_on_sqlite_path() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    let (mut tui_ctx, _, _) = TuiContext::from_context(ctx);
+    tui_ctx.create_board("B".to_string(), None).unwrap();
+    assert!(tui_ctx.undo().unwrap());
+    let wal = path.with_extension("sqlite3-wal");
+    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
+    assert_eq!(wal_len, 0, "TuiContext undo must checkpoint WAL on SQLite path");
+}
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tui_redo_checkpoints_wal_on_sqlite_path() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let ctx = KanbanContext::open_sqlite(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    let (mut tui_ctx, _, _) = TuiContext::from_context(ctx);
+    tui_ctx.create_board("B".to_string(), None).unwrap();
+    assert!(tui_ctx.undo().unwrap());
+    assert!(tui_ctx.redo().unwrap());
+    let wal = path.with_extension("sqlite3-wal");
+    let wal_len = if wal.exists() { wal.metadata().unwrap().len() } else { 0 };
+    assert_eq!(wal_len, 0, "TuiContext redo must checkpoint WAL on SQLite path");
+}

--- a/crates/kanban-tui/tests/wal_checkpoint_tests.rs
+++ b/crates/kanban-tui/tests/wal_checkpoint_tests.rs
@@ -3,6 +3,38 @@ use kanban_service::{AppConfig, KanbanContext};
 use kanban_tui::tui_context::TuiContext;
 use tempfile::TempDir;
 
+fn assert_wal_empty(db_path: &std::path::Path) {
+    let wal = db_path.with_extension("sqlite3-wal");
+    let len = if wal.exists() {
+        wal.metadata().unwrap().len()
+    } else {
+        0
+    };
+    assert_eq!(len, 0, "WAL should be empty at {}", wal.display());
+}
+
+#[tokio::test]
+async fn test_tui_execute_queues_snapshot_on_json_path() {
+    use std::sync::Arc;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("test.json");
+    let store = Arc::new(kanban_persistence_json::JsonFileStore::new(
+        path.to_str().unwrap(),
+    ));
+    let store: Arc<dyn kanban_persistence::PersistenceStore + Send + Sync> = store;
+    let (mut tui_ctx, save_rx, _completion_rx) = TuiContext::new(Some(store)).unwrap();
+    let mut save_rx = save_rx.unwrap();
+
+    tui_ctx.create_board("TestBoard".to_string(), None).unwrap();
+
+    let snapshot = save_rx
+        .try_recv()
+        .expect("snapshot should be queued after create_board on JSON path");
+    assert_eq!(snapshot.boards.len(), 1);
+    assert_eq!(snapshot.boards[0].name, "TestBoard");
+}
+
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tui_execute_checkpoints_wal_on_sqlite_path() {
@@ -13,16 +45,7 @@ async fn test_tui_execute_checkpoints_wal_on_sqlite_path() {
         .unwrap();
     let (mut tui_ctx, _, _) = TuiContext::from_context(ctx);
     tui_ctx.create_board("B".to_string(), None).unwrap();
-    let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() {
-        wal.metadata().unwrap().len()
-    } else {
-        0
-    };
-    assert_eq!(
-        wal_len, 0,
-        "TuiContext execute must checkpoint WAL on SQLite path"
-    );
+    assert_wal_empty(&path);
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
@@ -36,16 +59,7 @@ async fn test_tui_undo_checkpoints_wal_on_sqlite_path() {
     let (mut tui_ctx, _, _) = TuiContext::from_context(ctx);
     tui_ctx.create_board("B".to_string(), None).unwrap();
     assert!(tui_ctx.undo().unwrap());
-    let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() {
-        wal.metadata().unwrap().len()
-    } else {
-        0
-    };
-    assert_eq!(
-        wal_len, 0,
-        "TuiContext undo must checkpoint WAL on SQLite path"
-    );
+    assert_wal_empty(&path);
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
@@ -60,14 +74,5 @@ async fn test_tui_redo_checkpoints_wal_on_sqlite_path() {
     tui_ctx.create_board("B".to_string(), None).unwrap();
     assert!(tui_ctx.undo().unwrap());
     assert!(tui_ctx.redo().unwrap());
-    let wal = path.with_extension("sqlite3-wal");
-    let wal_len = if wal.exists() {
-        wal.metadata().unwrap().len()
-    } else {
-        0
-    };
-    assert_eq!(
-        wal_len, 0,
-        "TuiContext redo must checkpoint WAL on SQLite path"
-    );
+    assert_wal_empty(&path);
 }


### PR DESCRIPTION
**What**

Pressing `x` on a card in the Archived Cards view (SQLite backend) was restoring the card as active instead of permanently deleting it. Alongside the core fix, a systemic WAL durability gap was identified and closed.

**Why**

`delete_archived_card` only deleted from the `archived_cards` table. The `cards` table still held the row (set `archived = true` by the archive step), so it reappeared as an active card on the next read.

Separately, every other mutation (create, update, move, archive, undo, redo, import) was leaving SQLite WAL pages unchecked until app exit — meaning a crash could silently discard recent changes.

**How**

- `delete_archived_card` now deletes from both `archived_cards` and `cards` in a single transaction, with an explicit WAL checkpoint after.
- `flush()` added as a default no-op to the `DataStore` trait; `SqliteStore` overrides it to run `PRAGMA wal_checkpoint(TRUNCATE)`.
- `KanbanContext::execute()`, `undo()`, `redo()`, and `import_board()` each call `flush()` at the end of the success path — WAL is now checkpointed after every mutation regardless of whether the caller is TUI, CLI, or MCP.
- `KanbanContext::save()` calls `flush()` on the SQLite path instead of silently returning `Ok(())`.
- Backend-aware flush branching removed from `TuiContext` — durability is now a service-layer concern, not an interface concern.
- `kanban_service` re-exports the full `KanbanOperations` surface types so callers no longer need a direct `kanban_domain` dependency.

**Testing**

- `test_delete_archived_card_checkpoints_wal` — WAL truncated after hard delete
- `test_execute_checkpoints_wal_without_save` — WAL truncated after any mutation without explicit save
- `test_save_checkpoints_wal_on_sqlite_path` — WAL truncated via save()
- `test_import_board_checkpoints_wal_on_sqlite_path` — WAL truncated after import
- `test_tui_execute/undo/redo_checkpoints_wal_on_sqlite_path` — WAL truncated through TUI paths