### PR TITLE
KAN-455 fix(tui): scroll board edit and filter popup lists to keep selection visible

### DIFF
--- a/.changeset/kan-455-no-scrolling-in-board-edit-view-sprint-and-column-lists.md
+++ b/.changeset/kan-455-no-scrolling-in-board-edit-view-sprint-and-column-lists.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+---
+
+The sprint and column lists in the board edit view, and the sprint
+section of the card list filter popup, now scroll to keep the selected
+item visible. Previously these three lists tracked the j/k cursor but
+never scrolled, so items past the visible area of the panel were
+unreachable on small terminals or on boards with many sprints or
+columns.
+
+Scrolling matches the minimal-scroll behavior of the main card list:
+the viewport only shifts when the cursor crosses an edge, so navigating
+back and forth inside the visible area no longer reshuffles the list.

--- a/crates/kanban-core/src/pagination.rs
+++ b/crates/kanban-core/src/pagination.rs
@@ -4,8 +4,38 @@
 //! viewport given a scroll offset. They are pure in-memory state and are never
 //! serialized or exposed through the CLI/MCP API.
 //!
+//! [`scroll_offset_to_keep_visible`] is the pure scroll-math primitive used by
+//! `Page::scroll_to_visible` and by callers that track a scroll offset outside
+//! of [`Page`].
+//!
 //! For the serialized pagination envelope used by CLI and MCP list responses,
 //! see [`super::paginated_list`].
+
+/// Compute the scroll offset that keeps `selected` inside a viewport of
+/// `viewport_height` rows. Minimal-scroll semantics: if `selected` is already
+/// visible, the offset is unchanged; otherwise it shifts just enough to bring
+/// `selected` to the nearest edge of the viewport.
+///
+/// This is the pure form of [`Page::scroll_to_visible`] and the canonical
+/// helper for any scrollable list that wants the same behavior as the main
+/// card list.
+pub fn scroll_offset_to_keep_visible(
+    current_offset: usize,
+    selected: usize,
+    viewport_height: usize,
+) -> usize {
+    if viewport_height == 0 {
+        return current_offset;
+    }
+    let scroll_end = current_offset + viewport_height;
+    if selected < current_offset {
+        selected
+    } else if selected >= scroll_end {
+        selected.saturating_sub(viewport_height - 1)
+    } else {
+        current_offset
+    }
+}
 
 /// Information about the visible portion of a paginated list.
 #[derive(Debug, Clone)]
