### PR TITLE
Hotfix: KAN-449 test(tui): make apply_config_edit non-default-content test sa…

### DIFF
--- a/.changeset/kan-449-make-apply-config-edit-test-sandbox-safe.md
+++ b/.changeset/kan-449-make-apply-config-edit-test-sandbox-safe.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Make settings_ui_tests `apply_config_edit` non-default-content test sandbox-safe (KAN-449)
+
+- `test_apply_config_edit_with_non_default_content_writes_config` now pins `configuration_location` to a `tempfile::tempdir()` path before building the DTO. Without this, `AppConfigDto::from_config` resolves `configuration_location` via `effective_configuration_location` → `dirs::config_dir()` → `$HOME/.config/kanban/config.toml`, and `config::save`'s `create_dir_all` fails with `EACCES` in build sandboxes (nixpkgs, etc.) where `$HOME` is non-writable.
+- No production code change. Same failure class as the 2026-05-07 nixpkgs-update log that KAN-396 closed for the other `apply_config_edit` tests; this is the one new instance that landed in #267 and slipped past that fix.

--- a/crates/kanban-tui/tests/settings_ui_tests.rs
+++ b/crates/kanban-tui/tests/settings_ui_tests.rs
@@ -355,9 +355,15 @@ fn test_render_settings_cli_override_without_config_storage_hides_config_storage
 
 #[test]
 fn test_apply_config_edit_with_non_default_content_writes_config() {
+    // configuration_location is pinned to a tempdir so the test passes in
+    // build sandboxes (nixpkgs, etc.) where $HOME is non-writable and
+    // config::save's fallback to dirs::config_dir() would hit EACCES.
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
     let mut app = App::test_default();
     app.app_config = kanban_core::AppConfig {
         default_card_prefix: Some("feat".into()),
+        configuration_location: Some(config_path.to_string_lossy().into_owned()),
         ..Default::default()
     };
     let format = EditFormat::Json;


### PR DESCRIPTION
…ndbox-safe (#269)

* test(tui): make apply_config_edit non-default-content test sandbox-safe

The test landed in #267 calls apply_config_edit on a config built from AppConfig::default(), whose serialised DTO carries configuration_location = dirs::config_dir() (e.g. $HOME/.config/kanban/config.toml). In a Nix build sandbox $HOME is non-writable, so config::save's create_dir_all fails with EACCES and the assert!(result.is_ok()) panics — same failure class as the 2026-05-07 nixpkgs-update log that KAN-396 closed for the other apply_config_edit tests.

Pin configuration_location to a tempdir so save writes under $TMPDIR instead of $HOME.

Verified by running the pre-fix test binary with
`env -u XDG_CONFIG_HOME HOME=/var/empty`: pre-fix FAILS at the is_ok assertion, post-fix PASSES.

* chore: add changeset for KAN-449