### PR TITLE
KAN-434 refactor(service): collapse singular card methods into shorthands over plural

### DIFF
--- a/.changeset/kan-434-collapse-singular-service-methods.md
+++ b/.changeset/kan-434-collapse-singular-service-methods.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Service layer cleanup: singular card mutations now share orchestration with their batch counterparts (KAN-434)
+
+- `update_card` is a one-line shorthand over `update_cards(vec![(id, updates)])`. The status ↔ completion-column auto-sync now fires symmetrically on `update_card` as well — a column-only update into the completion column auto-sets `status=Done`, and a column-only update out of it clears `Done`. Previously only status-driven updates triggered the column move, so column-only callers silently missed the sync. No production caller exercised that path before this release, so existing behaviour is preserved and the gap is closed.
+- `assign_card_to_sprint` is a one-line shorthand over `assign_cards_to_sprint(vec![card_id], sprint_id)`. Behaviour is unchanged — both implementations dispatched the same underlying domain command.
+- Both singulars retain their original public signature (`KanbanResult<Card>`) and trailing `get_card` for the return value. CLI, MCP, and TUI delegations are untouched.
+
+The design principle: **singular builds on plural, not the other way around.** The atomic-transaction infrastructure (`KanbanContext::execute(Vec<Command>)`) is the fundamental unit at the service layer; the per-card singular is a convenience wrapper for the batch-of-one case. This keeps orchestration in one place — when future tweaks land (e.g. the per-board auto-sync opt-out tracked as KAN-432), they only need to touch the plural.

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -888,11 +888,6 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
-        // Singular is a shorthand over the plural — `update_cards` owns the
-        // status ↔ completion-column orchestration, the per-batch position
-        // offsets, and the future config-driven opt-out (KAN-432). Keeping
-        // the singular as a one-line wrapper guarantees that any tweak lands
-        // in exactly one place.
         self.update_cards(vec![(id, updates)])?;
         self.get_card(id)?
             .ok_or_else(|| KanbanError::not_found("card", id))
@@ -985,10 +980,6 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
-        // Singular is a shorthand over the plural. Both dispatched the same
-        // `AssignCardsToSprint { ids: vec![card_id], sprint_id }` command;
-        // keeping the singular as a one-line wrapper means any orchestration
-        // change (logging, sprint-state validation, etc.) lands in one place.
         self.assign_cards_to_sprint(vec![card_id], sprint_id)?;
         self.get_card(card_id)?
             .ok_or_else(|| KanbanError::not_found("card", card_id))

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -888,29 +888,12 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
-        use kanban_domain::commands::{MoveCard, UpdateCard};
-
-        // Decide whether we need to chain a column move *before* moving `updates`
-        // into the UpdateCard command, so we don't have to clone the struct.
-        let chained_move = match (updates.status, &updates.column_id) {
-            (Some(new_status), None) => self.compute_target_column_for_status(id, new_status)?,
-            _ => None,
-        };
-
-        let mut batch = vec![Command::Card(CardCommand::Update(UpdateCard {
-            card_id: id,
-            updates,
-        }))];
-
-        if let Some((target_col, pos)) = chained_move {
-            batch.push(Command::Card(CardCommand::Move(MoveCard {
-                card_id: id,
-                new_column_id: target_col,
-                new_position: pos,
-            })));
-        }
-
-        self.execute(batch)?;
+        // Singular is a shorthand over the plural — `update_cards` owns the
+        // status ↔ completion-column orchestration, the per-batch position
+        // offsets, and the future config-driven opt-out (KAN-432). Keeping
+        // the singular as a one-line wrapper guarantees that any tweak lands
+        // in exactly one place.
+        self.update_cards(vec![(id, updates)])?;
         self.get_card(id)?
             .ok_or_else(|| KanbanError::not_found("card", id))
     }

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -985,12 +985,11 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
-        use kanban_domain::commands::AssignCardsToSprint;
-        let cmd = Command::Card(CardCommand::AssignToSprint(AssignCardsToSprint {
-            ids: vec![card_id],
-            sprint_id,
-        }));
-        self.execute(vec![cmd])?;
+        // Singular is a shorthand over the plural. Both dispatched the same
+        // `AssignCardsToSprint { ids: vec![card_id], sprint_id }` command;
+        // keeping the singular as a one-line wrapper means any orchestration
+        // change (logging, sprint-state validation, etc.) lands in one place.
+        self.assign_cards_to_sprint(vec![card_id], sprint_id)?;
         self.get_card(card_id)?
             .ok_or_else(|| KanbanError::not_found("card", card_id))
     }

--- a/crates/kanban-service/tests/completion_sync.rs
+++ b/crates/kanban-service/tests/completion_sync.rs
@@ -193,6 +193,93 @@ async fn test_update_card_with_explicit_column_id_and_status_respects_both() -> 
     Ok(())
 }
 
