### PR TITLE
chore/rebalance-changeset-bump-levels-for-0.5.0

### DIFF
--- a/.changeset/kan-405-json-backend-should-not-persist-command-log-between-sessions.md
+++ b/.changeset/kan-405-json-backend-should-not-persist-command-log-between-sessions.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 Fix undo crash and strip command log from persistence (KAN-404, KAN-405)

--- a/.changeset/kan-406-sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section.md
+++ b/.changeset/kan-406-sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section.md
@@ -1,5 +1,5 @@
 ---
-bump: minor
+bump: patch
 ---
 
 Group sprints by status in the sprint assignment dialog (KAN-406)


### PR DESCRIPTION
Rebalance which changeset carries the minor bump for the upcoming 0.5.0 release (PR #251).

- KAN-405 → patch is upgraded to **minor**
- KAN-406 → minor is downgraded to **patch**

Net release bump is unchanged (still 0.4.1 → 0.5.0), but the rationale now matches what users actually need to know before upgrading.

## What

- `.changeset/kan-405-…md`: `bump: patch` → `bump: minor`
- `.changeset/kan-406-…md`: `bump: minor` → `bump: patch`

## Why

Reviewing the release PR (#251) flagged that the bump levels didn't reflect actual user impact:

- **KAN-405** (in-session undo + strip command log) drops legacy `command_log` / `undo_state` tables on first SQLite open. Downgrading to a pre-0.5.0 build against an upgraded SQLite database is **not supported** — that's the actual breaking-ish change driving 0.4.1 → 0.5.0. It belongs on a minor.
- **KAN-406** (sprint assignment dialog grouping) is mostly a UX rearrangement of an existing dialog. The only genuinely new capability is retrospective assignment to Completed/Ended sprints, which is small enough to ride a patch.

The previous labelling — KAN-406 as the lone minor justifier — meant the release was tagged minor for the smallest user-visible change, while the actual one-way data migration in KAN-405 was buried under "patch". Reviewers reading #251 would have to look elsewhere to see the upgrade-direction concern.

## How

Two single-line frontmatter edits in `.changeset/`. No code changes, no test changes.

## Testing

- `cargo test --workspace` — unaffected (no source changes).
- The release workflow's changeset aggregator picks up the new bump levels on the next `develop` → `master` merge (PR #251).
- After this lands and #251 merges, the release artefact at 0.5.0 will:
  - GitHub release notes will list KAN-405 as the minor change driving the bump.
  - KAN-406 will be in the patch list alongside KAN-330, KAN-332, KAN-397, KAN-418, and the Windows fix.