### PR TITLE
KAN-391/pr-208-release-0-4-0-fix-validate-release-sh-staleness-before-merge

### DIFF
--- a/.changeset/kan-391-fix-validate-release-staleness.md
+++ b/.changeset/kan-391-fix-validate-release-staleness.md
@@ -2,5 +2,7 @@
 bump: patch
 ---
 
-- fix(ci): derive validate-release crate list dynamically via cargo metadata
+- fix(ci): derive release-script crate list dynamically via cargo metadata
+- fix(ci): propagate list-crates failures cleanly to release-script consumers
+- fix(ci): broaden crate-list-sync drift regex to catch inline arrays
 - test(ci): add crate list sync invariant guard

--- a/.changeset/kan-391-fix-validate-release-staleness.md
+++ b/.changeset/kan-391-fix-validate-release-staleness.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+- fix(ci): derive validate-release crate list dynamically via cargo metadata
+- test(ci): add crate list sync invariant guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,7 @@ jobs:
       - name: Validate release build
         run: |
           nix develop --command validate-release
+
+      - name: Check crate list sync invariant
+        run: |
+          nix develop --command check-crate-list-sync

--- a/flake.nix
+++ b/flake.nix
@@ -61,11 +61,17 @@
           text = builtins.readFile ./scripts/validate-release.sh;
         };
 
+        checkCrateListSync = pkgs.writeShellApplication {
+          name = "check-crate-list-sync";
+          runtimeInputs = with pkgs; [coreutils gnugrep findutils diffutils listCrates];
+          text = builtins.readFile ./scripts/check-crate-list-sync.sh;
+        };
+
         kanban = pkgs.callPackage ./default.nix { src = self; gitRev = self.rev or null; };
       in {
         devShells.default = import ./shell.nix {
           inherit pkgs rustToolchain;
-          inherit changeset aggregateChangelog bumpVersion publishCrates validateRelease listCrates;
+          inherit changeset aggregateChangelog bumpVersion publishCrates validateRelease listCrates checkCrateListSync;
         };
 
         devShells.demo = import ./demo/shell.nix { inherit pkgs kanban; };
@@ -83,6 +89,7 @@
           publish-crates = publishCrates;
           validate-release = validateRelease;
           list-crates = listCrates;
+          check-crate-list-sync = checkCrateListSync;
           changeset = changeset;
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,12 @@
           text = builtins.readFile ./scripts/aggregate-changelog.sh;
         };
 
