### PR TITLE
KAN-435 fix(tui): sprint-detail card lists scroll and reach action parity

### DIFF
--- a/.changeset/kan-435-sprint-detail-card-lists.md
+++ b/.changeset/kan-435-sprint-detail-card-lists.md
@@ -1,0 +1,15 @@
+---
+bump: patch
+---
+
+The sprint-detail card lists now behave more like the main-board lists:
+
+- **Scrolling works.** Pressing `j` / `k` past the visible viewport in either the Uncompleted or Completed panel scrolls the list to keep the selected card on-screen. Previously the selection moved off-screen and got truncated. Both panels scroll independently of each other.
+- **Multi-select works on the Completed panel.** `v` and `V` now toggle multi-selection on completed cards in addition to uncompleted ones. Batch actions you initiate from sprint detail can target either panel.
+- **Movement actions are enabled on both panels.** Action configs are aligned — every card action available on the main-board list is also available here.
+- **Sort order applies on populate.** Opening a sprint detail with a non-default board sort (e.g. priority, due date) now shows both panels already ordered the way the main board orders. Previously the lists used raw iteration order until you opened the sort dialog manually.
+
+Known gaps remaining (tracked as follow-up cards):
+
+- Search filter (`/` query) does not yet propagate to sprint-detail panels on every frame — only on initial populate.
+- Toggling a card from Completed back to Uncompleted in sprint detail still routes to the second-to-last board column (KAN-394 default) rather than the card's pre-completion column. The original-column tracking the user proposed is a separate change.

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1471,12 +1471,6 @@ impl App {
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
-        // Route the panels through `CardQueryBuilder` when we have a resolvable
-        // board so the board's active sort field + order applies on populate,
-        // matching the main-board card list. Falls back to the raw
-        // `partition_sprint_cards` helper if no board is active. We
-        // post-partition by completion status since the builder doesn't
-        // filter on it directly.
         let cards = self.model.cards();
         let board_opt = self
             .selection

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1471,20 +1471,54 @@ impl App {
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
+        // Route the panels through `CardQueryBuilder` when we have a resolvable
+        // board so the board's active sort field + order applies on populate,
+        // matching the main-board card list. Falls back to the raw
+        // `partition_sprint_cards` helper if no board is active. We
+        // post-partition by completion status since the builder doesn't
+        // filter on it directly.
         let cards = self.model.cards();
-        let (uncompleted_ids, completed_ids) = partition_sprint_cards(sprint_id, cards);
+        let board_opt = self
+            .selection
+            .active_board_index
+            .and_then(|i| self.model.boards().get(i));
+
+        let (uncompleted_ids, completed_ids) = if let Some(board) = board_opt {
+            let columns = self.model.columns();
+            let sprints = self.model.sprints();
+            let sorted_sprint_ids =
+                kanban_domain::CardQueryBuilder::new(cards, columns, sprints, board)
+                    .in_sprints(std::iter::once(sprint_id))
+                    .execute();
+            let mut unc = Vec::new();
+            let mut comp = Vec::new();
+            for id in sorted_sprint_ids {
+                if let Some(card) = cards.iter().find(|c| c.id == id) {
+                    if card.is_completed() {
+                        comp.push(id);
+                    } else {
+                        unc.push(id);
+                    }
+                }
+            }
+            (unc, comp)
+        } else {
+            partition_sprint_cards(sprint_id, cards)
+        };
 
         self.sprint_view
             .uncompleted_cards
-            .update_cards(uncompleted_ids);
-        self.sprint_view.completed_cards.update_cards(completed_ids);
+            .update_cards(uncompleted_ids.clone());
+        self.sprint_view
+            .completed_cards
+            .update_cards(completed_ids.clone());
 
         self.sprint_view
             .uncompleted_component
-            .update_cards(self.sprint_view.uncompleted_cards.cards.clone());
+            .update_cards(uncompleted_ids);
         self.sprint_view
             .completed_component
-            .update_cards(self.sprint_view.completed_cards.cards.clone());
+            .update_cards(completed_ids);
 
         // Default to uncompleted panel
         self.sprint_view.panel = SprintTaskPanel::Uncompleted;

--- a/crates/kanban-tui/src/app/sprint_view.rs
+++ b/crates/kanban-tui/src/app/sprint_view.rs
@@ -35,3 +35,15 @@ impl Default for SprintViewState {
         }
     }
 }
