### PR TITLE
KAN-419 fix(tui): show sprint history on cards with >= 1 sprint assigned

### DIFF
--- a/.changeset/kan-419-show-sprint-history-on-cards-with-1-plus-sprint-assigned.md
+++ b/.changeset/kan-419-show-sprint-history-on-cards-with-1-plus-sprint-assigned.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Show sprint history on cards with 1+ sprint assigned (KAN-419)
+
+- Sprint history box now appears in the card details view as soon as a card has 1 or more sprints assigned, instead of requiring 2+ sprints
+- This makes it easier to see what sprints a card is on without needing to view multiple sprint transitions

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -69,7 +69,7 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
         let card = &card;
         if let Some(board_idx) = app.selection.active_board_index {
             if let Some(board) = app.model.boards().get(board_idx) {
-                let has_sprint_logs = card.sprint_logs.len() > 1;
+                let has_sprint_logs = !card.sprint_logs.is_empty();
                 let card_id = card.id;
 
                 // Get parent and child information


### PR DESCRIPTION
Show sprint history box in card details view when a card has 1 or more sprints assigned:

- Sprint history box now displays as soon as a card has 1+ sprint assigned, instead of requiring 2+ sprints
- Makes it easier to see what sprints a card is on without needing multiple sprint transitions

**What**: Changed the visibility condition for the sprint history box from `> 1` to `>= 1` sprint logs.

**Why**: Users couldn't see sprint history information for cards on their first sprint assignment, making it difficult to track which sprints a card is associated with in the card details view.

**How**: Modified `crates/kanban-tui/src/ui/card_detail.rs:72` to use `!card.sprint_logs.is_empty()` instead of `card.sprint_logs.len() > 1`.

**Testing**: `cargo test --workspace` passes cleanly, `cargo clippy --all-targets --all-features -- -D warnings` passes, and `cargo fmt --all` verified formatting.