### PR TITLE
[hotfix] 0.4.0: strip version from internal dev-deps to break publish cycle

### DIFF
--- a/crates/kanban-persistence-json/Cargo.toml
+++ b/crates/kanban-persistence-json/Cargo.toml
@@ -24,6 +24,6 @@ tracing.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
-kanban-service = { path = "../kanban-service", version = "^0.4", features = ["test-helpers"] }
+kanban-service = { path = "../kanban-service", features = ["test-helpers"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/kanban-persistence-sqlite/Cargo.toml
+++ b/crates/kanban-persistence-sqlite/Cargo.toml
@@ -25,6 +25,6 @@ tracing.workspace = true
 flate2 = "1"
 
 [dev-dependencies]
-kanban-service = { path = "../kanban-service", version = "^0.4", features = ["test-helpers"] }
+kanban-service = { path = "../kanban-service", features = ["test-helpers"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/kanban-service/Cargo.toml
+++ b/crates/kanban-service/Cargo.toml
@@ -32,7 +32,7 @@ tracing.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
-kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.4" }
-kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.4" }
-kanban-persistence = { path = "../kanban-persistence", version = "^0.4", features = ["test-helpers"] }
+kanban-persistence-json = { path = "../kanban-persistence-json" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite" }
+kanban-persistence = { path = "../kanban-persistence", features = ["test-helpers"] }
 tokio = { workspace = true, features = ["full"] }

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -33,11 +33,17 @@ echo ""
 echo "Step 3: Checking cross-crate dependencies..."
 deps_out=$(list-crates --names) || { echo "❌ list-crates failed"; exit 1; }
 mapfile -t INTERNAL_DEPS <<< "$deps_out"
+# Only [dependencies] need version specs; [dev-dependencies] are stripped from
+# the published manifest by cargo and shouldn't carry version constraints
+# because they may form circular path-deps with sibling crates that publish
+# later in the dependency order (e.g. kanban-persistence-sqlite dev-deps on
+# kanban-service which itself depends on kanban-persistence-sqlite optionally).
 for crate in "${CRATES[@]}"; do
+  deps_section=$(awk '/^\[dependencies\]/{flag=1; next} /^\[/{flag=0} flag' "$crate/Cargo.toml")
   for dep in "${INTERNAL_DEPS[@]}"; do
-    if grep -q "$dep = { path = " "$crate/Cargo.toml" 2>/dev/null; then
-      if ! grep "$dep = { path = " "$crate/Cargo.toml" | grep -q 'version = '; then
-        echo "❌ Error: $crate is missing version spec for $dep"
+    if echo "$deps_section" | grep -q "$dep = { path = "; then
+      if ! echo "$deps_section" | grep "$dep = { path = " | grep -q 'version = '; then
+        echo "❌ Error: $crate is missing version spec for $dep in [dependencies]"
         echo "   Use: $dep = { path = \"../$dep\", version = \"^0.1\" }"
         exit 1
       fi


### PR DESCRIPTION
The 0.4.0 release workflow ([run #25301310704](https://github.com/fulsomenko/kanban/actions/runs/25301310704)) aborted publishing at \`kanban-persistence-sqlite\` with:

\`\`\`
failed to select a version for the requirement \`kanban-service = "^0.4"\`
candidate versions found which didn't match: 0.3.5
required by package \`kanban-persistence-sqlite v0.4.0\`
\`\`\`

## Root cause

\`cargo publish\`'s package step rewrites \`path = "../foo"\` references to registry references and verifies the version resolves on crates.io — for dev-dependencies too. The workspace has a real dev-dep cycle:

- \`kanban-persistence-sqlite\` dev-deps on \`kanban-service\` with \`version = "^0.4"\`
- \`kanban-persistence-json\` dev-deps on \`kanban-service\` with \`version = "^0.4"\`
- \`kanban-service\` itself depends optionally on sqlite/json — so it must publish *after* them

sqlite/json need to publish first, but their dev-dep on kanban-service@0.4 doesn't exist on crates.io yet.

## Fix

Per cargo's documented behavior:

> When uploading, dev-dependencies that have a \`path\` source and no \`version\` are removed from the published manifest.

Drop the \`version\` field from internal dev-deps. Cargo strips them at publish time, breaking the cycle. Downstream consumers don't see dev-deps anyway.

Touches:
- \`crates/kanban-persistence-sqlite/Cargo.toml\` — drop version on \`kanban-service\` dev-dep
- \`crates/kanban-persistence-json/Cargo.toml\` — drop version on \`kanban-service\` dev-dep
- \`crates/kanban-service/Cargo.toml\` — drop versions on internal dev-deps for consistency
- \`scripts/validate-release.sh\` — scope Step 3's "every internal path-dep needs version" check to \`[dependencies]\` only (dev-deps don't need it)

\`tui\`/\`cli\`/\`mcp\` dev-deps point to crates that publish *earlier* in the chain (json/sqlite/service publish before tui), so they don't form a cycle and aren't touched in this hotfix.

## Verification

- \`cargo check --workspace --all-features\` passes locally
- \`cd crates/kanban-persistence-sqlite && cargo publish --dry-run --allow-dirty\` succeeds (cycle broken — confirmed)
- validate-release.sh Step 3 still passes against the post-fix tree (verified with extracted shell)

## Recovery sequence (post-merge)

1. Merge this PR into master
2. From master, run locally with credentials: \`CARGO_REGISTRY_TOKEN=… nix run .#publish-crates\` — script's "already exists" check skips the 3 already-published crates (core/domain/persistence) and resumes from sqlite
3. Once all 9 crates are published: \`git tag v0.4.0 <merge-sha> && git push origin v0.4.0 && gh release create v0.4.0 --generate-notes\`
4. \`aur-publish.yml\` fires on the GitHub Release event and updates AUR