+        listCrates = pkgs.writeShellApplication {
+          name = "list-crates";
+          runtimeInputs = with pkgs; [rustToolchain cargo coreutils jq gnused];
+          text = builtins.readFile ./scripts/list-crates.sh;
+        };
+
         validateRelease = pkgs.writeShellApplication {
           name = "validate-release";
           runtimeInputs = with pkgs; [rustToolchain cargo coreutils gnugrep gnused];
@@ -59,7 +65,7 @@
       in {
         devShells.default = import ./shell.nix {
           inherit pkgs rustToolchain;
-          inherit changeset aggregateChangelog bumpVersion publishCrates validateRelease;
+          inherit changeset aggregateChangelog bumpVersion publishCrates validateRelease listCrates;
         };
 
         devShells.demo = import ./demo/shell.nix { inherit pkgs kanban; };
@@ -76,6 +82,7 @@
           bump-version = bumpVersion;
           publish-crates = publishCrates;
           validate-release = validateRelease;
+          list-crates = listCrates;
           changeset = changeset;
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
 
         publishCrates = pkgs.writeShellApplication {
           name = "publish-crates";
-          runtimeInputs = [rustToolchain pkgs.cargo pkgs.coreutils validateRelease];
+          runtimeInputs = [rustToolchain pkgs.cargo pkgs.coreutils pkgs.curl pkgs.gnugrep validateRelease listCrates];
           text = builtins.readFile ./scripts/publish-crates.sh;
         };
 
@@ -57,7 +57,7 @@
 
         validateRelease = pkgs.writeShellApplication {
           name = "validate-release";
-          runtimeInputs = with pkgs; [rustToolchain cargo coreutils gnugrep gnused];
+          runtimeInputs = with pkgs; [rustToolchain cargo coreutils gnugrep gnused listCrates];
           text = builtins.readFile ./scripts/validate-release.sh;
         };
 

--- a/scripts/check-crate-list-sync.sh
+++ b/scripts/check-crate-list-sync.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Drift-prevention invariant: fail if either release script regressed to
+# a hardcoded crate list array. The dynamic helper (list-crates) is the
+# single source of truth.
+
+failed=0
+for f in scripts/validate-release.sh scripts/publish-crates.sh; do
+  if grep -qE '^\s*"crates/' "$f"; then
+    echo "❌ $f contains a hardcoded crates/ array literal — use list-crates"
+    failed=1
+  fi
+done
+
+expected=$(list-crates --names | sort)
+on_disk=$(find crates -mindepth 2 -maxdepth 2 -name Cargo.toml -printf '%h\n' | xargs -n1 basename | sort)
+if [ "$expected" != "$on_disk" ]; then
+  echo "❌ list-crates output disagrees with crates/ workspace members:"
+  diff <(echo "$expected") <(echo "$on_disk") || true
+  failed=1
+fi
+
+if [ $failed -eq 0 ]; then
+  echo "✓ crate list sync OK"
+fi
+exit $failed

--- a/scripts/check-crate-list-sync.sh
+++ b/scripts/check-crate-list-sync.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 failed=0
 for f in scripts/validate-release.sh scripts/publish-crates.sh; do
-  if grep -qE '^\s*"crates/' "$f"; then
+  if grep -qE '"crates/[a-z][a-z0-9-]*"' "$f"; then
     echo "❌ $f contains a hardcoded crates/ array literal — use list-crates"
     failed=1
   fi

--- a/scripts/check-crate-list-sync.sh
+++ b/scripts/check-crate-list-sync.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 # Drift-prevention invariant: fail if either release script regressed to
 # a hardcoded crate list array. The dynamic helper (list-crates) is the
 # single source of truth.
+#
+# Scope: only validate-release.sh and publish-crates.sh are checked. The
+# other release scripts (bump-version.sh, aggregate-changelog.sh) already
+# iterate crates/*/Cargo.toml via filesystem glob — they have no array
+# literal to drift, so the invariant doesn't apply to them.
 
 failed=0
 for f in scripts/validate-release.sh scripts/publish-crates.sh; do

--- a/scripts/list-crates.sh
+++ b/scripts/list-crates.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Emit topo-ordered list of workspace crates suitable for sequential cargo publish.
+# Modes: --paths (default) -> "crates/<name>"; --names -> bare crate name.
+
+mode="${1:---paths}"
+
+command -v cargo >/dev/null || { echo "list-crates: cargo missing" >&2; exit 2; }
+command -v jq    >/dev/null || { echo "list-crates: jq missing"    >&2; exit 2; }
+command -v tsort >/dev/null || { echo "list-crates: tsort missing" >&2; exit 2; }
+
+metadata=$(cargo metadata --no-deps --format-version 1 --offline 2>/dev/null) \
+  || metadata=$(cargo metadata --no-deps --format-version 1)
+
+# kind == null filters dev/build deps. Without this filter the graph cycles:
+# kanban-persistence-json dev-depends on kanban-service while kanban-service
+# normal-depends on kanban-persistence-json.
+ordered=$(printf '%s\n' "$metadata" | jq -r '
+  .packages[]
+  | . as $p
+  | (([$p.dependencies[] | select(.path != null and .kind == null) | .name] | unique) as $deps
+     | if ($deps | length) == 0
+       then "\($p.name) \($p.name)"
+       else ($deps[] | "\(.) \($p.name)") end)
+' | tsort)
+
+if [ -z "$ordered" ]; then
+  echo "list-crates: empty crate list (cargo metadata produced no packages)" >&2
+  exit 3
+fi
+
+case "$mode" in
+  --names) printf '%s\n' "$ordered" ;;
+  --paths) printf '%s\n' "$ordered" | sed 's|^|crates/|' ;;
+  *) echo "list-crates: unknown mode $mode" >&2; exit 2 ;;
+esac

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,27 +1,9 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# Crates must be published in dependency order:
-# - kanban-core: no internal deps
-# - kanban-domain: depends on kanban-core
-# - kanban-persistence: depends on kanban-core, kanban-domain
-# - kanban-persistence-json: depends on kanban-core, kanban-domain, kanban-persistence
-# - kanban-persistence-sqlite: depends on kanban-core, kanban-domain, kanban-persistence
-# - kanban-service: depends on kanban-core, kanban-domain, kanban-persistence, kanban-persistence-json
-# - kanban-tui: depends on kanban-core, kanban-domain, kanban-persistence, kanban-persistence-json, kanban-persistence-sqlite
-# - kanban-mcp: depends on kanban-core, kanban-domain, kanban-persistence, kanban-persistence-json, kanban-persistence-sqlite, kanban-service
-# - kanban-cli: depends on all above
-CRATES=(
-  "crates/kanban-core"
-  "crates/kanban-domain"
-  "crates/kanban-persistence"
-  "crates/kanban-persistence-json"
-  "crates/kanban-persistence-sqlite"
-  "crates/kanban-service"
-  "crates/kanban-tui"
-  "crates/kanban-mcp"
-  "crates/kanban-cli"
-)
+# Crates published in topological dependency order via list-crates.
+mapfile -t CRATES < <(list-crates --paths)
+[ "${#CRATES[@]}" -gt 0 ] || { echo "❌ list-crates returned empty"; exit 1; }
 
 check_version_exists() {
   local crate_name=$1

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -2,8 +2,8 @@
 set -uo pipefail
 
 # Crates published in topological dependency order via list-crates.
-mapfile -t CRATES < <(list-crates --paths)
-[ "${#CRATES[@]}" -gt 0 ] || { echo "❌ list-crates returned empty"; exit 1; }
+crates_out=$(list-crates --paths) || { echo "❌ list-crates failed"; exit 1; }
+mapfile -t CRATES <<< "$crates_out"
 
 check_version_exists() {
   local crate_name=$1

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CRATES=(
-  "crates/kanban-core"
-  "crates/kanban-domain"
-  "crates/kanban-mcp"
-  "crates/kanban-persistence"
-  "crates/kanban-tui"
-  "crates/kanban-cli"
-)
+mapfile -t CRATES < <(list-crates --paths)
+[ "${#CRATES[@]}" -gt 0 ] || { echo "❌ list-crates returned empty"; exit 1; }
 
 echo "🔍 Validating release build..."
 echo ""
@@ -37,7 +31,7 @@ echo "✓ Version consistency verified"
 
 echo ""
 echo "Step 3: Checking cross-crate dependencies..."
-INTERNAL_DEPS=("kanban-core" "kanban-mcp" "kanban-domain" "kanban-persistence" "kanban-tui")
+mapfile -t INTERNAL_DEPS < <(list-crates --names)
 for crate in "${CRATES[@]}"; do
   for dep in "${INTERNAL_DEPS[@]}"; do
     if grep -q "$dep = { path = " "$crate/Cargo.toml" 2>/dev/null; then
@@ -58,7 +52,13 @@ echo "✓ Workspace check passed"
 
 echo ""
 echo "Step 5: Validating individual crate dry-run publishes..."
-echo "  (Using --no-verify since workspace crates aren't yet on crates.io)"
+# --no-verify skips the per-crate compile during dry-run. This is necessary
+# because `cargo publish --dry-run` resolves path-deps to their crates.io
+# version, but workspace crates with API changes between releases can't
+# compile against their previously-published siblings until each is
+# published in dependency order. Step 4 (`cargo check --workspace`) already
+# verifies compile against the local source. Step 5's value here is the
+# manifest/package-shape check, not the build.
 for crate in "${CRATES[@]}"; do
   echo "  Validating $crate..."
   cd "$crate"

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mapfile -t CRATES < <(list-crates --paths)
-[ "${#CRATES[@]}" -gt 0 ] || { echo "❌ list-crates returned empty"; exit 1; }
+crates_out=$(list-crates --paths) || { echo "❌ list-crates failed"; exit 1; }
+mapfile -t CRATES <<< "$crates_out"
 
 echo "🔍 Validating release build..."
 echo ""
@@ -31,7 +31,8 @@ echo "✓ Version consistency verified"
 
 echo ""
 echo "Step 3: Checking cross-crate dependencies..."
-mapfile -t INTERNAL_DEPS < <(list-crates --names)
+deps_out=$(list-crates --names) || { echo "❌ list-crates failed"; exit 1; }
+mapfile -t INTERNAL_DEPS <<< "$deps_out"
 for crate in "${CRATES[@]}"; do
   for dep in "${INTERNAL_DEPS[@]}"; do
     if grep -q "$dep = { path = " "$crate/Cargo.toml" 2>/dev/null; then

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,7 @@
   bumpVersion ? null,
   publishCrates ? null,
   validateRelease ? null,
+  listCrates ? null,
 }:
 
 let
@@ -15,6 +16,7 @@ let
     bumpVersion
     publishCrates
     validateRelease
+    listCrates
   ];
 in
 

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@
   publishCrates ? null,
   validateRelease ? null,
   listCrates ? null,
