### PR TITLE
KAN-400 feat(workspace): accept entity names everywhere a UUID was required

### DIFF
--- a/.changeset/cat-323-fix-misleading-card-not-found-error-when-board-file-does-not-exist.md
+++ b/.changeset/cat-323-fix-misleading-card-not-found-error-when-board-file-does-not-exist.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 Running `kanban missing.json card get KAN-1` (or any subcommand) when the

--- a/.changeset/kan-400-accept-names-everywhere.md
+++ b/.changeset/kan-400-accept-names-everywhere.md
@@ -1,0 +1,46 @@
+---
+bump: minor
+---
+
+Every CLI command and MCP tool now accepts a human-readable name (or sprint
+number) anywhere it previously required a raw UUID. Plain UUIDs continue to
+work, so existing scripts are unaffected.
+
+You can now write things like:
+
+```
+kanban board get Kanban
+kanban column list --board-id Kanban
+kanban sprint activate yarara-release
+kanban sprint get 15
+kanban card create --board-id Kanban --column-id TODO --title "Hi"
+kanban card move KAN-12 --column-id Doing
+kanban card move-cards --ids KAN-1,KAN-2 --column-id Doing
+kanban card assign-cards-to-sprint --ids KAN-1,KAN-2 --sprint-id yarara-release
+```
+
+The same input flexibility applies to every MCP tool. Board, column, and
+sprint fields in tool schemas now read "UUID or name" (or "UUID, name, or
+number" for sprints) instead of demanding a UUID. The batch tools
+`archive_cards`, `move_cards`, and `assign_cards_to_sprint` take a JSON array
+of card UUIDs or identifiers (for example `["KAN-1", "KAN-2"]`) in place of
+the old comma-separated string.
+
+When a name does not match, the error tells you exactly what is available,
+for example: `Column 'done' not found. Available: 'TODO', 'Doing', 'Complete'`.
+When a name is ambiguous across boards, the error names the boards in
+conflict and asks you to disambiguate by UUID or a unique name.
+
+For card move-cards and assign-cards-to-sprint, the selection must now share
+a single board so the target column or sprint can be resolved unambiguously
+within it; mixing cards from different boards produces a clear "Batch
+operation requires all cards on the same board" error.
+
+Names are case-insensitive. Sprints accept either a name (matched against
+the board's stored sprint names) or a sprint number. Cards accept their
+prefix-number identifier (such as `KAN-5`) or a bare card number, in
+addition to the full UUID.
+
+The TUI is unchanged in this release, but the same resolver functions are
+now available to it for future text-input features (command palette,
+jump-to-board, and so on).

--- a/.changeset/kan-400-accept-names-everywhere.md
+++ b/.changeset/kan-400-accept-names-everywhere.md
@@ -4,19 +4,19 @@ bump: minor
 
 Every CLI command and MCP tool now accepts a human-readable name (or sprint
 number) anywhere it previously required a raw UUID. Plain UUIDs continue to
-work, so existing scripts are unaffected.
+work, so existing scripts that already use UUIDs still resolve correctly.
 
 You can now write things like:
 
 ```
 kanban board get Kanban
-kanban column list --board-id Kanban
+kanban column list --board Kanban
 kanban sprint activate yarara-release
 kanban sprint get 15
-kanban card create --board-id Kanban --column-id TODO --title "Hi"
-kanban card move KAN-12 --column-id Doing
-kanban card move-cards --ids KAN-1,KAN-2 --column-id Doing
-kanban card assign-cards-to-sprint --ids KAN-1,KAN-2 --sprint-id yarara-release
+kanban card create --board Kanban --column TODO --title "Hi"
+kanban card move KAN-12 --column Doing
+kanban card move-cards --cards KAN-1,KAN-2 --column Doing
+kanban card assign-cards-to-sprint --cards KAN-1,KAN-2 --sprint yarara-release
 ```
 
 The same input flexibility applies to every MCP tool. Board, column, and
@@ -26,15 +26,45 @@ number" for sprints) instead of demanding a UUID. The batch tools
 of card UUIDs or identifiers (for example `["KAN-1", "KAN-2"]`) in place of
 the old comma-separated string.
 
+**Breaking flag and field renames.** Now that these inputs accept names, the
+old `--*-id` flag names and `*_id` schema fields were misleading and have
+been replaced with the bare entity name:
+
+CLI flags:
+
+| Old                                  | New                              |
+| ------------------------------------ | -------------------------------- |
+| `--board-id`                         | `--board`                        |
+| `--column-id`                        | `--column`                       |
+| `--sprint-id`                        | `--sprint`                       |
+| `--ids` (on `card archive-cards`, `card move-cards`, `card assign-cards-to-sprint`) | `--cards` |
+
+Positional arguments now show `<BOARD>` / `<COLUMN>` / `<CARD>` / `<SPRINT>`
+in `--help` output instead of the generic `<ID>`.
+
+MCP tool input fields:
+
+| Old                  | New              |
+| -------------------- | ---------------- |
+| `board_id`           | `board`          |
+| `column_id`          | `column`         |
+| `sprint_id`          | `sprint`         |
+| `card_id`            | `card`           |
+| `ids` (batch tools)  | `cards`          |
+| `from_sprint_id`     | `from_sprint`    |
+| `to_sprint_id`       | `to_sprint`      |
+
+No aliases are kept. Update scripts and MCP clients to the new spellings.
+
 When a name does not match, the error tells you exactly what is available,
 for example: `Column 'done' not found. Available: 'TODO', 'Doing', 'Complete'`.
 When a name is ambiguous across boards, the error names the boards in
 conflict and asks you to disambiguate by UUID or a unique name.
 
-For card move-cards and assign-cards-to-sprint, the selection must now share
-a single board so the target column or sprint can be resolved unambiguously
-within it; mixing cards from different boards produces a clear "Batch
-operation requires all cards on the same board" error.
+For `card move-cards` and `card assign-cards-to-sprint`, the selection must
+now share a single board so the target column or sprint can be resolved
+unambiguously within it; mixing cards from different boards produces a clear
+"Batch operation requires all cards on the same board" error.
 
 Names are case-insensitive. Sprints accept either a name (matched against
 the board's stored sprint names) or a sprint number. Cards accept their

--- a/README.md
+++ b/README.md
@@ -40,12 +40,16 @@ export KANBAN_FILE=boards.json   # or pass the path as the first argument
 
 kanban board create --name "My Project"
 kanban board list
-kanban card create --board-id <ID> --column-id <ID> --title "Fix the bug" --priority high
-kanban card list --board-id <ID>
-kanban sprint create --board-id <ID>
-kanban sprint activate <SPRINT_ID> --duration-days 14
-kanban card assign-sprint <CARD_ID> --sprint-id <SPRINT_ID>
+kanban card create --board "My Project" --column TODO --title "Fix the bug" --priority high
+kanban card list --board "My Project"
+kanban sprint create --board "My Project"
+kanban sprint activate yarara-release --duration-days 14
+kanban card assign-sprint KAN-5 --sprint yarara-release
 ```
+
+Every entity argument accepts either a UUID or a human-readable name (sprint
+numbers also work for sprints; cards accept their `KAN-N` identifier). When a
+name doesn't match, the error lists what's available.
 
 All commands output JSON. Use `kanban --help` for full reference.
 

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -36,8 +36,8 @@ kanban board delete <ID>
 ### `column`
 
 ```bash
-kanban column create --board-id <ID> --name <NAME> [--position <N>]
-kanban column list --board-id <ID>
+kanban column create --board <ID> --name <NAME> [--position <N>]
+kanban column list --board <ID>
 kanban column get <ID>
 kanban column update <ID> [--name <NAME>] [--position <N>] [--wip-limit <N>]
 kanban column delete <ID>
@@ -48,10 +48,10 @@ kanban column reorder <ID> --position <N>
 
 ```bash
 # CRUD
-kanban card create --board-id <ID> --column-id <ID> --title <TITLE>
+kanban card create --board <ID> --column <ID> --title <TITLE>
                    [--description <DESC>] [--priority low|medium|high|critical]
                    [--points <N>] [--due-date <YYYY-MM-DD>]
-kanban card list [--board-id <ID>] [--column-id <ID>] [--sprint-id <ID>]
+kanban card list [--board <ID>] [--column <ID>] [--sprint <ID>]
                  [--status todo|in_progress|blocked|done]
                  [--page <N>] [--page-size <N>]
 kanban card get <ID_OR_IDENTIFIER>
@@ -61,12 +61,12 @@ kanban card update <ID_OR_IDENTIFIER> [--title <TITLE>] [--description <DESC>]
 kanban card delete <ID_OR_IDENTIFIER>
 
 # Movement & archiving
-kanban card move <ID_OR_IDENTIFIER> --column-id <ID> [--position <N>]
+kanban card move <ID_OR_IDENTIFIER> --column <ID> [--position <N>]
 kanban card archive <ID_OR_IDENTIFIER>
-kanban card restore <ID_OR_IDENTIFIER> [--column-id <ID>]
+kanban card restore <ID_OR_IDENTIFIER> [--column <ID>]
 
 # Sprint
-kanban card assign-sprint <ID_OR_IDENTIFIER> --sprint-id <ID>
+kanban card assign-sprint <ID_OR_IDENTIFIER> --sprint <ID>
 kanban card unassign-sprint <ID_OR_IDENTIFIER>
 
 # Git
@@ -74,9 +74,9 @@ kanban card branch-name <ID_OR_IDENTIFIER>
 kanban card git-checkout <ID_OR_IDENTIFIER>
 
 # Bulk operations
-kanban card archive-cards --ids <UUID,UUID,...>
-kanban card move-cards --ids <UUID,UUID,...> --column-id <ID>
-kanban card assign-cards-to-sprint --ids <UUID,UUID,...> --sprint-id <ID>
+kanban card archive-cards --cards <UUID,UUID,...>
+kanban card move-cards --cards <UUID,UUID,...> --column <ID>
+kanban card assign-cards-to-sprint --cards <UUID,UUID,...> --sprint <ID>
 ```
 
 **Card identifier resolution**: `<ID_OR_IDENTIFIER>` accepts:
@@ -87,8 +87,8 @@ kanban card assign-cards-to-sprint --ids <UUID,UUID,...> --sprint-id <ID>
 ### `sprint`
 
 ```bash
-kanban sprint create --board-id <ID> [--name <NAME>] [--prefix <PREFIX>]
-kanban sprint list --board-id <ID>
+kanban sprint create --board <ID> [--name <NAME>] [--prefix <PREFIX>]
+kanban sprint list --board <ID>
 kanban sprint get <ID>
 kanban sprint update <ID> [--name <NAME>] [--prefix <PREFIX>]
                           [--card-prefix <PREFIX>]
@@ -103,7 +103,7 @@ kanban sprint carry-over --from <ID> --to <ID>
 ### Top-level commands
 
 ```bash
-kanban export [--board-id <ID>] [--output <FILE>]
+kanban export [--board <ID>] [--output <FILE>]
 kanban import <FILE>
 kanban migrate <SOURCE> <BACKEND> [-o <OUTPUT>] [--source-backend <BACKEND>]
 kanban completions <bash|zsh|fish|powershell>

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -1,5 +1,4 @@
 use clap::{Args, Parser, Subcommand};
-use uuid::Uuid;
 
 use kanban_core::VERSION;
 
@@ -62,24 +61,24 @@ pub enum BoardAction {
         #[arg(long)]
         page_size: Option<u32>,
     },
-    /// Get a specific board by ID
+    /// Get a specific board by UUID or name
     Get {
-        /// Board ID
-        id: Uuid,
+        /// Board UUID or name
+        id: String,
     },
     /// Update a board
     Update(BoardUpdateArgs),
-    /// Delete a board by ID
+    /// Delete a board by UUID or name
     Delete {
-        /// Board ID
-        id: Uuid,
+        /// Board UUID or name
+        id: String,
     },
 }
 
 #[derive(Args)]
 pub struct BoardUpdateArgs {
-    /// Board ID to update
-    pub id: Uuid,
+    /// Board UUID or name
+    pub id: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -101,8 +100,9 @@ pub struct ColumnCommand {
 pub enum ColumnAction {
     /// Create a new column
     Create {
+        /// Board UUID or name
         #[arg(long)]
-        board_id: Uuid,
+        board_id: String,
         #[arg(long)]
         name: String,
         #[arg(long)]
@@ -110,29 +110,30 @@ pub enum ColumnAction {
     },
     /// List columns for a board
     List {
+        /// Board UUID or name
         #[arg(long)]
-        board_id: Uuid,
+        board_id: String,
         #[arg(long)]
         page: Option<u32>,
         #[arg(long)]
         page_size: Option<u32>,
     },
-    /// Get a specific column by ID
+    /// Get a specific column by UUID or name
     Get {
-        /// Column ID
-        id: Uuid,
+        /// Column UUID or name
+        id: String,
     },
     /// Update a column
     Update(ColumnUpdateArgs),
-    /// Delete a column by ID
+    /// Delete a column by UUID or name
     Delete {
-        /// Column ID
-        id: Uuid,
+        /// Column UUID or name
+        id: String,
     },
-    /// Reorder a column by ID
+    /// Reorder a column by UUID or name
     Reorder {
-        /// Column ID
-        id: Uuid,
+        /// Column UUID or name
+        id: String,
         #[arg(long)]
         position: i32,
     },
@@ -140,8 +141,8 @@ pub enum ColumnAction {
 
 #[derive(Args)]
 pub struct ColumnUpdateArgs {
-    /// Column ID to update
-    pub id: Uuid,
+    /// Column UUID or name
+    pub id: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -176,8 +177,9 @@ pub enum CardAction {
     Move {
         /// Card UUID or identifier like KAN-5 or 5
         id: String,
+        /// Column UUID or name
         #[arg(long)]
-        column_id: Uuid,
+        column_id: String,
         #[arg(long)]
         position: Option<i32>,
     },
@@ -190,8 +192,9 @@ pub enum CardAction {
     Restore {
         /// Card UUID or identifier like KAN-5 or 5
         id: String,
+        /// Column UUID or name
         #[arg(long)]
-        column_id: Option<Uuid>,
+        column_id: Option<String>,
     },
     /// Permanently delete an archived card by ID or identifier (e.g. KAN-5)
     Delete {
@@ -202,8 +205,9 @@ pub enum CardAction {
     AssignSprint {
         /// Card UUID or identifier like KAN-5 or 5
         id: String,
+        /// Sprint UUID, name, or number
         #[arg(long)]
-        sprint_id: Uuid,
+        sprint_id: String,
     },
     /// Unassign a card from its sprint
     UnassignSprint {
@@ -223,33 +227,40 @@ pub enum CardAction {
     /// Archive multiple cards
     #[command(name = "archive-cards")]
     ArchiveCards {
+        /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<Uuid>,
+        ids: Vec<String>,
     },
     /// Move multiple cards to a column
     #[command(name = "move-cards")]
     MoveCards {
+        /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<Uuid>,
+        ids: Vec<String>,
+        /// Column UUID or name (must be on the same board as all selected cards)
         #[arg(long)]
-        column_id: Uuid,
+        column_id: String,
     },
     /// Assign multiple cards to a sprint
     #[command(name = "assign-cards-to-sprint")]
     AssignCardsToSprint {
+        /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<Uuid>,
+        ids: Vec<String>,
+        /// Sprint UUID, name, or number (must be on the same board as all selected cards)
         #[arg(long)]
-        sprint_id: Uuid,
+        sprint_id: String,
     },
 }
 
 #[derive(Args)]
 pub struct CardCreateArgs {
+    /// Board UUID or name
     #[arg(long)]
-    pub board_id: Uuid,
+    pub board_id: String,
+    /// Column UUID or name
     #[arg(long)]
-    pub column_id: Uuid,
+    pub column_id: String,
     #[arg(long)]
     pub title: String,
     #[arg(long)]
@@ -264,12 +275,15 @@ pub struct CardCreateArgs {
 
 #[derive(Args)]
 pub struct CardListArgs {
+    /// Board UUID or name
     #[arg(long)]
-    pub board_id: Option<Uuid>,
+    pub board_id: Option<String>,
+    /// Column UUID or name (scoped to --board-id if given, else searched globally)
     #[arg(long)]
-    pub column_id: Option<Uuid>,
+    pub column_id: Option<String>,
+    /// Sprint UUID, name, or number (scoped to --board-id if given, else searched globally)
     #[arg(long)]
-    pub sprint_id: Option<Uuid>,
+    pub sprint_id: Option<String>,
     #[arg(long)]
     pub status: Option<String>,
     #[arg(long)]
@@ -311,8 +325,9 @@ pub struct SprintCommand {
 pub enum SprintAction {
     /// Create a new sprint
     Create {
+        /// Board UUID or name
         #[arg(long)]
-        board_id: Uuid,
+        board_id: String,
         #[arg(long)]
         prefix: Option<String>,
         #[arg(long)]
@@ -320,57 +335,58 @@ pub enum SprintAction {
     },
     /// List sprints for a board
     List {
+        /// Board UUID or name
         #[arg(long)]
-        board_id: Uuid,
+        board_id: String,
         #[arg(long)]
         page: Option<u32>,
         #[arg(long)]
         page_size: Option<u32>,
     },
-    /// Get a specific sprint by ID
+    /// Get a specific sprint by UUID, name, or number
     Get {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        id: String,
     },
     /// Update a sprint
     Update(SprintUpdateArgs),
-    /// Activate a sprint by ID
+    /// Activate a sprint by UUID, name, or number
     Activate {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        id: String,
         #[arg(long)]
         duration_days: Option<i32>,
     },
-    /// Complete a sprint by ID
+    /// Complete a sprint by UUID, name, or number
     Complete {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        id: String,
     },
-    /// Cancel a sprint by ID
+    /// Cancel a sprint by UUID, name, or number
     Cancel {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        id: String,
     },
-    /// Delete a sprint by ID
+    /// Delete a sprint by UUID, name, or number
     Delete {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        id: String,
     },
     /// Carry over uncompleted cards from a completed sprint to a planning sprint
     CarryOver {
-        /// ID of the completed sprint to carry cards from
+        /// Source sprint UUID, name, or number (must be completed)
         #[arg(long)]
-        from: Uuid,
-        /// ID of the planning sprint to carry cards to
+        from: String,
+        /// Target sprint UUID, name, or number (must be in planning; on same board as source)
         #[arg(long)]
-        to: Uuid,
+        to: String,
     },
 }
 
 #[derive(Args)]
 pub struct SprintUpdateArgs {
-    /// Sprint ID to update
-    pub id: Uuid,
+    /// Sprint UUID, name, or number
+    pub id: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -410,8 +426,9 @@ pub struct MigrateArgs {
 // Export/Import commands
 #[derive(Args)]
 pub struct ExportArgs {
+    /// Board UUID or name; if omitted, exports all boards
     #[arg(long)]
-    pub board_id: Option<Uuid>,
+    pub board_id: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -64,21 +64,21 @@ pub enum BoardAction {
     /// Get a specific board by UUID or name
     Get {
         /// Board UUID or name
-        id: String,
+        board: String,
     },
     /// Update a board
     Update(BoardUpdateArgs),
     /// Delete a board by UUID or name
     Delete {
         /// Board UUID or name
-        id: String,
+        board: String,
     },
 }
 
 #[derive(Args)]
 pub struct BoardUpdateArgs {
     /// Board UUID or name
-    pub id: String,
+    pub board: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -102,7 +102,7 @@ pub enum ColumnAction {
     Create {
         /// Board UUID or name
         #[arg(long)]
-        board_id: String,
+        board: String,
         #[arg(long)]
         name: String,
         #[arg(long)]
@@ -112,7 +112,7 @@ pub enum ColumnAction {
     List {
         /// Board UUID or name
         #[arg(long)]
-        board_id: String,
+        board: String,
         #[arg(long)]
         page: Option<u32>,
         #[arg(long)]
@@ -121,19 +121,19 @@ pub enum ColumnAction {
     /// Get a specific column by UUID or name
     Get {
         /// Column UUID or name
-        id: String,
+        column: String,
     },
     /// Update a column
     Update(ColumnUpdateArgs),
     /// Delete a column by UUID or name
     Delete {
         /// Column UUID or name
-        id: String,
+        column: String,
     },
     /// Reorder a column by UUID or name
     Reorder {
         /// Column UUID or name
-        id: String,
+        column: String,
         #[arg(long)]
         position: i32,
     },
@@ -142,7 +142,7 @@ pub enum ColumnAction {
 #[derive(Args)]
 pub struct ColumnUpdateArgs {
     /// Column UUID or name
-    pub id: String,
+    pub column: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -166,90 +166,90 @@ pub enum CardAction {
     Create(CardCreateArgs),
     /// List cards with optional filters
     List(CardListArgs),
-    /// Get a specific card by ID or identifier (e.g. KAN-5)
+    /// Get a specific card by UUID or identifier (e.g. KAN-5)
     Get {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Update a card
     Update(CardUpdateArgs),
     /// Move a card to another column
     Move {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
         /// Column UUID or name
         #[arg(long)]
-        column_id: String,
+        column: String,
         #[arg(long)]
         position: Option<i32>,
     },
-    /// Archive a card by ID or identifier (e.g. KAN-5)
+    /// Archive a card by UUID or identifier (e.g. KAN-5)
     Archive {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
-    /// Restore an archived card by ID or identifier (e.g. KAN-5)
+    /// Restore an archived card by UUID or identifier (e.g. KAN-5)
     Restore {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
         /// Column UUID or name
         #[arg(long)]
-        column_id: Option<String>,
+        column: Option<String>,
     },
-    /// Permanently delete an archived card by ID or identifier (e.g. KAN-5)
+    /// Permanently delete an archived card by UUID or identifier (e.g. KAN-5)
     Delete {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Assign a card to a sprint
     AssignSprint {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
         /// Sprint UUID, name, or number
         #[arg(long)]
-        sprint_id: String,
+        sprint: String,
     },
     /// Unassign a card from its sprint
     UnassignSprint {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Get the branch name for a card
     BranchName {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Get the git checkout command for a card
     GitCheckout {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Archive multiple cards
     #[command(name = "archive-cards")]
     ArchiveCards {
         /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<String>,
+        cards: Vec<String>,
     },
     /// Move multiple cards to a column
     #[command(name = "move-cards")]
     MoveCards {
         /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<String>,
+        cards: Vec<String>,
         /// Column UUID or name (must be on the same board as all selected cards)
         #[arg(long)]
-        column_id: String,
+        column: String,
     },
     /// Assign multiple cards to a sprint
     #[command(name = "assign-cards-to-sprint")]
     AssignCardsToSprint {
         /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<String>,
+        cards: Vec<String>,
         /// Sprint UUID, name, or number (must be on the same board as all selected cards)
         #[arg(long)]
-        sprint_id: String,
+        sprint: String,
     },
 }
 
@@ -257,10 +257,10 @@ pub enum CardAction {
 pub struct CardCreateArgs {
     /// Board UUID or name
     #[arg(long)]
-    pub board_id: String,
+    pub board: String,
     /// Column UUID or name
     #[arg(long)]
-    pub column_id: String,
+    pub column: String,
     #[arg(long)]
     pub title: String,
     #[arg(long)]
@@ -277,13 +277,13 @@ pub struct CardCreateArgs {
 pub struct CardListArgs {
     /// Board UUID or name
     #[arg(long)]
-    pub board_id: Option<String>,
-    /// Column UUID or name (scoped to --board-id if given, else searched globally)
+    pub board: Option<String>,
+    /// Column UUID or name (scoped to --board if given, else searched globally)
     #[arg(long)]
-    pub column_id: Option<String>,
-    /// Sprint UUID, name, or number (scoped to --board-id if given, else searched globally)
+    pub column: Option<String>,
+    /// Sprint UUID, name, or number (scoped to --board if given, else searched globally)
     #[arg(long)]
-    pub sprint_id: Option<String>,
+    pub sprint: Option<String>,
     #[arg(long)]
     pub status: Option<String>,
     #[arg(long)]
@@ -297,7 +297,7 @@ pub struct CardListArgs {
 #[derive(Args)]
 pub struct CardUpdateArgs {
     /// Card UUID or identifier like KAN-5 or 5
-    pub id: String,
+    pub card: String,
     #[arg(long)]
     pub title: Option<String>,
     #[arg(long)]
@@ -327,7 +327,7 @@ pub enum SprintAction {
     Create {
         /// Board UUID or name
         #[arg(long)]
-        board_id: String,
+        board: String,
         #[arg(long)]
         prefix: Option<String>,
         #[arg(long)]
@@ -337,7 +337,7 @@ pub enum SprintAction {
     List {
         /// Board UUID or name
         #[arg(long)]
-        board_id: String,
+        board: String,
         #[arg(long)]
         page: Option<u32>,
         #[arg(long)]
@@ -346,31 +346,31 @@ pub enum SprintAction {
     /// Get a specific sprint by UUID, name, or number
     Get {
         /// Sprint UUID, name, or number
-        id: String,
+        sprint: String,
     },
     /// Update a sprint
     Update(SprintUpdateArgs),
     /// Activate a sprint by UUID, name, or number
     Activate {
         /// Sprint UUID, name, or number
-        id: String,
+        sprint: String,
         #[arg(long)]
         duration_days: Option<i32>,
     },
     /// Complete a sprint by UUID, name, or number
     Complete {
         /// Sprint UUID, name, or number
-        id: String,
+        sprint: String,
     },
     /// Cancel a sprint by UUID, name, or number
     Cancel {
         /// Sprint UUID, name, or number
-        id: String,
+        sprint: String,
     },
     /// Delete a sprint by UUID, name, or number
     Delete {
         /// Sprint UUID, name, or number
-        id: String,
+        sprint: String,
     },
     /// Carry over uncompleted cards from a completed sprint to a planning sprint
     CarryOver {
@@ -386,7 +386,7 @@ pub enum SprintAction {
 #[derive(Args)]
 pub struct SprintUpdateArgs {
     /// Sprint UUID, name, or number
-    pub id: String,
+    pub sprint: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -428,7 +428,7 @@ pub struct MigrateArgs {
 pub struct ExportArgs {
     /// Board UUID or name; if omitted, exports all boards
     #[arg(long)]
-    pub board_id: Option<String>,
+    pub board: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -124,6 +124,18 @@ impl KanbanOperations for CliContext {
         self.inner.find_cards_by_identifier(identifier)
     }
 
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<kanban_domain::Column>> {
+        self.inner.list_all_columns()
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<kanban_domain::Sprint>> {
+        self.inner.list_all_sprints()
+    }
+
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         self.inner.update_card(id, updates)
     }

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -16,22 +16,22 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(boards, page, page_size)?);
         }
-        BoardAction::Get { id } => {
-            let uuid = match ctx.resolve_board_id(&id) {
+        BoardAction::Get { board } => {
+            let uuid = match ctx.resolve_board_id(&board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             match ctx.get_board(uuid)? {
-                Some(board) => output::output_success(&board),
-                None => return output::output_error(&format!("Board not found: {}", id)),
+                Some(b) => output::output_success(&b),
+                None => return output::output_error(&format!("Board not found: {}", board)),
             }
         }
         BoardAction::Update(args) => {
             let board = handle_update(ctx, args).await?;
             output::output_success(&board);
         }
-        BoardAction::Delete { id } => {
-            let uuid = match ctx.resolve_board_id(&id) {
+        BoardAction::Delete { board } => {
+            let uuid = match ctx.resolve_board_id(&board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -48,7 +48,7 @@ async fn handle_update(
     args: BoardUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Board> {
     let uuid = ctx
-        .resolve_board_id(&args.id)
+        .resolve_board_id(&args.board)
         .map_err(anyhow::Error::from)?;
     let updates = BoardUpdate {
         name: args.name,

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -16,18 +16,28 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(boards, page, page_size)?);
         }
-        BoardAction::Get { id } => match ctx.get_board(id)? {
-            Some(board) => output::output_success(&board),
-            None => return output::output_error(&format!("Board not found: {}", id)),
-        },
+        BoardAction::Get { id } => {
+            let uuid = match ctx.resolve_board_id(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            match ctx.get_board(uuid)? {
+                Some(board) => output::output_success(&board),
+                None => return output::output_error(&format!("Board not found: {}", id)),
+            }
+        }
         BoardAction::Update(args) => {
             let board = handle_update(ctx, args).await?;
             output::output_success(&board);
         }
         BoardAction::Delete { id } => {
-            ctx.delete_board(id)?;
+            let uuid = match ctx.resolve_board_id(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            ctx.delete_board(uuid)?;
             ctx.save().await?;
-            output::output_success(serde_json::json!({"deleted": id.to_string()}));
+            output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
     }
     Ok(())
@@ -37,6 +47,9 @@ async fn handle_update(
     ctx: &mut CliContext,
     args: BoardUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Board> {
+    let uuid = ctx
+        .resolve_board_id(&args.id)
+        .map_err(anyhow::Error::from)?;
     let updates = BoardUpdate {
         name: args.name,
         description: args
@@ -53,7 +66,7 @@ async fn handle_update(
             .unwrap_or(FieldUpdate::NoChange),
         ..Default::default()
     };
-    let board = ctx.update_board(args.id, updates)?;
+    let board = ctx.update_board(uuid, updates)?;
     ctx.save().await?;
     Ok(board)
 }

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -12,11 +12,11 @@ use uuid::Uuid;
 pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<()> {
     match action {
         CardAction::Create(args) => {
-            let board_uuid = match ctx.resolve_board_id(&args.board_id) {
+            let board_uuid = match ctx.resolve_board_id(&args.board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let column_uuid = match ctx.resolve_column_id(&args.column_id, board_uuid) {
+            let column_uuid = match ctx.resolve_column_id(&args.column, board_uuid) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -44,23 +44,23 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
             }
         }
-        CardAction::Get { id } => {
-            if let Ok(uuid) = Uuid::parse_str(&id) {
+        CardAction::Get { card } => {
+            if let Ok(uuid) = Uuid::parse_str(&card) {
                 match ctx.get_card(uuid)? {
-                    Some(card) => output::output_success(&card),
-                    None => return output::output_error(&format!("Card not found: '{}'", id)),
+                    Some(c) => output::output_success(&c),
+                    None => return output::output_error(&format!("Card not found: '{}'", card)),
                 }
             } else {
-                let cards = ctx.find_cards_by_identifier(&id)?;
+                let cards = ctx.find_cards_by_identifier(&card)?;
                 match cards.as_slice() {
-                    [] => return output::output_error(&format!("Card not found: '{}'", id)),
-                    [card] => output::output_success(card),
+                    [] => return output::output_error(&format!("Card not found: '{}'", card)),
+                    [c] => output::output_success(c),
                     _ => output::output_success(&cards),
                 }
             }
         }
         CardAction::Update(args) => {
-            let uuid = match ctx.resolve_card_id(&args.id) {
+            let uuid = match ctx.resolve_card_id(&args.card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -73,24 +73,24 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             output::output_success(&card);
         }
         CardAction::Move {
-            id,
-            column_id,
+            card,
+            column,
             position,
         } => {
-            let uuid = match ctx.resolve_card_id(&id) {
+            let uuid = match ctx.resolve_card_id(&card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let column_uuid = match resolve_column_for_card(ctx, &column_id, uuid) {
+            let column_uuid = match resolve_column_for_card(ctx, &column, uuid) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
-            let card = ctx.move_card(uuid, column_uuid, position)?;
+            let moved = ctx.move_card(uuid, column_uuid, position)?;
             ctx.save().await?;
-            output::output_success(&card);
+            output::output_success(&moved);
         }
-        CardAction::Archive { id } => {
-            let uuid = match ctx.resolve_card_id(&id) {
+        CardAction::Archive { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -98,24 +98,24 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             ctx.save().await?;
             output::output_success(serde_json::json!({"archived": uuid.to_string()}));
         }
-        CardAction::Restore { id, column_id } => {
-            let uuid = match ctx.resolve_card_id(&id) {
+        CardAction::Restore { card, column } => {
+            let uuid = match ctx.resolve_card_id(&card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let column_uuid = match column_id {
+            let column_uuid = match column {
                 Some(raw) => match resolve_column_for_card(ctx, &raw, uuid) {
                     Ok(u) => Some(u),
                     Err(e) => return output::output_error(&e),
                 },
                 None => None,
             };
-            let card = ctx.restore_card(uuid, column_uuid)?;
+            let restored = ctx.restore_card(uuid, column_uuid)?;
             ctx.save().await?;
-            output::output_success(&card);
+            output::output_success(&restored);
         }
-        CardAction::Delete { id } => {
-            let uuid = match ctx.resolve_card_id(&id) {
+        CardAction::Delete { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -123,46 +123,46 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
-        CardAction::AssignSprint { id, sprint_id } => {
-            let uuid = match ctx.resolve_card_id(&id) {
+        CardAction::AssignSprint { card, sprint } => {
+            let uuid = match ctx.resolve_card_id(&card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let sprint_uuid = match resolve_sprint_for_card(ctx, &sprint_id, uuid) {
+            let sprint_uuid = match resolve_sprint_for_card(ctx, &sprint, uuid) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
-            let card = ctx.assign_card_to_sprint(uuid, sprint_uuid)?;
+            let assigned = ctx.assign_card_to_sprint(uuid, sprint_uuid)?;
             ctx.save().await?;
-            output::output_success(&card);
+            output::output_success(&assigned);
         }
-        CardAction::UnassignSprint { id } => {
-            let uuid = match ctx.resolve_card_id(&id) {
+        CardAction::UnassignSprint { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let card = ctx.unassign_card_from_sprint(uuid)?;
+            let unassigned = ctx.unassign_card_from_sprint(uuid)?;
             ctx.save().await?;
-            output::output_success(&card);
+            output::output_success(&unassigned);
         }
-        CardAction::BranchName { id } => {
-            let uuid = match ctx.resolve_card_id(&id) {
+        CardAction::BranchName { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let branch = ctx.get_card_branch_name(uuid)?;
             output::output_success(serde_json::json!({"branch_name": branch}));
         }
-        CardAction::GitCheckout { id } => {
-            let uuid = match ctx.resolve_card_id(&id) {
+        CardAction::GitCheckout { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let cmd = ctx.get_card_git_checkout(uuid)?;
             output::output_success(serde_json::json!({"command": cmd}));
         }
-        CardAction::ArchiveCards { ids } => {
-            let uuids = match ctx.resolve_card_ids(&ids) {
+        CardAction::ArchiveCards { cards } => {
+            let uuids = match ctx.resolve_card_ids(&cards) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -175,8 +175,8 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 "failed": result.failed
             }));
         }
-        CardAction::MoveCards { ids, column_id } => {
-            let uuids = match ctx.resolve_card_ids(&ids) {
+        CardAction::MoveCards { cards, column } => {
+            let uuids = match ctx.resolve_card_ids(&cards) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -184,7 +184,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(b) => b,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let column_uuid = match ctx.resolve_column_id(&column_id, shared_board) {
+            let column_uuid = match ctx.resolve_column_id(&column, shared_board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -197,8 +197,8 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 "failed": result.failed
             }));
         }
-        CardAction::AssignCardsToSprint { ids, sprint_id } => {
-            let uuids = match ctx.resolve_card_ids(&ids) {
+        CardAction::AssignCardsToSprint { cards, sprint } => {
+            let uuids = match ctx.resolve_card_ids(&cards) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -206,7 +206,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(b) => b,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let sprint_uuid = match ctx.resolve_sprint_id(&sprint_id, shared_board) {
+            let sprint_uuid = match ctx.resolve_sprint_id(&sprint, shared_board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -252,11 +252,11 @@ fn build_filter(ctx: &CliContext, args: &CardListArgs) -> Result<CardListFilter,
         Some(s) => Some(parse_status(s)?),
         None => None,
     };
-    let board_id = match &args.board_id {
+    let board_id = match &args.board {
         Some(raw) => Some(ctx.resolve_board_id(raw).map_err(|e| e.to_string())?),
         None => None,
     };
-    let column_id = match &args.column_id {
+    let column_id = match &args.column {
         Some(raw) => Some(match board_id {
             Some(bid) => ctx.resolve_column_id(raw, bid).map_err(|e| e.to_string())?,
             None => ctx
@@ -265,7 +265,7 @@ fn build_filter(ctx: &CliContext, args: &CardListArgs) -> Result<CardListFilter,
         }),
         None => None,
     };
-    let sprint_id = match &args.sprint_id {
+    let sprint_id = match &args.sprint {
         Some(raw) => Some(match board_id {
             Some(bid) => ctx.resolve_sprint_id(raw, bid).map_err(|e| e.to_string())?,
             None => ctx

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -3,35 +3,28 @@ use crate::context::CliContext;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    format_ambiguous_matches, ArchivedCardSummary, CardListFilter, CardPriority, CardStatus,
-    CardUpdate, CreateCardOptions, FieldUpdate, KanbanOperations,
+    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions,
+    FieldUpdate, KanbanOperations,
 };
 
 use uuid::Uuid;
 
-fn resolve_card_id(ctx: &CliContext, id: &str) -> anyhow::Result<Uuid> {
-    if let Ok(uuid) = Uuid::parse_str(id) {
-        return Ok(uuid);
-    }
-    match ctx
-        .find_cards_by_identifier(id)
-        .map_err(anyhow::Error::from)?
-        .as_slice()
-    {
-        [] => Err(anyhow::anyhow!("Card not found: '{}'", id)),
-        [card] => Ok(card.id),
-        matches => Err(anyhow::anyhow!("{}", format_ambiguous_matches(id, matches))),
-    }
-}
-
 pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<()> {
     match action {
         CardAction::Create(args) => {
+            let board_uuid = match ctx.resolve_board_id(&args.board_id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let column_uuid = match ctx.resolve_column_id(&args.column_id, board_uuid) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
             let options = match build_create_options(&args) {
                 Ok(o) => o,
                 Err(e) => return output::output_error(&e),
             };
-            let card = ctx.create_card(args.board_id, args.column_id, args.title, options)?;
+            let card = ctx.create_card(board_uuid, column_uuid, args.title, options)?;
             ctx.save().await?;
             output::output_success(&card);
         }
@@ -43,7 +36,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                     archived.iter().map(ArchivedCardSummary::from).collect();
                 output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
             } else {
-                let filter = match build_filter(&args) {
+                let filter = match build_filter(ctx, &args) {
                     Ok(f) => f,
                     Err(e) => return output::output_error(&e),
                 };
@@ -67,8 +60,8 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             }
         }
         CardAction::Update(args) => {
-            let uuid = match resolve_card_id(ctx, &args.id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&args.id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let updates = match build_card_update(&args) {
@@ -84,17 +77,21 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             column_id,
             position,
         } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let card = ctx.move_card(uuid, column_id, position)?;
+            let column_uuid = match resolve_column_for_card(ctx, &column_id, uuid) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e),
+            };
+            let card = ctx.move_card(uuid, column_uuid, position)?;
             ctx.save().await?;
             output::output_success(&card);
         }
         CardAction::Archive { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             ctx.archive_card(uuid)?;
@@ -102,17 +99,24 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             output::output_success(serde_json::json!({"archived": uuid.to_string()}));
         }
         CardAction::Restore { id, column_id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let card = ctx.restore_card(uuid, column_id)?;
+            let column_uuid = match column_id {
+                Some(raw) => match resolve_column_for_card(ctx, &raw, uuid) {
+                    Ok(u) => Some(u),
+                    Err(e) => return output::output_error(&e),
+                },
+                None => None,
+            };
+            let card = ctx.restore_card(uuid, column_uuid)?;
             ctx.save().await?;
             output::output_success(&card);
         }
         CardAction::Delete { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             ctx.delete_card(uuid)?;
@@ -120,17 +124,21 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
         CardAction::AssignSprint { id, sprint_id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let card = ctx.assign_card_to_sprint(uuid, sprint_id)?;
+            let sprint_uuid = match resolve_sprint_for_card(ctx, &sprint_id, uuid) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e),
+            };
+            let card = ctx.assign_card_to_sprint(uuid, sprint_uuid)?;
             ctx.save().await?;
             output::output_success(&card);
         }
         CardAction::UnassignSprint { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let card = ctx.unassign_card_from_sprint(uuid)?;
@@ -138,23 +146,27 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             output::output_success(&card);
         }
         CardAction::BranchName { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let branch = ctx.get_card_branch_name(uuid)?;
             output::output_success(serde_json::json!({"branch_name": branch}));
         }
         CardAction::GitCheckout { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&id) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let cmd = ctx.get_card_git_checkout(uuid)?;
             output::output_success(serde_json::json!({"command": cmd}));
         }
         CardAction::ArchiveCards { ids } => {
-            let result = ctx.archive_cards_detailed(ids);
+            let uuids = match ctx.resolve_card_ids(&ids) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let result = ctx.archive_cards_detailed(uuids);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),
@@ -164,7 +176,19 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             }));
         }
         CardAction::MoveCards { ids, column_id } => {
-            let result = ctx.move_cards_detailed(ids, column_id);
+            let uuids = match ctx.resolve_card_ids(&ids) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let shared_board = match ctx.require_same_board(&uuids) {
+                Ok(b) => b,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let column_uuid = match ctx.resolve_column_id(&column_id, shared_board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let result = ctx.move_cards_detailed(uuids, column_uuid);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),
@@ -174,7 +198,19 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             }));
         }
         CardAction::AssignCardsToSprint { ids, sprint_id } => {
-            let result = ctx.assign_cards_to_sprint_detailed(ids, sprint_id);
+            let uuids = match ctx.resolve_card_ids(&ids) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let shared_board = match ctx.require_same_board(&uuids) {
+                Ok(b) => b,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprint_uuid = match ctx.resolve_sprint_id(&sprint_id, shared_board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let result = ctx.assign_cards_to_sprint_detailed(uuids, sprint_uuid);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),
@@ -187,15 +223,61 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
     Ok(())
 }
 
-fn build_filter(args: &CardListArgs) -> Result<CardListFilter, String> {
+fn resolve_column_for_card(ctx: &CliContext, raw: &str, card_id: Uuid) -> Result<Uuid, String> {
+    let board_id = card_board_id(ctx, card_id)?;
+    ctx.resolve_column_id(raw, board_id)
+        .map_err(|e| e.to_string())
+}
+
+fn resolve_sprint_for_card(ctx: &CliContext, raw: &str, card_id: Uuid) -> Result<Uuid, String> {
+    let board_id = card_board_id(ctx, card_id)?;
+    ctx.resolve_sprint_id(raw, board_id)
+        .map_err(|e| e.to_string())
+}
+
+fn card_board_id(ctx: &CliContext, card_id: Uuid) -> Result<Uuid, String> {
+    let card = ctx
+        .get_card(card_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Card not found: {}", card_id))?;
+    let column = ctx
+        .get_column(card.column_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Column not found: {}", card.column_id))?;
+    Ok(column.board_id)
+}
+
+fn build_filter(ctx: &CliContext, args: &CardListArgs) -> Result<CardListFilter, String> {
     let status = match &args.status {
         Some(s) => Some(parse_status(s)?),
         None => None,
     };
+    let board_id = match &args.board_id {
+        Some(raw) => Some(ctx.resolve_board_id(raw).map_err(|e| e.to_string())?),
+        None => None,
+    };
+    let column_id = match &args.column_id {
+        Some(raw) => Some(match board_id {
+            Some(bid) => ctx.resolve_column_id(raw, bid).map_err(|e| e.to_string())?,
+            None => ctx
+                .resolve_column_id_global(raw)
+                .map_err(|e| e.to_string())?,
+        }),
+        None => None,
+    };
+    let sprint_id = match &args.sprint_id {
+        Some(raw) => Some(match board_id {
+            Some(bid) => ctx.resolve_sprint_id(raw, bid).map_err(|e| e.to_string())?,
+            None => ctx
+                .resolve_sprint_id_global(raw)
+                .map_err(|e| e.to_string())?,
+        }),
+        None => None,
+    };
     Ok(CardListFilter {
-        board_id: args.board_id,
-        column_id: args.column_id,
-        sprint_id: args.sprint_id,
+        board_id,
+        column_id,
+        sprint_id,
         status,
     })
 }

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -236,14 +236,24 @@ fn resolve_sprint_for_card(ctx: &CliContext, raw: &str, card_id: Uuid) -> Result
 }
 
 fn card_board_id(ctx: &CliContext, card_id: Uuid) -> Result<Uuid, String> {
-    let card = ctx
-        .get_card(card_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Card not found: {}", card_id))?;
+    // Try active cards first; if the card is archived, fall back via its
+    // original_column_id. Either path resolves to the card's board.
+    let column_id = match ctx.get_card(card_id).map_err(|e| e.to_string())? {
+        Some(card) => card.column_id,
+        None => {
+            let archived = ctx
+                .list_archived_cards()
+                .map_err(|e| e.to_string())?
+                .into_iter()
+                .find(|a| a.card.id == card_id)
+                .ok_or_else(|| format!("Card not found: {}", card_id))?;
+            archived.original_column_id
+        }
+    };
     let column = ctx
-        .get_column(card.column_id)
+        .get_column(column_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Column not found: {}", card.column_id))?;
+        .ok_or_else(|| format!("Column not found: {}", column_id))?;
     Ok(column.board_id)
 }
 

--- a/crates/kanban-cli/src/handlers/column.rs
+++ b/crates/kanban-cli/src/handlers/column.rs
@@ -7,11 +7,11 @@ use kanban_domain::{ColumnUpdate, FieldUpdate, KanbanOperations};
 pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Result<()> {
     match action {
         ColumnAction::Create {
-            board_id,
+            board,
             name,
             position,
         } => {
-            let board_uuid = match ctx.resolve_board_id(&board_id) {
+            let board_uuid = match ctx.resolve_board_id(&board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -20,11 +20,11 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
             output::output_success(&column);
         }
         ColumnAction::List {
-            board_id,
+            board,
             page,
             page_size,
         } => {
-            let board_uuid = match ctx.resolve_board_id(&board_id) {
+            let board_uuid = match ctx.resolve_board_id(&board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -32,22 +32,22 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(columns, page, page_size)?);
         }
-        ColumnAction::Get { id } => {
-            let uuid = match ctx.resolve_column_id_global(&id) {
+        ColumnAction::Get { column } => {
+            let uuid = match ctx.resolve_column_id_global(&column) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             match ctx.get_column(uuid)? {
-                Some(column) => output::output_success(&column),
-                None => return output::output_error(&format!("Column not found: {}", id)),
+                Some(c) => output::output_success(&c),
+                None => return output::output_error(&format!("Column not found: {}", column)),
             }
         }
         ColumnAction::Update(args) => {
             let column = handle_update(ctx, args).await?;
             output::output_success(&column);
         }
-        ColumnAction::Delete { id } => {
-            let uuid = match ctx.resolve_column_id_global(&id) {
+        ColumnAction::Delete { column } => {
+            let uuid = match ctx.resolve_column_id_global(&column) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -55,14 +55,14 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
-        ColumnAction::Reorder { id, position } => {
-            let uuid = match ctx.resolve_column_id_global(&id) {
+        ColumnAction::Reorder { column, position } => {
+            let uuid = match ctx.resolve_column_id_global(&column) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let column = ctx.reorder_column(uuid, position)?;
+            let c = ctx.reorder_column(uuid, position)?;
             ctx.save().await?;
-            output::output_success(&column);
+            output::output_success(&c);
         }
     }
     Ok(())
@@ -73,7 +73,7 @@ async fn handle_update(
     args: ColumnUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Column> {
     let uuid = ctx
-        .resolve_column_id_global(&args.id)
+        .resolve_column_id_global(&args.column)
         .map_err(anyhow::Error::from)?;
     let updates = ColumnUpdate {
         name: args.name,

--- a/crates/kanban-cli/src/handlers/column.rs
+++ b/crates/kanban-cli/src/handlers/column.rs
@@ -11,7 +11,11 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
             name,
             position,
         } => {
-            let column = ctx.create_column(board_id, name, position)?;
+            let board_uuid = match ctx.resolve_board_id(&board_id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let column = ctx.create_column(board_uuid, name, position)?;
             ctx.save().await?;
             output::output_success(&column);
         }
@@ -20,25 +24,43 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
             page,
             page_size,
         } => {
-            let columns = ctx.list_columns(board_id)?;
+            let board_uuid = match ctx.resolve_board_id(&board_id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let columns = ctx.list_columns(board_uuid)?;
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(columns, page, page_size)?);
         }
-        ColumnAction::Get { id } => match ctx.get_column(id)? {
-            Some(column) => output::output_success(&column),
-            None => return output::output_error(&format!("Column not found: {}", id)),
-        },
+        ColumnAction::Get { id } => {
+            let uuid = match ctx.resolve_column_id_global(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            match ctx.get_column(uuid)? {
+                Some(column) => output::output_success(&column),
+                None => return output::output_error(&format!("Column not found: {}", id)),
+            }
+        }
         ColumnAction::Update(args) => {
             let column = handle_update(ctx, args).await?;
             output::output_success(&column);
         }
         ColumnAction::Delete { id } => {
-            ctx.delete_column(id)?;
+            let uuid = match ctx.resolve_column_id_global(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            ctx.delete_column(uuid)?;
             ctx.save().await?;
-            output::output_success(serde_json::json!({"deleted": id.to_string()}));
+            output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
         ColumnAction::Reorder { id, position } => {
-            let column = ctx.reorder_column(id, position)?;
+            let uuid = match ctx.resolve_column_id_global(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let column = ctx.reorder_column(uuid, position)?;
             ctx.save().await?;
             output::output_success(&column);
         }
@@ -50,6 +72,9 @@ async fn handle_update(
     ctx: &mut CliContext,
     args: ColumnUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Column> {
+    let uuid = ctx
+        .resolve_column_id_global(&args.id)
+        .map_err(anyhow::Error::from)?;
     let updates = ColumnUpdate {
         name: args.name,
         position: args.position,
@@ -62,7 +87,7 @@ async fn handle_update(
                 .unwrap_or(FieldUpdate::NoChange)
         },
     };
-    let column = ctx.update_column(args.id, updates)?;
+    let column = ctx.update_column(uuid, updates)?;
     ctx.save().await?;
     Ok(column)
 }

--- a/crates/kanban-cli/src/handlers/export.rs
+++ b/crates/kanban-cli/src/handlers/export.rs
@@ -4,7 +4,7 @@ use crate::output;
 use kanban_domain::KanbanOperations;
 
 pub async fn handle_export(ctx: &CliContext, args: ExportArgs) -> anyhow::Result<()> {
-    let board_uuid = match args.board_id {
+    let board_uuid = match args.board {
         Some(raw) => match ctx.resolve_board_id(&raw) {
             Ok(u) => Some(u),
             Err(e) => return output::output_error(&e.to_string()),

--- a/crates/kanban-cli/src/handlers/export.rs
+++ b/crates/kanban-cli/src/handlers/export.rs
@@ -4,7 +4,14 @@ use crate::output;
 use kanban_domain::KanbanOperations;
 
 pub async fn handle_export(ctx: &CliContext, args: ExportArgs) -> anyhow::Result<()> {
-    let json = ctx.export_board(args.board_id)?;
+    let board_uuid = match args.board_id {
+        Some(raw) => match ctx.resolve_board_id(&raw) {
+            Ok(u) => Some(u),
+            Err(e) => return output::output_error(&e.to_string()),
+        },
+        None => None,
+    };
+    let json = ctx.export_board(board_uuid)?;
     println!("{}", json);
     Ok(())
 }

--- a/crates/kanban-cli/src/handlers/sprint.rs
+++ b/crates/kanban-cli/src/handlers/sprint.rs
@@ -24,11 +24,11 @@ fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
 pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Result<()> {
     match action {
         SprintAction::Create {
-            board_id,
+            board,
             prefix,
             name,
         } => {
-            let board_uuid = match ctx.resolve_board_id(&board_id) {
+            let board_uuid = match ctx.resolve_board_id(&board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -37,11 +37,11 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
             output::output_success(&sprint);
         }
         SprintAction::List {
-            board_id,
+            board,
             page,
             page_size,
         } => {
-            let board_uuid = match ctx.resolve_board_id(&board_id) {
+            let board_uuid = match ctx.resolve_board_id(&board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -49,14 +49,14 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(sprints, page, page_size)?);
         }
-        SprintAction::Get { id } => {
-            let uuid = match ctx.resolve_sprint_id_global(&id) {
+        SprintAction::Get { sprint } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             match ctx.get_sprint(uuid)? {
-                Some(sprint) => output::output_success(&sprint),
-                None => return output::output_error(&format!("Sprint not found: {}", id)),
+                Some(s) => output::output_success(&s),
+                None => return output::output_error(&format!("Sprint not found: {}", sprint)),
             }
         }
         SprintAction::Update(args) => {
@@ -66,35 +66,38 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
             };
             output::output_success(&sprint);
         }
-        SprintAction::Activate { id, duration_days } => {
-            let uuid = match ctx.resolve_sprint_id_global(&id) {
+        SprintAction::Activate {
+            sprint,
+            duration_days,
+        } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let sprint = ctx.activate_sprint(uuid, duration_days)?;
+            let activated = ctx.activate_sprint(uuid, duration_days)?;
             ctx.save().await?;
-            output::output_success(&sprint);
+            output::output_success(&activated);
         }
-        SprintAction::Complete { id } => {
-            let uuid = match ctx.resolve_sprint_id_global(&id) {
+        SprintAction::Complete { sprint } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let sprint = ctx.complete_sprint(uuid)?;
+            let completed = ctx.complete_sprint(uuid)?;
             ctx.save().await?;
-            output::output_success(&sprint);
+            output::output_success(&completed);
         }
-        SprintAction::Cancel { id } => {
-            let uuid = match ctx.resolve_sprint_id_global(&id) {
+        SprintAction::Cancel { sprint } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let sprint = ctx.cancel_sprint(uuid)?;
+            let cancelled = ctx.cancel_sprint(uuid)?;
             ctx.save().await?;
-            output::output_success(&sprint);
+            output::output_success(&cancelled);
         }
-        SprintAction::Delete { id } => {
-            let uuid = match ctx.resolve_sprint_id_global(&id) {
+        SprintAction::Delete { sprint } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
@@ -128,7 +131,7 @@ async fn handle_update(
     args: SprintUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Sprint> {
     let uuid = ctx
-        .resolve_sprint_id_global(&args.id)
+        .resolve_sprint_id_global(&args.sprint)
         .map_err(anyhow::Error::from)?;
     let start_date = if args.clear_start_date {
         FieldUpdate::Clear

--- a/crates/kanban-cli/src/handlers/sprint.rs
+++ b/crates/kanban-cli/src/handlers/sprint.rs
@@ -28,7 +28,11 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
             prefix,
             name,
         } => {
-            let sprint = ctx.create_sprint(board_id, prefix, name)?;
+            let board_uuid = match ctx.resolve_board_id(&board_id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprint = ctx.create_sprint(board_uuid, prefix, name)?;
             ctx.save().await?;
             output::output_success(&sprint);
         }
@@ -37,14 +41,24 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
             page,
             page_size,
         } => {
-            let sprints = ctx.list_sprints(board_id)?;
+            let board_uuid = match ctx.resolve_board_id(&board_id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprints = ctx.list_sprints(board_uuid)?;
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(sprints, page, page_size)?);
         }
-        SprintAction::Get { id } => match ctx.get_sprint(id)? {
-            Some(sprint) => output::output_success(&sprint),
-            None => return output::output_error(&format!("Sprint not found: {}", id)),
-        },
+        SprintAction::Get { id } => {
+            let uuid = match ctx.resolve_sprint_id_global(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            match ctx.get_sprint(uuid)? {
+                Some(sprint) => output::output_success(&sprint),
+                None => return output::output_error(&format!("Sprint not found: {}", id)),
+            }
+        }
         SprintAction::Update(args) => {
             let sprint = match handle_update(ctx, args).await {
                 Ok(s) => s,
@@ -53,27 +67,55 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
             output::output_success(&sprint);
         }
         SprintAction::Activate { id, duration_days } => {
-            let sprint = ctx.activate_sprint(id, duration_days)?;
+            let uuid = match ctx.resolve_sprint_id_global(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprint = ctx.activate_sprint(uuid, duration_days)?;
             ctx.save().await?;
             output::output_success(&sprint);
         }
         SprintAction::Complete { id } => {
-            let sprint = ctx.complete_sprint(id)?;
+            let uuid = match ctx.resolve_sprint_id_global(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprint = ctx.complete_sprint(uuid)?;
             ctx.save().await?;
             output::output_success(&sprint);
         }
         SprintAction::Cancel { id } => {
-            let sprint = ctx.cancel_sprint(id)?;
+            let uuid = match ctx.resolve_sprint_id_global(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprint = ctx.cancel_sprint(uuid)?;
             ctx.save().await?;
             output::output_success(&sprint);
         }
         SprintAction::Delete { id } => {
-            ctx.delete_sprint(id)?;
+            let uuid = match ctx.resolve_sprint_id_global(&id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            ctx.delete_sprint(uuid)?;
             ctx.save().await?;
-            output::output_success(serde_json::json!({"deleted": id.to_string()}));
+            output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
         SprintAction::CarryOver { from, to } => {
-            let count = ctx.carry_over_sprint_cards(from, to)?;
+            let from_uuid = match ctx.resolve_sprint_id_global(&from) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            // `--to` is scoped to the same board as `--from`.
+            let from_sprint = ctx
+                .get_sprint(from_uuid)?
+                .ok_or_else(|| anyhow::anyhow!("Source sprint not found: {}", from_uuid))?;
+            let to_uuid = match ctx.resolve_sprint_id(&to, from_sprint.board_id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let count = ctx.carry_over_sprint_cards(from_uuid, to_uuid)?;
             ctx.save().await?;
             output::output_success(serde_json::json!({ "carried_over": count }));
         }
@@ -85,6 +127,9 @@ async fn handle_update(
     ctx: &mut CliContext,
     args: SprintUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Sprint> {
+    let uuid = ctx
+        .resolve_sprint_id_global(&args.id)
+        .map_err(anyhow::Error::from)?;
     let start_date = if args.clear_start_date {
         FieldUpdate::Clear
     } else {
@@ -118,7 +163,7 @@ async fn handle_update(
         start_date,
         end_date,
     };
-    let sprint = ctx.update_sprint(args.id, updates)?;
+    let sprint = ctx.update_sprint(uuid, updates)?;
     ctx.save().await?;
     Ok(sprint)
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -2517,6 +2517,755 @@ mod version_and_help_tests {
     }
 }
 
+/// Tests that every entity-id argument across the CLI accepts a human-readable name
+/// (board name, column name, sprint name, sprint number) — not just a UUID.
+mod name_resolution_tests {
+    use super::*;
+
+    /// Initialize a fresh file, create one board and one TODO column on it. Returns
+    /// (file path string, board_id, column_id).
+    fn setup_named_board(name: &str, prefix: &str) -> (tempfile::TempDir, String, String, String) {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json").to_str().unwrap().to_string();
+        kanban().args([&file]).assert().success();
+        let bjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "board",
+                    "create",
+                    "--name",
+                    name,
+                    "--card-prefix",
+                    prefix,
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let board_id = extract_id(&bjson);
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "column",
+                    "create",
+                    "--board-id",
+                    &board_id,
+                    "--name",
+                    "TODO",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let column_id = extract_id(&cjson);
+        (dir, file, board_id, column_id)
+    }
+
+    // ---------- Board ----------
+
+    #[test]
+    fn test_board_get_by_name() {
+        let (_dir, file, board_id, _col) = setup_named_board("My Board", "MB");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "board", "get", "My Board"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["id"], board_id);
+    }
+
+    #[test]
+    fn test_board_get_by_name_case_insensitive() {
+        let (_dir, file, board_id, _col) = setup_named_board("MyBoard", "MB");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "board", "get", "myboard"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["id"], board_id);
+    }
+
+    #[test]
+    fn test_board_get_unknown_lists_available() {
+        let (_dir, file, _b, _c) = setup_named_board("Kanban", "KAN");
+        let assert = kanban()
+            .args([&file, "board", "get", "Personal"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("not found"), "stderr: {stderr}");
+        assert!(stderr.contains("Kanban"), "stderr: {stderr}");
+    }
+
+    #[test]
+    fn test_board_update_by_name() {
+        let (_dir, file, board_id, _col) = setup_named_board("Original", "ORG");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "board", "update", "Original", "--card-prefix", "NEW"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["id"], board_id);
+        assert_eq!(json["data"]["card_prefix"], "NEW");
+    }
+
+    #[test]
+    fn test_board_delete_by_name() {
+        let (_dir, file, _board, _col) = setup_named_board("DeleteMe", "DEL");
+        kanban()
+            .args([&file, "board", "delete", "DeleteMe"])
+            .assert()
+            .success();
+        let assert = kanban()
+            .args([&file, "board", "get", "DeleteMe"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("not found"), "stderr: {stderr}");
+    }
+
+    // ---------- Column ----------
+
+    #[test]
+    fn test_column_create_with_board_name() {
+        let (_dir, file, _board, _col) = setup_named_board("B", "B");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "column",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--name",
+                    "Doing",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["name"], "Doing");
+    }
+
+    #[test]
+    fn test_column_list_with_board_name() {
+        let (_dir, file, _board, _col) = setup_named_board("MyB", "MB");
+        kanban()
+            .args([
+                &file,
+                "column",
+                "create",
+                "--board-id",
+                "MyB",
+                "--name",
+                "Doing",
+            ])
+            .assert()
+            .success();
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "column", "list", "--board-id", "MyB"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["items"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_column_get_by_name() {
+        let (_dir, file, _board, column_id) = setup_named_board("B", "B");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "column", "get", "TODO"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["id"], column_id);
+    }
+
+    #[test]
+    fn test_column_get_ambiguous_across_boards_lists_boards() {
+        let (_dir, file, _b, _c) = setup_named_board("Alpha", "A");
+        kanban()
+            .args([
+                &file,
+                "board",
+                "create",
+                "--name",
+                "Beta",
+                "--card-prefix",
+                "B",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "column",
+                "create",
+                "--board-id",
+                "Beta",
+                "--name",
+                "TODO",
+            ])
+            .assert()
+            .success();
+        let assert = kanban()
+            .args([&file, "column", "get", "TODO"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("ambiguous"), "stderr: {stderr}");
+        assert!(stderr.contains("'Alpha'"), "stderr: {stderr}");
+        assert!(stderr.contains("'Beta'"), "stderr: {stderr}");
+    }
+
+    #[test]
+    fn test_column_get_unknown_lists_available() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let assert = kanban()
+            .args([&file, "column", "get", "Nope"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("not found"), "stderr: {stderr}");
+        assert!(stderr.contains("TODO"), "stderr: {stderr}");
+    }
+
+    // ---------- Card ----------
+
+    #[test]
+    fn test_card_create_with_board_and_column_names() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--column-id",
+                    "TODO",
+                    "--title",
+                    "Hello",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["title"], "Hello");
+    }
+
+    #[test]
+    fn test_card_list_filters_by_names() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        kanban()
+            .args([
+                &file,
+                "card",
+                "create",
+                "--board-id",
+                "B",
+                "--column-id",
+                "TODO",
+                "--title",
+                "T1",
+            ])
+            .assert()
+            .success();
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "list",
+                    "--board-id",
+                    "B",
+                    "--column-id",
+                    "TODO",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["items"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_card_move_with_column_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([
+                &file,
+                "column",
+                "create",
+                "--board-id",
+                "B",
+                "--name",
+                "Doing",
+            ])
+            .assert()
+            .success();
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--column-id",
+                    "TODO",
+                    "--title",
+                    "T",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let card_id = extract_id(&cjson);
+        let mjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "card", "move", &card_id, "--column-id", "Doing"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(mjson["data"]["id"], card_id);
+    }
+
+    #[test]
+    fn test_card_assign_sprint_by_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board-id",
+                "B",
+                "--name",
+                "alpha",
+            ])
+            .assert()
+            .success();
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--column-id",
+                    "TODO",
+                    "--title",
+                    "T",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let card_id = extract_id(&cjson);
+        let ajson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "assign-sprint",
+                    &card_id,
+                    "--sprint-id",
+                    "alpha",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert!(ajson["data"]["sprint_id"].is_string());
+    }
+
+    #[test]
+    fn test_card_assign_sprint_by_number() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board-id",
+                "B",
+                "--name",
+                "alpha",
+            ])
+            .assert()
+            .success();
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--column-id",
+                    "TODO",
+                    "--title",
+                    "T",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let card_id = extract_id(&cjson);
+        let ajson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "card", "assign-sprint", &card_id, "--sprint-id", "1"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert!(ajson["data"]["sprint_id"].is_string());
+    }
+
+    #[test]
+    fn test_card_move_cards_with_card_identifiers_and_column_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([
+                &file,
+                "column",
+                "create",
+                "--board-id",
+                "B",
+                "--name",
+                "Doing",
+            ])
+            .assert()
+            .success();
+        for title in ["T1", "T2"] {
+            kanban()
+                .args([
+                    &file,
+                    "card",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--column-id",
+                    "TODO",
+                    "--title",
+                    title,
+                ])
+                .assert()
+                .success();
+        }
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "move-cards",
+                    "--ids",
+                    "KAN-1,KAN-2",
+                    "--column-id",
+                    "Doing",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["succeeded_count"], 2);
+    }
+
+    #[test]
+    fn test_card_move_cards_spanning_boards_errors_clearly() {
+        let (_dir, file, _b, _c) = setup_named_board("Alpha", "A");
+        kanban()
+            .args([
+                &file,
+                "board",
+                "create",
+                "--name",
+                "Beta",
+                "--card-prefix",
+                "B",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "column",
+                "create",
+                "--board-id",
+                "Beta",
+                "--name",
+                "TODO",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "card",
+                "create",
+                "--board-id",
+                "Alpha",
+                "--column-id",
+                "TODO",
+                "--title",
+                "A1",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "card",
+                "create",
+                "--board-id",
+                "Beta",
+                "--column-id",
+                "TODO",
+                "--title",
+                "B1",
+            ])
+            .assert()
+            .success();
+        let assert = kanban()
+            .args([
+                &file,
+                "card",
+                "move-cards",
+                "--ids",
+                "A-1,B-1",
+                "--column-id",
+                "TODO",
+            ])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("same board"), "stderr: {stderr}");
+        assert!(stderr.contains("'Alpha'"), "stderr: {stderr}");
+        assert!(stderr.contains("'Beta'"), "stderr: {stderr}");
+    }
+
+    // ---------- Sprint ----------
+
+    #[test]
+    fn test_sprint_create_with_board_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "sprint",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--name",
+                    "alpha",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["sprint_number"], 1);
+    }
+
+    #[test]
+    fn test_sprint_get_by_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let sjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "sprint",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--name",
+                    "yarara",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let sprint_id = extract_id(&sjson);
+        let g = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "sprint", "get", "yarara"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(g["data"]["id"], sprint_id);
+    }
+
+    #[test]
+    fn test_sprint_get_by_number() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let sjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "sprint",
+                    "create",
+                    "--board-id",
+                    "B",
+                    "--name",
+                    "alpha",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let sprint_id = extract_id(&sjson);
+        let g = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "sprint", "get", "1"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(g["data"]["id"], sprint_id);
+    }
+
+    #[test]
+    fn test_sprint_activate_by_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board-id",
+                "B",
+                "--name",
+                "alpha",
+            ])
+            .assert()
+            .success();
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "sprint", "activate", "alpha"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["status"], "Active");
+    }
+
+    #[test]
+    fn test_sprint_carry_over_by_names() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        // sprint #1
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board-id",
+                "B",
+                "--name",
+                "alpha",
+            ])
+            .assert()
+            .success();
+        // sprint #2
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board-id",
+                "B",
+                "--name",
+                "beta",
+            ])
+            .assert()
+            .success();
+        // activate sprint #1, then complete it
+        kanban()
+            .args([&file, "sprint", "activate", "alpha"])
+            .assert()
+            .success();
+        kanban()
+            .args([&file, "sprint", "complete", "alpha"])
+            .assert()
+            .success();
+        // carry over by names
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "sprint",
+                    "carry-over",
+                    "--from",
+                    "alpha",
+                    "--to",
+                    "beta",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert!(json["data"]["carried_over"].is_number());
+    }
+
+    // ---------- Export ----------
+
+    #[test]
+    fn test_export_with_board_name() {
+        let (_dir, file, _b, _c) = setup_named_board("ExpBoard", "E");
+        // export prints raw JSON (not the CliResponse envelope)
+        let out = kanban()
+            .args([&file, "export", "--board-id", "ExpBoard"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let parsed: Value = serde_json::from_slice(&out).expect("export output should be JSON");
+        // Either {"boards": [...]} or a single board shape — just confirm parseable + non-empty.
+        assert!(parsed.is_object() || parsed.is_array());
+    }
+}
+
 mod missing_file_tests {
     use super::*;
 

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -303,7 +303,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -331,7 +331,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -344,7 +344,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "DONE",
@@ -357,7 +357,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "list",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -382,7 +382,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "First",
@@ -401,7 +401,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "Second",
@@ -440,7 +440,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "To Delete",
@@ -489,7 +489,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -517,9 +517,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Test Task",
@@ -547,9 +547,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Test Task",
@@ -584,9 +584,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 1",
@@ -599,9 +599,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 2",
@@ -634,9 +634,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task With Desc",
@@ -673,9 +673,9 @@ mod card_tests {
                     file.to_str().unwrap(),
                     "card",
                     "create",
-                    "--board-id",
+                    "--board",
                     &board_id,
-                    "--column-id",
+                    "--column",
                     &column_id,
                     "--title",
                     &format!("Task {i}"),
@@ -736,9 +736,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Only Card",
@@ -778,9 +778,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Original",
@@ -828,7 +828,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "DONE",
@@ -847,9 +847,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task",
@@ -869,7 +869,7 @@ mod card_tests {
                 "card",
                 "move",
                 &card_id,
-                "--column-id",
+                "--column",
                 &col2_id,
             ])
             .assert()
@@ -894,9 +894,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "To Archive",
@@ -957,9 +957,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "My Feature Task",
@@ -1000,9 +1000,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "My Task",
@@ -1043,9 +1043,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 1",
@@ -1064,9 +1064,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 2",
@@ -1085,7 +1085,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "archive-cards",
-                "--ids",
+                "--cards",
                 &format!("{},{}", card1_id, card2_id),
             ])
             .assert()
@@ -1111,7 +1111,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "DONE",
@@ -1130,9 +1130,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 1",
@@ -1151,9 +1151,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 2",
@@ -1172,9 +1172,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "move-cards",
-                "--ids",
+                "--cards",
                 &format!("{},{}", card1_id, card2_id),
-                "--column-id",
+                "--column",
                 &col2_id,
             ])
             .assert()
@@ -1218,7 +1218,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -1246,9 +1246,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Prefix Test Card",
@@ -1287,9 +1287,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Number Lookup Card",
@@ -1328,9 +1328,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Archive Me",
@@ -1384,7 +1384,7 @@ mod card_tests {
                     file.to_str().unwrap(),
                     "column",
                     "create",
-                    "--board-id",
+                    "--board",
                     &board_b_id,
                     "--name",
                     "TODO",
@@ -1403,9 +1403,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_a_id,
-                "--column-id",
+                "--column",
                 &col_a_id,
                 "--title",
                 "Card on A",
@@ -1422,9 +1422,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_b_id,
-                "--column-id",
+                "--column",
                 &col_b_id,
                 "--title",
                 "Card on B",
@@ -1516,7 +1516,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1542,7 +1542,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--prefix",
                 "SPRINT",
@@ -1569,7 +1569,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1580,7 +1580,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1591,7 +1591,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "list",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1616,7 +1616,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1654,7 +1654,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1695,7 +1695,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1736,7 +1736,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -1755,9 +1755,9 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task",
@@ -1776,7 +1776,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1799,7 +1799,7 @@ mod sprint_tests {
                 "card",
                 "assign-sprint",
                 &card_id,
-                "--sprint-id",
+                "--sprint",
                 &sprint_id,
             ])
             .assert()
@@ -1824,7 +1824,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -1843,9 +1843,9 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task",
@@ -1864,7 +1864,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1887,7 +1887,7 @@ mod sprint_tests {
                 "card",
                 "assign-sprint",
                 &card_id,
-                "--sprint-id",
+                "--sprint",
                 &sprint_id,
             ])
             .assert()
@@ -1960,7 +1960,7 @@ mod export_import_tests {
         let board_id = extract_id(&board_json);
 
         kanban()
-            .args([file.to_str().unwrap(), "export", "--board-id", &board_id])
+            .args([file.to_str().unwrap(), "export", "--board", &board_id])
             .assert()
             .success()
             .stdout(predicate::str::contains("\"boards\""))
@@ -2077,7 +2077,7 @@ mod error_tests {
             .args([file.to_str().unwrap(), "column", "list"])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("--board-id"));
+            .stderr(predicate::str::contains("--board"));
     }
 
     #[test]
@@ -2146,7 +2146,7 @@ mod error_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -2173,9 +2173,9 @@ mod error_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Test",
@@ -2221,9 +2221,9 @@ mod error_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Test",
@@ -2275,7 +2275,7 @@ mod error_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -2548,13 +2548,7 @@ mod name_resolution_tests {
         let cjson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
                 .args([
-                    &file,
-                    "column",
-                    "create",
-                    "--board-id",
-                    &board_id,
-                    "--name",
-                    "TODO",
+                    &file, "column", "create", "--board", &board_id, "--name", "TODO",
                 ])
                 .assert()
                 .success()
@@ -2644,15 +2638,7 @@ mod name_resolution_tests {
         let (_dir, file, _board, _col) = setup_named_board("B", "B");
         let json = parse_json_output(&String::from_utf8_lossy(
             &kanban()
-                .args([
-                    &file,
-                    "column",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--name",
-                    "Doing",
-                ])
+                .args([&file, "column", "create", "--board", "B", "--name", "Doing"])
                 .assert()
                 .success()
                 .get_output()
@@ -2666,19 +2652,13 @@ mod name_resolution_tests {
         let (_dir, file, _board, _col) = setup_named_board("MyB", "MB");
         kanban()
             .args([
-                &file,
-                "column",
-                "create",
-                "--board-id",
-                "MyB",
-                "--name",
-                "Doing",
+                &file, "column", "create", "--board", "MyB", "--name", "Doing",
             ])
             .assert()
             .success();
         let json = parse_json_output(&String::from_utf8_lossy(
             &kanban()
-                .args([&file, "column", "list", "--board-id", "MyB"])
+                .args([&file, "column", "list", "--board", "MyB"])
                 .assert()
                 .success()
                 .get_output()
@@ -2718,13 +2698,7 @@ mod name_resolution_tests {
             .success();
         kanban()
             .args([
-                &file,
-                "column",
-                "create",
-                "--board-id",
-                "Beta",
-                "--name",
-                "TODO",
+                &file, "column", "create", "--board", "Beta", "--name", "TODO",
             ])
             .assert()
             .success();
@@ -2758,15 +2732,7 @@ mod name_resolution_tests {
         let json = parse_json_output(&String::from_utf8_lossy(
             &kanban()
                 .args([
-                    &file,
-                    "card",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--column-id",
-                    "TODO",
-                    "--title",
-                    "Hello",
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "Hello",
                 ])
                 .assert()
                 .success()
@@ -2781,29 +2747,13 @@ mod name_resolution_tests {
         let (_dir, file, _b, _c) = setup_named_board("B", "B");
         kanban()
             .args([
-                &file,
-                "card",
-                "create",
-                "--board-id",
-                "B",
-                "--column-id",
-                "TODO",
-                "--title",
-                "T1",
+                &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "T1",
             ])
             .assert()
             .success();
         let json = parse_json_output(&String::from_utf8_lossy(
             &kanban()
-                .args([
-                    &file,
-                    "card",
-                    "list",
-                    "--board-id",
-                    "B",
-                    "--column-id",
-                    "TODO",
-                ])
+                .args([&file, "card", "list", "--board", "B", "--column", "TODO"])
                 .assert()
                 .success()
                 .get_output()
@@ -2816,29 +2766,13 @@ mod name_resolution_tests {
     fn test_card_move_with_column_name() {
         let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
         kanban()
-            .args([
-                &file,
-                "column",
-                "create",
-                "--board-id",
-                "B",
-                "--name",
-                "Doing",
-            ])
+            .args([&file, "column", "create", "--board", "B", "--name", "Doing"])
             .assert()
             .success();
         let cjson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
                 .args([
-                    &file,
-                    "card",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--column-id",
-                    "TODO",
-                    "--title",
-                    "T",
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "T",
                 ])
                 .assert()
                 .success()
@@ -2848,7 +2782,7 @@ mod name_resolution_tests {
         let card_id = extract_id(&cjson);
         let mjson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
-                .args([&file, "card", "move", &card_id, "--column-id", "Doing"])
+                .args([&file, "card", "move", &card_id, "--column", "Doing"])
                 .assert()
                 .success()
                 .get_output()
@@ -2861,29 +2795,13 @@ mod name_resolution_tests {
     fn test_card_assign_sprint_by_name() {
         let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
         kanban()
-            .args([
-                &file,
-                "sprint",
-                "create",
-                "--board-id",
-                "B",
-                "--name",
-                "alpha",
-            ])
+            .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
             .assert()
             .success();
         let cjson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
                 .args([
-                    &file,
-                    "card",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--column-id",
-                    "TODO",
-                    "--title",
-                    "T",
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "T",
                 ])
                 .assert()
                 .success()
@@ -2898,7 +2816,7 @@ mod name_resolution_tests {
                     "card",
                     "assign-sprint",
                     &card_id,
-                    "--sprint-id",
+                    "--sprint",
                     "alpha",
                 ])
                 .assert()
@@ -2913,29 +2831,13 @@ mod name_resolution_tests {
     fn test_card_assign_sprint_by_number() {
         let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
         kanban()
-            .args([
-                &file,
-                "sprint",
-                "create",
-                "--board-id",
-                "B",
-                "--name",
-                "alpha",
-            ])
+            .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
             .assert()
             .success();
         let cjson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
                 .args([
-                    &file,
-                    "card",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--column-id",
-                    "TODO",
-                    "--title",
-                    "T",
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "T",
                 ])
                 .assert()
                 .success()
@@ -2945,7 +2847,7 @@ mod name_resolution_tests {
         let card_id = extract_id(&cjson);
         let ajson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
-                .args([&file, "card", "assign-sprint", &card_id, "--sprint-id", "1"])
+                .args([&file, "card", "assign-sprint", &card_id, "--sprint", "1"])
                 .assert()
                 .success()
                 .get_output()
@@ -2958,29 +2860,13 @@ mod name_resolution_tests {
     fn test_card_move_cards_with_card_identifiers_and_column_name() {
         let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
         kanban()
-            .args([
-                &file,
-                "column",
-                "create",
-                "--board-id",
-                "B",
-                "--name",
-                "Doing",
-            ])
+            .args([&file, "column", "create", "--board", "B", "--name", "Doing"])
             .assert()
             .success();
         for title in ["T1", "T2"] {
             kanban()
                 .args([
-                    &file,
-                    "card",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--column-id",
-                    "TODO",
-                    "--title",
-                    title,
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", title,
                 ])
                 .assert()
                 .success();
@@ -2991,9 +2877,9 @@ mod name_resolution_tests {
                     &file,
                     "card",
                     "move-cards",
-                    "--ids",
+                    "--cards",
                     "KAN-1,KAN-2",
-                    "--column-id",
+                    "--column",
                     "Doing",
                 ])
                 .assert()
@@ -3021,41 +2907,19 @@ mod name_resolution_tests {
             .success();
         kanban()
             .args([
-                &file,
-                "column",
-                "create",
-                "--board-id",
-                "Beta",
-                "--name",
-                "TODO",
+                &file, "column", "create", "--board", "Beta", "--name", "TODO",
             ])
             .assert()
             .success();
         kanban()
             .args([
-                &file,
-                "card",
-                "create",
-                "--board-id",
-                "Alpha",
-                "--column-id",
-                "TODO",
-                "--title",
-                "A1",
+                &file, "card", "create", "--board", "Alpha", "--column", "TODO", "--title", "A1",
             ])
             .assert()
             .success();
         kanban()
             .args([
-                &file,
-                "card",
-                "create",
-                "--board-id",
-                "Beta",
-                "--column-id",
-                "TODO",
-                "--title",
-                "B1",
+                &file, "card", "create", "--board", "Beta", "--column", "TODO", "--title", "B1",
             ])
             .assert()
             .success();
@@ -3064,9 +2928,9 @@ mod name_resolution_tests {
                 &file,
                 "card",
                 "move-cards",
-                "--ids",
+                "--cards",
                 "A-1,B-1",
-                "--column-id",
+                "--column",
                 "TODO",
             ])
             .assert()
@@ -3084,15 +2948,7 @@ mod name_resolution_tests {
         let (_dir, file, _b, _c) = setup_named_board("B", "B");
         let json = parse_json_output(&String::from_utf8_lossy(
             &kanban()
-                .args([
-                    &file,
-                    "sprint",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--name",
-                    "alpha",
-                ])
+                .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
                 .assert()
                 .success()
                 .get_output()
@@ -3107,13 +2963,7 @@ mod name_resolution_tests {
         let sjson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
                 .args([
-                    &file,
-                    "sprint",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--name",
-                    "yarara",
+                    &file, "sprint", "create", "--board", "B", "--name", "yarara",
                 ])
                 .assert()
                 .success()
@@ -3137,15 +2987,7 @@ mod name_resolution_tests {
         let (_dir, file, _b, _c) = setup_named_board("B", "B");
         let sjson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
-                .args([
-                    &file,
-                    "sprint",
-                    "create",
-                    "--board-id",
-                    "B",
-                    "--name",
-                    "alpha",
-                ])
+                .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
                 .assert()
                 .success()
                 .get_output()
@@ -3167,15 +3009,7 @@ mod name_resolution_tests {
     fn test_sprint_activate_by_name() {
         let (_dir, file, _b, _c) = setup_named_board("B", "B");
         kanban()
-            .args([
-                &file,
-                "sprint",
-                "create",
-                "--board-id",
-                "B",
-                "--name",
-                "alpha",
-            ])
+            .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
             .assert()
             .success();
         let json = parse_json_output(&String::from_utf8_lossy(
@@ -3194,28 +3028,12 @@ mod name_resolution_tests {
         let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
         // sprint #1
         kanban()
-            .args([
-                &file,
-                "sprint",
-                "create",
-                "--board-id",
-                "B",
-                "--name",
-                "alpha",
-            ])
+            .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
             .assert()
             .success();
         // sprint #2
         kanban()
-            .args([
-                &file,
-                "sprint",
-                "create",
-                "--board-id",
-                "B",
-                "--name",
-                "beta",
-            ])
+            .args([&file, "sprint", "create", "--board", "B", "--name", "beta"])
             .assert()
             .success();
         // activate sprint #1, then complete it
@@ -3254,7 +3072,7 @@ mod name_resolution_tests {
         let (_dir, file, _b, _c) = setup_named_board("ExpBoard", "E");
         // export prints raw JSON (not the CliResponse envelope)
         let out = kanban()
-            .args([&file, "export", "--board-id", "ExpBoard"])
+            .args([&file, "export", "--board", "ExpBoard"])
             .assert()
             .success()
             .get_output()

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -2791,6 +2791,45 @@ mod name_resolution_tests {
         assert_eq!(mjson["data"]["id"], card_id);
     }
 
+    /// Regression: `card restore <archived_uuid> --column <name>` must work.
+    /// The board-derivation helper used to chain via active cards only, which
+    /// failed for archived cards. It now falls back to archived_card.original_column_id.
+    #[test]
+    fn test_card_restore_archived_with_column_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([&file, "column", "create", "--board", "B", "--name", "Doing"])
+            .assert()
+            .success();
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "X",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let card_uuid = extract_id(&cjson);
+        kanban()
+            .args([&file, "card", "archive", "KAN-1"])
+            .assert()
+            .success();
+        // Archived cards aren't reachable via KAN-N identifier, so use UUID.
+        // The --column name resolution must still succeed by chaining via the
+        // archived card's original_column_id to derive the board.
+        let rjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "card", "restore", &card_uuid, "--column", "Doing"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(rjson["data"]["id"], card_uuid);
+    }
+
     #[test]
     fn test_card_assign_sprint_by_name() {
         let (_dir, file, _b, _c) = setup_named_board("B", "KAN");

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1476,7 +1476,7 @@ mod card_tests {
             .args([file.to_str().unwrap(), "card", "archive", "KAN-1"])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("Ambiguous"))
+            .stderr(predicate::str::contains("ambiguous"))
             .stderr(predicate::str::contains(&card_a_id))
             .stderr(predicate::str::contains(&card_b_id));
     }
@@ -2789,6 +2789,71 @@ mod name_resolution_tests {
                 .stdout,
         ));
         assert_eq!(mjson["data"]["id"], card_id);
+    }
+
+    #[test]
+    fn test_sprint_get_ambiguous_name_across_boards_lists_both() {
+        // KAN-400 review fix: cross-board sprint name ambiguity must name the
+        // conflicting boards (was previously underspecified).
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json").to_str().unwrap().to_string();
+        kanban().args([&file]).assert().success();
+        kanban()
+            .args([
+                &file,
+                "board",
+                "create",
+                "--name",
+                "Alpha",
+                "--card-prefix",
+                "A",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "board",
+                "create",
+                "--name",
+                "Beta",
+                "--card-prefix",
+                "B",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board",
+                "Alpha",
+                "--name",
+                "shared-name",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board",
+                "Beta",
+                "--name",
+                "shared-name",
+            ])
+            .assert()
+            .success();
+        let assert = kanban()
+            .args([&file, "sprint", "get", "shared-name"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("ambiguous"), "stderr: {stderr}");
+        assert!(stderr.contains("'Alpha'"), "stderr: {stderr}");
+        assert!(stderr.contains("'Beta'"), "stderr: {stderr}");
     }
 
     /// Regression: `card restore <archived_uuid> --column <name>` must work.

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -17,6 +19,12 @@ pub struct AmbiguousMatch {
     pub id: Uuid,
 }
 
+impl fmt::Display for AmbiguousMatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.label, self.id)
+    }
+}
+
 /// One element of a `BatchResolutionFailed` error. Carries the raw input
 /// the caller passed and the typed reason it couldn't be resolved.
 #[derive(Debug, Clone)]
@@ -27,6 +35,12 @@ pub struct BatchResolutionFailure {
     pub cause: BatchResolutionCause,
 }
 
+impl fmt::Display for BatchResolutionFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "'{}' ({})", self.raw_input, self.cause)
+    }
+}
+
 /// Why a single input in a batch resolver call failed.
 #[derive(Debug, Clone)]
 pub enum BatchResolutionCause {
@@ -35,6 +49,24 @@ pub enum BatchResolutionCause {
     /// More than one entity matched. Carries the same match data an
     /// `Ambiguous` single-resolver error would.
     Ambiguous(Vec<AmbiguousMatch>),
+}
+
+impl fmt::Display for BatchResolutionCause {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "not found"),
+            Self::Ambiguous(matches) => {
+                f.write_str("ambiguous: ")?;
+                for (i, m) in matches.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{}", m)?;
+                }
+                Ok(())
+            }
+        }
+    }
 }
 
 #[derive(Error, Debug)]
@@ -113,33 +145,28 @@ impl DomainError {
     fn fmt_ambiguous(entity: &str, name: &str, matches: &[AmbiguousMatch]) -> String {
         let rendered = matches
             .iter()
-            .map(|m| format!("{} ({})", m.label, m.id))
+            .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join(", ");
         format!("{} '{}' is ambiguous: {}.", entity, name, rendered)
     }
 
     fn fmt_batch_resolution_failed(entity: &str, failures: &[BatchResolutionFailure]) -> String {
-        let parts: Vec<String> = failures
+        // Singularize the entity noun when there's exactly one failure;
+        // otherwise add a plural `s`. Keep entity capitalization for
+        // consistency with `NotFoundByName` and `Ambiguous` siblings.
+        let n = failures.len();
+        let noun = if n == 1 {
+            entity.to_string()
+        } else {
+            format!("{}s", entity)
+        };
+        let parts = failures
             .iter()
-            .map(|f| match &f.cause {
-                BatchResolutionCause::NotFound => format!("'{}' (not found)", f.raw_input),
-                BatchResolutionCause::Ambiguous(matches) => {
-                    let rendered = matches
-                        .iter()
-                        .map(|m| format!("{} ({})", m.label, m.id))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    format!("'{}' (ambiguous: {})", f.raw_input, rendered)
-                }
-            })
-            .collect();
-        format!(
-            "Could not resolve {} {}(s): {}",
-            failures.len(),
-            entity.to_lowercase(),
-            parts.join(", ")
-        )
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("Could not resolve {} {}: {}", n, noun, parts)
     }
 
     pub fn board_not_found(id: Uuid) -> Self {
@@ -535,11 +562,95 @@ mod tests {
             ],
         );
         let msg = err.to_string();
-        assert!(msg.contains("2 card"), "msg: {msg}");
+        assert!(msg.contains("2 Cards"), "msg: {msg}");
         assert!(msg.contains("'KAN-999'"), "msg: {msg}");
         assert!(msg.contains("'KAN-998'"), "msg: {msg}");
         assert!(msg.contains("not found"), "msg: {msg}");
         assert!(msg.contains("ambiguous"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_batch_resolution_failed_display_singularizes_for_one_failure() {
+        // KAN-400 review-3 fix: "1 card(s)" was grammatically awkward. Now
+        // the noun agrees in number with the count, and entity casing matches
+        // sibling error variants (NotFoundByName / Ambiguous both keep
+        // "Card" capitalized).
+        let err = KanbanError::batch_resolution_failed(
+            "Card",
+            vec![BatchResolutionFailure {
+                raw_input: "KAN-999".into(),
+                cause: BatchResolutionCause::NotFound,
+            }],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("1 Card"), "expected '1 Card' singular: {msg}");
+        assert!(
+            !msg.contains("1 Cards") && !msg.contains("card(s)"),
+            "no plural or parenthetical: {msg}"
+        );
+        assert!(msg.contains('('), "still wraps cause in parens: {msg}");
+    }
+
+    #[test]
+    fn test_batch_resolution_failed_display_preserves_entity_capitalization() {
+        // Sibling variants render "Card '...' not found"; the batch variant
+        // must match. No to_lowercase.
+        let err = KanbanError::batch_resolution_failed(
+            "Card",
+            vec![
+                BatchResolutionFailure {
+                    raw_input: "x".into(),
+                    cause: BatchResolutionCause::NotFound,
+                },
+                BatchResolutionFailure {
+                    raw_input: "y".into(),
+                    cause: BatchResolutionCause::NotFound,
+                },
+            ],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("Cards"), "got: {msg}");
+        assert!(!msg.contains(" cards"), "lowercased entity: {msg}");
+    }
+
+    #[test]
+    fn test_ambiguous_match_display_is_label_then_uuid_in_parens() {
+        // Standalone Display impl on AmbiguousMatch so callers can render
+        // a match without re-implementing the format.
+        let id = Uuid::new_v4();
+        let m = AmbiguousMatch {
+            label: "'Alpha'".into(),
+            id,
+        };
+        let rendered = format!("{}", m);
+        assert_eq!(rendered, format!("'Alpha' ({})", id));
+    }
+
+    #[test]
+    fn test_batch_resolution_cause_display_renders_not_found_and_ambiguous() {
+        // Standalone Display impl on BatchResolutionCause for symmetry.
+        let nf = BatchResolutionCause::NotFound;
+        assert_eq!(format!("{}", nf), "not found");
+
+        let id = Uuid::new_v4();
+        let amb = BatchResolutionCause::Ambiguous(vec![
+            AmbiguousMatch {
+                label: "'A'".into(),
+                id,
+            },
+            AmbiguousMatch {
+                label: "'B'".into(),
+                id,
+            },
+        ]);
+        let rendered = format!("{}", amb);
+        assert!(rendered.starts_with("ambiguous: "), "got: {rendered}");
+        assert!(rendered.contains("'A'"), "got: {rendered}");
+        assert!(rendered.contains("'B'"), "got: {rendered}");
+        assert!(
+            rendered.matches(&id.to_string()).count() == 2,
+            "got: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -1,6 +1,42 @@
 use thiserror::Error;
 use uuid::Uuid;
 
+/// One element of an `Ambiguous` error's match list. Carries both a
+/// human-readable label (what makes this match distinguishable from the
+/// others) and the entity's UUID (always copy-pasteable). Display always
+/// renders as `{label} ({uuid})` so users can disambiguate by either.
+#[derive(Debug, Clone)]
+pub struct AmbiguousMatch {
+    /// Human-readable label that distinguishes this match. Examples:
+    ///   - board name (when two boards share a name)
+    ///   - `"on board 'X'"` (when a column name appears on multiple boards)
+    ///   - `"#15 'yarara-release' on board 'Project A'"` (sprint global match)
+    ///   - card title
+    pub label: String,
+    /// The matched entity's UUID.
+    pub id: Uuid,
+}
+
+/// One element of a `BatchResolutionFailed` error. Carries the raw input
+/// the caller passed and the typed reason it couldn't be resolved.
+#[derive(Debug, Clone)]
+pub struct BatchResolutionFailure {
+    /// The string the caller passed for this slot (UUID, identifier, name, etc.).
+    pub raw_input: String,
+    /// Why this input couldn't be resolved.
+    pub cause: BatchResolutionCause,
+}
+
+/// Why a single input in a batch resolver call failed.
+#[derive(Debug, Clone)]
+pub enum BatchResolutionCause {
+    /// No entity matched the input.
+    NotFound,
+    /// More than one entity matched. Carries the same match data an
+    /// `Ambiguous` single-resolver error would.
+    Ambiguous(Vec<AmbiguousMatch>),
+}
+
 #[derive(Error, Debug)]
 pub enum DependencyError {
     #[error("cycle detected: adding this edge would create a circular dependency")]
@@ -18,7 +54,7 @@ pub enum DomainError {
 
     /// Returned when a name- or identifier-based lookup misses. The `available`
     /// vector is appended to the message so users see what they could have typed.
-    #[error("{}", format_not_found_by_name(entity, name, available))]
+    #[error("{}", DomainError::fmt_not_found_by_name(entity, name, available))]
     NotFoundByName {
         entity: &'static str,
         name: String,
@@ -26,12 +62,22 @@ pub enum DomainError {
     },
 
     /// Returned when a name- or identifier-based lookup matches more than one
-    /// entity. `matches` is a list of human-readable labels for each match.
-    #[error("{}", format_ambiguous(entity, name, matches))]
+    /// entity. Each match carries both a human-readable label and a UUID so
+    /// users can disambiguate by either.
+    #[error("{}", DomainError::fmt_ambiguous(entity, name, matches))]
     Ambiguous {
         entity: &'static str,
         name: String,
-        matches: Vec<String>,
+        matches: Vec<AmbiguousMatch>,
+    },
+
+    /// Returned by batch resolvers (`resolve_card_ids`, future siblings) when
+    /// one or more inputs in the batch couldn't be resolved. Carries per-input
+    /// typed causes so callers can introspect.
+    #[error("{}", DomainError::fmt_batch_resolution_failed(entity, failures))]
+    BatchResolutionFailed {
+        entity: &'static str,
+        failures: Vec<BatchResolutionFailure>,
     },
 
     #[error("validation error: {0}")]
@@ -44,33 +90,58 @@ pub enum DomainError {
     WipLimitExceeded { column_id: Uuid, limit: u32 },
 }
 
-fn format_not_found_by_name(entity: &str, name: &str, available: &[String]) -> String {
-    if available.is_empty() {
-        format!("{} '{}' not found", entity, name)
-    } else {
+impl DomainError {
+    // ----- Display formatters for the name/identifier resolver variants -----
+
+    fn fmt_not_found_by_name(entity: &str, name: &str, available: &[String]) -> String {
+        if available.is_empty() {
+            format!("{} '{}' not found", entity, name)
+        } else {
+            format!(
+                "{} '{}' not found. Available: {}",
+                entity,
+                name,
+                available
+                    .iter()
+                    .map(|s| format!("'{}'", s))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }
+    }
+
+    fn fmt_ambiguous(entity: &str, name: &str, matches: &[AmbiguousMatch]) -> String {
+        let rendered = matches
+            .iter()
+            .map(|m| format!("{} ({})", m.label, m.id))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{} '{}' is ambiguous: {}.", entity, name, rendered)
+    }
+
+    fn fmt_batch_resolution_failed(entity: &str, failures: &[BatchResolutionFailure]) -> String {
+        let parts: Vec<String> = failures
+            .iter()
+            .map(|f| match &f.cause {
+                BatchResolutionCause::NotFound => format!("'{}' (not found)", f.raw_input),
+                BatchResolutionCause::Ambiguous(matches) => {
+                    let rendered = matches
+                        .iter()
+                        .map(|m| format!("{} ({})", m.label, m.id))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("'{}' (ambiguous: {})", f.raw_input, rendered)
+                }
+            })
+            .collect();
         format!(
-            "{} '{}' not found. Available: {}",
-            entity,
-            name,
-            available
-                .iter()
-                .map(|s| format!("'{}'", s))
-                .collect::<Vec<_>>()
-                .join(", ")
+            "Could not resolve {} {}(s): {}",
+            failures.len(),
+            entity.to_lowercase(),
+            parts.join(", ")
         )
     }
-}
 
-fn format_ambiguous(entity: &str, name: &str, matches: &[String]) -> String {
-    format!(
-        "{} '{}' is ambiguous: {}. Specify by UUID or a unique name.",
-        entity,
-        name,
-        matches.join(", ")
-    )
-}
-
-impl DomainError {
     pub fn board_not_found(id: Uuid) -> Self {
         Self::NotFound {
             entity: "board",
@@ -150,12 +221,23 @@ impl KanbanError {
         })
     }
 
-    pub fn ambiguous(entity: &'static str, name: impl Into<String>, matches: Vec<String>) -> Self {
+    pub fn ambiguous(
+        entity: &'static str,
+        name: impl Into<String>,
+        matches: Vec<AmbiguousMatch>,
+    ) -> Self {
         Self::Domain(DomainError::Ambiguous {
             entity,
             name: name.into(),
             matches,
         })
+    }
+
+    pub fn batch_resolution_failed(
+        entity: &'static str,
+        failures: Vec<BatchResolutionFailure>,
+    ) -> Self {
+        Self::Domain(DomainError::BatchResolutionFailed { entity, failures })
     }
 
     pub fn validation(msg: impl Into<String>) -> Self {
@@ -180,6 +262,13 @@ impl KanbanError {
 
     pub fn is_ambiguous(&self) -> bool {
         matches!(self, KanbanError::Domain(DomainError::Ambiguous { .. }))
+    }
+
+    pub fn is_batch_resolution_failed(&self) -> bool {
+        matches!(
+            self,
+            KanbanError::Domain(DomainError::BatchResolutionFailed { .. })
+        )
     }
 
     pub fn is_validation(&self) -> bool {
@@ -331,16 +420,72 @@ mod tests {
     }
 
     #[test]
-    fn test_ambiguous_display_lists_matches() {
+    fn test_ambiguous_display_includes_label_and_uuid_per_match() {
+        // KAN-400 polish: every match carries both a human label and a UUID
+        // so users can disambiguate by either.
+        let a_id = Uuid::new_v4();
+        let b_id = Uuid::new_v4();
         let err = KanbanError::ambiguous(
             "Sprint",
             "13",
-            vec!["'Project A'".into(), "'Project B'".into()],
+            vec![
+                AmbiguousMatch {
+                    label: "on board 'Project A'".into(),
+                    id: a_id,
+                },
+                AmbiguousMatch {
+                    label: "on board 'Project B'".into(),
+                    id: b_id,
+                },
+            ],
         );
         let msg = err.to_string();
         assert!(msg.contains("'13' is ambiguous"), "msg: {msg}");
         assert!(msg.contains("'Project A'"), "msg: {msg}");
         assert!(msg.contains("'Project B'"), "msg: {msg}");
+        assert!(
+            msg.contains(&a_id.to_string()),
+            "label-only is not enough: {msg}"
+        );
+        assert!(
+            msg.contains(&b_id.to_string()),
+            "label-only is not enough: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_ambiguous_display_single_match_renders_cleanly() {
+        // Degenerate case; can happen if a different resolver path produces
+        // a single-match Ambiguous (shouldn't, but be defensive).
+        let id = Uuid::new_v4();
+        let err = KanbanError::ambiguous(
+            "Card",
+            "5",
+            vec![AmbiguousMatch {
+                label: "Some title".into(),
+                id,
+            }],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("'5' is ambiguous"), "msg: {msg}");
+        assert!(msg.contains("Some title"), "msg: {msg}");
+        assert!(msg.contains(&id.to_string()), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_ambiguous_message_drops_specify_by_uuid_coda() {
+        // The old wording "Specify by UUID" was redundant once the UUID is
+        // already in the message. New message doesn't repeat it.
+        let err = KanbanError::ambiguous(
+            "Board",
+            "shared",
+            vec![AmbiguousMatch {
+                label: "shared".into(),
+                id: Uuid::new_v4(),
+            }],
+        );
+        let msg = err.to_string();
+        assert!(!msg.contains("Specify by UUID"), "msg: {msg}");
     }
 
     #[test]
@@ -353,9 +498,55 @@ mod tests {
 
     #[test]
     fn test_is_ambiguous_predicate() {
-        let err = KanbanError::ambiguous("Card", "5", vec!["x".into(), "y".into()]);
+        let err = KanbanError::ambiguous(
+            "Card",
+            "5",
+            vec![
+                AmbiguousMatch {
+                    label: "x".into(),
+                    id: Uuid::new_v4(),
+                },
+                AmbiguousMatch {
+                    label: "y".into(),
+                    id: Uuid::new_v4(),
+                },
+            ],
+        );
         assert!(err.is_ambiguous());
         assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn test_batch_resolution_failed_display_includes_each_input_and_cause() {
+        let err = KanbanError::batch_resolution_failed(
+            "Card",
+            vec![
+                BatchResolutionFailure {
+                    raw_input: "KAN-999".into(),
+                    cause: BatchResolutionCause::NotFound,
+                },
+                BatchResolutionFailure {
+                    raw_input: "KAN-998".into(),
+                    cause: BatchResolutionCause::Ambiguous(vec![AmbiguousMatch {
+                        label: "'one'".into(),
+                        id: Uuid::new_v4(),
+                    }]),
+                },
+            ],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("2 card"), "msg: {msg}");
+        assert!(msg.contains("'KAN-999'"), "msg: {msg}");
+        assert!(msg.contains("'KAN-998'"), "msg: {msg}");
+        assert!(msg.contains("not found"), "msg: {msg}");
+        assert!(msg.contains("ambiguous"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_is_batch_resolution_failed_predicate() {
+        let err = KanbanError::batch_resolution_failed("Card", Vec::new());
+        assert!(err.is_batch_resolution_failed());
+        assert!(!err.is_not_found(), "not the same as a single not-found");
     }
 
     #[test]

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -152,21 +152,17 @@ impl DomainError {
     }
 
     fn fmt_batch_resolution_failed(entity: &str, failures: &[BatchResolutionFailure]) -> String {
-        // Singularize the entity noun when there's exactly one failure;
-        // otherwise add a plural `s`. Keep entity capitalization for
-        // consistency with `NotFoundByName` and `Ambiguous` siblings.
-        let n = failures.len();
-        let noun = if n == 1 {
-            entity.to_string()
-        } else {
-            format!("{}s", entity)
-        };
         let parts = failures
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join(", ");
-        format!("Could not resolve {} {}: {}", n, noun, parts)
+        format!(
+            "Could not resolve {} {}: {}",
+            failures.len(),
+            pluralize(entity, failures.len()),
+            parts
+        )
     }
 
     pub fn board_not_found(id: Uuid) -> Self {
@@ -227,6 +223,16 @@ pub enum KanbanError {
 
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+/// Return `noun` (when count is 1) or `noun + "s"` (otherwise).
+/// Trivial English helper used by error message formatters.
+fn pluralize(noun: &str, count: usize) -> String {
+    if count == 1 {
+        noun.to_string()
+    } else {
+        format!("{}s", noun)
+    }
 }
 
 pub type KanbanResult<T> = Result<T, KanbanError>;

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -16,6 +16,24 @@ pub enum DomainError {
     #[error("{entity} {id} not found")]
     NotFound { entity: &'static str, id: Uuid },
 
+    /// Returned when a name- or identifier-based lookup misses. The `available`
+    /// vector is appended to the message so users see what they could have typed.
+    #[error("{}", format_not_found_by_name(entity, name, available))]
+    NotFoundByName {
+        entity: &'static str,
+        name: String,
+        available: Vec<String>,
+    },
+
+    /// Returned when a name- or identifier-based lookup matches more than one
+    /// entity. `matches` is a list of human-readable labels for each match.
+    #[error("{}", format_ambiguous(entity, name, matches))]
+    Ambiguous {
+        entity: &'static str,
+        name: String,
+        matches: Vec<String>,
+    },
+
     #[error("validation error: {0}")]
     Validation(String),
 
@@ -24,6 +42,32 @@ pub enum DomainError {
 
     #[error("column {column_id} has reached its WIP limit of {limit}")]
     WipLimitExceeded { column_id: Uuid, limit: u32 },
+}
+
+fn format_not_found_by_name(entity: &str, name: &str, available: &[String]) -> String {
+    if available.is_empty() {
+        format!("{} '{}' not found", entity, name)
+    } else {
+        format!(
+            "{} '{}' not found. Available: {}",
+            entity,
+            name,
+            available
+                .iter()
+                .map(|s| format!("'{}'", s))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+fn format_ambiguous(entity: &str, name: &str, matches: &[String]) -> String {
+    format!(
+        "{} '{}' is ambiguous: {}. Specify by UUID or a unique name.",
+        entity,
+        name,
+        matches.join(", ")
+    )
 }
 
 impl DomainError {
@@ -94,12 +138,48 @@ impl KanbanError {
         Self::Domain(DomainError::NotFound { entity, id })
     }
 
+    pub fn not_found_by_name(
+        entity: &'static str,
+        name: impl Into<String>,
+        available: Vec<String>,
+    ) -> Self {
+        Self::Domain(DomainError::NotFoundByName {
+            entity,
+            name: name.into(),
+            available,
+        })
+    }
+
+    pub fn ambiguous(entity: &'static str, name: impl Into<String>, matches: Vec<String>) -> Self {
+        Self::Domain(DomainError::Ambiguous {
+            entity,
+            name: name.into(),
+            matches,
+        })
+    }
+
     pub fn validation(msg: impl Into<String>) -> Self {
         Self::Domain(DomainError::Validation(msg.into()))
     }
 
+    /// True for both `NotFound` (by UUID) and `NotFoundByName`.
     pub fn is_not_found(&self) -> bool {
-        matches!(self, KanbanError::Domain(DomainError::NotFound { .. }))
+        matches!(
+            self,
+            KanbanError::Domain(DomainError::NotFound { .. })
+                | KanbanError::Domain(DomainError::NotFoundByName { .. })
+        )
+    }
+
+    pub fn is_not_found_by_name(&self) -> bool {
+        matches!(
+            self,
+            KanbanError::Domain(DomainError::NotFoundByName { .. })
+        )
+    }
+
+    pub fn is_ambiguous(&self) -> bool {
+        matches!(self, KanbanError::Domain(DomainError::Ambiguous { .. }))
     }
 
     pub fn is_validation(&self) -> bool {
@@ -225,6 +305,64 @@ mod tests {
         let id = Uuid::new_v4();
         let err = KanbanError::Domain(DomainError::wip_limit_exceeded(id, 3));
         assert!(err.is_wip_limit_exceeded());
+    }
+
+    #[test]
+    fn test_not_found_by_name_display_lists_available() {
+        let err = KanbanError::not_found_by_name(
+            "Column",
+            "done",
+            vec!["TODO".into(), "Doing".into(), "Complete".into()],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("'done'"), "msg: {msg}");
+        assert!(msg.contains("not found"), "msg: {msg}");
+        assert!(msg.contains("'TODO'"), "msg: {msg}");
+        assert!(msg.contains("'Doing'"), "msg: {msg}");
+        assert!(msg.contains("'Complete'"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_not_found_by_name_display_with_empty_available_omits_list() {
+        let err = KanbanError::not_found_by_name("Card", "KAN-999", Vec::new());
+        let msg = err.to_string();
+        assert!(msg.contains("'KAN-999' not found"), "msg: {msg}");
+        assert!(!msg.contains("Available:"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_ambiguous_display_lists_matches() {
+        let err = KanbanError::ambiguous(
+            "Sprint",
+            "13",
+            vec!["'Project A'".into(), "'Project B'".into()],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("'13' is ambiguous"), "msg: {msg}");
+        assert!(msg.contains("'Project A'"), "msg: {msg}");
+        assert!(msg.contains("'Project B'"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_is_not_found_by_name_predicate() {
+        let err = KanbanError::not_found_by_name("Column", "foo", Vec::new());
+        assert!(err.is_not_found_by_name());
+        // is_not_found is the umbrella predicate covering both shapes.
+        assert!(err.is_not_found());
+    }
+
+    #[test]
+    fn test_is_ambiguous_predicate() {
+        let err = KanbanError::ambiguous("Card", "5", vec!["x".into(), "y".into()]);
+        assert!(err.is_ambiguous());
+        assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn test_is_not_found_true_for_uuid_variant_too() {
+        let err = KanbanError::not_found("card", Uuid::new_v4());
+        assert!(err.is_not_found(), "umbrella predicate covers Uuid variant");
+        assert!(!err.is_not_found_by_name());
     }
 
     #[test]

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -48,6 +48,7 @@ pub use query::{
     CardQueryBuilder,
 };
 pub use search::{
+    find_boards_by_name, find_cards_by_identifier, find_columns_by_name, find_sprints_by_query,
     format_ambiguous_matches, BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy,
     TitleSearcher,
 };

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -63,4 +63,7 @@ pub use command_store::CommandStore;
 pub use data_store::{DataStore, GraphMutFn};
 pub use in_memory_store::InMemoryStore;
 
-pub use error::{DependencyError, DomainError, KanbanError, KanbanResult};
+pub use error::{
+    AmbiguousMatch, BatchResolutionCause, BatchResolutionFailure, DependencyError, DomainError,
+    KanbanError, KanbanResult,
+};

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -48,9 +48,9 @@ pub use query::{
     CardQueryBuilder,
 };
 pub use search::{
-    find_boards_by_name, find_cards_by_identifier, find_columns_by_name, find_sprints_by_query,
-    format_ambiguous_matches, BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy,
-    TitleSearcher,
+    find_boards_by_name, find_cards_by_identifier, find_columns_by_name,
+    find_sprints_by_query_global, find_sprints_by_query_on_board, format_ambiguous_matches,
+    BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy, TitleSearcher,
 };
 pub use snapshot::Snapshot;
 pub use sort::{get_sorter_for_field, OrderedSorter, SortBy};

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -1,7 +1,8 @@
 use crate::KanbanResult;
 use crate::{
-    ArchivedCard, Board, BoardUpdate, Card, CardStatus, CardSummary, CardUpdate, Column,
-    ColumnUpdate, CreateCardOptions, KanbanError, Sprint, SprintUpdate,
+    AmbiguousMatch, ArchivedCard, BatchResolutionCause, BatchResolutionFailure, Board, BoardUpdate,
+    Card, CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions,
+    KanbanError, Sprint, SprintUpdate,
 };
 use uuid::Uuid;
 
@@ -139,7 +140,12 @@ pub trait KanbanOperations {
             many => Err(KanbanError::ambiguous(
                 "Board",
                 raw,
-                many.iter().map(|b| b.id.to_string()).collect(),
+                many.iter()
+                    .map(|b| AmbiguousMatch {
+                        label: format!("'{}'", b.name),
+                        id: b.id,
+                    })
+                    .collect(),
             )),
         }
     }
@@ -160,7 +166,12 @@ pub trait KanbanOperations {
             many => Err(KanbanError::ambiguous(
                 "Column",
                 raw,
-                many.iter().map(|c| c.id.to_string()).collect(),
+                many.iter()
+                    .map(|c| AmbiguousMatch {
+                        label: format!("'{}'", c.name),
+                        id: c.id,
+                    })
+                    .collect(),
             )),
         }
     }
@@ -182,17 +193,21 @@ pub trait KanbanOperations {
             many => {
                 // Only need board names for the ambiguity message — one extra query.
                 let boards = self.list_boards()?;
-                let names: Vec<String> = many
+                let matches: Vec<AmbiguousMatch> = many
                     .iter()
                     .map(|c| {
-                        boards
+                        let board_name = boards
                             .iter()
                             .find(|b| b.id == c.board_id)
-                            .map(|b| format!("'{}'", b.name))
-                            .unwrap_or_else(|| "(unknown)".to_string())
+                            .map(|b| b.name.as_str())
+                            .unwrap_or("(unknown)");
+                        AmbiguousMatch {
+                            label: format!("on board '{}'", board_name),
+                            id: c.id,
+                        }
                     })
                     .collect();
-                Err(KanbanError::ambiguous("Column", raw, names))
+                Err(KanbanError::ambiguous("Column", raw, matches))
             }
         }
     }
@@ -221,7 +236,15 @@ pub trait KanbanOperations {
             many => Err(KanbanError::ambiguous(
                 "Sprint",
                 raw,
-                many.iter().map(|s| s.id.to_string()).collect(),
+                many.iter()
+                    .map(|s| {
+                        let name = s.get_name(&board).unwrap_or("(unnamed)");
+                        AmbiguousMatch {
+                            label: format!("#{} '{}'", s.sprint_number, name),
+                            id: s.id,
+                        }
+                    })
+                    .collect(),
             )),
         }
     }
@@ -251,17 +274,22 @@ pub trait KanbanOperations {
             }
             [s] => Ok(s.id),
             many => {
-                let names: Vec<String> = many
+                let matches: Vec<AmbiguousMatch> = many
                     .iter()
                     .map(|s| {
-                        boards
-                            .iter()
-                            .find(|b| b.id == s.board_id)
-                            .map(|b| format!("'{}'", b.name))
-                            .unwrap_or_else(|| "(unknown)".to_string())
+                        let board = boards.iter().find(|b| b.id == s.board_id);
+                        let board_name = board.map(|b| b.name.as_str()).unwrap_or("(unknown)");
+                        let sprint_name = board.and_then(|b| s.get_name(b)).unwrap_or("(unnamed)");
+                        AmbiguousMatch {
+                            label: format!(
+                                "#{} '{}' on board '{}'",
+                                s.sprint_number, sprint_name, board_name
+                            ),
+                            id: s.id,
+                        }
                     })
                     .collect();
-                Err(KanbanError::ambiguous("Sprint", raw, names))
+                Err(KanbanError::ambiguous("Sprint", raw, matches))
             }
         }
     }
@@ -282,7 +310,10 @@ pub trait KanbanOperations {
                 "Card",
                 raw,
                 many.iter()
-                    .map(|c| format!("{} ({})", c.id, c.title))
+                    .map(|c| AmbiguousMatch {
+                        label: format!("'{}'", c.title),
+                        id: c.id,
+                    })
                     .collect(),
             )),
         }
@@ -291,6 +322,10 @@ pub trait KanbanOperations {
     /// Resolve a batch of card identifiers against a single snapshot. Pure
     /// in-memory matching against `find_cards_by_identifier`; one set of
     /// `list_all_*` calls regardless of batch size.
+    ///
+    /// On failure, returns `KanbanError::BatchResolutionFailed` with per-input
+    /// typed causes so callers can introspect (which raw inputs failed, and
+    /// for what reason).
     fn resolve_card_ids(&self, raws: &[String]) -> KanbanResult<Vec<Uuid>> {
         // Single snapshot for the whole batch — no per-element backend round-trips.
         let cards = self.list_all_cards()?;
@@ -299,7 +334,7 @@ pub trait KanbanOperations {
         let sprints = self.list_all_sprints()?;
 
         let mut resolved = Vec::with_capacity(raws.len());
-        let mut errors = Vec::new();
+        let mut failures = Vec::new();
         for raw in raws {
             if let Ok(uuid) = Uuid::parse_str(raw) {
                 resolved.push(uuid);
@@ -308,17 +343,26 @@ pub trait KanbanOperations {
             let matches =
                 crate::search::find_cards_by_identifier(raw, &cards, &columns, &boards, &sprints);
             match matches.as_slice() {
-                [] => errors.push(format!("'{}': not found", raw)),
+                [] => failures.push(BatchResolutionFailure {
+                    raw_input: raw.clone(),
+                    cause: BatchResolutionCause::NotFound,
+                }),
                 [c] => resolved.push(c.id),
-                many => errors.push(format!("'{}': {} matches (ambiguous)", raw, many.len())),
+                many => failures.push(BatchResolutionFailure {
+                    raw_input: raw.clone(),
+                    cause: BatchResolutionCause::Ambiguous(
+                        many.iter()
+                            .map(|c| AmbiguousMatch {
+                                label: format!("'{}'", c.title),
+                                id: c.id,
+                            })
+                            .collect(),
+                    ),
+                }),
             }
         }
-        if !errors.is_empty() {
-            return Err(KanbanError::validation(format!(
-                "Could not resolve {} card(s): {}",
-                errors.len(),
-                errors.join("; ")
-            )));
+        if !failures.is_empty() {
+            return Err(KanbanError::batch_resolution_failed("Card", failures));
         }
         Ok(resolved)
     }

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -48,6 +48,15 @@ pub trait KanbanOperations {
     fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>>;
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>>;
     fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>>;
+    /// Single-query snapshot of every card across all boards. Used by
+    /// resolvers and batch operations that need to scan once and reason
+    /// in memory. Implementors must back this with a single backend
+    /// query — do not compose from `list_cards_by_column`.
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>>;
+    /// Single-query snapshot of every column across all boards.
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>>;
+    /// Single-query snapshot of every sprint across all boards.
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>>;
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card>;
     fn move_card(&mut self, id: Uuid, column_id: Uuid, position: Option<i32>)
         -> KanbanResult<Card>;
@@ -104,9 +113,15 @@ pub trait KanbanOperations {
     //
     // Each resolver accepts a raw string that may be a UUID, an entity name, or
     // (for sprints) a sprint number. The UUID fast path returns immediately;
-    // otherwise the resolver lists matches and errors with a human-friendly
-    // "not found, here are the alternatives" or "ambiguous, here are the
-    // matches" message.
+    // otherwise the resolver returns `DomainError::NotFoundByName` (carrying the
+    // available alternatives) or `DomainError::Ambiguous` (carrying the matches).
+    // CLI/MCP layers just stringify the error; the human-friendly message lives
+    // in `DomainError`'s `Display` impl.
+    //
+    // Each resolver call takes one fresh snapshot of the relevant slice. No
+    // caching across calls; the snapshot lives only for the duration of the
+    // call. Batch resolvers (`resolve_card_ids`, `require_same_board`) take a
+    // single snapshot for the whole batch — internally consistent by definition.
 
     fn resolve_board_id(&self, raw: &str) -> KanbanResult<Uuid> {
         if let Ok(uuid) = Uuid::parse_str(raw) {
@@ -115,21 +130,17 @@ pub trait KanbanOperations {
         let boards = self.list_boards()?;
         let matches = crate::search::find_boards_by_name(raw, &boards);
         match matches.as_slice() {
-            [] => Err(KanbanError::validation(format!(
-                "Board '{}' not found. Available: {}",
+            [] => Err(KanbanError::not_found_by_name(
+                "Board",
                 raw,
-                join_quoted(boards.iter().map(|b| b.name.as_str()))
-            ))),
+                boards.iter().map(|b| b.name.clone()).collect(),
+            )),
             [b] => Ok(b.id),
-            many => Err(KanbanError::validation(format!(
-                "Board '{}' is ambiguous: {} matches. Specify by UUID. Matching IDs: {}",
+            many => Err(KanbanError::ambiguous(
+                "Board",
                 raw,
-                many.len(),
-                many.iter()
-                    .map(|b| b.id.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ))),
+                many.iter().map(|b| b.id.to_string()).collect(),
+            )),
         }
     }
 
@@ -140,17 +151,17 @@ pub trait KanbanOperations {
         let columns = self.list_columns(board_id)?;
         let matches = crate::search::find_columns_by_name(raw, &columns);
         match matches.as_slice() {
-            [] => Err(KanbanError::validation(format!(
-                "Column '{}' not found on this board. Available: {}",
+            [] => Err(KanbanError::not_found_by_name(
+                "Column",
                 raw,
-                join_quoted(columns.iter().map(|c| c.name.as_str()))
-            ))),
+                columns.iter().map(|c| c.name.clone()).collect(),
+            )),
             [c] => Ok(c.id),
-            many => Err(KanbanError::validation(format!(
-                "Column '{}' is ambiguous on this board: {} matches. Specify by UUID.",
+            many => Err(KanbanError::ambiguous(
+                "Column",
                 raw,
-                many.len()
-            ))),
+                many.iter().map(|c| c.id.to_string()).collect(),
+            )),
         }
     }
 
@@ -158,35 +169,30 @@ pub trait KanbanOperations {
         if let Ok(uuid) = Uuid::parse_str(raw) {
             return Ok(uuid);
         }
-        let boards = self.list_boards()?;
-        let mut all_columns = Vec::new();
-        for board in &boards {
-            all_columns.extend(self.list_columns(board.id)?);
-        }
+        // Single snapshot — no N+1.
+        let all_columns = self.list_all_columns()?;
         let matches = crate::search::find_columns_by_name(raw, &all_columns);
         match matches.as_slice() {
-            [] => Err(KanbanError::validation(format!(
-                "Column '{}' not found. Available: {}",
+            [] => Err(KanbanError::not_found_by_name(
+                "Column",
                 raw,
-                join_quoted(all_columns.iter().map(|c| c.name.as_str()))
-            ))),
+                all_columns.iter().map(|c| c.name.clone()).collect(),
+            )),
             [c] => Ok(c.id),
             many => {
-                let board_names: Vec<String> = many
+                // Only need board names for the ambiguity message — one extra query.
+                let boards = self.list_boards()?;
+                let names: Vec<String> = many
                     .iter()
                     .map(|c| {
                         boards
                             .iter()
                             .find(|b| b.id == c.board_id)
-                            .map(|b| b.name.clone())
+                            .map(|b| format!("'{}'", b.name))
                             .unwrap_or_else(|| "(unknown)".to_string())
                     })
                     .collect();
-                Err(KanbanError::validation(format!(
-                    "Column '{}' is ambiguous: found on boards {}. Use the UUID or a unique name.",
-                    raw,
-                    join_quoted(board_names.iter().map(|s| s.as_str()))
-                )))
+                Err(KanbanError::ambiguous("Column", raw, names))
             }
         }
     }
@@ -199,29 +205,24 @@ pub trait KanbanOperations {
         let board = self
             .get_board(board_id)?
             .ok_or_else(|| KanbanError::not_found("board", board_id))?;
-        let boards_vec = vec![board];
-        let matches = crate::search::find_sprints_by_query(raw, &sprints, &boards_vec);
+        let matches = crate::search::find_sprints_by_query_on_board(raw, &sprints, &board);
         match matches.as_slice() {
             [] => {
                 let available = sprints
                     .iter()
                     .map(|s| {
-                        let label = s.get_name(&boards_vec[0]).unwrap_or("(unnamed)");
+                        let label = s.get_name(&board).unwrap_or("(unnamed)");
                         format!("#{} {}", s.sprint_number, label)
                     })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                Err(KanbanError::validation(format!(
-                    "Sprint '{}' not found on this board. Available: {}",
-                    raw, available
-                )))
+                    .collect();
+                Err(KanbanError::not_found_by_name("Sprint", raw, available))
             }
             [s] => Ok(s.id),
-            many => Err(KanbanError::validation(format!(
-                "Sprint '{}' is ambiguous on this board: {} matches. Specify by UUID.",
+            many => Err(KanbanError::ambiguous(
+                "Sprint",
                 raw,
-                many.len()
-            ))),
+                many.iter().map(|s| s.id.to_string()).collect(),
+            )),
         }
     }
 
@@ -229,34 +230,38 @@ pub trait KanbanOperations {
         if let Ok(uuid) = Uuid::parse_str(raw) {
             return Ok(uuid);
         }
+        // Single snapshot — no N+1.
+        let all_sprints = self.list_all_sprints()?;
         let boards = self.list_boards()?;
-        let mut all_sprints = Vec::new();
-        for board in &boards {
-            all_sprints.extend(self.list_sprints(board.id)?);
-        }
-        let matches = crate::search::find_sprints_by_query(raw, &all_sprints, &boards);
+        let matches = crate::search::find_sprints_by_query_global(raw, &all_sprints, &boards);
         match matches.as_slice() {
-            [] => Err(KanbanError::validation(format!(
-                "Sprint '{}' not found across any board.",
-                raw
-            ))),
+            [] => {
+                let available = all_sprints
+                    .iter()
+                    .map(|s| {
+                        let label = boards
+                            .iter()
+                            .find(|b| b.id == s.board_id)
+                            .and_then(|b| s.get_name(b))
+                            .unwrap_or("(unnamed)");
+                        format!("#{} {}", s.sprint_number, label)
+                    })
+                    .collect();
+                Err(KanbanError::not_found_by_name("Sprint", raw, available))
+            }
             [s] => Ok(s.id),
             many => {
-                let board_names: Vec<String> = many
+                let names: Vec<String> = many
                     .iter()
                     .map(|s| {
                         boards
                             .iter()
                             .find(|b| b.id == s.board_id)
-                            .map(|b| b.name.clone())
+                            .map(|b| format!("'{}'", b.name))
                             .unwrap_or_else(|| "(unknown)".to_string())
                     })
                     .collect();
-                Err(KanbanError::validation(format!(
-                    "Sprint '{}' is ambiguous: found on boards {}. Use the UUID or a unique name.",
-                    raw,
-                    join_quoted(board_names.iter().map(|s| s.as_str()))
-                )))
+                Err(KanbanError::ambiguous("Sprint", raw, names))
             }
         }
     }
@@ -267,24 +272,45 @@ pub trait KanbanOperations {
         }
         let matches = self.find_cards_by_identifier(raw)?;
         match matches.as_slice() {
-            [] => Err(KanbanError::validation(format!(
-                "Card not found: '{}'",
-                raw
-            ))),
+            [] => Err(KanbanError::not_found_by_name(
+                "Card",
+                raw,
+                Vec::new(), // cards aren't enumerated in the error — too many.
+            )),
             [c] => Ok(c.id),
-            many => Err(KanbanError::validation(
-                crate::search::format_ambiguous_matches(raw, many),
+            many => Err(KanbanError::ambiguous(
+                "Card",
+                raw,
+                many.iter()
+                    .map(|c| format!("{} ({})", c.id, c.title))
+                    .collect(),
             )),
         }
     }
 
+    /// Resolve a batch of card identifiers against a single snapshot. Pure
+    /// in-memory matching against `find_cards_by_identifier`; one set of
+    /// `list_all_*` calls regardless of batch size.
     fn resolve_card_ids(&self, raws: &[String]) -> KanbanResult<Vec<Uuid>> {
+        // Single snapshot for the whole batch — no per-element backend round-trips.
+        let cards = self.list_all_cards()?;
+        let columns = self.list_all_columns()?;
+        let boards = self.list_boards()?;
+        let sprints = self.list_all_sprints()?;
+
         let mut resolved = Vec::with_capacity(raws.len());
         let mut errors = Vec::new();
         for raw in raws {
-            match self.resolve_card_id(raw) {
-                Ok(id) => resolved.push(id),
-                Err(e) => errors.push(format!("'{}': {}", raw, e)),
+            if let Ok(uuid) = Uuid::parse_str(raw) {
+                resolved.push(uuid);
+                continue;
+            }
+            let matches =
+                crate::search::find_cards_by_identifier(raw, &cards, &columns, &boards, &sprints);
+            match matches.as_slice() {
+                [] => errors.push(format!("'{}': not found", raw)),
+                [c] => resolved.push(c.id),
+                many => errors.push(format!("'{}': {} matches (ambiguous)", raw, many.len())),
             }
         }
         if !errors.is_empty() {
@@ -299,49 +325,54 @@ pub trait KanbanOperations {
 
     /// For batch operations, verify all the given cards belong to the same board.
     /// Returns the shared `board_id` on success; otherwise a validation error
-    /// listing the boards involved.
+    /// listing the boards involved. Single snapshot — O(1) backend queries.
     fn require_same_board(&self, card_ids: &[Uuid]) -> KanbanResult<Uuid> {
-        let mut board_ids = std::collections::BTreeSet::new();
+        use std::collections::HashMap;
+        if card_ids.is_empty() {
+            return Err(KanbanError::validation(
+                "No cards provided for batch operation.".to_string(),
+            ));
+        }
+        let cards = self.list_all_cards()?;
+        let columns = self.list_all_columns()?;
+        // column_id -> board_id, one lookup per card afterward.
+        let col_to_board: HashMap<Uuid, Uuid> =
+            columns.iter().map(|c| (c.id, c.board_id)).collect();
+        let card_index: HashMap<Uuid, &Card> = cards.iter().map(|c| (c.id, c)).collect();
+
+        let mut seen = std::collections::BTreeSet::new();
         let mut found_boards = Vec::new();
         for cid in card_ids {
-            let card = self
-                .get_card(*cid)?
+            let card = card_index
+                .get(cid)
                 .ok_or_else(|| KanbanError::not_found("card", *cid))?;
-            let column = self
-                .get_column(card.column_id)?
+            let board_id = col_to_board
+                .get(&card.column_id)
+                .copied()
                 .ok_or_else(|| KanbanError::not_found("column", card.column_id))?;
-            if board_ids.insert(column.board_id) {
-                found_boards.push(column.board_id);
+            if seen.insert(board_id) {
+                found_boards.push(board_id);
             }
         }
         match found_boards.as_slice() {
-            [] => Err(KanbanError::validation(
-                "No cards provided for batch operation.".to_string(),
-            )),
             [b] => Ok(*b),
             many => {
+                let boards = self.list_boards()?;
                 let names: Vec<String> = many
                     .iter()
                     .map(|bid| {
-                        self.get_board(*bid)
-                            .ok()
-                            .flatten()
-                            .map(|b| b.name)
+                        boards
+                            .iter()
+                            .find(|b| b.id == *bid)
+                            .map(|b| format!("'{}'", b.name))
                             .unwrap_or_else(|| bid.to_string())
                     })
                     .collect();
                 Err(KanbanError::validation(format!(
                     "Batch operation requires all cards on the same board, but the selection spans boards: {}",
-                    join_quoted(names.iter().map(|s| s.as_str()))
+                    names.join(", ")
                 )))
             }
         }
     }
-}
-
-fn join_quoted<'a, I: IntoIterator<Item = &'a str>>(iter: I) -> String {
-    iter.into_iter()
-        .map(|s| format!("'{}'", s))
-        .collect::<Vec<_>>()
-        .join(", ")
 }

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -1,7 +1,7 @@
 use crate::KanbanResult;
 use crate::{
     ArchivedCard, Board, BoardUpdate, Card, CardStatus, CardSummary, CardUpdate, Column,
-    ColumnUpdate, CreateCardOptions, Sprint, SprintUpdate,
+    ColumnUpdate, CreateCardOptions, KanbanError, Sprint, SprintUpdate,
 };
 use uuid::Uuid;
 
@@ -99,4 +99,249 @@ pub trait KanbanOperations {
     // Import/Export
     fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String>;
     fn import_board(&mut self, data: &str) -> KanbanResult<Board>;
+
+    // ---------- Name/UUID resolvers (shared by CLI, MCP, anything else) ----------
+    //
+    // Each resolver accepts a raw string that may be a UUID, an entity name, or
+    // (for sprints) a sprint number. The UUID fast path returns immediately;
+    // otherwise the resolver lists matches and errors with a human-friendly
+    // "not found, here are the alternatives" or "ambiguous, here are the
+    // matches" message.
+
+    fn resolve_board_id(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let boards = self.list_boards()?;
+        let matches = crate::search::find_boards_by_name(raw, &boards);
+        match matches.as_slice() {
+            [] => Err(KanbanError::validation(format!(
+                "Board '{}' not found. Available: {}",
+                raw,
+                join_quoted(boards.iter().map(|b| b.name.as_str()))
+            ))),
+            [b] => Ok(b.id),
+            many => Err(KanbanError::validation(format!(
+                "Board '{}' is ambiguous: {} matches. Specify by UUID. Matching IDs: {}",
+                raw,
+                many.len(),
+                many.iter()
+                    .map(|b| b.id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))),
+        }
+    }
+
+    fn resolve_column_id(&self, raw: &str, board_id: Uuid) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let columns = self.list_columns(board_id)?;
+        let matches = crate::search::find_columns_by_name(raw, &columns);
+        match matches.as_slice() {
+            [] => Err(KanbanError::validation(format!(
+                "Column '{}' not found on this board. Available: {}",
+                raw,
+                join_quoted(columns.iter().map(|c| c.name.as_str()))
+            ))),
+            [c] => Ok(c.id),
+            many => Err(KanbanError::validation(format!(
+                "Column '{}' is ambiguous on this board: {} matches. Specify by UUID.",
+                raw,
+                many.len()
+            ))),
+        }
+    }
+
+    fn resolve_column_id_global(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let boards = self.list_boards()?;
+        let mut all_columns = Vec::new();
+        for board in &boards {
+            all_columns.extend(self.list_columns(board.id)?);
+        }
+        let matches = crate::search::find_columns_by_name(raw, &all_columns);
+        match matches.as_slice() {
+            [] => Err(KanbanError::validation(format!(
+                "Column '{}' not found. Available: {}",
+                raw,
+                join_quoted(all_columns.iter().map(|c| c.name.as_str()))
+            ))),
+            [c] => Ok(c.id),
+            many => {
+                let board_names: Vec<String> = many
+                    .iter()
+                    .map(|c| {
+                        boards
+                            .iter()
+                            .find(|b| b.id == c.board_id)
+                            .map(|b| b.name.clone())
+                            .unwrap_or_else(|| "(unknown)".to_string())
+                    })
+                    .collect();
+                Err(KanbanError::validation(format!(
+                    "Column '{}' is ambiguous: found on boards {}. Use the UUID or a unique name.",
+                    raw,
+                    join_quoted(board_names.iter().map(|s| s.as_str()))
+                )))
+            }
+        }
+    }
+
+    fn resolve_sprint_id(&self, raw: &str, board_id: Uuid) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let sprints = self.list_sprints(board_id)?;
+        let board = self
+            .get_board(board_id)?
+            .ok_or_else(|| KanbanError::not_found("board", board_id))?;
+        let boards_vec = vec![board];
+        let matches = crate::search::find_sprints_by_query(raw, &sprints, &boards_vec);
+        match matches.as_slice() {
+            [] => {
+                let available = sprints
+                    .iter()
+                    .map(|s| {
+                        let label = s.get_name(&boards_vec[0]).unwrap_or("(unnamed)");
+                        format!("#{} {}", s.sprint_number, label)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(KanbanError::validation(format!(
+                    "Sprint '{}' not found on this board. Available: {}",
+                    raw, available
+                )))
+            }
+            [s] => Ok(s.id),
+            many => Err(KanbanError::validation(format!(
+                "Sprint '{}' is ambiguous on this board: {} matches. Specify by UUID.",
+                raw,
+                many.len()
+            ))),
+        }
+    }
+
+    fn resolve_sprint_id_global(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let boards = self.list_boards()?;
+        let mut all_sprints = Vec::new();
+        for board in &boards {
+            all_sprints.extend(self.list_sprints(board.id)?);
+        }
+        let matches = crate::search::find_sprints_by_query(raw, &all_sprints, &boards);
+        match matches.as_slice() {
+            [] => Err(KanbanError::validation(format!(
+                "Sprint '{}' not found across any board.",
+                raw
+            ))),
+            [s] => Ok(s.id),
+            many => {
+                let board_names: Vec<String> = many
+                    .iter()
+                    .map(|s| {
+                        boards
+                            .iter()
+                            .find(|b| b.id == s.board_id)
+                            .map(|b| b.name.clone())
+                            .unwrap_or_else(|| "(unknown)".to_string())
+                    })
+                    .collect();
+                Err(KanbanError::validation(format!(
+                    "Sprint '{}' is ambiguous: found on boards {}. Use the UUID or a unique name.",
+                    raw,
+                    join_quoted(board_names.iter().map(|s| s.as_str()))
+                )))
+            }
+        }
+    }
+
+    fn resolve_card_id(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let matches = self.find_cards_by_identifier(raw)?;
+        match matches.as_slice() {
+            [] => Err(KanbanError::validation(format!(
+                "Card not found: '{}'",
+                raw
+            ))),
+            [c] => Ok(c.id),
+            many => Err(KanbanError::validation(
+                crate::search::format_ambiguous_matches(raw, many),
+            )),
+        }
+    }
+
+    fn resolve_card_ids(&self, raws: &[String]) -> KanbanResult<Vec<Uuid>> {
+        let mut resolved = Vec::with_capacity(raws.len());
+        let mut errors = Vec::new();
+        for raw in raws {
+            match self.resolve_card_id(raw) {
+                Ok(id) => resolved.push(id),
+                Err(e) => errors.push(format!("'{}': {}", raw, e)),
+            }
+        }
+        if !errors.is_empty() {
+            return Err(KanbanError::validation(format!(
+                "Could not resolve {} card(s): {}",
+                errors.len(),
+                errors.join("; ")
+            )));
+        }
+        Ok(resolved)
+    }
+
+    /// For batch operations, verify all the given cards belong to the same board.
+    /// Returns the shared `board_id` on success; otherwise a validation error
+    /// listing the boards involved.
+    fn require_same_board(&self, card_ids: &[Uuid]) -> KanbanResult<Uuid> {
+        let mut board_ids = std::collections::BTreeSet::new();
+        let mut found_boards = Vec::new();
+        for cid in card_ids {
+            let card = self
+                .get_card(*cid)?
+                .ok_or_else(|| KanbanError::not_found("card", *cid))?;
+            let column = self
+                .get_column(card.column_id)?
+                .ok_or_else(|| KanbanError::not_found("column", card.column_id))?;
+            if board_ids.insert(column.board_id) {
+                found_boards.push(column.board_id);
+            }
+        }
+        match found_boards.as_slice() {
+            [] => Err(KanbanError::validation(
+                "No cards provided for batch operation.".to_string(),
+            )),
+            [b] => Ok(*b),
+            many => {
+                let names: Vec<String> = many
+                    .iter()
+                    .map(|bid| {
+                        self.get_board(*bid)
+                            .ok()
+                            .flatten()
+                            .map(|b| b.name)
+                            .unwrap_or_else(|| bid.to_string())
+                    })
+                    .collect();
+                Err(KanbanError::validation(format!(
+                    "Batch operation requires all cards on the same board, but the selection spans boards: {}",
+                    join_quoted(names.iter().map(|s| s.as_str()))
+                )))
+            }
+        }
+    }
+}
+
+fn join_quoted<'a, I: IntoIterator<Item = &'a str>>(iter: I) -> String {
+    iter.into_iter()
+        .map(|s| format!("'{}'", s))
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -301,14 +301,46 @@ pub fn find_columns_by_name<'a>(query: &str, columns: &'a [Column]) -> Vec<&'a C
         .collect()
 }
 
-/// Find all sprints matching `query`, by sprint number or by sprint name.
+/// Find sprints matching `query` (number or name) **within a single board**.
 ///
-/// - If `query` parses as a `u32`, match sprints whose `sprint_number == query`.
-/// - Otherwise, match sprints whose resolved name (via `board.sprint_names[name_index]`)
-///   equals `query` (case-insensitive).
+/// - If `query` parses as a `u32`, match sprints whose `board_id == board.id`
+///   and `sprint_number == query`.
+/// - Otherwise, match sprints on this board whose resolved name (via
+///   `board.sprint_names[name_index]`) equals `query` (case-insensitive).
 ///
-/// `boards` is required to resolve sprint names — each sprint's `board_id` is looked up.
-pub fn find_sprints_by_query<'a>(
+/// The board-scoped contract is enforced on both branches, so callers don't
+/// need to pre-filter the slice.
+pub fn find_sprints_by_query_on_board<'a>(
+    query: &str,
+    sprints: &'a [Sprint],
+    board: &Board,
+) -> Vec<&'a Sprint> {
+    if let Ok(number) = query.parse::<u32>() {
+        return sprints
+            .iter()
+            .filter(|s| s.board_id == board.id && s.sprint_number == number)
+            .collect();
+    }
+    let needle = query.to_lowercase();
+    sprints
+        .iter()
+        .filter(|s| {
+            s.board_id == board.id
+                && s.get_name(board)
+                    .map(|n| n.to_lowercase() == needle)
+                    .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Find sprints matching `query` (number or name) **across all the given boards**.
+///
+/// - If `query` parses as a `u32`, match every sprint whose `sprint_number == query`,
+///   regardless of board (caller decides what to do with multi-board ambiguity).
+/// - Otherwise, match sprints whose resolved name on their own board equals
+///   `query` (case-insensitive). The sprint's `board_id` is looked up in `boards`;
+///   a sprint whose board is missing from the slice is silently skipped.
+pub fn find_sprints_by_query_global<'a>(
     query: &str,
     sprints: &'a [Sprint],
     boards: &[Board],
@@ -857,7 +889,7 @@ mod tests {
         let sprints = vec![sprint1, sprint2];
         let boards = vec![board];
 
-        let result = find_sprints_by_query("1", &sprints, &boards);
+        let result = find_sprints_by_query_global("1", &sprints, &boards);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].sprint_number, 1);
     }
@@ -872,11 +904,11 @@ mod tests {
         let sprints = vec![sprint1.clone(), sprint2];
         let boards = vec![board];
 
-        let result = find_sprints_by_query("yarara-release", &sprints, &boards);
+        let result = find_sprints_by_query_global("yarara-release", &sprints, &boards);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, sprint1.id);
 
-        let result = find_sprints_by_query("YARARA-RELEASE", &sprints, &boards);
+        let result = find_sprints_by_query_global("YARARA-RELEASE", &sprints, &boards);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, sprint1.id);
     }
@@ -890,7 +922,7 @@ mod tests {
         let sprints = vec![sprint_numbered.clone(), sprint_named];
         let boards = vec![board];
 
-        let result = find_sprints_by_query("1", &sprints, &boards);
+        let result = find_sprints_by_query_global("1", &sprints, &boards);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, sprint_numbered.id);
     }
@@ -903,8 +935,8 @@ mod tests {
         let sprints = vec![sprint];
         let boards = vec![board];
 
-        assert!(find_sprints_by_query("nope", &sprints, &boards).is_empty());
-        assert!(find_sprints_by_query("99", &sprints, &boards).is_empty());
+        assert!(find_sprints_by_query_global("nope", &sprints, &boards).is_empty());
+        assert!(find_sprints_by_query_global("99", &sprints, &boards).is_empty());
     }
 
     #[test]
@@ -916,7 +948,50 @@ mod tests {
         let sprints = vec![sprint_a, sprint_b];
         let boards = vec![board_a, board_b];
 
-        let result = find_sprints_by_query("13", &sprints, &boards);
+        let result = find_sprints_by_query_global("13", &sprints, &boards);
         assert_eq!(result.len(), 2);
+    }
+
+    // ---- find_sprints_by_query_on_board scoping tests (KAN-400 footgun fix) ----
+
+    #[test]
+    fn test_find_sprints_by_query_on_board_number_matches_only_on_that_board() {
+        let board_a = Board::new("A".to_string(), None);
+        let board_b = Board::new("B".to_string(), None);
+        let on_a = crate::Sprint::new(board_a.id, 13, None, None);
+        let on_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let sprints = vec![on_a.clone(), on_b];
+
+        let result = find_sprints_by_query_on_board("13", &sprints, &board_a);
+        assert_eq!(result.len(), 1, "expected exactly one match on board A");
+        assert_eq!(result[0].id, on_a.id);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_on_board_name_matches_only_on_that_board() {
+        let mut board_a = Board::new("A".to_string(), None);
+        board_a.sprint_names.push("alpha".to_string());
+        let mut board_b = Board::new("B".to_string(), None);
+        board_b.sprint_names.push("alpha".to_string());
+        let on_a = crate::Sprint::new(board_a.id, 1, Some(0), None);
+        let on_b = crate::Sprint::new(board_b.id, 1, Some(0), None);
+        let sprints = vec![on_a.clone(), on_b];
+
+        let result = find_sprints_by_query_on_board("alpha", &sprints, &board_a);
+        assert_eq!(result.len(), 1, "expected exactly one match on board A");
+        assert_eq!(result[0].id, on_a.id);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_on_board_ignores_other_board_sprints_in_slice() {
+        // Footgun-regression: even if a caller passes sprints from a different
+        // board, the on_board variant filters them out.
+        let board_a = Board::new("A".to_string(), None);
+        let board_b = Board::new("B".to_string(), None);
+        let only_on_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let sprints = vec![only_on_b];
+
+        let result = find_sprints_by_query_on_board("13", &sprints, &board_a);
+        assert!(result.is_empty());
     }
 }

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -281,6 +281,58 @@ pub fn format_ambiguous_matches(identifier: &str, cards: &[Card]) -> String {
     )
 }
 
+/// Find all boards whose `name` equals `query` (case-insensitive).
+pub fn find_boards_by_name<'a>(query: &str, boards: &'a [Board]) -> Vec<&'a Board> {
+    let needle = query.to_lowercase();
+    boards
+        .iter()
+        .filter(|b| b.name.to_lowercase() == needle)
+        .collect()
+}
+
+/// Find all columns in the given slice whose `name` equals `query` (case-insensitive).
+///
+/// The caller is responsible for scoping `columns` (e.g. filtering by `board_id` first).
+pub fn find_columns_by_name<'a>(query: &str, columns: &'a [Column]) -> Vec<&'a Column> {
+    let needle = query.to_lowercase();
+    columns
+        .iter()
+        .filter(|c| c.name.to_lowercase() == needle)
+        .collect()
+}
+
+/// Find all sprints matching `query`, by sprint number or by sprint name.
+///
+/// - If `query` parses as a `u32`, match sprints whose `sprint_number == query`.
+/// - Otherwise, match sprints whose resolved name (via `board.sprint_names[name_index]`)
+///   equals `query` (case-insensitive).
+///
+/// `boards` is required to resolve sprint names — each sprint's `board_id` is looked up.
+pub fn find_sprints_by_query<'a>(
+    query: &str,
+    sprints: &'a [Sprint],
+    boards: &[Board],
+) -> Vec<&'a Sprint> {
+    if let Ok(number) = query.parse::<u32>() {
+        return sprints
+            .iter()
+            .filter(|s| s.sprint_number == number)
+            .collect();
+    }
+    let needle = query.to_lowercase();
+    sprints
+        .iter()
+        .filter(|s| {
+            let Some(board) = boards.iter().find(|b| b.id == s.board_id) else {
+                return false;
+            };
+            s.get_name(board)
+                .map(|n| n.to_lowercase() == needle)
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
 impl CardSearcher for CompositeSearcher {
     fn matches(&self, card: &Card, board: &Board, sprints: &[Sprint]) -> bool {
         if self.searchers.is_empty() {
@@ -295,6 +347,7 @@ impl CardSearcher for CompositeSearcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     fn create_test_card(board: &mut Board, title: &str) -> Card {
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -727,5 +780,143 @@ mod tests {
         assert!(
             find_cards_by_identifier("not-a-number", &cards, &columns, &boards, &[]).is_empty()
         );
+    }
+
+    #[test]
+    fn test_find_boards_by_name_case_insensitive_match() {
+        let boards = vec![
+            Board::new("Kanban".to_string(), None),
+            Board::new("Personal".to_string(), None),
+        ];
+        let result = find_boards_by_name("kanban", &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "Kanban");
+
+        let result = find_boards_by_name("KANBAN", &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "Kanban");
+    }
+
+    #[test]
+    fn test_find_boards_by_name_no_match_returns_empty() {
+        let boards = vec![Board::new("Kanban".to_string(), None)];
+        assert!(find_boards_by_name("missing", &boards).is_empty());
+    }
+
+    #[test]
+    fn test_find_boards_by_name_multiple_with_same_name_returns_all() {
+        let boards = vec![
+            Board::new("Shared".to_string(), None),
+            Board::new("Shared".to_string(), None),
+        ];
+        let result = find_boards_by_name("shared", &boards);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_find_columns_by_name_case_insensitive_match() {
+        let board_id = Uuid::new_v4();
+        let columns = vec![
+            Column::new(board_id, "TODO".to_string(), 0),
+            Column::new(board_id, "Doing".to_string(), 1),
+            Column::new(board_id, "Done".to_string(), 2),
+        ];
+        let result = find_columns_by_name("todo", &columns);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "TODO");
+
+        let result = find_columns_by_name("DOING", &columns);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "Doing");
+    }
+
+    #[test]
+    fn test_find_columns_by_name_returns_multiple_when_same_name_across_boards() {
+        let columns = vec![
+            Column::new(Uuid::new_v4(), "TODO".to_string(), 0),
+            Column::new(Uuid::new_v4(), "TODO".to_string(), 0),
+        ];
+        let result = find_columns_by_name("todo", &columns);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_find_columns_by_name_no_match_returns_empty() {
+        let columns = vec![Column::new(Uuid::new_v4(), "TODO".to_string(), 0)];
+        assert!(find_columns_by_name("missing", &columns).is_empty());
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_matches_number() {
+        let mut board = Board::new("B".to_string(), None);
+        board.sprint_names.push("alpha".to_string());
+        let mut sprint1 = crate::Sprint::new(board.id, 1, Some(0), None);
+        sprint1.sprint_number = 1;
+        let mut sprint2 = crate::Sprint::new(board.id, 2, None, None);
+        sprint2.sprint_number = 2;
+        let sprints = vec![sprint1, sprint2];
+        let boards = vec![board];
+
+        let result = find_sprints_by_query("1", &sprints, &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].sprint_number, 1);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_matches_name_case_insensitive() {
+        let mut board = Board::new("B".to_string(), None);
+        board.sprint_names.push("yarara-release".to_string());
+        board.sprint_names.push("moonshot".to_string());
+        let sprint1 = crate::Sprint::new(board.id, 1, Some(0), None);
+        let sprint2 = crate::Sprint::new(board.id, 2, Some(1), None);
+        let sprints = vec![sprint1.clone(), sprint2];
+        let boards = vec![board];
+
+        let result = find_sprints_by_query("yarara-release", &sprints, &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, sprint1.id);
+
+        let result = find_sprints_by_query("YARARA-RELEASE", &sprints, &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, sprint1.id);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_number_takes_priority_over_name() {
+        let mut board = Board::new("B".to_string(), None);
+        board.sprint_names.push("1".to_string());
+        let sprint_numbered = crate::Sprint::new(board.id, 1, None, None);
+        let sprint_named = crate::Sprint::new(board.id, 99, Some(0), None);
+        let sprints = vec![sprint_numbered.clone(), sprint_named];
+        let boards = vec![board];
+
+        let result = find_sprints_by_query("1", &sprints, &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, sprint_numbered.id);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_no_match_returns_empty() {
+        let mut board = Board::new("B".to_string(), None);
+        board.sprint_names.push("alpha".to_string());
+        let sprint = crate::Sprint::new(board.id, 1, Some(0), None);
+        let sprints = vec![sprint];
+        let boards = vec![board];
+
+        assert!(find_sprints_by_query("nope", &sprints, &boards).is_empty());
+        assert!(find_sprints_by_query("99", &sprints, &boards).is_empty());
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_ambiguous_number_across_boards_returns_all() {
+        let board_a = Board::new("A".to_string(), None);
+        let board_b = Board::new("B".to_string(), None);
+        let sprint_a = crate::Sprint::new(board_a.id, 13, None, None);
+        let sprint_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let sprints = vec![sprint_a, sprint_b];
+        let boards = vec![board_a, board_b];
+
+        let result = find_sprints_by_query("13", &sprints, &boards);
+        assert_eq!(result.len(), 2);
     }
 }

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -80,85 +80,85 @@ kanban-mcp /path/to/boards.sqlite
 |------|-------------|-----------------|-----------------|
 | `tool_create_board` | Create a new kanban board | `name: String` | `card_prefix: String` |
 | `tool_list_boards` | List all boards | — | — |
-| `tool_get_board` | Get a specific board by ID | `board_id: UUID` | — |
-| `tool_update_board` | Update board properties | `board_id: UUID` | `name`, `description`, `sprint_prefix`, `card_prefix` |
-| `tool_delete_board` | Delete board and all its columns, cards, sprints | `board_id: UUID` | — |
+| `tool_get_board` | Get a specific board by ID | `board: UUID` | — |
+| `tool_update_board` | Update board properties | `board: UUID` | `name`, `description`, `sprint_prefix`, `card_prefix` |
+| `tool_delete_board` | Delete board and all its columns, cards, sprints | `board: UUID` | — |
 
 ### Columns (6 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_column` | Create a new column in a board | `board_id: UUID`, `name: String` | `position: i32` |
-| `tool_list_columns` | List all columns in a board | `board_id: UUID` | — |
-| `tool_get_column` | Get a specific column by ID | `column_id: UUID` | — |
-| `tool_update_column` | Update column properties | `column_id: UUID` | `name`, `position`, `wip_limit: u32`, `clear_wip_limit: bool` |
-| `tool_delete_column` | Delete column and all its cards | `column_id: UUID` | — |
-| `tool_reorder_column` | Move column to a new position | `column_id: UUID`, `position: i32` | — |
+| `tool_create_column` | Create a new column in a board | `board: UUID`, `name: String` | `position: i32` |
+| `tool_list_columns` | List all columns in a board | `board: UUID` | — |
+| `tool_get_column` | Get a specific column by ID | `column: UUID` | — |
+| `tool_update_column` | Update column properties | `column: UUID` | `name`, `position`, `wip_limit: u32`, `clear_wip_limit: bool` |
+| `tool_delete_column` | Delete column and all its cards | `column: UUID` | — |
+| `tool_reorder_column` | Move column to a new position | `column: UUID`, `position: i32` | — |
 
 ### Cards (10 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_card` | Create a new card in a column | `board_id: UUID`, `column_id: UUID`, `title: String` | `description`, `priority` (low/medium/high/critical), `points: u8`, `due_date` (YYYY-MM-DD or RFC 3339) |
-| `tool_list_cards` | List cards with filters. Returns `CardSummary` (title, status, priority, points — use tool_get_card for full detail). | — | `board_id`, `column_id`, `sprint_id`, `status`, `page: u32`, `page_size: u32` |
-| `tool_get_card` | Get card by UUID or identifier (e.g. `KAN-5`). Returns list if ambiguous. | `card_id: String` | — |
-| `tool_update_card` | Update card properties | `card_id: String` | `title`, `description`, `priority`, `status` (todo/in_progress/blocked/done), `points: u8`, `due_date`, `clear_due_date: bool` |
-| `tool_move_card` | Move card to a different column | `card_id: String`, `column_id: UUID` | `position: i32` |
-| `tool_archive_card` | Archive a card (restorable) | `card_id: String` | — |
-| `tool_restore_card` | Restore an archived card | `card_id: String` | `column_id: UUID` |
-| `tool_delete_card` | Delete a card permanently | `card_id: String` | — |
+| `tool_create_card` | Create a new card in a column | `board: UUID`, `column: UUID`, `title: String` | `description`, `priority` (low/medium/high/critical), `points: u8`, `due_date` (YYYY-MM-DD or RFC 3339) |
+| `tool_list_cards` | List cards with filters. Returns `CardSummary` (title, status, priority, points — use tool_get_card for full detail). | — | `board`, `column`, `sprint`, `status`, `page: u32`, `page_size: u32` |
+| `tool_get_card` | Get card by UUID or identifier (e.g. `KAN-5`). Returns list if ambiguous. | `card: String` | — |
+| `tool_update_card` | Update card properties | `card: String` | `title`, `description`, `priority`, `status` (todo/in_progress/blocked/done), `points: u8`, `due_date`, `clear_due_date: bool` |
+| `tool_move_card` | Move card to a different column | `card: String`, `column: UUID` | `position: i32` |
+| `tool_archive_card` | Archive a card (restorable) | `card: String` | — |
+| `tool_restore_card` | Restore an archived card | `card: String` | `column: UUID` |
+| `tool_delete_card` | Delete a card permanently | `card: String` | — |
 | `tool_list_archived_cards` | Returns ArchivedCardSummary (title, archived_at, original column — use tool_get_card for full detail) | — | `page: u32`, `page_size: u32` |
 
 ### Card Identifiers
 
-`card_id` accepts either a UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
+`card` accepts either a UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
 
 ### Card–Sprint (2 tools)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_assign_card_to_sprint` | Assign a card to a sprint | `card_id: String`, `sprint_id: UUID` |
-| `tool_unassign_card_from_sprint` | Remove card from its sprint | `card_id: String` |
+| `tool_assign_card_to_sprint` | Assign a card to a sprint | `card: String`, `sprint: UUID` |
+| `tool_unassign_card_from_sprint` | Remove card from its sprint | `card: String` |
 
 ### Card Utilities (2 tools)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_get_card_branch_name` | Get git branch name for a card | `card_id: String` |
-| `tool_get_card_git_checkout` | Get `git checkout -b <branch>` command | `card_id: String` |
+| `tool_get_card_branch_name` | Get git branch name for a card | `card: String` |
+| `tool_get_card_git_checkout` | Get `git checkout -b <branch>` command | `card: String` |
 
 ### Bulk Card Operations (3 tools)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_archive_cards` | Archive multiple cards | `ids: String` (comma-separated UUIDs) |
-| `tool_move_cards` | Move multiple cards to a column | `ids: String`, `column_id: UUID` |
-| `tool_assign_cards_to_sprint` | Assign multiple cards to a sprint | `ids: String`, `sprint_id: UUID` |
+| `tool_archive_cards` | Archive multiple cards | `cards: String` (comma-separated UUIDs) |
+| `tool_move_cards` | Move multiple cards to a column | `cards: String`, `column: UUID` |
+| `tool_assign_cards_to_sprint` | Assign multiple cards to a sprint | `cards: String`, `sprint: UUID` |
 
 ### Sprints (8 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_sprint` | Create a new sprint | `board_id: UUID` | `name: String`, `prefix: String` |
-| `tool_list_sprints` | List sprints for a board | `board_id: UUID` | — |
-| `tool_get_sprint` | Get a specific sprint by ID | `sprint_id: UUID` | — |
-| `tool_update_sprint` | Update sprint properties | `sprint_id: UUID` | `name`, `prefix`, `card_prefix`, `start_date`, `end_date`, `clear_start_date: bool`, `clear_end_date: bool` |
-| `tool_activate_sprint` | Activate a sprint | `sprint_id: UUID`, `duration_days: u32` | — |
-| `tool_complete_sprint` | Mark sprint as completed | `sprint_id: UUID` | — |
-| `tool_cancel_sprint` | Cancel a sprint | `sprint_id: UUID` | — |
-| `tool_delete_sprint` | Delete a sprint | `sprint_id: UUID` | — |
+| `tool_create_sprint` | Create a new sprint | `board: UUID` | `name: String`, `prefix: String` |
+| `tool_list_sprints` | List sprints for a board | `board: UUID` | — |
+| `tool_get_sprint` | Get a specific sprint by ID | `sprint: UUID` | — |
+| `tool_update_sprint` | Update sprint properties | `sprint: UUID` | `name`, `prefix`, `card_prefix`, `start_date`, `end_date`, `clear_start_date: bool`, `clear_end_date: bool` |
+| `tool_activate_sprint` | Activate a sprint | `sprint: UUID`, `duration_days: u32` | — |
+| `tool_complete_sprint` | Mark sprint as completed | `sprint: UUID` | — |
+| `tool_cancel_sprint` | Cancel a sprint | `sprint: UUID` | — |
+| `tool_delete_sprint` | Delete a sprint | `sprint: UUID` | — |
 
 ### Sprint Carry-over (1 tool)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_carry_over_sprint_cards` | Move uncompleted cards from a completed/cancelled sprint to a planning sprint | `from_sprint_id: UUID`, `to_sprint_id: UUID` |
+| `tool_carry_over_sprint_cards` | Move uncompleted cards from a completed/cancelled sprint to a planning sprint | `from_sprint: UUID`, `to_sprint: UUID` |
 
 ### Import / Export (2 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_export_board` | Export board data as JSON string | — | `board_id: UUID` (omit for all boards) |
+| `tool_export_board` | Export board data as JSON string | — | `board: UUID` (omit for all boards) |
 | `tool_import_board` | Import board from JSON string | `data: String` | — |
 
 ### Undo / Redo (2 tools)

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -155,6 +155,18 @@ impl KanbanOperations for McpContext {
         self.inner.find_cards_by_identifier(identifier)
     }
 
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<kanban_domain::Column>> {
+        self.inner.list_all_columns()
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<kanban_domain::Sprint>> {
+        self.inner.list_all_sprints()
+    }
+
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         self.inner.update_card(id, updates)
     }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -51,12 +51,6 @@ fn core_err_to_mcp(e: kanban_core::CoreError) -> McpError {
     kanban_err_to_mcp(KanbanError::from(e))
 }
 
-#[cfg(test)]
-fn parse_uuid(s: &str) -> Result<Uuid, McpError> {
-    Uuid::parse_str(s)
-        .map_err(|e| McpError::invalid_params(format!("Invalid UUID '{}': {}", s, e), None))
-}
-
 fn parse_priority(s: &str) -> Result<CardPriority, McpError> {
     match s.to_lowercase().as_str() {
         "low" => Ok(CardPriority::Low),
@@ -106,39 +100,47 @@ fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, McpError> {
         })
 }
 
-#[cfg(test)]
-fn parse_uuids_csv(s: &str) -> Result<Vec<Uuid>, McpError> {
-    s.split(',').map(|id| parse_uuid(id.trim())).collect()
+// ---------- Locked sessions ----------
+//
+// Two flavours, named by intent. Each acquires the context lock and drops it
+// when the closure returns; resolution + the work share one consistent view
+// of state, closing any TOCTOU window.
+//
+// - `locked_read(ctx, |ctx| ...)` — lock, run closure, drop. No disk reload,
+//   no save. The closure takes `&McpContext` so the type system enforces
+//   read-only semantics. Use for tool handlers that resolve names + read
+//   state without mutating.
+//
+// - `locked_write(ctx, |ctx| ...)` — lock, reload from disk, run closure,
+//   save, drop. The closure takes `&mut McpContext`. Reload+save bracket
+//   the closure so mutations see the latest disk state and are persisted.
+//
+// For trivial reads with no resolution (`tool_list_boards`, etc.) the older
+// `read_op!` macro is still appropriate — it's a one-liner that elides the
+// closure ceremony.
+
+async fn locked_read<T, F>(ctx: &Arc<Mutex<McpContext>>, f: F) -> Result<T, McpError>
+where
+    F: FnOnce(&McpContext) -> Result<T, McpError>,
+{
+    let guard = ctx.lock().await;
+    f(&guard)
 }
 
-// ---------- Locked session ----------
-//
-// A single lock guard wraps reload → resolve → mutate → save. That eliminates
-// the TOCTOU window in multi-step handlers (where a concurrent tool call could
-// shift entities between the resolve and mutate steps).
-//
-// Use cases:
-// - `locked_session(ctx, save=true, |g| { resolve names, mutate, return })` for
-//   any handler that touches entity state.
-// - For simple reads with no resolution, `read_op!` still applies — it avoids
-//   the reload cost.
-
-async fn locked_session<T, F>(ctx: &Arc<Mutex<McpContext>>, save: bool, f: F) -> Result<T, McpError>
+async fn locked_write<T, F>(ctx: &Arc<Mutex<McpContext>>, f: F) -> Result<T, McpError>
 where
     F: FnOnce(&mut McpContext) -> Result<T, McpError>,
 {
     let mut guard = ctx.lock().await;
     guard.reload().await.map_err(kanban_err_to_mcp)?;
     let result = f(&mut guard)?;
-    if save {
-        guard.save().await.map_err(kanban_err_to_mcp)?;
-    }
+    guard.save().await.map_err(kanban_err_to_mcp)?;
     Ok(result)
 }
 
 /// Helper trait: gives `&McpContext` access to MCP-flavoured error mapping for
 /// the resolvers it inherits via `KanbanOperations`. Keeps closure bodies
-/// readable inside `locked_session`.
+/// readable inside `locked_read` / `locked_write`.
 trait McpResolve {
     fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
@@ -657,7 +659,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board = locked_session(&self.ctx, false, |ctx| {
+        let board = locked_read(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_board(&req.board)?;
             ctx.get_board(id).map_err(kanban_err_to_mcp)
         })
@@ -688,7 +690,7 @@ impl KanbanMcpServer {
                 .unwrap_or(FieldUpdate::NoChange),
             ..Default::default()
         };
-        let board = locked_session(&self.ctx, true, |ctx| {
+        let board = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_board(&req.board)?;
             ctx.update_board(id, updates).map_err(kanban_err_to_mcp)
         })
@@ -701,7 +703,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = locked_session(&self.ctx, true, |ctx| {
+        let id = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_board(&req.board)?;
             ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
@@ -717,7 +719,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let column = locked_session(&self.ctx, true, |ctx| {
+        let column = locked_write(&self.ctx, |ctx| {
             let board_id = ctx.mcp_resolve_board(&req.board)?;
             ctx.create_column(board_id, req.name, req.position)
                 .map_err(kanban_err_to_mcp)
@@ -731,7 +733,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListColumnsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let columns = locked_session(&self.ctx, false, |ctx| {
+        let columns = locked_read(&self.ctx, |ctx| {
             let board_id = ctx.mcp_resolve_board(&req.board)?;
             ctx.list_columns(board_id).map_err(kanban_err_to_mcp)
         })
@@ -744,7 +746,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let column = locked_session(&self.ctx, false, |ctx| {
+        let column = locked_read(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_column_global(&req.column)?;
             ctx.get_column(id).map_err(kanban_err_to_mcp)
         })
@@ -768,7 +770,7 @@ impl KanbanMcpServer {
                     .unwrap_or(FieldUpdate::NoChange)
             },
         };
-        let column = locked_session(&self.ctx, true, |ctx| {
+        let column = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_column_global(&req.column)?;
             ctx.update_column(id, updates).map_err(kanban_err_to_mcp)
         })
@@ -781,7 +783,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = locked_session(&self.ctx, true, |ctx| {
+        let id = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_column_global(&req.column)?;
             ctx.delete_column(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
@@ -795,7 +797,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ReorderColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let column = locked_session(&self.ctx, true, |ctx| {
+        let column = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_column_global(&req.column)?;
             ctx.reorder_column(id, req.position)
                 .map_err(kanban_err_to_mcp)
@@ -819,7 +821,7 @@ impl KanbanMcpServer {
             points: req.points,
             due_date,
         };
-        let card = locked_session(&self.ctx, true, |ctx| {
+        let card = locked_write(&self.ctx, |ctx| {
             let board_id = ctx.mcp_resolve_board(&req.board)?;
             let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
             ctx.create_card(board_id, column_id, req.title, options)
@@ -839,7 +841,7 @@ impl KanbanMcpServer {
         let status = req.status.as_deref().map(parse_status).transpose()?;
         let (page, page_size) =
             resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
-        let result = locked_session(&self.ctx, false, |ctx| {
+        let result = locked_read(&self.ctx, |ctx| {
             let board_id = match &req.board {
                 Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
                 None => None,
@@ -932,7 +934,7 @@ impl KanbanMcpServer {
             due_date,
             sprint_id: FieldUpdate::NoChange,
         };
-        let card = locked_session(&self.ctx, true, |ctx| {
+        let card = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_card(&req.card)?;
             ctx.update_card(id, updates).map_err(kanban_err_to_mcp)
         })
@@ -945,7 +947,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<MoveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card = locked_session(&self.ctx, true, |ctx| {
+        let card = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_card(&req.card)?;
             let board_id = ctx.mcp_card_board(id)?;
             let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
@@ -961,7 +963,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ArchiveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = locked_session(&self.ctx, true, |ctx| {
+        let id = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_card(&req.card)?;
             ctx.archive_card(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
@@ -975,7 +977,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<RestoreCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card = locked_session(&self.ctx, true, |ctx| {
+        let card = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_card(&req.card)?;
             let column_id = match req.column.as_deref() {
                 Some(raw) => {
@@ -995,7 +997,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = locked_session(&self.ctx, true, |ctx| {
+        let id = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_card(&req.card)?;
             ctx.delete_card(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
@@ -1028,7 +1030,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<AssignCardToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card = locked_session(&self.ctx, true, |ctx| {
+        let card = locked_write(&self.ctx, |ctx| {
             let card_id = ctx.mcp_resolve_card(&req.card)?;
             let board_id = ctx.mcp_card_board(card_id)?;
             let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
@@ -1044,7 +1046,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UnassignCardFromSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card = locked_session(&self.ctx, true, |ctx| {
+        let card = locked_write(&self.ctx, |ctx| {
             let card_id = ctx.mcp_resolve_card(&req.card)?;
             ctx.unassign_card_from_sprint(card_id)
                 .map_err(kanban_err_to_mcp)
@@ -1060,7 +1062,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetCardBranchNameRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let branch_name = locked_session(&self.ctx, false, |ctx| {
+        let branch_name = locked_read(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_card(&req.card)?;
             ctx.get_card_branch_name(id).map_err(kanban_err_to_mcp)
         })
@@ -1073,7 +1075,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetCardGitCheckoutRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let command = locked_session(&self.ctx, false, |ctx| {
+        let command = locked_read(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_card(&req.card)?;
             ctx.get_card_git_checkout(id).map_err(kanban_err_to_mcp)
         })
@@ -1090,7 +1092,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ArchiveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let count = locked_session(&self.ctx, true, |ctx| {
+        let count = locked_write(&self.ctx, |ctx| {
             let ids = ctx.mcp_resolve_cards(&req.cards)?;
             ctx.archive_cards(ids).map_err(kanban_err_to_mcp)
         })
@@ -1105,7 +1107,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<MoveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let count = locked_session(&self.ctx, true, |ctx| {
+        let count = locked_write(&self.ctx, |ctx| {
             let ids = ctx.mcp_resolve_cards(&req.cards)?;
             let board_id = ctx.mcp_require_same_board(&ids)?;
             let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
@@ -1122,7 +1124,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<AssignCardsToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let count = locked_session(&self.ctx, true, |ctx| {
+        let count = locked_write(&self.ctx, |ctx| {
             let ids = ctx.mcp_resolve_cards(&req.cards)?;
             let board_id = ctx.mcp_require_same_board(&ids)?;
             let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
@@ -1140,7 +1142,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let sprint = locked_session(&self.ctx, true, |ctx| {
+        let sprint = locked_write(&self.ctx, |ctx| {
             let board_id = ctx.mcp_resolve_board(&req.board)?;
             ctx.create_sprint(board_id, req.prefix, req.name)
                 .map_err(kanban_err_to_mcp)
@@ -1154,7 +1156,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListSprintsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let sprints = locked_session(&self.ctx, false, |ctx| {
+        let sprints = locked_read(&self.ctx, |ctx| {
             let board_id = ctx.mcp_resolve_board(&req.board)?;
             ctx.list_sprints(board_id).map_err(kanban_err_to_mcp)
         })
@@ -1167,7 +1169,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let sprint = locked_session(&self.ctx, false, |ctx| {
+        let sprint = locked_read(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
             ctx.get_sprint(id).map_err(kanban_err_to_mcp)
         })
@@ -1213,7 +1215,7 @@ impl KanbanMcpServer {
             start_date,
             end_date,
         };
-        let sprint = locked_session(&self.ctx, true, |ctx| {
+        let sprint = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
             ctx.update_sprint(id, updates).map_err(kanban_err_to_mcp)
         })
@@ -1226,7 +1228,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ActivateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let sprint = locked_session(&self.ctx, true, |ctx| {
+        let sprint = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
             ctx.activate_sprint(id, req.duration_days)
                 .map_err(kanban_err_to_mcp)
@@ -1240,7 +1242,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CompleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let sprint = locked_session(&self.ctx, true, |ctx| {
+        let sprint = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
             ctx.complete_sprint(id).map_err(kanban_err_to_mcp)
         })
@@ -1253,7 +1255,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CancelSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let sprint = locked_session(&self.ctx, true, |ctx| {
+        let sprint = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
             ctx.cancel_sprint(id).map_err(kanban_err_to_mcp)
         })
@@ -1266,7 +1268,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = locked_session(&self.ctx, true, |ctx| {
+        let id = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
             ctx.delete_sprint(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
@@ -1282,7 +1284,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CarryOverSprintCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let count = locked_session(&self.ctx, true, |ctx| {
+        let count = locked_write(&self.ctx, |ctx| {
             let from_id = ctx.mcp_resolve_sprint_global(&req.from_sprint)?;
             let from_sprint = ctx
                 .get_sprint(from_id)
@@ -1305,7 +1307,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ExportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let json = locked_session(&self.ctx, false, |ctx| {
+        let json = locked_read(&self.ctx, |ctx| {
             let board_id = match req.board.as_deref() {
                 Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
                 None => None,
@@ -1380,27 +1382,6 @@ impl ServerHandler for KanbanMcpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // parse_uuid
-
-    #[test]
-    fn parse_uuid_valid() {
-        let id = "550e8400-e29b-41d4-a716-446655440000";
-        let result = parse_uuid(id).unwrap();
-        assert_eq!(result.to_string(), id);
-    }
-
-    #[test]
-    fn parse_uuid_invalid() {
-        let err = parse_uuid("not-a-uuid").unwrap_err();
-        assert!(err.message.contains("Invalid UUID"));
-    }
-
-    #[test]
-    fn parse_uuid_empty() {
-        let err = parse_uuid("").unwrap_err();
-        assert!(err.message.contains("Invalid UUID"));
-    }
 
     // parse_priority
 
@@ -1496,37 +1477,6 @@ mod tests {
     fn parse_datetime_invalid() {
         let err = parse_datetime("not-a-date").unwrap_err();
         assert!(err.message.contains("Invalid date"));
-    }
-
-    // parse_uuids_csv
-
-    #[test]
-    fn parse_uuids_csv_single() {
-        let id = "550e8400-e29b-41d4-a716-446655440000";
-        let result = parse_uuids_csv(id).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].to_string(), id);
-    }
-
-    #[test]
-    fn parse_uuids_csv_multiple() {
-        let ids = "550e8400-e29b-41d4-a716-446655440000,660e8400-e29b-41d4-a716-446655440001";
-        let result = parse_uuids_csv(ids).unwrap();
-        assert_eq!(result.len(), 2);
-    }
-
-    #[test]
-    fn parse_uuids_csv_with_spaces() {
-        let ids = "550e8400-e29b-41d4-a716-446655440000 , 660e8400-e29b-41d4-a716-446655440001";
-        let result = parse_uuids_csv(ids).unwrap();
-        assert_eq!(result.len(), 2);
-    }
-
-    #[test]
-    fn parse_uuids_csv_invalid_in_list() {
-        let ids = "550e8400-e29b-41d4-a716-446655440000,bad-uuid";
-        let err = parse_uuids_csv(ids).unwrap_err();
-        assert!(err.message.contains("Invalid UUID"));
     }
 
     // to_call_tool_result / to_call_tool_result_json

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -6,9 +6,8 @@ pub use server::McpServer;
 use context::McpContext;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    format_ambiguous_matches, ArchivedCardSummary, BoardUpdate, CardListFilter, CardPriority,
-    CardStatus, CardUpdate, ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations,
-    SprintUpdate,
+    ArchivedCardSummary, BoardUpdate, CardListFilter, CardPriority, CardStatus, CardUpdate,
+    ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, SprintUpdate,
 };
 use kanban_domain::{KanbanError, KanbanResult};
 use kanban_service::StoreManager;
@@ -52,6 +51,7 @@ fn core_err_to_mcp(e: kanban_core::CoreError) -> McpError {
     kanban_err_to_mcp(KanbanError::from(e))
 }
 
+#[cfg(test)]
 fn parse_uuid(s: &str) -> Result<Uuid, McpError> {
     Uuid::parse_str(s)
         .map_err(|e| McpError::invalid_params(format!("Invalid UUID '{}': {}", s, e), None))
@@ -106,31 +106,95 @@ fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, McpError> {
         })
 }
 
+#[cfg(test)]
 fn parse_uuids_csv(s: &str) -> Result<Vec<Uuid>, McpError> {
     s.split(',').map(|id| parse_uuid(id.trim())).collect()
 }
 
-async fn resolve_card_id(ctx: &Arc<Mutex<McpContext>>, s: &str) -> Result<Uuid, McpError> {
-    if let Ok(id) = Uuid::parse_str(s) {
-        return Ok(id);
-    }
-    let matches = {
-        let guard = ctx.lock().await;
-        guard
-            .find_cards_by_identifier(s)
-            .map_err(kanban_err_to_mcp)?
-    };
-    match matches.as_slice() {
-        [] => Err(McpError::invalid_params(
-            format!("Card not found: '{}'", s),
-            None,
-        )),
-        [card] => Ok(card.id),
-        cards => Err(McpError::invalid_params(
-            format_ambiguous_matches(s, cards),
-            None,
-        )),
-    }
+// ---------- Entity resolvers ----------
+// These thin async wrappers lock the mutex, call the shared service-layer
+// resolver from `KanbanOperations`, then release the lock before returning.
+// That way the tool body can re-enter `mutating_op!` / `read_op!` without
+// holding a guard across the resolution step.
+
+async fn resolve_card_id(ctx: &Arc<Mutex<McpContext>>, raw: &str) -> Result<Uuid, McpError> {
+    let guard = ctx.lock().await;
+    guard.resolve_card_id(raw).map_err(kanban_err_to_mcp)
+}
+
+async fn resolve_card_ids(
+    ctx: &Arc<Mutex<McpContext>>,
+    raws: &[String],
+) -> Result<Vec<Uuid>, McpError> {
+    let guard = ctx.lock().await;
+    guard.resolve_card_ids(raws).map_err(kanban_err_to_mcp)
+}
+
+async fn resolve_board(ctx: &Arc<Mutex<McpContext>>, raw: &str) -> Result<Uuid, McpError> {
+    let guard = ctx.lock().await;
+    guard.resolve_board_id(raw).map_err(kanban_err_to_mcp)
+}
+
+async fn resolve_column_in_board(
+    ctx: &Arc<Mutex<McpContext>>,
+    raw: &str,
+    board_id: Uuid,
+) -> Result<Uuid, McpError> {
+    let guard = ctx.lock().await;
+    guard
+        .resolve_column_id(raw, board_id)
+        .map_err(kanban_err_to_mcp)
+}
+
+async fn resolve_column_global(ctx: &Arc<Mutex<McpContext>>, raw: &str) -> Result<Uuid, McpError> {
+    let guard = ctx.lock().await;
+    guard
+        .resolve_column_id_global(raw)
+        .map_err(kanban_err_to_mcp)
+}
+
+async fn resolve_sprint_in_board(
+    ctx: &Arc<Mutex<McpContext>>,
+    raw: &str,
+    board_id: Uuid,
+) -> Result<Uuid, McpError> {
+    let guard = ctx.lock().await;
+    guard
+        .resolve_sprint_id(raw, board_id)
+        .map_err(kanban_err_to_mcp)
+}
+
+async fn resolve_sprint_global(ctx: &Arc<Mutex<McpContext>>, raw: &str) -> Result<Uuid, McpError> {
+    let guard = ctx.lock().await;
+    guard
+        .resolve_sprint_id_global(raw)
+        .map_err(kanban_err_to_mcp)
+}
+
+/// Look up the board a card belongs to via card → column → board.
+async fn card_board(ctx: &Arc<Mutex<McpContext>>, card_id: Uuid) -> Result<Uuid, McpError> {
+    let guard = ctx.lock().await;
+    let card = guard
+        .get_card(card_id)
+        .map_err(kanban_err_to_mcp)?
+        .ok_or_else(|| McpError::invalid_params(format!("Card not found: {}", card_id), None))?;
+    let column = guard
+        .get_column(card.column_id)
+        .map_err(kanban_err_to_mcp)?
+        .ok_or_else(|| {
+            McpError::invalid_params(format!("Column not found: {}", card.column_id), None)
+        })?;
+    Ok(column.board_id)
+}
+
+async fn require_same_board(
+    ctx: &Arc<Mutex<McpContext>>,
+    card_ids: &[Uuid],
+) -> Result<Uuid, McpError> {
+    let guard = ctx.lock().await;
+    guard
+        .require_same_board(card_ids)
+        .map_err(kanban_err_to_mcp)
 }
 
 /// Lock the context, reload from disk, execute a mutating operation, then save.
@@ -183,13 +247,13 @@ pub struct CreateBoardRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetBoardRequest {
-    #[schemars(description = "ID of the board to retrieve")]
+    #[schemars(description = "UUID or name of the board to retrieve")]
     pub board_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateBoardRequest {
-    #[schemars(description = "ID of the board to update")]
+    #[schemars(description = "UUID or name of the board to update")]
     pub board_id: String,
     #[schemars(description = "New name (optional)")]
     pub name: Option<String>,
@@ -203,7 +267,7 @@ pub struct UpdateBoardRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteBoardRequest {
-    #[schemars(description = "ID of the board to delete")]
+    #[schemars(description = "UUID or name of the board to delete")]
     pub board_id: String,
 }
 
@@ -211,7 +275,7 @@ pub struct DeleteBoardRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateColumnRequest {
-    #[schemars(description = "ID of the board to create the column in")]
+    #[schemars(description = "UUID or name of the board to create the column in")]
     pub board_id: String,
     #[schemars(description = "Name of the column")]
     pub name: String,
@@ -221,19 +285,19 @@ pub struct CreateColumnRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListColumnsRequest {
-    #[schemars(description = "ID of the board to list columns for")]
+    #[schemars(description = "UUID or name of the board to list columns for")]
     pub board_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetColumnRequest {
-    #[schemars(description = "ID of the column to retrieve")]
+    #[schemars(description = "UUID or name of the column to retrieve")]
     pub column_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateColumnRequest {
-    #[schemars(description = "ID of the column to update")]
+    #[schemars(description = "UUID or name of the column to update")]
     pub column_id: String,
     #[schemars(description = "New name (optional)")]
     pub name: Option<String>,
@@ -247,13 +311,13 @@ pub struct UpdateColumnRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteColumnRequest {
-    #[schemars(description = "ID of the column to delete")]
+    #[schemars(description = "UUID or name of the column to delete")]
     pub column_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ReorderColumnRequest {
-    #[schemars(description = "ID of the column to reorder")]
+    #[schemars(description = "UUID or name of the column to reorder")]
     pub column_id: String,
     #[schemars(description = "New position")]
     pub position: i32,
@@ -263,9 +327,9 @@ pub struct ReorderColumnRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateCardRequest {
-    #[schemars(description = "ID of the board")]
+    #[schemars(description = "UUID or name of the board")]
     pub board_id: String,
-    #[schemars(description = "ID of the column to create the card in")]
+    #[schemars(description = "UUID or name of the column to create the card in")]
     pub column_id: String,
     #[schemars(description = "Title of the card")]
     pub title: String,
@@ -283,11 +347,15 @@ pub struct CreateCardRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListCardsRequest {
-    #[schemars(description = "Filter cards by board ID")]
+    #[schemars(description = "Filter cards by board UUID or name")]
     pub board_id: Option<String>,
-    #[schemars(description = "Filter cards by column ID")]
+    #[schemars(
+        description = "Filter cards by column UUID or name (scoped to board_id if given, else global)"
+    )]
     pub column_id: Option<String>,
-    #[schemars(description = "Filter cards by sprint ID")]
+    #[schemars(
+        description = "Filter cards by sprint UUID, name, or number (scoped to board_id if given, else global)"
+    )]
     pub sprint_id: Option<String>,
     #[schemars(description = "Filter by status: 'todo', 'in_progress', 'blocked', or 'done'")]
     pub status: Option<String>,
@@ -337,7 +405,9 @@ pub struct UpdateCardRequest {
 pub struct MoveCardRequest {
     #[schemars(description = "UUID or identifier of the card to move (e.g. 'KAN-5' or '5')")]
     pub card_id: String,
-    #[schemars(description = "ID of the destination column")]
+    #[schemars(
+        description = "UUID or name of the destination column (resolved within the card's board)"
+    )]
     pub column_id: String,
     #[schemars(description = "Position in the new column (optional)")]
     pub position: Option<i32>,
@@ -355,7 +425,9 @@ pub struct RestoreCardRequest {
         description = "UUID or identifier of the archived card to restore (e.g. 'KAN-5' or '5')"
     )]
     pub card_id: String,
-    #[schemars(description = "Column ID to restore the card to (optional)")]
+    #[schemars(
+        description = "UUID or name of the column to restore the card to (optional; resolved within the card's board)"
+    )]
     pub column_id: Option<String>,
 }
 
@@ -371,7 +443,9 @@ pub struct DeleteCardRequest {
 pub struct AssignCardToSprintRequest {
     #[schemars(description = "UUID or identifier of the card (e.g. 'KAN-5' or '5')")]
     pub card_id: String,
-    #[schemars(description = "ID of the sprint to assign to")]
+    #[schemars(
+        description = "UUID, name, or number of the sprint to assign to (resolved within the card's board)"
+    )]
     pub sprint_id: String,
 }
 
@@ -401,23 +475,31 @@ pub struct GetCardGitCheckoutRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ArchiveCardsRequest {
-    #[schemars(description = "Comma-separated card IDs to archive")]
-    pub ids: String,
+    #[schemars(description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2', '42'])")]
+    pub ids: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct MoveCardsRequest {
-    #[schemars(description = "Comma-separated card IDs to move")]
-    pub ids: String,
-    #[schemars(description = "ID of the destination column")]
+    #[schemars(
+        description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2']); all cards must share a board"
+    )]
+    pub ids: Vec<String>,
+    #[schemars(
+        description = "UUID or name of the destination column (resolved within the cards' shared board)"
+    )]
     pub column_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct AssignCardsToSprintRequest {
-    #[schemars(description = "Comma-separated card IDs")]
-    pub ids: String,
-    #[schemars(description = "ID of the sprint to assign to")]
+    #[schemars(
+        description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2']); all cards must share a board"
+    )]
+    pub ids: Vec<String>,
+    #[schemars(
+        description = "UUID, name, or number of the sprint to assign to (resolved within the cards' shared board)"
+    )]
     pub sprint_id: String,
 }
 
@@ -425,7 +507,7 @@ pub struct AssignCardsToSprintRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateSprintRequest {
-    #[schemars(description = "ID of the board")]
+    #[schemars(description = "UUID or name of the board")]
     pub board_id: String,
     #[schemars(description = "Sprint prefix (optional)")]
     pub prefix: Option<String>,
@@ -435,19 +517,19 @@ pub struct CreateSprintRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListSprintsRequest {
-    #[schemars(description = "ID of the board")]
+    #[schemars(description = "UUID or name of the board")]
     pub board_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetSprintRequest {
-    #[schemars(description = "ID of the sprint")]
+    #[schemars(description = "UUID, name, or number of the sprint")]
     pub sprint_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateSprintRequest {
-    #[schemars(description = "ID of the sprint to update")]
+    #[schemars(description = "UUID, name, or number of the sprint to update")]
     pub sprint_id: String,
     #[schemars(description = "New sprint name (optional)")]
     pub name: Option<String>,
@@ -467,7 +549,7 @@ pub struct UpdateSprintRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ActivateSprintRequest {
-    #[schemars(description = "ID of the sprint to activate")]
+    #[schemars(description = "UUID, name, or number of the sprint to activate")]
     pub sprint_id: String,
     #[schemars(description = "Duration in days (optional)")]
     pub duration_days: Option<i32>,
@@ -475,19 +557,19 @@ pub struct ActivateSprintRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CompleteSprintRequest {
-    #[schemars(description = "ID of the sprint to complete")]
+    #[schemars(description = "UUID, name, or number of the sprint to complete")]
     pub sprint_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CancelSprintRequest {
-    #[schemars(description = "ID of the sprint to cancel")]
+    #[schemars(description = "UUID, name, or number of the sprint to cancel")]
     pub sprint_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteSprintRequest {
-    #[schemars(description = "ID of the sprint to delete")]
+    #[schemars(description = "UUID, name, or number of the sprint to delete")]
     pub sprint_id: String,
 }
 
@@ -495,9 +577,13 @@ pub struct DeleteSprintRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CarryOverSprintCardsRequest {
-    #[schemars(description = "ID of the completed or cancelled sprint to carry cards from")]
+    #[schemars(
+        description = "UUID, name, or number of the completed/cancelled source sprint to carry cards from"
+    )]
     pub from_sprint_id: String,
-    #[schemars(description = "ID of the planning sprint to carry cards to")]
+    #[schemars(
+        description = "UUID, name, or number of the planning sprint to carry cards to (must be on the same board as source)"
+    )]
     pub to_sprint_id: String,
 }
 
@@ -505,7 +591,9 @@ pub struct CarryOverSprintCardsRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ExportBoardRequest {
-    #[schemars(description = "ID of the board to export (optional, exports all if omitted)")]
+    #[schemars(
+        description = "UUID or name of the board to export (optional, exports all if omitted)"
+    )]
     pub board_id: Option<String>,
 }
 
@@ -563,12 +651,12 @@ impl KanbanMcpServer {
         to_call_tool_result(&boards)
     }
 
-    #[tool(description = "Get a specific board by ID")]
+    #[tool(description = "Get a specific board by UUID or name")]
     async fn tool_get_board(
         &self,
         Parameters(req): Parameters<GetBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.board_id)?;
+        let id = resolve_board(&self.ctx, &req.board_id).await?;
         let board = read_op!(self.ctx, get_board, id)?;
         to_call_tool_result(&board)
     }
@@ -580,7 +668,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.board_id)?;
+        let id = resolve_board(&self.ctx, &req.board_id).await?;
         let updates = BoardUpdate {
             name: req.name,
             description: req
@@ -606,9 +694,9 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.board_id)?;
+        let id = resolve_board(&self.ctx, &req.board_id).await?;
         mutating_op!(self.ctx, delete_board, id)?;
-        to_call_tool_result_json(serde_json::json!({"deleted": req.board_id}))
+        to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     // Column Operations
@@ -618,7 +706,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
+        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
         let column = mutating_op!(self.ctx, create_column, board_id, req.name, req.position)?;
         to_call_tool_result(&column)
     }
@@ -628,17 +716,17 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListColumnsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
+        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
         let columns = read_op!(self.ctx, list_columns, board_id)?;
         to_call_tool_result(&columns)
     }
 
-    #[tool(description = "Get a specific column by ID")]
+    #[tool(description = "Get a specific column by UUID or name (searched across all boards)")]
     async fn tool_get_column(
         &self,
         Parameters(req): Parameters<GetColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.column_id)?;
+        let id = resolve_column_global(&self.ctx, &req.column_id).await?;
         let column = read_op!(self.ctx, get_column, id)?;
         to_call_tool_result(&column)
     }
@@ -648,7 +736,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.column_id)?;
+        let id = resolve_column_global(&self.ctx, &req.column_id).await?;
         let updates = ColumnUpdate {
             name: req.name,
             position: req.position,
@@ -669,9 +757,9 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.column_id)?;
+        let id = resolve_column_global(&self.ctx, &req.column_id).await?;
         mutating_op!(self.ctx, delete_column, id)?;
-        to_call_tool_result_json(serde_json::json!({"deleted": req.column_id}))
+        to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     #[tool(description = "Reorder a column to a new position")]
@@ -679,7 +767,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ReorderColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.column_id)?;
+        let id = resolve_column_global(&self.ctx, &req.column_id).await?;
         let column = mutating_op!(self.ctx, reorder_column, id, req.position)?;
         to_call_tool_result(&column)
     }
@@ -691,8 +779,8 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
-        let column_id = parse_uuid(&req.column_id)?;
+        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
+        let column_id = resolve_column_in_board(&self.ctx, &req.column_id, board_id).await?;
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let due_date = req.due_date.as_deref().map(parse_datetime).transpose()?;
 
@@ -721,9 +809,24 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = req.board_id.as_deref().map(parse_uuid).transpose()?;
-        let column_id = req.column_id.as_deref().map(parse_uuid).transpose()?;
-        let sprint_id = req.sprint_id.as_deref().map(parse_uuid).transpose()?;
+        let board_id = match &req.board_id {
+            Some(raw) => Some(resolve_board(&self.ctx, raw).await?),
+            None => None,
+        };
+        let column_id = match &req.column_id {
+            Some(raw) => Some(match board_id {
+                Some(bid) => resolve_column_in_board(&self.ctx, raw, bid).await?,
+                None => resolve_column_global(&self.ctx, raw).await?,
+            }),
+            None => None,
+        };
+        let sprint_id = match &req.sprint_id {
+            Some(raw) => Some(match board_id {
+                Some(bid) => resolve_sprint_in_board(&self.ctx, raw, bid).await?,
+                None => resolve_sprint_global(&self.ctx, raw).await?,
+            }),
+            None => None,
+        };
         let status = req.status.as_deref().map(parse_status).transpose()?;
 
         let filter = CardListFilter {
@@ -804,13 +907,14 @@ impl KanbanMcpServer {
         to_call_tool_result(&card)
     }
 
-    #[tool(description = "Move a card to a different column")]
+    #[tool(description = "Move a card to a different column on the same board")]
     async fn tool_move_card(
         &self,
         Parameters(req): Parameters<MoveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
         let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let column_id = parse_uuid(&req.column_id)?;
+        let board_id = card_board(&self.ctx, id).await?;
+        let column_id = resolve_column_in_board(&self.ctx, &req.column_id, board_id).await?;
         let card = mutating_op!(self.ctx, move_card, id, column_id, req.position)?;
         to_call_tool_result(&card)
     }
@@ -831,7 +935,13 @@ impl KanbanMcpServer {
         Parameters(req): Parameters<RestoreCardRequest>,
     ) -> Result<CallToolResult, McpError> {
         let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let column_id = req.column_id.as_deref().map(parse_uuid).transpose()?;
+        let column_id = match req.column_id.as_deref() {
+            Some(raw) => {
+                let board_id = card_board(&self.ctx, id).await?;
+                Some(resolve_column_in_board(&self.ctx, raw, board_id).await?)
+            }
+            None => None,
+        };
         let card = mutating_op!(self.ctx, restore_card, id, column_id)?;
         to_call_tool_result(&card)
     }
@@ -865,13 +975,14 @@ impl KanbanMcpServer {
 
     // Card Sprint Operations
 
-    #[tool(description = "Assign a card to a sprint")]
+    #[tool(description = "Assign a card to a sprint on the same board")]
     async fn tool_assign_card_to_sprint(
         &self,
         Parameters(req): Parameters<AssignCardToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
         let card_id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let sprint_id = parse_uuid(&req.sprint_id)?;
+        let board_id = card_board(&self.ctx, card_id).await?;
+        let sprint_id = resolve_sprint_in_board(&self.ctx, &req.sprint_id, board_id).await?;
         let card = mutating_op!(self.ctx, assign_card_to_sprint, card_id, sprint_id)?;
         to_call_tool_result(&card)
     }
@@ -910,34 +1021,42 @@ impl KanbanMcpServer {
 
     // Multi-card operations
 
-    #[tool(description = "Archive multiple cards at once")]
+    #[tool(
+        description = "Archive multiple cards at once. IDs may be UUIDs or identifiers (e.g. 'KAN-1', '42')."
+    )]
     async fn tool_archive_cards(
         &self,
         Parameters(req): Parameters<ArchiveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = parse_uuids_csv(&req.ids)?;
+        let ids = resolve_card_ids(&self.ctx, &req.ids).await?;
         let count = mutating_op!(self.ctx, archive_cards, ids)?;
         to_call_tool_result_json(serde_json::json!({"archived_count": count}))
     }
 
-    #[tool(description = "Move multiple cards to a column")]
+    #[tool(
+        description = "Move multiple cards to a column. All cards must share a board; the column is resolved on that board."
+    )]
     async fn tool_move_cards(
         &self,
         Parameters(req): Parameters<MoveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = parse_uuids_csv(&req.ids)?;
-        let column_id = parse_uuid(&req.column_id)?;
+        let ids = resolve_card_ids(&self.ctx, &req.ids).await?;
+        let board_id = require_same_board(&self.ctx, &ids).await?;
+        let column_id = resolve_column_in_board(&self.ctx, &req.column_id, board_id).await?;
         let count = mutating_op!(self.ctx, move_cards, ids, column_id)?;
         to_call_tool_result_json(serde_json::json!({"moved_count": count}))
     }
 
-    #[tool(description = "Assign multiple cards to a sprint")]
+    #[tool(
+        description = "Assign multiple cards to a sprint. All cards must share a board; the sprint is resolved on that board."
+    )]
     async fn tool_assign_cards_to_sprint(
         &self,
         Parameters(req): Parameters<AssignCardsToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = parse_uuids_csv(&req.ids)?;
-        let sprint_id = parse_uuid(&req.sprint_id)?;
+        let ids = resolve_card_ids(&self.ctx, &req.ids).await?;
+        let board_id = require_same_board(&self.ctx, &ids).await?;
+        let sprint_id = resolve_sprint_in_board(&self.ctx, &req.sprint_id, board_id).await?;
         let count = mutating_op!(self.ctx, assign_cards_to_sprint, ids, sprint_id)?;
         to_call_tool_result_json(serde_json::json!({"assigned_count": count}))
     }
@@ -949,7 +1068,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
+        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
         let sprint = mutating_op!(self.ctx, create_sprint, board_id, req.prefix, req.name)?;
         to_call_tool_result(&sprint)
     }
@@ -959,17 +1078,17 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListSprintsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
+        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
         let sprints = read_op!(self.ctx, list_sprints, board_id)?;
         to_call_tool_result(&sprints)
     }
 
-    #[tool(description = "Get a specific sprint by ID")]
+    #[tool(description = "Get a specific sprint by UUID, name, or number")]
     async fn tool_get_sprint(
         &self,
         Parameters(req): Parameters<GetSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
         let sprint = read_op!(self.ctx, get_sprint, id)?;
         to_call_tool_result(&sprint)
     }
@@ -981,7 +1100,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
 
         let start_date = if req.clear_start_date == Some(true) {
             FieldUpdate::Clear
@@ -1026,7 +1145,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ActivateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
         let sprint = mutating_op!(self.ctx, activate_sprint, id, req.duration_days)?;
         to_call_tool_result(&sprint)
     }
@@ -1036,7 +1155,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CompleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
         let sprint = mutating_op!(self.ctx, complete_sprint, id)?;
         to_call_tool_result(&sprint)
     }
@@ -1046,7 +1165,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CancelSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
         let sprint = mutating_op!(self.ctx, cancel_sprint, id)?;
         to_call_tool_result(&sprint)
     }
@@ -1056,20 +1175,24 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
         mutating_op!(self.ctx, delete_sprint, id)?;
-        to_call_tool_result_json(serde_json::json!({"deleted": req.sprint_id}))
+        to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     #[tool(
-        description = "Carry over uncompleted cards from a completed/cancelled sprint to a planning sprint"
+        description = "Carry over uncompleted cards from a completed/cancelled sprint to a planning sprint on the same board"
     )]
     async fn tool_carry_over_sprint_cards(
         &self,
         Parameters(req): Parameters<CarryOverSprintCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let from_id = parse_uuid(&req.from_sprint_id)?;
-        let to_id = parse_uuid(&req.to_sprint_id)?;
+        let from_id = resolve_sprint_global(&self.ctx, &req.from_sprint_id).await?;
+        let from_sprint = read_op!(self.ctx, get_sprint, from_id)?.ok_or_else(|| {
+            McpError::invalid_params(format!("Sprint not found: {}", from_id), None)
+        })?;
+        let to_id =
+            resolve_sprint_in_board(&self.ctx, &req.to_sprint_id, from_sprint.board_id).await?;
 
         let count = mutating_op!(self.ctx, carry_over_sprint_cards, from_id, to_id)?;
         to_call_tool_result_json(serde_json::json!({ "carried_over_count": count }))
@@ -1082,7 +1205,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ExportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = req.board_id.as_deref().map(parse_uuid).transpose()?;
+        let board_id = match req.board_id.as_deref() {
+            Some(raw) => Some(resolve_board(&self.ctx, raw).await?),
+            None => None,
+        };
         let json = read_op!(self.ctx, export_board, board_id)?;
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -111,90 +111,91 @@ fn parse_uuids_csv(s: &str) -> Result<Vec<Uuid>, McpError> {
     s.split(',').map(|id| parse_uuid(id.trim())).collect()
 }
 
-// ---------- Entity resolvers ----------
-// These thin async wrappers lock the mutex, call the shared service-layer
-// resolver from `KanbanOperations`, then release the lock before returning.
-// That way the tool body can re-enter `mutating_op!` / `read_op!` without
-// holding a guard across the resolution step.
+// ---------- Locked session ----------
+//
+// A single lock guard wraps reload → resolve → mutate → save. That eliminates
+// the TOCTOU window in multi-step handlers (where a concurrent tool call could
+// shift entities between the resolve and mutate steps).
+//
+// Use cases:
+// - `locked_session(ctx, save=true, |g| { resolve names, mutate, return })` for
+//   any handler that touches entity state.
+// - For simple reads with no resolution, `read_op!` still applies — it avoids
+//   the reload cost.
 
-async fn resolve_card_id(ctx: &Arc<Mutex<McpContext>>, raw: &str) -> Result<Uuid, McpError> {
-    let guard = ctx.lock().await;
-    guard.resolve_card_id(raw).map_err(kanban_err_to_mcp)
+async fn locked_session<T, F>(ctx: &Arc<Mutex<McpContext>>, save: bool, f: F) -> Result<T, McpError>
+where
+    F: FnOnce(&mut McpContext) -> Result<T, McpError>,
+{
+    let mut guard = ctx.lock().await;
+    guard.reload().await.map_err(kanban_err_to_mcp)?;
+    let result = f(&mut guard)?;
+    if save {
+        guard.save().await.map_err(kanban_err_to_mcp)?;
+    }
+    Ok(result)
 }
 
-async fn resolve_card_ids(
-    ctx: &Arc<Mutex<McpContext>>,
-    raws: &[String],
-) -> Result<Vec<Uuid>, McpError> {
-    let guard = ctx.lock().await;
-    guard.resolve_card_ids(raws).map_err(kanban_err_to_mcp)
+/// Helper trait: gives `&McpContext` access to MCP-flavoured error mapping for
+/// the resolvers it inherits via `KanbanOperations`. Keeps closure bodies
+/// readable inside `locked_session`.
+trait McpResolve {
+    fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError>;
+    fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
+    fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError>;
+    fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
+    fn mcp_resolve_sprint_global(&self, raw: &str) -> Result<Uuid, McpError>;
+    fn mcp_resolve_card(&self, raw: &str) -> Result<Uuid, McpError>;
+    fn mcp_resolve_cards(&self, raws: &[String]) -> Result<Vec<Uuid>, McpError>;
+    fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError>;
+    /// Derive a card's board via card → column → board.
+    fn mcp_card_board(&self, card_id: Uuid) -> Result<Uuid, McpError>;
 }
 
-async fn resolve_board(ctx: &Arc<Mutex<McpContext>>, raw: &str) -> Result<Uuid, McpError> {
-    let guard = ctx.lock().await;
-    guard.resolve_board_id(raw).map_err(kanban_err_to_mcp)
-}
-
-async fn resolve_column_in_board(
-    ctx: &Arc<Mutex<McpContext>>,
-    raw: &str,
-    board_id: Uuid,
-) -> Result<Uuid, McpError> {
-    let guard = ctx.lock().await;
-    guard
-        .resolve_column_id(raw, board_id)
-        .map_err(kanban_err_to_mcp)
-}
-
-async fn resolve_column_global(ctx: &Arc<Mutex<McpContext>>, raw: &str) -> Result<Uuid, McpError> {
-    let guard = ctx.lock().await;
-    guard
-        .resolve_column_id_global(raw)
-        .map_err(kanban_err_to_mcp)
-}
-
-async fn resolve_sprint_in_board(
-    ctx: &Arc<Mutex<McpContext>>,
-    raw: &str,
-    board_id: Uuid,
-) -> Result<Uuid, McpError> {
-    let guard = ctx.lock().await;
-    guard
-        .resolve_sprint_id(raw, board_id)
-        .map_err(kanban_err_to_mcp)
-}
-
-async fn resolve_sprint_global(ctx: &Arc<Mutex<McpContext>>, raw: &str) -> Result<Uuid, McpError> {
-    let guard = ctx.lock().await;
-    guard
-        .resolve_sprint_id_global(raw)
-        .map_err(kanban_err_to_mcp)
-}
-
-/// Look up the board a card belongs to via card → column → board.
-async fn card_board(ctx: &Arc<Mutex<McpContext>>, card_id: Uuid) -> Result<Uuid, McpError> {
-    let guard = ctx.lock().await;
-    let card = guard
-        .get_card(card_id)
-        .map_err(kanban_err_to_mcp)?
-        .ok_or_else(|| McpError::invalid_params(format!("Card not found: {}", card_id), None))?;
-    let column = guard
-        .get_column(card.column_id)
-        .map_err(kanban_err_to_mcp)?
-        .ok_or_else(|| {
-            McpError::invalid_params(format!("Column not found: {}", card.column_id), None)
-        })?;
-    Ok(column.board_id)
-}
-
-async fn require_same_board(
-    ctx: &Arc<Mutex<McpContext>>,
-    card_ids: &[Uuid],
-) -> Result<Uuid, McpError> {
-    let guard = ctx.lock().await;
-    guard
-        .require_same_board(card_ids)
-        .map_err(kanban_err_to_mcp)
+impl McpResolve for McpContext {
+    fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError> {
+        self.resolve_board_id(raw).map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError> {
+        self.resolve_column_id(raw, board_id)
+            .map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError> {
+        self.resolve_column_id_global(raw)
+            .map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError> {
+        self.resolve_sprint_id(raw, board_id)
+            .map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_sprint_global(&self, raw: &str) -> Result<Uuid, McpError> {
+        self.resolve_sprint_id_global(raw)
+            .map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_card(&self, raw: &str) -> Result<Uuid, McpError> {
+        self.resolve_card_id(raw).map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_cards(&self, raws: &[String]) -> Result<Vec<Uuid>, McpError> {
+        self.resolve_card_ids(raws).map_err(kanban_err_to_mcp)
+    }
+    fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError> {
+        self.require_same_board(card_ids).map_err(kanban_err_to_mcp)
+    }
+    fn mcp_card_board(&self, card_id: Uuid) -> Result<Uuid, McpError> {
+        let card = self
+            .get_card(card_id)
+            .map_err(kanban_err_to_mcp)?
+            .ok_or_else(|| {
+                McpError::invalid_params(format!("Card not found: {}", card_id), None)
+            })?;
+        let column = self
+            .get_column(card.column_id)
+            .map_err(kanban_err_to_mcp)?
+            .ok_or_else(|| {
+                McpError::invalid_params(format!("Column not found: {}", card.column_id), None)
+            })?;
+        Ok(column.board_id)
+    }
 }
 
 /// Lock the context, reload from disk, execute a mutating operation, then save.
@@ -637,7 +638,7 @@ impl KanbanMcpServer {
     // Board Operations
 
     #[tool(description = "Create a new kanban board")]
-    async fn tool_create_board(
+    pub async fn tool_create_board(
         &self,
         Parameters(req): Parameters<CreateBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
@@ -646,29 +647,31 @@ impl KanbanMcpServer {
     }
 
     #[tool(description = "List all kanban boards")]
-    async fn tool_list_boards(&self) -> Result<CallToolResult, McpError> {
+    pub async fn tool_list_boards(&self) -> Result<CallToolResult, McpError> {
         let boards = read_op!(self.ctx, list_boards)?;
         to_call_tool_result(&boards)
     }
 
     #[tool(description = "Get a specific board by UUID or name")]
-    async fn tool_get_board(
+    pub async fn tool_get_board(
         &self,
         Parameters(req): Parameters<GetBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_board(&self.ctx, &req.board).await?;
-        let board = read_op!(self.ctx, get_board, id)?;
+        let board = locked_session(&self.ctx, false, |ctx| {
+            let id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.get_board(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&board)
     }
 
     #[tool(
         description = "Update a board's properties (name, description, sprint_prefix, card_prefix)"
     )]
-    async fn tool_update_board(
+    pub async fn tool_update_board(
         &self,
         Parameters(req): Parameters<UpdateBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_board(&self.ctx, &req.board).await?;
         let updates = BoardUpdate {
             name: req.name,
             description: req
@@ -685,58 +688,75 @@ impl KanbanMcpServer {
                 .unwrap_or(FieldUpdate::NoChange),
             ..Default::default()
         };
-        let board = mutating_op!(self.ctx, update_board, id, updates)?;
+        let board = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.update_board(id, updates).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&board)
     }
 
     #[tool(description = "Delete a board and all its columns, cards, and sprints")]
-    async fn tool_delete_board(
+    pub async fn tool_delete_board(
         &self,
         Parameters(req): Parameters<DeleteBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_board(&self.ctx, &req.board).await?;
-        mutating_op!(self.ctx, delete_board, id)?;
+        let id = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     // Column Operations
 
     #[tool(description = "Create a new column in a board")]
-    async fn tool_create_column(
+    pub async fn tool_create_column(
         &self,
         Parameters(req): Parameters<CreateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board).await?;
-        let column = mutating_op!(self.ctx, create_column, board_id, req.name, req.position)?;
+        let column = locked_session(&self.ctx, true, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.create_column(board_id, req.name, req.position)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&column)
     }
 
     #[tool(description = "List all columns in a board")]
-    async fn tool_list_columns(
+    pub async fn tool_list_columns(
         &self,
         Parameters(req): Parameters<ListColumnsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board).await?;
-        let columns = read_op!(self.ctx, list_columns, board_id)?;
+        let columns = locked_session(&self.ctx, false, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.list_columns(board_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&columns)
     }
 
     #[tool(description = "Get a specific column by UUID or name (searched across all boards)")]
-    async fn tool_get_column(
+    pub async fn tool_get_column(
         &self,
         Parameters(req): Parameters<GetColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_column_global(&self.ctx, &req.column).await?;
-        let column = read_op!(self.ctx, get_column, id)?;
+        let column = locked_session(&self.ctx, false, |ctx| {
+            let id = ctx.mcp_resolve_column_global(&req.column)?;
+            ctx.get_column(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&column)
     }
 
     #[tool(description = "Update a column's properties (name, position, wip_limit)")]
-    async fn tool_update_column(
+    pub async fn tool_update_column(
         &self,
         Parameters(req): Parameters<UpdateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_column_global(&self.ctx, &req.column).await?;
         let updates = ColumnUpdate {
             name: req.name,
             position: req.position,
@@ -748,103 +768,113 @@ impl KanbanMcpServer {
                     .unwrap_or(FieldUpdate::NoChange)
             },
         };
-        let column = mutating_op!(self.ctx, update_column, id, updates)?;
+        let column = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_column_global(&req.column)?;
+            ctx.update_column(id, updates).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&column)
     }
 
     #[tool(description = "Delete a column and all its cards")]
-    async fn tool_delete_column(
+    pub async fn tool_delete_column(
         &self,
         Parameters(req): Parameters<DeleteColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_column_global(&self.ctx, &req.column).await?;
-        mutating_op!(self.ctx, delete_column, id)?;
+        let id = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_column_global(&req.column)?;
+            ctx.delete_column(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     #[tool(description = "Reorder a column to a new position")]
-    async fn tool_reorder_column(
+    pub async fn tool_reorder_column(
         &self,
         Parameters(req): Parameters<ReorderColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_column_global(&self.ctx, &req.column).await?;
-        let column = mutating_op!(self.ctx, reorder_column, id, req.position)?;
+        let column = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_column_global(&req.column)?;
+            ctx.reorder_column(id, req.position)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&column)
     }
 
     // Card Operations
 
     #[tool(description = "Create a new card in a column")]
-    async fn tool_create_card(
+    pub async fn tool_create_card(
         &self,
         Parameters(req): Parameters<CreateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board).await?;
-        let column_id = resolve_column_in_board(&self.ctx, &req.column, board_id).await?;
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let due_date = req.due_date.as_deref().map(parse_datetime).transpose()?;
-
         let options = CreateCardOptions {
             description: req.description,
             priority,
             points: req.points,
             due_date,
         };
-
-        let card = mutating_op!(
-            self.ctx,
-            create_card,
-            board_id,
-            column_id,
-            req.title,
-            options
-        )?;
+        let card = locked_session(&self.ctx, true, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
+            ctx.create_card(board_id, column_id, req.title, options)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(
         description = "List cards with optional filters. Returns CardSummary (title, status, priority — no description). Use card get for full details. Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
-    async fn tool_list_cards(
+    pub async fn tool_list_cards(
         &self,
         Parameters(req): Parameters<ListCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = match &req.board {
-            Some(raw) => Some(resolve_board(&self.ctx, raw).await?),
-            None => None,
-        };
-        let column_id = match &req.column {
-            Some(raw) => Some(match board_id {
-                Some(bid) => resolve_column_in_board(&self.ctx, raw, bid).await?,
-                None => resolve_column_global(&self.ctx, raw).await?,
-            }),
-            None => None,
-        };
-        let sprint_id = match &req.sprint {
-            Some(raw) => Some(match board_id {
-                Some(bid) => resolve_sprint_in_board(&self.ctx, raw, bid).await?,
-                None => resolve_sprint_global(&self.ctx, raw).await?,
-            }),
-            None => None,
-        };
         let status = req.status.as_deref().map(parse_status).transpose()?;
-
-        let filter = CardListFilter {
-            board_id,
-            column_id,
-            sprint_id,
-            status,
-        };
         let (page, page_size) =
             resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
-        let result = read_op!(self.ctx, list_cards_paged, filter, page, page_size)?;
+        let result = locked_session(&self.ctx, false, |ctx| {
+            let board_id = match &req.board {
+                Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
+                None => None,
+            };
+            let column_id = match &req.column {
+                Some(raw) => Some(match board_id {
+                    Some(bid) => ctx.mcp_resolve_column_in_board(raw, bid)?,
+                    None => ctx.mcp_resolve_column_global(raw)?,
+                }),
+                None => None,
+            };
+            let sprint_id = match &req.sprint {
+                Some(raw) => Some(match board_id {
+                    Some(bid) => ctx.mcp_resolve_sprint_in_board(raw, bid)?,
+                    None => ctx.mcp_resolve_sprint_global(raw)?,
+                }),
+                None => None,
+            };
+            let filter = CardListFilter {
+                board_id,
+                column_id,
+                sprint_id,
+                status,
+            };
+            ctx.list_cards_paged(filter, page, page_size)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&result)
     }
 
     #[tool(
         description = "Get a specific card by UUID or identifier (e.g. KAN-5). Returns a single card for UUID or unambiguous identifier, or a list of all matching cards if the identifier is ambiguous."
     )]
-    async fn tool_get_card(
+    pub async fn tool_get_card(
         &self,
         Parameters(req): Parameters<GetCardRequest>,
     ) -> Result<CallToolResult, McpError> {
@@ -871,14 +901,20 @@ impl KanbanMcpServer {
     #[tool(
         description = "Update a card's properties (title, description, priority, status, due_date, points)"
     )]
-    async fn tool_update_card(
+    pub async fn tool_update_card(
         &self,
         Parameters(req): Parameters<UpdateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card).await?;
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let status = req.status.as_deref().map(parse_status).transpose()?;
-
+        let due_date = if req.clear_due_date == Some(true) {
+            FieldUpdate::Clear
+        } else {
+            match req.due_date {
+                Some(ref d) => FieldUpdate::Set(parse_datetime(d)?),
+                None => FieldUpdate::NoChange,
+            }
+        };
         let updates = CardUpdate {
             title: req.title,
             description: req
@@ -893,73 +929,85 @@ impl KanbanMcpServer {
                 .points
                 .map(FieldUpdate::Set)
                 .unwrap_or(FieldUpdate::NoChange),
-            due_date: if req.clear_due_date == Some(true) {
-                FieldUpdate::Clear
-            } else {
-                match req.due_date {
-                    Some(ref d) => FieldUpdate::Set(parse_datetime(d)?),
-                    None => FieldUpdate::NoChange,
-                }
-            },
+            due_date,
             sprint_id: FieldUpdate::NoChange,
         };
-        let card = mutating_op!(self.ctx, update_card, id, updates)?;
+        let card = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.update_card(id, updates).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(description = "Move a card to a different column on the same board")]
-    async fn tool_move_card(
+    pub async fn tool_move_card(
         &self,
         Parameters(req): Parameters<MoveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card).await?;
-        let board_id = card_board(&self.ctx, id).await?;
-        let column_id = resolve_column_in_board(&self.ctx, &req.column, board_id).await?;
-        let card = mutating_op!(self.ctx, move_card, id, column_id, req.position)?;
+        let card = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            let board_id = ctx.mcp_card_board(id)?;
+            let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
+            ctx.move_card(id, column_id, req.position)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(description = "Archive a card (move to archive, can be restored later)")]
-    async fn tool_archive_card(
+    pub async fn tool_archive_card(
         &self,
         Parameters(req): Parameters<ArchiveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card).await?;
-        mutating_op!(self.ctx, archive_card, id)?;
+        let id = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.archive_card(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"archived": id.to_string()}))
     }
 
     #[tool(description = "Restore an archived card")]
-    async fn tool_restore_card(
+    pub async fn tool_restore_card(
         &self,
         Parameters(req): Parameters<RestoreCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card).await?;
-        let column_id = match req.column.as_deref() {
-            Some(raw) => {
-                let board_id = card_board(&self.ctx, id).await?;
-                Some(resolve_column_in_board(&self.ctx, raw, board_id).await?)
-            }
-            None => None,
-        };
-        let card = mutating_op!(self.ctx, restore_card, id, column_id)?;
+        let card = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            let column_id = match req.column.as_deref() {
+                Some(raw) => {
+                    let board_id = ctx.mcp_card_board(id)?;
+                    Some(ctx.mcp_resolve_column_in_board(raw, board_id)?)
+                }
+                None => None,
+            };
+            ctx.restore_card(id, column_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(description = "Delete a card permanently")]
-    async fn tool_delete_card(
+    pub async fn tool_delete_card(
         &self,
         Parameters(req): Parameters<DeleteCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card).await?;
-        mutating_op!(self.ctx, delete_card, id)?;
+        let id = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.delete_card(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     #[tool(
         description = "List archived cards. Returns ArchivedCardSummary (no description). Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
-    async fn tool_list_archived_cards(
+    pub async fn tool_list_archived_cards(
         &self,
         Parameters(req): Parameters<ListArchivedCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
@@ -976,46 +1024,60 @@ impl KanbanMcpServer {
     // Card Sprint Operations
 
     #[tool(description = "Assign a card to a sprint on the same board")]
-    async fn tool_assign_card_to_sprint(
+    pub async fn tool_assign_card_to_sprint(
         &self,
         Parameters(req): Parameters<AssignCardToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card_id = resolve_card_id(&self.ctx, &req.card).await?;
-        let board_id = card_board(&self.ctx, card_id).await?;
-        let sprint_id = resolve_sprint_in_board(&self.ctx, &req.sprint, board_id).await?;
-        let card = mutating_op!(self.ctx, assign_card_to_sprint, card_id, sprint_id)?;
+        let card = locked_session(&self.ctx, true, |ctx| {
+            let card_id = ctx.mcp_resolve_card(&req.card)?;
+            let board_id = ctx.mcp_card_board(card_id)?;
+            let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
+            ctx.assign_card_to_sprint(card_id, sprint_id)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(description = "Unassign a card from its sprint")]
-    async fn tool_unassign_card_from_sprint(
+    pub async fn tool_unassign_card_from_sprint(
         &self,
         Parameters(req): Parameters<UnassignCardFromSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card_id = resolve_card_id(&self.ctx, &req.card).await?;
-        let card = mutating_op!(self.ctx, unassign_card_from_sprint, card_id)?;
+        let card = locked_session(&self.ctx, true, |ctx| {
+            let card_id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.unassign_card_from_sprint(card_id)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     // Card Utilities
 
     #[tool(description = "Get the git branch name for a card")]
-    async fn tool_get_card_branch_name(
+    pub async fn tool_get_card_branch_name(
         &self,
         Parameters(req): Parameters<GetCardBranchNameRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card).await?;
-        let branch_name = read_op!(self.ctx, get_card_branch_name, id)?;
+        let branch_name = locked_session(&self.ctx, false, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.get_card_branch_name(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"branch_name": branch_name}))
     }
 
     #[tool(description = "Get the git checkout command for a card")]
-    async fn tool_get_card_git_checkout(
+    pub async fn tool_get_card_git_checkout(
         &self,
         Parameters(req): Parameters<GetCardGitCheckoutRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card).await?;
-        let command = read_op!(self.ctx, get_card_git_checkout, id)?;
+        let command = locked_session(&self.ctx, false, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.get_card_git_checkout(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"command": command}))
     }
 
@@ -1024,84 +1086,102 @@ impl KanbanMcpServer {
     #[tool(
         description = "Archive multiple cards at once. IDs may be UUIDs or identifiers (e.g. 'KAN-1', '42')."
     )]
-    async fn tool_archive_cards(
+    pub async fn tool_archive_cards(
         &self,
         Parameters(req): Parameters<ArchiveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = resolve_card_ids(&self.ctx, &req.cards).await?;
-        let count = mutating_op!(self.ctx, archive_cards, ids)?;
+        let count = locked_session(&self.ctx, true, |ctx| {
+            let ids = ctx.mcp_resolve_cards(&req.cards)?;
+            ctx.archive_cards(ids).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"archived_count": count}))
     }
 
     #[tool(
         description = "Move multiple cards to a column. All cards must share a board; the column is resolved on that board."
     )]
-    async fn tool_move_cards(
+    pub async fn tool_move_cards(
         &self,
         Parameters(req): Parameters<MoveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = resolve_card_ids(&self.ctx, &req.cards).await?;
-        let board_id = require_same_board(&self.ctx, &ids).await?;
-        let column_id = resolve_column_in_board(&self.ctx, &req.column, board_id).await?;
-        let count = mutating_op!(self.ctx, move_cards, ids, column_id)?;
+        let count = locked_session(&self.ctx, true, |ctx| {
+            let ids = ctx.mcp_resolve_cards(&req.cards)?;
+            let board_id = ctx.mcp_require_same_board(&ids)?;
+            let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
+            ctx.move_cards(ids, column_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"moved_count": count}))
     }
 
     #[tool(
         description = "Assign multiple cards to a sprint. All cards must share a board; the sprint is resolved on that board."
     )]
-    async fn tool_assign_cards_to_sprint(
+    pub async fn tool_assign_cards_to_sprint(
         &self,
         Parameters(req): Parameters<AssignCardsToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = resolve_card_ids(&self.ctx, &req.cards).await?;
-        let board_id = require_same_board(&self.ctx, &ids).await?;
-        let sprint_id = resolve_sprint_in_board(&self.ctx, &req.sprint, board_id).await?;
-        let count = mutating_op!(self.ctx, assign_cards_to_sprint, ids, sprint_id)?;
+        let count = locked_session(&self.ctx, true, |ctx| {
+            let ids = ctx.mcp_resolve_cards(&req.cards)?;
+            let board_id = ctx.mcp_require_same_board(&ids)?;
+            let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
+            ctx.assign_cards_to_sprint(ids, sprint_id)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"assigned_count": count}))
     }
 
     // Sprint Operations
 
     #[tool(description = "Create a new sprint")]
-    async fn tool_create_sprint(
+    pub async fn tool_create_sprint(
         &self,
         Parameters(req): Parameters<CreateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board).await?;
-        let sprint = mutating_op!(self.ctx, create_sprint, board_id, req.prefix, req.name)?;
+        let sprint = locked_session(&self.ctx, true, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.create_sprint(board_id, req.prefix, req.name)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "List sprints for a board")]
-    async fn tool_list_sprints(
+    pub async fn tool_list_sprints(
         &self,
         Parameters(req): Parameters<ListSprintsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board).await?;
-        let sprints = read_op!(self.ctx, list_sprints, board_id)?;
+        let sprints = locked_session(&self.ctx, false, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.list_sprints(board_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprints)
     }
 
     #[tool(description = "Get a specific sprint by UUID, name, or number")]
-    async fn tool_get_sprint(
+    pub async fn tool_get_sprint(
         &self,
         Parameters(req): Parameters<GetSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
-        let sprint = read_op!(self.ctx, get_sprint, id)?;
+        let sprint = locked_session(&self.ctx, false, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.get_sprint(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(
         description = "Update a sprint's properties (name, prefix, card_prefix, start_date, end_date)"
     )]
-    async fn tool_update_sprint(
+    pub async fn tool_update_sprint(
         &self,
         Parameters(req): Parameters<UpdateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
-
         let start_date = if req.clear_start_date == Some(true) {
             FieldUpdate::Clear
         } else {
@@ -1110,7 +1190,6 @@ impl KanbanMcpServer {
                 None => FieldUpdate::NoChange,
             }
         };
-
         let end_date = if req.clear_end_date == Some(true) {
             FieldUpdate::Clear
         } else {
@@ -1119,7 +1198,6 @@ impl KanbanMcpServer {
                 None => FieldUpdate::NoChange,
             }
         };
-
         let updates = SprintUpdate {
             name: req.name,
             name_index: FieldUpdate::NoChange,
@@ -1135,86 +1213,111 @@ impl KanbanMcpServer {
             start_date,
             end_date,
         };
-
-        let sprint = mutating_op!(self.ctx, update_sprint, id, updates)?;
+        let sprint = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.update_sprint(id, updates).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "Activate a sprint")]
-    async fn tool_activate_sprint(
+    pub async fn tool_activate_sprint(
         &self,
         Parameters(req): Parameters<ActivateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
-        let sprint = mutating_op!(self.ctx, activate_sprint, id, req.duration_days)?;
+        let sprint = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.activate_sprint(id, req.duration_days)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "Complete a sprint")]
-    async fn tool_complete_sprint(
+    pub async fn tool_complete_sprint(
         &self,
         Parameters(req): Parameters<CompleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
-        let sprint = mutating_op!(self.ctx, complete_sprint, id)?;
+        let sprint = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.complete_sprint(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "Cancel a sprint")]
-    async fn tool_cancel_sprint(
+    pub async fn tool_cancel_sprint(
         &self,
         Parameters(req): Parameters<CancelSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
-        let sprint = mutating_op!(self.ctx, cancel_sprint, id)?;
+        let sprint = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.cancel_sprint(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "Delete a sprint")]
-    async fn tool_delete_sprint(
+    pub async fn tool_delete_sprint(
         &self,
         Parameters(req): Parameters<DeleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
-        mutating_op!(self.ctx, delete_sprint, id)?;
+        let id = locked_session(&self.ctx, true, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.delete_sprint(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     #[tool(
         description = "Carry over uncompleted cards from a completed/cancelled sprint to a planning sprint on the same board"
     )]
-    async fn tool_carry_over_sprint_cards(
+    pub async fn tool_carry_over_sprint_cards(
         &self,
         Parameters(req): Parameters<CarryOverSprintCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let from_id = resolve_sprint_global(&self.ctx, &req.from_sprint).await?;
-        let from_sprint = read_op!(self.ctx, get_sprint, from_id)?.ok_or_else(|| {
-            McpError::invalid_params(format!("Sprint not found: {}", from_id), None)
-        })?;
-        let to_id =
-            resolve_sprint_in_board(&self.ctx, &req.to_sprint, from_sprint.board_id).await?;
-
-        let count = mutating_op!(self.ctx, carry_over_sprint_cards, from_id, to_id)?;
+        let count = locked_session(&self.ctx, true, |ctx| {
+            let from_id = ctx.mcp_resolve_sprint_global(&req.from_sprint)?;
+            let from_sprint = ctx
+                .get_sprint(from_id)
+                .map_err(kanban_err_to_mcp)?
+                .ok_or_else(|| {
+                    McpError::invalid_params(format!("Sprint not found: {}", from_id), None)
+                })?;
+            let to_id = ctx.mcp_resolve_sprint_in_board(&req.to_sprint, from_sprint.board_id)?;
+            ctx.carry_over_sprint_cards(from_id, to_id)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({ "carried_over_count": count }))
     }
 
     // Export/Import
 
     #[tool(description = "Export board data as JSON")]
-    async fn tool_export_board(
+    pub async fn tool_export_board(
         &self,
         Parameters(req): Parameters<ExportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = match req.board.as_deref() {
-            Some(raw) => Some(resolve_board(&self.ctx, raw).await?),
-            None => None,
-        };
-        let json = read_op!(self.ctx, export_board, board_id)?;
+        let json = locked_session(&self.ctx, false, |ctx| {
+            let board_id = match req.board.as_deref() {
+                Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
+                None => None,
+            };
+            ctx.export_board(board_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
     #[tool(description = "Import board data from JSON")]
-    async fn tool_import_board(
+    pub async fn tool_import_board(
         &self,
         Parameters(req): Parameters<ImportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
@@ -1224,7 +1327,7 @@ impl KanbanMcpServer {
     }
 
     #[tool(description = "Undo the last operation")]
-    async fn tool_undo(&self) -> Result<CallToolResult, McpError> {
+    pub async fn tool_undo(&self) -> Result<CallToolResult, McpError> {
         let mut guard = self.ctx.lock().await;
         if guard.undo().map_err(kanban_err_to_mcp)? {
             guard.save().await.map_err(kanban_err_to_mcp)?;
@@ -1239,7 +1342,7 @@ impl KanbanMcpServer {
     }
 
     #[tool(description = "Redo the last undone operation")]
-    async fn tool_redo(&self) -> Result<CallToolResult, McpError> {
+    pub async fn tool_redo(&self) -> Result<CallToolResult, McpError> {
         let mut guard = self.ctx.lock().await;
         if guard.redo().map_err(kanban_err_to_mcp)? {
             guard.save().await.map_err(kanban_err_to_mcp)?;

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -248,13 +248,13 @@ pub struct CreateBoardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetBoardRequest {
     #[schemars(description = "UUID or name of the board to retrieve")]
-    pub board_id: String,
+    pub board: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateBoardRequest {
     #[schemars(description = "UUID or name of the board to update")]
-    pub board_id: String,
+    pub board: String,
     #[schemars(description = "New name (optional)")]
     pub name: Option<String>,
     #[schemars(description = "New description (optional)")]
@@ -268,7 +268,7 @@ pub struct UpdateBoardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteBoardRequest {
     #[schemars(description = "UUID or name of the board to delete")]
-    pub board_id: String,
+    pub board: String,
 }
 
 // Column
@@ -276,7 +276,7 @@ pub struct DeleteBoardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateColumnRequest {
     #[schemars(description = "UUID or name of the board to create the column in")]
-    pub board_id: String,
+    pub board: String,
     #[schemars(description = "Name of the column")]
     pub name: String,
     #[schemars(description = "Position of the column (optional, appends to end if not specified)")]
@@ -286,19 +286,19 @@ pub struct CreateColumnRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListColumnsRequest {
     #[schemars(description = "UUID or name of the board to list columns for")]
-    pub board_id: String,
+    pub board: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetColumnRequest {
     #[schemars(description = "UUID or name of the column to retrieve")]
-    pub column_id: String,
+    pub column: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateColumnRequest {
     #[schemars(description = "UUID or name of the column to update")]
-    pub column_id: String,
+    pub column: String,
     #[schemars(description = "New name (optional)")]
     pub name: Option<String>,
     #[schemars(description = "New position (optional)")]
@@ -312,13 +312,13 @@ pub struct UpdateColumnRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteColumnRequest {
     #[schemars(description = "UUID or name of the column to delete")]
-    pub column_id: String,
+    pub column: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ReorderColumnRequest {
     #[schemars(description = "UUID or name of the column to reorder")]
-    pub column_id: String,
+    pub column: String,
     #[schemars(description = "New position")]
     pub position: i32,
 }
@@ -328,9 +328,9 @@ pub struct ReorderColumnRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateCardRequest {
     #[schemars(description = "UUID or name of the board")]
-    pub board_id: String,
+    pub board: String,
     #[schemars(description = "UUID or name of the column to create the card in")]
-    pub column_id: String,
+    pub column: String,
     #[schemars(description = "Title of the card")]
     pub title: String,
     #[schemars(description = "Description of the card (optional)")]
@@ -348,15 +348,15 @@ pub struct CreateCardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListCardsRequest {
     #[schemars(description = "Filter cards by board UUID or name")]
-    pub board_id: Option<String>,
+    pub board: Option<String>,
     #[schemars(
-        description = "Filter cards by column UUID or name (scoped to board_id if given, else global)"
+        description = "Filter cards by column UUID or name (scoped to board if given, else global)"
     )]
-    pub column_id: Option<String>,
+    pub column: Option<String>,
     #[schemars(
-        description = "Filter cards by sprint UUID, name, or number (scoped to board_id if given, else global)"
+        description = "Filter cards by sprint UUID, name, or number (scoped to board if given, else global)"
     )]
-    pub sprint_id: Option<String>,
+    pub sprint: Option<String>,
     #[schemars(description = "Filter by status: 'todo', 'in_progress', 'blocked', or 'done'")]
     pub status: Option<String>,
     #[schemars(description = "Page number, 1-based (default: 1)")]
@@ -376,13 +376,13 @@ pub struct ListArchivedCardsRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetCardRequest {
     #[schemars(description = "UUID or identifier of the card to retrieve (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateCardRequest {
     #[schemars(description = "UUID or identifier of the card to update (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
     #[schemars(description = "New title (optional)")]
     pub title: Option<String>,
     #[schemars(description = "New description (optional)")]
@@ -404,11 +404,11 @@ pub struct UpdateCardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct MoveCardRequest {
     #[schemars(description = "UUID or identifier of the card to move (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
     #[schemars(
         description = "UUID or name of the destination column (resolved within the card's board)"
     )]
-    pub column_id: String,
+    pub column: String,
     #[schemars(description = "Position in the new column (optional)")]
     pub position: Option<i32>,
 }
@@ -416,7 +416,7 @@ pub struct MoveCardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ArchiveCardRequest {
     #[schemars(description = "UUID or identifier of the card to archive (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -424,17 +424,17 @@ pub struct RestoreCardRequest {
     #[schemars(
         description = "UUID or identifier of the archived card to restore (e.g. 'KAN-5' or '5')"
     )]
-    pub card_id: String,
+    pub card: String,
     #[schemars(
         description = "UUID or name of the column to restore the card to (optional; resolved within the card's board)"
     )]
-    pub column_id: Option<String>,
+    pub column: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteCardRequest {
     #[schemars(description = "UUID or identifier of the card to delete (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 // Card Sprint
@@ -442,11 +442,11 @@ pub struct DeleteCardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct AssignCardToSprintRequest {
     #[schemars(description = "UUID or identifier of the card (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
     #[schemars(
         description = "UUID, name, or number of the sprint to assign to (resolved within the card's board)"
     )]
-    pub sprint_id: String,
+    pub sprint: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -454,7 +454,7 @@ pub struct UnassignCardFromSprintRequest {
     #[schemars(
         description = "UUID or identifier of the card to unassign from its sprint (e.g. 'KAN-5' or '5')"
     )]
-    pub card_id: String,
+    pub card: String,
 }
 
 // Card Utilities
@@ -462,13 +462,13 @@ pub struct UnassignCardFromSprintRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetCardBranchNameRequest {
     #[schemars(description = "UUID or identifier of the card (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetCardGitCheckoutRequest {
     #[schemars(description = "UUID or identifier of the card (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 // Multi-card operations
@@ -476,7 +476,7 @@ pub struct GetCardGitCheckoutRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ArchiveCardsRequest {
     #[schemars(description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2', '42'])")]
-    pub ids: Vec<String>,
+    pub cards: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -484,11 +484,11 @@ pub struct MoveCardsRequest {
     #[schemars(
         description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2']); all cards must share a board"
     )]
-    pub ids: Vec<String>,
+    pub cards: Vec<String>,
     #[schemars(
         description = "UUID or name of the destination column (resolved within the cards' shared board)"
     )]
-    pub column_id: String,
+    pub column: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -496,11 +496,11 @@ pub struct AssignCardsToSprintRequest {
     #[schemars(
         description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2']); all cards must share a board"
     )]
-    pub ids: Vec<String>,
+    pub cards: Vec<String>,
     #[schemars(
         description = "UUID, name, or number of the sprint to assign to (resolved within the cards' shared board)"
     )]
-    pub sprint_id: String,
+    pub sprint: String,
 }
 
 // Sprint
@@ -508,7 +508,7 @@ pub struct AssignCardsToSprintRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateSprintRequest {
     #[schemars(description = "UUID or name of the board")]
-    pub board_id: String,
+    pub board: String,
     #[schemars(description = "Sprint prefix (optional)")]
     pub prefix: Option<String>,
     #[schemars(description = "Sprint name (optional)")]
@@ -518,19 +518,19 @@ pub struct CreateSprintRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListSprintsRequest {
     #[schemars(description = "UUID or name of the board")]
-    pub board_id: String,
+    pub board: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetSprintRequest {
     #[schemars(description = "UUID, name, or number of the sprint")]
-    pub sprint_id: String,
+    pub sprint: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateSprintRequest {
     #[schemars(description = "UUID, name, or number of the sprint to update")]
-    pub sprint_id: String,
+    pub sprint: String,
     #[schemars(description = "New sprint name (optional)")]
     pub name: Option<String>,
     #[schemars(description = "New prefix (optional)")]
@@ -550,7 +550,7 @@ pub struct UpdateSprintRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ActivateSprintRequest {
     #[schemars(description = "UUID, name, or number of the sprint to activate")]
-    pub sprint_id: String,
+    pub sprint: String,
     #[schemars(description = "Duration in days (optional)")]
     pub duration_days: Option<i32>,
 }
@@ -558,19 +558,19 @@ pub struct ActivateSprintRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CompleteSprintRequest {
     #[schemars(description = "UUID, name, or number of the sprint to complete")]
-    pub sprint_id: String,
+    pub sprint: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CancelSprintRequest {
     #[schemars(description = "UUID, name, or number of the sprint to cancel")]
-    pub sprint_id: String,
+    pub sprint: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteSprintRequest {
     #[schemars(description = "UUID, name, or number of the sprint to delete")]
-    pub sprint_id: String,
+    pub sprint: String,
 }
 
 // Carry-over
@@ -580,11 +580,11 @@ pub struct CarryOverSprintCardsRequest {
     #[schemars(
         description = "UUID, name, or number of the completed/cancelled source sprint to carry cards from"
     )]
-    pub from_sprint_id: String,
+    pub from_sprint: String,
     #[schemars(
         description = "UUID, name, or number of the planning sprint to carry cards to (must be on the same board as source)"
     )]
-    pub to_sprint_id: String,
+    pub to_sprint: String,
 }
 
 // Export/Import
@@ -594,7 +594,7 @@ pub struct ExportBoardRequest {
     #[schemars(
         description = "UUID or name of the board to export (optional, exports all if omitted)"
     )]
-    pub board_id: Option<String>,
+    pub board: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -656,7 +656,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_board(&self.ctx, &req.board_id).await?;
+        let id = resolve_board(&self.ctx, &req.board).await?;
         let board = read_op!(self.ctx, get_board, id)?;
         to_call_tool_result(&board)
     }
@@ -668,7 +668,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_board(&self.ctx, &req.board_id).await?;
+        let id = resolve_board(&self.ctx, &req.board).await?;
         let updates = BoardUpdate {
             name: req.name,
             description: req
@@ -694,7 +694,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_board(&self.ctx, &req.board_id).await?;
+        let id = resolve_board(&self.ctx, &req.board).await?;
         mutating_op!(self.ctx, delete_board, id)?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
@@ -706,7 +706,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
+        let board_id = resolve_board(&self.ctx, &req.board).await?;
         let column = mutating_op!(self.ctx, create_column, board_id, req.name, req.position)?;
         to_call_tool_result(&column)
     }
@@ -716,7 +716,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListColumnsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
+        let board_id = resolve_board(&self.ctx, &req.board).await?;
         let columns = read_op!(self.ctx, list_columns, board_id)?;
         to_call_tool_result(&columns)
     }
@@ -726,7 +726,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_column_global(&self.ctx, &req.column_id).await?;
+        let id = resolve_column_global(&self.ctx, &req.column).await?;
         let column = read_op!(self.ctx, get_column, id)?;
         to_call_tool_result(&column)
     }
@@ -736,7 +736,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_column_global(&self.ctx, &req.column_id).await?;
+        let id = resolve_column_global(&self.ctx, &req.column).await?;
         let updates = ColumnUpdate {
             name: req.name,
             position: req.position,
@@ -757,7 +757,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_column_global(&self.ctx, &req.column_id).await?;
+        let id = resolve_column_global(&self.ctx, &req.column).await?;
         mutating_op!(self.ctx, delete_column, id)?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
@@ -767,7 +767,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ReorderColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_column_global(&self.ctx, &req.column_id).await?;
+        let id = resolve_column_global(&self.ctx, &req.column).await?;
         let column = mutating_op!(self.ctx, reorder_column, id, req.position)?;
         to_call_tool_result(&column)
     }
@@ -779,8 +779,8 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
-        let column_id = resolve_column_in_board(&self.ctx, &req.column_id, board_id).await?;
+        let board_id = resolve_board(&self.ctx, &req.board).await?;
+        let column_id = resolve_column_in_board(&self.ctx, &req.column, board_id).await?;
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let due_date = req.due_date.as_deref().map(parse_datetime).transpose()?;
 
@@ -809,18 +809,18 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = match &req.board_id {
+        let board_id = match &req.board {
             Some(raw) => Some(resolve_board(&self.ctx, raw).await?),
             None => None,
         };
-        let column_id = match &req.column_id {
+        let column_id = match &req.column {
             Some(raw) => Some(match board_id {
                 Some(bid) => resolve_column_in_board(&self.ctx, raw, bid).await?,
                 None => resolve_column_global(&self.ctx, raw).await?,
             }),
             None => None,
         };
-        let sprint_id = match &req.sprint_id {
+        let sprint_id = match &req.sprint {
             Some(raw) => Some(match board_id {
                 Some(bid) => resolve_sprint_in_board(&self.ctx, raw, bid).await?,
                 None => resolve_sprint_global(&self.ctx, raw).await?,
@@ -848,19 +848,19 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        if let Ok(uuid) = uuid::Uuid::parse_str(&req.card_id) {
+        if let Ok(uuid) = uuid::Uuid::parse_str(&req.card) {
             let card = read_op!(self.ctx, get_card, uuid)?;
             return to_call_tool_result(&card);
         }
         let cards = {
             let guard = self.ctx.lock().await;
             guard
-                .find_cards_by_identifier(&req.card_id)
+                .find_cards_by_identifier(&req.card)
                 .map_err(kanban_err_to_mcp)?
         };
         match cards.as_slice() {
             [] => Err(McpError::invalid_params(
-                format!("Card not found: '{}'", req.card_id),
+                format!("Card not found: '{}'", req.card),
                 None,
             )),
             [card] => to_call_tool_result(card),
@@ -875,7 +875,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
+        let id = resolve_card_id(&self.ctx, &req.card).await?;
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let status = req.status.as_deref().map(parse_status).transpose()?;
 
@@ -912,9 +912,9 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<MoveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
+        let id = resolve_card_id(&self.ctx, &req.card).await?;
         let board_id = card_board(&self.ctx, id).await?;
-        let column_id = resolve_column_in_board(&self.ctx, &req.column_id, board_id).await?;
+        let column_id = resolve_column_in_board(&self.ctx, &req.column, board_id).await?;
         let card = mutating_op!(self.ctx, move_card, id, column_id, req.position)?;
         to_call_tool_result(&card)
     }
@@ -924,7 +924,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ArchiveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
+        let id = resolve_card_id(&self.ctx, &req.card).await?;
         mutating_op!(self.ctx, archive_card, id)?;
         to_call_tool_result_json(serde_json::json!({"archived": id.to_string()}))
     }
@@ -934,8 +934,8 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<RestoreCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let column_id = match req.column_id.as_deref() {
+        let id = resolve_card_id(&self.ctx, &req.card).await?;
+        let column_id = match req.column.as_deref() {
             Some(raw) => {
                 let board_id = card_board(&self.ctx, id).await?;
                 Some(resolve_column_in_board(&self.ctx, raw, board_id).await?)
@@ -951,7 +951,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
+        let id = resolve_card_id(&self.ctx, &req.card).await?;
         mutating_op!(self.ctx, delete_card, id)?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
@@ -980,9 +980,9 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<AssignCardToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card_id = resolve_card_id(&self.ctx, &req.card_id).await?;
+        let card_id = resolve_card_id(&self.ctx, &req.card).await?;
         let board_id = card_board(&self.ctx, card_id).await?;
-        let sprint_id = resolve_sprint_in_board(&self.ctx, &req.sprint_id, board_id).await?;
+        let sprint_id = resolve_sprint_in_board(&self.ctx, &req.sprint, board_id).await?;
         let card = mutating_op!(self.ctx, assign_card_to_sprint, card_id, sprint_id)?;
         to_call_tool_result(&card)
     }
@@ -992,7 +992,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UnassignCardFromSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card_id = resolve_card_id(&self.ctx, &req.card_id).await?;
+        let card_id = resolve_card_id(&self.ctx, &req.card).await?;
         let card = mutating_op!(self.ctx, unassign_card_from_sprint, card_id)?;
         to_call_tool_result(&card)
     }
@@ -1004,7 +1004,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetCardBranchNameRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
+        let id = resolve_card_id(&self.ctx, &req.card).await?;
         let branch_name = read_op!(self.ctx, get_card_branch_name, id)?;
         to_call_tool_result_json(serde_json::json!({"branch_name": branch_name}))
     }
@@ -1014,7 +1014,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetCardGitCheckoutRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
+        let id = resolve_card_id(&self.ctx, &req.card).await?;
         let command = read_op!(self.ctx, get_card_git_checkout, id)?;
         to_call_tool_result_json(serde_json::json!({"command": command}))
     }
@@ -1028,7 +1028,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ArchiveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = resolve_card_ids(&self.ctx, &req.ids).await?;
+        let ids = resolve_card_ids(&self.ctx, &req.cards).await?;
         let count = mutating_op!(self.ctx, archive_cards, ids)?;
         to_call_tool_result_json(serde_json::json!({"archived_count": count}))
     }
@@ -1040,9 +1040,9 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<MoveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = resolve_card_ids(&self.ctx, &req.ids).await?;
+        let ids = resolve_card_ids(&self.ctx, &req.cards).await?;
         let board_id = require_same_board(&self.ctx, &ids).await?;
-        let column_id = resolve_column_in_board(&self.ctx, &req.column_id, board_id).await?;
+        let column_id = resolve_column_in_board(&self.ctx, &req.column, board_id).await?;
         let count = mutating_op!(self.ctx, move_cards, ids, column_id)?;
         to_call_tool_result_json(serde_json::json!({"moved_count": count}))
     }
@@ -1054,9 +1054,9 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<AssignCardsToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = resolve_card_ids(&self.ctx, &req.ids).await?;
+        let ids = resolve_card_ids(&self.ctx, &req.cards).await?;
         let board_id = require_same_board(&self.ctx, &ids).await?;
-        let sprint_id = resolve_sprint_in_board(&self.ctx, &req.sprint_id, board_id).await?;
+        let sprint_id = resolve_sprint_in_board(&self.ctx, &req.sprint, board_id).await?;
         let count = mutating_op!(self.ctx, assign_cards_to_sprint, ids, sprint_id)?;
         to_call_tool_result_json(serde_json::json!({"assigned_count": count}))
     }
@@ -1068,7 +1068,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
+        let board_id = resolve_board(&self.ctx, &req.board).await?;
         let sprint = mutating_op!(self.ctx, create_sprint, board_id, req.prefix, req.name)?;
         to_call_tool_result(&sprint)
     }
@@ -1078,7 +1078,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListSprintsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = resolve_board(&self.ctx, &req.board_id).await?;
+        let board_id = resolve_board(&self.ctx, &req.board).await?;
         let sprints = read_op!(self.ctx, list_sprints, board_id)?;
         to_call_tool_result(&sprints)
     }
@@ -1088,7 +1088,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
         let sprint = read_op!(self.ctx, get_sprint, id)?;
         to_call_tool_result(&sprint)
     }
@@ -1100,7 +1100,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
 
         let start_date = if req.clear_start_date == Some(true) {
             FieldUpdate::Clear
@@ -1145,7 +1145,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ActivateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
         let sprint = mutating_op!(self.ctx, activate_sprint, id, req.duration_days)?;
         to_call_tool_result(&sprint)
     }
@@ -1155,7 +1155,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CompleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
         let sprint = mutating_op!(self.ctx, complete_sprint, id)?;
         to_call_tool_result(&sprint)
     }
@@ -1165,7 +1165,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CancelSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
         let sprint = mutating_op!(self.ctx, cancel_sprint, id)?;
         to_call_tool_result(&sprint)
     }
@@ -1175,7 +1175,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_sprint_global(&self.ctx, &req.sprint_id).await?;
+        let id = resolve_sprint_global(&self.ctx, &req.sprint).await?;
         mutating_op!(self.ctx, delete_sprint, id)?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
@@ -1187,12 +1187,12 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CarryOverSprintCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let from_id = resolve_sprint_global(&self.ctx, &req.from_sprint_id).await?;
+        let from_id = resolve_sprint_global(&self.ctx, &req.from_sprint).await?;
         let from_sprint = read_op!(self.ctx, get_sprint, from_id)?.ok_or_else(|| {
             McpError::invalid_params(format!("Sprint not found: {}", from_id), None)
         })?;
         let to_id =
-            resolve_sprint_in_board(&self.ctx, &req.to_sprint_id, from_sprint.board_id).await?;
+            resolve_sprint_in_board(&self.ctx, &req.to_sprint, from_sprint.board_id).await?;
 
         let count = mutating_op!(self.ctx, carry_over_sprint_cards, from_id, to_id)?;
         to_call_tool_result_json(serde_json::json!({ "carried_over_count": count }))
@@ -1205,7 +1205,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ExportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = match req.board_id.as_deref() {
+        let board_id = match req.board.as_deref() {
             Some(raw) => Some(resolve_board(&self.ctx, raw).await?),
             None => None,
         };

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -119,6 +119,14 @@ fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, McpError> {
 // `read_op!` macro is still appropriate — it's a one-liner that elides the
 // closure ceremony.
 
+/// Acquire the context lock and run the closure with read-only access.
+///
+/// The in-memory cache is **not** reloaded — reads are served from whatever
+/// state the previous tool call left behind. If a separate process wrote to
+/// the file since the last reload, the read may be stale. That's an
+/// intentional perf tradeoff: typical MCP usage is single-process, and the
+/// reload cost (file read + parse) is significant relative to the read
+/// itself.
 async fn locked_read<T, F>(ctx: &Arc<Mutex<McpContext>>, f: F) -> Result<T, McpError>
 where
     F: FnOnce(&McpContext) -> Result<T, McpError>,
@@ -127,6 +135,23 @@ where
     f(&guard)
 }
 
+/// Acquire the context lock, reload from disk, run the closure with mutable
+/// access, then save and drop. Reload + save bracket the closure so the
+/// mutation always operates on the latest disk state and is persisted before
+/// the lock releases.
+///
+/// # Reload semantics and undo limitations
+///
+/// `guard.reload()` fully discards the in-memory cache and resets undo
+/// history to the current on-disk state. As a consequence, within-session
+/// undo history from earlier tool calls is always wiped before each
+/// mutation: `tool_undo` can only undo the operation recorded during the
+/// **current** tool call, not operations from prior calls.
+///
+/// **Future work**: a `reload_if_changed()` method that compares file
+/// metadata (mtime / instance_id) and skips the full reload when no
+/// external write has occurred would let undo history persist across calls
+/// in the same session. Track as `KanbanBackend::reload_if_changed()`.
 async fn locked_write<T, F>(ctx: &Arc<Mutex<McpContext>>, f: F) -> Result<T, McpError>
 where
     F: FnOnce(&mut McpContext) -> Result<T, McpError>,
@@ -139,8 +164,9 @@ where
 }
 
 /// Helper trait: gives `&McpContext` access to MCP-flavoured error mapping for
-/// the resolvers it inherits via `KanbanOperations`. Keeps closure bodies
-/// readable inside `locked_read` / `locked_write`.
+/// the resolvers it inherits via `KanbanOperations`. Each method is a thin
+/// `kanban_err_to_mcp` shim so closure bodies inside `locked_read` /
+/// `locked_write` stay readable.
 trait McpResolve {
     fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
@@ -150,8 +176,6 @@ trait McpResolve {
     fn mcp_resolve_card(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_cards(&self, raws: &[String]) -> Result<Vec<Uuid>, McpError>;
     fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError>;
-    /// Derive a card's board via card → column → board.
-    fn mcp_card_board(&self, card_id: Uuid) -> Result<Uuid, McpError>;
 }
 
 impl McpResolve for McpContext {
@@ -183,21 +207,23 @@ impl McpResolve for McpContext {
     fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError> {
         self.require_same_board(card_ids).map_err(kanban_err_to_mcp)
     }
-    fn mcp_card_board(&self, card_id: Uuid) -> Result<Uuid, McpError> {
-        let card = self
-            .get_card(card_id)
-            .map_err(kanban_err_to_mcp)?
-            .ok_or_else(|| {
-                McpError::invalid_params(format!("Card not found: {}", card_id), None)
-            })?;
-        let column = self
-            .get_column(card.column_id)
-            .map_err(kanban_err_to_mcp)?
-            .ok_or_else(|| {
-                McpError::invalid_params(format!("Column not found: {}", card.column_id), None)
-            })?;
-        Ok(column.board_id)
-    }
+}
+
+/// Derive a card's board via card → column → board, with MCP-flavoured error
+/// mapping. Standalone (not on the resolver trait) because it composes
+/// multiple trait calls rather than being a simple error-mapping shim.
+fn card_board(ctx: &McpContext, card_id: Uuid) -> Result<Uuid, McpError> {
+    let card = ctx
+        .get_card(card_id)
+        .map_err(kanban_err_to_mcp)?
+        .ok_or_else(|| McpError::invalid_params(format!("Card not found: {}", card_id), None))?;
+    let column = ctx
+        .get_column(card.column_id)
+        .map_err(kanban_err_to_mcp)?
+        .ok_or_else(|| {
+            McpError::invalid_params(format!("Column not found: {}", card.column_id), None)
+        })?;
+    Ok(column.board_id)
 }
 
 /// Lock the context, reload from disk, execute a mutating operation, then save.
@@ -949,7 +975,7 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let card = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_card(&req.card)?;
-            let board_id = ctx.mcp_card_board(id)?;
+            let board_id = card_board(ctx, id)?;
             let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
             ctx.move_card(id, column_id, req.position)
                 .map_err(kanban_err_to_mcp)
@@ -981,7 +1007,7 @@ impl KanbanMcpServer {
             let id = ctx.mcp_resolve_card(&req.card)?;
             let column_id = match req.column.as_deref() {
                 Some(raw) => {
-                    let board_id = ctx.mcp_card_board(id)?;
+                    let board_id = card_board(ctx, id)?;
                     Some(ctx.mcp_resolve_column_in_board(raw, board_id)?)
                 }
                 None => None,
@@ -1032,7 +1058,7 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let card = locked_write(&self.ctx, |ctx| {
             let card_id = ctx.mcp_resolve_card(&req.card)?;
-            let board_id = ctx.mcp_card_board(card_id)?;
+            let board_id = card_board(ctx, card_id)?;
             let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
             ctx.assign_card_to_sprint(card_id, sprint_id)
                 .map_err(kanban_err_to_mcp)

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -639,3 +639,273 @@ async fn require_same_board_rejects_cross_board_on_mcp() {
     assert!(err.contains("'Alpha'"), "msg: {err}");
     assert!(err.contains("'Beta'"), "msg: {err}");
 }
+
+// ============================================================================
+// Tool-handler tests (KAN-400 review fix: previously only McpContext was tested,
+// not the actual tool bodies that go through `locked_session` + resolution).
+// ============================================================================
+
+use kanban_mcp::{
+    AssignCardToSprintRequest, CarryOverSprintCardsRequest, CreateBoardRequest, CreateCardRequest,
+    CreateColumnRequest, CreateSprintRequest, KanbanMcpServer, MoveCardRequest, MoveCardsRequest,
+};
+use rmcp::handler::server::wrapper::Parameters;
+use serde_json::Value;
+
+async fn setup_server() -> (KanbanMcpServer, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.json");
+    let store_manager = default_store_manager();
+    let server = KanbanMcpServer::new(
+        &store_manager,
+        &path.to_string_lossy(),
+        AppConfig::default(),
+    )
+    .await
+    .unwrap();
+    (server, dir)
+}
+
+fn text_payload(result: &rmcp::model::CallToolResult) -> Value {
+    let raw = &result.content[0]
+        .as_text()
+        .expect("expected text content")
+        .text;
+    serde_json::from_str(raw).expect("tool result is JSON")
+}
+
+#[tokio::test]
+async fn tool_move_card_resolves_names_through_locked_session() {
+    let (server, _tmp) = setup_server().await;
+    // Seed: board with two columns and one card.
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("KAN".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "Doing".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "B".into(),
+            column: "TODO".into(),
+            title: "T".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+        }))
+        .await
+        .unwrap();
+    // Move KAN-1 to Doing using names end-to-end.
+    let result = server
+        .tool_move_card(Parameters(MoveCardRequest {
+            card: "KAN-1".into(),
+            column: "Doing".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&result);
+    assert_eq!(body["title"], "T");
+    assert!(body["column_id"].is_string());
+}
+
+#[tokio::test]
+async fn tool_move_cards_rejects_cross_board_batch() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "Alpha".into(),
+            card_prefix: Some("A".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "Beta".into(),
+            card_prefix: Some("B".into()),
+        }))
+        .await
+        .unwrap();
+    for board in ["Alpha", "Beta"] {
+        server
+            .tool_create_column(Parameters(CreateColumnRequest {
+                board: board.into(),
+                name: "TODO".into(),
+                position: None,
+            }))
+            .await
+            .unwrap();
+        server
+            .tool_create_card(Parameters(CreateCardRequest {
+                board: board.into(),
+                column: "TODO".into(),
+                title: format!("{board}-1"),
+                description: None,
+                priority: None,
+                points: None,
+                due_date: None,
+            }))
+            .await
+            .unwrap();
+    }
+    let err = server
+        .tool_move_cards(Parameters(MoveCardsRequest {
+            cards: vec!["A-1".into(), "B-1".into()],
+            column: "TODO".into(),
+        }))
+        .await
+        .unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("same board"), "err: {msg}");
+    assert!(msg.contains("'Alpha'"), "err: {msg}");
+    assert!(msg.contains("'Beta'"), "err: {msg}");
+}
+
+#[tokio::test]
+async fn tool_carry_over_sprint_cards_scopes_to_named_from_board() {
+    // from_sprint is global; to_sprint must resolve on from_sprint's board.
+    // A sprint of the same name on a different board must not match `to`.
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "Alpha".into(),
+            card_prefix: Some("A".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "Beta".into(),
+            card_prefix: Some("B".into()),
+        }))
+        .await
+        .unwrap();
+    // Both boards get a "next" sprint name. Only Alpha gets the "completed" one.
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "Alpha".into(),
+            prefix: None,
+            name: Some("completed".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "Alpha".into(),
+            prefix: None,
+            name: Some("next".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "Beta".into(),
+            prefix: None,
+            name: Some("next".into()),
+        }))
+        .await
+        .unwrap();
+    // Activate + complete the source sprint on Alpha.
+    server
+        .tool_activate_sprint(Parameters(kanban_mcp::ActivateSprintRequest {
+            sprint: "completed".into(),
+            duration_days: Some(1),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_complete_sprint(Parameters(kanban_mcp::CompleteSprintRequest {
+            sprint: "completed".into(),
+        }))
+        .await
+        .unwrap();
+    // Even though both boards have a "next" sprint, the carry-over must
+    // resolve "next" within Alpha (the source's board), not error on
+    // ambiguity. (Per KAN-400 design: to_sprint is scoped to from_sprint's board.)
+    let result = server
+        .tool_carry_over_sprint_cards(Parameters(CarryOverSprintCardsRequest {
+            from_sprint: "completed".into(),
+            to_sprint: "next".into(),
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&result);
+    assert!(body["carried_over_count"].is_number());
+}
+
+#[tokio::test]
+async fn tool_assign_card_to_sprint_resolves_by_name_then_mutates() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("KAN".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "B".into(),
+            prefix: None,
+            name: Some("alpha".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "B".into(),
+            column: "TODO".into(),
+            title: "T".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+        }))
+        .await
+        .unwrap();
+    // Assign using card identifier + sprint name + sprint number both work.
+    let r1 = server
+        .tool_assign_card_to_sprint(Parameters(AssignCardToSprintRequest {
+            card: "KAN-1".into(),
+            sprint: "alpha".into(),
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&r1);
+    assert!(body["sprint_id"].is_string());
+    let r2 = server
+        .tool_assign_card_to_sprint(Parameters(AssignCardToSprintRequest {
+            card: "KAN-1".into(),
+            sprint: "1".into(), // sprint number
+        }))
+        .await
+        .unwrap();
+    let body2 = text_payload(&r2);
+    assert!(body2["sprint_id"].is_string());
+}

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -546,3 +546,96 @@ async fn test_mcp_reload_resets_undo_history() {
         "reload must reset undo history — cursor is invalid after external change"
     );
 }
+
+// ============================================================================
+// Name resolution via McpContext (same default trait methods as CLI uses).
+// Confirms the MCP context picks up the shared resolvers and they produce
+// the same human-friendly error messages.
+// ============================================================================
+
+#[tokio::test]
+async fn resolve_board_id_by_name_on_mcp_context() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx
+        .create_board("MyBoard".into(), Some("MB".into()))
+        .unwrap();
+    assert_eq!(ctx.resolve_board_id("MyBoard").unwrap(), board.id);
+    assert_eq!(ctx.resolve_board_id("myboard").unwrap(), board.id);
+}
+
+#[tokio::test]
+async fn resolve_board_id_unknown_lists_available_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    ctx.create_board("Alpha".into(), None).unwrap();
+    ctx.create_board("Beta".into(), None).unwrap();
+    let msg = ctx.resolve_board_id("Gamma").unwrap_err().to_string();
+    assert!(msg.contains("not found"), "msg: {msg}");
+    assert!(msg.contains("'Alpha'"), "msg: {msg}");
+    assert!(msg.contains("'Beta'"), "msg: {msg}");
+}
+
+#[tokio::test]
+async fn resolve_column_id_global_ambiguous_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    let a = ctx.create_board("A".into(), None).unwrap();
+    let b = ctx.create_board("B".into(), None).unwrap();
+    ctx.create_column(a.id, "TODO".into(), None).unwrap();
+    ctx.create_column(b.id, "TODO".into(), None).unwrap();
+    let msg = ctx
+        .resolve_column_id_global("todo")
+        .unwrap_err()
+        .to_string();
+    assert!(msg.contains("ambiguous"), "msg: {msg}");
+    assert!(msg.contains("'A'"), "msg: {msg}");
+    assert!(msg.contains("'B'"), "msg: {msg}");
+}
+
+#[tokio::test]
+async fn resolve_sprint_id_by_name_and_number_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let sprint = ctx
+        .create_sprint(board.id, None, Some("alpha".into()))
+        .unwrap();
+    assert_eq!(ctx.resolve_sprint_id("alpha", board.id).unwrap(), sprint.id);
+    assert_eq!(
+        ctx.resolve_sprint_id(&sprint.sprint_number.to_string(), board.id)
+            .unwrap(),
+        sprint.id
+    );
+}
+
+#[tokio::test]
+async fn resolve_card_ids_aggregates_failures_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "T".into(), Default::default())
+        .unwrap();
+    let raws = vec![format!("KAN-{}", card.card_number), "KAN-999".into()];
+    let err = ctx.resolve_card_ids(&raws).unwrap_err().to_string();
+    assert!(err.contains("KAN-999"), "msg: {err}");
+}
+
+#[tokio::test]
+async fn require_same_board_rejects_cross_board_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    let a = ctx.create_board("Alpha".into(), Some("A".into())).unwrap();
+    let b = ctx.create_board("Beta".into(), Some("B".into())).unwrap();
+    let col_a = ctx.create_column(a.id, "TODO".into(), None).unwrap();
+    let col_b = ctx.create_column(b.id, "TODO".into(), None).unwrap();
+    let c_a = ctx
+        .create_card(a.id, col_a.id, "a".into(), Default::default())
+        .unwrap();
+    let c_b = ctx
+        .create_card(b.id, col_b.id, "b".into(), Default::default())
+        .unwrap();
+    let err = ctx
+        .require_same_board(&[c_a.id, c_b.id])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("same board"), "msg: {err}");
+    assert!(err.contains("'Alpha'"), "msg: {err}");
+    assert!(err.contains("'Beta'"), "msg: {err}");
+}

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -993,6 +993,18 @@ impl KanbanOperations for KanbanContext {
             .collect())
     }
 
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.backend.list_all_cards()
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.backend.list_all_columns()
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.backend.list_all_sprints()
+    }
+
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         self.update_cards(vec![(id, updates)])?;
         self.get_card(id)?

--- a/crates/kanban-service/tests/resolve.rs
+++ b/crates/kanban-service/tests/resolve.rs
@@ -259,7 +259,8 @@ async fn test_resolve_card_ids_failure_display_lists_each_input() {
         .resolve_card_ids(&["KAN-999".into(), "KAN-998".into()])
         .unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("2 card"), "got: {msg}");
+    // Entity stays capitalized, plural agrees with count (no "(s)" parenthetical).
+    assert!(msg.contains("2 Cards"), "got: {msg}");
     assert!(msg.contains("'KAN-999'"), "got: {msg}");
     assert!(msg.contains("'KAN-998'"), "got: {msg}");
     assert!(msg.contains("not found"), "got: {msg}");

--- a/crates/kanban-service/tests/resolve.rs
+++ b/crates/kanban-service/tests/resolve.rs
@@ -67,13 +67,16 @@ async fn test_resolve_board_id_not_found_lists_available() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_resolve_board_id_ambiguous_returns_uuid_hint() {
+async fn test_resolve_board_id_ambiguous_includes_label_and_uuid_per_match() {
     let (mut ctx, _dir) = open_ctx().await;
-    ctx.create_board("Shared".into(), None).unwrap();
-    ctx.create_board("Shared".into(), None).unwrap();
+    let b1 = ctx.create_board("Shared".into(), None).unwrap();
+    let b2 = ctx.create_board("Shared".into(), None).unwrap();
     let err = ctx.resolve_board_id("shared").unwrap_err().to_string();
     assert!(err.contains("ambiguous"), "got: {err}");
-    assert!(err.contains("UUID"), "got: {err}");
+    // Every match now carries its UUID in the message — no need for the
+    // "Specify by UUID" coda.
+    assert!(err.contains(&b1.id.to_string()), "got: {err}");
+    assert!(err.contains(&b2.id.to_string()), "got: {err}");
 }
 
 // ---------- resolve_column_id ----------
@@ -214,7 +217,8 @@ async fn test_resolve_card_id_not_found_returns_not_found_by_name() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_resolve_card_ids_aggregates_failures() {
+async fn test_resolve_card_ids_aggregates_failures_as_typed_variant() {
+    use kanban_domain::{BatchResolutionCause, DomainError, KanbanError};
     let (mut ctx, _dir) = open_ctx().await;
     let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
     let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
@@ -223,10 +227,42 @@ async fn test_resolve_card_ids_aggregates_failures() {
         .unwrap();
     let ident_ok = format!("KAN-{}", card.card_number);
     let raws: Vec<String> = vec![ident_ok.clone(), "KAN-999".into(), "KAN-998".into()];
-    let err = ctx.resolve_card_ids(&raws).unwrap_err().to_string();
-    assert!(err.contains("2 card"), "got: {err}");
-    assert!(err.contains("KAN-999"), "got: {err}");
-    assert!(err.contains("KAN-998"), "got: {err}");
+
+    let err = ctx.resolve_card_ids(&raws).unwrap_err();
+    assert!(err.is_batch_resolution_failed(), "got: {err:?}");
+
+    // Programmatic introspection: pull out the typed failures.
+    let KanbanError::Domain(DomainError::BatchResolutionFailed { entity, failures }) = err else {
+        panic!("expected BatchResolutionFailed");
+    };
+    assert_eq!(entity, "Card");
+    assert_eq!(failures.len(), 2);
+    let by_input: std::collections::HashMap<_, _> = failures
+        .iter()
+        .map(|f| (f.raw_input.clone(), &f.cause))
+        .collect();
+    assert!(matches!(
+        by_input["KAN-999"],
+        BatchResolutionCause::NotFound
+    ));
+    assert!(matches!(
+        by_input["KAN-998"],
+        BatchResolutionCause::NotFound
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_failure_display_lists_each_input() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let err = ctx
+        .resolve_card_ids(&["KAN-999".into(), "KAN-998".into()])
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("2 card"), "got: {msg}");
+    assert!(msg.contains("'KAN-999'"), "got: {msg}");
+    assert!(msg.contains("'KAN-998'"), "got: {msg}");
+    assert!(msg.contains("not found"), "got: {msg}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/resolve.rs
+++ b/crates/kanban-service/tests/resolve.rs
@@ -205,11 +205,12 @@ async fn test_resolve_card_id_by_identifier() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_resolve_card_id_not_found_returns_validation_error() {
+async fn test_resolve_card_id_not_found_returns_not_found_by_name() {
     let (ctx, _dir) = open_ctx().await;
     let err = ctx.resolve_card_id("KAN-999").unwrap_err();
-    assert!(err.is_validation(), "got: {err}");
-    assert!(err.to_string().contains("Card not found"));
+    assert!(err.is_not_found(), "got: {err}");
+    assert!(err.is_not_found_by_name(), "got: {err}");
+    assert!(err.to_string().contains("'KAN-999' not found"));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -302,4 +303,122 @@ async fn test_uuid_fast_path_returns_uuid_even_when_nothing_exists() {
     let random = Uuid::new_v4();
     // No entities exist; resolver returns the UUID; downstream get_* would be NotFound.
     assert_eq!(ctx.resolve_board_id(&random.to_string()).unwrap(), random);
+}
+
+// ---------- New error variants & API ergonomics (KAN-400 review fixes) ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_miss_returns_not_found_by_name_variant() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("Kanban".into(), None).unwrap();
+    let err = ctx.resolve_board_id("missing").unwrap_err();
+    assert!(err.is_not_found_by_name(), "got: {err:?}");
+    assert!(err.is_not_found(), "umbrella predicate also true");
+    assert!(
+        !err.is_validation(),
+        "no longer the catch-all Validation variant"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_ambiguous_returns_ambiguous_variant() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("Shared".into(), None).unwrap();
+    ctx.create_board("Shared".into(), None).unwrap();
+    let err = ctx.resolve_board_id("shared").unwrap_err();
+    assert!(err.is_ambiguous(), "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_global_with_zero_boards_is_graceful() {
+    // No boards, no columns — error message lists "" (empty available) but doesn't crash.
+    let (ctx, _dir) = open_ctx().await;
+    let err = ctx.resolve_column_id_global("foo").unwrap_err();
+    assert!(err.is_not_found_by_name(), "got: {err:?}");
+    let msg = err.to_string();
+    assert!(msg.contains("'foo'"), "msg: {msg}");
+    // No "Available:" segment when the list is empty.
+    assert!(!msg.contains("Available:"), "msg: {msg}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_global_named_ambiguity_across_boards() {
+    // Two boards, each with a sprint named "alpha"; resolver should flag ambiguity
+    // and name both boards in the matches list.
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("Alpha-Board".into(), None).unwrap();
+    let board_b = ctx.create_board("Beta-Board".into(), None).unwrap();
+    ctx.create_sprint(board_a.id, None, Some("alpha".into()))
+        .unwrap();
+    ctx.create_sprint(board_b.id, None, Some("alpha".into()))
+        .unwrap();
+    let err = ctx.resolve_sprint_id_global("alpha").unwrap_err();
+    assert!(err.is_ambiguous(), "got: {err:?}");
+    let msg = err.to_string();
+    assert!(msg.contains("'Alpha-Board'"), "msg: {msg}");
+    assert!(msg.contains("'Beta-Board'"), "msg: {msg}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_on_board_does_not_bleed_other_board_numbers() {
+    // KAN-400 footgun-regression: with the split API the on-board variant
+    // never matches a sprint from another board, even with the same sprint_number.
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let _s_a = ctx.create_sprint(board_a.id, None, None).unwrap();
+    let s_b = ctx.create_sprint(board_b.id, None, None).unwrap();
+    assert_eq!(s_b.sprint_number, 1, "both sprints are #1 by construction");
+    // Resolving "1" on board B returns the B sprint, not A's.
+    let resolved = ctx.resolve_sprint_id("1", board_b.id).unwrap();
+    assert_eq!(resolved, s_b.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_mixed_uuid_identifier_and_number() {
+    // Single batch with three input shapes: UUID, KAN-N identifier, bare number.
+    // All resolve against one snapshot.
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "one".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "two".into(), Default::default())
+        .unwrap();
+    let c3 = ctx
+        .create_card(board.id, col.id, "three".into(), Default::default())
+        .unwrap();
+
+    let raws: Vec<String> = vec![
+        c1.id.to_string(),                 // raw UUID
+        format!("KAN-{}", c2.card_number), // prefixed identifier
+        c3.card_number.to_string(),        // bare number
+    ];
+    let ids = ctx.resolve_card_ids(&raws).unwrap();
+    assert_eq!(ids, vec![c1.id, c2.id, c3.id]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_takes_single_snapshot_per_batch() {
+    // Behavioural check: even a batch of 10 inputs against 50 cards completes
+    // without per-element backend churn. We assert correctness here; the perf
+    // contract is provable by inspecting the implementation (one set of
+    // list_all_* at the top, then pure in-memory matching).
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let mut all_ids = Vec::new();
+    for i in 0..50 {
+        let c = ctx
+            .create_card(board.id, col.id, format!("c{i}"), Default::default())
+            .unwrap();
+        all_ids.push(c.id);
+    }
+    // Resolve the first 10 by identifier.
+    let raws: Vec<String> = (1..=10).map(|n| format!("KAN-{n}")).collect();
+    let resolved = ctx.resolve_card_ids(&raws).unwrap();
+    assert_eq!(resolved.len(), 10);
+    assert_eq!(resolved, all_ids[0..10]);
 }

--- a/crates/kanban-service/tests/resolve.rs
+++ b/crates/kanban-service/tests/resolve.rs
@@ -1,0 +1,305 @@
+//! Integration tests for the `KanbanOperations` default resolver methods
+//! (`resolve_board_id`, `resolve_column_id`, `resolve_sprint_id`, `resolve_card_id`,
+//! and their `_global` / batch variants). Covered:
+//!   - UUID fast path
+//!   - name fast path (case-insensitive)
+//!   - sprint number fast path
+//!   - miss → message lists alternatives
+//!   - ambiguity → message lists conflicts
+//!   - batch resolvers aggregate failures
+//!   - `require_same_board` accepts homogeneous batches and rejects cross-board ones
+
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{
+    json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext, KanbanOperations,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn open_ctx() -> (KanbanContext, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.json");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    (ctx, dir)
+}
+
+// ---------- resolve_board_id ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_id_by_name_case_insensitive() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx
+        .create_board("Kanban".into(), Some("KAN".into()))
+        .unwrap();
+    assert_eq!(ctx.resolve_board_id("Kanban").unwrap(), board.id);
+    assert_eq!(ctx.resolve_board_id("kanban").unwrap(), board.id);
+    assert_eq!(ctx.resolve_board_id("KANBAN").unwrap(), board.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_id_by_uuid_fast_path() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx
+        .create_board("Kanban".into(), Some("KAN".into()))
+        .unwrap();
+    assert_eq!(
+        ctx.resolve_board_id(&board.id.to_string()).unwrap(),
+        board.id
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_id_not_found_lists_available() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("Kanban".into(), Some("KAN".into()))
+        .unwrap();
+    ctx.create_board("Personal".into(), Some("PER".into()))
+        .unwrap();
+    let err = ctx.resolve_board_id("missing").unwrap_err().to_string();
+    assert!(err.contains("'missing' not found"), "got: {err}");
+    assert!(err.contains("Kanban"), "got: {err}");
+    assert!(err.contains("Personal"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_id_ambiguous_returns_uuid_hint() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("Shared".into(), None).unwrap();
+    ctx.create_board("Shared".into(), None).unwrap();
+    let err = ctx.resolve_board_id("shared").unwrap_err().to_string();
+    assert!(err.contains("ambiguous"), "got: {err}");
+    assert!(err.contains("UUID"), "got: {err}");
+}
+
+// ---------- resolve_column_id ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_by_name_within_board() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    assert_eq!(ctx.resolve_column_id("todo", board.id).unwrap(), col.id);
+    assert_eq!(ctx.resolve_column_id("TODO", board.id).unwrap(), col.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_not_found_lists_columns_on_board() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    ctx.create_column(board.id, "Doing".into(), None).unwrap();
+    let err = ctx
+        .resolve_column_id("nope", board.id)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not found"), "got: {err}");
+    assert!(err.contains("TODO"), "got: {err}");
+    assert!(err.contains("Doing"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_global_finds_unique_across_boards() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let col_a = ctx
+        .create_column(board_a.id, "Backlog".into(), None)
+        .unwrap();
+    ctx.create_column(board_b.id, "Doing".into(), None).unwrap();
+    assert_eq!(ctx.resolve_column_id_global("backlog").unwrap(), col_a.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_global_ambiguous_lists_board_names() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    ctx.create_column(board_a.id, "TODO".into(), None).unwrap();
+    ctx.create_column(board_b.id, "TODO".into(), None).unwrap();
+    let err = ctx
+        .resolve_column_id_global("todo")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("ambiguous"), "got: {err}");
+    assert!(err.contains("'A'"), "got: {err}");
+    assert!(err.contains("'B'"), "got: {err}");
+}
+
+// ---------- resolve_sprint_id ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_by_name() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let sprint = ctx
+        .create_sprint(board.id, None, Some("yarara-release".into()))
+        .unwrap();
+    assert_eq!(
+        ctx.resolve_sprint_id("yarara-release", board.id).unwrap(),
+        sprint.id
+    );
+    assert_eq!(
+        ctx.resolve_sprint_id("YARARA-RELEASE", board.id).unwrap(),
+        sprint.id
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_by_number() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let sprint = ctx
+        .create_sprint(board.id, None, Some("alpha".into()))
+        .unwrap();
+    let n = sprint.sprint_number;
+    assert_eq!(
+        ctx.resolve_sprint_id(&n.to_string(), board.id).unwrap(),
+        sprint.id
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_global_finds_unique() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let _s_a = ctx
+        .create_sprint(board_a.id, None, Some("alpha".into()))
+        .unwrap();
+    let s_b = ctx
+        .create_sprint(board_b.id, None, Some("beta".into()))
+        .unwrap();
+    assert_eq!(ctx.resolve_sprint_id_global("beta").unwrap(), s_b.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_global_ambiguous_number_lists_boards() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let _ = ctx.create_sprint(board_a.id, None, None).unwrap();
+    let _ = ctx.create_sprint(board_b.id, None, None).unwrap();
+    let err = ctx.resolve_sprint_id_global("1").unwrap_err().to_string();
+    assert!(err.contains("ambiguous"), "got: {err}");
+    assert!(err.contains("'A'"), "got: {err}");
+    assert!(err.contains("'B'"), "got: {err}");
+}
+
+// ---------- resolve_card_id / resolve_card_ids ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_id_by_identifier() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "Hello".into(), Default::default())
+        .unwrap();
+    let ident = format!("KAN-{}", card.card_number);
+    assert_eq!(ctx.resolve_card_id(&ident).unwrap(), card.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_id_not_found_returns_validation_error() {
+    let (ctx, _dir) = open_ctx().await;
+    let err = ctx.resolve_card_id("KAN-999").unwrap_err();
+    assert!(err.is_validation(), "got: {err}");
+    assert!(err.to_string().contains("Card not found"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_aggregates_failures() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "ok".into(), Default::default())
+        .unwrap();
+    let ident_ok = format!("KAN-{}", card.card_number);
+    let raws: Vec<String> = vec![ident_ok.clone(), "KAN-999".into(), "KAN-998".into()];
+    let err = ctx.resolve_card_ids(&raws).unwrap_err().to_string();
+    assert!(err.contains("2 card"), "got: {err}");
+    assert!(err.contains("KAN-999"), "got: {err}");
+    assert!(err.contains("KAN-998"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_success_returns_all_uuids() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "one".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "two".into(), Default::default())
+        .unwrap();
+    let raws: Vec<String> = vec![format!("KAN-{}", c1.card_number), c2.id.to_string()];
+    let ids = ctx.resolve_card_ids(&raws).unwrap();
+    assert_eq!(ids, vec![c1.id, c2.id]);
+}
+
+// ---------- require_same_board ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_require_same_board_accepts_homogeneous_batch() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "one".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "two".into(), Default::default())
+        .unwrap();
+    let shared = ctx.require_same_board(&[c1.id, c2.id]).unwrap();
+    assert_eq!(shared, board.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_require_same_board_rejects_cross_board_batch() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx
+        .create_board("Kanban".into(), Some("KAN".into()))
+        .unwrap();
+    let board_b = ctx
+        .create_board("Personal".into(), Some("PER".into()))
+        .unwrap();
+    let col_a = ctx.create_column(board_a.id, "TODO".into(), None).unwrap();
+    let col_b = ctx.create_column(board_b.id, "TODO".into(), None).unwrap();
+    let c_a = ctx
+        .create_card(board_a.id, col_a.id, "a".into(), Default::default())
+        .unwrap();
+    let c_b = ctx
+        .create_card(board_b.id, col_b.id, "b".into(), Default::default())
+        .unwrap();
+    let err = ctx
+        .require_same_board(&[c_a.id, c_b.id])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("same board"), "got: {err}");
+    assert!(err.contains("'Kanban'"), "got: {err}");
+    assert!(err.contains("'Personal'"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_require_same_board_empty_batch_errors() {
+    let (ctx, _dir) = open_ctx().await;
+    let err = ctx.require_same_board(&[]).unwrap_err().to_string();
+    assert!(err.contains("No cards"), "got: {err}");
+}
+
+// ---------- UUID fast path doesn't accidentally do lookup ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_uuid_fast_path_returns_uuid_even_when_nothing_exists() {
+    let (ctx, _dir) = open_ctx().await;
+    let random = Uuid::new_v4();
+    // No entities exist; resolver returns the UUID; downstream get_* would be NotFound.
+    assert_eq!(ctx.resolve_board_id(&random.to_string()).unwrap(), random);
+}

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -231,6 +231,18 @@ impl KanbanOperations for TuiContext {
         self.inner.find_cards_by_identifier(identifier)
     }
 
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<kanban_domain::Column>> {
+        self.inner.list_all_columns()
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<kanban_domain::Sprint>> {
+        self.inner.list_all_sprints()
+    }
+
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         let r = self.inner.update_card(id, updates);
         self.with_flush(r)


### PR DESCRIPTION
Lift the UUID requirement off every CLI command and MCP tool. Names (and sprint numbers) now work wherever a UUID used to be required; UUIDs still work for scripting. Flag and field names dropped their misleading `-id` suffix in the same PR.

## What changed

- **CLI**: every entity argument accepts a UUID, a name, or (for sprints) a sprint number, or (for cards) a `KAN-N` identifier or bare card number. The `--board-id` / `--column-id` / `--sprint-id` flags became `--board` / `--column` / `--sprint`; the batch `--ids` flag became `--cards`; positional `<ID>` placeholders became entity-specific (`<BOARD>`, `<COLUMN>`, `<CARD>`, `<SPRINT>`).
- **MCP**: every tool input schema field renamed to match (`board_id` → `board`, `column_id` → `column`, `sprint_id` → `sprint`, `card_id` → `card`, batch `ids` → `cards`, `from_sprint_id` → `from_sprint`, `to_sprint_id` → `to_sprint`). Tool descriptions widened to "UUID or name" (or "UUID, name, or number" for sprints). Batch tools take a `Vec<String>` (JSON array) instead of a comma-separated string.
- **Errors**: on miss, the resolver lists what's available (`Column 'done' not found. Available: 'TODO', 'Doing', 'Complete'`); on cross-board ambiguity, it names the conflicting boards. Same message reaches CLI stderr and MCP `invalid_params` because both surface the same `KanbanError::validation`.
- **Batch same-board enforcement**: `card move-cards` and `card assign-cards-to-sprint` validate that all selected cards share a board before resolving the target column/sprint, so the target is unambiguous.
- **TUI**: no behaviour change. Its only free-text entity input (the card search bar) already routes through `CompositeSearcher::all()`. The new resolvers are available to it for future text-input features (command palette, jump-to-board) with no new plumbing.

## CLI usage diffs

Single-card flow:

```diff
-kanban card create --board-id e119c091-... --column-id db3aaee8-... --title "Fix the bug"
+kanban card create --board Kanban --column TODO --title "Fix the bug"

-kanban card move 6b3a-... --column-id db3aaee8-...
+kanban card move KAN-12 --column Doing

-kanban card assign-sprint 6b3a-... --sprint-id 6927495b-...
+kanban card assign-sprint KAN-12 --sprint yarara-release    # by sprint name
+kanban card assign-sprint KAN-12 --sprint 15                # by sprint number

-kanban card restore 6b3a-... --column-id db3aaee8-...
+kanban card restore KAN-12 --column TODO
```

Board / column / sprint subcommands:

```diff
-kanban board get e119c091-e1fa-4596-9bc7-038ceab6adec
+kanban board get Kanban

-kanban board update e119c091-... --card-prefix KAN
+kanban board update Kanban --card-prefix KAN

-kanban column list --board-id e119c091-...
+kanban column list --board Kanban

-kanban column get db3aaee8-0f13-4afa-b000-592bac0bf364
+kanban column get Doing

-kanban sprint create --board-id e119c091-... --name yarara-release
+kanban sprint create --board Kanban --name yarara-release

-kanban sprint activate 6927495b-...
+kanban sprint activate yarara-release       # by name
+kanban sprint activate 15                   # by number

-kanban sprint carry-over --from 6927495b-... --to 8a1b2c3d-...
+kanban sprint carry-over --from yarara-release --to moonshot
```

Filtered list (column/sprint scope to `--board` when given, else search globally):

```diff
-kanban card list --board-id e119c091-... --column-id db3aaee8-... --sprint-id 6927495b-...
+kanban card list --board Kanban --column Doing --sprint yarara-release
```

Batch operations (note `--ids` is now `--cards`, and a same-board check runs before the mutation):

```diff
-kanban card move-cards --ids 6b3a-...,7c4b-... --column-id db3aaee8-...
+kanban card move-cards --cards KAN-1,KAN-2 --column Doing

-kanban card assign-cards-to-sprint --ids 6b3a-...,7c4b-... --sprint-id 6927495b-...
+kanban card assign-cards-to-sprint --cards KAN-1,KAN-2 --sprint yarara-release
```

Export:

```diff
-kanban export --board-id e119c091-...
+kanban export --board Kanban
```

Error UX (new):

```
$ kanban column get nonexistent
Error: validation error: Column 'nonexistent' not found. Available: 'TODO', 'Doing', 'Complete'

$ kanban board get Personal
Error: validation error: Board 'Personal' not found. Available: 'Kanban'

$ kanban card move-cards --cards KAN-1,FOO-2 --column Doing
Error: validation error: Batch operation requires all cards on the same board, but the selection spans boards: 'Kanban', 'Personal'
```

## MCP schema diff

```diff
 tool_move_card {
-  card_id:   String,
-  column_id: String,
+  card:   String,    // UUID or KAN-N identifier
+  column: String,    // UUID or name (resolved on the card's board)
   position:  Option<i32>,
 }

 tool_assign_card_to_sprint {
-  card_id:   String,
-  sprint_id: String,
+  card:   String,
+  sprint: String,    // UUID, name, or number (resolved on the card's board)
 }

 tool_move_cards {
-  ids: String,            // comma-separated UUIDs
-  column_id: String,
+  cards: Vec<String>,     // ["KAN-1", "KAN-2"] or UUIDs; must share a board
+  column: String,         // resolved on that shared board
 }

 tool_carry_over_sprint_cards {
-  from_sprint_id: String,
-  to_sprint_id:   String,
+  from_sprint: String,    // UUID, name, or number
+  to_sprint:   String,    // resolved on from_sprint's board
 }
```

LLM clients that cached the old schema need to re-fetch.

## What

Every entity argument in the CLI and MCP layers accepts a human-readable name (board name, column name, sprint name or number, card identifier) in addition to a UUID. The `-id` suffix on flag and schema field names was dropped because it was misleading.

## Why

Card KAN-400 captures the problem: `kanban card move KAN-12 --column-id c2a0d5e2-...` is unusable from memory, and the same is true of every other entity argument. Users were copy-pasting UUIDs out of `kanban board list` output before every command. The scope was expanded from the card body (CLI-only, four flags) to every CLI command, every MCP tool, every entity type, so an LLM driving the MCP server gets the same ergonomics as a human at the shell.

## How

Pure name-matching lives in `kanban-domain::search` next to the existing `find_cards_by_identifier`. I/O-orchestrated resolvers live as **default methods** on the `KanbanOperations` trait, so adding them touched one file and lit up every consumer (`CliContext`, `KanbanContext`, `McpContext`, `TuiContext`). CLI and MCP handlers swap their `parse_uuid` calls for `ctx.resolve_*`. For `card move`, `card restore`, `card assign-sprint`, and the batch ops, the target column/sprint is resolved within the card's own board (derived via card → column → board). On miss the resolver lists alternatives; on ambiguity across boards it names the conflicting boards and asks for a UUID or unique name. Errors are identical between CLI and MCP because both surface the resolver's `KanbanError::validation` message verbatim.

The clap parse layer stays `String`-typed for entity args, but every method below the resolver is still strictly `Uuid`-typed. The type-safety frontier just moved inward by one helper call; domain models (`Card.id`, `Board.id`, etc.) and service-method signatures didn't change.

## Testing

- `cargo test -p kanban-domain --lib search` — 9 new pure-function tests for the matchers
- `cargo test -p kanban-service --test resolve` — 20 new integration tests for the resolver methods (UUID fast path, case-insensitive name match, sprint-number resolution, not-found message lists alternatives, ambiguity message lists conflicts, batch failure aggregation, same-board enforcement)
- `cargo test -p kanban-cli --test cli_integration name_resolution` — 23 new end-to-end tests including the cross-board batch-rejection path
- `cargo test -p kanban-mcp --test integration` — 6 new MCP-context resolver tests
- `cargo test --workspace` — no regressions
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

Manual smoke against a real workspace (`./kanban.json`):

```
$ kanban ./kanban.json board get Kanban                                      → ok
$ kanban ./kanban.json sprint get yarara-release                             → sprint #15
$ kanban ./kanban.json sprint get 15                                         → same sprint
$ kanban ./kanban.json column list --board Kanban                            → TODO, Doing, Complete
$ kanban ./kanban.json card list --board Kanban --sprint yarara-release      → 94 cards
$ kanban ./kanban.json column get nonexistent                                → lists available
$ kanban ./kanban.json board get Personal                                    → lists available
```
