### PR TITLE
KAN-421 feat(tui): add raw key event trace logging to EventHandler

### DIFF
--- a/.changeset/kan-421-add-build-time-debug-info-for-target-os-and-cfg-flags.md
+++ b/.changeset/kan-421-add-build-time-debug-info-for-target-os-and-cfg-flags.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Add platform debug logging to EventHandler (KAN-421)
+
+- Setting `RUST_LOG=debug` or `KANBAN_DEBUG_LOG` now logs the build target (OS, arch, family, endian, pointer width) once at startup when the event loop initialises
+- Setting `RUST_LOG=trace` logs every raw key event (code, kind, modifiers) before the Windows key filter runs — on Windows this captures both Press and Release events, which is the exact signal needed to diagnose key-doubling issues

--- a/.changeset/kan-421-add-build-time-debug-info-for-target-os-and-cfg-flags.md
+++ b/.changeset/kan-421-add-build-time-debug-info-for-target-os-and-cfg-flags.md
@@ -2,7 +2,6 @@
 bump: patch
 ---
 
-Add platform debug logging to EventHandler (KAN-421)
+Add raw key event trace logging to EventHandler (KAN-421)
 
-- Setting `RUST_LOG=debug` or `KANBAN_DEBUG_LOG` now logs the build target (OS, arch, family, endian, pointer width) once at startup when the event loop initialises
 - Setting `RUST_LOG=trace` logs every raw key event (code, kind, modifiers) before the Windows key filter runs — on Windows this captures both Press and Release events, which is the exact signal needed to diagnose key-doubling issues

--- a/crates/kanban-tui/src/events.rs
+++ b/crates/kanban-tui/src/events.rs
@@ -24,19 +24,6 @@ impl Default for EventHandler {
 
 impl EventHandler {
     pub fn new() -> Self {
-        tracing::debug!(
-            target_os = std::env::consts::OS,
-            target_arch = std::env::consts::ARCH,
-            target_family = std::env::consts::FAMILY,
-            target_endian = if cfg!(target_endian = "little") {
-                "little"
-            } else {
-                "big"
-            },
-            target_pointer_width = std::mem::size_of::<usize>() * 8,
-            "EventHandler starting"
-        );
-
         let (tx, rx) = mpsc::unbounded_channel();
         let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel();
 

--- a/crates/kanban-tui/src/events.rs
+++ b/crates/kanban-tui/src/events.rs
@@ -24,6 +24,19 @@ impl Default for EventHandler {
 
 impl EventHandler {
     pub fn new() -> Self {
+        tracing::debug!(
+            target_os = std::env::consts::OS,
+            target_arch = std::env::consts::ARCH,
+            target_family = std::env::consts::FAMILY,
+            target_endian = if cfg!(target_endian = "little") {
+                "little"
+            } else {
+                "big"
+            },
+            target_pointer_width = std::mem::size_of::<usize>() * 8,
+            "EventHandler starting"
+        );
+
         let (tx, rx) = mpsc::unbounded_channel();
         let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel();
 
@@ -37,6 +50,7 @@ impl EventHandler {
                         let mut had_key = false;
                         while event::poll(Duration::from_millis(0)).unwrap_or(false) {
                             if let Ok(CrosstermEvent::Key(key)) = event::read() {
+                                tracing::trace!(code = ?key.code, kind = ?key.kind, modifiers = ?key.modifiers, "raw key event");
                                 #[cfg(target_os = "windows")]
                                 if key.kind != KeyEventKind::Press {
                                     continue;


### PR DESCRIPTION
Add a `trace!` log line per raw key event in the TUI event loop to aid cross-platform key-handling debugging:

- `tracing::trace!` fires immediately after `event::read()` succeeds, before the `#[cfg(target_os = "windows")]` filter — capturing `code`, `kind` (Press/Release/Repeat), and `modifiers` for every raw crossterm event
- On Windows this records both `Press` and `Release` events before the filter drops `Release`, making key-doubling bugs like the one fixed in #247 immediately self-diagnosing from a log file
- On Linux only `Press` events appear, providing a baseline for comparison

**What**: One `trace!` call in `crates/kanban-tui/src/events.rs`, placed before the Windows key filter.

**Why**: PR #247 (Windows key-doubling fix) was diagnosed by reading crossterm docs and external issue trackers. With this log, a developer can reproduce the problem with `RUST_LOG=trace` and see the Press+Release pair directly in the log output.

**How**: `tracing::trace!(code = ?key.code, kind = ?key.kind, modifiers = ?key.modifiers, "raw key event")` — placed at the earliest point after a key event is read, before any filtering.

**Note**: A startup platform `debug!` log (OS, arch, etc.) was also prototyped in this branch but moved out of scope — it belongs in a shared tracing init root, tracked in KAN-422.

**Testing**: `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean).

---

## How to use these logs

### Capturing key event traces

Key events are logged at `trace` level. The TUI suppresses all output by default, so you need both `RUST_LOG=trace` and `KANBAN_DEBUG_LOG` to capture them:

```bash
RUST_LOG=trace KANBAN_DEBUG_LOG=/tmp/kanban.log kanban my-board.json
```

Use the TUI normally, then exit. Open `/tmp/kanban.log` and look for `raw key event` lines:

```
2026-05-11T18:37:00Z TRACE kanban_tui::events: raw key event code=Char('j') kind=Press modifiers=NONE
```

### Diagnosing Windows key-doubling (PR #247 class of bugs)

On a correctly patched Windows build, each physical keypress produces one trace line:

```
TRACE kanban_tui::events: raw key event code=Char('j') kind=Press modifiers=NONE
```

On an affected build (filter missing or broken), you see two:

```
TRACE kanban_tui::events: raw key event code=Char('j') kind=Press  modifiers=NONE
TRACE kanban_tui::events: raw key event code=Char('j') kind=Release modifiers=NONE
```

The `Release` line is the signal — it means the filter is not discarding non-Press events, and the app will register every key twice.

### Filtering the log

```bash
# Key events only
grep "raw key event" /tmp/kanban.log

# See what kinds were received (should be Press-only on a healthy build)
grep "raw key event" /tmp/kanban.log | grep -o 'kind=[^ ]*' | sort | uniq -c

# Debug level only (no trace noise) — startup/persistence logs
KANBAN_DEBUG_LOG=/tmp/kanban.log kanban my-board.json
grep -v "raw key event" /tmp/kanban.log
```

### Log levels reference

| `RUST_LOG` | What you see |
|---|---|
| (unset) | `warn` and above only |
| `debug` | persistence, file-watch, save events |
| `trace` | everything above + raw key events (every keypress) |