### PR TITLE
KAN-406/sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section

### DIFF
--- a/.changeset/kan-406-sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section.md
+++ b/.changeset/kan-406-sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+Group sprints by status in the sprint assignment dialog (KAN-406)
+
+- Sprint assignment dialog (single-card and multi-card) now splits sprints into two headed sections: `Active / Planned` and `Completed / Ended`.
+- Completed sprints render in green, Ended sprints (Active sprints whose `end_date` has passed) in red, so retrospective assignment targets are visually distinct.
+- Cards can now be assigned to Completed and Ended sprints — useful for logging work against past sprints in retrospect.
+- `j`/`k` navigation skips section headers; the dialog scrolls to keep the selected entry on-screen when the list overflows the viewport.
+- `Cancelled` sprints remain hidden.

--- a/.changeset/kan-406-sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section.md
+++ b/.changeset/kan-406-sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section.md
@@ -8,4 +8,5 @@ Group sprints by status in the sprint assignment dialog (KAN-406)
 - Completed sprints render in green, Ended sprints (Active sprints whose `end_date` has passed) in red, so retrospective assignment targets are visually distinct.
 - Cards can now be assigned to Completed and Ended sprints — useful for logging work against past sprints in retrospect.
 - `j`/`k` navigation skips section headers; the dialog scrolls to keep the selected entry on-screen when the list overflows the viewport.
+- When the list is scrolled past a section's header, the relevant header label stays pinned at the top row so the active section is always visible.
 - `Cancelled` sprints remain hidden.

--- a/crates/kanban-domain/README.md
+++ b/crates/kanban-domain/README.md
@@ -133,11 +133,16 @@ sprint.activate(duration_days: u32)
 sprint.formatted_name(board: &Board, default_prefix: &str) -> String
 // e.g. "KAN-3/bugfix-week" or "KAN-3"
 
-sprint.is_ended() -> bool
-// True if Active and end_date is in the past.
+sprint.is_ended(now: DateTime<Utc>) -> bool
+// True if Active and end_date is before `now`.
 
