### PR TITLE
[hotfix] fix(ci): aur-publish VERSION propagation + soft-fail commit-back

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -35,6 +35,7 @@ jobs:
           sed -i "s|^pkgver=.*|pkgver=${VERSION}|" ./aur/PKGBUILD
           sed -i "s|^pkgrel=.*|pkgrel=1|" ./aur/PKGBUILD
           sed -i "s|sha256sums=.*|sha256sums=(\"${SHA256}\")|" ./aur/PKGBUILD
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - uses: cachix/install-nix-action@v27
         with:
@@ -54,8 +55,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add aur/PKGBUILD aur/.SRCINFO
-          git diff --cached --quiet || git commit -m "chore: update AUR package to ${VERSION}"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: update AUR package to ${VERSION}"
+          if ! git push 2>&1; then
+            echo "::warning::Could not push aur/ updates to GitHub (likely branch protection blocking the bot). AUR deploy will still proceed; the repo's aur/ files will lag behind the AUR repo until manually synced or the bot is added to the master bypass list."
+          fi
 
       - name: Deploy to AUR
         uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1


### PR DESCRIPTION
After PR #236 fixed the makepkg.conf issue, the manual re-trigger of aur-publish for v0.4.0 ([run #25347178075](https://github.com/fulsomenko/kanban/actions/runs/25347178075)) surfaced two more bugs in the same workflow:

## Bug 1: \`\${VERSION}\` empty in commit step

The 'Update PKGBUILD version and sha256' step computes \`VERSION="\${RAW_TAG#v}"\` as a bash local. The 'Commit updated AUR files' step references \`\${VERSION}\` — but bash locals don't survive across workflow steps (each step is a fresh shell). Result: commit message was \`'chore: update AUR package to '\` with an empty version.

**Fix:** \`echo "VERSION=\$VERSION" >> "\$GITHUB_ENV"\` at the end of the first step, making VERSION available as an env var in all subsequent steps.

## Bug 2: branch protection rejects bot push, killing the deploy

The commit-back step does \`git push\` to master. Master has branch protection forbidding direct pushes — \`github-actions[bot]\` isn't in the bypass list. The push fails with \`GH013: Repository rule violations\`, the step exits non-zero, and the **'Deploy to AUR' step gets skipped**. So even though the makepkg.conf fix worked, AUR was never actually updated.

**Fix:** handle the push failure with \`::warning::\` and \`exit 0\` instead of letting it fail the step. The deploy step now always runs. The repo's \`aur/\` files will lag the AUR repo until either:
- The bot is added to the master bypass list (config-only, no code change), or
- The aur/ files are manually synced

This trade-off is correct: AUR deploys (the user-visible artifact) are what actually matter; the commit-back to GitHub is purely for history visibility.

## Recovery for v0.4.0

After this merges:

\`\`\`bash
gh workflow run aur-publish.yml --ref master -f tag=v0.4.0
\`\`\`

Same manual dispatch as before. With both fixes applied, the run should reach 'Deploy to AUR' and succeed.