+// --- KAN-434: column-only update_card must auto-sync status, mirroring update_cards ---
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_card_column_only_to_completion_column_sets_status_done() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let fx = build_fixture(&mut ctx, true).await;
+
+    // Column-only update, no status pinned. Card is currently Todo in Backlog.
+    let updated = ctx.update_card(
+        fx.card_id,
+        CardUpdate {
+            column_id: Some(fx.done_id),
+            ..Default::default()
+        },
+    )?;
+
+    assert_eq!(updated.column_id, fx.done_id);
+    assert_eq!(
+        updated.status,
+        CardStatus::Done,
+        "column-only update_card into completion column must auto-set status=Done"
+    );
+    assert!(updated.completed_at.is_some());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_card_column_only_away_from_completion_clears_done() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let fx = build_fixture(&mut ctx, true).await;
+
+    // Pre-state: card in completion column with status=Done.
+    ctx.update_card(
+        fx.card_id,
+        CardUpdate {
+            status: Some(CardStatus::Done),
+            ..Default::default()
+        },
+    )?;
+    let pre = ctx.get_card(fx.card_id)?.unwrap();
+    assert_eq!(pre.column_id, fx.done_id);
+    assert_eq!(pre.status, CardStatus::Done);
+
+    // Column-only update moving it back to Backlog. No status pinned.
+    let moved = ctx.update_card(
+        fx.card_id,
+        CardUpdate {
+            column_id: Some(fx.backlog_id),
+            ..Default::default()
+        },
+    )?;
+
+    assert_eq!(moved.column_id, fx.backlog_id);
+    assert_eq!(
+        moved.status,
+        CardStatus::Todo,
+        "column-only update_card away from completion column must clear Done"
+    );
+    assert!(moved.completed_at.is_none());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_card_column_only_to_non_completion_column_no_status_change() -> KanbanResult<()>
+{
+    let mut ctx = make_ctx().await;
+    let fx = build_fixture(&mut ctx, true).await;
+
+    // Move from Backlog → InProgress (neither side is the completion column).
+    let updated = ctx.update_card(
+        fx.card_id,
+        CardUpdate {
+            column_id: Some(fx.progress_id),
+            ..Default::default()
+        },
+    )?;
+
+    assert_eq!(updated.column_id, fx.progress_id);
+    assert_eq!(
+        updated.status,
+        CardStatus::Todo,
+        "moving between non-completion columns must not flip status"
+    );
+    assert!(updated.completed_at.is_none());
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_move_cards_batch_to_completion_column_sets_status_done_on_all() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;


### PR DESCRIPTION
Collapse `KanbanContext::update_card` and `assign_card_to_sprint` into one-line shorthands over their plural counterparts, closing the column-only auto-sync gap on `update_card`:

- `update_card(id, updates)` now delegates to `update_cards(vec![(id, updates)])` + a trailing `get_card`. The asymmetric `match (status, &column_id)` block is gone.
- `assign_card_to_sprint(card_id, sprint_id)` now delegates to `assign_cards_to_sprint(vec![card_id], sprint_id)` + a trailing `get_card`. Pure mechanical reduction — both implementations dispatched the same `AssignCardsToSprint` domain command.
- `archive_card` is already a shorthand over `archive_cards` — left as-is.
- `move_card` is out of scope: `move_cards` has no per-card position parameter, and routing through `update_cards` would bypass `MoveCard::execute`'s WIP-limit check. Tracked as a follow-up.

**What**: The service layer had three card-mutation singulars with their own ad-hoc batch construction sitting next to their plural counterparts that already did the same orchestration (better, in the case of `update_cards`). This PR makes `update_card` and `assign_card_to_sprint` shorthand wrappers over the plural, and pins down the design principle in the codebase: singular builds on plural, not the other way around.

**Why**: The duplicated orchestration in `update_card` carried a behavioural gap — its `match (status, &column_id)` arm only auto-synced `status → column`, never `column → status`. A column-only call to `update_card` silently missed the auto-sync that `update_cards` performs for the same payload. The same applied to `assign_card_to_sprint` to a lesser degree: identical orchestration, two places to maintain. Future tweaks (e.g. KAN-432's per-board auto-sync opt-out) need to land in exactly one place — the plural — instead of being threaded through every singular.

**How**: Singular methods now construct a one-element `vec![]`, call the plural, and trail with `get_card(id)` to satisfy the `KanbanResult<Card>` return type. `KanbanContext::execute(Vec<Command>)` remains the atomic-transaction unit at the service layer; singular is convenience for the batch-of-one case. The plural owns the per-batch position offsets and the symmetric status ↔ completion column auto-sync, so the singular inherits both for free.

Behaviour change for `update_card`: a column-only call (`CardUpdate { column_id: Some(col), .. }`) now triggers the same column → status auto-sync that `update_cards` does. No current production caller exercised this path (TUI uses status only or both fields; CLI/MCP forward to `move_card` for column changes), so this is a gap closure rather than a break.

**Testing**: `cargo test -p kanban-service --test completion_sync test_update_card_column_only` (3 new tests — to-completion, away-from-completion, non-boundary move; the first two were red against `develop` and turn green after the `update_card` collapse); `cargo test --workspace` (1363 passing, 0 failing — the existing `assign_card_to_sprint` coverage in `kanban-mcp/tests/integration.rs`, `kanban-service/tests/carry_over.rs`, and `kanban-service/src/test_helpers/contract/{card,lifecycle,sprint_log,archive}.rs` is the safety net for the mechanical reduction); `cargo clippy --all-targets --all-features -- -D warnings` (clean); `cargo fmt --check` (clean).