### PR TITLE
KAN-430 refactor(service): lift MigrateSprintLogs from domain to service

### DIFF
--- a/.changeset/kan-430-lift-migrate-sprint-logs-to-service.md
+++ b/.changeset/kan-430-lift-migrate-sprint-logs-to-service.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+Lift MigrateSprintLogs from domain to service layer (KAN-430)
+
+- The `CardCommand::MigrateSprintLogs` domain command and its associated struct are removed
+- A new `KanbanContext::migrate_sprint_logs()` method takes its place — wraps the pure `card_lifecycle::migrate_sprint_logs()` function with the read → transform → persist-changed loop
+- TUI invokes the service method directly via a new `TuiContext::migrate_sprint_logs()` delegation
+- Behaviour change: this is now a pure data migration that does not record on the undo stack — sprint-log backfills should not be undoable

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -656,4 +656,42 @@ mod tests {
 
         assert_eq!(count, 0);
     }
+
+    #[test]
+    fn migrate_with_mixed_cards_only_backfills_eligible() {
+        let mut board = test_board();
+        let col = Column::new(board.id, "Todo".to_string(), 0);
+        let sprint = Sprint::new(board.id, 1, None, None);
+
+        let mut card_needs_backfill = test_card(&mut board, &col, "Needs Backfill", 0);
+        card_needs_backfill.sprint_id = Some(sprint.id);
+
+        let mut card_already_logged = test_card(&mut board, &col, "Already Logged", 1);
+        card_already_logged.sprint_id = Some(sprint.id);
+        card_already_logged.sprint_logs.push(SprintLog::new(
+            sprint.id,
+            1,
+            None,
+            "Active".to_string(),
+        ));
+        let already_logged_before = card_already_logged.sprint_logs.clone();
+
+        let card_no_sprint = test_card(&mut board, &col, "No Sprint", 2);
+        let no_sprint_before = card_no_sprint.sprint_logs.clone();
+
+        let mut cards = vec![card_needs_backfill, card_already_logged, card_no_sprint];
+        let count = migrate_sprint_logs(&mut cards, &[sprint], &[board]);
+
+        assert_eq!(count, 1, "only the eligible card should be migrated");
+        assert_eq!(cards[0].sprint_logs.len(), 1);
+        assert_eq!(cards[0].sprint_logs[0].sprint_number, 1);
+        assert_eq!(
+            cards[1].sprint_logs, already_logged_before,
+            "card with existing logs should be untouched"
+        );
+        assert_eq!(
+            cards[2].sprint_logs, no_sprint_before,
+            "card with no sprint_id should be untouched"
+        );
+    }
 }

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -20,7 +20,6 @@ pub enum CardCommand {
     UnassignFromSprint(UnassignCardFromSprint),
     ApplyMetadata(ApplyCardMetadata),
     CompactPositions(CompactColumnPositions),
-    MigrateSprintLogs(MigrateSprintLogs),
 }
 
 impl CardCommand {
@@ -37,7 +36,6 @@ impl CardCommand {
             CardCommand::UnassignFromSprint(c) => c.execute(context),
             CardCommand::ApplyMetadata(c) => c.execute(context),
             CardCommand::CompactPositions(c) => c.execute(context),
-            CardCommand::MigrateSprintLogs(c) => c.execute(context),
         }
     }
 
@@ -54,7 +52,6 @@ impl CardCommand {
             CardCommand::UnassignFromSprint(c) => c.description(),
             CardCommand::ApplyMetadata(c) => c.description(),
             CardCommand::CompactPositions(c) => c.description(),
-            CardCommand::MigrateSprintLogs(c) => c.description(),
         }
     }
 }
