### PR TITLE
KAN-426 fix(tui): make KeyEventKind::Press filter unconditional across all platforms

### DIFF
--- a/.changeset/kan-426-replace-cfg-gated-keyeventkind-filter.md
+++ b/.changeset/kan-426-replace-cfg-gated-keyeventkind-filter.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Make KeyEventKind::Press filter unconditional across all platforms (KAN-426)
+
+- The Windows-only `#[cfg(target_os = "windows")]` gate on the key event filter is removed — the filter now runs on all platforms
+- On Linux/macOS crossterm only emits `Press` events in standard terminal mode, so the filter is a no-op there; behaviour is unchanged on all platforms
+- Removes platform-specific code divergence and makes the filter testable on any OS

--- a/crates/kanban-tui/src/events.rs
+++ b/crates/kanban-tui/src/events.rs
@@ -1,9 +1,6 @@
-use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent};
+use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind};
 use std::time::Duration;
 use tokio::sync::mpsc;
-
-#[cfg(target_os = "windows")]
-use crossterm::event::KeyEventKind;
 
 #[derive(Debug, Clone)]
 pub enum Event {
@@ -38,7 +35,6 @@ impl EventHandler {
                         while event::poll(Duration::from_millis(0)).unwrap_or(false) {
                             if let Ok(CrosstermEvent::Key(key)) = event::read() {
                                 tracing::trace!(code = ?key.code, kind = ?key.kind, modifiers = ?key.modifiers, "raw key event");
-                                #[cfg(target_os = "windows")]
                                 if key.kind != KeyEventKind::Press {
                                     continue;
                                 }


### PR DESCRIPTION
Remove the `#[cfg(target_os = "windows")]` gates from the `KeyEventKind::Press` filter in `EventHandler`:

- Merge `KeyEventKind` into the existing crossterm import on line 1, removing the `#[cfg]`-gated separate import
- Remove the `#[cfg(target_os = "windows")]` attribute from the filter block, making it unconditional

**What**: The key event filter that drops non-`Press` events (Release, Repeat) now runs on every platform, not only Windows.

**Why**: The `#[cfg]` gate was added in #247 to fix key-doubling on Windows. However, the filter is a no-op on Linux/macOS in standard terminal mode — crossterm only emits `KeyEventKind::Press` there unless the kitty keyboard protocol (`PushKeyboardEnhancementFlags`) is active, which this project does not use. The guard created unnecessary platform divergence and made the filter untestable on Linux/macOS.

**How**: Two-line change in `crates/kanban-tui/src/events.rs`: fold `KeyEventKind` into the existing import and drop the `#[cfg]` attribute from the `if` guard. No logic added or removed.

**Testing**: `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean, no unused-import warnings).