### PR TITLE
KAN-418/fix kanban -V output drop Error prefix and stray trailing newline

### DIFF
--- a/.changeset/kan-418-fix-kanban-v-output.md
+++ b/.changeset/kan-418-fix-kanban-v-output.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Fix `kanban -V` / `--version` / `--help` output (KAN-418)
+
+- `kanban -V` and `kanban --version` now write to **stdout** with exit code **0** instead of stderr with exit 1, and no longer carry the spurious `Error:` prefix
+- The trailing blank line after the version output is gone — output ends in a single newline
+- `kanban --help` is fixed by the same path: stdout, exit 0, no `Error:` prefix
+- Real argument errors (e.g. unknown flags) are unaffected — they continue to surface on stderr with a non-zero exit code
+- The `commit:` line in `-V` output is still omitted when no commit hash is available at build time (e.g. `cargo install kanban` from crates.io)

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -93,7 +93,15 @@ where
             ))
         })
     });
-    let matches = cmd.try_get_matches_from_mut(args)?;
+    // For -V/--version and --help, clap returns Err with a kind that
+    // signals "print this and exit cleanly". `e.exit()` writes those to
+    // stdout with exit code 0; for real argument errors it writes to
+    // stderr with exit code 2. Without it the error propagates through
+    // main's generic eprintln!("Error: {e}") path, sending the version
+    // / help text to stderr with exit 1 and a doubled trailing newline.
+    let matches = cmd
+        .try_get_matches_from_mut(args)
+        .unwrap_or_else(|e| e.exit());
     let cli = Cli::from_arg_matches(&matches)?;
     Ok((cli, cmd))
 }

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -94,11 +94,13 @@ where
         })
     });
     // For -V/--version and --help, clap returns Err with a kind that
-    // signals "print this and exit cleanly". `e.exit()` writes those to
-    // stdout with exit code 0; for real argument errors it writes to
-    // stderr with exit code 2. Without it the error propagates through
-    // main's generic eprintln!("Error: {e}") path, sending the version
-    // / help text to stderr with exit 1 and a doubled trailing newline.
+    // signals "print this and exit cleanly". `e.exit()` dispatches
+    // per-kind internally — DisplayHelp / DisplayVersion go to stdout
+    // with exit code 0; real argument errors go to stderr with exit
+    // code 2. No `match e.kind()` needed here. Without it the error
+    // propagates through main's generic eprintln!("Error: {e}") path,
+    // sending the version / help text to stderr with exit 1 and a
+    // doubled trailing newline.
     let matches = cmd
         .try_get_matches_from_mut(args)
         .unwrap_or_else(|e| e.exit());

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -2420,11 +2420,27 @@ mod version_and_help_tests {
             .assert()
             .success();
         let output = assert.get_output();
-        assert!(output.stderr.is_empty());
+        assert!(
+            output.stderr.is_empty(),
+            "stderr must be empty for --version, got: {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
         let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.starts_with("kanban "));
-        assert!(!stdout.starts_with("Error:"));
-        assert!(stdout.ends_with('\n') && !stdout.ends_with("\n\n"));
+        assert!(
+            stdout.starts_with("kanban "),
+            "stdout must start with \"kanban \", got: {:?}",
+            stdout
+        );
+        assert!(
+            !stdout.starts_with("Error:"),
+            "stdout must not start with \"Error:\", got: {:?}",
+            stdout
+        );
+        assert!(
+            stdout.ends_with('\n') && !stdout.ends_with("\n\n"),
+            "stdout must end with exactly one newline, got: {:?}",
+            stdout
+        );
     }
 
     // --help must also reach stdout with exit 0 — same clap pitfall.

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -2368,3 +2368,105 @@ mod no_file_tests {
             .success();
     }
 }
