### PR TITLE
[hotfix] fix(ci): aur-publish action inputs need snake_case

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -69,9 +69,9 @@ jobs:
         with:
           pkgname: kanban
           pkgbuild: ./aur/PKGBUILD
-          commit-username: github-actions[bot]
-          commit-email: 41898282+github-actions[bot]@users.noreply.github.com
-          commit-message: "Update to ${{ github.event.release.tag_name || inputs.tag }}"
-          ssh-private-key: ${{ secrets.AUR_SSH_KEY }}
+          commit_username: github-actions[bot]
+          commit_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_message: "Update to ${{ github.event.release.tag_name || inputs.tag }}"
+          ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
           updpkgsums: false
-          allow-empty-commits: false
+          allow_empty_commits: false


### PR DESCRIPTION
The previous AUR run ([#25348177683](https://github.com/fulsomenko/kanban/actions/runs/25348177683)) reached 'Deploy to AUR' (great — confirms PR #239's fixes work) but failed validation:

\`\`\`
::error::Invalid Value: inputs.commit_username is empty.
\`\`\`

## Root cause

KSXGitHub/github-actions-deploy-aur declares its inputs in snake_case (per its [action.yml](https://github.com/KSXGitHub/github-actions-deploy-aur/blob/v4.1.3/action.yml)):

\`\`\`yaml
commit_username:
commit_email:
ssh_private_key:
commit_message:
allow_empty_commits:
\`\`\`

Our workflow was passing them in kebab-case:

\`\`\`yaml
commit-username:
commit-email:
ssh-private-key:
commit-message:
allow-empty-commits:
\`\`\`

GitHub Actions doesn't alias hyphens to underscores in input names — the action received empty strings for all five.

## Why this is only surfacing now

Latent bug since the workflow was first authored. v4.1.1 crashed earlier in the entrypoint (\`bash: --command: invalid option\`) before reaching the action's input-validation step in build.sh — the empty inputs went unnoticed. v4.1.3 (PR #239) fixed the entrypoint, the validation now runs, and it correctly rejects empty \`commit_username\`.

## Fix

Five inputs renamed kebab-case → snake_case. \`pkgname\`, \`pkgbuild\`, \`updpkgsums\` unchanged (no hyphens).

## Recovery for v0.4.0

\`\`\`bash
gh workflow run aur-publish.yml --ref master -f tag=v0.4.0
\`\`\`

Local docker simulation against v4.1.3 (with our PKGBUILD + dummy SSH key) confirmed the action gets all the way to the SSH push before failing on the dummy key — so this is the last expected gap.