### PR TITLE
KAN-420 chore: bump minimum Rust version to 1.74

### DIFF
--- a/.changeset/kan-420-bump-minimum-rust-version.md
+++ b/.changeset/kan-420-bump-minimum-rust-version.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Bump minimum Rust version to 1.74 (KAN-420)
+
+- `CONTRIBUTING.md` prerequisites now correctly state Rust 1.74+ instead of 1.70+
+- `rust-version = "1.74"` added to the workspace `Cargo.toml` so `cargo` enforces the minimum at build time
+- The actual floor is set by `ratatui 0.29` and `clap 4.5`, both of which declare a 1.74 MSRV

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for considering contributing to Kanban! This document provides guideli
 
 ### Prerequisites
 
-- Rust 1.70+ with cargo
+- Rust 1.74+ with cargo
 - Nix (recommended for reproducible environment)
 
 ### Getting Started

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 [workspace.package]
 version = "0.4.1"
 edition = "2021"
+rust-version = "1.74"
 authors = ["Max Emil Yoon Blomstervall"]
 license = "Apache-2.0"
 repository = "https://github.com/fulsomenko/kanban"


### PR DESCRIPTION
Correct the documented and enforced minimum Rust version from 1.70 to 1.74:

- `CONTRIBUTING.md` prerequisites updated from `Rust 1.70+` to `Rust 1.74+`
- `rust-version = "1.74"` added to `[workspace.package]` in `Cargo.toml` so `cargo` rejects builds on older toolchains at the resolver level

**What**: The stated minimum Rust version was 1.70, but the actual floor is 1.74, set by `ratatui 0.29` and `clap 4.5` (both declare a 1.74 MSRV). This PR aligns the documentation and the workspace manifest with reality.

**Why**: Contributors installing an older toolchain would hit cryptic dependency errors instead of a clear "this toolchain is too old" message. Setting `rust-version` in the manifest surfaces that error immediately and unambiguously.

**How**: One-line change to `CONTRIBUTING.md` and one field added to `[workspace.package]` in the root `Cargo.toml`. No code changes.

**Testing**: `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all` (no changes).