+  checkCrateListSync ? null,
 }:
 
 let
@@ -17,6 +18,7 @@ let
     publishCrates
     validateRelease
     listCrates
+    checkCrateListSync
   ];
 in
 


### PR DESCRIPTION
Surfaced during PR #208 (release 0.4.0) review:

- `scripts/validate-release.sh`'s hardcoded CRATES array drifted to 6 entries while `scripts/publish-crates.sh` held all 9, silently skipping validation for `kanban-service`, `kanban-persistence-json`, `kanban-persistence-sqlite`
- A future malformed manifest in any of those 3 crates would pass validation but fail at actual publish, leaving crates.io half-published

## What

- New `scripts/list-crates.sh` — derives workspace crates from `cargo metadata` + `jq` + `tsort`, filtering dev-deps via `kind == null` to break the cycle (kanban-persistence-json dev-deps on kanban-service which normal-deps on kanban-persistence-json)
- `scripts/validate-release.sh` and `scripts/publish-crates.sh` now populate `CRATES` via `mapfile -t CRATES < <(list-crates --paths)`. `validate-release.sh`'s `INTERNAL_DEPS` is also derived dynamically
- New `scripts/check-crate-list-sync.sh` — CI invariant that fails if either consumer script regresses to a hardcoded array literal, or if `list-crates` output disagrees with on-disk workspace members
- Wired into `flake.nix`, `shell.nix`, and `.github/workflows/ci.yml` (new step in `release-validation` job)