@@ -163,18 +193,8 @@ impl Page {
 
     /// Scroll to make an item visible in the viewport.
     pub fn scroll_to_visible(&mut self, item_idx: usize, viewport_height: usize) {
-        if viewport_height == 0 {
-            return;
-        }
-
-        let scroll_start = self.scroll_offset;
-        let scroll_end = scroll_start + viewport_height;
-
-        if item_idx < scroll_start {
-            self.scroll_offset = item_idx;
-        } else if item_idx >= scroll_end {
-            self.scroll_offset = item_idx.saturating_sub(viewport_height - 1);
-        }
+        self.scroll_offset =
+            scroll_offset_to_keep_visible(self.scroll_offset, item_idx, viewport_height);
     }
 
     /// Navigate up by one item, returning the new index.

--- a/crates/kanban-core/src/pagination.rs
+++ b/crates/kanban-core/src/pagination.rs
@@ -228,6 +228,41 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_scroll_offset_to_keep_visible_zero_viewport_is_noop() {
+        assert_eq!(scroll_offset_to_keep_visible(7, 99, 0), 7);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_already_visible_keeps_offset() {
+        // viewport rows 5..=9, selected 7 → stays at offset 5
+        assert_eq!(scroll_offset_to_keep_visible(5, 7, 5), 5);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_selection_above_scrolls_up() {
+        // viewport rows 10..=14, selected 3 → snap offset to 3
+        assert_eq!(scroll_offset_to_keep_visible(10, 3, 5), 3);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_selection_below_scrolls_down() {
+        // viewport rows 0..=4, selected 7 → selected becomes last visible (offset 3)
+        assert_eq!(scroll_offset_to_keep_visible(0, 7, 5), 3);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_at_top_edge_no_scroll() {
+        // viewport rows 5..=9, selected 5 (top edge) → keep
+        assert_eq!(scroll_offset_to_keep_visible(5, 5, 5), 5);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_at_bottom_edge_no_scroll() {
+        // viewport rows 5..=9, selected 9 (bottom edge) → keep
+        assert_eq!(scroll_offset_to_keep_visible(5, 9, 5), 5);
+    }
+
+    #[test]
     fn test_page_info_empty() {
         let page = Page::new(0);
         let info = page.get_page_info(10);

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -1,4 +1,5 @@
 use kanban_core::SelectionState;
+use std::cell::Cell;
 use uuid::Uuid;
 
 #[derive(Default)]
@@ -7,6 +8,7 @@ pub struct DialogInputState {
     pub import_selection: SelectionState,
     pub priority_selection: SelectionState,
     pub column_selection: SelectionState,
+    pub column_scroll: Cell<usize>,
     pub sprint_assign_selection: SelectionState,
     pub task_list_view_selection: SelectionState,
     pub carry_over_sprint_selection: SelectionState,

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -1,4 +1,5 @@
 use kanban_core::SelectionState;
+use std::cell::Cell;
 
 #[derive(Default)]
 pub struct SelectionHub {
@@ -7,6 +8,7 @@ pub struct SelectionHub {
     pub active_card_index: Option<usize>,
     pub active_card_id: Option<uuid::Uuid>,
     pub sprint: SelectionState,
+    pub sprint_scroll: Cell<usize>,
     pub active_sprint_index: Option<usize>,
     pub card_navigation_history: Vec<usize>,
     pub settings_config: SelectionState,

--- a/crates/kanban-tui/src/components/filter_popup.rs
+++ b/crates/kanban-tui/src/components/filter_popup.rs
@@ -2,6 +2,7 @@ use crate::app::App;
 use crate::components::centered_rect;
 use crate::filters::FilterDialogState;
 use crate::theme::*;
+use kanban_core::pagination::scroll_offset_to_keep_visible;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
@@ -115,14 +116,29 @@ fn render_filter_sprints_section(
         }
     }
 
-    let section =
-        Paragraph::new(sprint_lines).block(Block::default().borders(Borders::ALL).border_style(
-            if section_index == 0 {
-                focused_border()
-            } else {
-                Style::default()
-            },
-        ));
+    let selected_line_idx = if dialog_state.item_selection == 0 {
+        1
+    } else {
+        dialog_state.item_selection + 2
+    };
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let scroll = scroll_offset_to_keep_visible(
+        dialog_state.item_scroll.get(),
+        selected_line_idx,
+        viewport_height,
+    );
+    dialog_state.item_scroll.set(scroll);
+    let section = Paragraph::new(sprint_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(if section_index == 0 {
+                    focused_border()
+                } else {
+                    Style::default()
+                }),
+        )
+        .scroll((scroll as u16, 0));
     frame.render_widget(section, area);
 }
 

--- a/crates/kanban-tui/src/filters.rs
+++ b/crates/kanban-tui/src/filters.rs
@@ -1,4 +1,5 @@
 use kanban_domain::CardFilters;
+use std::cell::Cell;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FilterDialogSection {
@@ -12,6 +13,7 @@ pub struct FilterDialogState {
     pub current_section: FilterDialogSection,
     pub section_index: usize,
     pub item_selection: usize,
+    pub item_scroll: Cell<usize>,
     pub filters: CardFilters,
 }
 
@@ -21,6 +23,7 @@ impl FilterDialogState {
             current_section: FilterDialogSection::Sprints,
             section_index: 0,
             item_selection: 0,
+            item_scroll: Cell::new(0),
             filters,
         }
     }
@@ -28,6 +31,7 @@ impl FilterDialogState {
     pub fn next_section(&mut self) {
         self.section_index = (self.section_index + 1) % 3;
         self.item_selection = 0;
+        self.item_scroll.set(0);
         self.current_section = match self.section_index {
             0 => FilterDialogSection::Sprints,
             1 => FilterDialogSection::DateRange,
@@ -43,6 +47,7 @@ impl FilterDialogState {
             self.section_index - 1
         };
         self.item_selection = 0;
+        self.item_scroll.set(0);
         self.current_section = match self.section_index {
             0 => FilterDialogSection::Sprints,
             1 => FilterDialogSection::DateRange,

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -1,6 +1,7 @@
 use crate::app::{App, BoardFocus};
 use crate::components::*;
 use crate::theme::*;
+use kanban_core::pagination::scroll_offset_to_keep_visible;
 use kanban_domain::{Sprint, SprintStatus};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -215,7 +216,17 @@ fn render_board_sprints_list(
         }
     }
 
-    let sprints = Paragraph::new(sprint_lines).block(sprints_config.block());
+    let selected_idx = app.selection.sprint.get().unwrap_or(0);
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let scroll = scroll_offset_to_keep_visible(
+        app.selection.sprint_scroll.get(),
+        selected_idx,
+        viewport_height,
+    );
+    app.selection.sprint_scroll.set(scroll);
+    let sprints = Paragraph::new(sprint_lines)
+        .block(sprints_config.block())
+        .scroll((scroll as u16, 0));
     frame.render_widget(sprints, area);
 }
 
@@ -272,6 +283,16 @@ fn render_board_columns_list(
         }
     }
 
-    let columns = Paragraph::new(column_lines).block(columns_config.block());
+    let selected_idx = app.dialog_input.column_selection.get().unwrap_or(0);
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let scroll = scroll_offset_to_keep_visible(
+        app.dialog_input.column_scroll.get(),
+        selected_idx,
+        viewport_height,
+    );
+    app.dialog_input.column_scroll.set(scroll);
+    let columns = Paragraph::new(column_lines)
+        .block(columns_config.block())
+        .scroll((scroll as u16, 0));
     frame.render_widget(columns, area);
 }

--- a/crates/kanban-tui/tests/scroll_board_edit_lists.rs
+++ b/crates/kanban-tui/tests/scroll_board_edit_lists.rs
@@ -62,7 +62,7 @@ fn test_board_columns_list_scrolls_to_keep_selection_visible() {
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();
     for i in 0..20 {
         app.ctx
-            .create_column(board.id, format!("ColMark{:02}", i), Some(i as i32))
+            .create_column(board.id, format!("ColMark{:02}", i), Some(i))
             .unwrap();
     }
     app.prepare_frame();

--- a/crates/kanban-tui/tests/scroll_board_edit_lists.rs
+++ b/crates/kanban-tui/tests/scroll_board_edit_lists.rs
@@ -1,0 +1,159 @@
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::app::BoardFocus;
+use kanban_tui::App;
+
+fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
+}
+
+#[test]
+fn test_board_sprints_list_scrolls_to_keep_selection_visible() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    for i in 0..20 {
+        app.ctx
+            .create_sprint(board.id, None, Some(format!("SpMark{:02}", i)))
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app.push_mode(AppMode::BoardDetail);
+    app.focus.board_focus = BoardFocus::Sprints;
+    app.selection.sprint.set(Some(19));
+
+    let output = render_to_string(&mut app, 80, 30);
+
+    assert!(
+        output.contains("SpMark19"),
+        "selected sprint (last one) should be visible after scroll, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("SpMark00"),
+        "first sprint should have scrolled off-screen, got:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_board_columns_list_scrolls_to_keep_selection_visible() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    for i in 0..20 {
+        app.ctx
+            .create_column(board.id, format!("ColMark{:02}", i), Some(i as i32))
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app.push_mode(AppMode::BoardDetail);
+    app.focus.board_focus = BoardFocus::Columns;
+    app.dialog_input.column_selection.set(Some(19));
+
+    let output = render_to_string(&mut app, 80, 30);
+
+    assert!(
+        output.contains("ColMark19"),
+        "selected column (last one) should be visible after scroll, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("ColMark00"),
+        "first column should have scrolled off-screen, got:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_board_sprints_scroll_offset_is_stable_when_selection_moves_within_viewport() {
+    // Once scrolled, navigating one item up keeps the same scroll offset:
+    // the previously-selected item stays visible, only the cursor moves.
+    // This is the minimal-scroll semantics shared with the main card list.
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    for i in 0..20 {
+        app.ctx
+            .create_sprint(board.id, None, Some(format!("StaySp{:02}", i)))
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app.push_mode(AppMode::BoardDetail);
+    app.focus.board_focus = BoardFocus::Sprints;
+
+    app.selection.sprint.set(Some(19));
+    render_to_string(&mut app, 80, 30);
+    let offset_after_jump_down = app.selection.sprint_scroll.get();
+    assert!(
+        offset_after_jump_down > 0,
+        "expected non-zero scroll after selecting last sprint, got {}",
+        offset_after_jump_down
+    );
+
+    app.selection.sprint.set(Some(18));
+    render_to_string(&mut app, 80, 30);
+    assert_eq!(
+        app.selection.sprint_scroll.get(),
+        offset_after_jump_down,
+        "scroll offset should remain stable when selection moves within viewport"
+    );
+}
+
+#[test]
+fn test_filter_popup_sprints_scrolls_to_keep_selection_visible() {
+    use kanban_domain::CardFilters;
+    use kanban_tui::filters::FilterDialogState;
+
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    for i in 0..20 {
+        app.ctx
+            .create_sprint(board.id, None, Some(format!("FpMark{:02}", i)))
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
+    let mut dialog = FilterDialogState::new(CardFilters::default());
+    // item_selection 0 = "show unassigned" row, 1..=20 = sprints index-0..19
+    // Select the last sprint (index 19 in the sprint list).
+    dialog.item_selection = 20;
+    app.filter.dialog_state = Some(dialog);
+
+    let output = render_to_string(&mut app, 80, 30);
+
+    assert!(
+        output.contains("FpMark19"),
+        "selected sprint (last in filter popup) should be visible after scroll, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("FpMark00"),
+        "first sprint in filter popup should have scrolled off-screen, got:\n{}",
+        output
+    );
+}


### PR DESCRIPTION
Three `j/k`-navigable paragraph lists in the TUI now scroll to keep the selected item visible:

- Board edit view — Sprints panel (`render_board_sprints_list` in `crates/kanban-tui/src/ui/board_detail.rs`)
- Board edit view — Columns panel (`render_board_columns_list` in `crates/kanban-tui/src/ui/board_detail.rs`)
- Card list filter popup — Sprints section (`render_filter_sprints_section` in `crates/kanban-tui/src/components/filter_popup.rs`)

**What**: Each of the three lists now derives a scroll offset from its current selection and the viewport height, then applies that offset via `Paragraph::scroll((offset, 0))`. Behavior matches the minimal-scroll semantics of the main card list: the viewport only shifts when the cursor crosses an edge, so navigating back and forth inside the visible area does not reshuffle the list.

**Why**: All three lists tracked the cursor with `j/k` but rendered `Paragraph::new(lines)` with no scroll offset. On small terminals or boards with many sprints/columns, items past the panel boundary were unreachable even though selection moved there.

**How**:

- Extracted the pure scroll-math primitive `scroll_offset_to_keep_visible(current_offset, selected, viewport_height) -> usize` into `kanban-core::pagination`. `Page::scroll_to_visible` now delegates to it, so `ListComponent`, `card_list`, and every other Page-based list reuse the same logic (no behavior change there).
- Added `Cell<usize>` scroll offset fields alongside the existing selections: `SelectionHub.sprint_scroll`, `DialogInputState.column_scroll`, `FilterDialogState.item_scroll` (the last is reset in `next_section`/`prev_section`). Cell lets the renderer mutate the offset from a `&App` borrow.
- Each renderer reads the cell, calls the pure function, writes back, and applies the offset.
- The filter popup's `selected_line_idx` translation accounts for the title row, the unassigned-sprints checkbox, and the separator that precede the sprint rows.

A follow-up card (**KAN-456**) is filed in the kanban board for migrating all `SelectionState`-backed lists to `ListComponent` (the proper architectural unification). This PR sets that up by making `scroll_offset_to_keep_visible` the single source of truth for the math.

**Testing**: `cargo test -p kanban-tui --test scroll_board_edit_lists` (4 new integration tests, including `test_board_sprints_scroll_offset_is_stable_when_selection_moves_within_viewport` which verifies the minimal-scroll behavioral property), `cargo test -p kanban-core --lib pagination` (20 tests; 6 new for the pure function, 14 existing), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --check` (clean).