### PR TITLE
KAN-323 fix(cli): require existing file for all subcommands, init on no-subcommand path

### DIFF
--- a/.changeset/cat-323-fix-misleading-card-not-found-error-when-board-file-does-not-exist.md
+++ b/.changeset/cat-323-fix-misleading-card-not-found-error-when-board-file-does-not-exist.md
@@ -1,0 +1,16 @@
+---
+bump: patch
+---
+
+Running `kanban missing.json card get KAN-1` (or any subcommand) when the
+file does not exist now reports `Board file not found: 'missing.json'`
+instead of the misleading `Card not found: 'KAN-1'`. The check covers
+every path that can supply the file — positional argument, `KANBAN_FILE`
+environment variable, and `storage_location` in the config file.
+
+`board create` previously had an implicit dual role: it created the domain
+entity AND initialised the storage file when it did not exist yet. That
+responsibility has moved to `kanban <file>` with no subcommand. Running
+`kanban newboard.json` now creates an empty storage file if one does not
+exist and exits cleanly, making it safe to use in scripts and CI without a
+live terminal. In a TTY the TUI launches as before.

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -287,13 +287,12 @@ Provide the file path in one of these ways:
                     use kanban_persistence::{
                         snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot,
                     };
-                    let store = store_manager
-                        .make_store_with_config(validated_file.as_deref(), &config)?;
+                    let store =
+                        store_manager.make_store_with_config(validated_file.as_deref(), &config)?;
                     if !store.exists().await {
                         let data = snapshot_to_json_bytes(&Snapshot::new())
                             .map_err(|e| anyhow::anyhow!("{e}"))?;
-                        let metadata =
-                            PersistenceMetadata::new(uuid::Uuid::new_v4());
+                        let metadata = PersistenceMetadata::new(uuid::Uuid::new_v4());
                         store
                             .save(StoreSnapshot { data, metadata })
                             .await

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -280,22 +280,47 @@ Provide the file path in one of these ways:
 
         match command {
             None => {
-                #[cfg(feature = "tui")]
-                {
-                    let error_log = std::sync::Arc::new(std::sync::Mutex::new(
-                        kanban_tui::error_log::ErrorLogState::default(),
-                    ));
-                    init_tracing_tui(std::sync::Arc::clone(&error_log));
-
-                    let (mut app, save_rx) =
-                        App::new_with_store(store_manager, validated_file).await?;
-                    app.set_error_log(error_log);
-                    app.run(save_rx).await?;
+                let has_explicit_file =
+                    validated_file.is_some() || config.storage_location.is_some();
+                if has_explicit_file && !std::path::Path::new(&effective_file).exists() {
+                    use kanban_domain::Snapshot;
+                    use kanban_persistence::{
+                        snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot,
+                    };
+                    let store = store_manager
+                        .make_store_with_config(validated_file.as_deref(), &config)?;
+                    if !store.exists().await {
+                        let data = snapshot_to_json_bytes(&Snapshot::new())
+                            .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        let metadata =
+                            PersistenceMetadata::new(uuid::Uuid::new_v4());
+                        store
+                            .save(StoreSnapshot { data, metadata })
+                            .await
+                            .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    }
                 }
-                #[cfg(not(feature = "tui"))]
-                anyhow::bail!(
-                    "TUI not available in this build. Run `kanban --help` for available subcommands."
-                );
+                {
+                    use std::io::IsTerminal;
+                    if std::io::stdin().is_terminal() {
+                        #[cfg(feature = "tui")]
+                        {
+                            let error_log = std::sync::Arc::new(std::sync::Mutex::new(
+                                kanban_tui::error_log::ErrorLogState::default(),
+                            ));
+                            init_tracing_tui(std::sync::Arc::clone(&error_log));
+                            let (mut app, save_rx) =
+                                App::new_with_store(store_manager, validated_file).await?;
+                            app.set_error_log(error_log);
+                            app.run(save_rx).await?;
+                        }
+                        #[cfg(not(feature = "tui"))]
+                        anyhow::bail!(
+                            "TUI not available in this build. Run `kanban --help` for available subcommands."
+                        );
+                    }
+                    // Non-TTY: file created above if needed, exit cleanly.
+                }
             }
             Some(Commands::Completions { .. }) => unreachable!(),
             Some(Commands::Migrate(args)) => {

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -304,6 +304,12 @@ Provide the file path in one of these ways:
             }
             Some(cmd) => {
                 init_tracing_cli();
+                if !std::path::Path::new(&effective_file).exists() {
+                    return crate::output::output_error(&format!(
+                        "Board file not found: '{}'",
+                        effective_file
+                    ));
+                }
                 let mut ctx = CliContext::load(&store_manager, &effective_file, config).await?;
                 dispatch_subcommand(&mut ctx, cmd).await?;
             }

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -280,6 +280,7 @@ Provide the file path in one of these ways:
 
         match command {
             None => {
+                // KANBAN_FILE env var resolves into validated_file via clap's env attribute.
                 let has_explicit_file =
                     validated_file.is_some() || config.storage_location.is_some();
                 if has_explicit_file && !std::path::Path::new(&effective_file).exists() {
@@ -289,37 +290,33 @@ Provide the file path in one of these ways:
                     };
                     let store =
                         store_manager.make_store_with_config(validated_file.as_deref(), &config)?;
-                    if !store.exists().await {
-                        let data = snapshot_to_json_bytes(&Snapshot::new())
-                            .map_err(|e| anyhow::anyhow!("{e}"))?;
-                        let metadata = PersistenceMetadata::new(uuid::Uuid::new_v4());
-                        store
-                            .save(StoreSnapshot { data, metadata })
-                            .await
-                            .map_err(|e| anyhow::anyhow!("{e}"))?;
-                    }
+                    let data = snapshot_to_json_bytes(&Snapshot::new())
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    let metadata = PersistenceMetadata::new(uuid::Uuid::new_v4());
+                    store
+                        .save(StoreSnapshot { data, metadata })
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
                 }
-                {
-                    use std::io::IsTerminal;
-                    if std::io::stdin().is_terminal() {
-                        #[cfg(feature = "tui")]
-                        {
-                            let error_log = std::sync::Arc::new(std::sync::Mutex::new(
-                                kanban_tui::error_log::ErrorLogState::default(),
-                            ));
-                            init_tracing_tui(std::sync::Arc::clone(&error_log));
-                            let (mut app, save_rx) =
-                                App::new_with_store(store_manager, validated_file).await?;
-                            app.set_error_log(error_log);
-                            app.run(save_rx).await?;
-                        }
-                        #[cfg(not(feature = "tui"))]
-                        anyhow::bail!(
-                            "TUI not available in this build. Run `kanban --help` for available subcommands."
-                        );
+                use std::io::IsTerminal;
+                if std::io::stdin().is_terminal() {
+                    #[cfg(feature = "tui")]
+                    {
+                        let error_log = std::sync::Arc::new(std::sync::Mutex::new(
+                            kanban_tui::error_log::ErrorLogState::default(),
+                        ));
+                        init_tracing_tui(std::sync::Arc::clone(&error_log));
+                        let (mut app, save_rx) =
+                            App::new_with_store(store_manager, validated_file).await?;
+                        app.set_error_log(error_log);
+                        app.run(save_rx).await?;
                     }
-                    // Non-TTY: file created above if needed, exit cleanly.
+                    #[cfg(not(feature = "tui"))]
+                    anyhow::bail!(
+                        "TUI not available in this build. Run `kanban --help` for available subcommands."
+                    );
                 }
+                // Non-TTY: file created above if needed, exit cleanly.
             }
             Some(Commands::Completions { .. }) => unreachable!(),
             Some(Commands::Migrate(args)) => {

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -24,6 +24,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -48,6 +49,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let create_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -90,6 +92,8 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
         let output = kanban()
             .args([file.to_str().unwrap(), "board", "list"])
             .assert()
@@ -108,6 +112,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         kanban()
             .args([
                 file.to_str().unwrap(),
@@ -148,6 +153,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let create_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -183,6 +189,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let create_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -225,6 +232,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let create_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -265,6 +273,7 @@ mod column_tests {
     use super::*;
 
     fn setup_board(file: &std::path::Path) -> String {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -457,6 +466,7 @@ mod card_tests {
     use super::*;
 
     fn setup_board_and_column(file: &std::path::Path) -> (String, String) {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1183,6 +1193,7 @@ mod card_tests {
         file: &std::path::Path,
         prefix: &str,
     ) -> (String, String) {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1475,6 +1486,7 @@ mod sprint_tests {
     use super::*;
 
     fn setup_board(file: &std::path::Path) -> String {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1903,6 +1915,7 @@ mod export_import_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1928,6 +1941,7 @@ mod export_import_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1959,6 +1973,7 @@ mod export_import_tests {
         let file = dir.path().join("test.json");
         let import_file = dir.path().join("import.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1985,6 +2000,11 @@ mod export_import_tests {
         .unwrap();
 
         let new_file = dir.path().join("new.json");
+        kanban()
+            .args([new_file.to_str().unwrap()])
+            .assert()
+            .success();
+
         let output = kanban()
             .args([
                 new_file.to_str().unwrap(),
@@ -2034,6 +2054,7 @@ mod error_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         kanban()
             .args([
                 file.to_str().unwrap(),
@@ -2063,6 +2084,7 @@ mod error_tests {
     fn test_card_get_nonexistent_numeric_identifier() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
+        setup_board_and_column(&file);
 
         kanban()
             .args([file.to_str().unwrap(), "card", "get", "555"])
@@ -2077,6 +2099,7 @@ mod error_tests {
     fn test_card_get_nonexistent_prefix_identifier() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
+        setup_board_and_column(&file);
 
         kanban()
             .args([file.to_str().unwrap(), "card", "get", "KAN-5"])
@@ -2101,6 +2124,7 @@ mod error_tests {
     }
 
     fn setup_board_and_column(file: &std::path::Path) -> (String, String) {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -2169,6 +2193,7 @@ mod error_tests {
     fn test_card_list_invalid_status() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
+        setup_board_and_column(&file);
 
         kanban()
             .args([
@@ -2228,6 +2253,7 @@ mod error_tests {
     }
 
     fn setup_sprint(file: &std::path::Path) -> String {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -2341,6 +2367,10 @@ mod no_file_tests {
         let file = dir.path().join("via-env.json");
         // Seed the file via the positional path so this test verifies env-var
         // resolution rather than implicit JSON auto-create-on-open.
+        kanban_no_config(dir.path())
+            .args([file.to_str().unwrap()])
+            .assert()
+            .success();
         kanban_no_config(dir.path())
             .args([
                 file.to_str().unwrap(),
@@ -2484,5 +2514,40 @@ mod version_and_help_tests {
             !stderr.is_empty(),
             "an unknown flag must surface a stderr error message"
         );
+    }
+}
+
+mod missing_file_tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_file_gives_clear_error() {
+        kanban()
+            .args(["doesntexist.json", "card", "get", "KAN-1"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("\"success\":false"))
+            .stderr(predicate::str::contains("Board file not found"));
+    }
+
+    #[test]
+    fn test_board_create_requires_existing_file() {
+        kanban()
+            .args(["doesntexist.json", "board", "create", "--name", "Test"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Board file not found"));
+    }
+
+    #[test]
+    fn test_no_subcommand_creates_file_when_missing() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("new.json");
+        assert!(!file.exists());
+        kanban()
+            .args([file.to_str().unwrap()])
+            .assert()
+            .success();
+        assert!(file.exists(), "kanban <file> must create the file when missing");
     }
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -2544,10 +2544,10 @@ mod missing_file_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("new.json");
         assert!(!file.exists());
-        kanban()
-            .args([file.to_str().unwrap()])
-            .assert()
-            .success();
-        assert!(file.exists(), "kanban <file> must create the file when missing");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        assert!(
+            file.exists(),
+            "kanban <file> must create the file when missing"
+        );
     }
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -2084,7 +2084,7 @@ mod error_tests {
     fn test_card_get_nonexistent_numeric_identifier() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
-        setup_board_and_column(&file);
+        kanban().args([file.to_str().unwrap()]).assert().success();
 
         kanban()
             .args([file.to_str().unwrap(), "card", "get", "555"])
@@ -2099,7 +2099,7 @@ mod error_tests {
     fn test_card_get_nonexistent_prefix_identifier() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
-        setup_board_and_column(&file);
+        kanban().args([file.to_str().unwrap()]).assert().success();
 
         kanban()
             .args([file.to_str().unwrap(), "card", "get", "KAN-5"])
@@ -2193,7 +2193,7 @@ mod error_tests {
     fn test_card_list_invalid_status() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
-        setup_board_and_column(&file);
+        kanban().args([file.to_str().unwrap()]).assert().success();
 
         kanban()
             .args([
@@ -2522,8 +2522,10 @@ mod missing_file_tests {
 
     #[test]
     fn test_missing_file_gives_clear_error() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("doesntexist.json");
         kanban()
-            .args(["doesntexist.json", "card", "get", "KAN-1"])
+            .args([file.to_str().unwrap(), "card", "get", "KAN-1"])
             .assert()
             .failure()
             .stderr(predicate::str::contains("\"success\":false"))
@@ -2532,8 +2534,10 @@ mod missing_file_tests {
 
     #[test]
     fn test_board_create_requires_existing_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("doesntexist.json");
         kanban()
-            .args(["doesntexist.json", "board", "create", "--name", "Test"])
+            .args([file.to_str().unwrap(), "board", "create", "--name", "Test"])
             .assert()
             .failure()
             .stderr(predicate::str::contains("Board file not found"));


### PR DESCRIPTION
Fix misleading errors when a board file does not exist and give `kanban <file>` sole responsibility for storage initialisation:

- `app.rs` `Some(cmd)` arm: add file-existence check before `CliContext::load`; all three path sources (positional arg, `KANBAN_FILE` env var, config `storage_location`) resolve into `effective_file` before the check runs, so a single guard covers every case uniformly
- `app.rs` `None` arm: create an empty storage file when the path is explicit and the file does not exist; gate TUI launch on `stdin().is_terminal()` so non-TTY callers (scripts, tests) exit cleanly after init
- `cli_integration.rs`: add `missing_file_tests` module with three tests; update all setup helpers and inline board_tests to prepend `kanban <file>` (no subcommand) before `board create`; replace the board-create-plus-delete bootstrap in `test_board_list_empty` with the no-subcommand init call

**What**: All CLI subcommands now reject a missing storage file with a clear `Board file not found` error, regardless of how the path was supplied. `kanban <file>` with no subcommand initialises an empty file when it does not exist, replacing the implicit init that `board create` used to perform.

**Why**: Passing a non-existent file to any subcommand (e.g. `kanban missing.json card get KAN-1`) produced a domain error (`Card not found`) from the empty in-memory store that was silently substituted for the missing file. The same misleading error occurred whether the path came from a positional argument, the `KANBAN_FILE` environment variable, or `storage_location` in the config file. `board create` also had an exemption that gave it a dual role as both entity creator and storage bootstrapper, a separation-of-concerns problem and UX jagged edge.

**How**: The file-existence check in `run_with_args` runs after all three path sources have been resolved into `effective_file`, so a single check covers every case. The no-subcommand init writes an empty `Snapshot` directly via `PersistenceStore::save`, bypassing the `dirty` flag that would otherwise make `KanbanContext::flush` a no-op for an untouched context. For SQLite, `StoreFactory::create` opens the database file immediately so `store.exists()` returns true and the write is skipped.

**Testing**: `cargo test -p kanban-cli --test cli_integration` (62 tests, 3 new in `missing_file_tests`), `cargo test --workspace` (all green), `cargo clippy --all-targets --all-features -- -D warnings` (clean).