## Why

Hand-curated lists in 2 separate scripts are guaranteed to drift; this PR proved it. Making the list dynamic eliminates the class of bug structurally rather than relying on contributor discipline. Adding a 10th workspace crate now requires a `Cargo.toml` change only — no script edits.

## How

`cargo metadata --no-deps --format-version 1` emits the workspace package list with their `path` deps. A `jq` filter selects only `kind == null` (normal) deps to break the dev-dep cycle, then `tsort` produces a valid topological linearization. Self-edges for leaf crates (e.g. `kanban-core`) ensure they aren't dropped by `tsort`.

## Note: original review's "drop --no-verify" finding was a misdiagnosis

Item #2 of the original PR #208 review recommended dropping `--no-verify` from `validate-release.sh` Step 5 to make the dry-run actually compile each crate. Implementation revealed this is the inherent chicken-and-egg of workspace publishing: `cargo publish --dry-run` resolves path-deps to their **crates.io** versions, so a workspace mid-refactor can never dry-run-verify until each crate is republished in dependency order. Concrete evidence: published `kanban-domain 0.3.5` defines `pub trait Command`, but local develop has refactored to `pub enum Command` (KAN-260/KAN-348). Compile fails E0782 — new code against old published API. The original `--no-verify --offline` flags are a deliberate workaround, kept as-is, with an explanatory comment added in Step 5 so the next reviewer doesn't repeat the mistake. Tracked separately in the workspace-publishing-tool spike card.

## Testing

- `nix flake check` — passes (validates new derivations)
- `nix run .#list-crates` — emits 9 lines in topo order ending with `kanban-cli`
- `nix run .#check-crate-list-sync` — reports `✓ crate list sync OK`
- `nix run .#validate-release` — full validation passes locally; Steps 1-4 do real work, Step 5 is intentionally a manifest/package-shape check (per the note above)
- Red-state rehearsal: ran `check-crate-list-sync.sh` against the pre-fix tree where both scripts had hardcoded arrays — failed as expected, proving the invariant catches the drift bug