-Sprint::assignable(sprints: &[Sprint], board_id: Uuid) -> Vec<&Sprint>
-// Returns sprints in Planning or Active state.
+Sprint::for_assignment_dialog(
+    sprints: &[Sprint],
+    board_id: Uuid,
+    now: DateTime<Utc>,
+) -> (Vec<&Sprint>, Vec<&Sprint>)
+// Splits a board's sprints into (active_or_planned, completed_or_ended).
+// Cancelled sprints are excluded; each section is sorted by sprint_number desc.
 ```
 
 ---

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -128,6 +128,12 @@ impl Sprint {
         self.updated_at = Utc::now();
     }
 
+    /// Returns true when this is an Active sprint whose `end_date` is in the past.
+    ///
+    /// Boundary: `now == end_date` returns `false` — the sprint's clock has
+    /// not strictly passed. The bucket logic in
+    /// [`Sprint::for_assignment_dialog`] calls this internally and inherits the
+    /// same boundary semantics.
     pub fn is_ended(&self, now: DateTime<Utc>) -> bool {
         if self.status != SprintStatus::Active {
             return false;

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -136,12 +136,12 @@ impl Sprint {
         self.updated_at = Utc::now();
     }
 
-    pub fn is_ended(&self) -> bool {
+    pub fn is_ended(&self, now: DateTime<Utc>) -> bool {
         if self.status != SprintStatus::Active {
             return false;
         }
         if let Some(end_date) = self.end_date {
-            Utc::now() > end_date
+            now > end_date
         } else {
             false
         }

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -175,3 +175,207 @@ pub struct SprintUpdate {
     pub start_date: FieldUpdate<DateTime<Utc>>,
     pub end_date: FieldUpdate<DateTime<Utc>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn make_sprint(
+        sprint_number: u32,
+        board_id: Uuid,
+        status: SprintStatus,
+        end_date: Option<DateTime<Utc>>,
+    ) -> Sprint {
+        Sprint {
+            id: Uuid::new_v4(),
+            board_id,
+            sprint_number,
+            name_index: None,
+            prefix: None,
+            card_prefix: None,
+            status,
+            start_date: None,
+            end_date,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+        }
+    }
+
+    #[test]
+    fn test_is_ended_returns_true_for_active_with_past_end_date() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let s = make_sprint(
+            1,
+            Uuid::new_v4(),
+            SprintStatus::Active,
+            Some(ts("2026-05-06T00:00:00Z")),
+        );
+        assert!(s.is_ended(now));
+    }
+
+    #[test]
+    fn test_is_ended_returns_false_for_active_with_future_end_date() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let s = make_sprint(
+            1,
+            Uuid::new_v4(),
+            SprintStatus::Active,
+            Some(ts("2026-05-08T00:00:00Z")),
+        );
+        assert!(!s.is_ended(now));
+    }
+
+    #[test]
+    fn test_is_ended_returns_false_for_completed_status_even_with_past_end_date() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let s = make_sprint(
+            1,
+            Uuid::new_v4(),
+            SprintStatus::Completed,
+            Some(ts("2026-05-01T00:00:00Z")),
+        );
+        assert!(!s.is_ended(now));
+    }
+
+    #[test]
+    fn test_is_ended_returns_false_for_active_with_no_end_date() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let s = make_sprint(1, Uuid::new_v4(), SprintStatus::Active, None);
+        assert!(!s.is_ended(now));
+    }
+
+    #[test]
+    fn test_for_assignment_dialog_buckets_planning_into_active_section() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let s = make_sprint(1, board, SprintStatus::Planning, None);
+        let sprints = vec![s.clone()];
+        let (active, ended) = Sprint::for_assignment_dialog(&sprints, board, now);
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, s.id);
+        assert_eq!(ended.len(), 0);
+    }
+
+    #[test]
+    fn test_for_assignment_dialog_buckets_active_with_future_end_date_into_active_section() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let s = make_sprint(
+            2,
+            board,
+            SprintStatus::Active,
+            Some(ts("2026-05-20T00:00:00Z")),
+        );
+        let sprints = vec![s.clone()];
+        let (active, ended) = Sprint::for_assignment_dialog(&sprints, board, now);
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, s.id);
+        assert_eq!(ended.len(), 0);
+    }
+
+    #[test]
+    fn test_for_assignment_dialog_buckets_active_with_past_end_date_into_completed_ended_section() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let s = make_sprint(
+            3,
+            board,
+            SprintStatus::Active,
+            Some(ts("2026-05-01T00:00:00Z")),
+        );
+        let sprints = vec![s.clone()];
+        let (active, ended) = Sprint::for_assignment_dialog(&sprints, board, now);
+        assert_eq!(active.len(), 0);
+        assert_eq!(ended.len(), 1);
+        assert_eq!(ended[0].id, s.id);
+    }
+
+    #[test]
+    fn test_for_assignment_dialog_buckets_completed_into_completed_ended_section() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let s = make_sprint(
+            4,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-04-01T00:00:00Z")),
+        );
+        let sprints = vec![s.clone()];
+        let (active, ended) = Sprint::for_assignment_dialog(&sprints, board, now);
+        assert_eq!(active.len(), 0);
+        assert_eq!(ended.len(), 1);
+        assert_eq!(ended[0].id, s.id);
+    }
+
+    #[test]
+    fn test_for_assignment_dialog_excludes_cancelled_from_both_sections() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let s = make_sprint(5, board, SprintStatus::Cancelled, None);
+        let sprints = vec![s];
+        let (active, ended) = Sprint::for_assignment_dialog(&sprints, board, now);
+        assert_eq!(active.len(), 0);
+        assert_eq!(ended.len(), 0);
+    }
+
+    #[test]
+    fn test_for_assignment_dialog_excludes_other_boards() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let mine = make_sprint(1, board, SprintStatus::Planning, None);
+        let theirs_active = make_sprint(2, other, SprintStatus::Planning, None);
+        let theirs_completed = make_sprint(3, other, SprintStatus::Completed, None);
+        let sprints = vec![mine.clone(), theirs_active, theirs_completed];
+        let (active, ended) = Sprint::for_assignment_dialog(&sprints, board, now);
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, mine.id);
+        assert_eq!(ended.len(), 0);
+    }
+
+    #[test]
+    fn test_for_assignment_dialog_orders_each_section_by_sprint_number_descending() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let p1 = make_sprint(1, board, SprintStatus::Planning, None);
+        let p3 = make_sprint(3, board, SprintStatus::Planning, None);
+        let a2 = make_sprint(
+            2,
+            board,
+            SprintStatus::Active,
+            Some(ts("2026-05-20T00:00:00Z")),
+        );
+        let c10 = make_sprint(
+            10,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-04-01T00:00:00Z")),
+        );
+        let c5 = make_sprint(
+            5,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-03-01T00:00:00Z")),
+        );
+        let e7 = make_sprint(
+            7,
+            board,
+            SprintStatus::Active,
+            Some(ts("2026-05-01T00:00:00Z")),
+        );
+        let sprints = vec![p1.clone(), p3.clone(), a2.clone(), c10.clone(), c5.clone(), e7.clone()];
+        let (active, ended) = Sprint::for_assignment_dialog(&sprints, board, now);
+        assert_eq!(
+            active.iter().map(|s| s.sprint_number).collect::<Vec<_>>(),
+            vec![3, 2, 1]
+        );
+        assert_eq!(
+            ended.iter().map(|s| s.sprint_number).collect::<Vec<_>>(),
+            vec![10, 7, 5]
+        );
+    }
+}

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -147,6 +147,42 @@ impl Sprint {
         }
     }
 
+    /// Splits sprints on `board_id` into two sections for the assignment dialog:
+    /// `(active_or_planned, completed_or_ended)`.
+    ///
+    /// - **Active / planned**: `Planning` status, plus `Active` sprints whose
+    ///   `end_date` is in the future (or `None`).
+    /// - **Completed / ended**: `Completed` status, plus `Active` sprints whose
+    ///   `end_date` has passed (i.e. `is_ended(now)` is true).
+    /// - `Cancelled` sprints and sprints from other boards are excluded.
+    ///
+    /// Each section is sorted by `sprint_number` descending.
+    pub fn for_assignment_dialog(
+        sprints: &[Sprint],
+        board_id: Uuid,
+        now: DateTime<Utc>,
+    ) -> (Vec<&Sprint>, Vec<&Sprint>) {
+        let mut active = Vec::new();
+        let mut ended = Vec::new();
+        for s in sprints.iter().filter(|s| s.board_id == board_id) {
+            match s.status {
+                SprintStatus::Cancelled => {}
+                SprintStatus::Planning => active.push(s),
+                SprintStatus::Active => {
+                    if s.is_ended(now) {
+                        ended.push(s);
+                    } else {
+                        active.push(s);
+                    }
+                }
+                SprintStatus::Completed => ended.push(s),
+            }
+        }
+        active.sort_by(|a, b| b.sprint_number.cmp(&a.sprint_number));
+        ended.sort_by(|a, b| b.sprint_number.cmp(&a.sprint_number));
+        (active, ended)
+    }
+
     /// Update sprint with partial changes
     pub fn update(&mut self, updates: SprintUpdate) {
         updates.name_index.apply_to(&mut self.name_index);

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -33,14 +33,6 @@ pub struct Sprint {
 pub type SprintId = Uuid;
 
 impl Sprint {
-    pub fn assignable(sprints: &[Sprint], board_id: Uuid) -> Vec<&Sprint> {
-        sprints
-            .iter()
-            .filter(|s| s.board_id == board_id)
-            .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)
-            .collect()
-    }
-
     pub fn new(
         board_id: Uuid,
         sprint_number: u32,
@@ -403,7 +395,14 @@ mod tests {
             SprintStatus::Active,
             Some(ts("2026-05-01T00:00:00Z")),
         );
-        let sprints = vec![p1.clone(), p3.clone(), a2.clone(), c10.clone(), c5.clone(), e7.clone()];
+        let sprints = vec![
+            p1.clone(),
+            p3.clone(),
+            a2.clone(),
+            c10.clone(),
+            c5.clone(),
+            e7.clone(),
+        ];
         let (active, ended) = Sprint::for_assignment_dialog(&sprints, board, now);
         assert_eq!(
             active.iter().map(|s| s.sprint_number).collect::<Vec<_>>(),

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -2131,6 +2131,8 @@ impl App {
     }
 
     pub fn get_current_sprint_selection_index(&self) -> usize {
+        use crate::components::sprint_assign_list::{build_entries, sprint_id_of};
+
         if let Some(card_idx) = self.selection.active_card_index {
             let cards = self.model.cards();
             if let Some(card) = cards.get(card_idx) {
@@ -2139,10 +2141,10 @@ impl App {
                         let boards = self.model.boards();
                         if let Some(board) = boards.get(board_idx) {
                             let sprints = self.model.sprints();
-                            let board_sprints = Sprint::assignable(sprints, board.id);
-                            for (idx, sprint) in board_sprints.iter().enumerate() {
-                                if sprint.id == card_sprint_id {
-                                    return idx + 1;
+                            let entries = build_entries(sprints, board.id, chrono::Utc::now());
+                            for (idx, entry) in entries.iter().enumerate() {
+                                if sprint_id_of(entry) == Some(card_sprint_id) {
+                                    return idx;
                                 }
                             }
                         }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1469,7 +1469,7 @@ impl App {
             .model
             .sprints()
             .iter()
-            .filter(|s| s.is_ended())
+            .filter(|s| s.is_ended(chrono::Utc::now()))
             .collect();
 
         if !ended_sprints.is_empty() {

--- a/crates/kanban-tui/src/components/mod.rs
+++ b/crates/kanban-tui/src/components/mod.rs
@@ -14,6 +14,7 @@ pub mod relationship_popup;
 pub mod relationship_section;
 pub mod selection_dialog;
 pub mod selection_list;
+pub mod sprint_assign_list;
 
 pub use banner::*;
 pub use card_detail_sections::*;
@@ -31,3 +32,4 @@ pub use relationship_popup::*;
 pub use relationship_section::*;
 pub use selection_dialog::*;
 pub use selection_list::*;
+pub use sprint_assign_list::*;

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::components::sprint_assign_list::{
-    build_entries, scroll_offset_to_show, SprintAssignEntry,
+    build_entries, render_entry_line, scroll_offset_to_show,
 };
 use kanban_domain::SprintStatus;
 use ratatui::Frame;
@@ -362,74 +362,3 @@ impl SelectionDialog for SprintAssignDialog {
     }
 }
 
-fn render_entry_line<'a>(
-    entry: &SprintAssignEntry<'_>,
-    is_selected: bool,
-    current_sprint_id: Option<uuid::Uuid>,
-    board: &kanban_domain::Board,
-) -> ratatui::text::Line<'a> {
-    use ratatui::style::{Color, Modifier, Style};
-    use ratatui::text::{Line, Span};
-
-    match entry {
-        SprintAssignEntry::Header(label) => Line::from(Span::styled(
-            (*label).to_string(),
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        )),
-        SprintAssignEntry::None => {
-            let is_current = current_sprint_id.is_none();
-            let prefix = if is_selected { "> " } else { "  " };
-            let suffix = if is_current { " (current)" } else { "" };
-            let style = if is_selected {
-                Style::default().fg(Color::White).bg(Color::Blue)
-            } else if is_current {
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(Color::White)
-            };
-            Line::from(Span::styled(format!("{}(None){}", prefix, suffix), style))
-        }
-        SprintAssignEntry::ActiveOrPlanned(s) => {
-            let is_current = current_sprint_id == Some(s.id);
-            let prefix = if is_selected { "> " } else { "  " };
-            let suffix = if is_current { " (current)" } else { "" };
-            let style = if is_selected {
-                Style::default().fg(Color::White).bg(Color::Blue)
-            } else if is_current {
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(Color::White)
-            };
-            Line::from(Span::styled(
-                format!("{}{}{}", prefix, s.formatted_name(board, "sprint"), suffix),
-                style,
-            ))
-        }
-        SprintAssignEntry::Completed(s) | SprintAssignEntry::Ended(s) => {
-            let is_current = current_sprint_id == Some(s.id);
-            let prefix = if is_selected { "> " } else { "  " };
-            let suffix = if is_current { " (current)" } else { "" };
-            let status_color = if matches!(entry, SprintAssignEntry::Completed(_)) {
-                Color::Green
-            } else {
-                Color::Red
-            };
-            let style = if is_selected {
-                Style::default().fg(Color::White).bg(Color::Blue)
-            } else {
-                // Status colour wins; no bold override even when is_current.
-                Style::default().fg(status_color)
-            };
-            Line::from(Span::styled(
-                format!("{}{}{}", prefix, s.formatted_name(board, "sprint"), suffix),
-                style,
-            ))
-        }
-    }
-}

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::components::sprint_assign_list::{
-    build_entries, render_entry_line, scroll_offset_to_show,
+    build_entries, render_entry_line, scroll_offset_to_show, section_header_for, SprintAssignEntry,
 };
 use kanban_domain::SprintStatus;
 use ratatui::Frame;
@@ -356,9 +356,57 @@ impl SelectionDialog for SprintAssignDialog {
         }
 
         let selected = app.dialog_input.sprint_assign_selection.get().unwrap_or(0);
+        let entries_for_header = if let Some(board_idx) = app.selection.active_board_index {
+            app.model
+                .boards()
+                .get(board_idx)
+                .map(|b| build_entries(app.model.sprints(), b.id, chrono::Utc::now()))
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
         let scroll = scroll_offset_to_show(selected, lines.len(), chunks[1].height as usize);
         let list = Paragraph::new(lines).scroll((scroll as u16, 0));
         frame.render_widget(list, chunks[1]);
+        render_sticky_section_header(frame, chunks[1], &entries_for_header, selected, scroll);
     }
+}
+
+fn render_sticky_section_header(
+    frame: &mut Frame,
+    list_area: ratatui::layout::Rect,
+    entries: &[SprintAssignEntry<'_>],
+    selected: usize,
+    scroll: usize,
+) {
+    use ratatui::{
+        layout::Rect,
+        style::{Color, Modifier, Style},
+        text::{Line, Span},
+        widgets::Paragraph,
+    };
+
+    if list_area.height == 0 {
+        return;
+    }
+    let Some((header_idx, label)) = section_header_for(entries, selected) else {
+        return;
+    };
+    if header_idx >= scroll {
+        return;
+    }
+    let overlay = Paragraph::new(Line::from(Span::styled(
+        label.to_string(),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    )));
+    let top_row = Rect {
+        x: list_area.x,
+        y: list_area.y,
+        width: list_area.width,
+        height: 1,
+    };
+    frame.render_widget(overlay, top_row);
 }
 

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -409,4 +409,3 @@ fn render_sticky_section_header(
     };
     frame.render_widget(overlay, top_row);
 }
-

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use crate::components::sprint_assign_list::{build_entries, SprintAssignEntry};
+use crate::components::sprint_assign_list::{build_entries, scroll_offset_to_show, SprintAssignEntry};
 use kanban_domain::SprintStatus;
 use ratatui::Frame;
 
@@ -353,7 +353,13 @@ impl SelectionDialog for SprintAssignDialog {
             }
         }
 
-        let list = Paragraph::new(lines);
+        let selected = app
+            .dialog_input
+            .sprint_assign_selection
+            .get()
+            .unwrap_or(0);
+        let scroll = scroll_offset_to_show(selected, lines.len(), chunks[1].height as usize);
+        let list = Paragraph::new(lines).scroll((scroll as u16, 0));
         frame.render_widget(list, chunks[1]);
     }
 }

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,5 +1,7 @@
 use crate::app::App;
-use crate::components::sprint_assign_list::{build_entries, scroll_offset_to_show, SprintAssignEntry};
+use crate::components::sprint_assign_list::{
+    build_entries, scroll_offset_to_show, SprintAssignEntry,
+};
 use kanban_domain::SprintStatus;
 use ratatui::Frame;
 
@@ -353,11 +355,7 @@ impl SelectionDialog for SprintAssignDialog {
             }
         }
 
-        let selected = app
-            .dialog_input
-            .sprint_assign_selection
-            .get()
-            .unwrap_or(0);
+        let selected = app.dialog_input.sprint_assign_selection.get().unwrap_or(0);
         let scroll = scroll_offset_to_show(selected, lines.len(), chunks[1].height as usize);
         let list = Paragraph::new(lines).scroll((scroll as u16, 0));
         frame.render_widget(list, chunks[1]);
@@ -393,10 +391,7 @@ fn render_entry_line<'a>(
             } else {
                 Style::default().fg(Color::White)
             };
-            Line::from(Span::styled(
-                format!("{}(None){}", prefix, suffix),
-                style,
-            ))
+            Line::from(Span::styled(format!("{}(None){}", prefix, suffix), style))
         }
         SprintAssignEntry::ActiveOrPlanned(s) => {
             let is_current = current_sprint_id == Some(s.id);

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,5 +1,6 @@
 use crate::app::App;
-use kanban_domain::{Sprint, SprintStatus};
+use crate::components::sprint_assign_list::{build_entries, SprintAssignEntry};
+use kanban_domain::SprintStatus;
 use ratatui::Frame;
 
 pub trait SelectionDialog {
@@ -291,22 +292,17 @@ impl SelectionDialog for SprintAssignDialog {
             let boards = app.model.boards();
             if let Some(board) = boards.get(board_idx) {
                 let sprints = app.model.sprints();
-                let sprint_count = Sprint::assignable(sprints, board.id).len();
-                sprint_count + 1 // +1 for None option
-            } else {
-                1
+                return build_entries(sprints, board.id, chrono::Utc::now()).len();
             }
-        } else {
-            1
         }
+        1
     }
 
     fn render(&self, app: &App, frame: &mut Frame) {
         use crate::components::centered_rect;
         use ratatui::{
             layout::{Constraint, Direction, Layout},
-            style::{Color, Modifier, Style},
-            text::{Line, Span},
+            style::{Color, Style},
             widgets::{Block, Borders, Clear, Paragraph},
         };
 
@@ -336,7 +332,7 @@ impl SelectionDialog for SprintAssignDialog {
             let boards = app.model.boards();
             if let Some(board) = boards.get(board_idx) {
                 let sprints = app.model.sprints();
-                let board_sprints = Sprint::assignable(sprints, board.id);
+                let entries = build_entries(sprints, board.id, chrono::Utc::now());
 
                 let cards = app.model.cards();
                 let current_sprint_id = if let Some(card_idx) = app.selection.active_card_index {
@@ -345,45 +341,94 @@ impl SelectionDialog for SprintAssignDialog {
                     None
                 };
 
-                for (idx, sprint_option) in std::iter::once(None)
-                    .chain(board_sprints.iter().map(|s| Some(*s)))
-                    .enumerate()
-                {
+                for (idx, entry) in entries.iter().enumerate() {
                     let is_selected = app.dialog_input.sprint_assign_selection.get() == Some(idx);
-                    let is_current = match (sprint_option, current_sprint_id) {
-                        (None, None) => true,
-                        (Some(s), Some(id)) => s.id == id,
-                        _ => false,
-                    };
-
-                    let style = if is_selected {
-                        Style::default().fg(Color::White).bg(Color::Blue)
-                    } else if is_current {
-                        Style::default()
-                            .fg(Color::Green)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(Color::White)
-                    };
-
-                    let prefix = if is_selected { "> " } else { "  " };
-                    let current_indicator = if is_current { " (current)" } else { "" };
-
-                    let sprint_name = if let Some(sprint) = sprint_option {
-                        sprint.formatted_name(board, "sprint")
-                    } else {
-                        "(None)".to_string()
-                    };
-
-                    lines.push(Line::from(Span::styled(
-                        format!("{}{}{}", prefix, sprint_name, current_indicator),
-                        style,
-                    )));
+                    lines.push(render_entry_line(
+                        entry,
+                        is_selected,
+                        current_sprint_id,
+                        board,
+                    ));
                 }
             }
         }
 
         let list = Paragraph::new(lines);
         frame.render_widget(list, chunks[1]);
+    }
+}
+
+fn render_entry_line<'a>(
+    entry: &SprintAssignEntry<'_>,
+    is_selected: bool,
+    current_sprint_id: Option<uuid::Uuid>,
+    board: &kanban_domain::Board,
+) -> ratatui::text::Line<'a> {
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::{Line, Span};
+
+    match entry {
+        SprintAssignEntry::Header(label) => Line::from(Span::styled(
+            (*label).to_string(),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        SprintAssignEntry::None => {
+            let is_current = current_sprint_id.is_none();
+            let prefix = if is_selected { "> " } else { "  " };
+            let suffix = if is_current { " (current)" } else { "" };
+            let style = if is_selected {
+                Style::default().fg(Color::White).bg(Color::Blue)
+            } else if is_current {
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            Line::from(Span::styled(
+                format!("{}(None){}", prefix, suffix),
+                style,
+            ))
+        }
+        SprintAssignEntry::ActiveOrPlanned(s) => {
+            let is_current = current_sprint_id == Some(s.id);
+            let prefix = if is_selected { "> " } else { "  " };
+            let suffix = if is_current { " (current)" } else { "" };
+            let style = if is_selected {
+                Style::default().fg(Color::White).bg(Color::Blue)
+            } else if is_current {
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            Line::from(Span::styled(
+                format!("{}{}{}", prefix, s.formatted_name(board, "sprint"), suffix),
+                style,
+            ))
+        }
+        SprintAssignEntry::Completed(s) | SprintAssignEntry::Ended(s) => {
+            let is_current = current_sprint_id == Some(s.id);
+            let prefix = if is_selected { "> " } else { "  " };
+            let suffix = if is_current { " (current)" } else { "" };
+            let status_color = if matches!(entry, SprintAssignEntry::Completed(_)) {
+                Color::Green
+            } else {
+                Color::Red
+            };
+            let style = if is_selected {
+                Style::default().fg(Color::White).bg(Color::Blue)
+            } else {
+                // Status colour wins; no bold override even when is_current.
+                Style::default().fg(status_color)
+            };
+            Line::from(Span::styled(
+                format!("{}{}{}", prefix, s.formatted_name(board, "sprint"), suffix),
+                style,
+            ))
+        }
     }
 }

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -55,15 +55,11 @@ pub fn build_entries<'a>(
 }
 
 fn first_selectable(entries: &[SprintAssignEntry]) -> Option<usize> {
-    entries
-        .iter()
-        .position(|e| is_selectable(e))
+    entries.iter().position(|e| is_selectable(e))
 }
 
 fn last_selectable(entries: &[SprintAssignEntry]) -> Option<usize> {
-    entries
-        .iter()
-        .rposition(|e| is_selectable(e))
+    entries.iter().rposition(|e| is_selectable(e))
 }
 
 fn cur_if_selectable(entries: &[SprintAssignEntry], cur: Option<usize>) -> Option<usize> {
@@ -175,8 +171,14 @@ mod tests {
         let now = ts("2026-05-07T00:00:00Z");
         let board = Uuid::new_v4();
         let entries = build_entries(&[], board, now);
-        assert!(!entries.is_empty(), "entries must contain at least the None option");
-        assert!(is_none_entry(&entries[0]), "index 0 must be the None unassign entry");
+        assert!(
+            !entries.is_empty(),
+            "entries must contain at least the None option"
+        );
+        assert!(
+            is_none_entry(&entries[0]),
+            "index 0 must be the None unassign entry"
+        );
     }
 
     #[test]
@@ -261,7 +263,10 @@ mod tests {
                 _ => {}
             }
         }
-        assert!(saw_completed && saw_ended, "section must contain both Completed and Ended entries");
+        assert!(
+            saw_completed && saw_ended,
+            "section must contain both Completed and Ended entries"
+        );
     }
 
     #[test]

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -1,5 +1,9 @@
 use chrono::{DateTime, Utc};
-use kanban_domain::{Sprint, SprintStatus};
+use kanban_domain::{Board, Sprint, SprintStatus};
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
 use uuid::Uuid;
 
 /// Entry in the sprint-assignment dialog list. Headers are non-selectable;
@@ -105,6 +109,78 @@ pub fn sprint_id_of(entry: &SprintAssignEntry) -> Option<Uuid> {
         | SprintAssignEntry::Completed(s)
         | SprintAssignEntry::Ended(s) => Some(s.id),
         SprintAssignEntry::Header(_) | SprintAssignEntry::None => None,
+    }
+}
+
+/// Renders a single dialog row for the given entry. Shared by both the
+/// single-card and multi-card sprint-assign dialogs. Pass
+/// `current_sprint_id = None` from contexts that don't track a current
+/// sprint (e.g. the multi-card variant).
+pub fn render_entry_line(
+    entry: &SprintAssignEntry<'_>,
+    is_selected: bool,
+    current_sprint_id: Option<Uuid>,
+    board: &Board,
+) -> Line<'static> {
+    match entry {
+        SprintAssignEntry::Header(label) => Line::from(Span::styled(
+            (*label).to_string(),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        SprintAssignEntry::None => {
+            let is_current = current_sprint_id.is_none();
+            let prefix = if is_selected { "> " } else { "  " };
+            let suffix = if is_current { " (current)" } else { "" };
+            let style = if is_selected {
+                Style::default().fg(Color::White).bg(Color::Blue)
+            } else if is_current {
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            Line::from(Span::styled(format!("{}(None){}", prefix, suffix), style))
+        }
+        SprintAssignEntry::ActiveOrPlanned(s) => {
+            let is_current = current_sprint_id == Some(s.id);
+            let prefix = if is_selected { "> " } else { "  " };
+            let suffix = if is_current { " (current)" } else { "" };
+            let style = if is_selected {
+                Style::default().fg(Color::White).bg(Color::Blue)
+            } else if is_current {
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            Line::from(Span::styled(
+                format!("{}{}{}", prefix, s.formatted_name(board, "sprint"), suffix),
+                style,
+            ))
+        }
+        SprintAssignEntry::Completed(s) | SprintAssignEntry::Ended(s) => {
+            let is_current = current_sprint_id == Some(s.id);
+            let prefix = if is_selected { "> " } else { "  " };
+            let suffix = if is_current { " (current)" } else { "" };
+            let status_color = if matches!(entry, SprintAssignEntry::Completed(_)) {
+                Color::Green
+            } else {
+                Color::Red
+            };
+            let style = if is_selected {
+                Style::default().fg(Color::White).bg(Color::Blue)
+            } else {
+                Style::default().fg(status_color)
+            };
+            Line::from(Span::styled(
+                format!("{}{}{}", prefix, s.formatted_name(board, "sprint"), suffix),
+                style,
+            ))
+        }
     }
 }
 

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use kanban_domain::Sprint;
+use kanban_domain::{Sprint, SprintStatus};
 use uuid::Uuid;
 
 /// Entry in the sprint-assignment dialog list. Headers are non-selectable;
@@ -16,34 +16,100 @@ pub enum SprintAssignEntry<'a> {
 pub const ACTIVE_PLANNED_HEADER: &str = "Active / Planned";
 pub const COMPLETED_ENDED_HEADER: &str = "Completed / Ended";
 
+fn is_selectable(entry: &SprintAssignEntry) -> bool {
+    !matches!(entry, SprintAssignEntry::Header(_))
+}
+
 /// Build the entry list for the dialog. Headers are emitted only when their
 /// section is non-empty. The `(None)` entry is always at index 0.
 pub fn build_entries<'a>(
-    _sprints: &'a [Sprint],
-    _board_id: Uuid,
-    _now: DateTime<Utc>,
+    sprints: &'a [Sprint],
+    board_id: Uuid,
+    now: DateTime<Utc>,
 ) -> Vec<SprintAssignEntry<'a>> {
-    Vec::new()
+    let (active, completed_or_ended) = Sprint::for_assignment_dialog(sprints, board_id, now);
+    let mut entries: Vec<SprintAssignEntry<'a>> = Vec::with_capacity(
+        1 + active.len()
+            + completed_or_ended.len()
+            + usize::from(!active.is_empty())
+            + usize::from(!completed_or_ended.is_empty()),
+    );
+    entries.push(SprintAssignEntry::None);
+    if !active.is_empty() {
+        entries.push(SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER));
+        for s in active {
+            entries.push(SprintAssignEntry::ActiveOrPlanned(s));
+        }
+    }
+    if !completed_or_ended.is_empty() {
+        entries.push(SprintAssignEntry::Header(COMPLETED_ENDED_HEADER));
+        for s in completed_or_ended {
+            if s.status == SprintStatus::Completed {
+                entries.push(SprintAssignEntry::Completed(s));
+            } else {
+                entries.push(SprintAssignEntry::Ended(s));
+            }
+        }
+    }
+    entries
+}
+
+fn first_selectable(entries: &[SprintAssignEntry]) -> Option<usize> {
+    entries
+        .iter()
+        .position(|e| is_selectable(e))
+}
+
+fn last_selectable(entries: &[SprintAssignEntry]) -> Option<usize> {
+    entries
+        .iter()
+        .rposition(|e| is_selectable(e))
+}
+
+fn cur_if_selectable(entries: &[SprintAssignEntry], cur: Option<usize>) -> Option<usize> {
+    cur.filter(|&c| entries.get(c).map(is_selectable).unwrap_or(false))
 }
 
 /// Move selection to the next selectable entry, skipping headers.
 /// Clamps at the last selectable entry. Returns `None` if no selectable
 /// entries exist.
-pub fn next_selectable(_entries: &[SprintAssignEntry], _cur: Option<usize>) -> Option<usize> {
-    None
+pub fn next_selectable(entries: &[SprintAssignEntry], cur: Option<usize>) -> Option<usize> {
+    let start = cur.map(|i| i + 1).unwrap_or(0);
+    entries
+        .iter()
+        .enumerate()
+        .skip(start)
+        .find(|(_, e)| is_selectable(e))
+        .map(|(i, _)| i)
+        .or_else(|| cur_if_selectable(entries, cur))
+        .or_else(|| last_selectable(entries))
 }
 
 /// Move selection to the previous selectable entry, skipping headers.
 /// Clamps at the first selectable entry. Returns `None` if no selectable
 /// entries exist.
-pub fn prev_selectable(_entries: &[SprintAssignEntry], _cur: Option<usize>) -> Option<usize> {
-    None
+pub fn prev_selectable(entries: &[SprintAssignEntry], cur: Option<usize>) -> Option<usize> {
+    let end = cur.unwrap_or(entries.len());
+    entries
+        .iter()
+        .enumerate()
+        .take(end)
+        .rev()
+        .find(|(_, e)| is_selectable(e))
+        .map(|(i, _)| i)
+        .or_else(|| cur_if_selectable(entries, cur))
+        .or_else(|| first_selectable(entries))
 }
 
 /// Returns the sprint id for a sprint-bearing entry, or `None` for
 /// `Header` and `None` entries.
-pub fn sprint_id_of(_entry: &SprintAssignEntry) -> Option<Uuid> {
-    None
+pub fn sprint_id_of(entry: &SprintAssignEntry) -> Option<Uuid> {
+    match entry {
+        SprintAssignEntry::ActiveOrPlanned(s)
+        | SprintAssignEntry::Completed(s)
+        | SprintAssignEntry::Ended(s) => Some(s.id),
+        SprintAssignEntry::Header(_) | SprintAssignEntry::None => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -112,6 +112,23 @@ pub fn sprint_id_of(entry: &SprintAssignEntry) -> Option<Uuid> {
     }
 }
 
+/// Computes the vertical scroll offset (in rows) so that the entry at
+/// `selected` is visible inside a viewport of `height` rows over a list of
+/// `total` rows. Stateless: the offset is fully determined by these inputs.
+///
+/// Behavior:
+/// - When the list fits, no scroll.
+/// - When `selected` is in the first `height` rows, no scroll.
+/// - Otherwise, scroll just enough that `selected` is the last visible row,
+///   clamped so the bottom of the list aligns with the bottom of the viewport.
+pub fn scroll_offset_to_show(selected: usize, total: usize, height: usize) -> usize {
+    if height == 0 || total <= height || selected < height {
+        return 0;
+    }
+    let max_offset = total.saturating_sub(height);
+    (selected + 1).saturating_sub(height).min(max_offset)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -343,5 +360,43 @@ mod tests {
         let none = SprintAssignEntry::None;
         assert_eq!(sprint_id_of(&header), None);
         assert_eq!(sprint_id_of(&none), None);
+    }
+
+    #[test]
+    fn test_scroll_offset_is_zero_when_list_fits_in_viewport() {
+        assert_eq!(scroll_offset_to_show(0, 3, 5), 0);
+        assert_eq!(scroll_offset_to_show(2, 3, 5), 0);
+        assert_eq!(scroll_offset_to_show(5, 6, 6), 0);
+    }
+
+    #[test]
+    fn test_scroll_offset_is_zero_when_selected_is_in_first_viewport() {
+        // selected at any of the first `height` indices keeps offset at 0
+        assert_eq!(scroll_offset_to_show(0, 20, 5), 0);
+        assert_eq!(scroll_offset_to_show(4, 20, 5), 0);
+    }
+
+    #[test]
+    fn test_scroll_offset_keeps_selected_visible_when_below_viewport() {
+        // height=5, selected=5 → must scroll by 1 so selected is last visible
+        assert_eq!(scroll_offset_to_show(5, 20, 5), 1);
+        // height=5, selected=10 → scroll by 6
+        assert_eq!(scroll_offset_to_show(10, 20, 5), 6);
+    }
+
+    #[test]
+    fn test_scroll_offset_clamps_at_last_full_viewport() {
+        // total=20, height=5 → max meaningful offset is 15 (showing rows 15-19)
+        assert_eq!(scroll_offset_to_show(19, 20, 5), 15);
+    }
+
+    #[test]
+    fn test_scroll_offset_handles_zero_height() {
+        assert_eq!(scroll_offset_to_show(5, 20, 0), 0);
+    }
+
+    #[test]
+    fn test_scroll_offset_handles_empty_list() {
+        assert_eq!(scroll_offset_to_show(0, 0, 5), 0);
     }
 }

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -1,0 +1,281 @@
+use chrono::{DateTime, Utc};
+use kanban_domain::Sprint;
+use uuid::Uuid;
+
+/// Entry in the sprint-assignment dialog list. Headers are non-selectable;
+/// `None` is the unassign option (always at index 0); the three sprint
+/// variants carry the section context the renderer uses for styling.
+pub enum SprintAssignEntry<'a> {
+    Header(&'static str),
+    None,
+    ActiveOrPlanned(&'a Sprint),
+    Completed(&'a Sprint),
+    Ended(&'a Sprint),
+}
+
+pub const ACTIVE_PLANNED_HEADER: &str = "Active / Planned";
+pub const COMPLETED_ENDED_HEADER: &str = "Completed / Ended";
+
+/// Build the entry list for the dialog. Headers are emitted only when their
+/// section is non-empty. The `(None)` entry is always at index 0.
+pub fn build_entries<'a>(
+    _sprints: &'a [Sprint],
+    _board_id: Uuid,
+    _now: DateTime<Utc>,
+) -> Vec<SprintAssignEntry<'a>> {
+    Vec::new()
+}
+
+/// Move selection to the next selectable entry, skipping headers.
+/// Clamps at the last selectable entry. Returns `None` if no selectable
+/// entries exist.
+pub fn next_selectable(_entries: &[SprintAssignEntry], _cur: Option<usize>) -> Option<usize> {
+    None
+}
+
+/// Move selection to the previous selectable entry, skipping headers.
+/// Clamps at the first selectable entry. Returns `None` if no selectable
+/// entries exist.
+pub fn prev_selectable(_entries: &[SprintAssignEntry], _cur: Option<usize>) -> Option<usize> {
+    None
+}
+
+/// Returns the sprint id for a sprint-bearing entry, or `None` for
+/// `Header` and `None` entries.
+pub fn sprint_id_of(_entry: &SprintAssignEntry) -> Option<Uuid> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::SprintStatus;
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn make_sprint(
+        sprint_number: u32,
+        board_id: Uuid,
+        status: SprintStatus,
+        end_date: Option<DateTime<Utc>>,
+    ) -> Sprint {
+        Sprint {
+            id: Uuid::new_v4(),
+            board_id,
+            sprint_number,
+            name_index: None,
+            prefix: None,
+            card_prefix: None,
+            status,
+            start_date: None,
+            end_date,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+        }
+    }
+
+    fn is_none_entry(entry: &SprintAssignEntry) -> bool {
+        matches!(entry, SprintAssignEntry::None)
+    }
+
+    fn header_label<'a>(entry: &SprintAssignEntry<'a>) -> Option<&'static str> {
+        match entry {
+            SprintAssignEntry::Header(label) => Some(*label),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn test_build_entries_always_includes_none_at_index_0() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let entries = build_entries(&[], board, now);
+        assert!(!entries.is_empty(), "entries must contain at least the None option");
+        assert!(is_none_entry(&entries[0]), "index 0 must be the None unassign entry");
+    }
+
+    #[test]
+    fn test_build_entries_omits_active_section_header_when_no_active_or_planned() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let sprints = [make_sprint(
+            1,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-04-01T00:00:00Z")),
+        )];
+        let entries = build_entries(&sprints, board, now);
+        assert!(
+            entries
+                .iter()
+                .all(|e| header_label(e) != Some(ACTIVE_PLANNED_HEADER)),
+            "active/planned header must be omitted when section is empty"
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|e| header_label(e) == Some(COMPLETED_ENDED_HEADER)),
+            "completed/ended header must appear when section is non-empty"
+        );
+    }
+
+    #[test]
+    fn test_build_entries_omits_completed_ended_section_header_when_section_empty() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let sprints = [make_sprint(1, board, SprintStatus::Planning, None)];
+        let entries = build_entries(&sprints, board, now);
+        assert!(
+            entries
+                .iter()
+                .any(|e| header_label(e) == Some(ACTIVE_PLANNED_HEADER)),
+            "active/planned header must appear when section is non-empty"
+        );
+        assert!(
+            entries
+                .iter()
+                .all(|e| header_label(e) != Some(COMPLETED_ENDED_HEADER)),
+            "completed/ended header must be omitted when section is empty"
+        );
+    }
+
+    #[test]
+    fn test_build_entries_emits_completed_and_ended_in_same_section() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let sprints = [
+            make_sprint(
+                5,
+                board,
+                SprintStatus::Completed,
+                Some(ts("2026-04-01T00:00:00Z")),
+            ),
+            make_sprint(
+                7,
+                board,
+                SprintStatus::Active,
+                Some(ts("2026-05-01T00:00:00Z")),
+            ),
+        ];
+        let entries = build_entries(&sprints, board, now);
+
+        // Layout expected: [None, Header("Completed / Ended"), Ended(7), Completed(5)]
+        // (sorted desc by sprint_number within section)
+        let header_idx = entries
+            .iter()
+            .position(|e| header_label(e) == Some(COMPLETED_ENDED_HEADER))
+            .expect("completed/ended header present");
+        let after = &entries[header_idx + 1..];
+        let mut saw_completed = false;
+        let mut saw_ended = false;
+        for e in after {
+            match e {
+                SprintAssignEntry::Completed(_) => saw_completed = true,
+                SprintAssignEntry::Ended(_) => saw_ended = true,
+                SprintAssignEntry::Header(_) => panic!("no second header expected"),
+                _ => {}
+            }
+        }
+        assert!(saw_completed && saw_ended, "section must contain both Completed and Ended entries");
+    }
+
+    #[test]
+    fn test_next_selectable_skips_headers() {
+        // Build a fixture: [None, Header("A"), Sprint, Header("B"), Sprint]
+        let board = Uuid::new_v4();
+        let s1 = make_sprint(1, board, SprintStatus::Planning, None);
+        let s2 = make_sprint(
+            2,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-04-01T00:00:00Z")),
+        );
+        let entries = vec![
+            SprintAssignEntry::None,
+            SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER),
+            SprintAssignEntry::ActiveOrPlanned(&s1),
+            SprintAssignEntry::Header(COMPLETED_ENDED_HEADER),
+            SprintAssignEntry::Completed(&s2),
+        ];
+        // From None (idx 0) → next must skip the header at 1, land on 2
+        assert_eq!(next_selectable(&entries, Some(0)), Some(2));
+        // From idx 2 → next must skip header at 3, land on 4
+        assert_eq!(next_selectable(&entries, Some(2)), Some(4));
+    }
+
+    #[test]
+    fn test_prev_selectable_skips_headers() {
+        let board = Uuid::new_v4();
+        let s1 = make_sprint(1, board, SprintStatus::Planning, None);
+        let s2 = make_sprint(
+            2,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-04-01T00:00:00Z")),
+        );
+        let entries = vec![
+            SprintAssignEntry::None,
+            SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER),
+            SprintAssignEntry::ActiveOrPlanned(&s1),
+            SprintAssignEntry::Header(COMPLETED_ENDED_HEADER),
+            SprintAssignEntry::Completed(&s2),
+        ];
+        // From idx 4 → prev must skip header at 3, land on 2
+        assert_eq!(prev_selectable(&entries, Some(4)), Some(2));
+        // From idx 2 → prev must skip header at 1, land on 0
+        assert_eq!(prev_selectable(&entries, Some(2)), Some(0));
+    }
+
+    #[test]
+    fn test_next_selectable_clamps_at_last_selectable() {
+        let board = Uuid::new_v4();
+        let s1 = make_sprint(1, board, SprintStatus::Planning, None);
+        let entries = vec![
+            SprintAssignEntry::None,
+            SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER),
+            SprintAssignEntry::ActiveOrPlanned(&s1),
+        ];
+        // Already at last selectable (idx 2); next should stay at 2
+        assert_eq!(next_selectable(&entries, Some(2)), Some(2));
+    }
+
+    #[test]
+    fn test_prev_selectable_clamps_at_first_selectable() {
+        let board = Uuid::new_v4();
+        let s1 = make_sprint(
+            1,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-04-01T00:00:00Z")),
+        );
+        let entries = vec![
+            SprintAssignEntry::None,
+            SprintAssignEntry::Header(COMPLETED_ENDED_HEADER),
+            SprintAssignEntry::Completed(&s1),
+        ];
+        // Already at first selectable (idx 0); prev should stay at 0
+        assert_eq!(prev_selectable(&entries, Some(0)), Some(0));
+    }
+
+    #[test]
+    fn test_sprint_id_of_returns_id_for_sprint_entries() {
+        let board = Uuid::new_v4();
+        let s = make_sprint(1, board, SprintStatus::Planning, None);
+        let active = SprintAssignEntry::ActiveOrPlanned(&s);
+        let completed = SprintAssignEntry::Completed(&s);
+        let ended = SprintAssignEntry::Ended(&s);
+        assert_eq!(sprint_id_of(&active), Some(s.id));
+        assert_eq!(sprint_id_of(&completed), Some(s.id));
+        assert_eq!(sprint_id_of(&ended), Some(s.id));
+    }
+
+    #[test]
+    fn test_sprint_id_of_returns_none_for_header_and_none_entries() {
+        let header = SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER);
+        let none = SprintAssignEntry::None;
+        assert_eq!(sprint_id_of(&header), None);
+        assert_eq!(sprint_id_of(&none), None);
+    }
+}

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -32,11 +32,10 @@ pub fn build_entries<'a>(
     now: DateTime<Utc>,
 ) -> Vec<SprintAssignEntry<'a>> {
     let (active, completed_or_ended) = Sprint::for_assignment_dialog(sprints, board_id, now);
+    let active_header = if active.is_empty() { 0 } else { 1 };
+    let lower_header = if completed_or_ended.is_empty() { 0 } else { 1 };
     let mut entries: Vec<SprintAssignEntry<'a>> = Vec::with_capacity(
-        1 + active.len()
-            + completed_or_ended.len()
-            + usize::from(!active.is_empty())
-            + usize::from(!completed_or_ended.is_empty()),
+        1 + active.len() + completed_or_ended.len() + active_header + lower_header,
     );
     entries.push(SprintAssignEntry::None);
     if !active.is_empty() {

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -101,6 +101,25 @@ pub fn prev_selectable(entries: &[SprintAssignEntry], cur: Option<usize>) -> Opt
         .or_else(|| first_selectable(entries))
 }
 
+/// Returns the `(header_index, label)` of the section header that
+/// encloses `entries[idx]` — the closest `Header` walking backwards.
+/// Returns `None` when `idx` is out of bounds, points at the (None)
+/// entry at index 0, or precedes the first header.
+pub fn section_header_for(
+    entries: &[SprintAssignEntry],
+    idx: usize,
+) -> Option<(usize, &'static str)> {
+    if idx >= entries.len() {
+        return None;
+    }
+    for i in (0..idx).rev() {
+        if let SprintAssignEntry::Header(label) = entries[i] {
+            return Some((i, label));
+        }
+    }
+    None
+}
+
 /// Returns the sprint id for a sprint-bearing entry, or `None` for
 /// `Header` and `None` entries.
 pub fn sprint_id_of(entry: &SprintAssignEntry) -> Option<Uuid> {
@@ -479,5 +498,55 @@ mod tests {
     #[test]
     fn test_scroll_offset_handles_empty_list() {
         assert_eq!(scroll_offset_to_show(0, 0, 5), 0);
+    }
+
+    #[test]
+    fn test_section_header_for_returns_none_for_index_zero() {
+        let entries = vec![SprintAssignEntry::None];
+        assert_eq!(section_header_for(&entries, 0), None);
+    }
+
+    #[test]
+    fn test_section_header_for_returns_none_for_out_of_bounds() {
+        let entries: Vec<SprintAssignEntry> = vec![SprintAssignEntry::None];
+        assert_eq!(section_header_for(&entries, 5), None);
+    }
+
+    #[test]
+    fn test_section_header_for_returns_active_header_for_entry_in_active_section() {
+        let board = Uuid::new_v4();
+        let s = make_sprint(1, board, SprintStatus::Planning, None);
+        let entries = vec![
+            SprintAssignEntry::None,
+            SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER),
+            SprintAssignEntry::ActiveOrPlanned(&s),
+        ];
+        assert_eq!(
+            section_header_for(&entries, 2),
+            Some((1, ACTIVE_PLANNED_HEADER))
+        );
+    }
+
+    #[test]
+    fn test_section_header_for_returns_completed_header_for_entry_in_lower_section() {
+        let board = Uuid::new_v4();
+        let s_active = make_sprint(1, board, SprintStatus::Planning, None);
+        let s_completed = make_sprint(
+            2,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-04-01T00:00:00Z")),
+        );
+        let entries = vec![
+            SprintAssignEntry::None,
+            SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER),
+            SprintAssignEntry::ActiveOrPlanned(&s_active),
+            SprintAssignEntry::Header(COMPLETED_ENDED_HEADER),
+            SprintAssignEntry::Completed(&s_completed),
+        ];
+        assert_eq!(
+            section_header_for(&entries, 4),
+            Some((3, COMPLETED_ENDED_HEADER))
+        );
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -5,7 +5,7 @@ use kanban_domain::commands::{
     BoardCommand, CardCommand, Command, CreateCard, MoveCard, RestoreCard, SetBoardTaskSort,
     UpdateCard,
 };
-use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations, SortOrder, Sprint};
+use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations, SortOrder};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -94,8 +94,20 @@ impl App {
                 let boards = self.model.boards();
                 if let Some(board) = boards.get(board_idx) {
                     let sprints = self.model.sprints();
-                    let sprint_count = Sprint::assignable(sprints, board.id).len();
-                    if sprint_count > 0 {
+                    let entries = crate::components::sprint_assign_list::build_entries(
+                        sprints,
+                        board.id,
+                        chrono::Utc::now(),
+                    );
+                    let has_assignable = entries.iter().any(|e| {
+                        matches!(
+                            e,
+                            crate::components::sprint_assign_list::SprintAssignEntry::ActiveOrPlanned(_)
+                                | crate::components::sprint_assign_list::SprintAssignEntry::Completed(_)
+                                | crate::components::sprint_assign_list::SprintAssignEntry::Ended(_)
+                        )
+                    });
+                    if has_assignable {
                         if let Some(selected_card) = self.get_selected_card_in_context() {
                             let card_id = selected_card.id;
                             let actual_idx =

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,6 +1,9 @@
 use crate::app::App;
+use crate::components::sprint_assign_list::{
+    build_entries, next_selectable, prev_selectable, sprint_id_of, SprintAssignEntry,
+};
 use crossterm::event::KeyCode;
-use kanban_domain::{KanbanOperations, SortField, SortOrder, Sprint};
+use kanban_domain::{KanbanOperations, SortField, SortOrder};
 
 const PRIORITY_COUNT: usize = 4;
 
@@ -236,61 +239,50 @@ impl App {
                 self.dialog_input.sprint_assign_selection.clear();
             }
             KeyCode::Char('j') | KeyCode::Down => {
-                if let Some(board_idx) = self.selection.active_board_index {
-                    let boards = self.model.boards();
-                    if let Some(board) = boards.get(board_idx) {
-                        let sprints = self.model.sprints();
-                        let sprint_count = Sprint::assignable(sprints, board.id).len();
-                        self.dialog_input
-                            .sprint_assign_selection
-                            .next(sprint_count + 1);
-                    }
+                let entries = self.sprint_assign_entries();
+                let cur = self.dialog_input.sprint_assign_selection.get();
+                if let Some(next) = next_selectable(&entries, cur) {
+                    self.dialog_input.sprint_assign_selection.set(Some(next));
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.dialog_input.sprint_assign_selection.prev();
+                let entries = self.sprint_assign_entries();
+                let cur = self.dialog_input.sprint_assign_selection.get();
+                if let Some(prev) = prev_selectable(&entries, cur) {
+                    self.dialog_input.sprint_assign_selection.set(Some(prev));
+                }
             }
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if let Some(selection_idx) = self.dialog_input.sprint_assign_selection.get() {
                     if let Some(card_idx) = self.selection.active_card_index {
-                        let card_id = {
-                            if let Some(card) = self.model.cards().get(card_idx) {
-                                card.id
-                            } else {
-                                return;
-                            }
+                        let card_id = match self.model.cards().get(card_idx) {
+                            Some(card) => card.id,
+                            None => return,
                         };
 
-                        if selection_idx == 0 {
-                            // Unassign from sprint
-                            let unassign_cmd = kanban_domain::commands::Command::Card(
-                                kanban_domain::commands::CardCommand::UnassignFromSprint(
-                                    kanban_domain::commands::UnassignCardFromSprint {
-                                        card_id,
-                                        timestamp: chrono::Utc::now(),
-                                    },
-                                ),
-                            );
-                            if let Err(e) = self.execute_commands_batch(vec![unassign_cmd]) {
-                                tracing::error!("Failed to unassign card from sprint: {}", e);
-                                self.set_error(format!(
-                                    "Failed to unassign card from sprint: {}",
-                                    e
-                                ));
-                            } else {
-                                tracing::info!("Unassigned card from sprint");
+                        let entries = self.sprint_assign_entries();
+                        match entries.get(selection_idx) {
+                            Some(SprintAssignEntry::None) => {
+                                let unassign_cmd = kanban_domain::commands::Command::Card(
+                                    kanban_domain::commands::CardCommand::UnassignFromSprint(
+                                        kanban_domain::commands::UnassignCardFromSprint {
+                                            card_id,
+                                            timestamp: chrono::Utc::now(),
+                                        },
+                                    ),
+                                );
+                                if let Err(e) = self.execute_commands_batch(vec![unassign_cmd]) {
+                                    tracing::error!("Failed to unassign card from sprint: {}", e);
+                                    self.set_error(format!(
+                                        "Failed to unassign card from sprint: {}",
+                                        e
+                                    ));
+                                } else {
+                                    tracing::info!("Unassigned card from sprint");
+                                }
                             }
-                        } else if let Some(board_idx) = self.selection.active_board_index {
-                            if let Some(board_id) = self.model.boards().get(board_idx).map(|b| b.id)
-                            {
-                                let sprints = self.model.sprints();
-                                let board_sprints = Sprint::assignable(sprints, board_id);
-                                if let Some(sprint) = board_sprints.get(selection_idx - 1) {
-                                    let sprint_id = sprint.id;
-
-                                    let mut commands: Vec<kanban_domain::commands::Command> =
-                                        Vec::new();
-
+                            Some(entry) => {
+                                if let Some(sprint_id) = sprint_id_of(entry) {
                                     let assign_cmd = kanban_domain::commands::Command::Card(
                                         kanban_domain::commands::CardCommand::AssignToSprint(
                                             kanban_domain::commands::AssignCardsToSprint {
@@ -299,9 +291,7 @@ impl App {
                                             },
                                         ),
                                     );
-                                    commands.push(assign_cmd);
-
-                                    if let Err(e) = self.execute_commands_batch(commands) {
+                                    if let Err(e) = self.execute_commands_batch(vec![assign_cmd]) {
                                         tracing::error!("Failed to assign card to sprint: {}", e);
                                         self.set_error(format!(
                                             "Failed to assign card to sprint: {}",
@@ -315,6 +305,7 @@ impl App {
                                     }
                                 }
                             }
+                            None => {}
                         }
                     }
                 }
@@ -323,6 +314,17 @@ impl App {
             }
             _ => {}
         }
+    }
+
+    fn sprint_assign_entries(&self) -> Vec<SprintAssignEntry<'_>> {
+        if let Some(board_idx) = self.selection.active_board_index {
+            let boards = self.model.boards();
+            if let Some(board) = boards.get(board_idx) {
+                let sprints = self.model.sprints();
+                return build_entries(sprints, board.id, chrono::Utc::now());
+            }
+        }
+        Vec::new()
     }
 
     pub fn handle_assign_multiple_cards_to_sprint_popup(&mut self, key_code: KeyCode) {
@@ -334,58 +336,56 @@ impl App {
                 self.multi_select.selection_mode_active = false;
             }
             KeyCode::Char('j') | KeyCode::Down => {
-                if let Some(board_idx) = self.selection.active_board_index {
-                    let boards = self.model.boards();
-                    if let Some(board) = boards.get(board_idx) {
-                        let sprints = self.model.sprints();
-                        let sprint_count = Sprint::assignable(sprints, board.id).len();
-                        self.dialog_input
-                            .sprint_assign_selection
-                            .next(sprint_count + 1);
-                    }
+                let entries = self.sprint_assign_entries();
+                let cur = self.dialog_input.sprint_assign_selection.get();
+                if let Some(next) = next_selectable(&entries, cur) {
+                    self.dialog_input.sprint_assign_selection.set(Some(next));
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.dialog_input.sprint_assign_selection.prev();
+                let entries = self.sprint_assign_entries();
+                let cur = self.dialog_input.sprint_assign_selection.get();
+                if let Some(prev) = prev_selectable(&entries, cur) {
+                    self.dialog_input.sprint_assign_selection.set(Some(prev));
+                }
             }
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if let Some(selection_idx) = self.dialog_input.sprint_assign_selection.get() {
                     let card_ids: Vec<uuid::Uuid> =
                         self.multi_select.selected_cards.iter().copied().collect();
 
-                    if selection_idx == 0 {
-                        // Unassign cards from sprint - batch all unassignments
-                        let mut unassign_commands: Vec<kanban_domain::commands::Command> =
-                            Vec::new();
-                        for card_id in &card_ids {
-                            let cmd = kanban_domain::commands::Command::Card(
-                                kanban_domain::commands::CardCommand::UnassignFromSprint(
-                                    kanban_domain::commands::UnassignCardFromSprint {
-                                        card_id: *card_id,
-                                        timestamp: chrono::Utc::now(),
-                                    },
-                                ),
-                            );
-                            unassign_commands.push(cmd);
+                    let entries = self.sprint_assign_entries();
+                    match entries.get(selection_idx) {
+                        Some(SprintAssignEntry::None) => {
+                            let mut unassign_commands: Vec<kanban_domain::commands::Command> =
+                                Vec::new();
+                            for card_id in &card_ids {
+                                let cmd = kanban_domain::commands::Command::Card(
+                                    kanban_domain::commands::CardCommand::UnassignFromSprint(
+                                        kanban_domain::commands::UnassignCardFromSprint {
+                                            card_id: *card_id,
+                                            timestamp: chrono::Utc::now(),
+                                        },
+                                    ),
+                                );
+                                unassign_commands.push(cmd);
+                            }
+                            if let Err(e) = self.execute_commands_batch(unassign_commands) {
+                                tracing::error!("Failed to unassign cards from sprint: {}", e);
+                                self.set_error(format!(
+                                    "Failed to unassign cards from sprint: {}",
+                                    e
+                                ));
+                            } else {
+                                tracing::info!(
+                                    "Unassigned {} cards from sprint",
+                                    self.multi_select.selected_cards.len()
+                                );
+                            }
                         }
-
-                        if let Err(e) = self.execute_commands_batch(unassign_commands) {
-                            tracing::error!("Failed to unassign cards from sprint: {}", e);
-                            self.set_error(format!("Failed to unassign cards from sprint: {}", e));
-                        } else {
-                            tracing::info!(
-                                "Unassigned {} cards from sprint",
-                                self.multi_select.selected_cards.len()
-                            );
-                        }
-                    } else if let Some(board_idx) = self.selection.active_board_index {
-                        let boards = self.model.boards();
-                        if let Some(board_id) = boards.get(board_idx).map(|b| b.id) {
-                            let sprints = self.model.sprints();
-                            let board_sprints = Sprint::assignable(sprints, board_id);
-                            if let Some(sprint) = board_sprints.get(selection_idx - 1) {
-                                let sprint_id = sprint.id;
-
+                        Some(entry) => {
+                            if let Some(sprint_id) = sprint_id_of(entry) {
+                                let assigned_count = self.multi_select.selected_cards.len();
                                 let commands: Vec<kanban_domain::commands::Command> =
                                     vec![kanban_domain::commands::Command::Card(
                                         kanban_domain::commands::CardCommand::AssignToSprint(
@@ -395,22 +395,22 @@ impl App {
                                             },
                                         ),
                                     )];
-
                                 if let Err(e) = self.execute_commands_batch(commands) {
                                     tracing::error!("Failed to assign cards to sprint: {}", e);
                                     self.set_error(format!(
                                         "Failed to assign cards to sprint: {}",
                                         e
                                     ));
+                                } else {
+                                    tracing::info!(
+                                        "Assigned {} cards to sprint with id: {}",
+                                        assigned_count,
+                                        sprint_id
+                                    );
                                 }
-
-                                tracing::info!(
-                                    "Assigned {} cards to sprint with id: {}",
-                                    self.multi_select.selected_cards.len(),
-                                    sprint_id
-                                );
                             }
                         }
+                        None => {}
                     }
                 }
                 self.pop_mode();

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -179,7 +179,7 @@ fn render_board_sprints_list(
                 .count();
 
             let is_active_sprint = board.active_sprint_id == Some(sprint.id);
-            let is_ended = sprint.is_ended();
+            let is_ended = sprint.is_ended(chrono::Utc::now());
 
             let mut base_style = normal_text();
             if is_selected && is_focused {

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -3,7 +3,6 @@ use crate::components::*;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::{Color, Style},
-    text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
@@ -56,9 +55,8 @@ pub(crate) fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
 
 pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     use crate::components::sprint_assign_list::{
-        build_entries, scroll_offset_to_show, SprintAssignEntry,
+        build_entries, render_entry_line, scroll_offset_to_show,
     };
-    use ratatui::style::Modifier;
 
     let area = centered_rect(60, 50, frame.area());
 
@@ -90,56 +88,9 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
         if let Some(board) = app.model.boards().get(board_idx) {
             let sprints = app.model.sprints();
             let entries = build_entries(sprints, board.id, chrono::Utc::now());
-
             for (idx, entry) in entries.iter().enumerate() {
                 let is_selected = app.dialog_input.sprint_assign_selection.get() == Some(idx);
-                let line = match entry {
-                    SprintAssignEntry::Header(label) => Line::from(Span::styled(
-                        (*label).to_string(),
-                        Style::default()
-                            .fg(Color::Yellow)
-                            .add_modifier(Modifier::BOLD),
-                    )),
-                    SprintAssignEntry::None => {
-                        let prefix = if is_selected { "> " } else { "  " };
-                        let style = if is_selected {
-                            Style::default().fg(Color::White).bg(Color::Blue)
-                        } else {
-                            Style::default().fg(Color::White)
-                        };
-                        Line::from(Span::styled(format!("{}(None)", prefix), style))
-                    }
-                    SprintAssignEntry::ActiveOrPlanned(s) => {
-                        let prefix = if is_selected { "> " } else { "  " };
-                        let style = if is_selected {
-                            Style::default().fg(Color::White).bg(Color::Blue)
-                        } else {
-                            Style::default().fg(Color::White)
-                        };
-                        Line::from(Span::styled(
-                            format!("{}{}", prefix, s.formatted_name(board, "sprint")),
-                            style,
-                        ))
-                    }
-                    SprintAssignEntry::Completed(s) | SprintAssignEntry::Ended(s) => {
-                        let prefix = if is_selected { "> " } else { "  " };
-                        let status_color = if matches!(entry, SprintAssignEntry::Completed(_)) {
-                            Color::Green
-                        } else {
-                            Color::Red
-                        };
-                        let style = if is_selected {
-                            Style::default().fg(Color::White).bg(Color::Blue)
-                        } else {
-                            Style::default().fg(status_color)
-                        };
-                        Line::from(Span::styled(
-                            format!("{}{}", prefix, s.formatted_name(board, "sprint")),
-                            style,
-                        ))
-                    }
-                };
-                lines.push(line);
+                lines.push(render_entry_line(entry, is_selected, None, board));
             }
         }
     }

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -55,7 +55,9 @@ pub(crate) fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
 }
 
 pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
-    use crate::components::sprint_assign_list::{build_entries, SprintAssignEntry};
+    use crate::components::sprint_assign_list::{
+        build_entries, scroll_offset_to_show, SprintAssignEntry,
+    };
     use ratatui::style::Modifier;
 
     let area = centered_rect(60, 50, frame.area());
@@ -142,6 +144,12 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
         }
     }
 
-    let list = Paragraph::new(lines);
+    let selected = app
+        .dialog_input
+        .sprint_assign_selection
+        .get()
+        .unwrap_or(0);
+    let scroll = scroll_offset_to_show(selected, lines.len(), chunks[1].height as usize);
+    let list = Paragraph::new(lines).scroll((scroll as u16, 0));
     frame.render_widget(list, chunks[1]);
 }

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -55,8 +55,10 @@ pub(crate) fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
 
 pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     use crate::components::sprint_assign_list::{
-        build_entries, render_entry_line, scroll_offset_to_show,
+        build_entries, render_entry_line, scroll_offset_to_show, section_header_for,
     };
+    use ratatui::style::Modifier;
+    use ratatui::text::{Line, Span};
 
     let area = centered_rect(60, 50, frame.area());
 
@@ -83,6 +85,7 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     frame.render_widget(label, chunks[0]);
 
     let mut lines = vec![];
+    let mut entries_for_header = Vec::new();
 
     if let Some(board_idx) = app.selection.active_board_index {
         if let Some(board) = app.model.boards().get(board_idx) {
@@ -92,6 +95,7 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
                 let is_selected = app.dialog_input.sprint_assign_selection.get() == Some(idx);
                 lines.push(render_entry_line(entry, is_selected, None, board));
             }
+            entries_for_header = entries;
         }
     }
 
@@ -99,4 +103,22 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     let scroll = scroll_offset_to_show(selected, lines.len(), chunks[1].height as usize);
     let list = Paragraph::new(lines).scroll((scroll as u16, 0));
     frame.render_widget(list, chunks[1]);
+
+    if let Some((header_idx, label)) = section_header_for(&entries_for_header, selected) {
+        if header_idx < scroll && chunks[1].height > 0 {
+            let overlay = Paragraph::new(Line::from(Span::styled(
+                label.to_string(),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            let top_row = ratatui::layout::Rect {
+                x: chunks[1].x,
+                y: chunks[1].y,
+                width: chunks[1].width,
+                height: 1,
+            };
+            frame.render_widget(overlay, top_row);
+        }
+    }
 }

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -144,11 +144,7 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
         }
     }
 
-    let selected = app
-        .dialog_input
-        .sprint_assign_selection
-        .get()
-        .unwrap_or(0);
+    let selected = app.dialog_input.sprint_assign_selection.get().unwrap_or(0);
     let scroll = scroll_offset_to_show(selected, lines.len(), chunks[1].height as usize);
     let list = Paragraph::new(lines).scroll((scroll as u16, 0));
     frame.render_widget(list, chunks[1]);

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -55,7 +55,8 @@ pub(crate) fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
 }
 
 pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
-    use kanban_domain::Sprint;
+    use crate::components::sprint_assign_list::{build_entries, SprintAssignEntry};
+    use ratatui::style::Modifier;
 
     let area = centered_rect(60, 50, frame.area());
 
@@ -86,32 +87,57 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     if let Some(board_idx) = app.selection.active_board_index {
         if let Some(board) = app.model.boards().get(board_idx) {
             let sprints = app.model.sprints();
-            let board_sprints = Sprint::assignable(sprints, board.id);
+            let entries = build_entries(sprints, board.id, chrono::Utc::now());
 
-            for (idx, sprint_option) in std::iter::once(None)
-                .chain(board_sprints.iter().map(|s| Some(*s)))
-                .enumerate()
-            {
+            for (idx, entry) in entries.iter().enumerate() {
                 let is_selected = app.dialog_input.sprint_assign_selection.get() == Some(idx);
-
-                let style = if is_selected {
-                    Style::default().fg(Color::White).bg(Color::Blue)
-                } else {
-                    Style::default().fg(Color::White)
+                let line = match entry {
+                    SprintAssignEntry::Header(label) => Line::from(Span::styled(
+                        (*label).to_string(),
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    )),
+                    SprintAssignEntry::None => {
+                        let prefix = if is_selected { "> " } else { "  " };
+                        let style = if is_selected {
+                            Style::default().fg(Color::White).bg(Color::Blue)
+                        } else {
+                            Style::default().fg(Color::White)
+                        };
+                        Line::from(Span::styled(format!("{}(None)", prefix), style))
+                    }
+                    SprintAssignEntry::ActiveOrPlanned(s) => {
+                        let prefix = if is_selected { "> " } else { "  " };
+                        let style = if is_selected {
+                            Style::default().fg(Color::White).bg(Color::Blue)
+                        } else {
+                            Style::default().fg(Color::White)
+                        };
+                        Line::from(Span::styled(
+                            format!("{}{}", prefix, s.formatted_name(board, "sprint")),
+                            style,
+                        ))
+                    }
+                    SprintAssignEntry::Completed(s) | SprintAssignEntry::Ended(s) => {
+                        let prefix = if is_selected { "> " } else { "  " };
+                        let status_color = if matches!(entry, SprintAssignEntry::Completed(_)) {
+                            Color::Green
+                        } else {
+                            Color::Red
+                        };
+                        let style = if is_selected {
+                            Style::default().fg(Color::White).bg(Color::Blue)
+                        } else {
+                            Style::default().fg(status_color)
+                        };
+                        Line::from(Span::styled(
+                            format!("{}{}", prefix, s.formatted_name(board, "sprint")),
+                            style,
+                        ))
+                    }
                 };
-
-                let prefix = if is_selected { "> " } else { "  " };
-
-                let sprint_name = if let Some(sprint) = sprint_option {
-                    sprint.formatted_name(board, "sprint")
-                } else {
-                    "(None)".to_string()
-                };
-
-                lines.push(Line::from(Span::styled(
-                    format!("{}{}", prefix, sprint_name),
-                    style,
-                )));
+                lines.push(line);
             }
         }
     }

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -80,7 +80,7 @@ fn sprint_date_lines(sprint: &Sprint) -> Vec<Line<'static>> {
         ));
     }
     if let Some(end) = sprint.end_date {
-        let end_style = if sprint.is_ended() {
+        let end_style = if sprint.is_ended(chrono::Utc::now()) {
             Style::default().fg(Color::Red)
         } else {
             normal_text()

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -2,9 +2,7 @@ mod helpers;
 
 use chrono::{Duration, Utc};
 use crossterm::event::KeyCode;
-use kanban_domain::{
-    field_update::FieldUpdate, CreateCardOptions, KanbanOperations, SprintUpdate,
-};
+use kanban_domain::{field_update::FieldUpdate, CreateCardOptions, KanbanOperations, SprintUpdate};
 use kanban_tui::{
     app::mode::{AppMode, DialogMode},
     components::{SelectionDialog, SprintAssignDialog},
@@ -27,7 +25,10 @@ struct DialogFixture {
 fn setup_app_with_sprints() -> DialogFixture {
     let mut app = App::test_default();
     let board = app.ctx.create_board("B".into(), None).unwrap();
-    let column = app.ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
     let card = app
         .ctx
         .create_card(
@@ -339,7 +340,9 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
 
     // Pre-assign card to the completed sprint (simulates the retrospective
     // scenario where the user previously assigned to a Completed sprint).
-    app.ctx.assign_card_to_sprint(card_id, completed_id).unwrap();
+    app.ctx
+        .assign_card_to_sprint(card_id, completed_id)
+        .unwrap();
     app.prepare_frame();
 
     open_assign_dialog(&mut app);
@@ -392,7 +395,10 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
     // standard 120x30 test backend size.
     let mut app = App::test_default();
     let board = app.ctx.create_board("B".into(), None).unwrap();
-    let column = app.ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
     app.ctx
         .create_card(
             board.id,
@@ -453,4 +459,3 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
         output
     );
 }
-

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -386,3 +386,71 @@ fn sprint_at(app: &App, idx: usize) -> Option<Uuid> {
     sprint_id_of(entries.get(idx)?)
 }
 
+#[test]
+fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
+    // 30 planning sprints overflows the dialog's visible area at the
+    // standard 120x30 test backend size.
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("B".into(), None).unwrap();
+    let column = app.ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Task".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    for _ in 0..30 {
+        app.ctx.create_sprint(board.id, None, None).unwrap();
+    }
+    app.selection.active_board_index = Some(0);
+    app.selection.active_card_index = Some(0);
+    app.prepare_frame();
+
+    open_assign_dialog(&mut app);
+
+    // Sprints are sorted by sprint_number desc, so the oldest sprint sits at
+    // the bottom of the active section — guaranteed off-screen without scroll.
+    let oldest_id = app
+        .model
+        .sprints()
+        .iter()
+        .min_by_key(|s| s.sprint_number)
+        .map(|s| s.id)
+        .unwrap();
+
+    let max_steps = 50;
+    let mut steps = 0;
+    loop {
+        let idx = app
+            .dialog_input
+            .sprint_assign_selection
+            .get()
+            .expect("selection set");
+        if sprint_at(&app, idx) == Some(oldest_id) {
+            break;
+        }
+        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+        steps += 1;
+        assert!(steps < max_steps, "could not navigate to oldest sprint");
+    }
+
+    let board_after = app.model.boards()[0].clone();
+    let oldest = app
+        .model
+        .sprints()
+        .iter()
+        .find(|s| s.id == oldest_id)
+        .cloned()
+        .unwrap();
+    let oldest_name = oldest.formatted_name(&board_after, "sprint");
+
+    let output = render_dialog_to_string(&app);
+    assert!(
+        output.contains(&oldest_name),
+        "selected sprint at end of long list must remain visible after scroll; output:\n{}",
+        output
+    );
+}
+

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -1,0 +1,406 @@
+mod helpers;
+
+use chrono::{Duration, Utc};
+use crossterm::event::KeyCode;
+use kanban_domain::{
+    field_update::FieldUpdate, CreateCardOptions, KanbanOperations, SprintUpdate,
+};
+use kanban_tui::{
+    app::mode::{AppMode, DialogMode},
+    components::{SelectionDialog, SprintAssignDialog},
+    App,
+};
+use ratatui::backend::TestBackend;
+use ratatui::style::Color;
+use ratatui::Terminal;
+use uuid::Uuid;
+
+#[allow(dead_code)]
+struct DialogFixture {
+    app: App,
+    card_id: Uuid,
+    planning_id: Uuid,
+    completed_id: Uuid,
+    ended_id: Uuid,
+}
+
+fn setup_app_with_sprints() -> DialogFixture {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("B".into(), None).unwrap();
+    let column = app.ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Task".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let planning = app.ctx.create_sprint(board.id, None, None).unwrap();
+
+    let active = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx.activate_sprint(active.id, Some(7)).unwrap();
+    let past = Utc::now() - Duration::days(1);
+    app.ctx
+        .update_sprint(
+            active.id,
+            SprintUpdate {
+                end_date: FieldUpdate::Set(past),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    let to_complete = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx.activate_sprint(to_complete.id, Some(7)).unwrap();
+    app.ctx.complete_sprint(to_complete.id).unwrap();
+
+    app.selection.active_board_index = Some(0);
+    app.selection.active_card_index = Some(0);
+    app.prepare_frame();
+
+    DialogFixture {
+        app,
+        card_id: card.id,
+        planning_id: planning.id,
+        completed_id: to_complete.id,
+        ended_id: active.id,
+    }
+}
+
+fn open_assign_dialog(app: &mut App) {
+    app.dialog_input.sprint_assign_selection.set(Some(0));
+    app.push_mode(AppMode::Dialog(DialogMode::AssignCardToSprint));
+}
+
+fn render_dialog_to_string(app: &App) -> String {
+    let backend = TestBackend::new(120, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            let dialog = SprintAssignDialog;
+            dialog.render(app, frame);
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
+}
+
+fn render_dialog_with_colors(app: &App) -> Vec<(String, Option<Color>)> {
+    let backend = TestBackend::new(120, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            let dialog = SprintAssignDialog;
+            dialog.render(app, frame);
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = Vec::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            let cell = buffer.cell((x, y)).unwrap();
+            result.push((cell.symbol().to_string(), cell.style().fg));
+        }
+    }
+    result
+}
+
+fn line_color(grid: &[(String, Option<Color>)], substring: &str) -> Option<Color> {
+    let width = 120;
+    let height = grid.len() / width;
+    for y in 0..height {
+        let line: String = (0..width)
+            .map(|x| grid[y * width + x].0.clone())
+            .collect::<Vec<_>>()
+            .join("");
+        if let Some(start) = line.find(substring) {
+            // Return the fg color of the first cell of the substring.
+            return grid[y * width + start].1;
+        }
+    }
+    None
+}
+
+#[test]
+fn test_dialog_renders_active_planned_header_when_active_sprints_exist() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    open_assign_dialog(&mut app);
+    let output = render_dialog_to_string(&app);
+    assert!(
+        output.contains("Active / Planned"),
+        "expected Active / Planned header in dialog output:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_dialog_renders_completed_ended_header_when_either_completed_or_ended_exist() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    open_assign_dialog(&mut app);
+    let output = render_dialog_to_string(&app);
+    assert!(
+        output.contains("Completed / Ended"),
+        "expected Completed / Ended header in dialog output:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_dialog_renders_completed_in_green_and_ended_in_red() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    open_assign_dialog(&mut app);
+
+    // Find the completed and ended sprint by their formatted names.
+    let completed = app
+        .model
+        .sprints()
+        .iter()
+        .find(|s| s.id == fx.completed_id)
+        .cloned()
+        .unwrap();
+    let ended = app
+        .model
+        .sprints()
+        .iter()
+        .find(|s| s.id == fx.ended_id)
+        .cloned()
+        .unwrap();
+    let board = app.model.boards()[0].clone();
+    let completed_name = completed.formatted_name(&board, "sprint");
+    let ended_name = ended.formatted_name(&board, "sprint");
+
+    let grid = render_dialog_with_colors(&app);
+    let completed_color = line_color(&grid, &completed_name);
+    let ended_color = line_color(&grid, &ended_name);
+
+    assert_eq!(
+        completed_color,
+        Some(Color::Green),
+        "completed sprint should be green; got {:?} for {:?}",
+        completed_color,
+        completed_name
+    );
+    assert_eq!(
+        ended_color,
+        Some(Color::Red),
+        "ended sprint should be red; got {:?} for {:?}",
+        ended_color,
+        ended_name
+    );
+}
+
+#[test]
+fn test_down_arrow_skips_headers() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    open_assign_dialog(&mut app);
+    // Selection starts at 0 (None entry).
+    assert_eq!(app.dialog_input.sprint_assign_selection.get(), Some(0));
+
+    // Pressing j once should land on the first selectable entry past the
+    // (None) entry — the "Active / Planned" header is at index 1, so
+    // selection should jump to index 2 (the first sprint).
+    app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+    assert_eq!(
+        app.dialog_input.sprint_assign_selection.get(),
+        Some(2),
+        "down should skip the Active / Planned header"
+    );
+}
+
+#[test]
+fn test_assigning_to_completed_sprint_succeeds() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    let card_id = fx.card_id;
+    let target_sprint = fx.completed_id;
+
+    open_assign_dialog(&mut app);
+
+    // Walk down with j until selection_idx points at the completed sprint.
+    let max_steps = 20;
+    let mut steps = 0;
+    loop {
+        let idx = app
+            .dialog_input
+            .sprint_assign_selection
+            .get()
+            .expect("selection set");
+        if let Some(s) = sprint_at(&app, idx) {
+            if s == target_sprint {
+                break;
+            }
+        }
+        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+        steps += 1;
+        assert!(steps < max_steps, "could not navigate to completed sprint");
+    }
+    app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
+    let card = app
+        .model
+        .cards()
+        .iter()
+        .find(|c| c.id == card_id)
+        .cloned()
+        .unwrap();
+    assert_eq!(
+        card.sprint_id,
+        Some(target_sprint),
+        "card should be assigned to the completed sprint"
+    );
+}
+
+#[test]
+fn test_assigning_to_ended_sprint_succeeds() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    let card_id = fx.card_id;
+    let target_sprint = fx.ended_id;
+
+    open_assign_dialog(&mut app);
+
+    let max_steps = 20;
+    let mut steps = 0;
+    loop {
+        let idx = app
+            .dialog_input
+            .sprint_assign_selection
+            .get()
+            .expect("selection set");
+        if let Some(s) = sprint_at(&app, idx) {
+            if s == target_sprint {
+                break;
+            }
+        }
+        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+        steps += 1;
+        assert!(steps < max_steps, "could not navigate to ended sprint");
+    }
+    app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
+    let card = app
+        .model
+        .cards()
+        .iter()
+        .find(|c| c.id == card_id)
+        .cloned()
+        .unwrap();
+    assert_eq!(
+        card.sprint_id,
+        Some(target_sprint),
+        "card should be assigned to the ended sprint"
+    );
+}
+
+#[test]
+fn test_bulk_assign_handler_supports_completed_sprint() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    let card_id = fx.card_id;
+    let target_sprint = fx.completed_id;
+
+    // Switch to bulk-assign flow with one selected card.
+    app.multi_select.selected_cards.insert(card_id);
+    app.dialog_input.sprint_assign_selection.set(Some(0));
+    app.push_mode(AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint));
+
+    let max_steps = 20;
+    let mut steps = 0;
+    loop {
+        let idx = app
+            .dialog_input
+            .sprint_assign_selection
+            .get()
+            .expect("selection set");
+        if let Some(s) = sprint_at(&app, idx) {
+            if s == target_sprint {
+                break;
+            }
+        }
+        app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Char('j'));
+        steps += 1;
+        assert!(steps < max_steps, "could not navigate to completed sprint");
+    }
+    app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Enter);
+    let card = app
+        .model
+        .cards()
+        .iter()
+        .find(|c| c.id == card_id)
+        .cloned()
+        .unwrap();
+    assert_eq!(
+        card.sprint_id,
+        Some(target_sprint),
+        "bulk-assigned card should land on the completed sprint"
+    );
+}
+
+#[test]
+fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ended_section() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    let card_id = fx.card_id;
+    let completed_id = fx.completed_id;
+
+    // Pre-assign card to the completed sprint (simulates the retrospective
+    // scenario where the user previously assigned to a Completed sprint).
+    app.ctx.assign_card_to_sprint(card_id, completed_id).unwrap();
+    app.prepare_frame();
+
+    open_assign_dialog(&mut app);
+
+    let board = app.model.boards()[0].clone();
+    let completed = app
+        .model
+        .sprints()
+        .iter()
+        .find(|s| s.id == completed_id)
+        .cloned()
+        .unwrap();
+    let completed_name = completed.formatted_name(&board, "sprint");
+
+    let grid = render_dialog_with_colors(&app);
+
+    // The completed entry should still render in green (status colour wins),
+    // not in any "current sprint" highlight that would override it.
+    let color = line_color(&grid, &completed_name);
+    assert_eq!(
+        color,
+        Some(Color::Green),
+        "completed-current sprint must keep green status colour, got {:?}",
+        color
+    );
+
+    // It should also carry a " (current)" suffix for identification.
+    let output = render_dialog_to_string(&app);
+    assert!(
+        output.contains(&format!("{} (current)", completed_name)),
+        "expected ' (current)' suffix on the completed-current entry; output:\n{}",
+        output
+    );
+}
+
+// Helper: returns the sprint id selected by the dialog at index `idx`,
+// using the same entry layout the renderer/handler uses.
+fn sprint_at(app: &App, idx: usize) -> Option<Uuid> {
+    use kanban_domain::Sprint;
+    use kanban_tui::components::{build_entries, sprint_id_of};
+    let board = app.model.boards().first().cloned()?;
+    let sprints: Vec<Sprint> = app.model.sprints().to_vec();
+    let entries = build_entries(&sprints, board.id, Utc::now());
+    sprint_id_of(entries.get(idx)?)
+}
+

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -459,3 +459,102 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
         output
     );
 }
+
+#[test]
+fn test_sticky_header_appears_at_top_when_scrolled_past_active_planned_header() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("B".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Task".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    for _ in 0..30 {
+        app.ctx.create_sprint(board.id, None, None).unwrap();
+    }
+    app.selection.active_board_index = Some(0);
+    app.selection.active_card_index = Some(0);
+    app.prepare_frame();
+
+    open_assign_dialog(&mut app);
+
+    for _ in 0..50 {
+        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+    }
+
+    let output = render_dialog_to_string(&app);
+    assert!(
+        output.contains("Active / Planned"),
+        "Active / Planned header must be pinned at the top of the list area when scrolled past; output:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_sticky_header_does_not_duplicate_when_list_fits_without_scrolling() {
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    open_assign_dialog(&mut app);
+
+    let output = render_dialog_to_string(&app);
+    let count = output.matches("Active / Planned").count();
+    assert_eq!(
+        count, 1,
+        "without scroll, Active / Planned should appear exactly once (natural position); got {} in:\n{}",
+        count, output
+    );
+}
+
+#[test]
+fn test_sticky_header_switches_to_completed_ended_when_selecting_in_lower_section() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("B".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Task".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    for _ in 0..30 {
+        app.ctx.create_sprint(board.id, None, None).unwrap();
+    }
+    for _ in 0..30 {
+        let s = app.ctx.create_sprint(board.id, None, None).unwrap();
+        app.ctx.activate_sprint(s.id, Some(7)).unwrap();
+        app.ctx.complete_sprint(s.id).unwrap();
+    }
+    app.selection.active_board_index = Some(0);
+    app.selection.active_card_index = Some(0);
+    app.prepare_frame();
+
+    open_assign_dialog(&mut app);
+
+    for _ in 0..200 {
+        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+    }
+
+    let output = render_dialog_to_string(&app);
+    assert!(
+        output.contains("Completed / Ended"),
+        "Completed / Ended must be pinned at the top when selection is in the lower section; output:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("Active / Planned"),
+        "Active / Planned must not appear when selection is past it and the overlay belongs to the lower section; output:\n{}",
+        output
+    );
+}

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -2,7 +2,10 @@ mod helpers;
 
 use chrono::{Duration, Utc};
 use crossterm::event::KeyCode;
-use kanban_domain::{field_update::FieldUpdate, CreateCardOptions, KanbanOperations, SprintUpdate};
+use kanban_domain::{
+    field_update::FieldUpdate, CreateCardOptions, KanbanOperations, Sprint, SprintUpdate,
+};
+use kanban_tui::components::{build_entries, sprint_id_of};
 use kanban_tui::{
     app::mode::{AppMode, DialogMode},
     components::{SelectionDialog, SprintAssignDialog},
@@ -13,11 +16,12 @@ use ratatui::style::Color;
 use ratatui::Terminal;
 use uuid::Uuid;
 
-#[allow(dead_code)]
+const TEST_BACKEND_WIDTH: u16 = 120;
+const TEST_BACKEND_HEIGHT: u16 = 30;
+
 struct DialogFixture {
     app: App,
     card_id: Uuid,
-    planning_id: Uuid,
     completed_id: Uuid,
     ended_id: Uuid,
 }
@@ -39,7 +43,7 @@ fn setup_app_with_sprints() -> DialogFixture {
         )
         .unwrap();
 
-    let planning = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx.create_sprint(board.id, None, None).unwrap();
 
     let active = app.ctx.create_sprint(board.id, None, None).unwrap();
     app.ctx.activate_sprint(active.id, Some(7)).unwrap();
@@ -65,7 +69,6 @@ fn setup_app_with_sprints() -> DialogFixture {
     DialogFixture {
         app,
         card_id: card.id,
-        planning_id: planning.id,
         completed_id: to_complete.id,
         ended_id: active.id,
     }
@@ -77,7 +80,7 @@ fn open_assign_dialog(app: &mut App) {
 }
 
 fn render_dialog_to_string(app: &App) -> String {
-    let backend = TestBackend::new(120, 30);
+    let backend = TestBackend::new(TEST_BACKEND_WIDTH, TEST_BACKEND_HEIGHT);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|frame| {
@@ -97,7 +100,7 @@ fn render_dialog_to_string(app: &App) -> String {
 }
 
 fn render_dialog_with_colors(app: &App) -> Vec<(String, Option<Color>)> {
-    let backend = TestBackend::new(120, 30);
+    let backend = TestBackend::new(TEST_BACKEND_WIDTH, TEST_BACKEND_HEIGHT);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|frame| {
@@ -117,7 +120,7 @@ fn render_dialog_with_colors(app: &App) -> Vec<(String, Option<Color>)> {
 }
 
 fn line_color(grid: &[(String, Option<Color>)], substring: &str) -> Option<Color> {
-    let width = 120;
+    let width = TEST_BACKEND_WIDTH as usize;
     let height = grid.len() / width;
     for y in 0..height {
         let line: String = (0..width)
@@ -381,8 +384,6 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
 // Helper: returns the sprint id selected by the dialog at index `idx`,
 // using the same entry layout the renderer/handler uses.
 fn sprint_at(app: &App, idx: usize) -> Option<Uuid> {
-    use kanban_domain::Sprint;
-    use kanban_tui::components::{build_entries, sprint_id_of};
     let board = app.model.boards().first().cloned()?;
     let sprints: Vec<Sprint> = app.model.sprints().to_vec();
     let entries = build_entries(&sprints, board.id, Utc::now());
@@ -462,6 +463,8 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
 
 #[test]
 fn test_sticky_header_appears_at_top_when_scrolled_past_active_planned_header() {
+    // 30 planning sprints — selected at the last entry forces the
+    // Active / Planned header (at entry index 1) to scroll off the top.
     let mut app = App::test_default();
     let board = app.ctx.create_board("B".into(), None).unwrap();
     let column = app
@@ -485,6 +488,7 @@ fn test_sticky_header_appears_at_top_when_scrolled_past_active_planned_header() 
 
     open_assign_dialog(&mut app);
 
+    // Navigate to the last selectable entry.
     for _ in 0..50 {
         app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
     }
@@ -499,6 +503,8 @@ fn test_sticky_header_appears_at_top_when_scrolled_past_active_planned_header() 
 
 #[test]
 fn test_sticky_header_does_not_duplicate_when_list_fits_without_scrolling() {
+    // Short list — header sits at its natural position; no overlay should
+    // render so the label appears exactly once in the output.
     let fx = setup_app_with_sprints();
     let mut app = fx.app;
     open_assign_dialog(&mut app);
@@ -514,6 +520,9 @@ fn test_sticky_header_does_not_duplicate_when_list_fits_without_scrolling() {
 
 #[test]
 fn test_sticky_header_switches_to_completed_ended_when_selecting_in_lower_section() {
+    // 30 planning + 30 completed sprints. With the selection on the last
+    // completed entry, both section headers have scrolled off — the overlay
+    // should pin the *enclosing* section's header (Completed / Ended).
     let mut app = App::test_default();
     let board = app.ctx.create_board("B".into(), None).unwrap();
     let column = app
@@ -542,6 +551,8 @@ fn test_sticky_header_switches_to_completed_ended_when_selecting_in_lower_sectio
 
     open_assign_dialog(&mut app);
 
+    // Walk all the way to the last entry — guaranteed to be a completed sprint
+    // with the lower section's header scrolled off.
     for _ in 0..200 {
         app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
     }
@@ -552,6 +563,8 @@ fn test_sticky_header_switches_to_completed_ended_when_selecting_in_lower_sectio
         "Completed / Ended must be pinned at the top when selection is in the lower section; output:\n{}",
         output
     );
+    // The upper section's header is also scrolled off but should NOT appear —
+    // the overlay shows the *enclosing* section header for the selection.
     assert!(
         !output.contains("Active / Planned"),
         "Active / Planned must not appear when selection is past it and the overlay belongs to the lower section; output:\n{}",

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -249,13 +249,7 @@ fn test_assigning_to_completed_sprint_succeeds() {
         assert!(steps < max_steps, "could not navigate to completed sprint");
     }
     app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
-    let card = app
-        .model
-        .cards()
-        .iter()
-        .find(|c| c.id == card_id)
-        .cloned()
-        .unwrap();
+    let card = app.ctx.get_card(card_id).unwrap().unwrap();
     assert_eq!(
         card.sprint_id,
         Some(target_sprint),
@@ -290,13 +284,7 @@ fn test_assigning_to_ended_sprint_succeeds() {
         assert!(steps < max_steps, "could not navigate to ended sprint");
     }
     app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
-    let card = app
-        .model
-        .cards()
-        .iter()
-        .find(|c| c.id == card_id)
-        .cloned()
-        .unwrap();
+    let card = app.ctx.get_card(card_id).unwrap().unwrap();
     assert_eq!(
         card.sprint_id,
         Some(target_sprint),
@@ -334,13 +322,7 @@ fn test_bulk_assign_handler_supports_completed_sprint() {
         assert!(steps < max_steps, "could not navigate to completed sprint");
     }
     app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Enter);
-    let card = app
-        .model
-        .cards()
-        .iter()
-        .find(|c| c.id == card_id)
-        .cloned()
-        .unwrap();
+    let card = app.ctx.get_card(card_id).unwrap().unwrap();
     assert_eq!(
         card.sprint_id,
         Some(target_sprint),


### PR DESCRIPTION
Splits the sprint assignment dialog into two headed sections so users can assign cards to past sprints (e.g. retrospective bug logging) while keeping a clean visual distinction between active and historical sprints.

- Sprint assignment dialog now renders `Active / Planned` and `Completed / Ended` as separate headed sections (single-card and multi-card variants).
- Completed sprints render in green, Ended sprints (Active sprints whose `end_date` has passed) in red.
- Cards can now be assigned to Completed and Ended sprints. `Cancelled` sprints remain hidden.
- `j`/`k` skip section headers; the dialog scrolls to keep the selected entry visible when the list overflows the viewport.

## What

`Sprint::for_assignment_dialog(sprints, board_id, now) -> (Vec<&Sprint>, Vec<&Sprint>)` — new domain helper that splits a board's sprints into active+planned vs completed+ended. The TUI consumes it via a new `kanban_tui::components::sprint_assign_list` module exposing:

- `SprintAssignEntry { Header, None, ActiveOrPlanned, Completed, Ended }`
- `build_entries(sprints, board_id, now) -> Vec<SprintAssignEntry>`
- `next_selectable / prev_selectable` (skip-aware navigation, clamps at section boundaries)
- `sprint_id_of(entry)` (for current-sprint lookup)
- `scroll_offset_to_show(selected, total, height)` (stateless scroll math)

`Sprint::is_ended` was refactored from `&self -> bool` to `&self, now: DateTime<Utc> -> bool` so the bucket logic and tests can pin time deterministically. Three call sites (`ui/sprint_detail.rs`, `ui/board_detail.rs`, `app/mod.rs`) updated accordingly. The previous `Sprint::assignable` filter is removed — fully superseded.

## Why

`Sprint::assignable` excluded `Completed` sprints, blocking valid retrospective workflows ("this bug was actually fixed in sprint 12"). Showing completed sprints in a flat list would have lost the "what's assignable today vs historical" cue, so the work also introduces section headers. KAN-1 / KAN-118 / KAN-140 (filter-completed-from-assign) are superseded by this approach.

## How

1. Domain (`crates/kanban-domain/src/sprint.rs`): new `for_assignment_dialog`; `is_ended(now)` parameterised; `assignable` removed.
2. TUI builder (`crates/kanban-tui/src/components/sprint_assign_list.rs`, new): pure entry-list construction + skip-aware nav + stateless scroll-offset math, all unit-tested.
3. TUI render — single-card (`components/selection_dialog.rs::SprintAssignDialog::render`) and multi-card (`ui/dialogs/cards.rs::render_assign_multiple_cards_popup`): iterate the entry vec, style headers yellow-bold, Completed green, Ended red, current-sprint marker emits ` (current)` suffix without overriding status colour in the bottom section. Both pipe `scroll_offset_to_show` into `Paragraph::scroll`.
4. TUI handlers (`handlers/popup_handlers.rs`): `j`/`k` use `next_selectable`/`prev_selectable`; `Enter` matches on `SprintAssignEntry` so `None` unassigns and any sprint variant assigns via `sprint_id_of`. Symmetric for the multi-card handler.
5. Open-dialog gate (`handlers/card_handlers.rs`): now opens the dialog whenever any non-cancelled sprint exists, not just Active/Planning — including boards that have only completed sprints.
6. Current-sprint lookup (`app/mod.rs::get_current_sprint_selection_index`): scans the entry vec for an entry whose `sprint_id_of` matches the card's `sprint_id`.

## Testing

- 11 inline domain tests in `sprint.rs` (bucket logic, `is_ended` semantics, sort ordering, board scoping, Cancelled exclusion).
- 16 inline TUI builder tests in `sprint_assign_list.rs` (header omission, mixed Completed+Ended in one section, skip-aware nav, scroll-offset math edge cases).
- 9 integration tests in `crates/kanban-tui/tests/sprint_assign_dialog_tests.rs`:
  - Active / Planned and Completed / Ended headers render conditionally.
  - Completed-in-green, Ended-in-red colour assertion via cell-level `Color` inspection.
  - `j` skips the Active / Planned header.
  - End-to-end assigning to a Completed sprint and an Ended sprint via `handle_assign_card_to_sprint_popup` + `Enter`.
  - Bulk variant parity (`handle_assign_multiple_cards_to_sprint_popup`).
  - Current-sprint marker preserves status colour in the lower section.
  - Scroll: 30-sprint board, navigate to the oldest (last in active section); rendered output still contains its name.
- Full workspace `cargo clippy --all-targets --workspace -- -D warnings` and `cargo fmt --check` clean.
- Release binary built and ready for manual smoke testing.