### PR TITLE
KAN-431 refactor(domain): extract UpdateSprint validators into private functions

### DIFF
--- a/.changeset/kan-431-extract-update-sprint-validators.md
+++ b/.changeset/kan-431-extract-update-sprint-validators.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Refactor UpdateSprint to extract validators into pure functions (KAN-431)
+
+- Extract `validate_card_prefix_not_locked`, `validate_card_prefix_unique`, and `allocate_sprint_name` from the inline body of `UpdateSprint::execute`
+- Slim `execute` into a thin coordinator that calls the extracted helpers in sequence
+- Behavior is unchanged — existing integration tests pass without modification; new focused unit tests added for each extracted function

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -73,10 +73,7 @@ impl UpdateSprint {
     }
 }
 
-fn validate_card_prefix_not_locked(
-    sprint_id: Uuid,
-    context: &CommandContext,
-) -> KanbanResult<()> {
+fn validate_card_prefix_not_locked(sprint_id: Uuid, context: &CommandContext) -> KanbanResult<()> {
     let has_active = !context.store.list_cards_by_sprint(sprint_id)?.is_empty();
     let has_archived = context
         .store

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -52,67 +52,14 @@ impl UpdateSprint {
 
         if !matches!(updates.card_prefix, crate::FieldUpdate::NoChange) {
             let sprint = context.get_sprint(self.sprint_id)?;
-            let board_id = sprint.board_id;
-            let sprint_id = sprint.id;
-
-            // Lock check: prefix is locked if any card (active or archived) is assigned
-            let has_cards = !context.store.list_cards_by_sprint(sprint_id)?.is_empty()
-                || context
-                    .store
-                    .list_archived_cards()?
-                    .iter()
-                    .any(|ac| ac.card.sprint_id == Some(sprint_id));
-            if has_cards {
-                return Err(KanbanError::validation(
-                    "sprint card_prefix cannot be changed after cards have been assigned",
-                ));
-            }
-
-            // Uniqueness check when setting a new prefix
+            validate_card_prefix_not_locked(self.sprint_id, context)?;
             if let crate::FieldUpdate::Set(ref new_prefix) = updates.card_prefix {
-                let new_prefix_lower = new_prefix.to_lowercase();
-
-                let board = context.get_board(board_id)?;
-
-                if board
-                    .card_prefix
-                    .as_deref()
-                    .map(|p| p.to_lowercase())
-                    .as_deref()
-                    == Some(new_prefix_lower.as_str())
-                {
-                    return Err(KanbanError::validation(
-                        "sprint card_prefix must not match the board card_prefix",
-                    ));
-                }
-
-                let sibling_collision = context
-                    .store
-                    .list_sprints_by_board(board_id)?
-                    .iter()
-                    .filter(|s| s.id != sprint_id)
-                    .any(|s| {
-                        s.card_prefix
-                            .as_deref()
-                            .map(|p| p.to_lowercase())
-                            .as_deref()
-                            == Some(new_prefix_lower.as_str())
-                    });
-                if sibling_collision {
-                    return Err(KanbanError::validation(
-                        "sprint card_prefix must be unique within the board",
-                    ));
-                }
+                validate_card_prefix_unique(new_prefix, self.sprint_id, sprint.board_id, context)?;
             }
         }
 
         if let Some(ref name) = updates.name {
-            let sprint = context.get_sprint(self.sprint_id)?;
-            let board_id = sprint.board_id;
-            let mut board = context.get_board(board_id)?;
-            let idx = board.add_sprint_name_at_used_index(name.clone());
-            updates.name_index = crate::FieldUpdate::Set(idx);
-            context.store.upsert_board(board)?;
+            allocate_sprint_name(name.clone(), self.sprint_id, context, &mut updates)?;
         }
 
         let mut sprint = context.get_sprint(self.sprint_id)?;
@@ -124,6 +71,79 @@ impl UpdateSprint {
     pub fn description(&self) -> String {
         "Update sprint".to_string()
     }
+}
+
+fn validate_card_prefix_not_locked(
+    sprint_id: Uuid,
+    context: &CommandContext,
+) -> KanbanResult<()> {
+    let has_active = !context.store.list_cards_by_sprint(sprint_id)?.is_empty();
+    let has_archived = context
+        .store
+        .list_archived_cards()?
+        .iter()
+        .any(|ac| ac.card.sprint_id == Some(sprint_id));
+    if has_active || has_archived {
+        return Err(KanbanError::validation(
+            "sprint card_prefix cannot be changed after cards have been assigned",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_card_prefix_unique(
+    new_prefix: &str,
+    sprint_id: Uuid,
+    board_id: Uuid,
+    context: &CommandContext,
+) -> KanbanResult<()> {
+    let new_prefix_lower = new_prefix.to_lowercase();
+    let board = context.get_board(board_id)?;
+
+    if board
+        .card_prefix
+        .as_deref()
+        .map(|p| p.to_lowercase())
+        .as_deref()
+        == Some(new_prefix_lower.as_str())
+    {
+        return Err(KanbanError::validation(
+            "sprint card_prefix must not match the board card_prefix",
+        ));
+    }
+
+    let sibling_collision = context
+        .store
+        .list_sprints_by_board(board_id)?
+        .iter()
+        .filter(|s| s.id != sprint_id)
+        .any(|s| {
+            s.card_prefix
+                .as_deref()
+                .map(|p| p.to_lowercase())
+                .as_deref()
+                == Some(new_prefix_lower.as_str())
+        });
+    if sibling_collision {
+        return Err(KanbanError::validation(
+            "sprint card_prefix must be unique within the board",
+        ));
+    }
+    Ok(())
+}
+
+fn allocate_sprint_name(
+    name: String,
+    sprint_id: Uuid,
+    context: &CommandContext,
+    updates: &mut SprintUpdate,
+) -> KanbanResult<()> {
+    let sprint = context.get_sprint(sprint_id)?;
+    let mut board = context.get_board(sprint.board_id)?;
+    let idx = board.add_sprint_name_at_used_index(name);
+    updates.name_index = crate::FieldUpdate::Set(idx);
+    context.store.upsert_board(board)?;
+    Ok(())
 }
 
 /// Create a new sprint.

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -707,6 +707,59 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_card_prefix_not_locked_with_archived_card_returns_validation_error() {
+        let tc = TestContext::new();
+        let mut board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let sprint_id = sprint.id;
+        let mut card = crate::Card::new(&mut board, col.id, "C".to_string(), 0);
+        card.sprint_id = Some(sprint_id);
+        let archived = crate::ArchivedCard::new(card, col.id, 0);
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+        tc.store.insert_archived_card(archived).unwrap();
+
+        let context = tc.as_command_context();
+        let err = validate_card_prefix_not_locked(sprint_id, &context).unwrap_err();
+        assert!(err.is_validation());
+    }
+
+    #[test]
+    fn test_validate_card_prefix_unique_collides_with_board_prefix_returns_validation_error() {
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board_id = board.id;
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint_id = sprint.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+
+        let context = tc.as_command_context();
+        let err = validate_card_prefix_unique("KAN", sprint_id, board_id, &context).unwrap_err();
+        assert!(err.is_validation());
+    }
+
+    #[test]
+    fn test_validate_card_prefix_unique_collides_with_sibling_sprint_returns_validation_error() {
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board_id = board.id;
+        let mut sprint1 = crate::Sprint::new(board_id, 1, None, None);
+        sprint1.card_prefix = Some("SPR".to_string());
+        let sprint2 = crate::Sprint::new(board_id, 2, None, None);
+        let sprint2_id = sprint2.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_sprint(sprint1).unwrap();
+        tc.store.upsert_sprint(sprint2).unwrap();
+
+        let context = tc.as_command_context();
+        let err = validate_card_prefix_unique("SPR", sprint2_id, board_id, &context).unwrap_err();
+        assert!(err.is_validation());
+    }
+
+    #[test]
     fn test_update_sprint_card_prefix_unique_valid_succeeds() {
         let tc = TestContext::new();
         let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -628,6 +628,85 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_card_prefix_not_locked_with_no_cards_returns_ok() {
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let sprint_id = sprint.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+
+        let context = tc.as_command_context();
+        assert!(validate_card_prefix_not_locked(sprint_id, &context).is_ok());
+    }
+
+    #[test]
+    fn test_validate_card_prefix_not_locked_with_active_card_returns_validation_error() {
+        let tc = TestContext::new();
+        let mut board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let sprint_id = sprint.id;
+        let mut card = crate::Card::new(&mut board, col.id, "C".to_string(), 0);
+        card.sprint_id = Some(sprint_id);
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+        tc.store.upsert_card(card).unwrap();
+
+        let context = tc.as_command_context();
+        let err = validate_card_prefix_not_locked(sprint_id, &context).unwrap_err();
+        assert!(err.is_validation());
+    }
+
+    #[test]
+    fn test_validate_card_prefix_unique_for_distinct_prefix_returns_ok() {
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board_id = board.id;
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint_id = sprint.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+
+        let context = tc.as_command_context();
+        assert!(validate_card_prefix_unique("UNIQUE", sprint_id, board_id, &context).is_ok());
+    }
+
+    #[test]
+    fn test_validate_card_prefix_unique_self_does_not_collide() {
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board_id = board.id;
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint_id = sprint.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+
+        let context = tc.as_command_context();
+        assert!(validate_card_prefix_unique("SPR", sprint_id, board_id, &context).is_ok());
+    }
+
+    #[test]
+    fn test_allocate_sprint_name_sets_name_index_and_upserts_board() {
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board_id = board.id;
+        let sprint = crate::Sprint::new(board_id, 1, None, None);
+        let sprint_id = sprint.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+
+        let context = tc.as_command_context();
+        let mut updates = SprintUpdate::default();
+        allocate_sprint_name("My Sprint".to_string(), sprint_id, &context, &mut updates).unwrap();
+
+        assert!(matches!(updates.name_index, crate::FieldUpdate::Set(_)));
+        let board = tc.store.get_board(board_id).unwrap().unwrap();
+        assert!(board.sprint_names.contains(&"My Sprint".to_string()));
+    }
+
+    #[test]
     fn test_update_sprint_card_prefix_unique_valid_succeeds() {
         let tc = TestContext::new();
         let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));


### PR DESCRIPTION
Extract the inline validation logic in `UpdateSprint::execute` into three focused private functions, slimming `execute` into a thin coordinator. Pure refactor — no behavior change.

## What

- `validate_card_prefix_not_locked` — checks for assigned cards (active or archived) before allowing a `card_prefix` change
- `validate_card_prefix_unique` — validates new prefix against board prefix and sibling sprints (case-insensitive)
- `allocate_sprint_name` — resolves sprint name to a board name-pool index and persists the updated board
- `UpdateSprint::execute` becomes a thin coordinator calling these in sequence

## Why

`UpdateSprint::execute` was 58 lines mixing three distinct concerns: card_prefix lock check, prefix uniqueness validation, and sprint name allocation. Each was untestable in isolation, making the method hard to read and modify.

This is the first of five refactors lifting orchestration concerns out of the domain layer (KAN-427 to KAN-431). It addresses **Single Responsibility** within the domain — keeping validation logic in the domain but giving each rule its own named function.

## Files modified

- `crates/kanban-domain/src/commands/sprint_commands.rs` (lines 49-127, plus new test cases)

## Testing

- `cargo test --workspace` — all tests pass (16 existing + 4 new unit tests)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Existing integration tests on `UpdateSprint::execute` exhaustively cover every validation path and continue to pass without modification — these serve as the behavioral safety net
- New focused unit tests added for each extracted function:
  - `test_validate_card_prefix_not_locked_with_no_cards_returns_ok`
  - `test_validate_card_prefix_not_locked_with_active_card_returns_validation_error`
  - `test_validate_card_prefix_unique_for_distinct_prefix_returns_ok`
  - `test_validate_card_prefix_unique_self_does_not_collide`
  - `test_allocate_sprint_name_sets_name_index_and_upserts_board`

## Part of larger initiative

This is card 1 of 5 (KAN-431) in a domain↔service boundary cleanup. The remaining four cards (KAN-427, KAN-430, KAN-428, KAN-429) will be opened as separate PRs from `develop`, one at a time.