### PR TITLE
[hotfix] fix(ci): aur-publish makepkg.conf + manual dispatch

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -3,6 +3,12 @@ name: Publish to AUR
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., v0.4.0)'
+        required: true
+        type: string
 
 jobs:
   aur-publish:
@@ -17,7 +23,7 @@ jobs:
 
       - name: Update PKGBUILD version and sha256
         env:
-          RAW_TAG: ${{ github.event.release.tag_name }}
+          RAW_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           set -euo pipefail
           VERSION="${RAW_TAG#v}"
@@ -36,7 +42,12 @@ jobs:
             experimental-features = nix-command flakes
 
       - name: Generate .SRCINFO
-        run: nix shell nixpkgs#pacman -c sh -c "cd aur && makepkg --printsrcinfo > .SRCINFO"
+        run: |
+          nix shell nixpkgs#pacman -c sh -c '
+            PACMAN_ROOT="$(dirname "$(dirname "$(command -v makepkg)")")"
+            export MAKEPKG_CONF="$PACMAN_ROOT/etc/makepkg.conf"
+            cd aur && makepkg --printsrcinfo > .SRCINFO
+          '
 
       - name: Commit updated AUR files
         run: |


### PR DESCRIPTION
The v0.4.0 AUR publish workflow [run #25302822991](https://github.com/fulsomenko/kanban/actions/runs/25302822991) failed at the **Generate .SRCINFO** step:

\`\`\`
==> ERROR: /etc/makepkg.conf not found.
    Aborting...
\`\`\`

## Root cause

The step runs \`nix shell nixpkgs#pacman -c sh -c "cd aur && makepkg --printsrcinfo > .SRCINFO"\`. \`makepkg\` sources \`/etc/makepkg.conf\` early during startup. Nix-shipped pacman ships its config at \`\${pacman}/etc/makepkg.conf\` (under the nix store), and the Ubuntu runner has no system-wide \`/etc/makepkg.conf\`. So makepkg aborts before doing anything else.

This is the first end-to-end exercise of \`aur-publish.yml\` — the AUR submission for 0.3.x was likely done manually, so the bug never surfaced before.

## Fix

\`makepkg\` respects \`MAKEPKG_CONF\` env var. Pointing it at the nix-shipped config:

\`\`\`yaml
- name: Generate .SRCINFO
  run: |
    nix shell nixpkgs#pacman -c sh -c '
      PACMAN_ROOT="\$(dirname "\$(dirname "\$(command -v makepkg)")")"
      export MAKEPKG_CONF="\$PACMAN_ROOT/etc/makepkg.conf"
      cd aur && makepkg --printsrcinfo > .SRCINFO
    '
\`\`\`

Verified locally: \`makepkg --printsrcinfo\` produces correct output for the existing PKGBUILD when MAKEPKG_CONF is set.

## Also: workflow_dispatch trigger

Adds a \`workflow_dispatch\` trigger with a \`tag\` input so we can re-run the workflow manually for an existing release if it ever fails again. The version-extraction line falls back to \`inputs.tag\` when there's no \`release.tag_name\` (i.e., when fired by manual dispatch instead of release event).

For v0.4.0 specifically, after this PR merges:

\`\`\`bash
gh workflow run aur-publish.yml --ref master -f tag=v0.4.0
\`\`\`

That'll fire the fixed workflow against the existing v0.4.0 release.

## Verification

- Tested locally: \`MAKEPKG_CONF=\$pacman/etc/makepkg.conf makepkg --printsrcinfo\` produces valid output
- The expression \`\${{ github.event.release.tag_name || inputs.tag }}\` resolves correctly in both code paths (release event vs manual dispatch)