### PR TITLE
KAN-328 fix(tui): show toast when toggling sprint filter without active sprint

### DIFF
--- a/.changeset/kan-328-sprint-filter-toast.md
+++ b/.changeset/kan-328-sprint-filter-toast.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Pressing `t` to toggle the active-sprint filter on a board that has no
+active sprint now surfaces an error banner reading "No active sprint set
+for filtering" instead of failing silently. Previously the keypress
+appeared to do nothing while quietly emitting a warning to the trace log,
+leaving users confused about why the card list did not change.

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -196,8 +196,9 @@ impl App {
                             tracing::info!("Enabled sprint filter - showing active sprint only");
                         }
                     } else {
-                        tracing::warn!("No active sprint set for filtering");
-                        self.set_error("No active sprint set for filtering");
+                        let msg = "No active sprint set for filtering";
+                        tracing::warn!("{}", msg);
+                        self.set_error(msg);
                     }
                 }
             }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -197,6 +197,7 @@ impl App {
                         }
                     } else {
                         tracing::warn!("No active sprint set for filtering");
+                        self.set_error("No active sprint set for filtering");
                     }
                 }
             }

--- a/crates/kanban-tui/tests/sprint_filter_toggle_tests.rs
+++ b/crates/kanban-tui/tests/sprint_filter_toggle_tests.rs
@@ -1,0 +1,30 @@
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::components::banner::BannerVariant;
+use kanban_tui::App;
+
+#[test]
+fn test_toggle_sprint_filter_without_active_sprint_shows_error_banner() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("B".into(), None).unwrap();
+    app.ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    app.selection.active_board_index = Some(0);
+    app.focus.active = Focus::Cards;
+    app.prepare_frame();
+
+    app.handle_toggle_sprint_filter();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("expected error banner when no active sprint is set");
+    assert_eq!(banner.variant, BannerVariant::Error);
+    assert!(
+        banner.message.contains("No active sprint"),
+        "banner should explain why toggling did nothing: {}",
+        banner.message,
+    );
+}


### PR DESCRIPTION
Replace silent log warning with a user-visible error banner when pressing `t` to toggle the active-sprint filter on a board that has no active sprint:

- Add `self.set_error("No active sprint set for filtering")` alongside the existing `tracing::warn!` in `App::handle_toggle_sprint_filter` (`crates/kanban-tui/src/handlers/card_handlers.rs`).
- Keep the `tracing::warn!` line as a debug-trace breadcrumb so the existing log narration in this handler (two `tracing::info!` happy-path lines) stays consistent.
- New integration test `crates/kanban-tui/tests/sprint_filter_toggle_tests.rs::test_toggle_sprint_filter_without_active_sprint_shows_error_banner` asserts the banner is set with `BannerVariant::Error` and the expected message.

**What**: When `t` is pressed in the cards panel on a board whose `active_sprint_id` is `None`, the TUI now shows the red banner "No active sprint set for filtering" so the user understands the keypress was a no-op. Previously the warning only went to the trace log.

**Why**: The keypress appeared to do nothing, and the WARN line in the trace log was invisible during normal use. Reported via KAN-328 with the trace line `WARN kanban_tui::handlers::card_handlers: No active sprint set for filtering`.

**How**: Smallest possible change in the existing `else` branch of `handle_toggle_sprint_filter`. The banner system (`Banner`, `BannerVariant::Error`, `App::set_error`) is the established pattern for user-facing failure feedback in this crate (see `App::set_error` at `crates/kanban-tui/src/app/mod.rs` and prior call sites like `board_handlers.rs`). No new severity variant introduced. The TUI-only check on `board.active_sprint_id` is left in place; if this operation moves into `kanban-service` later, the same precondition would become a returned `KanbanResult::Err` so CLI and MCP could surface it too.

**Testing**: `cargo test -p kanban-tui --test sprint_filter_toggle_tests` (new test passes, fails without the impl change), `cargo test --workspace` (all green), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all -- --check` (clean).