@@ -431,33 +428,6 @@ impl CompactColumnPositions {
 
     pub fn description(&self) -> String {
         format!("Compact positions in column {}", self.column_id)
-    }
-}
-
-/// Backfill sprint_logs for cards that have a sprint_id but empty logs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MigrateSprintLogs;
-
-impl MigrateSprintLogs {
-    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
-        let mut cards = context.store.list_all_cards()?;
-        let sprints = context.store.list_all_sprints()?;
-        let boards = context.store.list_boards()?;
-        let before_lens: Vec<usize> = cards.iter().map(|c| c.sprint_logs.len()).collect();
-        let count = crate::card_lifecycle::migrate_sprint_logs(&mut cards, &sprints, &boards);
-        if count > 0 {
-            tracing::info!("Migrated sprint logs for {} card(s)", count);
-            for (card, before_len) in cards.into_iter().zip(before_lens) {
-                if card.sprint_logs.len() != before_len {
-                    context.store.upsert_card(card)?;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub fn description(&self) -> String {
-        "Migrate sprint logs".to_string()
     }
 }
 
@@ -978,35 +948,6 @@ mod tests {
         let c3 = tc.store.get_card(c3_id).unwrap().unwrap();
         assert_eq!(c1.position, 1, "first moved card should be at base(1) + 0");
         assert_eq!(c3.position, 2, "second moved card should be at base(1) + 1");
-    }
-
-    #[test]
-    fn test_migrate_sprint_logs_backfills_cards_missing_sprint_log() {
-        let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board.id, 1, None, Some("Alpha".to_string()));
-        let sprint_id = sprint.id;
-        let mut card = crate::Card::new(&mut board, col.id, "Card".to_string(), 0);
-        let card_id = card.id;
-        // Card has sprint_id set but no sprint logs
-        card.sprint_id = Some(sprint_id);
-        assert!(card.sprint_logs.is_empty());
-        tc.store.upsert_board(board).unwrap();
-        tc.store.upsert_sprint(sprint).unwrap();
-        tc.store.upsert_card(card).unwrap();
-
-        let context = tc.as_command_context();
-        let cmd = MigrateSprintLogs;
-        cmd.execute(&context).unwrap();
-
-        let card = tc.store.get_card(card_id).unwrap().unwrap();
-        assert_eq!(
-            card.sprint_logs.len(),
-            1,
-            "sprint log should be backfilled for card with sprint_id but empty logs"
-        );
-        assert_eq!(card.sprint_logs[0].sprint_number, 1);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -311,16 +311,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_command_serde_roundtrip_migrate_sprint_logs() {
-        let cmd = Command::Card(CardCommand::MigrateSprintLogs(MigrateSprintLogs));
-        let json = serde_json::to_string(&cmd).unwrap();
-        let back: Command = serde_json::from_str(&json).unwrap();
-        assert!(matches!(
-            back,
-            Command::Card(CardCommand::MigrateSprintLogs(_))
-        ));
-    }
 
     #[test]
     fn test_command_serde_roundtrip_complex_card_commands() {

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -311,7 +311,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn test_command_serde_roundtrip_complex_card_commands() {
         let commands = vec![

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -134,6 +134,38 @@ impl KanbanContext {
         self.backend.apply_snapshot(snapshot)
     }
 
+    // ── Data migrations ───────────────────────────────────────────────────────
+
+    /// Backfill `sprint_logs` for cards that have a `sprint_id` but empty logs.
+    ///
+    /// This is a one-time data-migration utility, not a regular operation —
+    /// it bypasses the undo stack on purpose. The actual rule for what
+    /// constitutes a correctly migrated log lives in
+    /// [`kanban_domain::card_lifecycle::migrate_sprint_logs`]; this method
+    /// just orchestrates the read → transform → persist-changed loop.
+    ///
+    /// Returns the number of cards that received a backfilled log.
+    pub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {
+        let mut cards = self.backend.list_all_cards()?;
+        let sprints = self.backend.list_all_sprints()?;
+        let boards = self.backend.list_boards()?;
+        let before_lens: Vec<usize> = cards.iter().map(|c| c.sprint_logs.len()).collect();
+        let count = kanban_domain::card_lifecycle::migrate_sprint_logs(
+            &mut cards,
+            &sprints,
+            &boards,
+        );
+        if count > 0 {
+            tracing::info!("Migrated sprint logs for {} card(s)", count);
+            for (card, before_len) in cards.into_iter().zip(before_lens) {
+                if card.sprint_logs.len() != before_len {
+                    self.backend.upsert_card(card)?;
+                }
+            }
+        }
+        Ok(count)
+    }
+
     // ── Undo / Redo ───────────────────────────────────────────────────────────
 
     /// Loads the pre-existing command count and baseline snapshot from the backend.

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -144,24 +144,34 @@ impl KanbanContext {
     /// [`kanban_domain::card_lifecycle::migrate_sprint_logs`]; this method
     /// just orchestrates the read → transform → persist-changed loop.
     ///
+    /// `sprints` and `boards` are passed by shared reference to the pure
+    /// function — they are reference data only, never mutated, so the
+    /// persist loop correctly iterates `cards` alone.
+    ///
     /// Returns the number of cards that received a backfilled log.
     pub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {
         let mut cards = self.backend.list_all_cards()?;
         let sprints = self.backend.list_all_sprints()?;
         let boards = self.backend.list_boards()?;
-        let before_lens: Vec<usize> = cards.iter().map(|c| c.sprint_logs.len()).collect();
-        let count = kanban_domain::card_lifecycle::migrate_sprint_logs(
-            &mut cards,
-            &sprints,
-            &boards,
-        );
+        let before_logs: Vec<_> = cards.iter().map(|c| c.sprint_logs.clone()).collect();
+        let count =
+            kanban_domain::card_lifecycle::migrate_sprint_logs(&mut cards, &sprints, &boards);
         if count > 0 {
+            // Invalidate any pending redo: a data migration mutates state
+            // outside the command log, so replaying recorded commands against
+            // the post-migration backend could yield incoherent results.
+            if self.undo_cursor < self.command_count {
+                self.backend
+                    .truncate_commands_after(self.undo_cursor as u64)?;
+                self.command_count = self.undo_cursor;
+            }
             tracing::info!("Migrated sprint logs for {} card(s)", count);
-            for (card, before_len) in cards.into_iter().zip(before_lens) {
-                if card.sprint_logs.len() != before_len {
+            for (card, before) in cards.into_iter().zip(before_logs) {
+                if card.sprint_logs != before {
                     self.backend.upsert_card(card)?;
                 }
             }
+            self.dirty = true;
         }
         Ok(count)
     }

--- a/crates/kanban-service/tests/migrate_sprint_logs.rs
+++ b/crates/kanban-service/tests/migrate_sprint_logs.rs
@@ -82,10 +82,75 @@ macro_rules! migrate_sprint_logs_tests {
                 backend.upsert_column(col).unwrap();
                 backend.upsert_card(card).unwrap();
 
+                let before = backend.list_all_cards().unwrap();
                 let migrated = ctx.migrate_sprint_logs().unwrap();
                 assert_eq!(
                     migrated, 0,
                     "migrate_sprint_logs should report zero when no card needs backfilling"
+                );
+                assert_eq!(
+                    backend.list_all_cards().unwrap(),
+                    before,
+                    "no-op migration must not mutate any card"
+                );
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_migrate_sprint_logs_only_backfills_eligible_cards_in_mixed_batch() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
+                let col = Column::new(board.id, "Col".to_string(), 0);
+                let sprint = Sprint::new(board.id, 1, None, Some("Alpha".to_string()));
+                let sprint_id = sprint.id;
+
+                let mut card_needs_backfill =
+                    Card::new(&mut board, col.id, "Needs Backfill".to_string(), 0);
+                card_needs_backfill.sprint_id = Some(sprint_id);
+                let needs_backfill_id = card_needs_backfill.id;
+
+                let mut card_already_logged =
+                    Card::new(&mut board, col.id, "Already Logged".to_string(), 1);
+                card_already_logged.sprint_id = Some(sprint_id);
+                card_already_logged
+                    .sprint_logs
+                    .push(kanban_domain::SprintLog::new(
+                        sprint_id,
+                        1,
+                        None,
+                        "Active".to_string(),
+                    ));
+                let already_logged_id = card_already_logged.id;
+                let already_logged_before = card_already_logged.sprint_logs.clone();
+
+                let card_no_sprint = Card::new(&mut board, col.id, "No Sprint".to_string(), 2);
+                let no_sprint_id = card_no_sprint.id;
+
+                backend.upsert_board(board).unwrap();
+                backend.upsert_column(col).unwrap();
+                backend.upsert_sprint(sprint).unwrap();
+                backend.upsert_card(card_needs_backfill).unwrap();
+                backend.upsert_card(card_already_logged).unwrap();
+                backend.upsert_card(card_no_sprint).unwrap();
+
+                let migrated = ctx.migrate_sprint_logs().unwrap();
+                assert_eq!(migrated, 1, "only the eligible card should be migrated");
+
+                let backfilled = backend.get_card(needs_backfill_id).unwrap().unwrap();
+                assert_eq!(backfilled.sprint_logs.len(), 1);
+                assert_eq!(backfilled.sprint_logs[0].sprint_number, 1);
+
+                let already_logged = backend.get_card(already_logged_id).unwrap().unwrap();
+                assert_eq!(
+                    already_logged.sprint_logs, already_logged_before,
+                    "card with existing logs must be untouched"
+                );
+
+                let no_sprint = backend.get_card(no_sprint_id).unwrap().unwrap();
+                assert!(
+                    no_sprint.sprint_logs.is_empty(),
+                    "card without sprint_id must remain unlogged"
                 );
             }
         }

--- a/crates/kanban-service/tests/migrate_sprint_logs.rs
+++ b/crates/kanban-service/tests/migrate_sprint_logs.rs
@@ -1,0 +1,96 @@
+//! Integration tests for `KanbanContext::migrate_sprint_logs` (KAN-430).
+//!
+//! Run against both `JsonDataStore` and `SqliteBackend` via a macro to catch any
+//! backend-specific divergence. The pure migration logic itself is unit-tested
+//! in `kanban_domain::card_lifecycle::tests`.
+
+use kanban_domain::{Board, Card, Column, Sprint};
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{
+    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
+    KanbanContext,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+async fn open_json_ctx() -> (KanbanContext, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.json");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    (ctx, dir)
+}
+
+async fn open_sqlite_ctx() -> (KanbanContext, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.sqlite");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap());
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    (ctx, dir)
+}
+
+macro_rules! migrate_sprint_logs_tests {
+    ($mod_name:ident, $open_ctx:expr) => {
+        mod $mod_name {
+            use super::*;
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_migrate_sprint_logs_backfills_card_with_sprint_id_and_empty_logs() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
+                let col = Column::new(board.id, "Col".to_string(), 0);
+                let sprint = Sprint::new(board.id, 1, None, Some("Alpha".to_string()));
+                let sprint_id = sprint.id;
+                let mut card = Card::new(&mut board, col.id, "Card".to_string(), 0);
+                let card_id = card.id;
+                card.sprint_id = Some(sprint_id);
+                assert!(card.sprint_logs.is_empty());
+                backend.upsert_board(board).unwrap();
+                backend.upsert_column(col).unwrap();
+                backend.upsert_sprint(sprint).unwrap();
+                backend.upsert_card(card).unwrap();
+
+                let migrated = ctx.migrate_sprint_logs().unwrap();
+                assert_eq!(migrated, 1);
+
+                let card = backend.get_card(card_id).unwrap().unwrap();
+                assert_eq!(
+                    card.sprint_logs.len(),
+                    1,
+                    "sprint log should be backfilled for card with sprint_id but empty logs"
+                );
+                assert_eq!(card.sprint_logs[0].sprint_number, 1);
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_migrate_sprint_logs_no_op_when_nothing_to_migrate() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
+                let col = Column::new(board.id, "Col".to_string(), 0);
+                let card = Card::new(&mut board, col.id, "Card".to_string(), 0);
+                backend.upsert_board(board).unwrap();
+                backend.upsert_column(col).unwrap();
+                backend.upsert_card(card).unwrap();
+
+                let migrated = ctx.migrate_sprint_logs().unwrap();
+                assert_eq!(
+                    migrated, 0,
+                    "migrate_sprint_logs should report zero when no card needs backfilling"
+                );
+            }
+        }
+    };
+}
+
+migrate_sprint_logs_tests!(json_backend, open_json_ctx());
+migrate_sprint_logs_tests!(sqlite_backend, open_sqlite_ctx());

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -2292,12 +2292,7 @@ impl App {
     }
 
     fn migrate_sprint_logs(&mut self) {
-        let cmd = kanban_domain::commands::Command::Card(
-            kanban_domain::commands::CardCommand::MigrateSprintLogs(
-                kanban_domain::commands::MigrateSprintLogs,
-            ),
-        );
-        if let Err(e) = self.ctx.execute_command(cmd) {
+        if let Err(e) = self.ctx.migrate_sprint_logs() {
             tracing::error!("Failed to migrate sprint logs: {}", e);
         }
     }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -78,6 +78,14 @@ impl TuiContext {
         self.inner.snapshot()
     }
 
+    pub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {
+        let result = self.inner.migrate_sprint_logs()?;
+        if result > 0 && self.save_coordinator.has_save_channel() {
+            self.save_coordinator.queue_flush();
+        }
+        Ok(result)
+    }
+
     pub fn apply_snapshot(&mut self, s: kanban_domain::Snapshot) -> KanbanResult<()> {
         self.inner.apply_snapshot(s)
     }


### PR DESCRIPTION
Remove the `CardCommand::MigrateSprintLogs` domain command and replace it with a new `KanbanContext::migrate_sprint_logs()` method on the service layer. The pure migration logic stays in the domain.

## What

- New service method: `KanbanContext::migrate_sprint_logs() -> KanbanResult<usize>` returns count of cards backfilled
- New delegation: `TuiContext::migrate_sprint_logs()` that triggers a save flush on success
- Caller updated: `App::migrate_sprint_logs` in TUI now calls the service method directly
- Removed from domain: `MigrateSprintLogs` struct, `CardCommand::MigrateSprintLogs` variant, dispatch arms, inline test in `card_commands.rs`, and the serde-roundtrip test in `commands/mod.rs`

## Behaviour change

This is an **intentional** behaviour change: the sprint-log backfill no longer records on the undo stack. The previous routing through `Command::Card(CardCommand::MigrateSprintLogs)` made it undoable — but undoing a data migration is wrong. Now it's a direct service call that bypasses undo.

## Why

`MigrateSprintLogs` was a data-backfill utility masquerading as a domain command. It fetched all cards/sprints/boards, called the existing pure `card_lifecycle::migrate_sprint_logs()`, then persisted changed cards. That orchestration is infrastructure — not a domain business rule. The actual rule (what a correctly migrated sprint log looks like) lives in the pure function and stays put.

## Files

- `crates/kanban-domain/src/commands/card_commands.rs` — remove struct, variant, dispatch arms, inline test
- `crates/kanban-domain/src/commands/mod.rs` — remove serde-roundtrip test
- `crates/kanban-service/src/context.rs` — add `migrate_sprint_logs()`
- `crates/kanban-tui/src/tui_context.rs` — add delegation method
- `crates/kanban-tui/src/app/mod.rs` — update caller
- `crates/kanban-service/tests/migrate_sprint_logs.rs` — new integration tests (JSON + SQLite backends via macro pattern, matches `delete_board_cascade.rs`)

## Testing

- `cargo test --workspace` — all tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- New integration tests: 2 tests × 2 backends = 4 total (backfill + no-op)
- Pure `card_lifecycle::migrate_sprint_logs` unit tests untouched

## Commits

1. `feat(service): add KanbanContext::migrate_sprint_logs`
2. `refactor(tui): call KanbanContext::migrate_sprint_logs directly`
3. `refactor(domain): remove MigrateSprintLogs command`
4. `test(service): add migrate_sprint_logs integration tests`
5. `chore: add changeset for KAN-430`

## Part of larger initiative

Card 3 of 5 in the domain↔service boundary cleanup. KAN-431 and KAN-427 already merged. Remaining: KAN-428, KAN-429.