### PR TITLE
KAN-449 test(tui): make apply_config_edit non-default-content test sandbox-safe

### DIFF
--- a/.changeset/kan-449-make-apply-config-edit-test-sandbox-safe.md
+++ b/.changeset/kan-449-make-apply-config-edit-test-sandbox-safe.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Make settings_ui_tests `apply_config_edit` non-default-content test sandbox-safe (KAN-449)
+
+- `test_apply_config_edit_with_non_default_content_writes_config` now pins `configuration_location` to a `tempfile::tempdir()` path before building the DTO. Without this, `AppConfigDto::from_config` resolves `configuration_location` via `effective_configuration_location` → `dirs::config_dir()` → `$HOME/.config/kanban/config.toml`, and `config::save`'s `create_dir_all` fails with `EACCES` in build sandboxes (nixpkgs, etc.) where `$HOME` is non-writable.
+- No production code change. Same failure class as the 2026-05-07 nixpkgs-update log that KAN-396 closed for the other `apply_config_edit` tests; this is the one new instance that landed in #267 and slipped past that fix.

--- a/crates/kanban-tui/tests/settings_ui_tests.rs
+++ b/crates/kanban-tui/tests/settings_ui_tests.rs
@@ -355,9 +355,15 @@ fn test_render_settings_cli_override_without_config_storage_hides_config_storage
 
 #[test]
 fn test_apply_config_edit_with_non_default_content_writes_config() {
+    // configuration_location is pinned to a tempdir so the test passes in
+    // build sandboxes (nixpkgs, etc.) where $HOME is non-writable and
+    // config::save's fallback to dirs::config_dir() would hit EACCES.
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
     let mut app = App::test_default();
     app.app_config = kanban_core::AppConfig {
         default_card_prefix: Some("feat".into()),
+        configuration_location: Some(config_path.to_string_lossy().into_owned()),
         ..Default::default()
     };
     let format = EditFormat::Json;


### PR DESCRIPTION
## Summary

**Card:** KAN-449

One-line follow-up to PR #267 (KAN-445) — the new test `test_apply_config_edit_with_non_default_content_writes_config` at `crates/kanban-tui/tests/settings_ui_tests.rs:357` reintroduces the exact nixpkgs sandbox failure class that KAN-396 closed for the other `apply_config_edit` tests. Discovered during the post-merge audit of the 0.5.0 release PR #251 — would have failed the next nixpkgs-update bump.

## Failure mode

The test builds a DTO from `AppConfig::default()`. `AppConfigDto::from_config` populates `configuration_location` with `effective_configuration_location(entity)`, which falls back to `config_path()` → `dirs::config_dir().join("kanban/config.toml")` when the entity's `configuration_location` is `None`. In a Nix build sandbox `$HOME` is a non-writable stub (often `/homeless-shelter`), so `config::save`'s `create_dir_all` returns `EACCES`, `apply_config_edit` returns `Err`, and `assert!(result.is_ok())` panics.

This is the same failure shape as the [2026-05-07 nixpkgs-update log](https://nixpkgs-update-logs.nix-community.org/kanban/2026-05-07.log) that KAN-396 fixed for the five tests in `settings_config_edit_tests.rs`.

## Fix

Pin `app.app_config.configuration_location` to a `tempfile::tempdir()` path **before** building the DTO, so `effective_configuration_location` returns the tempdir path instead of falling back to the OS config dir. Six lines.

## Verification

Reproduced the failure end-to-end on the dev machine by running the **pre-fix** test binary with `env -u XDG_CONFIG_HOME HOME=/var/empty` (forces `dirs::config_dir()` to resolve to an unwritable path, the same way the Nix sandbox does):

```
running 1 test
test test_apply_config_edit_with_non_default_content_writes_config ... FAILED
   3: settings_ui_tests::test_apply_config_edit_with_non_default_content_writes_config
             at ./crates/kanban-tui/tests/settings_ui_tests.rs:367:5
test result: FAILED. 0 passed; 1 failed
```

**Post-fix** under the same environment:

```
running 1 test
test test_apply_config_edit_with_non_default_content_writes_config ... ok
test result: ok. 1 passed; 0 failed
```

## Latent risk not addressed here

Two other tests in `settings_config_edit_tests.rs` (the `_ = app.apply_config_edit(...)` pattern at lines 274 and 294) currently pass on Nix only by accident — `save()` fails early, `self.app_config` is never updated, and the assertions hold for the wrong reason. They're not panicking today, so I'm leaving them. The durable fix is to make `config::save()` return an explicit error when `configuration_location` is unset rather than silently falling back to `dirs::config_dir()`, but that's a production-code change and bigger than this PR's scope.

## Test plan

- [x] `cargo test --package kanban-tui --test settings_ui_tests test_apply_config_edit_with_non_default_content_writes_config` passes on Linux normally
- [x] Pre-fix binary FAILS with `env -u XDG_CONFIG_HOME HOME=/var/empty`
- [x] Post-fix binary PASSES under the same sandbox-simulated environment
- [ ] CI green (Linux + Windows test-windows job from #267)
