### PR TITLE
KAN-403 fix(tui): selector jumps to newly created card

### DIFF
--- a/.changeset/kan-403-regression-card-selector-newly-created-card.md
+++ b/.changeset/kan-403-regression-card-selector-newly-created-card.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+After creating a new card in the TUI, the selector now jumps to the new card immediately — so the very next action (edit, move, mark complete, open details) lands on the card you just made. Previously, when another card was already selected, the selector stayed on that prior card and the next keystroke acted on it instead.
+
+This restores the demo-recording flow (Beat 2 creates a card, Beat 3 edits it) and matches the pre-regression behaviour.

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -384,6 +384,10 @@ impl App {
                     }
                 }
 
+                // Refresh the view-layer task list so the new card's ID is
+                // present before we try to select it. Without this the
+                // selection silently stays on the prior card (KAN-403).
+                self.prepare_frame();
                 self.select_card_by_id(card_id);
             }
         }

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -84,6 +84,40 @@ fn test_create_card_selects_newly_created_card() {
 }
 
 #[test]
+fn test_create_card_selects_newly_created_card_when_prior_selection_exists() {
+    // KAN-403 regression: when a card was already selected, creating a new
+    // card must move the selector to the new card, not stay on the prior one.
+    let mut app = setup_app_with_board();
+
+    app.focus.active = Focus::Cards;
+    app.input.set("First".to_string());
+    app.create_card();
+    app.prepare_frame();
+    let first_id = app
+        .get_selected_card_id()
+        .expect("first card should be selected after creation");
+
+    app.input.set("Second".to_string());
+    app.create_card();
+    app.prepare_frame();
+
+    let cards = app.model.cards();
+    let second = cards
+        .iter()
+        .find(|c| c.title == "Second")
+        .expect("second card exists in model");
+    assert_ne!(second.id, first_id);
+
+    let selected = app
+        .get_selected_card_id()
+        .expect("a card is selected after the second creation");
+    assert_eq!(
+        selected, second.id,
+        "selection must jump to the newly created card, not stay on the prior one"
+    );
+}
+
+#[test]
 fn test_create_card_auto_completes_in_done_column() {
     let mut app = App::test_default();
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();


### PR DESCRIPTION
After creating a new card in the TUI, the selector now jumps to the new card immediately. Previously, when a card was already selected, the selector stayed on that prior card and the next keystroke (edit, move, mark complete, open details) acted on the wrong one.

- `crates/kanban-tui/src/handlers/card_handlers.rs::create_card` calls `self.prepare_frame()` before `self.select_card_by_id(card_id)` so the active task list contains the new card's ID at selection time
- Selection logic stays fully inside the TUI crate — no service or domain changes
- New `test_create_card_selects_newly_created_card_when_prior_selection_exists` in `crates/kanban-tui/tests/stale_model_regression_tests.rs` exercises the broken-in-production path

**What**: A one-line fix in the `create_card` TUI handler plus a regression test that pins down the failure mode the existing test missed.

**Why**: `select_card_by_id` was being called against a view-layer task list (`CardList.cards`) that had not yet been refreshed to include the just-created card. The lookup failed silently. On the next render-loop `prepare_frame()`, `CardList::update_cards` re-applied the saved `current_card` (the prior selection) — so the selector stayed put. The existing `test_create_card_selects_newly_created_card` only passed because it created the *first* card in an empty column, where `update_item_count`'s 0 → 1 auto-pick happens to land on index 0 (the new card). It never exercised the production scenario where a prior selection clobbers the new card. Blocks the demo recording — Beat 2 creates a card, Beat 3 edits it, edit lands on the previous card.

**How**: Hoist one `self.prepare_frame()` call into `create_card` after `execute_command` and before `select_card_by_id`. That call loads the latest snapshot into the model, rebuilds the active task list via `refresh_task_lists`, and propagates the change to the card-list component. The new card's ID is now in the task list, so `select_card_by_id` finds it. The next render-loop `prepare_frame` is now redundant but harmless. Selection composition stays inside the TUI app — `select_card_by_id` and `prepare_frame` are both `impl App` methods in `kanban-tui`; nothing leaks to the service or domain layers.

**Testing**: `cargo test -p kanban-tui --test stale_model_regression_tests test_create_card_` (3/3 pass: existing tests untouched, new regression test green after the fix); `cargo test --workspace` (no regressions); `cargo clippy --all-targets --all-features -- -D warnings` (clean); `cargo fmt --check` (clean).