+
+mod version_and_help_tests {
+    use super::*;
+
+    fn kanban_no_config(dir: &std::path::Path) -> Command {
+        let mut cmd = kanban();
+        cmd.current_dir(dir)
+            .env_remove("KANBAN_FILE")
+            .env_remove("XDG_CONFIG_HOME")
+            .env("HOME", dir);
+        cmd
+    }
+
+    // The version output must go to stdout with a clean exit, no
+    // "Error:" prefix, and a single trailing newline. Both -V and
+    // --version must behave identically.
+    #[test]
+    fn test_short_version_flag_writes_clean_to_stdout() {
+        let dir = tempdir().unwrap();
+        let assert = kanban_no_config(dir.path()).args(["-V"]).assert().success();
+        let output = assert.get_output();
+        assert!(
+            output.stderr.is_empty(),
+            "stderr must be empty for -V, got: {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.starts_with("kanban "),
+            "stdout must start with \"kanban \", got: {:?}",
+            stdout
+        );
+        assert!(
+            !stdout.starts_with("Error:"),
+            "stdout must not start with \"Error:\", got: {:?}",
+            stdout
+        );
+        assert!(
+            stdout.ends_with('\n') && !stdout.ends_with("\n\n"),
+            "stdout must end with exactly one newline, got: {:?}",
+            stdout
+        );
+    }
+
+    #[test]
+    fn test_long_version_flag_writes_clean_to_stdout() {
+        let dir = tempdir().unwrap();
+        let assert = kanban_no_config(dir.path())
+            .args(["--version"])
+            .assert()
+            .success();
+        let output = assert.get_output();
+        assert!(output.stderr.is_empty());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.starts_with("kanban "));
+        assert!(!stdout.starts_with("Error:"));
+        assert!(stdout.ends_with('\n') && !stdout.ends_with("\n\n"));
+    }
+
+    // --help must also reach stdout with exit 0 — same clap pitfall.
+    #[test]
+    fn test_help_flag_writes_clean_to_stdout() {
+        let dir = tempdir().unwrap();
+        let assert = kanban_no_config(dir.path())
+            .args(["--help"])
+            .assert()
+            .success();
+        let output = assert.get_output();
+        assert!(
+            output.stderr.is_empty(),
+            "stderr must be empty for --help, got: {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.starts_with("Error:"),
+            "--help stdout must not start with \"Error:\", got: {:?}",
+            stdout
+        );
+        assert!(
+            stdout.contains("Usage:"),
+            "--help stdout must include a Usage: section, got: {:?}",
+            stdout
+        );
+    }
+
+    // Real argument errors continue to be treated as errors.
+    #[test]
+    fn test_unknown_flag_still_errors_to_stderr() {
+        let dir = tempdir().unwrap();
+        let assert = kanban_no_config(dir.path())
+            .args(["--no-such-flag"])
+            .assert()
+            .failure();
+        let output = assert.get_output();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.is_empty(),
+            "an unknown flag must surface a stderr error message"
+        );
+    }
+}


### PR DESCRIPTION
Fixes `kanban -V` / `--version` / `--help` output:

- Removes the spurious `Error:` prefix from version and help output
- Removes the trailing blank line after the version string
- Routes help/version to stdout with exit 0; real argument errors keep going to stderr with a non-zero exit
- The `commit:` line is still omitted when `GIT_COMMIT_HASH` is unset at build time (e.g. unpinned `cargo install` from crates.io)

## What

`kanban -V` and `kanban --version` previously printed the version to **stderr** with exit code **1**, prefixed with `Error: `, and a doubled trailing newline. `kanban --help` had the same problem with its usage text. After this PR all three behave like a normal CLI tool: stdout, exit 0, single trailing newline, no `Error:` prefix.

Before:
```
$ kanban -V
Error: kanban 0.4.1
commit: 375ef74d08233d28ae7ec4987bf493cf8f25786a
                                ← extra blank line
$ echo $?
1
```

After:
```
$ kanban -V
kanban 0.4.1
commit: d6788674ea4bcbad46a31c4b58591063abaeb283
$ echo $?
0
```

## Why

clap's `--version` / `--help` returns a `clap::Error` with a kind that signals "print this and exit cleanly". `parse_cli` was propagating it via `?`, so the message reached `main.rs`'s generic `eprintln!("Error: {e}")` branch. The user-visible result is that every `kanban -V` looks like the binary just crashed.

This is a regression from KAN-3 (the original `--version` feature, which only added the flag and the version string but didn't notice the propagation issue). Fix is small but very visible — every user who runs `kanban -V` once hits this.

## How

`crates/kanban-cli/src/app.rs:96` — replace:

```rust
let matches = cmd.try_get_matches_from_mut(args)?;
```

with:

```rust
let matches = cmd
    .try_get_matches_from_mut(args)
    .unwrap_or_else(|e| e.exit());
```

`clap::Error::exit` is purpose-built: `DisplayHelp` / `DisplayVersion` go to stdout with exit code 0, real argument errors (`UnknownArgument`, `InvalidValue`, …) go to stderr with exit code 2, and clap's own newline handling is preserved (single trailing newline in both cases — no doubled newline from `eprintln!`).

The `commit:` line in `-V` output continues to be gated by the existing `has_git_commit` cfg in `crates/kanban-core/build.rs` + `crates/kanban-core/src/version.rs`. When `GIT_COMMIT_HASH` is unset and `git rev-parse HEAD` fails (e.g. `cargo install kanban` from crates.io into a non-git tree), the `commit:` line is omitted entirely. No change to that contract.

## Testing

New `version_and_help_tests` module in `crates/kanban-cli/tests/cli_integration.rs` (4 tests, TDD pair with the fix):

- `test_short_version_flag_writes_clean_to_stdout` — `-V` writes to stdout, exits 0, starts with `"kanban "`, does not start with `"Error:"`, ends in exactly one trailing newline, stderr is empty.
- `test_long_version_flag_writes_clean_to_stdout` — same for `--version`.
- `test_help_flag_writes_clean_to_stdout` — `--help` writes to stdout, exits 0, contains `"Usage:"`, no `"Error:"` prefix.
- `test_unknown_flag_still_errors_to_stderr` — `--no-such-flag` still surfaces a stderr error with non-zero exit code (regression guard for the real-error path).

Manual smoke test confirmed all four scenarios in a real terminal:

- `kanban -V` → stdout, exit 0
- `kanban --version` → stdout, exit 0
- `kanban --help` → stdout, exit 0, full usage
- `kanban --no-such-flag` → stderr, exit 2, clap-formatted error

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` all pass.