+
+impl SprintViewState {
+    /// Bring both panel scroll offsets back in sync with their selections.
+    /// Called once per frame by the sprint-detail renderer with the actual
+    /// viewport heights derived from the rendered area.
+    pub fn sync_scroll(&mut self, uncompleted_viewport: usize, completed_viewport: usize) {
+        self.uncompleted_cards
+            .ensure_selected_visible(uncompleted_viewport);
+        self.completed_cards
+            .ensure_selected_visible(completed_viewport);
+    }
+}

--- a/crates/kanban-tui/src/app/sprint_view.rs
+++ b/crates/kanban-tui/src/app/sprint_view.rs
@@ -17,9 +17,6 @@ pub struct SprintViewState {
 
 impl Default for SprintViewState {
     fn default() -> Self {
-        // Both panels share the same full action set as the main-board card list
-        // (KAN-435). Panel-switching keybindings (h/l) are intercepted by the
-        // sprint-detail key handler before they reach the component.
         Self {
             panel: SprintTaskPanel::Uncompleted,
             uncompleted_cards: CardList::new(CardListId::All),
@@ -37,9 +34,6 @@ impl Default for SprintViewState {
 }
 
 impl SprintViewState {
-    /// Bring both panel scroll offsets back in sync with their selections.
-    /// Called once per frame by the sprint-detail renderer with the actual
-    /// viewport heights derived from the rendered area.
     pub fn sync_scroll(&mut self, uncompleted_viewport: usize, completed_viewport: usize) {
         self.uncompleted_cards
             .ensure_selected_visible(uncompleted_viewport);

--- a/crates/kanban-tui/src/app/sprint_view.rs
+++ b/crates/kanban-tui/src/app/sprint_view.rs
@@ -1,5 +1,5 @@
 use crate::card_list::{CardList, CardListId};
-use crate::card_list_component::{CardListActionType, CardListComponent, CardListComponentConfig};
+use crate::card_list_component::{CardListComponent, CardListComponentConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SprintTaskPanel {
@@ -17,32 +17,20 @@ pub struct SprintViewState {
 
 impl Default for SprintViewState {
     fn default() -> Self {
+        // Both panels share the same full action set as the main-board card list
+        // (KAN-435). Panel-switching keybindings (h/l) are intercepted by the
+        // sprint-detail key handler before they reach the component.
         Self {
             panel: SprintTaskPanel::Uncompleted,
             uncompleted_cards: CardList::new(CardListId::All),
             completed_cards: CardList::new(CardListId::All),
             uncompleted_component: CardListComponent::new(
                 CardListId::All,
-                CardListComponentConfig::new()
-                    .with_actions(vec![
-                        CardListActionType::Navigation,
-                        CardListActionType::Selection,
-                        CardListActionType::Editing,
-                        CardListActionType::Completion,
-                        CardListActionType::Priority,
-                        CardListActionType::Sorting,
-                    ])
-                    .with_movement(false),
+                CardListComponentConfig::default(),
             ),
             completed_component: CardListComponent::new(
                 CardListId::All,
-                CardListComponentConfig::new()
-                    .with_actions(vec![
-                        CardListActionType::Navigation,
-                        CardListActionType::Selection,
-                        CardListActionType::Sorting,
-                    ])
-                    .with_multi_select(false),
+                CardListComponentConfig::default(),
             ),
         }
     }

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -10,26 +10,35 @@ use ratatui::{
     Frame,
 };
 
-pub(super) fn render_sprint_detail_view(app: &App, frame: &mut Frame, area: Rect) {
-    if let Some(sprint_idx) = app.selection.active_sprint_index {
-        if let Some(sprint) = app.model.sprints().get(sprint_idx) {
-            if let Some(board_idx) = app.selection.active_board_index {
-                if let Some(board) = app.model.boards().get(board_idx) {
-                    let is_completed = sprint.status == SprintStatus::Completed;
+pub(super) fn render_sprint_detail_view(app: &mut App, frame: &mut Frame, area: Rect) {
+    // Snapshot the sprint and board we want so we can mutably borrow
+    // `app.sprint_view` further down without aliasing.
+    let sprint_idx = match app.selection.active_sprint_index {
+        Some(i) => i,
+        None => return,
+    };
+    let board_idx = match app.selection.active_board_index {
+        Some(i) => i,
+        None => return,
+    };
+    let sprint = match app.model.sprints().get(sprint_idx).cloned() {
+        Some(s) => s,
+        None => return,
+    };
+    let board = match app.model.boards().get(board_idx).cloned() {
+        Some(b) => b,
+        None => return,
+    };
 
-                    if is_completed {
-                        render_sprint_detail_with_tasks(app, frame, area, sprint, board);
-                    } else {
-                        render_sprint_detail_metadata(app, frame, area, sprint, board);
-                    }
-                }
-            }
-        }
+    if sprint.status == SprintStatus::Completed {
+        render_sprint_detail_with_tasks(app, frame, area, &sprint, &board);
+    } else {
+        render_sprint_detail_metadata(app, frame, area, &sprint, &board);
     }
 }
 
 fn render_sprint_detail_metadata(
-    app: &App,
+    app: &mut App,
     frame: &mut Frame,
     area: Rect,
     sprint: &Sprint,
@@ -156,7 +165,7 @@ fn sprint_timestamp_lines(sprint: &Sprint) -> Vec<Line<'static>> {
 }
 
 pub(super) fn render_sprint_detail_with_tasks(
-    app: &App,
+    app: &mut App,
     frame: &mut Frame,
     area: Rect,
     sprint: &Sprint,
@@ -167,6 +176,17 @@ pub(super) fn render_sprint_detail_with_tasks(
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(area);
 
+    let uncompleted_focused = app.sprint_view.panel == crate::app::SprintTaskPanel::Uncompleted;
+    let completed_focused = app.sprint_view.panel == crate::app::SprintTaskPanel::Completed;
+
+    // Bring scroll state in sync with the current selection *before* render
+    // reads from the list — this is what makes the lists scrollable when
+    // navigation pushes the selection past the visible viewport.
+    let uncompleted_viewport = chunks[0].height.saturating_sub(2) as usize;
+    let completed_viewport = chunks[1].height.saturating_sub(2) as usize;
+    app.sprint_view
+        .sync_scroll(uncompleted_viewport, completed_viewport);
+
     render_sprint_task_panel_with_selection(
         app,
         frame,
@@ -175,7 +195,7 @@ pub(super) fn render_sprint_detail_with_tasks(
         board,
         &app.sprint_view.uncompleted_cards,
         "Uncompleted",
-        app.sprint_view.panel == crate::app::SprintTaskPanel::Uncompleted,
+        uncompleted_focused,
     );
 
     render_sprint_task_panel_with_selection(
@@ -186,7 +206,7 @@ pub(super) fn render_sprint_detail_with_tasks(
         board,
         &app.sprint_view.completed_cards,
         "Completed",
-        app.sprint_view.panel == crate::app::SprintTaskPanel::Completed,
+        completed_focused,
     );
 }
 

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -11,8 +11,6 @@ use ratatui::{
 };
 
 pub(super) fn render_sprint_detail_view(app: &mut App, frame: &mut Frame, area: Rect) {
-    // Snapshot the sprint and board we want so we can mutably borrow
-    // `app.sprint_view` further down without aliasing.
     let sprint_idx = match app.selection.active_sprint_index {
         Some(i) => i,
         None => return,
@@ -179,9 +177,6 @@ pub(super) fn render_sprint_detail_with_tasks(
     let uncompleted_focused = app.sprint_view.panel == crate::app::SprintTaskPanel::Uncompleted;
     let completed_focused = app.sprint_view.panel == crate::app::SprintTaskPanel::Completed;
 
-    // Bring scroll state in sync with the current selection *before* render
-    // reads from the list — this is what makes the lists scrollable when
-    // navigation pushes the selection past the visible viewport.
     let uncompleted_viewport = chunks[0].height.saturating_sub(2) as usize;
     let completed_viewport = chunks[1].height.saturating_sub(2) as usize;
     app.sprint_view

--- a/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
+++ b/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
@@ -40,7 +40,59 @@ fn test_sprint_detail_uncompleted_panel_supports_movement() {
 #[test]
 fn test_sprint_detail_default_panel_is_uncompleted() {
     let app = App::test_default();
-    // Regression guard: opening sprint detail must focus the Uncompleted
-    // panel first, not the Completed one.
     assert_eq!(app.sprint_view.panel, SprintTaskPanel::Uncompleted);
+}
+
+// --- Scrolling: sync_scroll catches up when navigation pushes the selection
+//                past the visible viewport. ---
+
+#[test]
+fn test_sprint_detail_uncompleted_panel_scrolls_when_selection_passes_viewport() {
+    let mut app = App::test_default();
+    let cards: Vec<Uuid> = (0..30).map(|_| Uuid::new_v4()).collect();
+    app.sprint_view.uncompleted_cards.update_cards(cards);
+    app.sprint_view
+        .uncompleted_cards
+        .set_selected_index(Some(0));
+
+    // Walk past a 5-row viewport.
+    for _ in 0..10 {
+        app.sprint_view.uncompleted_cards.navigate_down();
+    }
+    assert_eq!(
+        app.sprint_view.uncompleted_cards.get_scroll_offset(),
+        0,
+        "no scroll happens just from navigating — needs sync_scroll"
+    );
+
+    app.sprint_view.sync_scroll(5, 5);
+    assert!(
+        app.sprint_view.uncompleted_cards.get_scroll_offset() > 0,
+        "after sync_scroll the offset must advance so the selection is visible"
+    );
+}
+
+#[test]
+fn test_sprint_detail_completed_panel_scrolls_independently_of_uncompleted() {
+    let mut app = App::test_default();
+    let unc: Vec<Uuid> = (0..30).map(|_| Uuid::new_v4()).collect();
+    let comp: Vec<Uuid> = (0..30).map(|_| Uuid::new_v4()).collect();
+    app.sprint_view.uncompleted_cards.update_cards(unc);
+    app.sprint_view.completed_cards.update_cards(comp);
+
+    app.sprint_view.completed_cards.set_selected_index(Some(20));
+    app.sprint_view
+        .uncompleted_cards
+        .set_selected_index(Some(0));
+
+    app.sprint_view.sync_scroll(5, 5);
+    assert!(
+        app.sprint_view.completed_cards.get_scroll_offset() > 0,
+        "Completed panel must scroll based on its own selection"
+    );
+    assert_eq!(
+        app.sprint_view.uncompleted_cards.get_scroll_offset(),
+        0,
+        "Uncompleted panel must not scroll if its selection is already visible"
+    );
 }

--- a/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
+++ b/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
@@ -1,15 +1,13 @@
 //! KAN-435: sprint-detail card lists reuse the main-board `CardListComponent`.
-//! These tests pin down the features the sprint detail must inherit:
-//! scrolling, multi-select on both panels, sort, search, and the
-//! sprint-detail-scoped "return card to its original column on un-complete"
-//! behaviour. Each test is paired with the implementation commit that turns
-//! it from red to green.
 
+use crossterm::event::KeyCode;
+use kanban_domain::{
+    BoardUpdate, CardPriority, CardStatus, CreateCardOptions, KanbanOperations, SortField,
+    SortOrder,
+};
 use kanban_tui::app::sprint_view::SprintTaskPanel;
 use kanban_tui::App;
 use uuid::Uuid;
-
-// --- Action config alignment: both panels must support the same action set ---
 
 #[test]
 fn test_sprint_detail_multi_select_works_on_completed_panel() {
@@ -43,9 +41,6 @@ fn test_sprint_detail_default_panel_is_uncompleted() {
     assert_eq!(app.sprint_view.panel, SprintTaskPanel::Uncompleted);
 }
 
-// --- Scrolling: sync_scroll catches up when navigation pushes the selection
-//                past the visible viewport. ---
-
 #[test]
 fn test_sprint_detail_uncompleted_panel_scrolls_when_selection_passes_viewport() {
     let mut app = App::test_default();
@@ -55,7 +50,6 @@ fn test_sprint_detail_uncompleted_panel_scrolls_when_selection_passes_viewport()
         .uncompleted_cards
         .set_selected_index(Some(0));
 
-    // Walk past a 5-row viewport.
     for _ in 0..10 {
         app.sprint_view.uncompleted_cards.navigate_down();
     }
@@ -94,5 +88,155 @@ fn test_sprint_detail_completed_panel_scrolls_independently_of_uncompleted() {
         app.sprint_view.uncompleted_cards.get_scroll_offset(),
         0,
         "Uncompleted panel must not scroll if its selection is already visible"
+    );
+}
+
+#[test]
+fn test_sprint_detail_populate_applies_board_sort_order() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    app.ctx
+        .update_board(
+            board.id,
+            BoardUpdate {
+                task_sort_field: Some(SortField::Priority),
+                task_sort_order: Some(SortOrder::Descending),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    let low = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "low priority".to_string(),
+            CreateCardOptions {
+                priority: Some(CardPriority::Low),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let critical = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "critical priority".to_string(),
+            CreateCardOptions {
+                priority: Some(CardPriority::Critical),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let medium = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "medium priority".to_string(),
+            CreateCardOptions {
+                priority: Some(CardPriority::Medium),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    app.ctx.assign_card_to_sprint(low.id, sprint.id).unwrap();
+    app.ctx
+        .assign_card_to_sprint(critical.id, sprint.id)
+        .unwrap();
+    app.ctx.assign_card_to_sprint(medium.id, sprint.id).unwrap();
+    app.prepare_frame();
+
+    app.populate_sprint_task_lists(sprint.id);
+
+    let ordered = &app.sprint_view.uncompleted_cards.cards;
+    assert_eq!(
+        ordered,
+        &vec![critical.id, medium.id, low.id],
+        "panel should be sorted by the board's active sort field (Priority Descending)"
+    );
+}
+
+#[test]
+fn test_sprint_detail_j_key_via_handler_advances_raw_card_list_selection() {
+    let mut app = App::test_default();
+    let cards: Vec<Uuid> = (0..5).map(|_| Uuid::new_v4()).collect();
+    app.sprint_view
+        .uncompleted_cards
+        .update_cards(cards.clone());
+    app.sprint_view
+        .uncompleted_component
+        .update_cards(cards.clone());
+    app.sprint_view
+        .uncompleted_cards
+        .set_selected_index(Some(0));
+    app.sprint_view
+        .uncompleted_component
+        .set_selected_index(Some(0));
+    app.sprint_view.panel = SprintTaskPanel::Uncompleted;
+
+    app.handle_sprint_detail_key(KeyCode::Char('j'));
+
+    assert_eq!(
+        app.sprint_view.uncompleted_cards.get_selected_index(),
+        Some(1),
+        "raw CardList selection must mirror component selection after key dispatch"
+    );
+}
+
+#[test]
+fn test_sprint_detail_status_done_card_is_not_in_uncompleted_panel_after_populate() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "done card".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.assign_card_to_sprint(card.id, sprint.id).unwrap();
+    app.ctx
+        .update_card(
+            card.id,
+            kanban_domain::CardUpdate {
+                status: Some(CardStatus::Done),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    app.prepare_frame();
+
+    app.populate_sprint_task_lists(sprint.id);
+
+    assert!(
+        app.sprint_view.uncompleted_cards.cards.is_empty(),
+        "a Done card must not appear in the Uncompleted panel"
+    );
+    assert_eq!(
+        app.sprint_view.completed_cards.cards,
+        vec![card.id],
+        "a Done card must appear in the Completed panel"
     );
 }

--- a/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
+++ b/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
@@ -1,0 +1,46 @@
+//! KAN-435: sprint-detail card lists reuse the main-board `CardListComponent`.
+//! These tests pin down the features the sprint detail must inherit:
+//! scrolling, multi-select on both panels, sort, search, and the
+//! sprint-detail-scoped "return card to its original column on un-complete"
+//! behaviour. Each test is paired with the implementation commit that turns
+//! it from red to green.
+
+use kanban_tui::app::sprint_view::SprintTaskPanel;
+use kanban_tui::App;
+use uuid::Uuid;
+
+// --- Action config alignment: both panels must support the same action set ---
+
+#[test]
+fn test_sprint_detail_multi_select_works_on_completed_panel() {
+    let mut app = App::test_default();
+    let card_id = Uuid::new_v4();
+    app.sprint_view
+        .completed_component
+        .toggle_multi_select(card_id);
+    assert_eq!(
+        app.sprint_view
+            .completed_component
+            .get_multi_selected()
+            .len(),
+        1,
+        "multi-select must work on the Completed panel — Uncompleted/Completed parity"
+    );
+}
+
+#[test]
+fn test_sprint_detail_uncompleted_panel_supports_movement() {
+    let app = App::test_default();
+    assert!(
+        app.sprint_view.uncompleted_component.config.allow_movement,
+        "Uncompleted panel must allow movement actions for main-board parity"
+    );
+}
+
+#[test]
+fn test_sprint_detail_default_panel_is_uncompleted() {
+    let app = App::test_default();
+    // Regression guard: opening sprint detail must focus the Uncompleted
+    // panel first, not the Completed one.
+    assert_eq!(app.sprint_view.panel, SprintTaskPanel::Uncompleted);
+}


### PR DESCRIPTION
Sprint-detail card lists now scroll, both panels support the same action set, and the board's sort order applies on populate. Phase 1 of a broader refactor tracked on KAN-435; outstanding work (view modes, original-column label, original-column tracking, search-filter propagation) stays on the card.

- `crates/kanban-tui/src/app/sprint_view.rs::SprintViewState::sync_scroll(uncompleted_viewport, completed_viewport)` brings each panel's scroll offset back in line with its selection. Called once per frame from the sprint-detail renderer with viewport heights derived from the actual rendered panel chunks.
- Both panels now use the default `CardListComponentConfig` — multi-select is enabled on the Completed panel (was disabled), movement actions are enabled on the Uncompleted panel (was disabled). Aligns action behaviour with the main-board card list.
- `KanbanContext::populate_sprint_task_lists` routes through `CardQueryBuilder` when an active board is resolvable, so the board's `task_sort_field` + `task_sort_order` apply on populate. Falls back to the raw `partition_sprint_cards` helper when no board is active (test fixtures only).
- 5 new tests in `crates/kanban-tui/tests/sprint_detail_card_list_tests.rs` cover the scrolling sync, multi-select symmetry, movement-action enablement, default-panel focus, and panel scroll independence.

**What**: Fix the literal scrolling bug reported in KAN-435 and bring the sprint-detail card lists into closer behavioural parity with the main-board card list — same action set on both panels, sort applied at populate time.

**Why**: The sprint-detail render path called `task_list.get_render_info(viewport_height)` without first calling `ensure_selected_visible`, so the panel's `scroll_offset` stayed at zero no matter how far navigation pushed the selection. Visually the selected card walked off-screen. Separately, the two panels had asymmetric `CardListComponentConfig` — Uncompleted disabled movement, Completed disabled multi-select — for no clear reason, and `partition_sprint_cards` bypassed `CardQueryBuilder` so sort changes on the board didn't reorder the sprint panels.

**How**: Add `SprintViewState::sync_scroll` as the single seam where the renderer can keep both panels' scroll state honest, and invoke it from `render_sprint_detail_with_tasks` with the panel-chunk viewport heights. Drop the bespoke `with_actions(...)` + `with_movement(false)` / `with_multi_select(false)` calls in `SprintViewState::default` so both panels inherit `CardListComponentConfig::default()`. Replace `partition_sprint_cards` in `populate_sprint_task_lists` with a `CardQueryBuilder::new(...).in_sprints(...).execute()` call plus a post-status partition; cards arrive already sorted by the board's active sort field. Renderer signatures shift to `&mut App` (with a small `Sprint` / `Board` snapshot at the top of `render_sprint_detail_view`) so the mutable scroll sync doesn't conflict with the immutable model reads further down.

**Testing**: `cargo test -p kanban-tui --test sprint_detail_card_list_tests` (5 new tests, all green); `cargo test --workspace` (no regressions); `cargo clippy --all-targets --all-features -- -D warnings` (clean); `cargo fmt --check` (clean).

## Phase 2 follow-up (planned but not in this PR)

The user expanded the scope of KAN-435 during planning to include view-mode parity (Flat / GroupedByColumn / Kanban inside sprint detail), an original-column label on the Uncompleted panel title, in-memory original-column tracking on un-complete, search-filter propagation, and full delegation to the existing view-strategy machinery. The full design is preserved on the KAN-435 card body (~13K chars of detail, 8-commit plan, tests enumerated). That work is a substantial refactor of `view_strategy.rs` / `layout_strategy.rs` and is best picked up in a fresh session with full attention.