### PR TITLE
KAN-397/ci-wire-aur-publish-into-release-workflow

### DIFF
--- a/.changeset/kan-397-ci-wire-aur-publish-into-release-workflow.md
+++ b/.changeset/kan-397-ci-wire-aur-publish-into-release-workflow.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Wire AUR publish into release workflow
+
+- Move AUR publish steps inline into release.yml so they run automatically on every release
+- Remove the dead `release: [published]` trigger from aur-publish.yml (GitHub Actions does not fire it when GITHUB_TOKEN creates the release)
+- Keep aur-publish.yml as a workflow_dispatch fallback for manual re-runs

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,8 +1,6 @@
 name: Publish to AUR
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         if: steps.check.outputs.has_changesets == 'true'
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:fulsomenko/kanban.git
 
       # bump-version reads changesets, aggregate-changelog reads then deletes them.
@@ -130,7 +130,7 @@ jobs:
         run: |
           set -euo pipefail
           URL="https://github.com/fulsomenko/kanban/archive/v${VERSION}.tar.gz"
-          SHA256=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
+          SHA256=$(curl -fsL "$URL" | sha256sum | cut -d' ' -f1)
           sed -i "s|^pkgver=.*|pkgver=${VERSION}|" ./aur/PKGBUILD
           sed -i "s|^pkgrel=.*|pkgrel=1|" ./aur/PKGBUILD
           sed -i "s|sha256sums=.*|sha256sums=(\"${SHA256}\")|" ./aur/PKGBUILD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,53 @@ jobs:
           tag_name: v${{ steps.release.outputs.new }}
           generate_release_notes: true
 
+      - name: Update PKGBUILD version and sha256
+        if: steps.check.outputs.has_changesets == 'true'
+        env:
+          VERSION: ${{ steps.release.outputs.new }}
+        run: |
+          set -euo pipefail
+          URL="https://github.com/fulsomenko/kanban/archive/v${VERSION}.tar.gz"
+          SHA256=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
+          sed -i "s|^pkgver=.*|pkgver=${VERSION}|" ./aur/PKGBUILD
+          sed -i "s|^pkgrel=.*|pkgrel=1|" ./aur/PKGBUILD
+          sed -i "s|sha256sums=.*|sha256sums=(\"${SHA256}\")|" ./aur/PKGBUILD
+
+      - name: Generate .SRCINFO
+        if: steps.check.outputs.has_changesets == 'true'
+        run: |
+          nix shell nixpkgs#pacman -c sh -c '
+            PACMAN_ROOT="$(dirname "$(dirname "$(command -v makepkg)")")"
+            export MAKEPKG_CONF="$PACMAN_ROOT/etc/makepkg.conf"
+            cd aur && makepkg --printsrcinfo > .SRCINFO
+          '
+
+      - name: Commit and push AUR files
+        if: steps.check.outputs.has_changesets == 'true'
+        env:
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+        run: |
+          git add aur/PKGBUILD aur/.SRCINFO
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update AUR package to v${{ steps.release.outputs.new }}"
+            git push origin master
+          fi
+
+      - name: Deploy to AUR
+        if: steps.check.outputs.has_changesets == 'true'
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7
+        with:
+          pkgname: kanban
+          pkgbuild: ./aur/PKGBUILD
+          commit_username: github-actions[bot]
+          commit_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_message: "Update to v${{ steps.release.outputs.new }}"
+          ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
+          updpkgsums: false
+          allow_empty_commits: false
+
       - name: Sync develop with master
         if: steps.check.outputs.has_changesets == 'true'
         env:


### PR DESCRIPTION
**What**: Move AUR publish steps inline into `release.yml` so they run automatically on every release.

**Why**: `aur-publish.yml` had a `release: types: [published]` trigger that never fires when `GITHUB_TOKEN` creates the release — GitHub blocks cascading workflow runs from the default token to prevent loops. For v0.4.0 and v0.4.1 the AUR publish had to be triggered manually via `workflow_dispatch`.

**How**: Add four steps to `release.yml` after "Create GitHub Release": update PKGBUILD, generate .SRCINFO, commit & push AUR files, deploy to AUR. Remove the dead `release: [published]` trigger from `aur-publish.yml` and keep it as `workflow_dispatch`-only for manual re-runs.