### PR TITLE
windows/fix-keyevent-handling

### DIFF
--- a/.changeset/windows-fix-keyevent-handling.md
+++ b/.changeset/windows-fix-keyevent-handling.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Fix duplicated key presses on Windows
+
+- Filter out non-Press KeyEventKind variants on Windows so each keystroke registers once instead of twice (Press + Release)
+- Resolves text input duplicating, backspace deleting two characters at a time, and the help menu not staying open
+- Linux behavior unchanged (compile-time cfg gate)

--- a/crates/kanban-tui/src/events.rs
+++ b/crates/kanban-tui/src/events.rs
@@ -1,6 +1,9 @@
-use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent};
 use std::time::Duration;
 use tokio::sync::mpsc;
+
+#[cfg(target_os = "windows")]
+use crossterm::event::KeyEventKind;
 
 #[derive(Debug, Clone)]
 pub enum Event {

--- a/crates/kanban-tui/src/events.rs
+++ b/crates/kanban-tui/src/events.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent};
+use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -34,6 +34,11 @@ impl EventHandler {
                         let mut had_key = false;
                         while event::poll(Duration::from_millis(0)).unwrap_or(false) {
                             if let Ok(CrosstermEvent::Key(key)) = event::read() {
+                                #[cfg(target_os = "windows")]
+                                if key.kind != KeyEventKind::Press {
+                                    continue;
+                                }
+
                                 had_key = true;
                                 if tx.send(Event::Key(key)).is_err() {
                                     break;


### PR DESCRIPTION
## What

Fixes duplicated key presses from being generated on Windows.

- Add Windows-only check to only respond to `crossterm::event::KeyEventKind::Press` events in `kanban-tui/src/events.rs`

## Why

I have a Windows-centric workflow (for the time being), and I happened to run into this issue after installing `kanban-cli 0.4.1`. I tried various troubleshooting steps that I'll leave out for brevity, but I found the root cause and decided it would be worth a time-boxed amount of effort to try and fix, as I'd like to be able to use this in Windows Terminal. (The issue affects all terminals in Windows.) The TUI would've been unusable for Windows users otherwise, as besides the fact that all text input gets duplicated (and backspace deletes 2 characters at a time), this also breaks the UI, such as not being able to keep the help menu open.

## How

Thankfully, this is a solved issue in crossterm (see the links below), and the logic of this project made it so that the fix only needed to be applied in one place. The fix is a Windows-only check using `cfg` to skip key events that aren't of kind `Press`.

https://github.com/veeso/tui-realm/issues/54
https://github.com/ratatui/ratatui/issues/347
https://docs.rs/crossterm/latest/crossterm/event/struct.KeyEvent.html

## Testing

I did not add any automatic tests, in part because I'm new to Rust and not sure how best to add such a specific thing with limited time, and in part because the change is most easily tested manually, which is what I did.

I started by testing and building and all the other necessary `cargo` commands using the latest commit of the `develop` branch. I tested using `cargo`/`rustc` 1.95.0 on both Windows and Linux (Debian 13).

### On Windows

I first ran tests on the `develop` branch to see if any tests were failing. Indeed, 2 tests fail on Windows:

failures:

```rust
---- config::tests::test_dto_from_config_with_data_file_shows_storage_fields stdout ----

thread 'config::tests::test_dto_from_config_with_data_file_shows_storage_fields' (38844) panicked at crates\kanban-service\src\config.rs:687:9:
got: Some("...coding\\kanban\\crates\\kanban-service\\kanban.json")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- config::tests::test_dto_from_explicit_config_preserves_values stdout ----

thread 'config::tests::test_dto_from_explicit_config_preserves_values' (31420) panicked at crates\kanban-service\src\config.rs:712:9:
got: Some("...\\coding\\kanban\\crates\\kanban-service\\kanban.sqlite")


failures:
    config::tests::test_dto_from_config_with_data_file_shows_storage_fields
    config::tests::test_dto_from_explicit_config_preserves_values

test result: FAILED. 73 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.40s
```

This is thankfully not the case on Linux (see below), but since I did not introduce these issues myself and it is out of scope for this fix, I decided to leave it be. This was only to establish a baseline so I knew I wouldn't be breaking any currently passing tests.

`cargo clippy` also yielded 13 warnings on the `develop` branch that I decided to leave be.

As for manual testing, I confirmed that the fix resulted in regular input behavior from key presses, including still functioning with holding down the same key to repeat it. As far as I can tell, I haven't broken any input behavior on Windows, and as it was completely broken prior to this, and given that it's a compile-time platform-specific conditional inclusion, it can only be an improvement without breaking behavior on Linux.

### On Linux

When running `cargo test`, there are 3 total ignored tests on both the `develop` branch and my branch, so I haven't introduced any new issues there.

*However*, I unfortunately introduced a new warning that got mentioned every time you ran `cargo build/run/clippy` or similar:

```rust
warning: unused import: `KeyEventKind`
 --> crates/kanban-tui/src/events.rs:1:74
  |
1 | use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind};
  |                                                                          ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: `kanban-tui` (lib) generated 1 warning (run `cargo fix --lib -p kanban-tui` to apply 1 suggestion)
```

My solution was to condition the use/import of `KeyEventKind` on another `cfg` check, but I had to add another commit for this, and hopefully the ordering and styling is agreeable to you (above and beyond the standard `cargo fmt` checks).

Either way, manual testing confirms that keypress behavior has not been modified on Linux, as should be expected.

And to be clear, that warning is no longer there on Linux. I just had to create a separate commit to specifically address the warning.

## Extra notes

- I generated a `changeset` for this, but it doesn't seem like I should include it in the PR message itself? Either way, I'm leaving it out of this initial message.
- The [CONTRIBUTING](https://github.com/fulsomenko/kanban/blob/develop/CONTRIBUTING.md#areas-for-contribution) guide does not explicitly mention that you accept fixes, but I'm hoping this one should be fine 😊
- There's an annoying issue where you can't create a kanban project with a specific filename. It seems you have to first create a board with just `kanban` and then rename `kanban.json` to what you want, before passing that new filename to the CLI. It could be that I just haven't explored it enough and should be doing it in a different way, but I wanted to bring it to your attention if it was an issue. I'm not going to create an issue for it or anything, and it's obviously out of scope of this PR. Just a small annoyance that could be worth putting on your own backlog if you have an issue with it yourself.
- Thank you for making this! I love the entire design philosophy behind it, and it fits my current use case pretty well (have to first use it more to make completely sure!)