### PR TITLE
Release 0.6.0

### DIFF
--- a/.changeset/cat-323-fix-misleading-card-not-found-error-when-board-file-does-not-exist.md
+++ b/.changeset/cat-323-fix-misleading-card-not-found-error-when-board-file-does-not-exist.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 Running `kanban missing.json card get KAN-1` (or any subcommand) when the

--- a/.changeset/cat-323-fix-misleading-card-not-found-error-when-board-file-does-not-exist.md
+++ b/.changeset/cat-323-fix-misleading-card-not-found-error-when-board-file-does-not-exist.md
@@ -1,0 +1,16 @@
+---
+bump: patch
+---
+
+Running `kanban missing.json card get KAN-1` (or any subcommand) when the
+file does not exist now reports `Board file not found: 'missing.json'`
+instead of the misleading `Card not found: 'KAN-1'`. The check covers
+every path that can supply the file — positional argument, `KANBAN_FILE`
+environment variable, and `storage_location` in the config file.
+
+`board create` previously had an implicit dual role: it created the domain
+entity AND initialised the storage file when it did not exist yet. That
+responsibility has moved to `kanban <file>` with no subcommand. Running
+`kanban newboard.json` now creates an empty storage file if one does not
+exist and exits cleanly, making it safe to use in scripts and CI without a
+live terminal. In a TTY the TUI launches as before.

--- a/.changeset/editor-improve-robustness.md
+++ b/.changeset/editor-improve-robustness.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+Refactor editor functionality to handle arbitrary EDITOR strings
+
+- Allow the user-defined EDITOR to fully determine what editor launches and how, while preserving limited fallback behavior to `notepad` and `vi` for Windows and non-Windows respectively
+- VS Code is still broken due to issues with `code --wait`, so editors that stay in the terminal are heavily preferred
+- Vim-like editors are the most well-tested for this project and expected to work on every OS without issue
+- Separate installs are currently recommended for Windows and WSL, as switching between them with the same binary can trigger consistent recompiles
+- On Windows, it is strongly recommended to set your `EDITOR` to a program that is in your `PATH`, for example `$env:EDITOR = "vim.exe"` in PowerShell. Path resolution for Windows-like paths in your `EDITOR` will cause issues.

--- a/.changeset/kan-328-sprint-filter-toast.md
+++ b/.changeset/kan-328-sprint-filter-toast.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Pressing `t` to toggle the active-sprint filter on a board that has no
+active sprint now surfaces an error banner reading "No active sprint set
+for filtering" instead of failing silently. Previously the keypress
+appeared to do nothing while quietly emitting a warning to the trace log,
+leaving users confused about why the card list did not change.

--- a/.changeset/kan-400-accept-names-everywhere.md
+++ b/.changeset/kan-400-accept-names-everywhere.md
@@ -1,0 +1,76 @@
+---
+bump: minor
+---
+
+Every CLI command and MCP tool now accepts a human-readable name (or sprint
+number) anywhere it previously required a raw UUID. Plain UUIDs continue to
+work, so existing scripts that already use UUIDs still resolve correctly.
+
+You can now write things like:
+
+```
+kanban board get Kanban
+kanban column list --board Kanban
+kanban sprint activate yarara-release
+kanban sprint get 15
+kanban card create --board Kanban --column TODO --title "Hi"
+kanban card move KAN-12 --column Doing
+kanban card move-cards --cards KAN-1,KAN-2 --column Doing
+kanban card assign-cards-to-sprint --cards KAN-1,KAN-2 --sprint yarara-release
+```
+
+The same input flexibility applies to every MCP tool. Board, column, and
+sprint fields in tool schemas now read "UUID or name" (or "UUID, name, or
+number" for sprints) instead of demanding a UUID. The batch tools
+`archive_cards`, `move_cards`, and `assign_cards_to_sprint` take a JSON array
+of card UUIDs or identifiers (for example `["KAN-1", "KAN-2"]`) in place of
+the old comma-separated string.
+
+**Breaking flag and field renames.** Now that these inputs accept names, the
+old `--*-id` flag names and `*_id` schema fields were misleading and have
+been replaced with the bare entity name:
+
+CLI flags:
+
+| Old                                  | New                              |
+| ------------------------------------ | -------------------------------- |
+| `--board-id`                         | `--board`                        |
+| `--column-id`                        | `--column`                       |
+| `--sprint-id`                        | `--sprint`                       |
+| `--ids` (on `card archive-cards`, `card move-cards`, `card assign-cards-to-sprint`) | `--cards` |
+
+Positional arguments now show `<BOARD>` / `<COLUMN>` / `<CARD>` / `<SPRINT>`
+in `--help` output instead of the generic `<ID>`.
+
+MCP tool input fields:
+
+| Old                  | New              |
+| -------------------- | ---------------- |
+| `board_id`           | `board`          |
+| `column_id`          | `column`         |
+| `sprint_id`          | `sprint`         |
+| `card_id`            | `card`           |
+| `ids` (batch tools)  | `cards`          |
+| `from_sprint_id`     | `from_sprint`    |
+| `to_sprint_id`       | `to_sprint`      |
+
+No aliases are kept. Update scripts and MCP clients to the new spellings.
+
+When a name does not match, the error tells you exactly what is available,
+for example: `Column 'done' not found. Available: 'TODO', 'Doing', 'Complete'`.
+When a name is ambiguous across boards, the error names the boards in
+conflict and asks you to disambiguate by UUID or a unique name.
+
+For `card move-cards` and `card assign-cards-to-sprint`, the selection must
+now share a single board so the target column or sprint can be resolved
+unambiguously within it; mixing cards from different boards produces a clear
+"Batch operation requires all cards on the same board" error.
+
+Names are case-insensitive. Sprints accept either a name (matched against
+the board's stored sprint names) or a sprint number. Cards accept their
+prefix-number identifier (such as `KAN-5`) or a bare card number, in
+addition to the full UUID.
+
+The TUI is unchanged in this release, but the same resolver functions are
+now available to it for future text-input features (command palette,
+jump-to-board, and so on).

--- a/.changeset/kan-455-no-scrolling-in-board-edit-view-sprint-and-column-lists.md
+++ b/.changeset/kan-455-no-scrolling-in-board-edit-view-sprint-and-column-lists.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+---
+
+The sprint and column lists in the board edit view, and the sprint
+section of the card list filter popup, now scroll to keep the selected
+item visible. Previously these three lists tracked the j/k cursor but
+never scrolled, so items past the visible area of the panel were
+unreachable on small terminals or on boards with many sprints or
+columns.
+
+Scrolling matches the minimal-scroll behavior of the main card list:
+the viewport only shifts when the cursor crosses an edge, so navigating
+back and forth inside the visible area no longer reshuffles the list.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "shell-words",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -1385,6 +1386,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -2216,6 +2218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +2989,15 @@ name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/README.md
+++ b/README.md
@@ -40,12 +40,16 @@ export KANBAN_FILE=boards.json   # or pass the path as the first argument
 
 kanban board create --name "My Project"
 kanban board list
-kanban card create --board-id <ID> --column-id <ID> --title "Fix the bug" --priority high
-kanban card list --board-id <ID>
-kanban sprint create --board-id <ID>
-kanban sprint activate <SPRINT_ID> --duration-days 14
-kanban card assign-sprint <CARD_ID> --sprint-id <SPRINT_ID>
+kanban card create --board "My Project" --column TODO --title "Fix the bug" --priority high
+kanban card list --board "My Project"
+kanban sprint create --board "My Project"
+kanban sprint activate yarara-release --duration-days 14
+kanban card assign-sprint KAN-5 --sprint yarara-release
 ```
+
+Every entity argument accepts either a UUID or a human-readable name (sprint
+numbers also work for sprints; cards accept their `KAN-N` identifier). When a
+name doesn't match, the error lists what's available.
 
 All commands output JSON. Use `kanban --help` for full reference.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ For `y`/`Y` clipboard operations to persist after the app exits, you need a clip
 - **Wayland**: `wl-clip-persist`, `cliphist`, `clipman`, or your DE's built-in manager
 - **X11**: Most desktop environments include one by default
 
+### Windows and WSL
+
+If your setup is Windows and WSL, and you often switch between them, then it is recommended to install separate binaries for each system to avoid constant recompiles.
+
+---
+
+## EDITOR configuration
+
+Changes are made in an external editor as defined by your `EDITOR`. Neovim, nano, or some other terminal-based editor is recommended, both for easier switching between edits and browsing, and because editors that leave the terminal may cause issues.
+
+VS Code is known not to work in the current implementation.
+
+`kanban` is well-tested on supported OSes and is designed to be shell-agnostic. If your `EDITOR` is not set, it will default to `notepad` on Windows and `vi` otherwise.
+
 ---
 
 ## Features

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -36,8 +36,8 @@ kanban board delete <ID>
 ### `column`
 
 ```bash
-kanban column create --board-id <ID> --name <NAME> [--position <N>]
-kanban column list --board-id <ID>
+kanban column create --board <ID> --name <NAME> [--position <N>]
+kanban column list --board <ID>
 kanban column get <ID>
 kanban column update <ID> [--name <NAME>] [--position <N>] [--wip-limit <N>]
 kanban column delete <ID>
@@ -48,10 +48,10 @@ kanban column reorder <ID> --position <N>
 
 ```bash
 # CRUD
-kanban card create --board-id <ID> --column-id <ID> --title <TITLE>
+kanban card create --board <ID> --column <ID> --title <TITLE>
                    [--description <DESC>] [--priority low|medium|high|critical]
                    [--points <N>] [--due-date <YYYY-MM-DD>]
-kanban card list [--board-id <ID>] [--column-id <ID>] [--sprint-id <ID>]
+kanban card list [--board <ID>] [--column <ID>] [--sprint <ID>]
                  [--status todo|in_progress|blocked|done]
                  [--page <N>] [--page-size <N>]
 kanban card get <ID_OR_IDENTIFIER>
@@ -61,12 +61,12 @@ kanban card update <ID_OR_IDENTIFIER> [--title <TITLE>] [--description <DESC>]
 kanban card delete <ID_OR_IDENTIFIER>
 
 # Movement & archiving
-kanban card move <ID_OR_IDENTIFIER> --column-id <ID> [--position <N>]
+kanban card move <ID_OR_IDENTIFIER> --column <ID> [--position <N>]
 kanban card archive <ID_OR_IDENTIFIER>
-kanban card restore <ID_OR_IDENTIFIER> [--column-id <ID>]
+kanban card restore <ID_OR_IDENTIFIER> [--column <ID>]
 
 # Sprint
-kanban card assign-sprint <ID_OR_IDENTIFIER> --sprint-id <ID>
+kanban card assign-sprint <ID_OR_IDENTIFIER> --sprint <ID>
 kanban card unassign-sprint <ID_OR_IDENTIFIER>
 
 # Git
@@ -74,9 +74,9 @@ kanban card branch-name <ID_OR_IDENTIFIER>
 kanban card git-checkout <ID_OR_IDENTIFIER>
 
 # Bulk operations
-kanban card archive-cards --ids <UUID,UUID,...>
-kanban card move-cards --ids <UUID,UUID,...> --column-id <ID>
-kanban card assign-cards-to-sprint --ids <UUID,UUID,...> --sprint-id <ID>
+kanban card archive-cards --cards <UUID,UUID,...>
+kanban card move-cards --cards <UUID,UUID,...> --column <ID>
+kanban card assign-cards-to-sprint --cards <UUID,UUID,...> --sprint <ID>
 ```
 
 **Card identifier resolution**: `<ID_OR_IDENTIFIER>` accepts:
@@ -87,8 +87,8 @@ kanban card assign-cards-to-sprint --ids <UUID,UUID,...> --sprint-id <ID>
 ### `sprint`
 
 ```bash
-kanban sprint create --board-id <ID> [--name <NAME>] [--prefix <PREFIX>]
-kanban sprint list --board-id <ID>
+kanban sprint create --board <ID> [--name <NAME>] [--prefix <PREFIX>]
+kanban sprint list --board <ID>
 kanban sprint get <ID>
 kanban sprint update <ID> [--name <NAME>] [--prefix <PREFIX>]
                           [--card-prefix <PREFIX>]
@@ -103,7 +103,7 @@ kanban sprint carry-over --from <ID> --to <ID>
 ### Top-level commands
 
 ```bash
-kanban export [--board-id <ID>] [--output <FILE>]
+kanban export [--board <ID>] [--output <FILE>]
 kanban import <FILE>
 kanban migrate <SOURCE> <BACKEND> [-o <OUTPUT>] [--source-backend <BACKEND>]
 kanban completions <bash|zsh|fish|powershell>

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -280,22 +280,43 @@ Provide the file path in one of these ways:
 
         match command {
             None => {
-                #[cfg(feature = "tui")]
-                {
-                    let error_log = std::sync::Arc::new(std::sync::Mutex::new(
-                        kanban_tui::error_log::ErrorLogState::default(),
-                    ));
-                    init_tracing_tui(std::sync::Arc::clone(&error_log));
-
-                    let (mut app, save_rx) =
-                        App::new_with_store(store_manager, validated_file).await?;
-                    app.set_error_log(error_log);
-                    app.run(save_rx).await?;
+                // KANBAN_FILE env var resolves into validated_file via clap's env attribute.
+                let has_explicit_file =
+                    validated_file.is_some() || config.storage_location.is_some();
+                if has_explicit_file && !std::path::Path::new(&effective_file).exists() {
+                    use kanban_domain::Snapshot;
+                    use kanban_persistence::{
+                        snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot,
+                    };
+                    let store =
+                        store_manager.make_store_with_config(validated_file.as_deref(), &config)?;
+                    let data = snapshot_to_json_bytes(&Snapshot::new())
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    let metadata = PersistenceMetadata::new(uuid::Uuid::new_v4());
+                    store
+                        .save(StoreSnapshot { data, metadata })
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
                 }
-                #[cfg(not(feature = "tui"))]
-                anyhow::bail!(
-                    "TUI not available in this build. Run `kanban --help` for available subcommands."
-                );
+                use std::io::IsTerminal;
+                if std::io::stdin().is_terminal() {
+                    #[cfg(feature = "tui")]
+                    {
+                        let error_log = std::sync::Arc::new(std::sync::Mutex::new(
+                            kanban_tui::error_log::ErrorLogState::default(),
+                        ));
+                        init_tracing_tui(std::sync::Arc::clone(&error_log));
+                        let (mut app, save_rx) =
+                            App::new_with_store(store_manager, validated_file).await?;
+                        app.set_error_log(error_log);
+                        app.run(save_rx).await?;
+                    }
+                    #[cfg(not(feature = "tui"))]
+                    anyhow::bail!(
+                        "TUI not available in this build. Run `kanban --help` for available subcommands."
+                    );
+                }
+                // Non-TTY: file created above if needed, exit cleanly.
             }
             Some(Commands::Completions { .. }) => unreachable!(),
             Some(Commands::Migrate(args)) => {
@@ -304,6 +325,12 @@ Provide the file path in one of these ways:
             }
             Some(cmd) => {
                 init_tracing_cli();
+                if !std::path::Path::new(&effective_file).exists() {
+                    return crate::output::output_error(&format!(
+                        "Board file not found: '{}'",
+                        effective_file
+                    ));
+                }
                 let mut ctx = CliContext::load(&store_manager, &effective_file, config).await?;
                 dispatch_subcommand(&mut ctx, cmd).await?;
             }

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -1,5 +1,4 @@
 use clap::{Args, Parser, Subcommand};
-use uuid::Uuid;
 
 use kanban_core::VERSION;
 
@@ -62,24 +61,24 @@ pub enum BoardAction {
         #[arg(long)]
         page_size: Option<u32>,
     },
-    /// Get a specific board by ID
+    /// Get a specific board by UUID or name
     Get {
-        /// Board ID
-        id: Uuid,
+        /// Board UUID or name
+        board: String,
     },
     /// Update a board
     Update(BoardUpdateArgs),
-    /// Delete a board by ID
+    /// Delete a board by UUID or name
     Delete {
-        /// Board ID
-        id: Uuid,
+        /// Board UUID or name
+        board: String,
     },
 }
 
 #[derive(Args)]
 pub struct BoardUpdateArgs {
-    /// Board ID to update
-    pub id: Uuid,
+    /// Board UUID or name
+    pub board: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -101,8 +100,9 @@ pub struct ColumnCommand {
 pub enum ColumnAction {
     /// Create a new column
     Create {
+        /// Board UUID or name
         #[arg(long)]
-        board_id: Uuid,
+        board: String,
         #[arg(long)]
         name: String,
         #[arg(long)]
@@ -110,29 +110,30 @@ pub enum ColumnAction {
     },
     /// List columns for a board
     List {
+        /// Board UUID or name
         #[arg(long)]
-        board_id: Uuid,
+        board: String,
         #[arg(long)]
         page: Option<u32>,
         #[arg(long)]
         page_size: Option<u32>,
     },
-    /// Get a specific column by ID
+    /// Get a specific column by UUID or name
     Get {
-        /// Column ID
-        id: Uuid,
+        /// Column UUID or name
+        column: String,
     },
     /// Update a column
     Update(ColumnUpdateArgs),
-    /// Delete a column by ID
+    /// Delete a column by UUID or name
     Delete {
-        /// Column ID
-        id: Uuid,
+        /// Column UUID or name
+        column: String,
     },
-    /// Reorder a column by ID
+    /// Reorder a column by UUID or name
     Reorder {
-        /// Column ID
-        id: Uuid,
+        /// Column UUID or name
+        column: String,
         #[arg(long)]
         position: i32,
     },
@@ -140,8 +141,8 @@ pub enum ColumnAction {
 
 #[derive(Args)]
 pub struct ColumnUpdateArgs {
-    /// Column ID to update
-    pub id: Uuid,
+    /// Column UUID or name
+    pub column: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -165,91 +166,101 @@ pub enum CardAction {
     Create(CardCreateArgs),
     /// List cards with optional filters
     List(CardListArgs),
-    /// Get a specific card by ID or identifier (e.g. KAN-5)
+    /// Get a specific card by UUID or identifier (e.g. KAN-5)
     Get {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Update a card
     Update(CardUpdateArgs),
     /// Move a card to another column
     Move {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
+        /// Column UUID or name
         #[arg(long)]
-        column_id: Uuid,
+        column: String,
         #[arg(long)]
         position: Option<i32>,
     },
-    /// Archive a card by ID or identifier (e.g. KAN-5)
+    /// Archive a card by UUID or identifier (e.g. KAN-5)
     Archive {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
-    /// Restore an archived card by ID or identifier (e.g. KAN-5)
+    /// Restore an archived card by UUID or identifier (e.g. KAN-5)
     Restore {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
+        /// Column UUID or name
         #[arg(long)]
-        column_id: Option<Uuid>,
+        column: Option<String>,
     },
-    /// Permanently delete an archived card by ID or identifier (e.g. KAN-5)
+    /// Permanently delete an archived card by UUID or identifier (e.g. KAN-5)
     Delete {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Assign a card to a sprint
     AssignSprint {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
+        /// Sprint UUID, name, or number
         #[arg(long)]
-        sprint_id: Uuid,
+        sprint: String,
     },
     /// Unassign a card from its sprint
     UnassignSprint {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Get the branch name for a card
     BranchName {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Get the git checkout command for a card
     GitCheckout {
         /// Card UUID or identifier like KAN-5 or 5
-        id: String,
+        card: String,
     },
     /// Archive multiple cards
     #[command(name = "archive-cards")]
     ArchiveCards {
+        /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<Uuid>,
+        cards: Vec<String>,
     },
     /// Move multiple cards to a column
     #[command(name = "move-cards")]
     MoveCards {
+        /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<Uuid>,
+        cards: Vec<String>,
+        /// Column UUID or name (must be on the same board as all selected cards)
         #[arg(long)]
-        column_id: Uuid,
+        column: String,
     },
     /// Assign multiple cards to a sprint
     #[command(name = "assign-cards-to-sprint")]
     AssignCardsToSprint {
+        /// Comma-separated card UUIDs or identifiers (e.g. KAN-1,KAN-2,42)
         #[arg(long, value_delimiter = ',')]
-        ids: Vec<Uuid>,
+        cards: Vec<String>,
+        /// Sprint UUID, name, or number (must be on the same board as all selected cards)
         #[arg(long)]
-        sprint_id: Uuid,
+        sprint: String,
     },
 }
 
 #[derive(Args)]
 pub struct CardCreateArgs {
+    /// Board UUID or name
     #[arg(long)]
-    pub board_id: Uuid,
+    pub board: String,
+    /// Column UUID or name
     #[arg(long)]
-    pub column_id: Uuid,
+    pub column: String,
     #[arg(long)]
     pub title: String,
     #[arg(long)]
@@ -264,12 +275,15 @@ pub struct CardCreateArgs {
 
 #[derive(Args)]
 pub struct CardListArgs {
+    /// Board UUID or name
     #[arg(long)]
-    pub board_id: Option<Uuid>,
+    pub board: Option<String>,
+    /// Column UUID or name (scoped to --board if given, else searched globally)
     #[arg(long)]
-    pub column_id: Option<Uuid>,
+    pub column: Option<String>,
+    /// Sprint UUID, name, or number (scoped to --board if given, else searched globally)
     #[arg(long)]
-    pub sprint_id: Option<Uuid>,
+    pub sprint: Option<String>,
     #[arg(long)]
     pub status: Option<String>,
     #[arg(long)]
@@ -283,7 +297,7 @@ pub struct CardListArgs {
 #[derive(Args)]
 pub struct CardUpdateArgs {
     /// Card UUID or identifier like KAN-5 or 5
-    pub id: String,
+    pub card: String,
     #[arg(long)]
     pub title: Option<String>,
     #[arg(long)]
@@ -311,8 +325,9 @@ pub struct SprintCommand {
 pub enum SprintAction {
     /// Create a new sprint
     Create {
+        /// Board UUID or name
         #[arg(long)]
-        board_id: Uuid,
+        board: String,
         #[arg(long)]
         prefix: Option<String>,
         #[arg(long)]
@@ -320,57 +335,58 @@ pub enum SprintAction {
     },
     /// List sprints for a board
     List {
+        /// Board UUID or name
         #[arg(long)]
-        board_id: Uuid,
+        board: String,
         #[arg(long)]
         page: Option<u32>,
         #[arg(long)]
         page_size: Option<u32>,
     },
-    /// Get a specific sprint by ID
+    /// Get a specific sprint by UUID, name, or number
     Get {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        sprint: String,
     },
     /// Update a sprint
     Update(SprintUpdateArgs),
-    /// Activate a sprint by ID
+    /// Activate a sprint by UUID, name, or number
     Activate {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        sprint: String,
         #[arg(long)]
         duration_days: Option<i32>,
     },
-    /// Complete a sprint by ID
+    /// Complete a sprint by UUID, name, or number
     Complete {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        sprint: String,
     },
-    /// Cancel a sprint by ID
+    /// Cancel a sprint by UUID, name, or number
     Cancel {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        sprint: String,
     },
-    /// Delete a sprint by ID
+    /// Delete a sprint by UUID, name, or number
     Delete {
-        /// Sprint ID
-        id: Uuid,
+        /// Sprint UUID, name, or number
+        sprint: String,
     },
     /// Carry over uncompleted cards from a completed sprint to a planning sprint
     CarryOver {
-        /// ID of the completed sprint to carry cards from
+        /// Source sprint UUID, name, or number (must be completed)
         #[arg(long)]
-        from: Uuid,
-        /// ID of the planning sprint to carry cards to
+        from: String,
+        /// Target sprint UUID, name, or number (must be in planning; on same board as source)
         #[arg(long)]
-        to: Uuid,
+        to: String,
     },
 }
 
 #[derive(Args)]
 pub struct SprintUpdateArgs {
-    /// Sprint ID to update
-    pub id: Uuid,
+    /// Sprint UUID, name, or number
+    pub sprint: String,
     #[arg(long)]
     pub name: Option<String>,
     #[arg(long)]
@@ -410,8 +426,9 @@ pub struct MigrateArgs {
 // Export/Import commands
 #[derive(Args)]
 pub struct ExportArgs {
+    /// Board UUID or name; if omitted, exports all boards
     #[arg(long)]
-    pub board_id: Option<Uuid>,
+    pub board: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -124,6 +124,18 @@ impl KanbanOperations for CliContext {
         self.inner.find_cards_by_identifier(identifier)
     }
 
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<kanban_domain::Column>> {
+        self.inner.list_all_columns()
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<kanban_domain::Sprint>> {
+        self.inner.list_all_sprints()
+    }
+
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         self.inner.update_card(id, updates)
     }

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -16,18 +16,28 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(boards, page, page_size)?);
         }
-        BoardAction::Get { id } => match ctx.get_board(id)? {
-            Some(board) => output::output_success(&board),
-            None => return output::output_error(&format!("Board not found: {}", id)),
-        },
+        BoardAction::Get { board } => {
+            let uuid = match ctx.resolve_board_id(&board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            match ctx.get_board(uuid)? {
+                Some(b) => output::output_success(&b),
+                None => return output::output_error(&format!("Board not found: {}", board)),
+            }
+        }
         BoardAction::Update(args) => {
             let board = handle_update(ctx, args).await?;
             output::output_success(&board);
         }
-        BoardAction::Delete { id } => {
-            ctx.delete_board(id)?;
+        BoardAction::Delete { board } => {
+            let uuid = match ctx.resolve_board_id(&board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            ctx.delete_board(uuid)?;
             ctx.save().await?;
-            output::output_success(serde_json::json!({"deleted": id.to_string()}));
+            output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
     }
     Ok(())
@@ -37,6 +47,9 @@ async fn handle_update(
     ctx: &mut CliContext,
     args: BoardUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Board> {
+    let uuid = ctx
+        .resolve_board_id(&args.board)
+        .map_err(anyhow::Error::from)?;
     let updates = BoardUpdate {
         name: args.name,
         description: args
@@ -53,7 +66,7 @@ async fn handle_update(
             .unwrap_or(FieldUpdate::NoChange),
         ..Default::default()
     };
-    let board = ctx.update_board(args.id, updates)?;
+    let board = ctx.update_board(uuid, updates)?;
     ctx.save().await?;
     Ok(board)
 }

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -3,35 +3,28 @@ use crate::context::CliContext;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    format_ambiguous_matches, ArchivedCardSummary, CardListFilter, CardPriority, CardStatus,
-    CardUpdate, CreateCardOptions, FieldUpdate, KanbanOperations,
+    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions,
+    FieldUpdate, KanbanOperations,
 };
 
 use uuid::Uuid;
 
-fn resolve_card_id(ctx: &CliContext, id: &str) -> anyhow::Result<Uuid> {
-    if let Ok(uuid) = Uuid::parse_str(id) {
-        return Ok(uuid);
-    }
-    match ctx
-        .find_cards_by_identifier(id)
-        .map_err(anyhow::Error::from)?
-        .as_slice()
-    {
-        [] => Err(anyhow::anyhow!("Card not found: '{}'", id)),
-        [card] => Ok(card.id),
-        matches => Err(anyhow::anyhow!("{}", format_ambiguous_matches(id, matches))),
-    }
-}
-
 pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<()> {
     match action {
         CardAction::Create(args) => {
+            let board_uuid = match ctx.resolve_board_id(&args.board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let column_uuid = match ctx.resolve_column_id(&args.column, board_uuid) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
             let options = match build_create_options(&args) {
                 Ok(o) => o,
                 Err(e) => return output::output_error(&e),
             };
-            let card = ctx.create_card(args.board_id, args.column_id, args.title, options)?;
+            let card = ctx.create_card(board_uuid, column_uuid, args.title, options)?;
             ctx.save().await?;
             output::output_success(&card);
         }
@@ -43,7 +36,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                     archived.iter().map(ArchivedCardSummary::from).collect();
                 output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
             } else {
-                let filter = match build_filter(&args) {
+                let filter = match build_filter(ctx, &args) {
                     Ok(f) => f,
                     Err(e) => return output::output_error(&e),
                 };
@@ -51,24 +44,24 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
             }
         }
-        CardAction::Get { id } => {
-            if let Ok(uuid) = Uuid::parse_str(&id) {
+        CardAction::Get { card } => {
+            if let Ok(uuid) = Uuid::parse_str(&card) {
                 match ctx.get_card(uuid)? {
-                    Some(card) => output::output_success(&card),
-                    None => return output::output_error(&format!("Card not found: '{}'", id)),
+                    Some(c) => output::output_success(&c),
+                    None => return output::output_error(&format!("Card not found: '{}'", card)),
                 }
             } else {
-                let cards = ctx.find_cards_by_identifier(&id)?;
+                let cards = ctx.find_cards_by_identifier(&card)?;
                 match cards.as_slice() {
-                    [] => return output::output_error(&format!("Card not found: '{}'", id)),
-                    [card] => output::output_success(card),
+                    [] => return output::output_error(&format!("Card not found: '{}'", card)),
+                    [c] => output::output_success(c),
                     _ => output::output_success(&cards),
                 }
             }
         }
         CardAction::Update(args) => {
-            let uuid = match resolve_card_id(ctx, &args.id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&args.card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let updates = match build_card_update(&args) {
@@ -80,81 +73,100 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
             output::output_success(&card);
         }
         CardAction::Move {
-            id,
-            column_id,
+            card,
+            column,
             position,
         } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+            let uuid = match ctx.resolve_card_id(&card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let card = ctx.move_card(uuid, column_id, position)?;
+            let column_uuid = match resolve_column_for_card(ctx, &column, uuid) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e),
+            };
+            let moved = ctx.move_card(uuid, column_uuid, position)?;
             ctx.save().await?;
-            output::output_success(&card);
+            output::output_success(&moved);
         }
-        CardAction::Archive { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+        CardAction::Archive { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             ctx.archive_card(uuid)?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"archived": uuid.to_string()}));
         }
-        CardAction::Restore { id, column_id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+        CardAction::Restore { card, column } => {
+            let uuid = match ctx.resolve_card_id(&card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let card = ctx.restore_card(uuid, column_id)?;
+            let column_uuid = match column {
+                Some(raw) => match resolve_column_for_card(ctx, &raw, uuid) {
+                    Ok(u) => Some(u),
+                    Err(e) => return output::output_error(&e),
+                },
+                None => None,
+            };
+            let restored = ctx.restore_card(uuid, column_uuid)?;
             ctx.save().await?;
-            output::output_success(&card);
+            output::output_success(&restored);
         }
-        CardAction::Delete { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+        CardAction::Delete { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             ctx.delete_card(uuid)?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
-        CardAction::AssignSprint { id, sprint_id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+        CardAction::AssignSprint { card, sprint } => {
+            let uuid = match ctx.resolve_card_id(&card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let card = ctx.assign_card_to_sprint(uuid, sprint_id)?;
+            let sprint_uuid = match resolve_sprint_for_card(ctx, &sprint, uuid) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e),
+            };
+            let assigned = ctx.assign_card_to_sprint(uuid, sprint_uuid)?;
             ctx.save().await?;
-            output::output_success(&card);
+            output::output_success(&assigned);
         }
-        CardAction::UnassignSprint { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+        CardAction::UnassignSprint { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let card = ctx.unassign_card_from_sprint(uuid)?;
+            let unassigned = ctx.unassign_card_from_sprint(uuid)?;
             ctx.save().await?;
-            output::output_success(&card);
+            output::output_success(&unassigned);
         }
-        CardAction::BranchName { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+        CardAction::BranchName { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let branch = ctx.get_card_branch_name(uuid)?;
             output::output_success(serde_json::json!({"branch_name": branch}));
         }
-        CardAction::GitCheckout { id } => {
-            let uuid = match resolve_card_id(ctx, &id) {
-                Ok(uuid) => uuid,
+        CardAction::GitCheckout { card } => {
+            let uuid = match ctx.resolve_card_id(&card) {
+                Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let cmd = ctx.get_card_git_checkout(uuid)?;
             output::output_success(serde_json::json!({"command": cmd}));
         }
-        CardAction::ArchiveCards { ids } => {
-            let result = ctx.archive_cards_detailed(ids);
+        CardAction::ArchiveCards { cards } => {
+            let uuids = match ctx.resolve_card_ids(&cards) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let result = ctx.archive_cards_detailed(uuids);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),
@@ -163,8 +175,20 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 "failed": result.failed
             }));
         }
-        CardAction::MoveCards { ids, column_id } => {
-            let result = ctx.move_cards_detailed(ids, column_id);
+        CardAction::MoveCards { cards, column } => {
+            let uuids = match ctx.resolve_card_ids(&cards) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let shared_board = match ctx.require_same_board(&uuids) {
+                Ok(b) => b,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let column_uuid = match ctx.resolve_column_id(&column, shared_board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let result = ctx.move_cards_detailed(uuids, column_uuid);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),
@@ -173,8 +197,20 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 "failed": result.failed
             }));
         }
-        CardAction::AssignCardsToSprint { ids, sprint_id } => {
-            let result = ctx.assign_cards_to_sprint_detailed(ids, sprint_id);
+        CardAction::AssignCardsToSprint { cards, sprint } => {
+            let uuids = match ctx.resolve_card_ids(&cards) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let shared_board = match ctx.require_same_board(&uuids) {
+                Ok(b) => b,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprint_uuid = match ctx.resolve_sprint_id(&sprint, shared_board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let result = ctx.assign_cards_to_sprint_detailed(uuids, sprint_uuid);
             ctx.save().await?;
             output::output_success(serde_json::json!({
                 "succeeded_count": result.succeeded.len(),
@@ -187,15 +223,71 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
     Ok(())
 }
 
-fn build_filter(args: &CardListArgs) -> Result<CardListFilter, String> {
+fn resolve_column_for_card(ctx: &CliContext, raw: &str, card_id: Uuid) -> Result<Uuid, String> {
+    let board_id = card_board_id(ctx, card_id)?;
+    ctx.resolve_column_id(raw, board_id)
+        .map_err(|e| e.to_string())
+}
+
+fn resolve_sprint_for_card(ctx: &CliContext, raw: &str, card_id: Uuid) -> Result<Uuid, String> {
+    let board_id = card_board_id(ctx, card_id)?;
+    ctx.resolve_sprint_id(raw, board_id)
+        .map_err(|e| e.to_string())
+}
+
+fn card_board_id(ctx: &CliContext, card_id: Uuid) -> Result<Uuid, String> {
+    // Try active cards first; if the card is archived, fall back via its
+    // original_column_id. Either path resolves to the card's board.
+    let column_id = match ctx.get_card(card_id).map_err(|e| e.to_string())? {
+        Some(card) => card.column_id,
+        None => {
+            let archived = ctx
+                .list_archived_cards()
+                .map_err(|e| e.to_string())?
+                .into_iter()
+                .find(|a| a.card.id == card_id)
+                .ok_or_else(|| format!("Card not found: {}", card_id))?;
+            archived.original_column_id
+        }
+    };
+    let column = ctx
+        .get_column(column_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Column not found: {}", column_id))?;
+    Ok(column.board_id)
+}
+
+fn build_filter(ctx: &CliContext, args: &CardListArgs) -> Result<CardListFilter, String> {
     let status = match &args.status {
         Some(s) => Some(parse_status(s)?),
         None => None,
     };
+    let board_id = match &args.board {
+        Some(raw) => Some(ctx.resolve_board_id(raw).map_err(|e| e.to_string())?),
+        None => None,
+    };
+    let column_id = match &args.column {
+        Some(raw) => Some(match board_id {
+            Some(bid) => ctx.resolve_column_id(raw, bid).map_err(|e| e.to_string())?,
+            None => ctx
+                .resolve_column_id_global(raw)
+                .map_err(|e| e.to_string())?,
+        }),
+        None => None,
+    };
+    let sprint_id = match &args.sprint {
+        Some(raw) => Some(match board_id {
+            Some(bid) => ctx.resolve_sprint_id(raw, bid).map_err(|e| e.to_string())?,
+            None => ctx
+                .resolve_sprint_id_global(raw)
+                .map_err(|e| e.to_string())?,
+        }),
+        None => None,
+    };
     Ok(CardListFilter {
-        board_id: args.board_id,
-        column_id: args.column_id,
-        sprint_id: args.sprint_id,
+        board_id,
+        column_id,
+        sprint_id,
         status,
     })
 }

--- a/crates/kanban-cli/src/handlers/column.rs
+++ b/crates/kanban-cli/src/handlers/column.rs
@@ -7,40 +7,62 @@ use kanban_domain::{ColumnUpdate, FieldUpdate, KanbanOperations};
 pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Result<()> {
     match action {
         ColumnAction::Create {
-            board_id,
+            board,
             name,
             position,
         } => {
-            let column = ctx.create_column(board_id, name, position)?;
+            let board_uuid = match ctx.resolve_board_id(&board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let column = ctx.create_column(board_uuid, name, position)?;
             ctx.save().await?;
             output::output_success(&column);
         }
         ColumnAction::List {
-            board_id,
+            board,
             page,
             page_size,
         } => {
-            let columns = ctx.list_columns(board_id)?;
+            let board_uuid = match ctx.resolve_board_id(&board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let columns = ctx.list_columns(board_uuid)?;
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(columns, page, page_size)?);
         }
-        ColumnAction::Get { id } => match ctx.get_column(id)? {
-            Some(column) => output::output_success(&column),
-            None => return output::output_error(&format!("Column not found: {}", id)),
-        },
+        ColumnAction::Get { column } => {
+            let uuid = match ctx.resolve_column_id_global(&column) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            match ctx.get_column(uuid)? {
+                Some(c) => output::output_success(&c),
+                None => return output::output_error(&format!("Column not found: {}", column)),
+            }
+        }
         ColumnAction::Update(args) => {
             let column = handle_update(ctx, args).await?;
             output::output_success(&column);
         }
-        ColumnAction::Delete { id } => {
-            ctx.delete_column(id)?;
+        ColumnAction::Delete { column } => {
+            let uuid = match ctx.resolve_column_id_global(&column) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            ctx.delete_column(uuid)?;
             ctx.save().await?;
-            output::output_success(serde_json::json!({"deleted": id.to_string()}));
+            output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
-        ColumnAction::Reorder { id, position } => {
-            let column = ctx.reorder_column(id, position)?;
+        ColumnAction::Reorder { column, position } => {
+            let uuid = match ctx.resolve_column_id_global(&column) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let c = ctx.reorder_column(uuid, position)?;
             ctx.save().await?;
-            output::output_success(&column);
+            output::output_success(&c);
         }
     }
     Ok(())
@@ -50,6 +72,9 @@ async fn handle_update(
     ctx: &mut CliContext,
     args: ColumnUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Column> {
+    let uuid = ctx
+        .resolve_column_id_global(&args.column)
+        .map_err(anyhow::Error::from)?;
     let updates = ColumnUpdate {
         name: args.name,
         position: args.position,
@@ -62,7 +87,7 @@ async fn handle_update(
                 .unwrap_or(FieldUpdate::NoChange)
         },
     };
-    let column = ctx.update_column(args.id, updates)?;
+    let column = ctx.update_column(uuid, updates)?;
     ctx.save().await?;
     Ok(column)
 }

--- a/crates/kanban-cli/src/handlers/export.rs
+++ b/crates/kanban-cli/src/handlers/export.rs
@@ -4,7 +4,14 @@ use crate::output;
 use kanban_domain::KanbanOperations;
 
 pub async fn handle_export(ctx: &CliContext, args: ExportArgs) -> anyhow::Result<()> {
-    let json = ctx.export_board(args.board_id)?;
+    let board_uuid = match args.board {
+        Some(raw) => match ctx.resolve_board_id(&raw) {
+            Ok(u) => Some(u),
+            Err(e) => return output::output_error(&e.to_string()),
+        },
+        None => None,
+    };
+    let json = ctx.export_board(board_uuid)?;
     println!("{}", json);
     Ok(())
 }

--- a/crates/kanban-cli/src/handlers/sprint.rs
+++ b/crates/kanban-cli/src/handlers/sprint.rs
@@ -24,27 +24,41 @@ fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
 pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Result<()> {
     match action {
         SprintAction::Create {
-            board_id,
+            board,
             prefix,
             name,
         } => {
-            let sprint = ctx.create_sprint(board_id, prefix, name)?;
+            let board_uuid = match ctx.resolve_board_id(&board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprint = ctx.create_sprint(board_uuid, prefix, name)?;
             ctx.save().await?;
             output::output_success(&sprint);
         }
         SprintAction::List {
-            board_id,
+            board,
             page,
             page_size,
         } => {
-            let sprints = ctx.list_sprints(board_id)?;
+            let board_uuid = match ctx.resolve_board_id(&board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let sprints = ctx.list_sprints(board_uuid)?;
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(sprints, page, page_size)?);
         }
-        SprintAction::Get { id } => match ctx.get_sprint(id)? {
-            Some(sprint) => output::output_success(&sprint),
-            None => return output::output_error(&format!("Sprint not found: {}", id)),
-        },
+        SprintAction::Get { sprint } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            match ctx.get_sprint(uuid)? {
+                Some(s) => output::output_success(&s),
+                None => return output::output_error(&format!("Sprint not found: {}", sprint)),
+            }
+        }
         SprintAction::Update(args) => {
             let sprint = match handle_update(ctx, args).await {
                 Ok(s) => s,
@@ -52,28 +66,59 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
             };
             output::output_success(&sprint);
         }
-        SprintAction::Activate { id, duration_days } => {
-            let sprint = ctx.activate_sprint(id, duration_days)?;
+        SprintAction::Activate {
+            sprint,
+            duration_days,
+        } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let activated = ctx.activate_sprint(uuid, duration_days)?;
             ctx.save().await?;
-            output::output_success(&sprint);
+            output::output_success(&activated);
         }
-        SprintAction::Complete { id } => {
-            let sprint = ctx.complete_sprint(id)?;
+        SprintAction::Complete { sprint } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let completed = ctx.complete_sprint(uuid)?;
             ctx.save().await?;
-            output::output_success(&sprint);
+            output::output_success(&completed);
         }
-        SprintAction::Cancel { id } => {
-            let sprint = ctx.cancel_sprint(id)?;
+        SprintAction::Cancel { sprint } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let cancelled = ctx.cancel_sprint(uuid)?;
             ctx.save().await?;
-            output::output_success(&sprint);
+            output::output_success(&cancelled);
         }
-        SprintAction::Delete { id } => {
-            ctx.delete_sprint(id)?;
+        SprintAction::Delete { sprint } => {
+            let uuid = match ctx.resolve_sprint_id_global(&sprint) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            ctx.delete_sprint(uuid)?;
             ctx.save().await?;
-            output::output_success(serde_json::json!({"deleted": id.to_string()}));
+            output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
         SprintAction::CarryOver { from, to } => {
-            let count = ctx.carry_over_sprint_cards(from, to)?;
+            let from_uuid = match ctx.resolve_sprint_id_global(&from) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            // `--to` is scoped to the same board as `--from`.
+            let from_sprint = ctx
+                .get_sprint(from_uuid)?
+                .ok_or_else(|| anyhow::anyhow!("Source sprint not found: {}", from_uuid))?;
+            let to_uuid = match ctx.resolve_sprint_id(&to, from_sprint.board_id) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            let count = ctx.carry_over_sprint_cards(from_uuid, to_uuid)?;
             ctx.save().await?;
             output::output_success(serde_json::json!({ "carried_over": count }));
         }
@@ -85,6 +130,9 @@ async fn handle_update(
     ctx: &mut CliContext,
     args: SprintUpdateArgs,
 ) -> anyhow::Result<kanban_domain::Sprint> {
+    let uuid = ctx
+        .resolve_sprint_id_global(&args.sprint)
+        .map_err(anyhow::Error::from)?;
     let start_date = if args.clear_start_date {
         FieldUpdate::Clear
     } else {
@@ -118,7 +166,7 @@ async fn handle_update(
         start_date,
         end_date,
     };
-    let sprint = ctx.update_sprint(args.id, updates)?;
+    let sprint = ctx.update_sprint(uuid, updates)?;
     ctx.save().await?;
     Ok(sprint)
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -303,7 +303,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -331,7 +331,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -344,7 +344,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "DONE",
@@ -357,7 +357,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "list",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -382,7 +382,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "First",
@@ -401,7 +401,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "Second",
@@ -440,7 +440,7 @@ mod column_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "To Delete",
@@ -489,7 +489,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -517,9 +517,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Test Task",
@@ -547,9 +547,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Test Task",
@@ -584,9 +584,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 1",
@@ -599,9 +599,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 2",
@@ -634,9 +634,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task With Desc",
@@ -673,9 +673,9 @@ mod card_tests {
                     file.to_str().unwrap(),
                     "card",
                     "create",
-                    "--board-id",
+                    "--board",
                     &board_id,
-                    "--column-id",
+                    "--column",
                     &column_id,
                     "--title",
                     &format!("Task {i}"),
@@ -736,9 +736,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Only Card",
@@ -778,9 +778,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Original",
@@ -828,7 +828,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "DONE",
@@ -847,9 +847,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task",
@@ -869,7 +869,7 @@ mod card_tests {
                 "card",
                 "move",
                 &card_id,
-                "--column-id",
+                "--column",
                 &col2_id,
             ])
             .assert()
@@ -894,9 +894,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "To Archive",
@@ -957,9 +957,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "My Feature Task",
@@ -1000,9 +1000,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "My Task",
@@ -1043,9 +1043,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 1",
@@ -1064,9 +1064,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 2",
@@ -1085,7 +1085,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "archive-cards",
-                "--ids",
+                "--cards",
                 &format!("{},{}", card1_id, card2_id),
             ])
             .assert()
@@ -1111,7 +1111,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "DONE",
@@ -1130,9 +1130,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 1",
@@ -1151,9 +1151,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task 2",
@@ -1172,9 +1172,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "move-cards",
-                "--ids",
+                "--cards",
                 &format!("{},{}", card1_id, card2_id),
-                "--column-id",
+                "--column",
                 &col2_id,
             ])
             .assert()
@@ -1218,7 +1218,7 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -1246,9 +1246,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Prefix Test Card",
@@ -1287,9 +1287,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Number Lookup Card",
@@ -1328,9 +1328,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Archive Me",
@@ -1384,7 +1384,7 @@ mod card_tests {
                     file.to_str().unwrap(),
                     "column",
                     "create",
-                    "--board-id",
+                    "--board",
                     &board_b_id,
                     "--name",
                     "TODO",
@@ -1403,9 +1403,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_a_id,
-                "--column-id",
+                "--column",
                 &col_a_id,
                 "--title",
                 "Card on A",
@@ -1422,9 +1422,9 @@ mod card_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_b_id,
-                "--column-id",
+                "--column",
                 &col_b_id,
                 "--title",
                 "Card on B",
@@ -1476,7 +1476,7 @@ mod card_tests {
             .args([file.to_str().unwrap(), "card", "archive", "KAN-1"])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("Ambiguous"))
+            .stderr(predicate::str::contains("ambiguous"))
             .stderr(predicate::str::contains(&card_a_id))
             .stderr(predicate::str::contains(&card_b_id));
     }
@@ -1516,7 +1516,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1542,7 +1542,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--prefix",
                 "SPRINT",
@@ -1569,7 +1569,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1580,7 +1580,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1591,7 +1591,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "list",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1616,7 +1616,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1654,7 +1654,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1695,7 +1695,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1736,7 +1736,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -1755,9 +1755,9 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task",
@@ -1776,7 +1776,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1799,7 +1799,7 @@ mod sprint_tests {
                 "card",
                 "assign-sprint",
                 &card_id,
-                "--sprint-id",
+                "--sprint",
                 &sprint_id,
             ])
             .assert()
@@ -1824,7 +1824,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -1843,9 +1843,9 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Task",
@@ -1864,7 +1864,7 @@ mod sprint_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -1887,7 +1887,7 @@ mod sprint_tests {
                 "card",
                 "assign-sprint",
                 &card_id,
-                "--sprint-id",
+                "--sprint",
                 &sprint_id,
             ])
             .assert()
@@ -1960,7 +1960,7 @@ mod export_import_tests {
         let board_id = extract_id(&board_json);
 
         kanban()
-            .args([file.to_str().unwrap(), "export", "--board-id", &board_id])
+            .args([file.to_str().unwrap(), "export", "--board", &board_id])
             .assert()
             .success()
             .stdout(predicate::str::contains("\"boards\""))
@@ -2077,7 +2077,7 @@ mod error_tests {
             .args([file.to_str().unwrap(), "column", "list"])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("--board-id"));
+            .stderr(predicate::str::contains("--board"));
     }
 
     #[test]
@@ -2146,7 +2146,7 @@ mod error_tests {
                 file.to_str().unwrap(),
                 "column",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
                 "--name",
                 "TODO",
@@ -2173,9 +2173,9 @@ mod error_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Test",
@@ -2221,9 +2221,9 @@ mod error_tests {
                 file.to_str().unwrap(),
                 "card",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
-                "--column-id",
+                "--column",
                 &column_id,
                 "--title",
                 "Test",
@@ -2275,7 +2275,7 @@ mod error_tests {
                 file.to_str().unwrap(),
                 "sprint",
                 "create",
-                "--board-id",
+                "--board",
                 &board_id,
             ])
             .assert()
@@ -2514,6 +2514,677 @@ mod version_and_help_tests {
             !stderr.is_empty(),
             "an unknown flag must surface a stderr error message"
         );
+    }
+}
+
+/// Tests that every entity-id argument across the CLI accepts a human-readable name
+/// (board name, column name, sprint name, sprint number) — not just a UUID.
+mod name_resolution_tests {
+    use super::*;
+
+    /// Initialize a fresh file, create one board and one TODO column on it. Returns
+    /// (file path string, board_id, column_id).
+    fn setup_named_board(name: &str, prefix: &str) -> (tempfile::TempDir, String, String, String) {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json").to_str().unwrap().to_string();
+        kanban().args([&file]).assert().success();
+        let bjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "board",
+                    "create",
+                    "--name",
+                    name,
+                    "--card-prefix",
+                    prefix,
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let board_id = extract_id(&bjson);
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file, "column", "create", "--board", &board_id, "--name", "TODO",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let column_id = extract_id(&cjson);
+        (dir, file, board_id, column_id)
+    }
+
+    // ---------- Board ----------
+
+    #[test]
+    fn test_board_get_by_name() {
+        let (_dir, file, board_id, _col) = setup_named_board("My Board", "MB");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "board", "get", "My Board"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["id"], board_id);
+    }
+
+    #[test]
+    fn test_board_get_by_name_case_insensitive() {
+        let (_dir, file, board_id, _col) = setup_named_board("MyBoard", "MB");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "board", "get", "myboard"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["id"], board_id);
+    }
+
+    #[test]
+    fn test_board_get_unknown_lists_available() {
+        let (_dir, file, _b, _c) = setup_named_board("Kanban", "KAN");
+        let assert = kanban()
+            .args([&file, "board", "get", "Personal"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("not found"), "stderr: {stderr}");
+        assert!(stderr.contains("Kanban"), "stderr: {stderr}");
+    }
+
+    #[test]
+    fn test_board_update_by_name() {
+        let (_dir, file, board_id, _col) = setup_named_board("Original", "ORG");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "board", "update", "Original", "--card-prefix", "NEW"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["id"], board_id);
+        assert_eq!(json["data"]["card_prefix"], "NEW");
+    }
+
+    #[test]
+    fn test_board_delete_by_name() {
+        let (_dir, file, _board, _col) = setup_named_board("DeleteMe", "DEL");
+        kanban()
+            .args([&file, "board", "delete", "DeleteMe"])
+            .assert()
+            .success();
+        let assert = kanban()
+            .args([&file, "board", "get", "DeleteMe"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("not found"), "stderr: {stderr}");
+    }
+
+    // ---------- Column ----------
+
+    #[test]
+    fn test_column_create_with_board_name() {
+        let (_dir, file, _board, _col) = setup_named_board("B", "B");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "column", "create", "--board", "B", "--name", "Doing"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["name"], "Doing");
+    }
+
+    #[test]
+    fn test_column_list_with_board_name() {
+        let (_dir, file, _board, _col) = setup_named_board("MyB", "MB");
+        kanban()
+            .args([
+                &file, "column", "create", "--board", "MyB", "--name", "Doing",
+            ])
+            .assert()
+            .success();
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "column", "list", "--board", "MyB"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["items"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_column_get_by_name() {
+        let (_dir, file, _board, column_id) = setup_named_board("B", "B");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "column", "get", "TODO"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["id"], column_id);
+    }
+
+    #[test]
+    fn test_column_get_ambiguous_across_boards_lists_boards() {
+        let (_dir, file, _b, _c) = setup_named_board("Alpha", "A");
+        kanban()
+            .args([
+                &file,
+                "board",
+                "create",
+                "--name",
+                "Beta",
+                "--card-prefix",
+                "B",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file, "column", "create", "--board", "Beta", "--name", "TODO",
+            ])
+            .assert()
+            .success();
+        let assert = kanban()
+            .args([&file, "column", "get", "TODO"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("ambiguous"), "stderr: {stderr}");
+        assert!(stderr.contains("'Alpha'"), "stderr: {stderr}");
+        assert!(stderr.contains("'Beta'"), "stderr: {stderr}");
+    }
+
+    #[test]
+    fn test_column_get_unknown_lists_available() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let assert = kanban()
+            .args([&file, "column", "get", "Nope"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("not found"), "stderr: {stderr}");
+        assert!(stderr.contains("TODO"), "stderr: {stderr}");
+    }
+
+    // ---------- Card ----------
+
+    #[test]
+    fn test_card_create_with_board_and_column_names() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "Hello",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["title"], "Hello");
+    }
+
+    #[test]
+    fn test_card_list_filters_by_names() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        kanban()
+            .args([
+                &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "T1",
+            ])
+            .assert()
+            .success();
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "card", "list", "--board", "B", "--column", "TODO"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["items"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_card_move_with_column_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([&file, "column", "create", "--board", "B", "--name", "Doing"])
+            .assert()
+            .success();
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "T",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let card_id = extract_id(&cjson);
+        let mjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "card", "move", &card_id, "--column", "Doing"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(mjson["data"]["id"], card_id);
+    }
+
+    #[test]
+    fn test_sprint_get_ambiguous_name_across_boards_lists_both() {
+        // KAN-400 review fix: cross-board sprint name ambiguity must name the
+        // conflicting boards (was previously underspecified).
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json").to_str().unwrap().to_string();
+        kanban().args([&file]).assert().success();
+        kanban()
+            .args([
+                &file,
+                "board",
+                "create",
+                "--name",
+                "Alpha",
+                "--card-prefix",
+                "A",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "board",
+                "create",
+                "--name",
+                "Beta",
+                "--card-prefix",
+                "B",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board",
+                "Alpha",
+                "--name",
+                "shared-name",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file,
+                "sprint",
+                "create",
+                "--board",
+                "Beta",
+                "--name",
+                "shared-name",
+            ])
+            .assert()
+            .success();
+        let assert = kanban()
+            .args([&file, "sprint", "get", "shared-name"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("ambiguous"), "stderr: {stderr}");
+        assert!(stderr.contains("'Alpha'"), "stderr: {stderr}");
+        assert!(stderr.contains("'Beta'"), "stderr: {stderr}");
+    }
+
+    /// Regression: `card restore <archived_uuid> --column <name>` must work.
+    /// The board-derivation helper used to chain via active cards only, which
+    /// failed for archived cards. It now falls back to archived_card.original_column_id.
+    #[test]
+    fn test_card_restore_archived_with_column_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([&file, "column", "create", "--board", "B", "--name", "Doing"])
+            .assert()
+            .success();
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "X",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let card_uuid = extract_id(&cjson);
+        kanban()
+            .args([&file, "card", "archive", "KAN-1"])
+            .assert()
+            .success();
+        // Archived cards aren't reachable via KAN-N identifier, so use UUID.
+        // The --column name resolution must still succeed by chaining via the
+        // archived card's original_column_id to derive the board.
+        let rjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "card", "restore", &card_uuid, "--column", "Doing"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(rjson["data"]["id"], card_uuid);
+    }
+
+    #[test]
+    fn test_card_assign_sprint_by_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
+            .assert()
+            .success();
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "T",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let card_id = extract_id(&cjson);
+        let ajson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "assign-sprint",
+                    &card_id,
+                    "--sprint",
+                    "alpha",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert!(ajson["data"]["sprint_id"].is_string());
+    }
+
+    #[test]
+    fn test_card_assign_sprint_by_number() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
+            .assert()
+            .success();
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", "T",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let card_id = extract_id(&cjson);
+        let ajson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "card", "assign-sprint", &card_id, "--sprint", "1"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert!(ajson["data"]["sprint_id"].is_string());
+    }
+
+    #[test]
+    fn test_card_move_cards_with_card_identifiers_and_column_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        kanban()
+            .args([&file, "column", "create", "--board", "B", "--name", "Doing"])
+            .assert()
+            .success();
+        for title in ["T1", "T2"] {
+            kanban()
+                .args([
+                    &file, "card", "create", "--board", "B", "--column", "TODO", "--title", title,
+                ])
+                .assert()
+                .success();
+        }
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "card",
+                    "move-cards",
+                    "--cards",
+                    "KAN-1,KAN-2",
+                    "--column",
+                    "Doing",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["succeeded_count"], 2);
+    }
+
+    #[test]
+    fn test_card_move_cards_spanning_boards_errors_clearly() {
+        let (_dir, file, _b, _c) = setup_named_board("Alpha", "A");
+        kanban()
+            .args([
+                &file,
+                "board",
+                "create",
+                "--name",
+                "Beta",
+                "--card-prefix",
+                "B",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file, "column", "create", "--board", "Beta", "--name", "TODO",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file, "card", "create", "--board", "Alpha", "--column", "TODO", "--title", "A1",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                &file, "card", "create", "--board", "Beta", "--column", "TODO", "--title", "B1",
+            ])
+            .assert()
+            .success();
+        let assert = kanban()
+            .args([
+                &file,
+                "card",
+                "move-cards",
+                "--cards",
+                "A-1,B-1",
+                "--column",
+                "TODO",
+            ])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(stderr.contains("same board"), "stderr: {stderr}");
+        assert!(stderr.contains("'Alpha'"), "stderr: {stderr}");
+        assert!(stderr.contains("'Beta'"), "stderr: {stderr}");
+    }
+
+    // ---------- Sprint ----------
+
+    #[test]
+    fn test_sprint_create_with_board_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["sprint_number"], 1);
+    }
+
+    #[test]
+    fn test_sprint_get_by_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let sjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file, "sprint", "create", "--board", "B", "--name", "yarara",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let sprint_id = extract_id(&sjson);
+        let g = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "sprint", "get", "yarara"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(g["data"]["id"], sprint_id);
+    }
+
+    #[test]
+    fn test_sprint_get_by_number() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        let sjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let sprint_id = extract_id(&sjson);
+        let g = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "sprint", "get", "1"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(g["data"]["id"], sprint_id);
+    }
+
+    #[test]
+    fn test_sprint_activate_by_name() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "B");
+        kanban()
+            .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
+            .assert()
+            .success();
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([&file, "sprint", "activate", "alpha"])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert_eq!(json["data"]["status"], "Active");
+    }
+
+    #[test]
+    fn test_sprint_carry_over_by_names() {
+        let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
+        // sprint #1
+        kanban()
+            .args([&file, "sprint", "create", "--board", "B", "--name", "alpha"])
+            .assert()
+            .success();
+        // sprint #2
+        kanban()
+            .args([&file, "sprint", "create", "--board", "B", "--name", "beta"])
+            .assert()
+            .success();
+        // activate sprint #1, then complete it
+        kanban()
+            .args([&file, "sprint", "activate", "alpha"])
+            .assert()
+            .success();
+        kanban()
+            .args([&file, "sprint", "complete", "alpha"])
+            .assert()
+            .success();
+        // carry over by names
+        let json = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file,
+                    "sprint",
+                    "carry-over",
+                    "--from",
+                    "alpha",
+                    "--to",
+                    "beta",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        assert!(json["data"]["carried_over"].is_number());
+    }
+
+    // ---------- Export ----------
+
+    #[test]
+    fn test_export_with_board_name() {
+        let (_dir, file, _b, _c) = setup_named_board("ExpBoard", "E");
+        // export prints raw JSON (not the CliResponse envelope)
+        let out = kanban()
+            .args([&file, "export", "--board", "ExpBoard"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let parsed: Value = serde_json::from_slice(&out).expect("export output should be JSON");
+        // Either {"boards": [...]} or a single board shape — just confirm parseable + non-empty.
+        assert!(parsed.is_object() || parsed.is_array());
     }
 }
 

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -24,6 +24,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -48,6 +49,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let create_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -90,6 +92,8 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
         let output = kanban()
             .args([file.to_str().unwrap(), "board", "list"])
             .assert()
@@ -108,6 +112,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         kanban()
             .args([
                 file.to_str().unwrap(),
@@ -148,6 +153,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let create_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -183,6 +189,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let create_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -225,6 +232,7 @@ mod board_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let create_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -265,6 +273,7 @@ mod column_tests {
     use super::*;
 
     fn setup_board(file: &std::path::Path) -> String {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -457,6 +466,7 @@ mod card_tests {
     use super::*;
 
     fn setup_board_and_column(file: &std::path::Path) -> (String, String) {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1183,6 +1193,7 @@ mod card_tests {
         file: &std::path::Path,
         prefix: &str,
     ) -> (String, String) {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1475,6 +1486,7 @@ mod sprint_tests {
     use super::*;
 
     fn setup_board(file: &std::path::Path) -> String {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1903,6 +1915,7 @@ mod export_import_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1928,6 +1941,7 @@ mod export_import_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1959,6 +1973,7 @@ mod export_import_tests {
         let file = dir.path().join("test.json");
         let import_file = dir.path().join("import.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         kanban()
             .args([
                 file.to_str().unwrap(),
@@ -1985,6 +2000,11 @@ mod export_import_tests {
         .unwrap();
 
         let new_file = dir.path().join("new.json");
+        kanban()
+            .args([new_file.to_str().unwrap()])
+            .assert()
+            .success();
+
         let output = kanban()
             .args([
                 new_file.to_str().unwrap(),
@@ -2034,6 +2054,7 @@ mod error_tests {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
 
+        kanban().args([file.to_str().unwrap()]).assert().success();
         kanban()
             .args([
                 file.to_str().unwrap(),
@@ -2063,6 +2084,7 @@ mod error_tests {
     fn test_card_get_nonexistent_numeric_identifier() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
 
         kanban()
             .args([file.to_str().unwrap(), "card", "get", "555"])
@@ -2077,6 +2099,7 @@ mod error_tests {
     fn test_card_get_nonexistent_prefix_identifier() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
 
         kanban()
             .args([file.to_str().unwrap(), "card", "get", "KAN-5"])
@@ -2101,6 +2124,7 @@ mod error_tests {
     }
 
     fn setup_board_and_column(file: &std::path::Path) -> (String, String) {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -2169,6 +2193,7 @@ mod error_tests {
     fn test_card_list_invalid_status() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
 
         kanban()
             .args([
@@ -2228,6 +2253,7 @@ mod error_tests {
     }
 
     fn setup_sprint(file: &std::path::Path) -> String {
+        kanban().args([file.to_str().unwrap()]).assert().success();
         let board_output = kanban()
             .args([
                 file.to_str().unwrap(),
@@ -2341,6 +2367,10 @@ mod no_file_tests {
         let file = dir.path().join("via-env.json");
         // Seed the file via the positional path so this test verifies env-var
         // resolution rather than implicit JSON auto-create-on-open.
+        kanban_no_config(dir.path())
+            .args([file.to_str().unwrap()])
+            .assert()
+            .success();
         kanban_no_config(dir.path())
             .args([
                 file.to_str().unwrap(),
@@ -2483,6 +2513,45 @@ mod version_and_help_tests {
         assert!(
             !stderr.is_empty(),
             "an unknown flag must surface a stderr error message"
+        );
+    }
+}
+
+mod missing_file_tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_file_gives_clear_error() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("doesntexist.json");
+        kanban()
+            .args([file.to_str().unwrap(), "card", "get", "KAN-1"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("\"success\":false"))
+            .stderr(predicate::str::contains("Board file not found"));
+    }
+
+    #[test]
+    fn test_board_create_requires_existing_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("doesntexist.json");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "create", "--name", "Test"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Board file not found"));
+    }
+
+    #[test]
+    fn test_no_subcommand_creates_file_when_missing() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("new.json");
+        assert!(!file.exists());
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        assert!(
+            file.exists(),
+            "kanban <file> must create the file when missing"
         );
     }
 }

--- a/crates/kanban-core/src/pagination.rs
+++ b/crates/kanban-core/src/pagination.rs
@@ -4,8 +4,38 @@
 //! viewport given a scroll offset. They are pure in-memory state and are never
 //! serialized or exposed through the CLI/MCP API.
 //!
+//! [`scroll_offset_to_keep_visible`] is the pure scroll-math primitive used by
+//! `Page::scroll_to_visible` and by callers that track a scroll offset outside
+//! of [`Page`].
+//!
 //! For the serialized pagination envelope used by CLI and MCP list responses,
 //! see [`super::paginated_list`].
+
+/// Compute the scroll offset that keeps `selected` inside a viewport of
+/// `viewport_height` rows. Minimal-scroll semantics: if `selected` is already
+/// visible, the offset is unchanged; otherwise it shifts just enough to bring
+/// `selected` to the nearest edge of the viewport.
+///
+/// This is the pure form of [`Page::scroll_to_visible`] and the canonical
+/// helper for any scrollable list that wants the same behavior as the main
+/// card list.
+pub fn scroll_offset_to_keep_visible(
+    current_offset: usize,
+    selected: usize,
+    viewport_height: usize,
+) -> usize {
+    if viewport_height == 0 {
+        return current_offset;
+    }
+    let scroll_end = current_offset + viewport_height;
+    if selected < current_offset {
+        selected
+    } else if selected >= scroll_end {
+        selected.saturating_sub(viewport_height - 1)
+    } else {
+        current_offset
+    }
+}
 
 /// Information about the visible portion of a paginated list.
 #[derive(Debug, Clone)]
@@ -163,18 +193,8 @@ impl Page {
 
     /// Scroll to make an item visible in the viewport.
     pub fn scroll_to_visible(&mut self, item_idx: usize, viewport_height: usize) {
-        if viewport_height == 0 {
-            return;
-        }
-
-        let scroll_start = self.scroll_offset;
-        let scroll_end = scroll_start + viewport_height;
-
-        if item_idx < scroll_start {
-            self.scroll_offset = item_idx;
-        } else if item_idx >= scroll_end {
-            self.scroll_offset = item_idx.saturating_sub(viewport_height - 1);
-        }
+        self.scroll_offset =
+            scroll_offset_to_keep_visible(self.scroll_offset, item_idx, viewport_height);
     }
 
     /// Navigate up by one item, returning the new index.
@@ -206,6 +226,41 @@ impl Default for Page {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_zero_viewport_is_noop() {
+        assert_eq!(scroll_offset_to_keep_visible(7, 99, 0), 7);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_already_visible_keeps_offset() {
+        // viewport rows 5..=9, selected 7 → stays at offset 5
+        assert_eq!(scroll_offset_to_keep_visible(5, 7, 5), 5);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_selection_above_scrolls_up() {
+        // viewport rows 10..=14, selected 3 → snap offset to 3
+        assert_eq!(scroll_offset_to_keep_visible(10, 3, 5), 3);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_selection_below_scrolls_down() {
+        // viewport rows 0..=4, selected 7 → selected becomes last visible (offset 3)
+        assert_eq!(scroll_offset_to_keep_visible(0, 7, 5), 3);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_at_top_edge_no_scroll() {
+        // viewport rows 5..=9, selected 5 (top edge) → keep
+        assert_eq!(scroll_offset_to_keep_visible(5, 5, 5), 5);
+    }
+
+    #[test]
+    fn test_scroll_offset_to_keep_visible_at_bottom_edge_no_scroll() {
+        // viewport rows 5..=9, selected 9 (bottom edge) → keep
+        assert_eq!(scroll_offset_to_keep_visible(5, 9, 5), 5);
+    }
 
     #[test]
     fn test_page_info_empty() {

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -1,5 +1,73 @@
+use std::fmt;
+
 use thiserror::Error;
 use uuid::Uuid;
+
+/// One element of an `Ambiguous` error's match list. Carries both a
+/// human-readable label (what makes this match distinguishable from the
+/// others) and the entity's UUID (always copy-pasteable). Display always
+/// renders as `{label} ({uuid})` so users can disambiguate by either.
+#[derive(Debug, Clone)]
+pub struct AmbiguousMatch {
+    /// Human-readable label that distinguishes this match. Examples:
+    ///   - board name (when two boards share a name)
+    ///   - `"on board 'X'"` (when a column name appears on multiple boards)
+    ///   - `"#15 'yarara-release' on board 'Project A'"` (sprint global match)
+    ///   - card title
+    pub label: String,
+    /// The matched entity's UUID.
+    pub id: Uuid,
+}
+
+impl fmt::Display for AmbiguousMatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.label, self.id)
+    }
+}
+
+/// One element of a `BatchResolutionFailed` error. Carries the raw input
+/// the caller passed and the typed reason it couldn't be resolved.
+#[derive(Debug, Clone)]
+pub struct BatchResolutionFailure {
+    /// The string the caller passed for this slot (UUID, identifier, name, etc.).
+    pub raw_input: String,
+    /// Why this input couldn't be resolved.
+    pub cause: BatchResolutionCause,
+}
+
+impl fmt::Display for BatchResolutionFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "'{}' ({})", self.raw_input, self.cause)
+    }
+}
+
+/// Why a single input in a batch resolver call failed.
+#[derive(Debug, Clone)]
+pub enum BatchResolutionCause {
+    /// No entity matched the input.
+    NotFound,
+    /// More than one entity matched. Carries the same match data an
+    /// `Ambiguous` single-resolver error would.
+    Ambiguous(Vec<AmbiguousMatch>),
+}
+
+impl fmt::Display for BatchResolutionCause {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "not found"),
+            Self::Ambiguous(matches) => {
+                f.write_str("ambiguous: ")?;
+                for (i, m) in matches.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{}", m)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum DependencyError {
@@ -16,6 +84,34 @@ pub enum DomainError {
     #[error("{entity} {id} not found")]
     NotFound { entity: &'static str, id: Uuid },
 
+    /// Returned when a name- or identifier-based lookup misses. The `available`
+    /// vector is appended to the message so users see what they could have typed.
+    #[error("{}", DomainError::fmt_not_found_by_name(entity, name, available))]
+    NotFoundByName {
+        entity: &'static str,
+        name: String,
+        available: Vec<String>,
+    },
+
+    /// Returned when a name- or identifier-based lookup matches more than one
+    /// entity. Each match carries both a human-readable label and a UUID so
+    /// users can disambiguate by either.
+    #[error("{}", DomainError::fmt_ambiguous(entity, name, matches))]
+    Ambiguous {
+        entity: &'static str,
+        name: String,
+        matches: Vec<AmbiguousMatch>,
+    },
+
+    /// Returned by batch resolvers (`resolve_card_ids`, future siblings) when
+    /// one or more inputs in the batch couldn't be resolved. Carries per-input
+    /// typed causes so callers can introspect.
+    #[error("{}", DomainError::fmt_batch_resolution_failed(entity, failures))]
+    BatchResolutionFailed {
+        entity: &'static str,
+        failures: Vec<BatchResolutionFailure>,
+    },
+
     #[error("validation error: {0}")]
     Validation(String),
 
@@ -27,6 +123,48 @@ pub enum DomainError {
 }
 
 impl DomainError {
+    // ----- Display formatters for the name/identifier resolver variants -----
+
+    fn fmt_not_found_by_name(entity: &str, name: &str, available: &[String]) -> String {
+        if available.is_empty() {
+            format!("{} '{}' not found", entity, name)
+        } else {
+            format!(
+                "{} '{}' not found. Available: {}",
+                entity,
+                name,
+                available
+                    .iter()
+                    .map(|s| format!("'{}'", s))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }
+    }
+
+    fn fmt_ambiguous(entity: &str, name: &str, matches: &[AmbiguousMatch]) -> String {
+        let rendered = matches
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{} '{}' is ambiguous: {}.", entity, name, rendered)
+    }
+
+    fn fmt_batch_resolution_failed(entity: &str, failures: &[BatchResolutionFailure]) -> String {
+        let parts = failures
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "Could not resolve {} {}: {}",
+            failures.len(),
+            pluralize(entity, failures.len()),
+            parts
+        )
+    }
+
     pub fn board_not_found(id: Uuid) -> Self {
         Self::NotFound {
             entity: "board",
@@ -87,6 +225,16 @@ pub enum KanbanError {
     Internal(String),
 }
 
+/// Return `noun` (when count is 1) or `noun + "s"` (otherwise).
+/// Trivial English helper used by error message formatters.
+fn pluralize(noun: &str, count: usize) -> String {
+    if count == 1 {
+        noun.to_string()
+    } else {
+        format!("{}s", noun)
+    }
+}
+
 pub type KanbanResult<T> = Result<T, KanbanError>;
 
 impl KanbanError {
@@ -94,12 +242,66 @@ impl KanbanError {
         Self::Domain(DomainError::NotFound { entity, id })
     }
 
+    pub fn not_found_by_name(
+        entity: &'static str,
+        name: impl Into<String>,
+        available: Vec<String>,
+    ) -> Self {
+        Self::Domain(DomainError::NotFoundByName {
+            entity,
+            name: name.into(),
+            available,
+        })
+    }
+
+    pub fn ambiguous(
+        entity: &'static str,
+        name: impl Into<String>,
+        matches: Vec<AmbiguousMatch>,
+    ) -> Self {
+        Self::Domain(DomainError::Ambiguous {
+            entity,
+            name: name.into(),
+            matches,
+        })
+    }
+
+    pub fn batch_resolution_failed(
+        entity: &'static str,
+        failures: Vec<BatchResolutionFailure>,
+    ) -> Self {
+        Self::Domain(DomainError::BatchResolutionFailed { entity, failures })
+    }
+
     pub fn validation(msg: impl Into<String>) -> Self {
         Self::Domain(DomainError::Validation(msg.into()))
     }
 
+    /// True for both `NotFound` (by UUID) and `NotFoundByName`.
     pub fn is_not_found(&self) -> bool {
-        matches!(self, KanbanError::Domain(DomainError::NotFound { .. }))
+        matches!(
+            self,
+            KanbanError::Domain(DomainError::NotFound { .. })
+                | KanbanError::Domain(DomainError::NotFoundByName { .. })
+        )
+    }
+
+    pub fn is_not_found_by_name(&self) -> bool {
+        matches!(
+            self,
+            KanbanError::Domain(DomainError::NotFoundByName { .. })
+        )
+    }
+
+    pub fn is_ambiguous(&self) -> bool {
+        matches!(self, KanbanError::Domain(DomainError::Ambiguous { .. }))
+    }
+
+    pub fn is_batch_resolution_failed(&self) -> bool {
+        matches!(
+            self,
+            KanbanError::Domain(DomainError::BatchResolutionFailed { .. })
+        )
     }
 
     pub fn is_validation(&self) -> bool {
@@ -225,6 +427,250 @@ mod tests {
         let id = Uuid::new_v4();
         let err = KanbanError::Domain(DomainError::wip_limit_exceeded(id, 3));
         assert!(err.is_wip_limit_exceeded());
+    }
+
+    #[test]
+    fn test_not_found_by_name_display_lists_available() {
+        let err = KanbanError::not_found_by_name(
+            "Column",
+            "done",
+            vec!["TODO".into(), "Doing".into(), "Complete".into()],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("'done'"), "msg: {msg}");
+        assert!(msg.contains("not found"), "msg: {msg}");
+        assert!(msg.contains("'TODO'"), "msg: {msg}");
+        assert!(msg.contains("'Doing'"), "msg: {msg}");
+        assert!(msg.contains("'Complete'"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_not_found_by_name_display_with_empty_available_omits_list() {
+        let err = KanbanError::not_found_by_name("Card", "KAN-999", Vec::new());
+        let msg = err.to_string();
+        assert!(msg.contains("'KAN-999' not found"), "msg: {msg}");
+        assert!(!msg.contains("Available:"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_ambiguous_display_includes_label_and_uuid_per_match() {
+        // KAN-400 polish: every match carries both a human label and a UUID
+        // so users can disambiguate by either.
+        let a_id = Uuid::new_v4();
+        let b_id = Uuid::new_v4();
+        let err = KanbanError::ambiguous(
+            "Sprint",
+            "13",
+            vec![
+                AmbiguousMatch {
+                    label: "on board 'Project A'".into(),
+                    id: a_id,
+                },
+                AmbiguousMatch {
+                    label: "on board 'Project B'".into(),
+                    id: b_id,
+                },
+            ],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("'13' is ambiguous"), "msg: {msg}");
+        assert!(msg.contains("'Project A'"), "msg: {msg}");
+        assert!(msg.contains("'Project B'"), "msg: {msg}");
+        assert!(
+            msg.contains(&a_id.to_string()),
+            "label-only is not enough: {msg}"
+        );
+        assert!(
+            msg.contains(&b_id.to_string()),
+            "label-only is not enough: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_ambiguous_display_single_match_renders_cleanly() {
+        // Degenerate case; can happen if a different resolver path produces
+        // a single-match Ambiguous (shouldn't, but be defensive).
+        let id = Uuid::new_v4();
+        let err = KanbanError::ambiguous(
+            "Card",
+            "5",
+            vec![AmbiguousMatch {
+                label: "Some title".into(),
+                id,
+            }],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("'5' is ambiguous"), "msg: {msg}");
+        assert!(msg.contains("Some title"), "msg: {msg}");
+        assert!(msg.contains(&id.to_string()), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_ambiguous_message_drops_specify_by_uuid_coda() {
+        // The old wording "Specify by UUID" was redundant once the UUID is
+        // already in the message. New message doesn't repeat it.
+        let err = KanbanError::ambiguous(
+            "Board",
+            "shared",
+            vec![AmbiguousMatch {
+                label: "shared".into(),
+                id: Uuid::new_v4(),
+            }],
+        );
+        let msg = err.to_string();
+        assert!(!msg.contains("Specify by UUID"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_is_not_found_by_name_predicate() {
+        let err = KanbanError::not_found_by_name("Column", "foo", Vec::new());
+        assert!(err.is_not_found_by_name());
+        // is_not_found is the umbrella predicate covering both shapes.
+        assert!(err.is_not_found());
+    }
+
+    #[test]
+    fn test_is_ambiguous_predicate() {
+        let err = KanbanError::ambiguous(
+            "Card",
+            "5",
+            vec![
+                AmbiguousMatch {
+                    label: "x".into(),
+                    id: Uuid::new_v4(),
+                },
+                AmbiguousMatch {
+                    label: "y".into(),
+                    id: Uuid::new_v4(),
+                },
+            ],
+        );
+        assert!(err.is_ambiguous());
+        assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn test_batch_resolution_failed_display_includes_each_input_and_cause() {
+        let err = KanbanError::batch_resolution_failed(
+            "Card",
+            vec![
+                BatchResolutionFailure {
+                    raw_input: "KAN-999".into(),
+                    cause: BatchResolutionCause::NotFound,
+                },
+                BatchResolutionFailure {
+                    raw_input: "KAN-998".into(),
+                    cause: BatchResolutionCause::Ambiguous(vec![AmbiguousMatch {
+                        label: "'one'".into(),
+                        id: Uuid::new_v4(),
+                    }]),
+                },
+            ],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("2 Cards"), "msg: {msg}");
+        assert!(msg.contains("'KAN-999'"), "msg: {msg}");
+        assert!(msg.contains("'KAN-998'"), "msg: {msg}");
+        assert!(msg.contains("not found"), "msg: {msg}");
+        assert!(msg.contains("ambiguous"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_batch_resolution_failed_display_singularizes_for_one_failure() {
+        // KAN-400 review-3 fix: "1 card(s)" was grammatically awkward. Now
+        // the noun agrees in number with the count, and entity casing matches
+        // sibling error variants (NotFoundByName / Ambiguous both keep
+        // "Card" capitalized).
+        let err = KanbanError::batch_resolution_failed(
+            "Card",
+            vec![BatchResolutionFailure {
+                raw_input: "KAN-999".into(),
+                cause: BatchResolutionCause::NotFound,
+            }],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("1 Card"), "expected '1 Card' singular: {msg}");
+        assert!(
+            !msg.contains("1 Cards") && !msg.contains("card(s)"),
+            "no plural or parenthetical: {msg}"
+        );
+        assert!(msg.contains('('), "still wraps cause in parens: {msg}");
+    }
+
+    #[test]
+    fn test_batch_resolution_failed_display_preserves_entity_capitalization() {
+        // Sibling variants render "Card '...' not found"; the batch variant
+        // must match. No to_lowercase.
+        let err = KanbanError::batch_resolution_failed(
+            "Card",
+            vec![
+                BatchResolutionFailure {
+                    raw_input: "x".into(),
+                    cause: BatchResolutionCause::NotFound,
+                },
+                BatchResolutionFailure {
+                    raw_input: "y".into(),
+                    cause: BatchResolutionCause::NotFound,
+                },
+            ],
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("Cards"), "got: {msg}");
+        assert!(!msg.contains(" cards"), "lowercased entity: {msg}");
+    }
+
+    #[test]
+    fn test_ambiguous_match_display_is_label_then_uuid_in_parens() {
+        // Standalone Display impl on AmbiguousMatch so callers can render
+        // a match without re-implementing the format.
+        let id = Uuid::new_v4();
+        let m = AmbiguousMatch {
+            label: "'Alpha'".into(),
+            id,
+        };
+        let rendered = format!("{}", m);
+        assert_eq!(rendered, format!("'Alpha' ({})", id));
+    }
+
+    #[test]
+    fn test_batch_resolution_cause_display_renders_not_found_and_ambiguous() {
+        // Standalone Display impl on BatchResolutionCause for symmetry.
+        let nf = BatchResolutionCause::NotFound;
+        assert_eq!(format!("{}", nf), "not found");
+
+        let id = Uuid::new_v4();
+        let amb = BatchResolutionCause::Ambiguous(vec![
+            AmbiguousMatch {
+                label: "'A'".into(),
+                id,
+            },
+            AmbiguousMatch {
+                label: "'B'".into(),
+                id,
+            },
+        ]);
+        let rendered = format!("{}", amb);
+        assert!(rendered.starts_with("ambiguous: "), "got: {rendered}");
+        assert!(rendered.contains("'A'"), "got: {rendered}");
+        assert!(rendered.contains("'B'"), "got: {rendered}");
+        assert!(
+            rendered.matches(&id.to_string()).count() == 2,
+            "got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_is_batch_resolution_failed_predicate() {
+        let err = KanbanError::batch_resolution_failed("Card", Vec::new());
+        assert!(err.is_batch_resolution_failed());
+        assert!(!err.is_not_found(), "not the same as a single not-found");
+    }
+
+    #[test]
+    fn test_is_not_found_true_for_uuid_variant_too() {
+        let err = KanbanError::not_found("card", Uuid::new_v4());
+        assert!(err.is_not_found(), "umbrella predicate covers Uuid variant");
+        assert!(!err.is_not_found_by_name());
     }
 
     #[test]

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -48,8 +48,9 @@ pub use query::{
     CardQueryBuilder,
 };
 pub use search::{
-    format_ambiguous_matches, BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy,
-    TitleSearcher,
+    find_boards_by_name, find_cards_by_identifier, find_columns_by_name,
+    find_sprints_by_query_global, find_sprints_by_query_on_board, format_ambiguous_matches,
+    BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy, TitleSearcher,
 };
 pub use snapshot::Snapshot;
 pub use sort::{get_sorter_for_field, OrderedSorter, SortBy};
@@ -62,4 +63,7 @@ pub use command_store::CommandStore;
 pub use data_store::{DataStore, GraphMutFn};
 pub use in_memory_store::InMemoryStore;
 
-pub use error::{DependencyError, DomainError, KanbanError, KanbanResult};
+pub use error::{
+    AmbiguousMatch, BatchResolutionCause, BatchResolutionFailure, DependencyError, DomainError,
+    KanbanError, KanbanResult,
+};

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -1,7 +1,8 @@
 use crate::KanbanResult;
 use crate::{
-    ArchivedCard, Board, BoardUpdate, Card, CardStatus, CardSummary, CardUpdate, Column,
-    ColumnUpdate, CreateCardOptions, Sprint, SprintUpdate,
+    AmbiguousMatch, ArchivedCard, BatchResolutionCause, BatchResolutionFailure, Board, BoardUpdate,
+    Card, CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions,
+    KanbanError, Sprint, SprintUpdate,
 };
 use uuid::Uuid;
 
@@ -48,6 +49,15 @@ pub trait KanbanOperations {
     fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>>;
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>>;
     fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>>;
+    /// Single-query snapshot of every card across all boards. Used by
+    /// resolvers and batch operations that need to scan once and reason
+    /// in memory. Implementors must back this with a single backend
+    /// query — do not compose from `list_cards_by_column`.
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>>;
+    /// Single-query snapshot of every column across all boards.
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>>;
+    /// Single-query snapshot of every sprint across all boards.
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>>;
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card>;
     fn move_card(&mut self, id: Uuid, column_id: Uuid, position: Option<i32>)
         -> KanbanResult<Card>;
@@ -99,4 +109,314 @@ pub trait KanbanOperations {
     // Import/Export
     fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String>;
     fn import_board(&mut self, data: &str) -> KanbanResult<Board>;
+
+    // ---------- Name/UUID resolvers (shared by CLI, MCP, anything else) ----------
+    //
+    // Each resolver accepts a raw string that may be a UUID, an entity name, or
+    // (for sprints) a sprint number. The UUID fast path returns immediately;
+    // otherwise the resolver returns `DomainError::NotFoundByName` (carrying the
+    // available alternatives) or `DomainError::Ambiguous` (carrying the matches).
+    // CLI/MCP layers just stringify the error; the human-friendly message lives
+    // in `DomainError`'s `Display` impl.
+    //
+    // Each resolver call takes one fresh snapshot of the relevant slice. No
+    // caching across calls; the snapshot lives only for the duration of the
+    // call. Batch resolvers (`resolve_card_ids`, `require_same_board`) take a
+    // single snapshot for the whole batch — internally consistent by definition.
+
+    fn resolve_board_id(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let boards = self.list_boards()?;
+        let matches = crate::search::find_boards_by_name(raw, &boards);
+        match matches.as_slice() {
+            [] => Err(KanbanError::not_found_by_name(
+                "Board",
+                raw,
+                boards.iter().map(|b| b.name.clone()).collect(),
+            )),
+            [b] => Ok(b.id),
+            many => Err(KanbanError::ambiguous(
+                "Board",
+                raw,
+                many.iter()
+                    .map(|b| AmbiguousMatch {
+                        label: format!("'{}'", b.name),
+                        id: b.id,
+                    })
+                    .collect(),
+            )),
+        }
+    }
+
+    fn resolve_column_id(&self, raw: &str, board_id: Uuid) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let columns = self.list_columns(board_id)?;
+        let matches = crate::search::find_columns_by_name(raw, &columns);
+        match matches.as_slice() {
+            [] => Err(KanbanError::not_found_by_name(
+                "Column",
+                raw,
+                columns.iter().map(|c| c.name.clone()).collect(),
+            )),
+            [c] => Ok(c.id),
+            many => Err(KanbanError::ambiguous(
+                "Column",
+                raw,
+                many.iter()
+                    .map(|c| AmbiguousMatch {
+                        label: format!("'{}'", c.name),
+                        id: c.id,
+                    })
+                    .collect(),
+            )),
+        }
+    }
+
+    fn resolve_column_id_global(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        // Single snapshot — no N+1.
+        let all_columns = self.list_all_columns()?;
+        let matches = crate::search::find_columns_by_name(raw, &all_columns);
+        match matches.as_slice() {
+            [] => Err(KanbanError::not_found_by_name(
+                "Column",
+                raw,
+                all_columns.iter().map(|c| c.name.clone()).collect(),
+            )),
+            [c] => Ok(c.id),
+            many => {
+                // Only need board names for the ambiguity message — one extra query.
+                let boards = self.list_boards()?;
+                let matches: Vec<AmbiguousMatch> = many
+                    .iter()
+                    .map(|c| {
+                        let board_name = boards
+                            .iter()
+                            .find(|b| b.id == c.board_id)
+                            .map(|b| b.name.as_str())
+                            .unwrap_or("(unknown)");
+                        AmbiguousMatch {
+                            label: format!("on board '{}'", board_name),
+                            id: c.id,
+                        }
+                    })
+                    .collect();
+                Err(KanbanError::ambiguous("Column", raw, matches))
+            }
+        }
+    }
+
+    fn resolve_sprint_id(&self, raw: &str, board_id: Uuid) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let sprints = self.list_sprints(board_id)?;
+        let board = self
+            .get_board(board_id)?
+            .ok_or_else(|| KanbanError::not_found("board", board_id))?;
+        let matches = crate::search::find_sprints_by_query_on_board(raw, &sprints, &board);
+        match matches.as_slice() {
+            [] => {
+                let available = sprints
+                    .iter()
+                    .map(|s| {
+                        let label = s.get_name(&board).unwrap_or("(unnamed)");
+                        format!("#{} {}", s.sprint_number, label)
+                    })
+                    .collect();
+                Err(KanbanError::not_found_by_name("Sprint", raw, available))
+            }
+            [s] => Ok(s.id),
+            many => Err(KanbanError::ambiguous(
+                "Sprint",
+                raw,
+                many.iter()
+                    .map(|s| {
+                        let name = s.get_name(&board).unwrap_or("(unnamed)");
+                        AmbiguousMatch {
+                            label: format!("#{} '{}'", s.sprint_number, name),
+                            id: s.id,
+                        }
+                    })
+                    .collect(),
+            )),
+        }
+    }
+
+    fn resolve_sprint_id_global(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        // Single snapshot — no N+1.
+        let all_sprints = self.list_all_sprints()?;
+        let boards = self.list_boards()?;
+        let matches = crate::search::find_sprints_by_query_global(raw, &all_sprints, &boards);
+        match matches.as_slice() {
+            [] => {
+                let available = all_sprints
+                    .iter()
+                    .map(|s| {
+                        let label = boards
+                            .iter()
+                            .find(|b| b.id == s.board_id)
+                            .and_then(|b| s.get_name(b))
+                            .unwrap_or("(unnamed)");
+                        format!("#{} {}", s.sprint_number, label)
+                    })
+                    .collect();
+                Err(KanbanError::not_found_by_name("Sprint", raw, available))
+            }
+            [s] => Ok(s.id),
+            many => {
+                let matches: Vec<AmbiguousMatch> = many
+                    .iter()
+                    .map(|s| {
+                        let board = boards.iter().find(|b| b.id == s.board_id);
+                        let board_name = board.map(|b| b.name.as_str()).unwrap_or("(unknown)");
+                        let sprint_name = board.and_then(|b| s.get_name(b)).unwrap_or("(unnamed)");
+                        AmbiguousMatch {
+                            label: format!(
+                                "#{} '{}' on board '{}'",
+                                s.sprint_number, sprint_name, board_name
+                            ),
+                            id: s.id,
+                        }
+                    })
+                    .collect();
+                Err(KanbanError::ambiguous("Sprint", raw, matches))
+            }
+        }
+    }
+
+    fn resolve_card_id(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let matches = self.find_cards_by_identifier(raw)?;
+        match matches.as_slice() {
+            [] => Err(KanbanError::not_found_by_name(
+                "Card",
+                raw,
+                Vec::new(), // cards aren't enumerated in the error — too many.
+            )),
+            [c] => Ok(c.id),
+            many => Err(KanbanError::ambiguous(
+                "Card",
+                raw,
+                many.iter()
+                    .map(|c| AmbiguousMatch {
+                        label: format!("'{}'", c.title),
+                        id: c.id,
+                    })
+                    .collect(),
+            )),
+        }
+    }
+
+    /// Resolve a batch of card identifiers against a single snapshot. Pure
+    /// in-memory matching against `find_cards_by_identifier`; one set of
+    /// `list_all_*` calls regardless of batch size.
+    ///
+    /// On failure, returns `KanbanError::BatchResolutionFailed` with per-input
+    /// typed causes so callers can introspect (which raw inputs failed, and
+    /// for what reason).
+    fn resolve_card_ids(&self, raws: &[String]) -> KanbanResult<Vec<Uuid>> {
+        // Single snapshot for the whole batch — no per-element backend round-trips.
+        let cards = self.list_all_cards()?;
+        let columns = self.list_all_columns()?;
+        let boards = self.list_boards()?;
+        let sprints = self.list_all_sprints()?;
+
+        let mut resolved = Vec::with_capacity(raws.len());
+        let mut failures = Vec::new();
+        for raw in raws {
+            if let Ok(uuid) = Uuid::parse_str(raw) {
+                resolved.push(uuid);
+                continue;
+            }
+            let matches =
+                crate::search::find_cards_by_identifier(raw, &cards, &columns, &boards, &sprints);
+            match matches.as_slice() {
+                [] => failures.push(BatchResolutionFailure {
+                    raw_input: raw.clone(),
+                    cause: BatchResolutionCause::NotFound,
+                }),
+                [c] => resolved.push(c.id),
+                many => failures.push(BatchResolutionFailure {
+                    raw_input: raw.clone(),
+                    cause: BatchResolutionCause::Ambiguous(
+                        many.iter()
+                            .map(|c| AmbiguousMatch {
+                                label: format!("'{}'", c.title),
+                                id: c.id,
+                            })
+                            .collect(),
+                    ),
+                }),
+            }
+        }
+        if !failures.is_empty() {
+            return Err(KanbanError::batch_resolution_failed("Card", failures));
+        }
+        Ok(resolved)
+    }
+
+    /// For batch operations, verify all the given cards belong to the same board.
+    /// Returns the shared `board_id` on success; otherwise a validation error
+    /// listing the boards involved. Single snapshot — O(1) backend queries.
+    fn require_same_board(&self, card_ids: &[Uuid]) -> KanbanResult<Uuid> {
+        use std::collections::HashMap;
+        if card_ids.is_empty() {
+            return Err(KanbanError::validation(
+                "No cards provided for batch operation.".to_string(),
+            ));
+        }
+        let cards = self.list_all_cards()?;
+        let columns = self.list_all_columns()?;
+        // column_id -> board_id, one lookup per card afterward.
+        let col_to_board: HashMap<Uuid, Uuid> =
+            columns.iter().map(|c| (c.id, c.board_id)).collect();
+        let card_index: HashMap<Uuid, &Card> = cards.iter().map(|c| (c.id, c)).collect();
+
+        let mut seen = std::collections::BTreeSet::new();
+        let mut found_boards = Vec::new();
+        for cid in card_ids {
+            let card = card_index
+                .get(cid)
+                .ok_or_else(|| KanbanError::not_found("card", *cid))?;
+            let board_id = col_to_board
+                .get(&card.column_id)
+                .copied()
+                .ok_or_else(|| KanbanError::not_found("column", card.column_id))?;
+            if seen.insert(board_id) {
+                found_boards.push(board_id);
+            }
+        }
+        match found_boards.as_slice() {
+            [b] => Ok(*b),
+            many => {
+                let boards = self.list_boards()?;
+                let names: Vec<String> = many
+                    .iter()
+                    .map(|bid| {
+                        boards
+                            .iter()
+                            .find(|b| b.id == *bid)
+                            .map(|b| format!("'{}'", b.name))
+                            .unwrap_or_else(|| bid.to_string())
+                    })
+                    .collect();
+                Err(KanbanError::validation(format!(
+                    "Batch operation requires all cards on the same board, but the selection spans boards: {}",
+                    names.join(", ")
+                )))
+            }
+        }
+    }
 }

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -281,6 +281,90 @@ pub fn format_ambiguous_matches(identifier: &str, cards: &[Card]) -> String {
     )
 }
 
+/// Find all boards whose `name` equals `query` (case-insensitive).
+pub fn find_boards_by_name<'a>(query: &str, boards: &'a [Board]) -> Vec<&'a Board> {
+    let needle = query.to_lowercase();
+    boards
+        .iter()
+        .filter(|b| b.name.to_lowercase() == needle)
+        .collect()
+}
+
+/// Find all columns in the given slice whose `name` equals `query` (case-insensitive).
+///
+/// The caller is responsible for scoping `columns` (e.g. filtering by `board_id` first).
+pub fn find_columns_by_name<'a>(query: &str, columns: &'a [Column]) -> Vec<&'a Column> {
+    let needle = query.to_lowercase();
+    columns
+        .iter()
+        .filter(|c| c.name.to_lowercase() == needle)
+        .collect()
+}
+
+/// Find sprints matching `query` (number or name) **within a single board**.
+///
+/// - If `query` parses as a `u32`, match sprints whose `board_id == board.id`
+///   and `sprint_number == query`.
+/// - Otherwise, match sprints on this board whose resolved name (via
+///   `board.sprint_names[name_index]`) equals `query` (case-insensitive).
+///
+/// The board-scoped contract is enforced on both branches, so callers don't
+/// need to pre-filter the slice.
+pub fn find_sprints_by_query_on_board<'a>(
+    query: &str,
+    sprints: &'a [Sprint],
+    board: &Board,
+) -> Vec<&'a Sprint> {
+    if let Ok(number) = query.parse::<u32>() {
+        return sprints
+            .iter()
+            .filter(|s| s.board_id == board.id && s.sprint_number == number)
+            .collect();
+    }
+    let needle = query.to_lowercase();
+    sprints
+        .iter()
+        .filter(|s| {
+            s.board_id == board.id
+                && s.get_name(board)
+                    .map(|n| n.to_lowercase() == needle)
+                    .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Find sprints matching `query` (number or name) **across all the given boards**.
+///
+/// - If `query` parses as a `u32`, match every sprint whose `sprint_number == query`,
+///   regardless of board (caller decides what to do with multi-board ambiguity).
+/// - Otherwise, match sprints whose resolved name on their own board equals
+///   `query` (case-insensitive). The sprint's `board_id` is looked up in `boards`;
+///   a sprint whose board is missing from the slice is silently skipped.
+pub fn find_sprints_by_query_global<'a>(
+    query: &str,
+    sprints: &'a [Sprint],
+    boards: &[Board],
+) -> Vec<&'a Sprint> {
+    if let Ok(number) = query.parse::<u32>() {
+        return sprints
+            .iter()
+            .filter(|s| s.sprint_number == number)
+            .collect();
+    }
+    let needle = query.to_lowercase();
+    sprints
+        .iter()
+        .filter(|s| {
+            let Some(board) = boards.iter().find(|b| b.id == s.board_id) else {
+                return false;
+            };
+            s.get_name(board)
+                .map(|n| n.to_lowercase() == needle)
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
 impl CardSearcher for CompositeSearcher {
     fn matches(&self, card: &Card, board: &Board, sprints: &[Sprint]) -> bool {
         if self.searchers.is_empty() {
@@ -295,6 +379,7 @@ impl CardSearcher for CompositeSearcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     fn create_test_card(board: &mut Board, title: &str) -> Card {
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
@@ -727,5 +812,186 @@ mod tests {
         assert!(
             find_cards_by_identifier("not-a-number", &cards, &columns, &boards, &[]).is_empty()
         );
+    }
+
+    #[test]
+    fn test_find_boards_by_name_case_insensitive_match() {
+        let boards = vec![
+            Board::new("Kanban".to_string(), None),
+            Board::new("Personal".to_string(), None),
+        ];
+        let result = find_boards_by_name("kanban", &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "Kanban");
+
+        let result = find_boards_by_name("KANBAN", &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "Kanban");
+    }
+
+    #[test]
+    fn test_find_boards_by_name_no_match_returns_empty() {
+        let boards = vec![Board::new("Kanban".to_string(), None)];
+        assert!(find_boards_by_name("missing", &boards).is_empty());
+    }
+
+    #[test]
+    fn test_find_boards_by_name_multiple_with_same_name_returns_all() {
+        let boards = vec![
+            Board::new("Shared".to_string(), None),
+            Board::new("Shared".to_string(), None),
+        ];
+        let result = find_boards_by_name("shared", &boards);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_find_columns_by_name_case_insensitive_match() {
+        let board_id = Uuid::new_v4();
+        let columns = vec![
+            Column::new(board_id, "TODO".to_string(), 0),
+            Column::new(board_id, "Doing".to_string(), 1),
+            Column::new(board_id, "Done".to_string(), 2),
+        ];
+        let result = find_columns_by_name("todo", &columns);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "TODO");
+
+        let result = find_columns_by_name("DOING", &columns);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "Doing");
+    }
+
+    #[test]
+    fn test_find_columns_by_name_returns_multiple_when_same_name_across_boards() {
+        let columns = vec![
+            Column::new(Uuid::new_v4(), "TODO".to_string(), 0),
+            Column::new(Uuid::new_v4(), "TODO".to_string(), 0),
+        ];
+        let result = find_columns_by_name("todo", &columns);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_find_columns_by_name_no_match_returns_empty() {
+        let columns = vec![Column::new(Uuid::new_v4(), "TODO".to_string(), 0)];
+        assert!(find_columns_by_name("missing", &columns).is_empty());
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_matches_number() {
+        let mut board = Board::new("B".to_string(), None);
+        board.sprint_names.push("alpha".to_string());
+        let mut sprint1 = crate::Sprint::new(board.id, 1, Some(0), None);
+        sprint1.sprint_number = 1;
+        let mut sprint2 = crate::Sprint::new(board.id, 2, None, None);
+        sprint2.sprint_number = 2;
+        let sprints = vec![sprint1, sprint2];
+        let boards = vec![board];
+
+        let result = find_sprints_by_query_global("1", &sprints, &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].sprint_number, 1);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_matches_name_case_insensitive() {
+        let mut board = Board::new("B".to_string(), None);
+        board.sprint_names.push("yarara-release".to_string());
+        board.sprint_names.push("moonshot".to_string());
+        let sprint1 = crate::Sprint::new(board.id, 1, Some(0), None);
+        let sprint2 = crate::Sprint::new(board.id, 2, Some(1), None);
+        let sprints = vec![sprint1.clone(), sprint2];
+        let boards = vec![board];
+
+        let result = find_sprints_by_query_global("yarara-release", &sprints, &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, sprint1.id);
+
+        let result = find_sprints_by_query_global("YARARA-RELEASE", &sprints, &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, sprint1.id);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_number_takes_priority_over_name() {
+        let mut board = Board::new("B".to_string(), None);
+        board.sprint_names.push("1".to_string());
+        let sprint_numbered = crate::Sprint::new(board.id, 1, None, None);
+        let sprint_named = crate::Sprint::new(board.id, 99, Some(0), None);
+        let sprints = vec![sprint_numbered.clone(), sprint_named];
+        let boards = vec![board];
+
+        let result = find_sprints_by_query_global("1", &sprints, &boards);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, sprint_numbered.id);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_no_match_returns_empty() {
+        let mut board = Board::new("B".to_string(), None);
+        board.sprint_names.push("alpha".to_string());
+        let sprint = crate::Sprint::new(board.id, 1, Some(0), None);
+        let sprints = vec![sprint];
+        let boards = vec![board];
+
+        assert!(find_sprints_by_query_global("nope", &sprints, &boards).is_empty());
+        assert!(find_sprints_by_query_global("99", &sprints, &boards).is_empty());
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_ambiguous_number_across_boards_returns_all() {
+        let board_a = Board::new("A".to_string(), None);
+        let board_b = Board::new("B".to_string(), None);
+        let sprint_a = crate::Sprint::new(board_a.id, 13, None, None);
+        let sprint_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let sprints = vec![sprint_a, sprint_b];
+        let boards = vec![board_a, board_b];
+
+        let result = find_sprints_by_query_global("13", &sprints, &boards);
+        assert_eq!(result.len(), 2);
+    }
+
+    // ---- find_sprints_by_query_on_board scoping tests (KAN-400 footgun fix) ----
+
+    #[test]
+    fn test_find_sprints_by_query_on_board_number_matches_only_on_that_board() {
+        let board_a = Board::new("A".to_string(), None);
+        let board_b = Board::new("B".to_string(), None);
+        let on_a = crate::Sprint::new(board_a.id, 13, None, None);
+        let on_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let sprints = vec![on_a.clone(), on_b];
+
+        let result = find_sprints_by_query_on_board("13", &sprints, &board_a);
+        assert_eq!(result.len(), 1, "expected exactly one match on board A");
+        assert_eq!(result[0].id, on_a.id);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_on_board_name_matches_only_on_that_board() {
+        let mut board_a = Board::new("A".to_string(), None);
+        board_a.sprint_names.push("alpha".to_string());
+        let mut board_b = Board::new("B".to_string(), None);
+        board_b.sprint_names.push("alpha".to_string());
+        let on_a = crate::Sprint::new(board_a.id, 1, Some(0), None);
+        let on_b = crate::Sprint::new(board_b.id, 1, Some(0), None);
+        let sprints = vec![on_a.clone(), on_b];
+
+        let result = find_sprints_by_query_on_board("alpha", &sprints, &board_a);
+        assert_eq!(result.len(), 1, "expected exactly one match on board A");
+        assert_eq!(result[0].id, on_a.id);
+    }
+
+    #[test]
+    fn test_find_sprints_by_query_on_board_ignores_other_board_sprints_in_slice() {
+        // Footgun-regression: even if a caller passes sprints from a different
+        // board, the on_board variant filters them out.
+        let board_a = Board::new("A".to_string(), None);
+        let board_b = Board::new("B".to_string(), None);
+        let only_on_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let sprints = vec![only_on_b];
+
+        let result = find_sprints_by_query_on_board("13", &sprints, &board_a);
+        assert!(result.is_empty());
     }
 }

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -80,85 +80,85 @@ kanban-mcp /path/to/boards.sqlite
 |------|-------------|-----------------|-----------------|
 | `tool_create_board` | Create a new kanban board | `name: String` | `card_prefix: String` |
 | `tool_list_boards` | List all boards | — | — |
-| `tool_get_board` | Get a specific board by ID | `board_id: UUID` | — |
-| `tool_update_board` | Update board properties | `board_id: UUID` | `name`, `description`, `sprint_prefix`, `card_prefix` |
-| `tool_delete_board` | Delete board and all its columns, cards, sprints | `board_id: UUID` | — |
+| `tool_get_board` | Get a specific board by ID | `board: UUID` | — |
+| `tool_update_board` | Update board properties | `board: UUID` | `name`, `description`, `sprint_prefix`, `card_prefix` |
+| `tool_delete_board` | Delete board and all its columns, cards, sprints | `board: UUID` | — |
 
 ### Columns (6 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_column` | Create a new column in a board | `board_id: UUID`, `name: String` | `position: i32` |
-| `tool_list_columns` | List all columns in a board | `board_id: UUID` | — |
-| `tool_get_column` | Get a specific column by ID | `column_id: UUID` | — |
-| `tool_update_column` | Update column properties | `column_id: UUID` | `name`, `position`, `wip_limit: u32`, `clear_wip_limit: bool` |
-| `tool_delete_column` | Delete column and all its cards | `column_id: UUID` | — |
-| `tool_reorder_column` | Move column to a new position | `column_id: UUID`, `position: i32` | — |
+| `tool_create_column` | Create a new column in a board | `board: UUID`, `name: String` | `position: i32` |
+| `tool_list_columns` | List all columns in a board | `board: UUID` | — |
+| `tool_get_column` | Get a specific column by ID | `column: UUID` | — |
+| `tool_update_column` | Update column properties | `column: UUID` | `name`, `position`, `wip_limit: u32`, `clear_wip_limit: bool` |
+| `tool_delete_column` | Delete column and all its cards | `column: UUID` | — |
+| `tool_reorder_column` | Move column to a new position | `column: UUID`, `position: i32` | — |
 
 ### Cards (10 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_card` | Create a new card in a column | `board_id: UUID`, `column_id: UUID`, `title: String` | `description`, `priority` (low/medium/high/critical), `points: u8`, `due_date` (YYYY-MM-DD or RFC 3339) |
-| `tool_list_cards` | List cards with filters. Returns `CardSummary` (title, status, priority, points — use tool_get_card for full detail). | — | `board_id`, `column_id`, `sprint_id`, `status`, `page: u32`, `page_size: u32` |
-| `tool_get_card` | Get card by UUID or identifier (e.g. `KAN-5`). Returns list if ambiguous. | `card_id: String` | — |
-| `tool_update_card` | Update card properties | `card_id: String` | `title`, `description`, `priority`, `status` (todo/in_progress/blocked/done), `points: u8`, `due_date`, `clear_due_date: bool` |
-| `tool_move_card` | Move card to a different column | `card_id: String`, `column_id: UUID` | `position: i32` |
-| `tool_archive_card` | Archive a card (restorable) | `card_id: String` | — |
-| `tool_restore_card` | Restore an archived card | `card_id: String` | `column_id: UUID` |
-| `tool_delete_card` | Delete a card permanently | `card_id: String` | — |
+| `tool_create_card` | Create a new card in a column | `board: UUID`, `column: UUID`, `title: String` | `description`, `priority` (low/medium/high/critical), `points: u8`, `due_date` (YYYY-MM-DD or RFC 3339) |
+| `tool_list_cards` | List cards with filters. Returns `CardSummary` (title, status, priority, points — use tool_get_card for full detail). | — | `board`, `column`, `sprint`, `status`, `page: u32`, `page_size: u32` |
+| `tool_get_card` | Get card by UUID or identifier (e.g. `KAN-5`). Returns list if ambiguous. | `card: String` | — |
+| `tool_update_card` | Update card properties | `card: String` | `title`, `description`, `priority`, `status` (todo/in_progress/blocked/done), `points: u8`, `due_date`, `clear_due_date: bool` |
+| `tool_move_card` | Move card to a different column | `card: String`, `column: UUID` | `position: i32` |
+| `tool_archive_card` | Archive a card (restorable) | `card: String` | — |
+| `tool_restore_card` | Restore an archived card | `card: String` | `column: UUID` |
+| `tool_delete_card` | Delete a card permanently | `card: String` | — |
 | `tool_list_archived_cards` | Returns ArchivedCardSummary (title, archived_at, original column — use tool_get_card for full detail) | — | `page: u32`, `page_size: u32` |
 
 ### Card Identifiers
 
-`card_id` accepts either a UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
+`card` accepts either a UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
 
 ### Card–Sprint (2 tools)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_assign_card_to_sprint` | Assign a card to a sprint | `card_id: String`, `sprint_id: UUID` |
-| `tool_unassign_card_from_sprint` | Remove card from its sprint | `card_id: String` |
+| `tool_assign_card_to_sprint` | Assign a card to a sprint | `card: String`, `sprint: UUID` |
+| `tool_unassign_card_from_sprint` | Remove card from its sprint | `card: String` |
 
 ### Card Utilities (2 tools)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_get_card_branch_name` | Get git branch name for a card | `card_id: String` |
-| `tool_get_card_git_checkout` | Get `git checkout -b <branch>` command | `card_id: String` |
+| `tool_get_card_branch_name` | Get git branch name for a card | `card: String` |
+| `tool_get_card_git_checkout` | Get `git checkout -b <branch>` command | `card: String` |
 
 ### Bulk Card Operations (3 tools)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_archive_cards` | Archive multiple cards | `ids: String` (comma-separated UUIDs) |
-| `tool_move_cards` | Move multiple cards to a column | `ids: String`, `column_id: UUID` |
-| `tool_assign_cards_to_sprint` | Assign multiple cards to a sprint | `ids: String`, `sprint_id: UUID` |
+| `tool_archive_cards` | Archive multiple cards | `cards: String` (comma-separated UUIDs) |
+| `tool_move_cards` | Move multiple cards to a column | `cards: String`, `column: UUID` |
+| `tool_assign_cards_to_sprint` | Assign multiple cards to a sprint | `cards: String`, `sprint: UUID` |
 
 ### Sprints (8 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_sprint` | Create a new sprint | `board_id: UUID` | `name: String`, `prefix: String` |
-| `tool_list_sprints` | List sprints for a board | `board_id: UUID` | — |
-| `tool_get_sprint` | Get a specific sprint by ID | `sprint_id: UUID` | — |
-| `tool_update_sprint` | Update sprint properties | `sprint_id: UUID` | `name`, `prefix`, `card_prefix`, `start_date`, `end_date`, `clear_start_date: bool`, `clear_end_date: bool` |
-| `tool_activate_sprint` | Activate a sprint | `sprint_id: UUID`, `duration_days: u32` | — |
-| `tool_complete_sprint` | Mark sprint as completed | `sprint_id: UUID` | — |
-| `tool_cancel_sprint` | Cancel a sprint | `sprint_id: UUID` | — |
-| `tool_delete_sprint` | Delete a sprint | `sprint_id: UUID` | — |
+| `tool_create_sprint` | Create a new sprint | `board: UUID` | `name: String`, `prefix: String` |
+| `tool_list_sprints` | List sprints for a board | `board: UUID` | — |
+| `tool_get_sprint` | Get a specific sprint by ID | `sprint: UUID` | — |
+| `tool_update_sprint` | Update sprint properties | `sprint: UUID` | `name`, `prefix`, `card_prefix`, `start_date`, `end_date`, `clear_start_date: bool`, `clear_end_date: bool` |
+| `tool_activate_sprint` | Activate a sprint | `sprint: UUID`, `duration_days: u32` | — |
+| `tool_complete_sprint` | Mark sprint as completed | `sprint: UUID` | — |
+| `tool_cancel_sprint` | Cancel a sprint | `sprint: UUID` | — |
+| `tool_delete_sprint` | Delete a sprint | `sprint: UUID` | — |
 
 ### Sprint Carry-over (1 tool)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_carry_over_sprint_cards` | Move uncompleted cards from a completed/cancelled sprint to a planning sprint | `from_sprint_id: UUID`, `to_sprint_id: UUID` |
+| `tool_carry_over_sprint_cards` | Move uncompleted cards from a completed/cancelled sprint to a planning sprint | `from_sprint: UUID`, `to_sprint: UUID` |
 
 ### Import / Export (2 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_export_board` | Export board data as JSON string | — | `board_id: UUID` (omit for all boards) |
+| `tool_export_board` | Export board data as JSON string | — | `board: UUID` (omit for all boards) |
 | `tool_import_board` | Import board from JSON string | `data: String` | — |
 
 ### Undo / Redo (2 tools)

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -155,6 +155,18 @@ impl KanbanOperations for McpContext {
         self.inner.find_cards_by_identifier(identifier)
     }
 
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<kanban_domain::Column>> {
+        self.inner.list_all_columns()
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<kanban_domain::Sprint>> {
+        self.inner.list_all_sprints()
+    }
+
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         self.inner.update_card(id, updates)
     }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -6,9 +6,8 @@ pub use server::McpServer;
 use context::McpContext;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    format_ambiguous_matches, ArchivedCardSummary, BoardUpdate, CardListFilter, CardPriority,
-    CardStatus, CardUpdate, ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations,
-    SprintUpdate,
+    ArchivedCardSummary, BoardUpdate, CardListFilter, CardPriority, CardStatus, CardUpdate,
+    ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations, SprintUpdate,
 };
 use kanban_domain::{KanbanError, KanbanResult};
 use kanban_service::StoreManager;
@@ -50,11 +49,6 @@ fn kanban_err_to_mcp(e: KanbanError) -> McpError {
 
 fn core_err_to_mcp(e: kanban_core::CoreError) -> McpError {
     kanban_err_to_mcp(KanbanError::from(e))
-}
-
-fn parse_uuid(s: &str) -> Result<Uuid, McpError> {
-    Uuid::parse_str(s)
-        .map_err(|e| McpError::invalid_params(format!("Invalid UUID '{}': {}", s, e), None))
 }
 
 fn parse_priority(s: &str) -> Result<CardPriority, McpError> {
@@ -106,31 +100,130 @@ fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, McpError> {
         })
 }
 
-fn parse_uuids_csv(s: &str) -> Result<Vec<Uuid>, McpError> {
-    s.split(',').map(|id| parse_uuid(id.trim())).collect()
+// ---------- Locked sessions ----------
+//
+// Two flavours, named by intent. Each acquires the context lock and drops it
+// when the closure returns; resolution + the work share one consistent view
+// of state, closing any TOCTOU window.
+//
+// - `locked_read(ctx, |ctx| ...)` — lock, run closure, drop. No disk reload,
+//   no save. The closure takes `&McpContext` so the type system enforces
+//   read-only semantics. Use for tool handlers that resolve names + read
+//   state without mutating.
+//
+// - `locked_write(ctx, |ctx| ...)` — lock, reload from disk, run closure,
+//   save, drop. The closure takes `&mut McpContext`. Reload+save bracket
+//   the closure so mutations see the latest disk state and are persisted.
+//
+// For trivial reads with no resolution (`tool_list_boards`, etc.) the older
+// `read_op!` macro is still appropriate — it's a one-liner that elides the
+// closure ceremony.
+
+/// Acquire the context lock and run the closure with read-only access.
+///
+/// The in-memory cache is **not** reloaded — reads are served from whatever
+/// state the previous tool call left behind. If a separate process wrote to
+/// the file since the last reload, the read may be stale. That's an
+/// intentional perf tradeoff: typical MCP usage is single-process, and the
+/// reload cost (file read + parse) is significant relative to the read
+/// itself.
+async fn locked_read<T, F>(ctx: &Arc<Mutex<McpContext>>, f: F) -> Result<T, McpError>
+where
+    F: FnOnce(&McpContext) -> Result<T, McpError>,
+{
+    let guard = ctx.lock().await;
+    f(&guard)
 }
 
-async fn resolve_card_id(ctx: &Arc<Mutex<McpContext>>, s: &str) -> Result<Uuid, McpError> {
-    if let Ok(id) = Uuid::parse_str(s) {
-        return Ok(id);
+/// Acquire the context lock, reload from disk, run the closure with mutable
+/// access, then save and drop. Reload + save bracket the closure so the
+/// mutation always operates on the latest disk state and is persisted before
+/// the lock releases.
+///
+/// # Reload semantics and undo limitations
+///
+/// `guard.reload()` fully discards the in-memory cache and resets undo
+/// history to the current on-disk state. As a consequence, within-session
+/// undo history from earlier tool calls is always wiped before each
+/// mutation: `tool_undo` can only undo the operation recorded during the
+/// **current** tool call, not operations from prior calls.
+///
+/// **Future work**: a `reload_if_changed()` method that compares file
+/// metadata (mtime / instance_id) and skips the full reload when no
+/// external write has occurred would let undo history persist across calls
+/// in the same session. Track as `KanbanBackend::reload_if_changed()`.
+async fn locked_write<T, F>(ctx: &Arc<Mutex<McpContext>>, f: F) -> Result<T, McpError>
+where
+    F: FnOnce(&mut McpContext) -> Result<T, McpError>,
+{
+    let mut guard = ctx.lock().await;
+    guard.reload().await.map_err(kanban_err_to_mcp)?;
+    let result = f(&mut guard)?;
+    guard.save().await.map_err(kanban_err_to_mcp)?;
+    Ok(result)
+}
+
+/// Helper trait: gives `&McpContext` access to MCP-flavoured error mapping for
+/// the resolvers it inherits via `KanbanOperations`. Each method is a thin
+/// `kanban_err_to_mcp` shim so closure bodies inside `locked_read` /
+/// `locked_write` stay readable.
+trait McpResolve {
+    fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError>;
+    fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
+    fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError>;
+    fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
+    fn mcp_resolve_sprint_global(&self, raw: &str) -> Result<Uuid, McpError>;
+    fn mcp_resolve_card(&self, raw: &str) -> Result<Uuid, McpError>;
+    fn mcp_resolve_cards(&self, raws: &[String]) -> Result<Vec<Uuid>, McpError>;
+    fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError>;
+}
+
+impl McpResolve for McpContext {
+    fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError> {
+        self.resolve_board_id(raw).map_err(kanban_err_to_mcp)
     }
-    let matches = {
-        let guard = ctx.lock().await;
-        guard
-            .find_cards_by_identifier(s)
-            .map_err(kanban_err_to_mcp)?
-    };
-    match matches.as_slice() {
-        [] => Err(McpError::invalid_params(
-            format!("Card not found: '{}'", s),
-            None,
-        )),
-        [card] => Ok(card.id),
-        cards => Err(McpError::invalid_params(
-            format_ambiguous_matches(s, cards),
-            None,
-        )),
+    fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError> {
+        self.resolve_column_id(raw, board_id)
+            .map_err(kanban_err_to_mcp)
     }
+    fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError> {
+        self.resolve_column_id_global(raw)
+            .map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError> {
+        self.resolve_sprint_id(raw, board_id)
+            .map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_sprint_global(&self, raw: &str) -> Result<Uuid, McpError> {
+        self.resolve_sprint_id_global(raw)
+            .map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_card(&self, raw: &str) -> Result<Uuid, McpError> {
+        self.resolve_card_id(raw).map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_cards(&self, raws: &[String]) -> Result<Vec<Uuid>, McpError> {
+        self.resolve_card_ids(raws).map_err(kanban_err_to_mcp)
+    }
+    fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError> {
+        self.require_same_board(card_ids).map_err(kanban_err_to_mcp)
+    }
+}
+
+/// Derive a card's board via card → column → board, with MCP-flavoured error
+/// mapping. Standalone (not on the resolver trait) because it composes
+/// multiple trait calls rather than being a simple error-mapping shim.
+fn card_board(ctx: &McpContext, card_id: Uuid) -> Result<Uuid, McpError> {
+    let card = ctx
+        .get_card(card_id)
+        .map_err(kanban_err_to_mcp)?
+        .ok_or_else(|| McpError::invalid_params(format!("Card not found: {}", card_id), None))?;
+    let column = ctx
+        .get_column(card.column_id)
+        .map_err(kanban_err_to_mcp)?
+        .ok_or_else(|| {
+            McpError::invalid_params(format!("Column not found: {}", card.column_id), None)
+        })?;
+    Ok(column.board_id)
 }
 
 /// Lock the context, reload from disk, execute a mutating operation, then save.
@@ -183,14 +276,14 @@ pub struct CreateBoardRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetBoardRequest {
-    #[schemars(description = "ID of the board to retrieve")]
-    pub board_id: String,
+    #[schemars(description = "UUID or name of the board to retrieve")]
+    pub board: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateBoardRequest {
-    #[schemars(description = "ID of the board to update")]
-    pub board_id: String,
+    #[schemars(description = "UUID or name of the board to update")]
+    pub board: String,
     #[schemars(description = "New name (optional)")]
     pub name: Option<String>,
     #[schemars(description = "New description (optional)")]
@@ -203,16 +296,16 @@ pub struct UpdateBoardRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteBoardRequest {
-    #[schemars(description = "ID of the board to delete")]
-    pub board_id: String,
+    #[schemars(description = "UUID or name of the board to delete")]
+    pub board: String,
 }
 
 // Column
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateColumnRequest {
-    #[schemars(description = "ID of the board to create the column in")]
-    pub board_id: String,
+    #[schemars(description = "UUID or name of the board to create the column in")]
+    pub board: String,
     #[schemars(description = "Name of the column")]
     pub name: String,
     #[schemars(description = "Position of the column (optional, appends to end if not specified)")]
@@ -221,20 +314,20 @@ pub struct CreateColumnRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListColumnsRequest {
-    #[schemars(description = "ID of the board to list columns for")]
-    pub board_id: String,
+    #[schemars(description = "UUID or name of the board to list columns for")]
+    pub board: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetColumnRequest {
-    #[schemars(description = "ID of the column to retrieve")]
-    pub column_id: String,
+    #[schemars(description = "UUID or name of the column to retrieve")]
+    pub column: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateColumnRequest {
-    #[schemars(description = "ID of the column to update")]
-    pub column_id: String,
+    #[schemars(description = "UUID or name of the column to update")]
+    pub column: String,
     #[schemars(description = "New name (optional)")]
     pub name: Option<String>,
     #[schemars(description = "New position (optional)")]
@@ -247,14 +340,14 @@ pub struct UpdateColumnRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteColumnRequest {
-    #[schemars(description = "ID of the column to delete")]
-    pub column_id: String,
+    #[schemars(description = "UUID or name of the column to delete")]
+    pub column: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ReorderColumnRequest {
-    #[schemars(description = "ID of the column to reorder")]
-    pub column_id: String,
+    #[schemars(description = "UUID or name of the column to reorder")]
+    pub column: String,
     #[schemars(description = "New position")]
     pub position: i32,
 }
@@ -263,10 +356,10 @@ pub struct ReorderColumnRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateCardRequest {
-    #[schemars(description = "ID of the board")]
-    pub board_id: String,
-    #[schemars(description = "ID of the column to create the card in")]
-    pub column_id: String,
+    #[schemars(description = "UUID or name of the board")]
+    pub board: String,
+    #[schemars(description = "UUID or name of the column to create the card in")]
+    pub column: String,
     #[schemars(description = "Title of the card")]
     pub title: String,
     #[schemars(description = "Description of the card (optional)")]
@@ -283,12 +376,16 @@ pub struct CreateCardRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListCardsRequest {
-    #[schemars(description = "Filter cards by board ID")]
-    pub board_id: Option<String>,
-    #[schemars(description = "Filter cards by column ID")]
-    pub column_id: Option<String>,
-    #[schemars(description = "Filter cards by sprint ID")]
-    pub sprint_id: Option<String>,
+    #[schemars(description = "Filter cards by board UUID or name")]
+    pub board: Option<String>,
+    #[schemars(
+        description = "Filter cards by column UUID or name (scoped to board if given, else global)"
+    )]
+    pub column: Option<String>,
+    #[schemars(
+        description = "Filter cards by sprint UUID, name, or number (scoped to board if given, else global)"
+    )]
+    pub sprint: Option<String>,
     #[schemars(description = "Filter by status: 'todo', 'in_progress', 'blocked', or 'done'")]
     pub status: Option<String>,
     #[schemars(description = "Page number, 1-based (default: 1)")]
@@ -308,13 +405,13 @@ pub struct ListArchivedCardsRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetCardRequest {
     #[schemars(description = "UUID or identifier of the card to retrieve (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateCardRequest {
     #[schemars(description = "UUID or identifier of the card to update (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
     #[schemars(description = "New title (optional)")]
     pub title: Option<String>,
     #[schemars(description = "New description (optional)")]
@@ -336,9 +433,11 @@ pub struct UpdateCardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct MoveCardRequest {
     #[schemars(description = "UUID or identifier of the card to move (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
-    #[schemars(description = "ID of the destination column")]
-    pub column_id: String,
+    pub card: String,
+    #[schemars(
+        description = "UUID or name of the destination column (resolved within the card's board)"
+    )]
+    pub column: String,
     #[schemars(description = "Position in the new column (optional)")]
     pub position: Option<i32>,
 }
@@ -346,7 +445,7 @@ pub struct MoveCardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ArchiveCardRequest {
     #[schemars(description = "UUID or identifier of the card to archive (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -354,15 +453,17 @@ pub struct RestoreCardRequest {
     #[schemars(
         description = "UUID or identifier of the archived card to restore (e.g. 'KAN-5' or '5')"
     )]
-    pub card_id: String,
-    #[schemars(description = "Column ID to restore the card to (optional)")]
-    pub column_id: Option<String>,
+    pub card: String,
+    #[schemars(
+        description = "UUID or name of the column to restore the card to (optional; resolved within the card's board)"
+    )]
+    pub column: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteCardRequest {
     #[schemars(description = "UUID or identifier of the card to delete (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 // Card Sprint
@@ -370,9 +471,11 @@ pub struct DeleteCardRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct AssignCardToSprintRequest {
     #[schemars(description = "UUID or identifier of the card (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
-    #[schemars(description = "ID of the sprint to assign to")]
-    pub sprint_id: String,
+    pub card: String,
+    #[schemars(
+        description = "UUID, name, or number of the sprint to assign to (resolved within the card's board)"
+    )]
+    pub sprint: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -380,7 +483,7 @@ pub struct UnassignCardFromSprintRequest {
     #[schemars(
         description = "UUID or identifier of the card to unassign from its sprint (e.g. 'KAN-5' or '5')"
     )]
-    pub card_id: String,
+    pub card: String,
 }
 
 // Card Utilities
@@ -388,45 +491,53 @@ pub struct UnassignCardFromSprintRequest {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetCardBranchNameRequest {
     #[schemars(description = "UUID or identifier of the card (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetCardGitCheckoutRequest {
     #[schemars(description = "UUID or identifier of the card (e.g. 'KAN-5' or '5')")]
-    pub card_id: String,
+    pub card: String,
 }
 
 // Multi-card operations
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ArchiveCardsRequest {
-    #[schemars(description = "Comma-separated card IDs to archive")]
-    pub ids: String,
+    #[schemars(description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2', '42'])")]
+    pub cards: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct MoveCardsRequest {
-    #[schemars(description = "Comma-separated card IDs to move")]
-    pub ids: String,
-    #[schemars(description = "ID of the destination column")]
-    pub column_id: String,
+    #[schemars(
+        description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2']); all cards must share a board"
+    )]
+    pub cards: Vec<String>,
+    #[schemars(
+        description = "UUID or name of the destination column (resolved within the cards' shared board)"
+    )]
+    pub column: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct AssignCardsToSprintRequest {
-    #[schemars(description = "Comma-separated card IDs")]
-    pub ids: String,
-    #[schemars(description = "ID of the sprint to assign to")]
-    pub sprint_id: String,
+    #[schemars(
+        description = "Card UUIDs or identifiers (e.g. ['KAN-1', 'KAN-2']); all cards must share a board"
+    )]
+    pub cards: Vec<String>,
+    #[schemars(
+        description = "UUID, name, or number of the sprint to assign to (resolved within the cards' shared board)"
+    )]
+    pub sprint: String,
 }
 
 // Sprint
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CreateSprintRequest {
-    #[schemars(description = "ID of the board")]
-    pub board_id: String,
+    #[schemars(description = "UUID or name of the board")]
+    pub board: String,
     #[schemars(description = "Sprint prefix (optional)")]
     pub prefix: Option<String>,
     #[schemars(description = "Sprint name (optional)")]
@@ -435,20 +546,20 @@ pub struct CreateSprintRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListSprintsRequest {
-    #[schemars(description = "ID of the board")]
-    pub board_id: String,
+    #[schemars(description = "UUID or name of the board")]
+    pub board: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetSprintRequest {
-    #[schemars(description = "ID of the sprint")]
-    pub sprint_id: String,
+    #[schemars(description = "UUID, name, or number of the sprint")]
+    pub sprint: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UpdateSprintRequest {
-    #[schemars(description = "ID of the sprint to update")]
-    pub sprint_id: String,
+    #[schemars(description = "UUID, name, or number of the sprint to update")]
+    pub sprint: String,
     #[schemars(description = "New sprint name (optional)")]
     pub name: Option<String>,
     #[schemars(description = "New prefix (optional)")]
@@ -467,46 +578,52 @@ pub struct UpdateSprintRequest {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ActivateSprintRequest {
-    #[schemars(description = "ID of the sprint to activate")]
-    pub sprint_id: String,
+    #[schemars(description = "UUID, name, or number of the sprint to activate")]
+    pub sprint: String,
     #[schemars(description = "Duration in days (optional)")]
     pub duration_days: Option<i32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CompleteSprintRequest {
-    #[schemars(description = "ID of the sprint to complete")]
-    pub sprint_id: String,
+    #[schemars(description = "UUID, name, or number of the sprint to complete")]
+    pub sprint: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CancelSprintRequest {
-    #[schemars(description = "ID of the sprint to cancel")]
-    pub sprint_id: String,
+    #[schemars(description = "UUID, name, or number of the sprint to cancel")]
+    pub sprint: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteSprintRequest {
-    #[schemars(description = "ID of the sprint to delete")]
-    pub sprint_id: String,
+    #[schemars(description = "UUID, name, or number of the sprint to delete")]
+    pub sprint: String,
 }
 
 // Carry-over
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct CarryOverSprintCardsRequest {
-    #[schemars(description = "ID of the completed or cancelled sprint to carry cards from")]
-    pub from_sprint_id: String,
-    #[schemars(description = "ID of the planning sprint to carry cards to")]
-    pub to_sprint_id: String,
+    #[schemars(
+        description = "UUID, name, or number of the completed/cancelled source sprint to carry cards from"
+    )]
+    pub from_sprint: String,
+    #[schemars(
+        description = "UUID, name, or number of the planning sprint to carry cards to (must be on the same board as source)"
+    )]
+    pub to_sprint: String,
 }
 
 // Export/Import
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ExportBoardRequest {
-    #[schemars(description = "ID of the board to export (optional, exports all if omitted)")]
-    pub board_id: Option<String>,
+    #[schemars(
+        description = "UUID or name of the board to export (optional, exports all if omitted)"
+    )]
+    pub board: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -549,7 +666,7 @@ impl KanbanMcpServer {
     // Board Operations
 
     #[tool(description = "Create a new kanban board")]
-    async fn tool_create_board(
+    pub async fn tool_create_board(
         &self,
         Parameters(req): Parameters<CreateBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
@@ -558,29 +675,31 @@ impl KanbanMcpServer {
     }
 
     #[tool(description = "List all kanban boards")]
-    async fn tool_list_boards(&self) -> Result<CallToolResult, McpError> {
+    pub async fn tool_list_boards(&self) -> Result<CallToolResult, McpError> {
         let boards = read_op!(self.ctx, list_boards)?;
         to_call_tool_result(&boards)
     }
 
-    #[tool(description = "Get a specific board by ID")]
-    async fn tool_get_board(
+    #[tool(description = "Get a specific board by UUID or name")]
+    pub async fn tool_get_board(
         &self,
         Parameters(req): Parameters<GetBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.board_id)?;
-        let board = read_op!(self.ctx, get_board, id)?;
+        let board = locked_read(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.get_board(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&board)
     }
 
     #[tool(
         description = "Update a board's properties (name, description, sprint_prefix, card_prefix)"
     )]
-    async fn tool_update_board(
+    pub async fn tool_update_board(
         &self,
         Parameters(req): Parameters<UpdateBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.board_id)?;
         let updates = BoardUpdate {
             name: req.name,
             description: req
@@ -597,58 +716,75 @@ impl KanbanMcpServer {
                 .unwrap_or(FieldUpdate::NoChange),
             ..Default::default()
         };
-        let board = mutating_op!(self.ctx, update_board, id, updates)?;
+        let board = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.update_board(id, updates).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&board)
     }
 
     #[tool(description = "Delete a board and all its columns, cards, and sprints")]
-    async fn tool_delete_board(
+    pub async fn tool_delete_board(
         &self,
         Parameters(req): Parameters<DeleteBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.board_id)?;
-        mutating_op!(self.ctx, delete_board, id)?;
-        to_call_tool_result_json(serde_json::json!({"deleted": req.board_id}))
+        let id = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
+        to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     // Column Operations
 
     #[tool(description = "Create a new column in a board")]
-    async fn tool_create_column(
+    pub async fn tool_create_column(
         &self,
         Parameters(req): Parameters<CreateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
-        let column = mutating_op!(self.ctx, create_column, board_id, req.name, req.position)?;
+        let column = locked_write(&self.ctx, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.create_column(board_id, req.name, req.position)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&column)
     }
 
     #[tool(description = "List all columns in a board")]
-    async fn tool_list_columns(
+    pub async fn tool_list_columns(
         &self,
         Parameters(req): Parameters<ListColumnsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
-        let columns = read_op!(self.ctx, list_columns, board_id)?;
+        let columns = locked_read(&self.ctx, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.list_columns(board_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&columns)
     }
 
-    #[tool(description = "Get a specific column by ID")]
-    async fn tool_get_column(
+    #[tool(description = "Get a specific column by UUID or name (searched across all boards)")]
+    pub async fn tool_get_column(
         &self,
         Parameters(req): Parameters<GetColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.column_id)?;
-        let column = read_op!(self.ctx, get_column, id)?;
+        let column = locked_read(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_column_global(&req.column)?;
+            ctx.get_column(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&column)
     }
 
     #[tool(description = "Update a column's properties (name, position, wip_limit)")]
-    async fn tool_update_column(
+    pub async fn tool_update_column(
         &self,
         Parameters(req): Parameters<UpdateColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.column_id)?;
         let updates = ColumnUpdate {
             name: req.name,
             position: req.position,
@@ -660,104 +796,129 @@ impl KanbanMcpServer {
                     .unwrap_or(FieldUpdate::NoChange)
             },
         };
-        let column = mutating_op!(self.ctx, update_column, id, updates)?;
+        let column = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_column_global(&req.column)?;
+            ctx.update_column(id, updates).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&column)
     }
 
     #[tool(description = "Delete a column and all its cards")]
-    async fn tool_delete_column(
+    pub async fn tool_delete_column(
         &self,
         Parameters(req): Parameters<DeleteColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.column_id)?;
-        mutating_op!(self.ctx, delete_column, id)?;
-        to_call_tool_result_json(serde_json::json!({"deleted": req.column_id}))
+        let id = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_column_global(&req.column)?;
+            ctx.delete_column(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
+        to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     #[tool(description = "Reorder a column to a new position")]
-    async fn tool_reorder_column(
+    pub async fn tool_reorder_column(
         &self,
         Parameters(req): Parameters<ReorderColumnRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.column_id)?;
-        let column = mutating_op!(self.ctx, reorder_column, id, req.position)?;
+        let column = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_column_global(&req.column)?;
+            ctx.reorder_column(id, req.position)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&column)
     }
 
     // Card Operations
 
     #[tool(description = "Create a new card in a column")]
-    async fn tool_create_card(
+    pub async fn tool_create_card(
         &self,
         Parameters(req): Parameters<CreateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
-        let column_id = parse_uuid(&req.column_id)?;
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let due_date = req.due_date.as_deref().map(parse_datetime).transpose()?;
-
         let options = CreateCardOptions {
             description: req.description,
             priority,
             points: req.points,
             due_date,
         };
-
-        let card = mutating_op!(
-            self.ctx,
-            create_card,
-            board_id,
-            column_id,
-            req.title,
-            options
-        )?;
+        let card = locked_write(&self.ctx, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
+            ctx.create_card(board_id, column_id, req.title, options)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(
         description = "List cards with optional filters. Returns CardSummary (title, status, priority — no description). Use card get for full details. Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
-    async fn tool_list_cards(
+    pub async fn tool_list_cards(
         &self,
         Parameters(req): Parameters<ListCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = req.board_id.as_deref().map(parse_uuid).transpose()?;
-        let column_id = req.column_id.as_deref().map(parse_uuid).transpose()?;
-        let sprint_id = req.sprint_id.as_deref().map(parse_uuid).transpose()?;
         let status = req.status.as_deref().map(parse_status).transpose()?;
-
-        let filter = CardListFilter {
-            board_id,
-            column_id,
-            sprint_id,
-            status,
-        };
         let (page, page_size) =
             resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
-        let result = read_op!(self.ctx, list_cards_paged, filter, page, page_size)?;
+        let result = locked_read(&self.ctx, |ctx| {
+            let board_id = match &req.board {
+                Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
+                None => None,
+            };
+            let column_id = match &req.column {
+                Some(raw) => Some(match board_id {
+                    Some(bid) => ctx.mcp_resolve_column_in_board(raw, bid)?,
+                    None => ctx.mcp_resolve_column_global(raw)?,
+                }),
+                None => None,
+            };
+            let sprint_id = match &req.sprint {
+                Some(raw) => Some(match board_id {
+                    Some(bid) => ctx.mcp_resolve_sprint_in_board(raw, bid)?,
+                    None => ctx.mcp_resolve_sprint_global(raw)?,
+                }),
+                None => None,
+            };
+            let filter = CardListFilter {
+                board_id,
+                column_id,
+                sprint_id,
+                status,
+            };
+            ctx.list_cards_paged(filter, page, page_size)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&result)
     }
 
     #[tool(
         description = "Get a specific card by UUID or identifier (e.g. KAN-5). Returns a single card for UUID or unambiguous identifier, or a list of all matching cards if the identifier is ambiguous."
     )]
-    async fn tool_get_card(
+    pub async fn tool_get_card(
         &self,
         Parameters(req): Parameters<GetCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        if let Ok(uuid) = uuid::Uuid::parse_str(&req.card_id) {
+        if let Ok(uuid) = uuid::Uuid::parse_str(&req.card) {
             let card = read_op!(self.ctx, get_card, uuid)?;
             return to_call_tool_result(&card);
         }
         let cards = {
             let guard = self.ctx.lock().await;
             guard
-                .find_cards_by_identifier(&req.card_id)
+                .find_cards_by_identifier(&req.card)
                 .map_err(kanban_err_to_mcp)?
         };
         match cards.as_slice() {
             [] => Err(McpError::invalid_params(
-                format!("Card not found: '{}'", req.card_id),
+                format!("Card not found: '{}'", req.card),
                 None,
             )),
             [card] => to_call_tool_result(card),
@@ -768,14 +929,20 @@ impl KanbanMcpServer {
     #[tool(
         description = "Update a card's properties (title, description, priority, status, due_date, points)"
     )]
-    async fn tool_update_card(
+    pub async fn tool_update_card(
         &self,
         Parameters(req): Parameters<UpdateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let status = req.status.as_deref().map(parse_status).transpose()?;
-
+        let due_date = if req.clear_due_date == Some(true) {
+            FieldUpdate::Clear
+        } else {
+            match req.due_date {
+                Some(ref d) => FieldUpdate::Set(parse_datetime(d)?),
+                None => FieldUpdate::NoChange,
+            }
+        };
         let updates = CardUpdate {
             title: req.title,
             description: req
@@ -790,66 +957,85 @@ impl KanbanMcpServer {
                 .points
                 .map(FieldUpdate::Set)
                 .unwrap_or(FieldUpdate::NoChange),
-            due_date: if req.clear_due_date == Some(true) {
-                FieldUpdate::Clear
-            } else {
-                match req.due_date {
-                    Some(ref d) => FieldUpdate::Set(parse_datetime(d)?),
-                    None => FieldUpdate::NoChange,
-                }
-            },
+            due_date,
             sprint_id: FieldUpdate::NoChange,
         };
-        let card = mutating_op!(self.ctx, update_card, id, updates)?;
+        let card = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.update_card(id, updates).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
-    #[tool(description = "Move a card to a different column")]
-    async fn tool_move_card(
+    #[tool(description = "Move a card to a different column on the same board")]
+    pub async fn tool_move_card(
         &self,
         Parameters(req): Parameters<MoveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let column_id = parse_uuid(&req.column_id)?;
-        let card = mutating_op!(self.ctx, move_card, id, column_id, req.position)?;
+        let card = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            let board_id = card_board(ctx, id)?;
+            let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
+            ctx.move_card(id, column_id, req.position)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(description = "Archive a card (move to archive, can be restored later)")]
-    async fn tool_archive_card(
+    pub async fn tool_archive_card(
         &self,
         Parameters(req): Parameters<ArchiveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        mutating_op!(self.ctx, archive_card, id)?;
+        let id = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.archive_card(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"archived": id.to_string()}))
     }
 
     #[tool(description = "Restore an archived card")]
-    async fn tool_restore_card(
+    pub async fn tool_restore_card(
         &self,
         Parameters(req): Parameters<RestoreCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let column_id = req.column_id.as_deref().map(parse_uuid).transpose()?;
-        let card = mutating_op!(self.ctx, restore_card, id, column_id)?;
+        let card = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            let column_id = match req.column.as_deref() {
+                Some(raw) => {
+                    let board_id = card_board(ctx, id)?;
+                    Some(ctx.mcp_resolve_column_in_board(raw, board_id)?)
+                }
+                None => None,
+            };
+            ctx.restore_card(id, column_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(description = "Delete a card permanently")]
-    async fn tool_delete_card(
+    pub async fn tool_delete_card(
         &self,
         Parameters(req): Parameters<DeleteCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        mutating_op!(self.ctx, delete_card, id)?;
+        let id = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.delete_card(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     #[tool(
         description = "List archived cards. Returns ArchivedCardSummary (no description). Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
-    async fn tool_list_archived_cards(
+    pub async fn tool_list_archived_cards(
         &self,
         Parameters(req): Parameters<ListArchivedCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
@@ -865,124 +1051,165 @@ impl KanbanMcpServer {
 
     // Card Sprint Operations
 
-    #[tool(description = "Assign a card to a sprint")]
-    async fn tool_assign_card_to_sprint(
+    #[tool(description = "Assign a card to a sprint on the same board")]
+    pub async fn tool_assign_card_to_sprint(
         &self,
         Parameters(req): Parameters<AssignCardToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card_id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let sprint_id = parse_uuid(&req.sprint_id)?;
-        let card = mutating_op!(self.ctx, assign_card_to_sprint, card_id, sprint_id)?;
+        let card = locked_write(&self.ctx, |ctx| {
+            let card_id = ctx.mcp_resolve_card(&req.card)?;
+            let board_id = card_board(ctx, card_id)?;
+            let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
+            ctx.assign_card_to_sprint(card_id, sprint_id)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     #[tool(description = "Unassign a card from its sprint")]
-    async fn tool_unassign_card_from_sprint(
+    pub async fn tool_unassign_card_from_sprint(
         &self,
         Parameters(req): Parameters<UnassignCardFromSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let card_id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let card = mutating_op!(self.ctx, unassign_card_from_sprint, card_id)?;
+        let card = locked_write(&self.ctx, |ctx| {
+            let card_id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.unassign_card_from_sprint(card_id)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&card)
     }
 
     // Card Utilities
 
     #[tool(description = "Get the git branch name for a card")]
-    async fn tool_get_card_branch_name(
+    pub async fn tool_get_card_branch_name(
         &self,
         Parameters(req): Parameters<GetCardBranchNameRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let branch_name = read_op!(self.ctx, get_card_branch_name, id)?;
+        let branch_name = locked_read(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.get_card_branch_name(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"branch_name": branch_name}))
     }
 
     #[tool(description = "Get the git checkout command for a card")]
-    async fn tool_get_card_git_checkout(
+    pub async fn tool_get_card_git_checkout(
         &self,
         Parameters(req): Parameters<GetCardGitCheckoutRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = resolve_card_id(&self.ctx, &req.card_id).await?;
-        let command = read_op!(self.ctx, get_card_git_checkout, id)?;
+        let command = locked_read(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_card(&req.card)?;
+            ctx.get_card_git_checkout(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"command": command}))
     }
 
     // Multi-card operations
 
-    #[tool(description = "Archive multiple cards at once")]
-    async fn tool_archive_cards(
+    #[tool(
+        description = "Archive multiple cards at once. IDs may be UUIDs or identifiers (e.g. 'KAN-1', '42')."
+    )]
+    pub async fn tool_archive_cards(
         &self,
         Parameters(req): Parameters<ArchiveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = parse_uuids_csv(&req.ids)?;
-        let count = mutating_op!(self.ctx, archive_cards, ids)?;
+        let count = locked_write(&self.ctx, |ctx| {
+            let ids = ctx.mcp_resolve_cards(&req.cards)?;
+            ctx.archive_cards(ids).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"archived_count": count}))
     }
 
-    #[tool(description = "Move multiple cards to a column")]
-    async fn tool_move_cards(
+    #[tool(
+        description = "Move multiple cards to a column. All cards must share a board; the column is resolved on that board."
+    )]
+    pub async fn tool_move_cards(
         &self,
         Parameters(req): Parameters<MoveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = parse_uuids_csv(&req.ids)?;
-        let column_id = parse_uuid(&req.column_id)?;
-        let count = mutating_op!(self.ctx, move_cards, ids, column_id)?;
+        let count = locked_write(&self.ctx, |ctx| {
+            let ids = ctx.mcp_resolve_cards(&req.cards)?;
+            let board_id = ctx.mcp_require_same_board(&ids)?;
+            let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
+            ctx.move_cards(ids, column_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"moved_count": count}))
     }
 
-    #[tool(description = "Assign multiple cards to a sprint")]
-    async fn tool_assign_cards_to_sprint(
+    #[tool(
+        description = "Assign multiple cards to a sprint. All cards must share a board; the sprint is resolved on that board."
+    )]
+    pub async fn tool_assign_cards_to_sprint(
         &self,
         Parameters(req): Parameters<AssignCardsToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let ids = parse_uuids_csv(&req.ids)?;
-        let sprint_id = parse_uuid(&req.sprint_id)?;
-        let count = mutating_op!(self.ctx, assign_cards_to_sprint, ids, sprint_id)?;
+        let count = locked_write(&self.ctx, |ctx| {
+            let ids = ctx.mcp_resolve_cards(&req.cards)?;
+            let board_id = ctx.mcp_require_same_board(&ids)?;
+            let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
+            ctx.assign_cards_to_sprint(ids, sprint_id)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({"assigned_count": count}))
     }
 
     // Sprint Operations
 
     #[tool(description = "Create a new sprint")]
-    async fn tool_create_sprint(
+    pub async fn tool_create_sprint(
         &self,
         Parameters(req): Parameters<CreateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
-        let sprint = mutating_op!(self.ctx, create_sprint, board_id, req.prefix, req.name)?;
+        let sprint = locked_write(&self.ctx, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.create_sprint(board_id, req.prefix, req.name)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "List sprints for a board")]
-    async fn tool_list_sprints(
+    pub async fn tool_list_sprints(
         &self,
         Parameters(req): Parameters<ListSprintsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = parse_uuid(&req.board_id)?;
-        let sprints = read_op!(self.ctx, list_sprints, board_id)?;
+        let sprints = locked_read(&self.ctx, |ctx| {
+            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.list_sprints(board_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprints)
     }
 
-    #[tool(description = "Get a specific sprint by ID")]
-    async fn tool_get_sprint(
+    #[tool(description = "Get a specific sprint by UUID, name, or number")]
+    pub async fn tool_get_sprint(
         &self,
         Parameters(req): Parameters<GetSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
-        let sprint = read_op!(self.ctx, get_sprint, id)?;
+        let sprint = locked_read(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.get_sprint(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(
         description = "Update a sprint's properties (name, prefix, card_prefix, start_date, end_date)"
     )]
-    async fn tool_update_sprint(
+    pub async fn tool_update_sprint(
         &self,
         Parameters(req): Parameters<UpdateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
-
         let start_date = if req.clear_start_date == Some(true) {
             FieldUpdate::Clear
         } else {
@@ -991,7 +1218,6 @@ impl KanbanMcpServer {
                 None => FieldUpdate::NoChange,
             }
         };
-
         let end_date = if req.clear_end_date == Some(true) {
             FieldUpdate::Clear
         } else {
@@ -1000,7 +1226,6 @@ impl KanbanMcpServer {
                 None => FieldUpdate::NoChange,
             }
         };
-
         let updates = SprintUpdate {
             name: req.name,
             name_index: FieldUpdate::NoChange,
@@ -1016,79 +1241,111 @@ impl KanbanMcpServer {
             start_date,
             end_date,
         };
-
-        let sprint = mutating_op!(self.ctx, update_sprint, id, updates)?;
+        let sprint = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.update_sprint(id, updates).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "Activate a sprint")]
-    async fn tool_activate_sprint(
+    pub async fn tool_activate_sprint(
         &self,
         Parameters(req): Parameters<ActivateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
-        let sprint = mutating_op!(self.ctx, activate_sprint, id, req.duration_days)?;
+        let sprint = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.activate_sprint(id, req.duration_days)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "Complete a sprint")]
-    async fn tool_complete_sprint(
+    pub async fn tool_complete_sprint(
         &self,
         Parameters(req): Parameters<CompleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
-        let sprint = mutating_op!(self.ctx, complete_sprint, id)?;
+        let sprint = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.complete_sprint(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "Cancel a sprint")]
-    async fn tool_cancel_sprint(
+    pub async fn tool_cancel_sprint(
         &self,
         Parameters(req): Parameters<CancelSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
-        let sprint = mutating_op!(self.ctx, cancel_sprint, id)?;
+        let sprint = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.cancel_sprint(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&sprint)
     }
 
     #[tool(description = "Delete a sprint")]
-    async fn tool_delete_sprint(
+    pub async fn tool_delete_sprint(
         &self,
         Parameters(req): Parameters<DeleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let id = parse_uuid(&req.sprint_id)?;
-        mutating_op!(self.ctx, delete_sprint, id)?;
-        to_call_tool_result_json(serde_json::json!({"deleted": req.sprint_id}))
+        let id = locked_write(&self.ctx, |ctx| {
+            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            ctx.delete_sprint(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
+        to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
     }
 
     #[tool(
-        description = "Carry over uncompleted cards from a completed/cancelled sprint to a planning sprint"
+        description = "Carry over uncompleted cards from a completed/cancelled sprint to a planning sprint on the same board"
     )]
-    async fn tool_carry_over_sprint_cards(
+    pub async fn tool_carry_over_sprint_cards(
         &self,
         Parameters(req): Parameters<CarryOverSprintCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let from_id = parse_uuid(&req.from_sprint_id)?;
-        let to_id = parse_uuid(&req.to_sprint_id)?;
-
-        let count = mutating_op!(self.ctx, carry_over_sprint_cards, from_id, to_id)?;
+        let count = locked_write(&self.ctx, |ctx| {
+            let from_id = ctx.mcp_resolve_sprint_global(&req.from_sprint)?;
+            let from_sprint = ctx
+                .get_sprint(from_id)
+                .map_err(kanban_err_to_mcp)?
+                .ok_or_else(|| {
+                    McpError::invalid_params(format!("Sprint not found: {}", from_id), None)
+                })?;
+            let to_id = ctx.mcp_resolve_sprint_in_board(&req.to_sprint, from_sprint.board_id)?;
+            ctx.carry_over_sprint_cards(from_id, to_id)
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result_json(serde_json::json!({ "carried_over_count": count }))
     }
 
     // Export/Import
 
     #[tool(description = "Export board data as JSON")]
-    async fn tool_export_board(
+    pub async fn tool_export_board(
         &self,
         Parameters(req): Parameters<ExportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board_id = req.board_id.as_deref().map(parse_uuid).transpose()?;
-        let json = read_op!(self.ctx, export_board, board_id)?;
+        let json = locked_read(&self.ctx, |ctx| {
+            let board_id = match req.board.as_deref() {
+                Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
+                None => None,
+            };
+            ctx.export_board(board_id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
     #[tool(description = "Import board data from JSON")]
-    async fn tool_import_board(
+    pub async fn tool_import_board(
         &self,
         Parameters(req): Parameters<ImportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
@@ -1098,7 +1355,7 @@ impl KanbanMcpServer {
     }
 
     #[tool(description = "Undo the last operation")]
-    async fn tool_undo(&self) -> Result<CallToolResult, McpError> {
+    pub async fn tool_undo(&self) -> Result<CallToolResult, McpError> {
         let mut guard = self.ctx.lock().await;
         if guard.undo().map_err(kanban_err_to_mcp)? {
             guard.save().await.map_err(kanban_err_to_mcp)?;
@@ -1113,7 +1370,7 @@ impl KanbanMcpServer {
     }
 
     #[tool(description = "Redo the last undone operation")]
-    async fn tool_redo(&self) -> Result<CallToolResult, McpError> {
+    pub async fn tool_redo(&self) -> Result<CallToolResult, McpError> {
         let mut guard = self.ctx.lock().await;
         if guard.redo().map_err(kanban_err_to_mcp)? {
             guard.save().await.map_err(kanban_err_to_mcp)?;
@@ -1151,27 +1408,6 @@ impl ServerHandler for KanbanMcpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // parse_uuid
-
-    #[test]
-    fn parse_uuid_valid() {
-        let id = "550e8400-e29b-41d4-a716-446655440000";
-        let result = parse_uuid(id).unwrap();
-        assert_eq!(result.to_string(), id);
-    }
-
-    #[test]
-    fn parse_uuid_invalid() {
-        let err = parse_uuid("not-a-uuid").unwrap_err();
-        assert!(err.message.contains("Invalid UUID"));
-    }
-
-    #[test]
-    fn parse_uuid_empty() {
-        let err = parse_uuid("").unwrap_err();
-        assert!(err.message.contains("Invalid UUID"));
-    }
 
     // parse_priority
 
@@ -1267,37 +1503,6 @@ mod tests {
     fn parse_datetime_invalid() {
         let err = parse_datetime("not-a-date").unwrap_err();
         assert!(err.message.contains("Invalid date"));
-    }
-
-    // parse_uuids_csv
-
-    #[test]
-    fn parse_uuids_csv_single() {
-        let id = "550e8400-e29b-41d4-a716-446655440000";
-        let result = parse_uuids_csv(id).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].to_string(), id);
-    }
-
-    #[test]
-    fn parse_uuids_csv_multiple() {
-        let ids = "550e8400-e29b-41d4-a716-446655440000,660e8400-e29b-41d4-a716-446655440001";
-        let result = parse_uuids_csv(ids).unwrap();
-        assert_eq!(result.len(), 2);
-    }
-
-    #[test]
-    fn parse_uuids_csv_with_spaces() {
-        let ids = "550e8400-e29b-41d4-a716-446655440000 , 660e8400-e29b-41d4-a716-446655440001";
-        let result = parse_uuids_csv(ids).unwrap();
-        assert_eq!(result.len(), 2);
-    }
-
-    #[test]
-    fn parse_uuids_csv_invalid_in_list() {
-        let ids = "550e8400-e29b-41d4-a716-446655440000,bad-uuid";
-        let err = parse_uuids_csv(ids).unwrap_err();
-        assert!(err.message.contains("Invalid UUID"));
     }
 
     // to_call_tool_result / to_call_tool_result_json

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -546,3 +546,366 @@ async fn test_mcp_reload_resets_undo_history() {
         "reload must reset undo history — cursor is invalid after external change"
     );
 }
+
+// ============================================================================
+// Name resolution via McpContext (same default trait methods as CLI uses).
+// Confirms the MCP context picks up the shared resolvers and they produce
+// the same human-friendly error messages.
+// ============================================================================
+
+#[tokio::test]
+async fn resolve_board_id_by_name_on_mcp_context() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx
+        .create_board("MyBoard".into(), Some("MB".into()))
+        .unwrap();
+    assert_eq!(ctx.resolve_board_id("MyBoard").unwrap(), board.id);
+    assert_eq!(ctx.resolve_board_id("myboard").unwrap(), board.id);
+}
+
+#[tokio::test]
+async fn resolve_board_id_unknown_lists_available_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    ctx.create_board("Alpha".into(), None).unwrap();
+    ctx.create_board("Beta".into(), None).unwrap();
+    let msg = ctx.resolve_board_id("Gamma").unwrap_err().to_string();
+    assert!(msg.contains("not found"), "msg: {msg}");
+    assert!(msg.contains("'Alpha'"), "msg: {msg}");
+    assert!(msg.contains("'Beta'"), "msg: {msg}");
+}
+
+#[tokio::test]
+async fn resolve_column_id_global_ambiguous_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    let a = ctx.create_board("A".into(), None).unwrap();
+    let b = ctx.create_board("B".into(), None).unwrap();
+    ctx.create_column(a.id, "TODO".into(), None).unwrap();
+    ctx.create_column(b.id, "TODO".into(), None).unwrap();
+    let msg = ctx
+        .resolve_column_id_global("todo")
+        .unwrap_err()
+        .to_string();
+    assert!(msg.contains("ambiguous"), "msg: {msg}");
+    assert!(msg.contains("'A'"), "msg: {msg}");
+    assert!(msg.contains("'B'"), "msg: {msg}");
+}
+
+#[tokio::test]
+async fn resolve_sprint_id_by_name_and_number_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let sprint = ctx
+        .create_sprint(board.id, None, Some("alpha".into()))
+        .unwrap();
+    assert_eq!(ctx.resolve_sprint_id("alpha", board.id).unwrap(), sprint.id);
+    assert_eq!(
+        ctx.resolve_sprint_id(&sprint.sprint_number.to_string(), board.id)
+            .unwrap(),
+        sprint.id
+    );
+}
+
+#[tokio::test]
+async fn resolve_card_ids_aggregates_failures_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "T".into(), Default::default())
+        .unwrap();
+    let raws = vec![format!("KAN-{}", card.card_number), "KAN-999".into()];
+    let err = ctx.resolve_card_ids(&raws).unwrap_err().to_string();
+    assert!(err.contains("KAN-999"), "msg: {err}");
+}
+
+#[tokio::test]
+async fn require_same_board_rejects_cross_board_on_mcp() {
+    let (mut ctx, _tmp) = setup().await;
+    let a = ctx.create_board("Alpha".into(), Some("A".into())).unwrap();
+    let b = ctx.create_board("Beta".into(), Some("B".into())).unwrap();
+    let col_a = ctx.create_column(a.id, "TODO".into(), None).unwrap();
+    let col_b = ctx.create_column(b.id, "TODO".into(), None).unwrap();
+    let c_a = ctx
+        .create_card(a.id, col_a.id, "a".into(), Default::default())
+        .unwrap();
+    let c_b = ctx
+        .create_card(b.id, col_b.id, "b".into(), Default::default())
+        .unwrap();
+    let err = ctx
+        .require_same_board(&[c_a.id, c_b.id])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("same board"), "msg: {err}");
+    assert!(err.contains("'Alpha'"), "msg: {err}");
+    assert!(err.contains("'Beta'"), "msg: {err}");
+}
+
+// ============================================================================
+// Tool-handler tests (KAN-400 review fix: previously only McpContext was tested,
+// not the actual tool bodies that go through `locked_session` + resolution).
+// ============================================================================
+
+use kanban_mcp::{
+    AssignCardToSprintRequest, CarryOverSprintCardsRequest, CreateBoardRequest, CreateCardRequest,
+    CreateColumnRequest, CreateSprintRequest, KanbanMcpServer, MoveCardRequest, MoveCardsRequest,
+};
+use rmcp::handler::server::wrapper::Parameters;
+use serde_json::Value;
+
+async fn setup_server() -> (KanbanMcpServer, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.json");
+    let store_manager = default_store_manager();
+    let server = KanbanMcpServer::new(
+        &store_manager,
+        &path.to_string_lossy(),
+        AppConfig::default(),
+    )
+    .await
+    .unwrap();
+    (server, dir)
+}
+
+fn text_payload(result: &rmcp::model::CallToolResult) -> Value {
+    let raw = &result.content[0]
+        .as_text()
+        .expect("expected text content")
+        .text;
+    serde_json::from_str(raw).expect("tool result is JSON")
+}
+
+#[tokio::test]
+async fn tool_move_card_resolves_names_through_locked_session() {
+    let (server, _tmp) = setup_server().await;
+    // Seed: board with two columns and one card.
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("KAN".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "Doing".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "B".into(),
+            column: "TODO".into(),
+            title: "T".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+        }))
+        .await
+        .unwrap();
+    // Move KAN-1 to Doing using names end-to-end.
+    let result = server
+        .tool_move_card(Parameters(MoveCardRequest {
+            card: "KAN-1".into(),
+            column: "Doing".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&result);
+    assert_eq!(body["title"], "T");
+    assert!(body["column_id"].is_string());
+}
+
+#[tokio::test]
+async fn tool_move_cards_rejects_cross_board_batch() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "Alpha".into(),
+            card_prefix: Some("A".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "Beta".into(),
+            card_prefix: Some("B".into()),
+        }))
+        .await
+        .unwrap();
+    for board in ["Alpha", "Beta"] {
+        server
+            .tool_create_column(Parameters(CreateColumnRequest {
+                board: board.into(),
+                name: "TODO".into(),
+                position: None,
+            }))
+            .await
+            .unwrap();
+        server
+            .tool_create_card(Parameters(CreateCardRequest {
+                board: board.into(),
+                column: "TODO".into(),
+                title: format!("{board}-1"),
+                description: None,
+                priority: None,
+                points: None,
+                due_date: None,
+            }))
+            .await
+            .unwrap();
+    }
+    let err = server
+        .tool_move_cards(Parameters(MoveCardsRequest {
+            cards: vec!["A-1".into(), "B-1".into()],
+            column: "TODO".into(),
+        }))
+        .await
+        .unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("same board"), "err: {msg}");
+    assert!(msg.contains("'Alpha'"), "err: {msg}");
+    assert!(msg.contains("'Beta'"), "err: {msg}");
+}
+
+#[tokio::test]
+async fn tool_carry_over_sprint_cards_scopes_to_named_from_board() {
+    // from_sprint is global; to_sprint must resolve on from_sprint's board.
+    // A sprint of the same name on a different board must not match `to`.
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "Alpha".into(),
+            card_prefix: Some("A".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "Beta".into(),
+            card_prefix: Some("B".into()),
+        }))
+        .await
+        .unwrap();
+    // Both boards get a "next" sprint name. Only Alpha gets the "completed" one.
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "Alpha".into(),
+            prefix: None,
+            name: Some("completed".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "Alpha".into(),
+            prefix: None,
+            name: Some("next".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "Beta".into(),
+            prefix: None,
+            name: Some("next".into()),
+        }))
+        .await
+        .unwrap();
+    // Activate + complete the source sprint on Alpha.
+    server
+        .tool_activate_sprint(Parameters(kanban_mcp::ActivateSprintRequest {
+            sprint: "completed".into(),
+            duration_days: Some(1),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_complete_sprint(Parameters(kanban_mcp::CompleteSprintRequest {
+            sprint: "completed".into(),
+        }))
+        .await
+        .unwrap();
+    // Even though both boards have a "next" sprint, the carry-over must
+    // resolve "next" within Alpha (the source's board), not error on
+    // ambiguity. (Per KAN-400 design: to_sprint is scoped to from_sprint's board.)
+    let result = server
+        .tool_carry_over_sprint_cards(Parameters(CarryOverSprintCardsRequest {
+            from_sprint: "completed".into(),
+            to_sprint: "next".into(),
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&result);
+    assert!(body["carried_over_count"].is_number());
+}
+
+#[tokio::test]
+async fn tool_assign_card_to_sprint_resolves_by_name_then_mutates() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("KAN".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "B".into(),
+            prefix: None,
+            name: Some("alpha".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "B".into(),
+            column: "TODO".into(),
+            title: "T".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+        }))
+        .await
+        .unwrap();
+    // Assign using card identifier + sprint name + sprint number both work.
+    let r1 = server
+        .tool_assign_card_to_sprint(Parameters(AssignCardToSprintRequest {
+            card: "KAN-1".into(),
+            sprint: "alpha".into(),
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&r1);
+    assert!(body["sprint_id"].is_string());
+    let r2 = server
+        .tool_assign_card_to_sprint(Parameters(AssignCardToSprintRequest {
+            card: "KAN-1".into(),
+            sprint: "1".into(), // sprint number
+        }))
+        .await
+        .unwrap();
+    let body2 = text_payload(&r2);
+    assert!(body2["sprint_id"].is_string());
+}

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -993,6 +993,18 @@ impl KanbanOperations for KanbanContext {
             .collect())
     }
 
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.backend.list_all_cards()
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.backend.list_all_columns()
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.backend.list_all_sprints()
+    }
+
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         self.update_cards(vec![(id, updates)])?;
         self.get_card(id)?

--- a/crates/kanban-service/tests/resolve.rs
+++ b/crates/kanban-service/tests/resolve.rs
@@ -1,0 +1,461 @@
+//! Integration tests for the `KanbanOperations` default resolver methods
+//! (`resolve_board_id`, `resolve_column_id`, `resolve_sprint_id`, `resolve_card_id`,
+//! and their `_global` / batch variants). Covered:
+//!   - UUID fast path
+//!   - name fast path (case-insensitive)
+//!   - sprint number fast path
+//!   - miss → message lists alternatives
+//!   - ambiguity → message lists conflicts
+//!   - batch resolvers aggregate failures
+//!   - `require_same_board` accepts homogeneous batches and rejects cross-board ones
+
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{
+    json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext, KanbanOperations,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn open_ctx() -> (KanbanContext, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.json");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    (ctx, dir)
+}
+
+// ---------- resolve_board_id ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_id_by_name_case_insensitive() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx
+        .create_board("Kanban".into(), Some("KAN".into()))
+        .unwrap();
+    assert_eq!(ctx.resolve_board_id("Kanban").unwrap(), board.id);
+    assert_eq!(ctx.resolve_board_id("kanban").unwrap(), board.id);
+    assert_eq!(ctx.resolve_board_id("KANBAN").unwrap(), board.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_id_by_uuid_fast_path() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx
+        .create_board("Kanban".into(), Some("KAN".into()))
+        .unwrap();
+    assert_eq!(
+        ctx.resolve_board_id(&board.id.to_string()).unwrap(),
+        board.id
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_id_not_found_lists_available() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("Kanban".into(), Some("KAN".into()))
+        .unwrap();
+    ctx.create_board("Personal".into(), Some("PER".into()))
+        .unwrap();
+    let err = ctx.resolve_board_id("missing").unwrap_err().to_string();
+    assert!(err.contains("'missing' not found"), "got: {err}");
+    assert!(err.contains("Kanban"), "got: {err}");
+    assert!(err.contains("Personal"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_id_ambiguous_includes_label_and_uuid_per_match() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let b1 = ctx.create_board("Shared".into(), None).unwrap();
+    let b2 = ctx.create_board("Shared".into(), None).unwrap();
+    let err = ctx.resolve_board_id("shared").unwrap_err().to_string();
+    assert!(err.contains("ambiguous"), "got: {err}");
+    // Every match now carries its UUID in the message — no need for the
+    // "Specify by UUID" coda.
+    assert!(err.contains(&b1.id.to_string()), "got: {err}");
+    assert!(err.contains(&b2.id.to_string()), "got: {err}");
+}
+
+// ---------- resolve_column_id ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_by_name_within_board() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    assert_eq!(ctx.resolve_column_id("todo", board.id).unwrap(), col.id);
+    assert_eq!(ctx.resolve_column_id("TODO", board.id).unwrap(), col.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_not_found_lists_columns_on_board() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    ctx.create_column(board.id, "Doing".into(), None).unwrap();
+    let err = ctx
+        .resolve_column_id("nope", board.id)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not found"), "got: {err}");
+    assert!(err.contains("TODO"), "got: {err}");
+    assert!(err.contains("Doing"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_global_finds_unique_across_boards() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let col_a = ctx
+        .create_column(board_a.id, "Backlog".into(), None)
+        .unwrap();
+    ctx.create_column(board_b.id, "Doing".into(), None).unwrap();
+    assert_eq!(ctx.resolve_column_id_global("backlog").unwrap(), col_a.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_global_ambiguous_lists_board_names() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    ctx.create_column(board_a.id, "TODO".into(), None).unwrap();
+    ctx.create_column(board_b.id, "TODO".into(), None).unwrap();
+    let err = ctx
+        .resolve_column_id_global("todo")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("ambiguous"), "got: {err}");
+    assert!(err.contains("'A'"), "got: {err}");
+    assert!(err.contains("'B'"), "got: {err}");
+}
+
+// ---------- resolve_sprint_id ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_by_name() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let sprint = ctx
+        .create_sprint(board.id, None, Some("yarara-release".into()))
+        .unwrap();
+    assert_eq!(
+        ctx.resolve_sprint_id("yarara-release", board.id).unwrap(),
+        sprint.id
+    );
+    assert_eq!(
+        ctx.resolve_sprint_id("YARARA-RELEASE", board.id).unwrap(),
+        sprint.id
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_by_number() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let sprint = ctx
+        .create_sprint(board.id, None, Some("alpha".into()))
+        .unwrap();
+    let n = sprint.sprint_number;
+    assert_eq!(
+        ctx.resolve_sprint_id(&n.to_string(), board.id).unwrap(),
+        sprint.id
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_global_finds_unique() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let _s_a = ctx
+        .create_sprint(board_a.id, None, Some("alpha".into()))
+        .unwrap();
+    let s_b = ctx
+        .create_sprint(board_b.id, None, Some("beta".into()))
+        .unwrap();
+    assert_eq!(ctx.resolve_sprint_id_global("beta").unwrap(), s_b.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_global_ambiguous_number_lists_boards() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let _ = ctx.create_sprint(board_a.id, None, None).unwrap();
+    let _ = ctx.create_sprint(board_b.id, None, None).unwrap();
+    let err = ctx.resolve_sprint_id_global("1").unwrap_err().to_string();
+    assert!(err.contains("ambiguous"), "got: {err}");
+    assert!(err.contains("'A'"), "got: {err}");
+    assert!(err.contains("'B'"), "got: {err}");
+}
+
+// ---------- resolve_card_id / resolve_card_ids ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_id_by_identifier() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "Hello".into(), Default::default())
+        .unwrap();
+    let ident = format!("KAN-{}", card.card_number);
+    assert_eq!(ctx.resolve_card_id(&ident).unwrap(), card.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_id_not_found_returns_not_found_by_name() {
+    let (ctx, _dir) = open_ctx().await;
+    let err = ctx.resolve_card_id("KAN-999").unwrap_err();
+    assert!(err.is_not_found(), "got: {err}");
+    assert!(err.is_not_found_by_name(), "got: {err}");
+    assert!(err.to_string().contains("'KAN-999' not found"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_aggregates_failures_as_typed_variant() {
+    use kanban_domain::{BatchResolutionCause, DomainError, KanbanError};
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "ok".into(), Default::default())
+        .unwrap();
+    let ident_ok = format!("KAN-{}", card.card_number);
+    let raws: Vec<String> = vec![ident_ok.clone(), "KAN-999".into(), "KAN-998".into()];
+
+    let err = ctx.resolve_card_ids(&raws).unwrap_err();
+    assert!(err.is_batch_resolution_failed(), "got: {err:?}");
+
+    // Programmatic introspection: pull out the typed failures.
+    let KanbanError::Domain(DomainError::BatchResolutionFailed { entity, failures }) = err else {
+        panic!("expected BatchResolutionFailed");
+    };
+    assert_eq!(entity, "Card");
+    assert_eq!(failures.len(), 2);
+    let by_input: std::collections::HashMap<_, _> = failures
+        .iter()
+        .map(|f| (f.raw_input.clone(), &f.cause))
+        .collect();
+    assert!(matches!(
+        by_input["KAN-999"],
+        BatchResolutionCause::NotFound
+    ));
+    assert!(matches!(
+        by_input["KAN-998"],
+        BatchResolutionCause::NotFound
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_failure_display_lists_each_input() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let err = ctx
+        .resolve_card_ids(&["KAN-999".into(), "KAN-998".into()])
+        .unwrap_err();
+    let msg = err.to_string();
+    // Entity stays capitalized, plural agrees with count (no "(s)" parenthetical).
+    assert!(msg.contains("2 Cards"), "got: {msg}");
+    assert!(msg.contains("'KAN-999'"), "got: {msg}");
+    assert!(msg.contains("'KAN-998'"), "got: {msg}");
+    assert!(msg.contains("not found"), "got: {msg}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_success_returns_all_uuids() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "one".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "two".into(), Default::default())
+        .unwrap();
+    let raws: Vec<String> = vec![format!("KAN-{}", c1.card_number), c2.id.to_string()];
+    let ids = ctx.resolve_card_ids(&raws).unwrap();
+    assert_eq!(ids, vec![c1.id, c2.id]);
+}
+
+// ---------- require_same_board ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_require_same_board_accepts_homogeneous_batch() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "one".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "two".into(), Default::default())
+        .unwrap();
+    let shared = ctx.require_same_board(&[c1.id, c2.id]).unwrap();
+    assert_eq!(shared, board.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_require_same_board_rejects_cross_board_batch() {
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx
+        .create_board("Kanban".into(), Some("KAN".into()))
+        .unwrap();
+    let board_b = ctx
+        .create_board("Personal".into(), Some("PER".into()))
+        .unwrap();
+    let col_a = ctx.create_column(board_a.id, "TODO".into(), None).unwrap();
+    let col_b = ctx.create_column(board_b.id, "TODO".into(), None).unwrap();
+    let c_a = ctx
+        .create_card(board_a.id, col_a.id, "a".into(), Default::default())
+        .unwrap();
+    let c_b = ctx
+        .create_card(board_b.id, col_b.id, "b".into(), Default::default())
+        .unwrap();
+    let err = ctx
+        .require_same_board(&[c_a.id, c_b.id])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("same board"), "got: {err}");
+    assert!(err.contains("'Kanban'"), "got: {err}");
+    assert!(err.contains("'Personal'"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_require_same_board_empty_batch_errors() {
+    let (ctx, _dir) = open_ctx().await;
+    let err = ctx.require_same_board(&[]).unwrap_err().to_string();
+    assert!(err.contains("No cards"), "got: {err}");
+}
+
+// ---------- UUID fast path doesn't accidentally do lookup ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_uuid_fast_path_returns_uuid_even_when_nothing_exists() {
+    let (ctx, _dir) = open_ctx().await;
+    let random = Uuid::new_v4();
+    // No entities exist; resolver returns the UUID; downstream get_* would be NotFound.
+    assert_eq!(ctx.resolve_board_id(&random.to_string()).unwrap(), random);
+}
+
+// ---------- New error variants & API ergonomics (KAN-400 review fixes) ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_miss_returns_not_found_by_name_variant() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("Kanban".into(), None).unwrap();
+    let err = ctx.resolve_board_id("missing").unwrap_err();
+    assert!(err.is_not_found_by_name(), "got: {err:?}");
+    assert!(err.is_not_found(), "umbrella predicate also true");
+    assert!(
+        !err.is_validation(),
+        "no longer the catch-all Validation variant"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_board_ambiguous_returns_ambiguous_variant() {
+    let (mut ctx, _dir) = open_ctx().await;
+    ctx.create_board("Shared".into(), None).unwrap();
+    ctx.create_board("Shared".into(), None).unwrap();
+    let err = ctx.resolve_board_id("shared").unwrap_err();
+    assert!(err.is_ambiguous(), "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_column_id_global_with_zero_boards_is_graceful() {
+    // No boards, no columns — error message lists "" (empty available) but doesn't crash.
+    let (ctx, _dir) = open_ctx().await;
+    let err = ctx.resolve_column_id_global("foo").unwrap_err();
+    assert!(err.is_not_found_by_name(), "got: {err:?}");
+    let msg = err.to_string();
+    assert!(msg.contains("'foo'"), "msg: {msg}");
+    // No "Available:" segment when the list is empty.
+    assert!(!msg.contains("Available:"), "msg: {msg}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_global_named_ambiguity_across_boards() {
+    // Two boards, each with a sprint named "alpha"; resolver should flag ambiguity
+    // and name both boards in the matches list.
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("Alpha-Board".into(), None).unwrap();
+    let board_b = ctx.create_board("Beta-Board".into(), None).unwrap();
+    ctx.create_sprint(board_a.id, None, Some("alpha".into()))
+        .unwrap();
+    ctx.create_sprint(board_b.id, None, Some("alpha".into()))
+        .unwrap();
+    let err = ctx.resolve_sprint_id_global("alpha").unwrap_err();
+    assert!(err.is_ambiguous(), "got: {err:?}");
+    let msg = err.to_string();
+    assert!(msg.contains("'Alpha-Board'"), "msg: {msg}");
+    assert!(msg.contains("'Beta-Board'"), "msg: {msg}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_id_on_board_does_not_bleed_other_board_numbers() {
+    // KAN-400 footgun-regression: with the split API the on-board variant
+    // never matches a sprint from another board, even with the same sprint_number.
+    let (mut ctx, _dir) = open_ctx().await;
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let _s_a = ctx.create_sprint(board_a.id, None, None).unwrap();
+    let s_b = ctx.create_sprint(board_b.id, None, None).unwrap();
+    assert_eq!(s_b.sprint_number, 1, "both sprints are #1 by construction");
+    // Resolving "1" on board B returns the B sprint, not A's.
+    let resolved = ctx.resolve_sprint_id("1", board_b.id).unwrap();
+    assert_eq!(resolved, s_b.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_mixed_uuid_identifier_and_number() {
+    // Single batch with three input shapes: UUID, KAN-N identifier, bare number.
+    // All resolve against one snapshot.
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "one".into(), Default::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "two".into(), Default::default())
+        .unwrap();
+    let c3 = ctx
+        .create_card(board.id, col.id, "three".into(), Default::default())
+        .unwrap();
+
+    let raws: Vec<String> = vec![
+        c1.id.to_string(),                 // raw UUID
+        format!("KAN-{}", c2.card_number), // prefixed identifier
+        c3.card_number.to_string(),        // bare number
+    ];
+    let ids = ctx.resolve_card_ids(&raws).unwrap();
+    assert_eq!(ids, vec![c1.id, c2.id, c3.id]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_takes_single_snapshot_per_batch() {
+    // Behavioural check: even a batch of 10 inputs against 50 cards completes
+    // without per-element backend churn. We assert correctness here; the perf
+    // contract is provable by inspecting the implementation (one set of
+    // list_all_* at the top, then pure in-memory matching).
+    let (mut ctx, _dir) = open_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let mut all_ids = Vec::new();
+    for i in 0..50 {
+        let c = ctx
+            .create_card(board.id, col.id, format!("c{i}"), Default::default())
+            .unwrap();
+        all_ids.push(c.id);
+    }
+    // Resolve the first 10 by identifier.
+    let raws: Vec<String> = (1..=10).map(|n| format!("KAN-{n}")).collect();
+    let resolved = ctx.resolve_card_ids(&raws).unwrap();
+    assert_eq!(resolved.len(), 10);
+    assert_eq!(resolved, all_ids[0..10]);
+}

--- a/crates/kanban-tui/Cargo.toml
+++ b/crates/kanban-tui/Cargo.toml
@@ -31,6 +31,8 @@ arboard = { version = "3.4", features = ["wayland-data-control"] }
 pulldown-cmark = "0.13"
 toml = "0.8"
 dunce.workspace = true
+shell-words = "^1.1"
+which = "^8.0"
 
 [features]
 test-helpers = []

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -1,4 +1,5 @@
 use kanban_core::SelectionState;
+use std::cell::Cell;
 use uuid::Uuid;
 
 #[derive(Default)]
@@ -7,6 +8,7 @@ pub struct DialogInputState {
     pub import_selection: SelectionState,
     pub priority_selection: SelectionState,
     pub column_selection: SelectionState,
+    pub column_scroll: Cell<usize>,
     pub sprint_assign_selection: SelectionState,
     pub task_list_view_selection: SelectionState,
     pub carry_over_sprint_selection: SelectionState,

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -1,4 +1,5 @@
 use kanban_core::SelectionState;
+use std::cell::Cell;
 
 #[derive(Default)]
 pub struct SelectionHub {
@@ -7,6 +8,7 @@ pub struct SelectionHub {
     pub active_card_index: Option<usize>,
     pub active_card_id: Option<uuid::Uuid>,
     pub sprint: SelectionState,
+    pub sprint_scroll: Cell<usize>,
     pub active_sprint_index: Option<usize>,
     pub card_navigation_history: Vec<usize>,
     pub settings_config: SelectionState,

--- a/crates/kanban-tui/src/components/filter_popup.rs
+++ b/crates/kanban-tui/src/components/filter_popup.rs
@@ -2,6 +2,7 @@ use crate::app::App;
 use crate::components::centered_rect;
 use crate::filters::FilterDialogState;
 use crate::theme::*;
+use kanban_core::pagination::scroll_offset_to_keep_visible;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
@@ -115,14 +116,29 @@ fn render_filter_sprints_section(
         }
     }
 
-    let section =
-        Paragraph::new(sprint_lines).block(Block::default().borders(Borders::ALL).border_style(
-            if section_index == 0 {
-                focused_border()
-            } else {
-                Style::default()
-            },
-        ));
+    let selected_line_idx = if dialog_state.item_selection == 0 {
+        1
+    } else {
+        dialog_state.item_selection + 2
+    };
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let scroll = scroll_offset_to_keep_visible(
+        dialog_state.item_scroll.get(),
+        selected_line_idx,
+        viewport_height,
+    );
+    dialog_state.item_scroll.set(scroll);
+    let section = Paragraph::new(sprint_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(if section_index == 0 {
+                    focused_border()
+                } else {
+                    Style::default()
+                }),
+        )
+        .scroll((scroll as u16, 0));
     frame.render_widget(section, area);
 }
 

--- a/crates/kanban-tui/src/editor.rs
+++ b/crates/kanban-tui/src/editor.rs
@@ -4,39 +4,50 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
+use std::env;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::Command;
 
-fn which_editor() -> String {
-    let editors = if cfg!(target_os = "windows") {
-        vec!["nvim", "vim", "nano", "notepad"]
+fn editor_env_hint(is_powershell: bool) -> &'static str {
+    if is_powershell {
+        "$env:EDITOR"
     } else {
-        vec!["nvim", "vim", "nano", "vi"]
-    };
+        "$EDITOR"
+    }
+}
 
-    for editor in &editors {
-        let which_cmd = if cfg!(target_os = "windows") {
-            "where"
-        } else {
-            "which"
-        };
+#[cfg(target_os = "windows")]
+fn fallback_editor() -> (String, Vec<String>) {
+    ("notepad".to_string(), vec![])
+}
 
-        if Command::new(which_cmd)
-            .arg(editor)
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-        {
-            return editor.to_string();
+#[cfg(not(target_os = "windows"))]
+fn fallback_editor() -> (String, Vec<String>) {
+    ("vi".to_string(), vec![])
+}
+
+fn parse_editor(full_command: &str) -> (String, Vec<String>) {
+    match shell_words::split(full_command) {
+        Ok(mut parts) if !parts.is_empty() => {
+            let program = parts.remove(0);
+            (program, parts)
         }
+        _ => (full_command.to_string(), vec![]),
     }
+}
 
-    if cfg!(target_os = "windows") {
-        "notepad".to_string()
-    } else {
-        "vi".to_string()
-    }
+fn resolve_editor_with(editor_env: Option<&str>) -> (PathBuf, Vec<String>) {
+    let (program, args) = match editor_env {
+        Some(value) => parse_editor(value),
+        None => fallback_editor(),
+    };
+    let path = which::which(&program).unwrap_or_else(|_| PathBuf::from(program));
+    (path, args)
+}
+
+fn resolve_editor() -> (PathBuf, Vec<String>) {
+    resolve_editor_with(env::var("EDITOR").ok().as_deref())
 }
 
 pub fn edit_in_external_editor(
@@ -45,7 +56,7 @@ pub fn edit_in_external_editor(
     temp_file: PathBuf,
     initial_content: &str,
 ) -> io::Result<Option<String>> {
-    let editor = std::env::var("EDITOR").unwrap_or_else(|_| which_editor());
+    let (program, args) = resolve_editor();
 
     std::fs::write(&temp_file, initial_content)?;
 
@@ -55,18 +66,19 @@ pub fn edit_in_external_editor(
     execute!(io::stdout(), LeaveAlternateScreen)?;
     io::stdout().flush()?;
 
-    let status = Command::new(&editor).arg(&temp_file).status();
+    let status = Command::new(&program).args(&args).arg(&temp_file).status();
 
     if let Err(ref e) = status {
-        tracing::error!("Failed to launch editor '{}': {}", editor, e);
+        tracing::error!("Failed to launch editor '{}': {}", program.display(), e);
         execute!(io::stdout(), EnterAlternateScreen)?;
         enable_raw_mode()?;
         terminal.clear()?;
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
             format!(
-                "Editor '{}' not found. Please set $EDITOR environment variable.",
-                editor
+                "Editor '{}' not found. Please set {} environment variable.",
+                program.display(),
+                editor_env_hint(env::var_os("PSModulePath").is_some()),
             ),
         ));
     }
@@ -92,4 +104,96 @@ pub fn edit_in_external_editor(
     let _ = std::fs::remove_file(&temp_file);
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn editor_env_hint_powershell() {
+        assert_eq!(editor_env_hint(true), "$env:EDITOR");
+    }
+
+    #[test]
+    fn editor_env_hint_non_powershell() {
+        assert_eq!(editor_env_hint(false), "$EDITOR");
+    }
+
+    #[test]
+    fn parse_editor_handles_single_word() {
+        let (program, args) = parse_editor("vim");
+        assert_eq!(program, "vim");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn parse_editor_splits_program_and_args() {
+        let (program, args) = parse_editor("vim -u NONE");
+        assert_eq!(program, "vim");
+        assert_eq!(args, vec!["-u", "NONE"]);
+    }
+
+    #[test]
+    fn parse_editor_handles_double_quoted_paths() {
+        let (program, args) = parse_editor("\"C:/Program Files/VS Code/code.cmd\" --wait");
+        assert_eq!(program, "C:/Program Files/VS Code/code.cmd");
+        assert_eq!(args, vec!["--wait"]);
+    }
+
+    #[test]
+    fn parse_editor_handles_single_quoted_paths() {
+        let (program, args) = parse_editor("\'C:/Program Files/VS Code/code.cmd\' --wait");
+        assert_eq!(program, "C:/Program Files/VS Code/code.cmd");
+        assert_eq!(args, vec!["--wait"]);
+    }
+
+    #[test]
+    fn parse_editor_handles_malformed_single_word_command() {
+        let (program, args) = parse_editor("'vim");
+        assert_eq!(program, "'vim");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn parse_editor_handles_malformed_multiword_command() {
+        let (program, args) = parse_editor("'vim -u NONE");
+        assert_eq!(program, "'vim -u NONE");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn resolve_editor_with_handles_simple_editor_path_no_args() {
+        let (path, args) = resolve_editor_with(Some("cargo"));
+        assert!(path.is_absolute());
+        assert!(path.ends_with("cargo") || path.ends_with("cargo.exe"));
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn resolve_editor_with_handles_simple_editor_path_with_args() {
+        let (path, args) = resolve_editor_with(Some("cargo version"));
+        assert!(path.is_absolute());
+        assert!(path.ends_with("cargo") || path.ends_with("cargo.exe"));
+        assert_eq!(args, vec!["version"]);
+    }
+
+    #[test]
+    fn resolve_editor_with_falls_back_when_env_missing() {
+        let (path, args) = resolve_editor_with(None);
+
+        if cfg!(target_os = "windows") {
+            assert!(path.ends_with("notepad") || path.ends_with("notepad.exe"));
+        } else {
+            assert!(path.ends_with("vi"));
+        }
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn resolve_editor_with_handles_nonexistent_program() {
+        let (path, args) = resolve_editor_with(Some("vi_and_emacs --flag"));
+        assert_eq!(path, PathBuf::from("vi_and_emacs"));
+        assert_eq!(args, vec!["--flag"]);
+    }
 }

--- a/crates/kanban-tui/src/filters.rs
+++ b/crates/kanban-tui/src/filters.rs
@@ -1,4 +1,5 @@
 use kanban_domain::CardFilters;
+use std::cell::Cell;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FilterDialogSection {
@@ -12,6 +13,7 @@ pub struct FilterDialogState {
     pub current_section: FilterDialogSection,
     pub section_index: usize,
     pub item_selection: usize,
+    pub item_scroll: Cell<usize>,
     pub filters: CardFilters,
 }
 
@@ -21,6 +23,7 @@ impl FilterDialogState {
             current_section: FilterDialogSection::Sprints,
             section_index: 0,
             item_selection: 0,
+            item_scroll: Cell::new(0),
             filters,
         }
     }
@@ -28,6 +31,7 @@ impl FilterDialogState {
     pub fn next_section(&mut self) {
         self.section_index = (self.section_index + 1) % 3;
         self.item_selection = 0;
+        self.item_scroll.set(0);
         self.current_section = match self.section_index {
             0 => FilterDialogSection::Sprints,
             1 => FilterDialogSection::DateRange,
@@ -43,6 +47,7 @@ impl FilterDialogState {
             self.section_index - 1
         };
         self.item_selection = 0;
+        self.item_scroll.set(0);
         self.current_section = match self.section_index {
             0 => FilterDialogSection::Sprints,
             1 => FilterDialogSection::DateRange,

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -196,7 +196,9 @@ impl App {
                             tracing::info!("Enabled sprint filter - showing active sprint only");
                         }
                     } else {
-                        tracing::warn!("No active sprint set for filtering");
+                        let msg = "No active sprint set for filtering";
+                        tracing::warn!("{}", msg);
+                        self.set_error(msg);
                     }
                 }
             }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -231,6 +231,18 @@ impl KanbanOperations for TuiContext {
         self.inner.find_cards_by_identifier(identifier)
     }
 
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<kanban_domain::Column>> {
+        self.inner.list_all_columns()
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<kanban_domain::Sprint>> {
+        self.inner.list_all_sprints()
+    }
+
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         let r = self.inner.update_card(id, updates);
         self.with_flush(r)

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -1,6 +1,7 @@
 use crate::app::{App, BoardFocus};
 use crate::components::*;
 use crate::theme::*;
+use kanban_core::pagination::scroll_offset_to_keep_visible;
 use kanban_domain::{Sprint, SprintStatus};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -215,7 +216,17 @@ fn render_board_sprints_list(
         }
     }
 
-    let sprints = Paragraph::new(sprint_lines).block(sprints_config.block());
+    let selected_idx = app.selection.sprint.get().unwrap_or(0);
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let scroll = scroll_offset_to_keep_visible(
+        app.selection.sprint_scroll.get(),
+        selected_idx,
+        viewport_height,
+    );
+    app.selection.sprint_scroll.set(scroll);
+    let sprints = Paragraph::new(sprint_lines)
+        .block(sprints_config.block())
+        .scroll((scroll as u16, 0));
     frame.render_widget(sprints, area);
 }
 
@@ -272,6 +283,16 @@ fn render_board_columns_list(
         }
     }
 
-    let columns = Paragraph::new(column_lines).block(columns_config.block());
+    let selected_idx = app.dialog_input.column_selection.get().unwrap_or(0);
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let scroll = scroll_offset_to_keep_visible(
+        app.dialog_input.column_scroll.get(),
+        selected_idx,
+        viewport_height,
+    );
+    app.dialog_input.column_scroll.set(scroll);
+    let columns = Paragraph::new(column_lines)
+        .block(columns_config.block())
+        .scroll((scroll as u16, 0));
     frame.render_widget(columns, area);
 }

--- a/crates/kanban-tui/tests/scroll_board_edit_lists.rs
+++ b/crates/kanban-tui/tests/scroll_board_edit_lists.rs
@@ -1,0 +1,159 @@
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::app::BoardFocus;
+use kanban_tui::App;
+
+fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
+}
+
+#[test]
+fn test_board_sprints_list_scrolls_to_keep_selection_visible() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    for i in 0..20 {
+        app.ctx
+            .create_sprint(board.id, None, Some(format!("SpMark{:02}", i)))
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app.push_mode(AppMode::BoardDetail);
+    app.focus.board_focus = BoardFocus::Sprints;
+    app.selection.sprint.set(Some(19));
+
+    let output = render_to_string(&mut app, 80, 30);
+
+    assert!(
+        output.contains("SpMark19"),
+        "selected sprint (last one) should be visible after scroll, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("SpMark00"),
+        "first sprint should have scrolled off-screen, got:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_board_columns_list_scrolls_to_keep_selection_visible() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    for i in 0..20 {
+        app.ctx
+            .create_column(board.id, format!("ColMark{:02}", i), Some(i))
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app.push_mode(AppMode::BoardDetail);
+    app.focus.board_focus = BoardFocus::Columns;
+    app.dialog_input.column_selection.set(Some(19));
+
+    let output = render_to_string(&mut app, 80, 30);
+
+    assert!(
+        output.contains("ColMark19"),
+        "selected column (last one) should be visible after scroll, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("ColMark00"),
+        "first column should have scrolled off-screen, got:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_board_sprints_scroll_offset_is_stable_when_selection_moves_within_viewport() {
+    // Once scrolled, navigating one item up keeps the same scroll offset:
+    // the previously-selected item stays visible, only the cursor moves.
+    // This is the minimal-scroll semantics shared with the main card list.
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    for i in 0..20 {
+        app.ctx
+            .create_sprint(board.id, None, Some(format!("StaySp{:02}", i)))
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app.push_mode(AppMode::BoardDetail);
+    app.focus.board_focus = BoardFocus::Sprints;
+
+    app.selection.sprint.set(Some(19));
+    render_to_string(&mut app, 80, 30);
+    let offset_after_jump_down = app.selection.sprint_scroll.get();
+    assert!(
+        offset_after_jump_down > 0,
+        "expected non-zero scroll after selecting last sprint, got {}",
+        offset_after_jump_down
+    );
+
+    app.selection.sprint.set(Some(18));
+    render_to_string(&mut app, 80, 30);
+    assert_eq!(
+        app.selection.sprint_scroll.get(),
+        offset_after_jump_down,
+        "scroll offset should remain stable when selection moves within viewport"
+    );
+}
+
+#[test]
+fn test_filter_popup_sprints_scrolls_to_keep_selection_visible() {
+    use kanban_domain::CardFilters;
+    use kanban_tui::filters::FilterDialogState;
+
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    for i in 0..20 {
+        app.ctx
+            .create_sprint(board.id, None, Some(format!("FpMark{:02}", i)))
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
+    let mut dialog = FilterDialogState::new(CardFilters::default());
+    // item_selection 0 = "show unassigned" row, 1..=20 = sprints index-0..19
+    // Select the last sprint (index 19 in the sprint list).
+    dialog.item_selection = 20;
+    app.filter.dialog_state = Some(dialog);
+
+    let output = render_to_string(&mut app, 80, 30);
+
+    assert!(
+        output.contains("FpMark19"),
+        "selected sprint (last in filter popup) should be visible after scroll, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("FpMark00"),
+        "first sprint in filter popup should have scrolled off-screen, got:\n{}",
+        output
+    );
+}

--- a/crates/kanban-tui/tests/sprint_filter_toggle_tests.rs
+++ b/crates/kanban-tui/tests/sprint_filter_toggle_tests.rs
@@ -1,0 +1,30 @@
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::components::banner::BannerVariant;
+use kanban_tui::App;
+
+#[test]
+fn test_toggle_sprint_filter_without_active_sprint_shows_error_banner() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("B".into(), None).unwrap();
+    app.ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    app.selection.active_board_index = Some(0);
+    app.focus.active = Focus::Cards;
+    app.prepare_frame();
+
+    app.handle_toggle_sprint_filter();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("expected error banner when no active sprint is set");
+    assert_eq!(banner.variant, BannerVariant::Error);
+    assert!(
+        banner.message.contains("No active sprint"),
+        "banner should explain why toggling did nothing: {}",
+        banner.message,
+    );
+}

--- a/kanban.json
+++ b/kanban.json
@@ -1,8 +1,8 @@
 {
   "version": 5,
   "metadata": {
-    "instance_id": "81d59d56-c037-4912-95c9-3c32370d4e60",
-    "saved_at": "2026-05-13T20:57:50.882432350Z"
+    "instance_id": "a0c9b6cd-77b5-416a-b19c-e362c91414eb",
+    "saved_at": "2026-05-14T20:09:30.573233690Z"
   },
   "data": {
     "archived_cards": [
@@ -799,7 +799,7 @@
     "boards": [
       {
         "active_sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "card_counter": 445,
+        "card_counter": 457,
         "card_prefix": "KAN",
         "completion_column_id": null,
         "created_at": "2025-10-10T08:47:44.779097Z",
@@ -835,6 +835,23 @@
     ],
     "cards": [
       {
+        "card_number": 1,
+        "column_id": "7724ace0-bb87-4f48-bf98-e8f65acc55db",
+        "completed_at": "2026-02-02T19:26:00.736845Z",
+        "created_at": "2026-02-02T19:24:07.251563Z",
+        "description": null,
+        "due_date": null,
+        "id": "b6ec50d0-a09d-44fc-976e-f1c4b01256c1",
+        "points": null,
+        "position": 0,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "card",
+        "updated_at": "2026-02-02T19:26:00.736846Z"
+      },
+      {
         "card_number": 2,
         "column_id": "d77bb354-8781-44c0-8b49-06a038629eca",
         "completed_at": null,
@@ -850,49 +867,6 @@
         "status": "Todo",
         "title": "second",
         "updated_at": "2026-02-02T19:26:19.218671Z"
-      },
-      {
-        "card_number": 207,
-        "column_id": "64e02b8a-c9a0-49dc-a21e-a20ed1620fa5",
-        "completed_at": null,
-        "created_at": "2026-02-02T19:47:42.519968Z",
-        "description": "## Problem\n\nTUI can update all fields on BoardUpdate (10), CardUpdate (11), and SprintUpdate (7), but CLI and MCP can only update a subset:\n\n- **BoardUpdate**: 4/10 fields exposed (missing: task_sort_field, task_sort_order, sprint_duration_days, task_list_view, active_sprint_id, completion_column_id)\n- **CardUpdate**: 6/11 fields exposed (missing: position, column_id, sprint_id, assigned_prefix, card_prefix)\n- **SprintUpdate**: 5/7 fields exposed (missing: name_index, status)\n\nSome missing fields have dedicated methods (move_card, assign_card_to_sprint, activate/complete/cancel_sprint), so those are intentional. But `assigned_prefix`, `card_prefix` on cards and all the board settings have NO way to be set outside TUI.\n\n## Root Cause\n\nArchitectural asymmetry:\n\n1. **TUI** (`tui_context.rs`) operates directly on in-memory Rust structs. It constructs full `CardUpdate`/`BoardUpdate`/`SprintUpdate` structs and passes them to the command executor. No serialization boundary.\n\n2. **CLI** (`cli.rs` + handlers) parses command-line arguments via clap, then constructs the update structs from those args. If no clap flag exists for a field, it's unreachable.\n\n3. **MCP** (`context.rs`) builds CLI argument vectors and shells out to the kanban binary, parsing JSON responses. It inherits all CLI limitations.\n\nThe domain layer supports all fields. The bottleneck is entirely in CLI argument definitions.\n\n## Why This Happened\n\nThe KanbanOperations trait enforces method parity (all 37 operations exist everywhere), but it doesn't enforce field-level completeness within those methods. The trait signature is:\n\n```rust\nfn update_card(&mut self, id: Uuid, updates: CardUpdate) -> Result<Card>;\n```\n\nBoth TUI and CLI implement this, but TUI populates all CardUpdate fields while CLI only populates fields that have corresponding clap arguments.\n\n## Solution Options\n\n### Option A: Add missing CLI flags\nAdd clap arguments for all missing fields in the update commands. Straightforward but expands CLI surface area significantly.\n\nFiles to modify:\n- `crates/kanban-cli/src/cli.rs` - Add clap args\n- `crates/kanban-cli/src/handlers/card.rs` - Wire args to CardUpdate\n- `crates/kanban-cli/src/handlers/board.rs` - Wire args to BoardUpdate\n- MCP would automatically get parity since it delegates to CLI\n\n### Option B: Direct domain access for MCP\nHave MCP implement KanbanOperations by directly manipulating the data file (like TUI does) instead of shelling out to CLI. This would give MCP full field access without CLI changes.\n\nDownside: Duplicates file I/O logic that currently lives in CLI.\n\n### Option C: Extract shared library\nFactor out the file I/O and state management into a shared library that both TUI and a new \"direct\" MCP implementation can use. CLI remains a thin wrapper.\n\nThis is the cleanest long-term but highest effort.\n\n## Recommendation\n\nOption A is pragmatic for now. The missing fields are:\n- Card: `assigned_prefix`, `card_prefix` (2 fields)\n- Board: `task_sort_field`, `task_sort_order`, `sprint_duration_days`, `task_list_view`, `active_sprint_id`, `completion_column_id` (6 fields)\n\nCard prefixes are useful for CLI users. Board settings are more TUI-specific but could still be exposed.\n\n## Files Reference\n\n- Trait: `crates/kanban-domain/src/operations.rs:19-89`\n- TUI impl: `crates/kanban-tui/src/tui_context.rs:92-571`\n- CLI impl: `crates/kanban-cli/src/context.rs:172-685`\n- MCP impl: `crates/kanban-mcp/src/context.rs:121-554`\n- CLI args: `crates/kanban-cli/src/cli.rs`",
-        "due_date": null,
-        "id": "fefd78db-0350-49bd-b3d7-2d656fc92871",
-        "points": null,
-        "position": 0,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Todo",
-        "title": "CLI/MCP field parity gap caused by architectural asymmetry",
-        "updated_at": "2026-02-02T19:47:42.519981Z"
-      },
-      {
-        "card_number": 210,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-02-17T22:22:00.293786995Z",
-        "description": "When a sprint is ended it is currently a repetetive process to transfer cards over to a new sprint\n\nyou have to\n\n- end the sprint\n- create a new sprint (come up with a name)\n- go back to cards list\n- filter by the ended sprint\n- select all unfinished cards\n- assign to new sprint\n\nCould be made better with a carry over option when ending a sprint\n\nIf no sprint names are available, dialog to give otherwise consume sprint names",
-        "due_date": null,
-        "id": "b849870a-252f-477f-96d2-bd633e54a6d3",
-        "points": 3,
-        "position": 0,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856523368Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Carry over cards from ended sprint",
-        "updated_at": "2026-04-04T23:44:57.674072207Z"
       },
       {
         "card_number": 9,
@@ -919,6 +893,40 @@
         "status": "Done",
         "title": "Change priority",
         "updated_at": "2025-10-16T20:47:08.170397Z"
+      },
+      {
+        "card_number": 3,
+        "column_id": "28c91933-5e8c-47ac-9b7d-87ceabbda0cd",
+        "completed_at": null,
+        "created_at": "2026-02-02T19:25:48.122033Z",
+        "description": null,
+        "due_date": null,
+        "id": "00a84be2-2540-414d-8878-b93ac419b4a9",
+        "points": null,
+        "position": 0,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "new",
+        "updated_at": "2026-02-02T19:25:48.122033Z"
+      },
+      {
+        "card_number": 207,
+        "column_id": "64e02b8a-c9a0-49dc-a21e-a20ed1620fa5",
+        "completed_at": null,
+        "created_at": "2026-02-02T19:47:42.519968Z",
+        "description": "## Problem\n\nTUI can update all fields on BoardUpdate (10), CardUpdate (11), and SprintUpdate (7), but CLI and MCP can only update a subset:\n\n- **BoardUpdate**: 4/10 fields exposed (missing: task_sort_field, task_sort_order, sprint_duration_days, task_list_view, active_sprint_id, completion_column_id)\n- **CardUpdate**: 6/11 fields exposed (missing: position, column_id, sprint_id, assigned_prefix, card_prefix)\n- **SprintUpdate**: 5/7 fields exposed (missing: name_index, status)\n\nSome missing fields have dedicated methods (move_card, assign_card_to_sprint, activate/complete/cancel_sprint), so those are intentional. But `assigned_prefix`, `card_prefix` on cards and all the board settings have NO way to be set outside TUI.\n\n## Root Cause\n\nArchitectural asymmetry:\n\n1. **TUI** (`tui_context.rs`) operates directly on in-memory Rust structs. It constructs full `CardUpdate`/`BoardUpdate`/`SprintUpdate` structs and passes them to the command executor. No serialization boundary.\n\n2. **CLI** (`cli.rs` + handlers) parses command-line arguments via clap, then constructs the update structs from those args. If no clap flag exists for a field, it's unreachable.\n\n3. **MCP** (`context.rs`) builds CLI argument vectors and shells out to the kanban binary, parsing JSON responses. It inherits all CLI limitations.\n\nThe domain layer supports all fields. The bottleneck is entirely in CLI argument definitions.\n\n## Why This Happened\n\nThe KanbanOperations trait enforces method parity (all 37 operations exist everywhere), but it doesn't enforce field-level completeness within those methods. The trait signature is:\n\n```rust\nfn update_card(&mut self, id: Uuid, updates: CardUpdate) -> Result<Card>;\n```\n\nBoth TUI and CLI implement this, but TUI populates all CardUpdate fields while CLI only populates fields that have corresponding clap arguments.\n\n## Solution Options\n\n### Option A: Add missing CLI flags\nAdd clap arguments for all missing fields in the update commands. Straightforward but expands CLI surface area significantly.\n\nFiles to modify:\n- `crates/kanban-cli/src/cli.rs` - Add clap args\n- `crates/kanban-cli/src/handlers/card.rs` - Wire args to CardUpdate\n- `crates/kanban-cli/src/handlers/board.rs` - Wire args to BoardUpdate\n- MCP would automatically get parity since it delegates to CLI\n\n### Option B: Direct domain access for MCP\nHave MCP implement KanbanOperations by directly manipulating the data file (like TUI does) instead of shelling out to CLI. This would give MCP full field access without CLI changes.\n\nDownside: Duplicates file I/O logic that currently lives in CLI.\n\n### Option C: Extract shared library\nFactor out the file I/O and state management into a shared library that both TUI and a new \"direct\" MCP implementation can use. CLI remains a thin wrapper.\n\nThis is the cleanest long-term but highest effort.\n\n## Recommendation\n\nOption A is pragmatic for now. The missing fields are:\n- Card: `assigned_prefix`, `card_prefix` (2 fields)\n- Board: `task_sort_field`, `task_sort_order`, `sprint_duration_days`, `task_list_view`, `active_sprint_id`, `completion_column_id` (6 fields)\n\nCard prefixes are useful for CLI users. Board settings are more TUI-specific but could still be exposed.\n\n## Files Reference\n\n- Trait: `crates/kanban-domain/src/operations.rs:19-89`\n- TUI impl: `crates/kanban-tui/src/tui_context.rs:92-571`\n- CLI impl: `crates/kanban-cli/src/context.rs:172-685`\n- MCP impl: `crates/kanban-mcp/src/context.rs:121-554`\n- CLI args: `crates/kanban-cli/src/cli.rs`",
+        "due_date": null,
+        "id": "fefd78db-0350-49bd-b3d7-2d656fc92871",
+        "points": null,
+        "position": 0,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "CLI/MCP field parity gap caused by architectural asymmetry",
+        "updated_at": "2026-02-02T19:47:42.519981Z"
       },
       {
         "card_number": 26,
@@ -1001,40 +1009,6 @@
         "status": "Todo",
         "title": "When titles are too long. they don't fit the tasks list",
         "updated_at": "2026-04-04T23:33:28.989222669Z"
-      },
-      {
-        "card_number": 3,
-        "column_id": "28c91933-5e8c-47ac-9b7d-87ceabbda0cd",
-        "completed_at": null,
-        "created_at": "2026-02-02T19:25:48.122033Z",
-        "description": null,
-        "due_date": null,
-        "id": "00a84be2-2540-414d-8878-b93ac419b4a9",
-        "points": null,
-        "position": 0,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Todo",
-        "title": "new",
-        "updated_at": "2026-02-02T19:25:48.122033Z"
-      },
-      {
-        "card_number": 1,
-        "column_id": "7724ace0-bb87-4f48-bf98-e8f65acc55db",
-        "completed_at": "2026-02-02T19:26:00.736845Z",
-        "created_at": "2026-02-02T19:24:07.251563Z",
-        "description": null,
-        "due_date": null,
-        "id": "b6ec50d0-a09d-44fc-976e-f1c4b01256c1",
-        "points": null,
-        "position": 0,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "card",
-        "updated_at": "2026-02-02T19:26:00.736846Z"
       },
       {
         "card_number": 28,
@@ -1145,6 +1119,32 @@
         "updated_at": "2026-04-06T20:54:41.238213574Z"
       },
       {
+        "card_number": 4,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-16T21:02:45.523148Z",
+        "created_at": "2025-10-10T08:47:57.834239Z",
+        "description": "The application is exporting boards using two different formats.\n\n```JSON\n{ board: { ... } }\n```\n\nand\n\n```JSON\n{ boards: [{ ... }] }\n```\n\nLet us make import and export only expect the latter.\n",
+        "due_date": null,
+        "id": "143615fe-fbcd-4d80-a88d-8173ec4b9573",
+        "points": 1,
+        "position": 2,
+        "priority": "Medium",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155905Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "Unify import and export",
+        "updated_at": "2025-10-18T21:08:32.067931Z"
+      },
+      {
         "card_number": 66,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -1225,84 +1225,6 @@
         "status": "Todo",
         "title": "Create new card from card",
         "updated_at": "2026-04-04T23:33:28.989213595Z"
-      },
-      {
-        "card_number": 256,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-03-30T00:10:04.739056992Z",
-        "description": "## Problem\n\n`App::new()` always loaded files via `import_board_from_file()`, which calls `std::fs::read_to_string()`. This fails on binary SQLite `.db` files with:\n\n```\nstream did not contain valid UTF-8\n```\n\nThe `StateManager` correctly created a SQLite store via the `StoreRegistry`, but the initial data load bypassed it entirely, going through the JSON-only import path.\n\n## Root Cause\n\nIn `crates/kanban-tui/src/app/mod.rs`, `App::new()` unconditionally called `import_board_from_file(filename)` for any existing file, regardless of backend type.\n\n## Fix\n\nTwo changes in `crates/kanban-tui/src/app/mod.rs`:\n\n1. **`App::new()`** — skip `import_board_from_file` for `.db`/`.sqlite`/`.sqlite3` extensions, since those require async store loading\n2. **`run()`** — added async initial state loading via `store.load()` at the start of the method (before terminal setup), using the same pattern as `auto_reload_from_external_change`\n\nJSON files continue using the existing sync import path unchanged.",
-        "due_date": null,
-        "id": "a30bf99a-dc77-4aa8-b307-c163bc6afb8a",
-        "points": 1,
-        "position": 2,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856496808Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Fix SQLite .db file loading (read_to_string on binary file)",
-        "updated_at": "2026-04-04T23:44:58.710998046Z"
-      },
-      {
-        "card_number": 4,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T21:02:45.523148Z",
-        "created_at": "2025-10-10T08:47:57.834239Z",
-        "description": "The application is exporting boards using two different formats.\n\n```JSON\n{ board: { ... } }\n```\n\nand\n\n```JSON\n{ boards: [{ ... }] }\n```\n\nLet us make import and export only expect the latter.\n",
-        "due_date": null,
-        "id": "143615fe-fbcd-4d80-a88d-8173ec4b9573",
-        "points": 1,
-        "position": 2,
-        "priority": "Medium",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155905Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "Unify import and export",
-        "updated_at": "2025-10-18T21:08:32.067931Z"
-      },
-      {
-        "card_number": 225,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-03-22T01:39:59.256575150Z",
-        "description": "Follow-up items from code review of PR #189 (KAN-224/decompose-app-rs-into-focused-modules). Zero blockers — PR was merged as-is.\n\n---\n\n## 1. Rename `SelectionHub` to something clearer\n\n**File:** `crates/kanban-tui/src/app/selection.rs:4`\n**Type:** Naming / readability\n\n```rust\npub struct SelectionHub {\n    pub board: SelectionState,\n    pub active_board_index: Option<usize>,\n    pub active_card_index: Option<usize>,\n    pub sprint: SelectionState,\n    pub active_sprint_index: Option<usize>,\n    pub card_navigation_history: Vec<usize>,\n}\n```\n\n`Hub` implies it coordinates or dispatches between things (like an event hub or message hub). This struct is just a plain data grouping of selection indices and cursor state. A reader seeing `self.selection.board` would not immediately know what \"hub\" means here.\n\n**Suggested names:** `AppSelection`, `CursorState`, or simply `SelectionState` (if the `kanban_core::SelectionState` name collision can be resolved via aliasing or renaming the core type).\n\n**Action:** Rename the struct and the `App` field from `selection: SelectionHub` to `selection: AppSelection` (or chosen name). Search all handler files for `self.selection.` — they all need updating but it is a trivial find-replace.\n\n---\n\n## 2. `FocusState` mixes two different lifecycle concerns\n\n**File:** `crates/kanban-tui/src/app/focus.rs:91-95`\n**Type:** Design / cohesion\n\n```rust\npub struct FocusState {\n    pub active: Focus,        // toggled on every Tab/hjkl press\n    pub card_focus: CardFocus,   // only meaningful inside CardDetail mode\n    pub board_focus: BoardFocus, // only meaningful inside BoardDetail mode\n}\n```\n\n`active` is the global panel focus (Boards vs Cards) and changes constantly during normal navigation. `card_focus` and `board_focus` are sub-panel cursors that are only semantically relevant when the app is in `AppMode::CardDetail` or `AppMode::BoardDetail` respectively — outside those modes their values are stale/irrelevant.\n\nGrouping them together in `FocusState` means a reader of `FocusState` has to mentally track when each field is valid. It also means detail-mode logic and navigation logic both mutate the same struct.\n\n**Option A (preferred):** Move `card_focus: CardFocus` into a `CardDetailState` struct (does not exist yet, could live in a new `card_detail.rs`), and `board_focus: BoardFocus` into a `BoardDetailState`. These would be separate `App` fields only consulted in their respective modes.\n\n**Option B (minimal):** Keep them in `FocusState` but rename to `FocusState.panel` (instead of `active`) to signal it is the panel-level concern, and add comments on `card_focus`/`board_focus` that they are detail-mode sub-cursors.\n\n---\n\n## 3. Drop redundant `#[derive(Default)]` on `PersistenceState`\n\n**File:** `crates/kanban-tui/src/app/persistence.rs:3,16`\n**Type:** Cleanup / consistency\n\n```rust\n#[derive(Default)]   // <-- never actually called\npub struct PersistenceState {\n    pub save_file: Option<String>,\n    pub file_change_rx: Option<...>,\n    pub file_watcher: Option<...>,\n    pub save_worker_handle: Option<...>,\n    pub save_completion_rx: Option<...>,\n}\n\nimpl PersistenceState {\n    pub fn new(save_file: Option<String>, save_completion_rx: ...) -> Self { ... }\n}\n```\n\n`App::new` always constructs `PersistenceState` via `PersistenceState::new(save_file, save_completion_rx)`. The `Default` impl (which would give all-`None`) is never invoked anywhere in the codebase. Having both is misleading — it suggests `Default` is a valid construction path when in practice `save_completion_rx` needs to come from the state manager and should never silently default to `None`.\n\n**Action:** Remove `#[derive(Default)]`. If `App` ever needs a fully-defaulted construction path (e.g. for tests), the `new(None, None)` call is explicit and clear enough. Alternatively, drop `new()` and use a struct literal in `App::new` — matching how every other sub-struct (`AnimationState::default()`, `FilterState::default()`, etc.) is constructed — but that requires callers to know all field names, so the `new()` constructor is probably worth keeping.\n\n---\n\n## 4. `viewport_height` and `last_frame_area` are redundant in `ViewState`\n\n**File:** `crates/kanban-tui/src/app/view.rs:11`\n**Type:** Cleanup / derived state\n\n```rust\npub struct ViewState {\n    pub strategy: Box<dyn ViewStrategy>,\n    pub card_list_component: CardListComponent,\n    pub viewport_height: usize,   // <-- redundant?\n    pub last_frame_area: Rect,    // <-- source of truth\n}\n```\n\n`last_frame_area` is a `ratatui::layout::Rect` that contains the full terminal dimensions from the most recent render frame. `viewport_height` is a `usize` that is a subset of that information (the height of the card list viewport area, which is derived from the frame area minus borders/padding).\n\nStoring both means there are two sources of truth that can drift: if `last_frame_area` is updated but `viewport_height` is not recomputed, scroll calculations could use a stale height.\n\n**Action:** Audit all reads of `self.view.viewport_height`. If it is always set immediately after a frame render using `last_frame_area`-derived math, consider computing it on-demand via a `ViewState::viewport_height()` method rather than storing it. If it is genuinely updated at a different cadence, document why.\n\n---\n\n## 5. `ANIMATION_DURATION_MS` bypasses the re-export pattern\n\n**File:** `crates/kanban-tui/src/app/animation.rs:6`, `crates/kanban-tui/src/app/mod.rs` (animation tick handler)\n**Type:** Consistency / style\n\nEvery other symbol from the 12 sub-modules is re-exported at the `app/mod.rs` level:\n```rust\npub mod animation;\npub use animation::{AnimationState, CardAnimation};  // types re-exported\n// ANIMATION_DURATION_MS is NOT re-exported\n```\n\nBut the const is accessed internally via its module path:\n```rust\nif elapsed >= animation::ANIMATION_DURATION_MS {\n```\n\nThis is the only place in `mod.rs` that reaches back into a sub-module via its path rather than using a re-exported name. It works, but it is inconsistent and slightly surprising — a reader skimming `mod.rs` would not see `ANIMATION_DURATION_MS` in the re-export list and might not realise it is defined in `animation.rs`.\n\n**Option A:** Add `pub use animation::ANIMATION_DURATION_MS;` to the re-export block (makes it consistent, but exports an internal implementation detail at crate level).\n\n**Option B (preferred):** Since this const is only used in one place inside `mod.rs`, make it `pub(super)` in `animation.rs` (currently `pub(crate)`) and access it as `animation::ANIMATION_DURATION_MS` — but add a comment in the re-export block: `// ANIMATION_DURATION_MS intentionally not re-exported (internal use only)`.\n\n**Option C:** Inline the value (`150u128`) directly at the use site and delete the named const — it is only used once.\n",
-        "due_date": null,
-        "id": "71022cd7-68e9-4c74-a824-6d9d9e2682d0",
-        "points": 1,
-        "position": 3,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856375455Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Follow-up nits from PR #189 app.rs decomposition",
-        "updated_at": "2026-04-04T23:44:57.911144927Z"
       },
       {
         "card_number": 11,
@@ -1413,6 +1335,32 @@
         "updated_at": "2025-10-16T21:02:46.170907Z"
       },
       {
+        "card_number": 225,
+        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
+        "completed_at": null,
+        "created_at": "2026-03-22T01:39:59.256575150Z",
+        "description": "Follow-up items from code review of PR #189 (KAN-224/decompose-app-rs-into-focused-modules). Zero blockers — PR was merged as-is.\n\n---\n\n## 1. Rename `SelectionHub` to something clearer\n\n**File:** `crates/kanban-tui/src/app/selection.rs:4`\n**Type:** Naming / readability\n\n```rust\npub struct SelectionHub {\n    pub board: SelectionState,\n    pub active_board_index: Option<usize>,\n    pub active_card_index: Option<usize>,\n    pub sprint: SelectionState,\n    pub active_sprint_index: Option<usize>,\n    pub card_navigation_history: Vec<usize>,\n}\n```\n\n`Hub` implies it coordinates or dispatches between things (like an event hub or message hub). This struct is just a plain data grouping of selection indices and cursor state. A reader seeing `self.selection.board` would not immediately know what \"hub\" means here.\n\n**Suggested names:** `AppSelection`, `CursorState`, or simply `SelectionState` (if the `kanban_core::SelectionState` name collision can be resolved via aliasing or renaming the core type).\n\n**Action:** Rename the struct and the `App` field from `selection: SelectionHub` to `selection: AppSelection` (or chosen name). Search all handler files for `self.selection.` — they all need updating but it is a trivial find-replace.\n\n---\n\n## 2. `FocusState` mixes two different lifecycle concerns\n\n**File:** `crates/kanban-tui/src/app/focus.rs:91-95`\n**Type:** Design / cohesion\n\n```rust\npub struct FocusState {\n    pub active: Focus,        // toggled on every Tab/hjkl press\n    pub card_focus: CardFocus,   // only meaningful inside CardDetail mode\n    pub board_focus: BoardFocus, // only meaningful inside BoardDetail mode\n}\n```\n\n`active` is the global panel focus (Boards vs Cards) and changes constantly during normal navigation. `card_focus` and `board_focus` are sub-panel cursors that are only semantically relevant when the app is in `AppMode::CardDetail` or `AppMode::BoardDetail` respectively — outside those modes their values are stale/irrelevant.\n\nGrouping them together in `FocusState` means a reader of `FocusState` has to mentally track when each field is valid. It also means detail-mode logic and navigation logic both mutate the same struct.\n\n**Option A (preferred):** Move `card_focus: CardFocus` into a `CardDetailState` struct (does not exist yet, could live in a new `card_detail.rs`), and `board_focus: BoardFocus` into a `BoardDetailState`. These would be separate `App` fields only consulted in their respective modes.\n\n**Option B (minimal):** Keep them in `FocusState` but rename to `FocusState.panel` (instead of `active`) to signal it is the panel-level concern, and add comments on `card_focus`/`board_focus` that they are detail-mode sub-cursors.\n\n---\n\n## 3. Drop redundant `#[derive(Default)]` on `PersistenceState`\n\n**File:** `crates/kanban-tui/src/app/persistence.rs:3,16`\n**Type:** Cleanup / consistency\n\n```rust\n#[derive(Default)]   // <-- never actually called\npub struct PersistenceState {\n    pub save_file: Option<String>,\n    pub file_change_rx: Option<...>,\n    pub file_watcher: Option<...>,\n    pub save_worker_handle: Option<...>,\n    pub save_completion_rx: Option<...>,\n}\n\nimpl PersistenceState {\n    pub fn new(save_file: Option<String>, save_completion_rx: ...) -> Self { ... }\n}\n```\n\n`App::new` always constructs `PersistenceState` via `PersistenceState::new(save_file, save_completion_rx)`. The `Default` impl (which would give all-`None`) is never invoked anywhere in the codebase. Having both is misleading — it suggests `Default` is a valid construction path when in practice `save_completion_rx` needs to come from the state manager and should never silently default to `None`.\n\n**Action:** Remove `#[derive(Default)]`. If `App` ever needs a fully-defaulted construction path (e.g. for tests), the `new(None, None)` call is explicit and clear enough. Alternatively, drop `new()` and use a struct literal in `App::new` — matching how every other sub-struct (`AnimationState::default()`, `FilterState::default()`, etc.) is constructed — but that requires callers to know all field names, so the `new()` constructor is probably worth keeping.\n\n---\n\n## 4. `viewport_height` and `last_frame_area` are redundant in `ViewState`\n\n**File:** `crates/kanban-tui/src/app/view.rs:11`\n**Type:** Cleanup / derived state\n\n```rust\npub struct ViewState {\n    pub strategy: Box<dyn ViewStrategy>,\n    pub card_list_component: CardListComponent,\n    pub viewport_height: usize,   // <-- redundant?\n    pub last_frame_area: Rect,    // <-- source of truth\n}\n```\n\n`last_frame_area` is a `ratatui::layout::Rect` that contains the full terminal dimensions from the most recent render frame. `viewport_height` is a `usize` that is a subset of that information (the height of the card list viewport area, which is derived from the frame area minus borders/padding).\n\nStoring both means there are two sources of truth that can drift: if `last_frame_area` is updated but `viewport_height` is not recomputed, scroll calculations could use a stale height.\n\n**Action:** Audit all reads of `self.view.viewport_height`. If it is always set immediately after a frame render using `last_frame_area`-derived math, consider computing it on-demand via a `ViewState::viewport_height()` method rather than storing it. If it is genuinely updated at a different cadence, document why.\n\n---\n\n## 5. `ANIMATION_DURATION_MS` bypasses the re-export pattern\n\n**File:** `crates/kanban-tui/src/app/animation.rs:6`, `crates/kanban-tui/src/app/mod.rs` (animation tick handler)\n**Type:** Consistency / style\n\nEvery other symbol from the 12 sub-modules is re-exported at the `app/mod.rs` level:\n```rust\npub mod animation;\npub use animation::{AnimationState, CardAnimation};  // types re-exported\n// ANIMATION_DURATION_MS is NOT re-exported\n```\n\nBut the const is accessed internally via its module path:\n```rust\nif elapsed >= animation::ANIMATION_DURATION_MS {\n```\n\nThis is the only place in `mod.rs` that reaches back into a sub-module via its path rather than using a re-exported name. It works, but it is inconsistent and slightly surprising — a reader skimming `mod.rs` would not see `ANIMATION_DURATION_MS` in the re-export list and might not realise it is defined in `animation.rs`.\n\n**Option A:** Add `pub use animation::ANIMATION_DURATION_MS;` to the re-export block (makes it consistent, but exports an internal implementation detail at crate level).\n\n**Option B (preferred):** Since this const is only used in one place inside `mod.rs`, make it `pub(super)` in `animation.rs` (currently `pub(crate)`) and access it as `animation::ANIMATION_DURATION_MS` — but add a comment in the re-export block: `// ANIMATION_DURATION_MS intentionally not re-exported (internal use only)`.\n\n**Option C:** Inline the value (`150u128`) directly at the use site and delete the named const — it is only used once.\n",
+        "due_date": null,
+        "id": "71022cd7-68e9-4c74-a824-6d9d9e2682d0",
+        "points": 1,
+        "position": 3,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856375455Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Follow-up nits from PR #189 app.rs decomposition",
+        "updated_at": "2026-04-04T23:44:57.911144927Z"
+      },
+      {
         "card_number": 342,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-10-16T21:02:46.691481Z",
@@ -1437,32 +1385,6 @@
         "status": "Done",
         "title": "Add git branches to card meta data",
         "updated_at": "2025-10-16T21:02:46.691481Z"
-      },
-      {
-        "card_number": 260,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-03-30T23:00:15.657707871Z",
-        "description": "## Problem\n\nThe current storage backend system requires compile-time feature flags threaded through 3 crates (`kanban-service` → `kanban-cli` → `kanban-tui`) for each backend. Third-party backends cannot be added without forking or rebuilding the app. This defeats the pluggable storage goal.\n\nDynamic plugin approaches (.so/dlopen, WASM, process-based IPC) all introduce significant complexity and tradeoffs (ABI instability, latency, unsafe code, heavy dependencies).\n\n## Solution: Inverted Dependency Model\n\nInstead of kanban loading plugins, **the plugin builds kanban**. The third-party backend owns `main()` and depends on kanban as a library.\n\n### Third-party usage\n\n```rust\n// kanban-s3/src/main.rs\nuse kanban_cli::App;\nuse kanban_s3_backend::S3StoreFactory;\n\nfn main() {\n    let mut app = App::default();\n    app.register_backend(S3StoreFactory);\n    app.run();\n}\n```\n\nUsers install with: `cargo install kanban-s3`\n\n### Changes Required\n\n#### 1. `kanban-cli` — expose as library + binary\n- Add `lib.rs` alongside `main.rs`\n- Export an `App` struct (or `AppBuilder`) with:\n  - `App::default()` — creates app with no backends\n  - `App::with_defaults()` — creates app with in-tree backends (JSON + SQLite)\n  - `app.register_backend(impl StoreFactory)` — register additional backends\n  - `app.run()` — starts the TUI/CLI\n- `main.rs` just calls `App::with_defaults().run()`\n\n#### 2. `kanban-mcp` — same pattern\n- Expose `KanbanMcpServer` builder with `register_backend`\n- Third parties can build a custom MCP server binary with their backend\n\n#### 3. `kanban-service` — simplify\n- Remove `default_registry()` and feature-gated backend registration\n- Accept a `StoreRegistry` from the caller (passed down from `App`)\n- Make all in-tree backends default deps (no more feature flags for JSON/SQLite)\n\n#### 4. `kanban-persistence` — add Tier 1 contract tests\n- Move persistence-level contract tests into `kanban-persistence` behind `test-helpers` feature\n- Tests operate at `StoreSnapshot` save/load level only (no `KanbanContext` dependency)\n- Third-party backends depend only on `kanban-persistence` for traits + test suite\n- Keep existing Tier 2 roundtrip tests in `kanban-service` for in-tree backends\n\n#### 5. Remove feature flag wiring\n- Remove `sqlite` feature from `kanban-cli`, `kanban-tui`, `kanban-mcp`\n- Remove `sqlite-storage`/`json-storage` features from `kanban-service`\n- Both backends become unconditional dependencies\n\n### Third-party backend developer experience\n\n1. Create crate, depend on `kanban-persistence` (for traits) and `kanban-cli` (for `App`)\n2. Implement `PersistenceStore` + `StoreFactory`\n3. Run `kanban_persistence::contract_tests!(my_factory)` in tests (Tier 1 — persistence level)\n4. Build binary: `App::default().register_backend(MyFactory).run()`\n5. Publish to crates.io\n\n### Multi-client compatibility (TUI, CLI, MCP)\n\nAll three client surfaces accept backends through the same pattern — they all flow to StoreRegistry -> KanbanContext:\n\n```rust\n// TUI\nApp::default().register_backend(PostgresStoreFactory).run();\n\n// CLI (headless)\nApp::default().register_backend(PostgresStoreFactory).run_cli();\n\n// MCP server\nMcpServer::default().register_backend(PostgresStoreFactory).serve();\n```\n\nThird-party crates can ship multiple binaries from one crate:\n\n```toml\n# kanban-postgres/Cargo.toml\n[[bin]]\nname = \"kanban-postgres\"\npath = \"src/main.rs\"         # TUI with Postgres\n\n[[bin]]\nname = \"kanban-postgres-mcp\"\npath = \"src/mcp.rs\"          # MCP server with Postgres\n```\n\nThis requires both kanban-cli and kanban-mcp to expose their runners as library APIs that accept a StoreRegistry. The internal flow is unchanged — stores are created before any client-specific code runs, so TUI/CLI/MCP never need to know which backend is in use.\n\n### What stays the same\n- `PersistenceStore` and `StoreFactory` trait definitions unchanged\n- `StoreRegistry` matching logic unchanged\n- All existing domain/service/TUI code unchanged\n- Default `kanban` binary ships with JSON + SQLite as today\n\n### Precedent\nThis is the same pattern used by axum, bevy, mdbook — the \"plugin\" owns main(), the framework is a library dependency.\n\n## Reference Implementation: PostgreSQL Backend (`kanban-persistence-postgres`)\n\nBuild a PostgreSQL storage backend as the first third-party-style plugin to validate the architecture. This serves as both a useful backend and a reference for third-party developers.\n\n### Why PostgreSQL\n- Validates the plugin model end-to-end with a real networked database (vs SQLite's embedded model)\n- Exercises the `StoreFactory` pattern with connection strings (`postgres://...`) instead of file paths\n- Proves the architecture works for backends where the locator is a URI, not a filesystem path\n- High demand use case: shared/team kanban boards backed by a central database\n\n### Implementation\n- New crate: `kanban-persistence-postgres` — lives in-tree under `crates/` like JSON and SQLite (same workspace, same code patterns, same quality bar)\n- **But wired as a plugin**: not registered in `default_registry()`, no feature flags in `kanban-service`/`kanban-cli`. Instead ships its own binary entrypoint using `App::default().register_backend(PostgresStoreFactory).run()`\n- This is the dogfooding constraint: if the in-tree Postgres crate can integrate purely through the plugin API, any external crate can too\n- Depends on `kanban-persistence` for traits, `sqlx` with `postgres` feature\n- `PostgresStoreFactory` matches `postgres://` and `postgresql://` URI schemes\n- Relational schema similar to SQLite backend but using PostgreSQL types (JSONB, TIMESTAMPTZ, etc.)\n- Must pass all Tier 1 contract tests from `kanban-persistence`\n- Must pass Tier 2 roundtrip tests from `kanban-service`\n- Integration tests run against a real PostgreSQL instance (docker-compose or testcontainers)\n\n### Validation criteria\n- A third-party developer can look at this crate and replicate the pattern for their own backend\n- The crate works both in-tree (as a default backend in the main binary) and as a standalone `cargo install kanban-postgres` binary\n- Documentation in the crate serves as a plugin development guide",
-        "due_date": null,
-        "id": "f78d2716-636a-49bc-b88f-c5b5329c84ae",
-        "points": 4,
-        "position": 4,
-        "priority": "High",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856462903Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Invert storage backend plugin architecture",
-        "updated_at": "2026-04-11T08:25:39.429162673Z"
       },
       {
         "card_number": 50,
@@ -1539,32 +1461,6 @@
         "updated_at": "2026-04-04T23:33:28.989225521Z"
       },
       {
-        "card_number": 325,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-04-06T20:38:32.331398030Z",
-        "description": "## Problem\n\nThere is no first-class CLI command to complete a card. The current workarounds are both bad:\n\n- `card update KAN-X --status done` — sets a metadata field that is redundant with column position (see KAN-324)\n- `card move KAN-X --column-id <uuid>` — requires the user to know the UUID of the completion column\n\nNeither is discoverable or ergonomic. Completing a card is one of the most common operations and should be a single, obvious command.\n\n## Proposed Commands\n\n```\nkanban <file> card complete <ID>   # move to completion column, set completed_at\nkanban <file> card reopen <ID>     # move back to first column, clear completed_at\n```\n\n## Behaviour\n\n**`card complete`**:\n1. Look up the card by identifier (e.g. `KAN-12`)\n2. Resolve the completion column: use `board.completion_column_id` if set; otherwise fall back to the column with the highest `position` value on the card's board\n3. Move the card to that column (reuse the `MoveCard` command internally)\n4. `completed_at` is set as a side effect of the move (see KAN-324 — this should be driven by column, not `CardStatus`)\n\n**`card reopen`**:\n1. Look up the card\n2. Resolve the first column: column with `position == 0` on the card's board\n3. Move the card there\n4. `completed_at` is cleared as a side effect\n\n## Offending Gap\n\n`kanban-cli/src/cli.rs` — `CardAction` enum has no `Complete` or `Reopen` variant:\n```rust\n// currently\npub enum CardAction {\n    Create(CardCreateArgs),\n    List(CardListArgs),\n    Get { id: String },\n    Update(CardUpdateArgs),\n    Move(CardMoveArgs),\n    Archive { id: String },\n    ...\n}\n```\n\n`kanban-mcp/src/lib.rs` — no `complete_card` or `reopen_card` tool registered.\n\nThe completion column resolution logic does not exist as a reusable function anywhere in `kanban-domain` — it is implied but never extracted.\n\n## Steps to Resolution\n\n1. **Domain** — add `fn resolve_completion_column(board: &Board, columns: &[Column]) -> Option<&Column>` and `fn resolve_first_column(columns: &[Column]) -> Option<&Column>` in `kanban-domain`\n2. **Red** — write tests for both resolution functions covering: `completion_column_id` set, `completion_column_id` null (falls back to max position), empty columns list\n3. **Service** — add `complete_card(card_id: Uuid)` and `reopen_card(card_id: Uuid)` to `KanbanOperations` trait and implement in `KanbanContext`\n4. **CLI** — add `Complete { id: String }` and `Reopen { id: String }` to `CardAction` in `cli.rs`; add handlers in `handlers/card.rs`\n5. **MCP** — register `complete_card` and `reopen_card` tools in `kanban-mcp/src/lib.rs`\n6. **Green + refactor** — run full test suite\n\n## Files Affected\n\n- `crates/kanban-domain/src/` — new column resolution helpers\n- `crates/kanban-service/src/context.rs` — `complete_card`, `reopen_card` impl\n- `crates/kanban-domain/src/operations.rs` (or wherever `KanbanOperations` is defined) — trait methods\n- `crates/kanban-cli/src/cli.rs` — new `CardAction` variants\n- `crates/kanban-cli/src/handlers/card.rs` — handler arms\n- `crates/kanban-mcp/src/lib.rs` — new tool registrations\n\n## Related\n\n- KAN-323 — fix misleading 'Card not found' on missing file\n- KAN-324 — remove `CardStatus`; `completed_at` should be driven by column move, not status field",
-        "due_date": null,
-        "id": "ec2fba00-8f90-4253-9ea6-e28920e12e90",
-        "points": null,
-        "position": 5,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541929321Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Add 'card complete' and 'card reopen' CLI commands",
-        "updated_at": "2026-04-06T21:44:46.541949414Z"
-      },
-      {
         "card_number": 36,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -1639,6 +1535,32 @@
         "updated_at": "2026-04-04T23:33:28.989174277Z"
       },
       {
+        "card_number": 325,
+        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
+        "completed_at": null,
+        "created_at": "2026-04-06T20:38:32.331398030Z",
+        "description": "## Problem\n\nThere is no first-class CLI command to complete a card. The current workarounds are both bad:\n\n- `card update KAN-X --status done` — sets a metadata field that is redundant with column position (see KAN-324)\n- `card move KAN-X --column-id <uuid>` — requires the user to know the UUID of the completion column\n\nNeither is discoverable or ergonomic. Completing a card is one of the most common operations and should be a single, obvious command.\n\n## Proposed Commands\n\n```\nkanban <file> card complete <ID>   # move to completion column, set completed_at\nkanban <file> card reopen <ID>     # move back to first column, clear completed_at\n```\n\n## Behaviour\n\n**`card complete`**:\n1. Look up the card by identifier (e.g. `KAN-12`)\n2. Resolve the completion column: use `board.completion_column_id` if set; otherwise fall back to the column with the highest `position` value on the card's board\n3. Move the card to that column (reuse the `MoveCard` command internally)\n4. `completed_at` is set as a side effect of the move (see KAN-324 — this should be driven by column, not `CardStatus`)\n\n**`card reopen`**:\n1. Look up the card\n2. Resolve the first column: column with `position == 0` on the card's board\n3. Move the card there\n4. `completed_at` is cleared as a side effect\n\n## Offending Gap\n\n`kanban-cli/src/cli.rs` — `CardAction` enum has no `Complete` or `Reopen` variant:\n```rust\n// currently\npub enum CardAction {\n    Create(CardCreateArgs),\n    List(CardListArgs),\n    Get { id: String },\n    Update(CardUpdateArgs),\n    Move(CardMoveArgs),\n    Archive { id: String },\n    ...\n}\n```\n\n`kanban-mcp/src/lib.rs` — no `complete_card` or `reopen_card` tool registered.\n\nThe completion column resolution logic does not exist as a reusable function anywhere in `kanban-domain` — it is implied but never extracted.\n\n## Steps to Resolution\n\n1. **Domain** — add `fn resolve_completion_column(board: &Board, columns: &[Column]) -> Option<&Column>` and `fn resolve_first_column(columns: &[Column]) -> Option<&Column>` in `kanban-domain`\n2. **Red** — write tests for both resolution functions covering: `completion_column_id` set, `completion_column_id` null (falls back to max position), empty columns list\n3. **Service** — add `complete_card(card_id: Uuid)` and `reopen_card(card_id: Uuid)` to `KanbanOperations` trait and implement in `KanbanContext`\n4. **CLI** — add `Complete { id: String }` and `Reopen { id: String }` to `CardAction` in `cli.rs`; add handlers in `handlers/card.rs`\n5. **MCP** — register `complete_card` and `reopen_card` tools in `kanban-mcp/src/lib.rs`\n6. **Green + refactor** — run full test suite\n\n## Files Affected\n\n- `crates/kanban-domain/src/` — new column resolution helpers\n- `crates/kanban-service/src/context.rs` — `complete_card`, `reopen_card` impl\n- `crates/kanban-domain/src/operations.rs` (or wherever `KanbanOperations` is defined) — trait methods\n- `crates/kanban-cli/src/cli.rs` — new `CardAction` variants\n- `crates/kanban-cli/src/handlers/card.rs` — handler arms\n- `crates/kanban-mcp/src/lib.rs` — new tool registrations\n\n## Related\n\n- KAN-323 — fix misleading 'Card not found' on missing file\n- KAN-324 — remove `CardStatus`; `completed_at` should be driven by column move, not status field",
+        "due_date": null,
+        "id": "ec2fba00-8f90-4253-9ea6-e28920e12e90",
+        "points": null,
+        "position": 5,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541929321Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Add 'card complete' and 'card reopen' CLI commands",
+        "updated_at": "2026-04-06T21:44:46.541949414Z"
+      },
+      {
         "card_number": 10,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-10-16T21:02:48.075303Z",
@@ -1663,58 +1585,6 @@
         "status": "Done",
         "title": "Add or update priorities",
         "updated_at": "2025-10-16T21:02:48.075303Z"
-      },
-      {
-        "card_number": 13,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T21:02:49.028474Z",
-        "created_at": "2025-10-10T23:01:18.553586Z",
-        "description": "Order tasks by\n\n- Points\n- Priority\n- Date created\n- Date due\n- Date updated\n- Status\n\nMVP\n---\n\nI think in the tasks panel. hit o (for order or organize) and then are presented with a dialogue where can choose one of the above options.\n\nThe dialogue should use the same selection mechanism as the projects and tasks lists do.\n\nAfter one of the options have been selected. The task list should be ordered according to the chosen option.\n\nFor now we leave out Date due from selection as we have not added this feature yet.\n\nOrder can be descending or ascending. a for ascending and d for descending after selecting an item. Taking suggestions on UX here..\n\n---\n\nFor the future. Keep in mind that I would also like to order the projects panel in the same way as the tasks panel but along a shorter list of options\n\n- Name\n- Date created\n- Date updated\n",
-        "due_date": null,
-        "id": "6a0cbe1e-a05e-4aca-bd53-f0057215d671",
-        "points": 2,
-        "position": 6,
-        "priority": "Medium",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155907Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "Add order tasks lists by",
-        "updated_at": "2025-10-16T21:02:49.028474Z"
-      },
-      {
-        "card_number": 324,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-04-06T20:37:11.537106294Z",
-        "description": "## Problem\n\n`CardStatus` is a redundant domain enum that duplicates state already expressed by which column a card lives in. It creates two sources of truth and confuses users who expect `--status Complete` to work when `Complete` is a column name:\n\n```\n{\"error\":\"Invalid status 'Complete'. Valid values: todo, in-progress, blocked, done\"}\n```\n\nThe four status values (`Todo`, `InProgress`, `Blocked`, `Done`) have no meaning independent of column. A card is \"in progress\" because it's in the Doing column — not because of a separate status field.\n\n## Offending Code\n\nThe enum itself:\n```rust\n// kanban-domain/src/card.rs:20-25\npub enum CardStatus {\n    Todo,\n    InProgress,\n    Blocked,\n    Done,\n}\n```\n\nThe only real work it does: auto-toggling `completed_at` when status becomes `Done`:\n```rust\n// kanban-domain/src/card.rs:168-174\npub fn update_status(&mut self, status: CardStatus) {\n    if status == CardStatus::Done && self.status != CardStatus::Done {\n        self.completed_at = Some(Utc::now());\n    } else if status != CardStatus::Done && self.status == CardStatus::Done {\n        self.completed_at = None;\n    }\n    self.status = status;\n}\n```\n\nThis is already handled by the move-to-completion-column lifecycle in `card_lifecycle.rs:145-147`:\n```rust\nif is_moving_to_completion && card.status != CardStatus::Done {\n    Some(CardStatus::Done)\n} else if is_moving_from_completion && card.status == CardStatus::Done {\n    Some(CardStatus::Todo)\n}\n```\n\nDuplicate `parse_status` functions in both CLI and MCP:\n```rust\n// kanban-cli/src/handlers/card.rs:271-281\nfn parse_status(s: &str) -> Result<CardStatus, String> { ... }\n\n// kanban-mcp/src/lib.rs:72-83\nfn parse_status(s: &str) -> Result<CardStatus, McpError> { ... }\n```\n\nSorting by status as a numeric rank — meaningless without column context:\n```rust\n// kanban-domain/src/sort/mod.rs:90-95\nfn status_value(status: &CardStatus) -> u8 {\n    CardStatus::Done => 3,\n    CardStatus::InProgress => 2,\n    CardStatus::Blocked => 1,\n    CardStatus::Todo => 0,\n}\n```\n\n## Proposed Fix\n\n1. **Remove `CardStatus` enum** from `kanban-domain/src/card.rs`\n2. **Derive completion from `completion_column_id`** on `Board` — when a card is moved to the board's completion column, set `completed_at`; when moved away, clear it. This is already partially done in `card_lifecycle.rs` and just needs the `CardStatus::Done` check replaced with a column comparison.\n3. **Remove `status` field from `Card` and `CardSummary`** structs\n4. **Remove `status` from `CardUpdate`** and `CardListFilter`\n5. **Remove `--status` flag from CLI** `card update` and `card list` commands; remove `parse_status` from both `kanban-cli` and `kanban-mcp`\n6. **Remove `SortField::Status`** if it exists, or remove status from the sort ranking in `sort/mod.rs`\n7. **Migration**: existing persisted `status` fields can be ignored on load (serde `#[serde(default)]` or `#[serde(skip)]`); no data migration needed since `column_id` already carries the state\n\n## Steps to Resolution\n\n1. Red: write tests asserting `completed_at` is set when a card is moved to the `completion_column_id` column (no `CardStatus` involved)\n2. Remove `CardStatus` enum and all references — compiler will enumerate every callsite\n3. Update `card_lifecycle.rs` to set/clear `completed_at` based on `completion_column_id` comparison instead of `CardStatus::Done` check\n4. Remove `status` field from `Card`, `CardSummary`, `CardUpdate`, `CardListFilter`\n5. Remove `--status` from CLI and MCP, remove both `parse_status` functions\n6. Update persistence: add `#[serde(skip)]` or ignore on deserialise for backwards compat with existing JSON files\n7. Remove `status` from the SQLite schema (or keep column, ignore on read)\n8. Green + refactor — run full test suite, update integration tests\n\n## Files Affected\n\n- `crates/kanban-domain/src/card.rs` — remove enum, field, `update_status()`\n- `crates/kanban-domain/src/card_lifecycle.rs` — replace `CardStatus::Done` checks with column comparison\n- `crates/kanban-domain/src/sort/mod.rs` — remove `status_value()` and `SortField::Status`\n- `crates/kanban-domain/src/lib.rs` — remove `CardStatus` from public exports\n- `crates/kanban-cli/src/handlers/card.rs` — remove `parse_status`, `--status` flag handling\n- `crates/kanban-mcp/src/lib.rs` — remove `parse_status`, status fields from tool schemas\n- `crates/kanban-persistence-sqlite/` — drop or ignore `status` column\n- All tests referencing `CardStatus`",
-        "due_date": null,
-        "id": "5e08bf0b-eb8f-4ef7-93f6-5127ccc82c0b",
-        "points": null,
-        "position": 6,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541925629Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Remove CardStatus — column position is the source of truth for card state",
-        "updated_at": "2026-04-06T21:44:46.541946104Z"
       },
       {
         "card_number": 38,
@@ -1789,6 +1659,58 @@
         "status": "Todo",
         "title": "branch name doesnt reflected the used version",
         "updated_at": "2026-04-04T23:33:28.989096160Z"
+      },
+      {
+        "card_number": 13,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-16T21:02:49.028474Z",
+        "created_at": "2025-10-10T23:01:18.553586Z",
+        "description": "Order tasks by\n\n- Points\n- Priority\n- Date created\n- Date due\n- Date updated\n- Status\n\nMVP\n---\n\nI think in the tasks panel. hit o (for order or organize) and then are presented with a dialogue where can choose one of the above options.\n\nThe dialogue should use the same selection mechanism as the projects and tasks lists do.\n\nAfter one of the options have been selected. The task list should be ordered according to the chosen option.\n\nFor now we leave out Date due from selection as we have not added this feature yet.\n\nOrder can be descending or ascending. a for ascending and d for descending after selecting an item. Taking suggestions on UX here..\n\n---\n\nFor the future. Keep in mind that I would also like to order the projects panel in the same way as the tasks panel but along a shorter list of options\n\n- Name\n- Date created\n- Date updated\n",
+        "due_date": null,
+        "id": "6a0cbe1e-a05e-4aca-bd53-f0057215d671",
+        "points": 2,
+        "position": 6,
+        "priority": "Medium",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155907Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "Add order tasks lists by",
+        "updated_at": "2025-10-16T21:02:49.028474Z"
+      },
+      {
+        "card_number": 324,
+        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
+        "completed_at": null,
+        "created_at": "2026-04-06T20:37:11.537106294Z",
+        "description": "## Problem\n\n`CardStatus` is a redundant domain enum that duplicates state already expressed by which column a card lives in. It creates two sources of truth and confuses users who expect `--status Complete` to work when `Complete` is a column name:\n\n```\n{\"error\":\"Invalid status 'Complete'. Valid values: todo, in-progress, blocked, done\"}\n```\n\nThe four status values (`Todo`, `InProgress`, `Blocked`, `Done`) have no meaning independent of column. A card is \"in progress\" because it's in the Doing column — not because of a separate status field.\n\n## Offending Code\n\nThe enum itself:\n```rust\n// kanban-domain/src/card.rs:20-25\npub enum CardStatus {\n    Todo,\n    InProgress,\n    Blocked,\n    Done,\n}\n```\n\nThe only real work it does: auto-toggling `completed_at` when status becomes `Done`:\n```rust\n// kanban-domain/src/card.rs:168-174\npub fn update_status(&mut self, status: CardStatus) {\n    if status == CardStatus::Done && self.status != CardStatus::Done {\n        self.completed_at = Some(Utc::now());\n    } else if status != CardStatus::Done && self.status == CardStatus::Done {\n        self.completed_at = None;\n    }\n    self.status = status;\n}\n```\n\nThis is already handled by the move-to-completion-column lifecycle in `card_lifecycle.rs:145-147`:\n```rust\nif is_moving_to_completion && card.status != CardStatus::Done {\n    Some(CardStatus::Done)\n} else if is_moving_from_completion && card.status == CardStatus::Done {\n    Some(CardStatus::Todo)\n}\n```\n\nDuplicate `parse_status` functions in both CLI and MCP:\n```rust\n// kanban-cli/src/handlers/card.rs:271-281\nfn parse_status(s: &str) -> Result<CardStatus, String> { ... }\n\n// kanban-mcp/src/lib.rs:72-83\nfn parse_status(s: &str) -> Result<CardStatus, McpError> { ... }\n```\n\nSorting by status as a numeric rank — meaningless without column context:\n```rust\n// kanban-domain/src/sort/mod.rs:90-95\nfn status_value(status: &CardStatus) -> u8 {\n    CardStatus::Done => 3,\n    CardStatus::InProgress => 2,\n    CardStatus::Blocked => 1,\n    CardStatus::Todo => 0,\n}\n```\n\n## Proposed Fix\n\n1. **Remove `CardStatus` enum** from `kanban-domain/src/card.rs`\n2. **Derive completion from `completion_column_id`** on `Board` — when a card is moved to the board's completion column, set `completed_at`; when moved away, clear it. This is already partially done in `card_lifecycle.rs` and just needs the `CardStatus::Done` check replaced with a column comparison.\n3. **Remove `status` field from `Card` and `CardSummary`** structs\n4. **Remove `status` from `CardUpdate`** and `CardListFilter`\n5. **Remove `--status` flag from CLI** `card update` and `card list` commands; remove `parse_status` from both `kanban-cli` and `kanban-mcp`\n6. **Remove `SortField::Status`** if it exists, or remove status from the sort ranking in `sort/mod.rs`\n7. **Migration**: existing persisted `status` fields can be ignored on load (serde `#[serde(default)]` or `#[serde(skip)]`); no data migration needed since `column_id` already carries the state\n\n## Steps to Resolution\n\n1. Red: write tests asserting `completed_at` is set when a card is moved to the `completion_column_id` column (no `CardStatus` involved)\n2. Remove `CardStatus` enum and all references — compiler will enumerate every callsite\n3. Update `card_lifecycle.rs` to set/clear `completed_at` based on `completion_column_id` comparison instead of `CardStatus::Done` check\n4. Remove `status` field from `Card`, `CardSummary`, `CardUpdate`, `CardListFilter`\n5. Remove `--status` from CLI and MCP, remove both `parse_status` functions\n6. Update persistence: add `#[serde(skip)]` or ignore on deserialise for backwards compat with existing JSON files\n7. Remove `status` from the SQLite schema (or keep column, ignore on read)\n8. Green + refactor — run full test suite, update integration tests\n\n## Files Affected\n\n- `crates/kanban-domain/src/card.rs` — remove enum, field, `update_status()`\n- `crates/kanban-domain/src/card_lifecycle.rs` — replace `CardStatus::Done` checks with column comparison\n- `crates/kanban-domain/src/sort/mod.rs` — remove `status_value()` and `SortField::Status`\n- `crates/kanban-domain/src/lib.rs` — remove `CardStatus` from public exports\n- `crates/kanban-cli/src/handlers/card.rs` — remove `parse_status`, `--status` flag handling\n- `crates/kanban-mcp/src/lib.rs` — remove `parse_status`, status fields from tool schemas\n- `crates/kanban-persistence-sqlite/` — drop or ignore `status` column\n- All tests referencing `CardStatus`",
+        "due_date": null,
+        "id": "5e08bf0b-eb8f-4ef7-93f6-5127ccc82c0b",
+        "points": null,
+        "position": 6,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541925629Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Remove CardStatus — column position is the source of truth for card state",
+        "updated_at": "2026-04-06T21:44:46.541946104Z"
       },
       {
         "card_number": 3,
@@ -1881,32 +1803,6 @@
         "status": "Todo",
         "title": "a sprint can only be completed after the duration is over",
         "updated_at": "2026-04-04T23:33:28.989069750Z"
-      },
-      {
-        "card_number": 323,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-04-06T20:36:22.081954307Z",
-        "description": "## Problem\n\nWhen a non-existent file path is passed to the CLI (e.g. `kanban demo.json card get KAN-12` when the correct path is `fixtures/demo.json`), the user sees:\n\n```\n{\"success\":false,\"api_version\":\"0.3.5\",\"error\":\"Card not found: 'KAN-12'\"}\nError: Card not found: 'KAN-12'\n```\n\nThis is wrong. The file doesn't exist — the card lookup never had a chance. The real error is a missing file.\n\n## Root Cause\n\n`KanbanContext::load` in `kanban-service/src/context.rs` is designed to support the TUI's \"new board\" flow — it silently returns an empty context when the file doesn't exist:\n\n```rust\n// kanban-service/src/context.rs:44-46\npub async fn load(...) -> KanbanResult<Self> {\n    if !store.exists().await {\n        return Ok(Self::empty(store, config));  // ← silent empty context\n    }\n    ...\n}\n```\n\nThe CLI loads via `CliContext::load` in `kanban-cli/src/context.rs`, which delegates directly without checking existence first:\n\n```rust\n// kanban-cli/src/context.rs:17-28\npub async fn load(file_path: &str, mut config: AppConfig) -> KanbanResult<Self> {\n    ...\n    Ok(Self {\n        inner: KanbanContext::load(make_store(&backend, file_path)?, config).await?,\n    })\n}\n```\n\nThe empty context has no cards, so any card operation then fails with a misleading domain-level error.\n\n## Proposed Fix\n\nAdd a file existence check in `CliContext::load` before delegating to `KanbanContext::load`:\n\n```rust\n// kanban-cli/src/context.rs\npub async fn load(file_path: &str, mut config: AppConfig) -> KanbanResult<Self> {\n    if !std::path::Path::new(file_path).exists() {\n        return Err(KanbanError::NotFound(format!(\n            \"Board file not found: '{}'\",\n            file_path\n        )));\n    }\n    ...\n}\n```\n\nThis keeps the TUI's empty-context path untouched (TUI uses `KanbanContext::load` directly via `App::new`) while giving CLI users a clear, actionable error message.\n\n## Steps to Resolution\n\n1. Add existence check at the top of `CliContext::load` in `kanban-cli/src/context.rs`\n2. Verify the error surfaces as a `{\"success\":false,...,\"error\":\"Board file not found: 'demo.json'\"}` JSON response\n3. Add a CLI integration test in `kanban-cli/tests/cli_integration.rs` asserting the correct error message on a missing file path\n4. Confirm the TUI is unaffected (it never calls `CliContext::load`)",
-        "due_date": null,
-        "id": "d9db775c-f075-4d9d-b3a7-9e8404dd0383",
-        "points": null,
-        "position": 7,
-        "priority": "High",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541917904Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Fix misleading 'Card not found' error when board file does not exist",
-        "updated_at": "2026-04-06T21:44:46.541940137Z"
       },
       {
         "card_number": 85,
@@ -2043,23 +1939,6 @@
         "updated_at": "2026-04-04T23:35:37.856518420Z"
       },
       {
-        "card_number": 17,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T21:02:51.760550Z",
-        "created_at": "2025-10-11T18:39:14.248330Z",
-        "description": "No need to explicitly generate IDS for cards.\n\nWe just give them IDs immediately\n",
-        "due_date": null,
-        "id": "ed0ead2b-6da9-4889-83b7-e4c60ab11032",
-        "points": 3,
-        "position": 9,
-        "priority": "High",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Give cards ID from the beginning",
-        "updated_at": "2025-10-16T22:12:30.986301Z"
-      },
-      {
         "card_number": 301,
         "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
         "completed_at": null,
@@ -2150,6 +2029,23 @@
         "status": "Todo",
         "title": "automatic sprint completion",
         "updated_at": "2026-04-04T23:33:28.989166792Z"
+      },
+      {
+        "card_number": 17,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-16T21:02:51.760550Z",
+        "created_at": "2025-10-11T18:39:14.248330Z",
+        "description": "No need to explicitly generate IDS for cards.\n\nWe just give them IDs immediately\n",
+        "due_date": null,
+        "id": "ed0ead2b-6da9-4889-83b7-e4c60ab11032",
+        "points": 3,
+        "position": 9,
+        "priority": "High",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "Give cards ID from the beginning",
+        "updated_at": "2025-10-16T22:12:30.986301Z"
       },
       {
         "card_number": 18,
@@ -2336,92 +2232,6 @@
         "updated_at": "2026-04-04T23:33:28.989109590Z"
       },
       {
-        "card_number": 302,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-04-04T23:50:48.834116789Z",
-        "description": "When starting the tui. A board is not preselected making the ui look very empty and stale.\n\nI think we should at the very least preselect the first board. or if we really wanted to.\n\nRemember the last board selected and select that\n",
-        "due_date": null,
-        "id": "ef22e57d-924a-432c-81dd-1b9b22bba4b4",
-        "points": 1,
-        "position": 11,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:51:55.287301384Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Starting the tui doesnt select a board",
-        "updated_at": "2026-04-04T23:51:55.287304833Z"
-      },
-      {
-        "card_number": 334,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-04-11T08:39:51.832815833Z",
-        "description": "**Bug:** When a card is assigned to a sprint with a prefix override (e.g. `CAT`), the card gets a new identifier (`CAT-260`). However, looking up the card using that identifier returns \"Card not found\" — only the original identifier (`KAN-260`) works.\n\n**Observed:**\n```\nkanban card get CAT-260  →  Error: Card not found: 'CAT-260'\nkanban card get KAN-260  →  success\n```\n\n**Expected:** The card should be retrievable by its sprint-assigned identifier (`CAT-260`).\n\n**Steps to reproduce:**\n1. Create a card on a board with prefix `KAN` — gets ID `KAN-260`\n2. Assign the card to a sprint with prefix override `CAT` — branch name becomes `CAT-260`\n3. Run `kanban card get CAT-260`\n4. Observe \"Card not found\" error\n\n**Root cause area:** Card lookup likely only indexes by the canonical `assigned_prefix` + `card_number`, not by the sprint-assigned prefix.",
-        "due_date": null,
-        "id": "0015392b-e4a8-4c6f-bfba-895c5e2f1f86",
-        "points": 3,
-        "position": 12,
-        "priority": "High",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": "2026-05-07T22:06:15.245065172Z",
-            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-            "sprint_name": "sphinx-centered",
-            "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:21.126609766Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T22:06:15.245067047Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Card not found when looked up by sprint-assigned prefix identifier",
-        "updated_at": "2026-05-07T22:06:15.245067738Z"
-      },
-      {
-        "card_number": 25,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T21:02:54.150999Z",
-        "created_at": "2025-10-11T20:53:06.269232Z",
-        "description": "Add the date and time for when a task was marked as completed\n",
-        "due_date": null,
-        "id": "e3482cf7-c53a-4ce8-8c33-11e2cca3d87a",
-        "points": 1,
-        "position": 12,
-        "priority": "Medium",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155909Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "Add completed when time to task",
-        "updated_at": "2025-10-17T06:21:36.538347Z"
-      },
-      {
         "card_number": 79,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -2488,6 +2298,58 @@
         "updated_at": "2026-04-04T23:33:28.989227646Z"
       },
       {
+        "card_number": 25,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-16T21:02:54.150999Z",
+        "created_at": "2025-10-11T20:53:06.269232Z",
+        "description": "Add the date and time for when a task was marked as completed\n",
+        "due_date": null,
+        "id": "e3482cf7-c53a-4ce8-8c33-11e2cca3d87a",
+        "points": 1,
+        "position": 12,
+        "priority": "Medium",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155909Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "Add completed when time to task",
+        "updated_at": "2025-10-17T06:21:36.538347Z"
+      },
+      {
+        "card_number": 27,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-16T21:02:54.835376Z",
+        "created_at": "2025-10-11T21:42:14.741535Z",
+        "description": "## TUI-Service layer disconnect\n\nThe TUI crate builds its own store registry and persistence stack independently from kanban-service. This causes real bugs:\n\n- SQLite feature gap (PR #204): added sqlite as default for kanban-cli and kanban-mcp, but TUI's indirect dependency through kanban-service didn't get it. Switching storage_backend json->sqlite in settings fails because the TUI registry only has the JSON factory.\n\n- Duplicated persistence orchestration: settings handler in kanban-tui manually calls migrate_store, validate_and_load_store, replace_store, resets selection, spawns save workers -- business logic that should live in the service layer.\n\n### Refactor goals\n\n1. Move storage backend switching (migrate/validate/reload) into kanban-service as a single operation\n2. TUI calls the service, not orchestrate persistence directly\n3. Eliminate the feature-flag disconnect -- the service owns which backends are available",
+        "due_date": null,
+        "id": "4cdf603d-2ba8-4bc0-9c19-a2a4531ccff6",
+        "points": 4,
+        "position": 13,
+        "priority": "Medium",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155910Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "Refactor, hunt for abstractions",
+        "updated_at": "2026-04-03T16:27:03.529324249Z"
+      },
+      {
         "card_number": 92,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -2538,30 +2400,21 @@
         "updated_at": "2026-01-10T15:31:10.374919Z"
       },
       {
-        "card_number": 27,
+        "card_number": 31,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T21:02:54.835376Z",
-        "created_at": "2025-10-11T21:42:14.741535Z",
-        "description": "## TUI-Service layer disconnect\n\nThe TUI crate builds its own store registry and persistence stack independently from kanban-service. This causes real bugs:\n\n- SQLite feature gap (PR #204): added sqlite as default for kanban-cli and kanban-mcp, but TUI's indirect dependency through kanban-service didn't get it. Switching storage_backend json->sqlite in settings fails because the TUI registry only has the JSON factory.\n\n- Duplicated persistence orchestration: settings handler in kanban-tui manually calls migrate_store, validate_and_load_store, replace_store, resets selection, spawns save workers -- business logic that should live in the service layer.\n\n### Refactor goals\n\n1. Move storage backend switching (migrate/validate/reload) into kanban-service as a single operation\n2. TUI calls the service, not orchestrate persistence directly\n3. Eliminate the feature-flag disconnect -- the service owns which backends are available",
+        "completed_at": "2025-10-16T21:02:55.771078Z",
+        "created_at": "2025-10-12T00:14:17.034422Z",
+        "description": "Specifically needed. in progress\n\nWe want to start working on board columns\n\nDupe of task `KAN-7/add-column-definitions`\n",
         "due_date": null,
-        "id": "4cdf603d-2ba8-4bc0-9c19-a2a4531ccff6",
-        "points": 4,
-        "position": 13,
+        "id": "6f66b041-2592-4e78-b348-cbc34c00c548",
+        "points": 5,
+        "position": 14,
         "priority": "Medium",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155910Z",
-            "status": "Completed"
-          }
-        ],
+        "sprint_id": null,
+        "sprint_logs": [],
         "status": "Done",
-        "title": "Refactor, hunt for abstractions",
-        "updated_at": "2026-04-03T16:27:03.529324249Z"
+        "title": "Update status of a card - Board Columns",
+        "updated_at": "2025-10-16T21:02:55.771078Z"
       },
       {
         "card_number": 47,
@@ -2646,55 +2499,30 @@
         "updated_at": "2026-04-04T23:33:28.989220333Z"
       },
       {
-        "card_number": 31,
+        "card_number": 43,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T21:02:55.771078Z",
-        "created_at": "2025-10-12T00:14:17.034422Z",
-        "description": "Specifically needed. in progress\n\nWe want to start working on board columns\n\nDupe of task `KAN-7/add-column-definitions`\n",
+        "completed_at": "2025-10-16T21:02:56.921732Z",
+        "created_at": "2025-10-12T16:45:41.135171Z",
+        "description": "in the projects panel there is a green text with `Projects` we can drop this as the panel header itself shows projects too.\n\nin the task list there is a green text of the current project. we can drop this and rely on the highlighted item in the projects list instead\n",
         "due_date": null,
-        "id": "6f66b041-2592-4e78-b348-cbc34c00c548",
-        "points": 5,
-        "position": 14,
+        "id": "5d31ae81-75a7-47c7-a6d1-5a9b0f06a5b7",
+        "points": 1,
+        "position": 15,
         "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Update status of a card - Board Columns",
-        "updated_at": "2025-10-16T21:02:55.771078Z"
-      },
-      {
-        "card_number": 341,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-04-13T20:27:32.244827437Z",
-        "description": "## Problem\n\nWhen a card is created, `assigned_prefix` is set from `board.card_prefix` at creation time. If the board prefix later changes, or the card is assigned to a sprint with its own `card_prefix`, the identifier lookup uses the stale `assigned_prefix` (it ranks above `sprint.card_prefix` in the hierarchy), making the card unreachable by its sprint prefix.\n\n---\n\n## Design Discussion\n\n### Why multi-alias (track all historical prefixes) does not work\n\n`prefix_counters` is per-prefix per-board. Two sprints can independently use the same `card_prefix`. If Card A (sprint 1, prefix SPR) and Card B (sprint 3, prefix SPR) both have card_number=5, `SPR-5` is genuinely ambiguous. The KAN-211 multi-match return handles ambiguity gracefully but does not eliminate it — two legitimately different cards with the same identifier is worse than a lookup oddity.\n\n### Why hierarchy reorder has the same collision risk\n\nReordering to `sprint.card_prefix → card.assigned_prefix → board.card_prefix` shifts which scenario causes the collision but does not eliminate it. A card created as KAN-5 assigned to sprint SPR resolves as SPR-5. A card created as SPR-5 (board prefix was SPR at creation) also resolves as SPR-5. Same collision, different trigger.\n\n### Sprint prefix uniqueness closes the collision\n\nAll constraints are scoped to a single board — `prefix_counters`, sprint `card_prefix` values, `assigned_prefix` values, and card numbers all live within one board. Cross-board sprints are not a realistic Scrum/Kanban scenario (that is program-level coordination, not sprint sharing).\n\nIf sprint `card_prefix` is enforced unique against `board.prefix_counters` (all historical board prefixes) AND against other sprints on the same board, then no sprint prefix can ever equal any card's `assigned_prefix`. The collision is structurally impossible.\n\n### card.card_prefix is dead weight\n\n`card.card_prefix` (the per-card override field) is always `None` at creation (card_commands.rs:154). The CLI handler hardcodes `card_prefix: FieldUpdate::NoChange`. The TUI has no UI for it. It has never been set in any code path. It adds a fourth level to the hierarchy with no practical benefit.\n\n### card.assigned_prefix should also be dropped\n\n`assigned_prefix` only exists to preserve the prefix a card was created under if `board.card_prefix` later changes. If the board prefix is locked (immutable once cards exist), `assigned_prefix` is always equal to `board.card_prefix` — redundant by definition. It can be dropped entirely and prefix resolved purely by function.\n\n---\n\n## Target Model\n\n**Prefix resolution (fully functional, nothing stored on card):**\n`sprint.card_prefix → board.card_prefix`\n\n- Card created on board → board prefix + board counter → e.g. KAN-5\n- Card assigned to sprint with prefix SPR → resolves as SPR-5 (same number, prefix is dynamic)\n- Card dropped from sprint → resolves as KAN-5 again\n- Card number is stable (assigned once at creation, never changes)\n\n**Locking rules:**\n- `board.card_prefix` is immutable once the first card is created\n- `sprint.card_prefix` is immutable once the first card is assigned to the sprint\n- Sprint `card_prefix` must not appear in `board.prefix_counters` (all historical board prefixes)\n- Sprint `card_prefix` must not match any other sprint's `card_prefix` on the same board\n\n**Counters:**\n- Board: `card_counter: u32` — single value, replaces `prefix_counters: HashMap<String, u32>` (since prefix is now locked, the HashMap always had one meaningful key)\n- Sprint: no card counter — sprint prefix is a label only, card numbers come from the board counter\n- Sprint numbering counter (`sprint_counters`) unchanged\n\n---\n\n## Migration Required (both backends)\n\n### Key insight: assigned_prefix IS the prefix change history\n\n`card.assigned_prefix` on existing cards already records exactly what prefix each card was created under — it is the historical record of board prefix changes, just stored per-card rather than per-board. The migration can use it precisely:\n\n1. Bucket all cards by `assigned_prefix` value\n2. Each bucket's `max(card_number) + 1` is the correct counter for that prefix\n3. The bucket matching `board.card_prefix` becomes `board.card_counter`\n4. Collision detection: if card_numbers overlap across buckets, those cards would become ambiguous post-migration — surface as errors before dropping the field\n\nThis makes the migration fully deterministic. No guessing, no heuristics. The existing field contains exactly the information needed to reconstruct counters correctly and detect every collision case. After the migration, the field is dropped and locking prevents the situation from recurring.\n\nSimilarly, `sprint_logs` on cards already tracks which sprints a card has been assigned to with timestamps — the same pattern applied to boards would reconstruct the full prefix history if needed.\n\n### JSON: V2 → V3\n\n1. For each board: bucket cards by `assigned_prefix`, find bucket matching `board.card_prefix`, set `board.card_counter` to `max(card_number) + 1` from that bucket\n2. Collision check: if any card_number appears in more than one `assigned_prefix` bucket, abort with an error listing the conflicting identifiers\n3. Drop `card.assigned_prefix` on every card\n4. Drop `card.card_prefix` on every card\n\n### SQLite: schema v1 → v2\n\n1. Same bucketing and collision check logic in a migration transaction\n2. Populate `card_counter` on boards table from the above\n3. `ALTER TABLE cards DROP COLUMN assigned_prefix`\n4. `ALTER TABLE cards DROP COLUMN card_prefix`\n5. Wrap in a single transaction — abort entirely on collision rather than partial migrate\n\n### Hard edge case\n\nIf a board changed prefix mid-life (KAN-1..50, then PROJ-1..30), card_numbers 1-30 exist in both buckets. Migration aborts with:\n```\nMigration error: board \"My Board\" has ambiguous card numbers after prefix change.\n  KAN-1..30 and PROJ-1..30 cannot both be identified post-migration.\n  Resolve by deleting or re-numbering cards in one prefix group before migrating.\n```\n\n---\n\n## Files Affected\n\n- `crates/kanban-domain/src/card.rs` — drop `card_prefix`, `assigned_prefix` fields; update `CardUpdate`, `branch_name()`\n- `crates/kanban-domain/src/board.rs` — replace `prefix_counters: HashMap` with `card_counter: u32`; add prefix lock enforcement\n- `crates/kanban-domain/src/commands/card_commands.rs` — update `CreateCard` to use `board.card_counter`\n- `crates/kanban-domain/src/commands/sprint_commands.rs` — enforce sprint prefix uniqueness and immutability\n- `crates/kanban-domain/src/search/mod.rs` — simplify hierarchy to two levels\n- `crates/kanban-persistence-json/src/lib.rs` — V2→V3 migration\n- `crates/kanban-persistence-sqlite/src/` — schema v1→v2 migration\n- `crates/kanban-mcp/src/lib.rs` — remove `card_prefix` from card update tool\n- `crates/kanban-cli/src/cli.rs` — remove `card_prefix` from card update command\n",
-        "due_date": null,
-        "id": "fa821ce3-4db2-4967-9c3a-b78b1117633a",
-        "points": null,
-        "position": 14,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
         "sprint_logs": [
           {
-            "ended_at": "2026-05-10T15:14:10.272419081Z",
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-13T23:43:22.006627035Z",
-            "status": "Active"
-          },
-          {
             "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-10T15:14:10.272419913Z",
-            "status": "Planning"
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155913Z",
+            "status": "Completed"
           }
         ],
-        "status": "Todo",
-        "title": "Redesign card identifier model: drop stored prefixes, lock board/sprint prefix, simplify counters",
-        "updated_at": "2026-05-10T15:14:10.272420713Z"
+        "status": "Done",
+        "title": "Remove projects projects and kanban green text",
+        "updated_at": "2025-10-16T21:02:56.921732Z"
       },
       {
         "card_number": 106,
@@ -2771,16 +2599,16 @@
         "updated_at": "2026-04-04T23:33:28.989153530Z"
       },
       {
-        "card_number": 43,
+        "card_number": 57,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T21:02:56.921732Z",
-        "created_at": "2025-10-12T16:45:41.135171Z",
-        "description": "in the projects panel there is a green text with `Projects` we can drop this as the panel header itself shows projects too.\n\nin the task list there is a green text of the current project. we can drop this and rely on the highlighted item in the projects list instead\n",
+        "completed_at": "2025-10-16T22:25:04.233204Z",
+        "created_at": "2025-10-16T22:12:16.643878Z",
+        "description": "Something is off with the selected card. it is not selecting the right car when using `v`, `e` or `space | enter`\n\nThis feature is looking rather fully fledged.\n\nLets go and try to complete it as soov as we can.\n\nWhats currently on my mind is what is the state of of develop.\n\nWe should probably add a develop / in review / merged column and see how that behaves and if we can move all the cards that are currently on develop into it.\n",
         "due_date": null,
-        "id": "5d31ae81-75a7-47c7-a6d1-5a9b0f06a5b7",
-        "points": 1,
-        "position": 15,
-        "priority": "Medium",
+        "id": "44079721-1755-4ef4-9713-adb3453f0343",
+        "points": 4,
+        "position": 16,
+        "priority": "High",
         "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
         "sprint_logs": [
           {
@@ -2788,39 +2616,13 @@
             "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
             "sprint_name": "an-eventful-october",
             "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155913Z",
+            "started_at": "2025-11-01T09:30:06.155914Z",
             "status": "Completed"
           }
         ],
         "status": "Done",
-        "title": "Remove projects projects and kanban green text",
-        "updated_at": "2025-10-16T21:02:56.921732Z"
-      },
-      {
-        "card_number": 245,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-03-29T14:54:57.405559892Z",
-        "description": "TUI handlers catch command execution errors with tracing::error! but never call set_error() to show them to the user. Wire up Banner display for NotFound and other domain errors so the user gets visible feedback when an action fails silently. See PR #200 review for context.",
-        "due_date": null,
-        "id": "a498add8-d3a4-44f7-8372-450c956de89f",
-        "points": 3,
-        "position": 15,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856507373Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Surface command errors to user via Banner in TUI handlers",
-        "updated_at": "2026-04-19T22:01:25.737729910Z"
+        "title": "`v` only works for one column",
+        "updated_at": "2025-10-17T06:13:05.136314Z"
       },
       {
         "card_number": 19,
@@ -2905,58 +2707,6 @@
         "updated_at": "2026-04-04T23:33:28.989186911Z"
       },
       {
-        "card_number": 57,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T22:25:04.233204Z",
-        "created_at": "2025-10-16T22:12:16.643878Z",
-        "description": "Something is off with the selected card. it is not selecting the right car when using `v`, `e` or `space | enter`\n\nThis feature is looking rather fully fledged.\n\nLets go and try to complete it as soov as we can.\n\nWhats currently on my mind is what is the state of of develop.\n\nWe should probably add a develop / in review / merged column and see how that behaves and if we can move all the cards that are currently on develop into it.\n",
-        "due_date": null,
-        "id": "44079721-1755-4ef4-9713-adb3453f0343",
-        "points": 4,
-        "position": 16,
-        "priority": "High",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155914Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "`v` only works for one column",
-        "updated_at": "2025-10-17T06:13:05.136314Z"
-      },
-      {
-        "card_number": 58,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-16T22:25:41.421733Z",
-        "created_at": "2025-10-16T22:25:18.533969Z",
-        "description": null,
-        "due_date": null,
-        "id": "41ec637a-35f3-47a6-bf82-2bfb38f9b2d3",
-        "points": null,
-        "position": 17,
-        "priority": "Medium",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155915Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "moving card to last column doesnt set complete",
-        "updated_at": "2025-12-20T10:08:51.150208Z"
-      },
-      {
         "card_number": 107,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -3039,6 +2789,32 @@
         "updated_at": "2026-04-04T23:33:28.989121434Z"
       },
       {
+        "card_number": 58,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-16T22:25:41.421733Z",
+        "created_at": "2025-10-16T22:25:18.533969Z",
+        "description": null,
+        "due_date": null,
+        "id": "41ec637a-35f3-47a6-bf82-2bfb38f9b2d3",
+        "points": null,
+        "position": 17,
+        "priority": "Medium",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155915Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "moving card to last column doesnt set complete",
+        "updated_at": "2025-12-20T10:08:51.150208Z"
+      },
+      {
         "card_number": 99,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -3113,72 +2889,21 @@
         "updated_at": "2026-04-04T23:33:28.989075467Z"
       },
       {
-        "card_number": 370,
+        "card_number": 454,
         "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
         "completed_at": null,
-        "created_at": "2026-04-27T08:24:12.170416957Z",
-        "description": "Register SqliteStoreFactory in the StoreRegistry so MCP/CLI route SQLite files through the registry like JSON, instead of the old open_sqlite bypass.\n\n## Done\n- Added `path`/`instance_id` fields to `SqliteStore`; implemented `PersistenceStore`\n- Added `SqliteStoreFactory` (magic-byte content sniffing, `create()` via registry)\n- Registered factory in `default_registry()` (sqlite first, then json)\n- Removed `is_sqlite`/`open_sqlite` bypass from `McpContext::new` and `CliContext::load`\n- Added unit tests for all new behaviour\n\nBranch: KAN-366/description-doesnt-load-in-card-details",
+        "created_at": "2026-05-14T19:12:22.566667363Z",
+        "description": "## Observed\n\nIn card detail view (render_card_detail_view in kanban-tui/src/ui/card_detail.rs), the sprint history panel is rendered only when !card.sprint_logs.is_empty() (line 72). This means a card with sprint_id set but empty sprint_logs, or a card with no sprint_id at all, shows only the full-width Metadata panel with no sprint context visible.\n\n## Root cause\n\nThe condition:\n\n    let has_sprint_logs = !card.sprint_logs.is_empty();\n\nis too strict. Cards that were never assigned to a sprint (sprint_id = None) are never touched by the migration, so they never show sprint context. Cards assigned to a sprint before the sprint_logs feature landed only get backfilled if sprint_id is set.\n\n## Reproducing\n\nVisit KAN-449 in the TUI card detail view. sprint_id=None, sprint_logs=[]. The metadata row renders full-width with no Sprint History box, even though it was actively worked on during sprint 13.\n\nContrast with KAN-26: 8 sprint_logs, Sprint History box renders correctly on the right half of the metadata row.\n\n## Fix direction\n\nChange the condition to render the sprint history panel whenever the card has either:\n- sprint_id.is_some() (currently in a sprint), OR\n- !sprint_logs.is_empty() (historical sprint involvement)\n\nWhen the panel renders for a card with sprint_id but no sprint_logs, show a single placeholder line like 'Assigned: <sprint-name>' derived from sprint_id plus the sprints list already available to the render function. This keeps layout consistent (metadata always splits 50/50 when sprint context exists) and surfaces the current sprint assignment already stored on the card.",
         "due_date": null,
-        "id": "200e9bcd-9654-49a0-affc-cab1866ab223",
+        "id": "f347ddc5-9884-45dd-b5b7-06321d32f7de",
         "points": null,
         "position": 18,
         "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": "2026-05-07T22:06:15.245080262Z",
-            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-            "sprint_name": "sphinx-centered",
-            "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:21.126605275Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T22:06:15.245080694Z",
-            "status": "Planning"
-          }
-        ],
+        "sprint_id": null,
+        "sprint_logs": [],
         "status": "Todo",
-        "title": "SQLite backend registry integration",
-        "updated_at": "2026-05-07T22:06:15.245080969Z"
-      },
-      {
-        "card_number": 369,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-04-27T07:12:25.392072773Z",
-        "description": null,
-        "due_date": null,
-        "id": "c4658b76-e0dd-41a5-86c7-f84334259f6b",
-        "points": null,
-        "position": 19,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": "2026-05-07T22:06:15.245078306Z",
-            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-            "sprint_name": "sphinx-centered",
-            "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:21.126606635Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T22:06:15.245078745Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Implement StoreFactory for SQLite backend",
-        "updated_at": "2026-05-07T22:06:15.245079082Z"
+        "title": "Sprint history panel not shown for cards with sprint_id but no sprint_logs",
+        "updated_at": "2026-05-14T19:12:22.566887480Z"
       },
       {
         "card_number": 100,
@@ -3255,6 +2980,40 @@
         "updated_at": "2026-04-04T23:33:28.989142580Z"
       },
       {
+        "card_number": 368,
+        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
+        "completed_at": null,
+        "created_at": "2026-04-25T18:28:30.275054977Z",
+        "description": "When listing cards, the total count in board summary includes archived cards but list_cards API doesn't return them. Card counters show 3 and 2 cards respectively but only 1 card is returned per board.",
+        "due_date": null,
+        "id": "138be5cc-f008-4f58-bc15-df865947c173",
+        "points": null,
+        "position": 20,
+        "priority": "High",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": "2026-05-07T22:06:15.245082160Z",
+            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+            "sprint_name": "sphinx-centered",
+            "sprint_number": 14,
+            "started_at": "2026-04-29T04:53:21.126576516Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T22:06:15.245082525Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Bug: Archived cards not included in list count",
+        "updated_at": "2026-05-07T22:06:15.245082792Z"
+      },
+      {
         "card_number": 41,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -3321,38 +3080,30 @@
         "updated_at": "2026-04-04T23:33:28.989111814Z"
       },
       {
-        "card_number": 368,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-04-25T18:28:30.275054977Z",
-        "description": "When listing cards, the total count in board summary includes archived cards but list_cards API doesn't return them. Card counters show 3 and 2 cards respectively but only 1 card is returned per board.",
+        "card_number": 21,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-17T06:21:18.677703Z",
+        "created_at": "2025-10-11T19:25:07.465576Z",
+        "description": "Be able to archive a card.\n",
         "due_date": null,
-        "id": "138be5cc-f008-4f58-bc15-df865947c173",
-        "points": null,
-        "position": 20,
-        "priority": "High",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "id": "6c1e0ca7-22bb-49e5-86bc-8d1e2a55c9ee",
+        "points": 2,
+        "position": 21,
+        "priority": "Low",
+        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
         "sprint_logs": [
           {
-            "ended_at": "2026-05-07T22:06:15.245082160Z",
-            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-            "sprint_name": "sphinx-centered",
-            "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:21.126576516Z",
-            "status": "Planning"
-          },
-          {
             "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T22:06:15.245082525Z",
-            "status": "Planning"
+            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+            "sprint_name": "an-experience-to-remember",
+            "sprint_number": 6,
+            "started_at": "2025-11-01T09:30:06.155908Z",
+            "status": "Active"
           }
         ],
-        "status": "Todo",
-        "title": "Bug: Archived cards not included in list count",
-        "updated_at": "2026-05-07T22:06:15.245082792Z"
+        "status": "Done",
+        "title": "Archive a card",
+        "updated_at": "2025-10-17T06:21:18.677707Z"
       },
       {
         "card_number": 52,
@@ -3437,32 +3188,6 @@
         "status": "Todo",
         "title": "SQLite lazy loading in Model (ensure_* + invalidate_*)",
         "updated_at": "2026-05-07T22:06:15.245084917Z"
-      },
-      {
-        "card_number": 21,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-17T06:21:18.677703Z",
-        "created_at": "2025-10-11T19:25:07.465576Z",
-        "description": "Be able to archive a card.\n",
-        "due_date": null,
-        "id": "6c1e0ca7-22bb-49e5-86bc-8d1e2a55c9ee",
-        "points": 2,
-        "position": 21,
-        "priority": "Low",
-        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-            "sprint_name": "an-experience-to-remember",
-            "sprint_number": 6,
-            "started_at": "2025-11-01T09:30:06.155908Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "Archive a card",
-        "updated_at": "2025-10-17T06:21:18.677707Z"
       },
       {
         "card_number": 319,
@@ -3591,6 +3316,32 @@
         "updated_at": "2026-04-04T23:33:28.989193890Z"
       },
       {
+        "card_number": 54,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-18T20:17:44.271652Z",
+        "created_at": "2025-10-15T16:36:21.133233Z",
+        "description": "in both the filtered task list and the sprint details. \n\nmake an output showing how many days there are left until the sprint ends\n\nif less than a day. show `hh:mm:ss`\n\nAfter finish show `+hh:mm:ss`\n",
+        "due_date": null,
+        "id": "1b503514-c96a-4ee7-83c4-4c4cd45b51a0",
+        "points": 1,
+        "position": 23,
+        "priority": "Low",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155914Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "days left on sprint",
+        "updated_at": "2025-10-18T20:17:44.271667Z"
+      },
+      {
         "card_number": 114,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -3665,58 +3416,6 @@
         "status": "Done",
         "title": "When inputting in the dialogues. Text is cut when going out of bounds for the iput box",
         "updated_at": "2025-10-17T06:21:24.897772Z"
-      },
-      {
-        "card_number": 54,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-18T20:17:44.271652Z",
-        "created_at": "2025-10-15T16:36:21.133233Z",
-        "description": "in both the filtered task list and the sprint details. \n\nmake an output showing how many days there are left until the sprint ends\n\nif less than a day. show `hh:mm:ss`\n\nAfter finish show `+hh:mm:ss`\n",
-        "due_date": null,
-        "id": "1b503514-c96a-4ee7-83c4-4c4cd45b51a0",
-        "points": 1,
-        "position": 23,
-        "priority": "Low",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155914Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "days left on sprint",
-        "updated_at": "2025-10-18T20:17:44.271667Z"
-      },
-      {
-        "card_number": 399,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-05-07T20:54:59.114273481Z",
-        "description": "## Problem\n\nThe CLI currently returns raw or unhelpful errors when given wrong input. Example: passing `--status done` to `card update` (which has no such flag) gives a generic clap error with no hint of what to do instead. First-time users hitting these errors get no guidance.\n\n## Goal\n\nEvery error a user can trigger should be:\n- **Clear**: say what went wrong in plain language\n- **Actionable**: suggest the correct command or flag\n- **Consistent**: same tone and format across all subcommands\n\n## Areas to audit\n\n- Unknown/invalid flags (e.g. `--status` on `card update`)\n- Wrong argument types (e.g. non-UUID where UUID expected)\n- Entity not found (board, column, card, sprint) — include the identifier that was looked up\n- Missing required args — name the arg and show an example\n- File not found / unreadable kanban.json\n- Permission errors on kanban.json\n\n## Approach\n\n1. Audit all CLI subcommands for error paths that reach the user\n2. For each: write a test that triggers the error, assert on the message\n3. Improve the message to be clear and actionable\n4. Consider a shared error formatting layer in `kanban-cli` so tone stays consistent",
-        "due_date": null,
-        "id": "b0f35374-4136-454b-8506-d60ac1ab5606",
-        "points": 3,
-        "position": 24,
-        "priority": "High",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T21:58:57.806928527Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Improve CLI error messages and user-facing error handling",
-        "updated_at": "2026-05-07T21:58:57.806928854Z"
       },
       {
         "card_number": 115,
@@ -3819,15 +3518,15 @@
         "updated_at": "2025-10-21T21:20:21.085162Z"
       },
       {
-        "card_number": 400,
+        "card_number": 399,
         "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
         "completed_at": null,
-        "created_at": "2026-05-07T21:01:37.437770936Z",
-        "description": "## Problem\n\nEvery CLI command that references another entity requires a raw UUID, which no human knows by heart. Examples:\n\n- `card move KAN-12 --column-id c2a0d5e2-...` — user must look up the column UUID first\n- `card create --board-id e119c0... --column-id c1a0d5...` — two UUIDs before anything happens\n- `card assign-sprint KAN-12 --sprint-id 3e05b8...` — user must look up the sprint UUID\n\n## Goal\n\nAccept a name (or sprint number) anywhere a UUID is accepted today. UUID still works for scripting.\n\n## Resolution per flag\n\n- `--column-id`: accept column name (case-insensitive); look up board via card's column → board chain\n- `--board-id` on `card create`: accept board name (case-insensitive)\n- `--sprint-id` on `assign-sprint` / `assign-cards-to-sprint`: accept sprint name or sprint number (e.g. `13`)\n- `--column-id` on `card restore` and `move-cards`: same as move\n\n## Error UX\n\nWhen the name doesn't match, list available options:\n`Column 'done' not found. Available: TODO, Doing, Complete`\n\n## Scope\n\n`kanban-cli` only — no service or domain changes needed.",
+        "created_at": "2026-05-07T20:54:59.114273481Z",
+        "description": "## Problem\n\nThe CLI currently returns raw or unhelpful errors when given wrong input. Example: passing `--status done` to `card update` (which has no such flag) gives a generic clap error with no hint of what to do instead. First-time users hitting these errors get no guidance.\n\n## Goal\n\nEvery error a user can trigger should be:\n- **Clear**: say what went wrong in plain language\n- **Actionable**: suggest the correct command or flag\n- **Consistent**: same tone and format across all subcommands\n\n## Areas to audit\n\n- Unknown/invalid flags (e.g. `--status` on `card update`)\n- Wrong argument types (e.g. non-UUID where UUID expected)\n- Entity not found (board, column, card, sprint) — include the identifier that was looked up\n- Missing required args — name the arg and show an example\n- File not found / unreadable kanban.json\n- Permission errors on kanban.json\n\n## Approach\n\n1. Audit all CLI subcommands for error paths that reach the user\n2. For each: write a test that triggers the error, assert on the message\n3. Improve the message to be clear and actionable\n4. Consider a shared error formatting layer in `kanban-cli` so tone stays consistent",
         "due_date": null,
-        "id": "b7a5ca63-d26b-432f-af69-6cf326d9e8f4",
+        "id": "b0f35374-4136-454b-8506-d60ac1ab5606",
         "points": 3,
-        "position": 25,
+        "position": 24,
         "priority": "High",
         "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
         "sprint_logs": [
@@ -3836,13 +3535,13 @@
             "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
             "sprint_name": "yarara-release",
             "sprint_number": 15,
-            "started_at": "2026-05-07T21:58:57.806923027Z",
+            "started_at": "2026-05-07T21:58:57.806928527Z",
             "status": "Planning"
           }
         ],
         "status": "Todo",
-        "title": "Accept entity names (not just UUIDs) in CLI --column-id, --board-id, --sprint-id args",
-        "updated_at": "2026-05-07T21:58:57.806923527Z"
+        "title": "Improve CLI error messages and user-facing error handling",
+        "updated_at": "2026-05-07T21:58:57.806928854Z"
       },
       {
         "card_number": 127,
@@ -3909,6 +3608,32 @@
         "status": "Todo",
         "title": "add filter for completed cards",
         "updated_at": "2026-04-04T23:44:57.050276300Z"
+      },
+      {
+        "card_number": 400,
+        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
+        "completed_at": null,
+        "created_at": "2026-05-07T21:01:37.437770936Z",
+        "description": "## Problem\n\nEvery CLI command that references another entity requires a raw UUID, which no human knows by heart. Examples:\n\n- `card move KAN-12 --column-id c2a0d5e2-...` — user must look up the column UUID first\n- `card create --board-id e119c0... --column-id c1a0d5...` — two UUIDs before anything happens\n- `card assign-sprint KAN-12 --sprint-id 3e05b8...` — user must look up the sprint UUID\n\n## Goal\n\nAccept a name (or sprint number) anywhere a UUID is accepted today. UUID still works for scripting.\n\n## Resolution per flag\n\n- `--column-id`: accept column name (case-insensitive); look up board via card's column → board chain\n- `--board-id` on `card create`: accept board name (case-insensitive)\n- `--sprint-id` on `assign-sprint` / `assign-cards-to-sprint`: accept sprint name or sprint number (e.g. `13`)\n- `--column-id` on `card restore` and `move-cards`: same as move\n\n## Error UX\n\nWhen the name doesn't match, list available options:\n`Column 'done' not found. Available: TODO, Doing, Complete`\n\n## Scope\n\n`kanban-cli` only — no service or domain changes needed.",
+        "due_date": null,
+        "id": "b7a5ca63-d26b-432f-af69-6cf326d9e8f4",
+        "points": 3,
+        "position": 25,
+        "priority": "High",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T21:58:57.806923027Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Accept entity names (not just UUIDs) in CLI --column-id, --board-id, --sprint-id args",
+        "updated_at": "2026-05-07T21:58:57.806923527Z"
       },
       {
         "card_number": 153,
@@ -4037,6 +3762,32 @@
         "updated_at": "2026-05-07T21:58:57.806931495Z"
       },
       {
+        "card_number": 63,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-21T21:11:29.582640Z",
+        "created_at": "2025-10-18T23:13:25.559834Z",
+        "description": null,
+        "due_date": null,
+        "id": "6366fa7d-4e1b-4ba8-92fa-f38855af37eb",
+        "points": 3,
+        "position": 28,
+        "priority": "Medium",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155915Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "ci-side-tracked",
+        "updated_at": "2025-10-21T21:11:29.582640Z"
+      },
+      {
         "card_number": 135,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -4103,58 +3854,6 @@
         "updated_at": "2026-04-04T23:33:28.989084935Z"
       },
       {
-        "card_number": 63,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-21T21:11:29.582640Z",
-        "created_at": "2025-10-18T23:13:25.559834Z",
-        "description": null,
-        "due_date": null,
-        "id": "6366fa7d-4e1b-4ba8-92fa-f38855af37eb",
-        "points": 3,
-        "position": 28,
-        "priority": "Medium",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155915Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "ci-side-tracked",
-        "updated_at": "2025-10-21T21:11:29.582640Z"
-      },
-      {
-        "card_number": 65,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-21T21:11:29.062050Z",
-        "created_at": "2025-10-19T00:07:27.116385Z",
-        "description": null,
-        "due_date": null,
-        "id": "6eea863d-df28-4ab0-9ff5-3878c448a99a",
-        "points": 3,
-        "position": 29,
-        "priority": "Medium",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155916Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "ci split 2",
-        "updated_at": "2025-10-21T21:11:29.062052Z"
-      },
-      {
         "card_number": 7,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-10-21T21:47:36.557987Z",
@@ -4181,30 +3880,30 @@
         "updated_at": "2025-10-21T21:47:36.557991Z"
       },
       {
-        "card_number": 403,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-05-07T21:45:57.299426314Z",
-        "description": "## Behaviour\n\nAfter creating a new card in the TUI, the selector stays on whichever card was previously selected instead of jumping to the newly created card. Any action taken immediately after creation (edit, move, open details) acts on the wrong card.\n\n## Expected\n\nThe selector should move to the newly created card immediately after creation, matching the pre-regression behaviour.\n\n## When it broke\n\nIntroduced in one of the recent large releases (v0.4.x range). The releases were substantial with many changes so the exact commit is unclear — bisect if needed.\n\n## Impact\n\nBlocks the demo recording (Beat 2 creates a card then immediately edits it in Beat 3 — the edit lands on the wrong card). Workaround for demo: manually navigate to the new card before editing.\n\n## Investigation starting point\n\nLook at the handler that processes card creation confirmation and the code path that refreshes the card list state. The selector position after list refresh is likely not being set to the new card's index.",
+        "card_number": 65,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-21T21:11:29.062050Z",
+        "created_at": "2025-10-19T00:07:27.116385Z",
+        "description": null,
         "due_date": null,
-        "id": "a41509b7-4ff6-4557-bd87-be5a83005b73",
-        "points": null,
+        "id": "6eea863d-df28-4ab0-9ff5-3878c448a99a",
+        "points": 3,
         "position": 29,
-        "priority": "High",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "priority": "Medium",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T21:58:57.806941614Z",
-            "status": "Planning"
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155916Z",
+            "status": "Completed"
           }
         ],
-        "status": "Todo",
-        "title": "Regression: card selector does not jump to newly created card",
-        "updated_at": "2026-05-07T21:58:57.806941818Z"
+        "status": "Done",
+        "title": "ci split 2",
+        "updated_at": "2025-10-21T21:11:29.062052Z"
       },
       {
         "card_number": 156,
@@ -4247,6 +3946,58 @@
         "status": "Todo",
         "title": "Document conflict resolution limitations",
         "updated_at": "2026-04-04T23:33:28.989181862Z"
+      },
+      {
+        "card_number": 62,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-21T21:11:29.959218Z",
+        "created_at": "2025-10-18T20:50:38.307753Z",
+        "description": "these cards are also tangentially part of the changes made for this one\n\n- KAN-59/hitting-c-to-complete-a-card-doesnt-move-it-to-the-last-column\n- MVP-7/add-column-definitions\n\n---\n\nWe should really get card relations going\n",
+        "due_date": null,
+        "id": "10a07993-862e-4dfa-ae9f-73a65145bd6c",
+        "points": 3,
+        "position": 30,
+        "priority": "High",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155915Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "ci improvements",
+        "updated_at": "2025-10-21T21:11:29.959218Z"
+      },
+      {
+        "card_number": 64,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2025-10-18T23:13:45.804096Z",
+        "description": null,
+        "due_date": null,
+        "id": "38f49d18-e53a-4df6-b1d2-13bb7044b5d0",
+        "points": 1,
+        "position": 30,
+        "priority": "Low",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155915Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "create task in the focused column",
+        "updated_at": "2025-10-21T21:48:13.559356Z"
       },
       {
         "card_number": 138,
@@ -4315,91 +4066,13 @@
         "updated_at": "2026-04-04T23:33:28.989144912Z"
       },
       {
-        "card_number": 62,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-21T21:11:29.959218Z",
-        "created_at": "2025-10-18T20:50:38.307753Z",
-        "description": "these cards are also tangentially part of the changes made for this one\n\n- KAN-59/hitting-c-to-complete-a-card-doesnt-move-it-to-the-last-column\n- MVP-7/add-column-definitions\n\n---\n\nWe should really get card relations going\n",
-        "due_date": null,
-        "id": "10a07993-862e-4dfa-ae9f-73a65145bd6c",
-        "points": 3,
-        "position": 30,
-        "priority": "High",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155915Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "ci improvements",
-        "updated_at": "2025-10-21T21:11:29.959218Z"
-      },
-      {
-        "card_number": 64,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": null,
-        "created_at": "2025-10-18T23:13:45.804096Z",
-        "description": null,
-        "due_date": null,
-        "id": "38f49d18-e53a-4df6-b1d2-13bb7044b5d0",
-        "points": 1,
-        "position": 30,
-        "priority": "Low",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155915Z",
-            "status": "Completed"
-          }
-        ],
-        "status": "Done",
-        "title": "create task in the focused column",
-        "updated_at": "2025-10-21T21:48:13.559356Z"
-      },
-      {
-        "card_number": 427,
+        "card_number": 422,
         "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
         "completed_at": null,
-        "created_at": "2026-05-11T21:52:13.395460114Z",
-        "description": "## Problem\n\n`DeleteBoard` in `kanban-domain` violates SRP. It knows how to cascade-delete across columns, active cards, archived cards, sprints, and the dependency graph — that is orchestration, not domain logic.\n\n```\n// crates/kanban-domain/src/commands/board_commands.rs:140-189\nimpl DeleteBoard {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        // collects column IDs → gathers active card IDs per column →\n        // fetches archived cards → removes graph edges →\n        // deletes active cards, archived cards, columns, sprints, board\n    }\n}\n```\n\nAdding any new entity type associated with a board (e.g. checklists, labels) requires modifying `DeleteBoard` — a violation of OCP.\n\n## Existing structure\n\nThe service layer already wraps this domain command:\n\n- `KanbanContext::delete_board()` at `crates/kanban-service/src/context.rs:752` — currently delegates to `BoardCommand::Delete(DeleteBoard { ... })`\n- `KanbanContext::snapshot()` / `apply_snapshot()` at `context.rs:129-135` — existing rollback primitives, reusable\n\nThis refactor is **invert the wrap**: pull the cascade orchestration up into the existing service method and reduce the domain command to atomic. The service method already exists — we are reshaping the boundary, not creating new orchestration entrypoints.\n\n## SOLID Solution\n\n**Single Responsibility / Open-Closed**: The domain command does one thing — delete the board record. Cascade orchestration belongs in the service layer, where composition is expected.\n\n**Dependency Inversion**: Service composes atomic domain commands; domain command no longer knows about siblings.\n\n### Step 1 — Make `DeleteBoard` atomic in the domain\n\n```rust\n// crates/kanban-domain/src/commands/board_commands.rs\nimpl DeleteBoard {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        context.store.delete_board(self.board_id)\n    }\n}\n```\n\n### Step 2 — Move cascade orchestration into existing `KanbanContext::delete_board()`\n\nThe existing wrapper at `context.rs:752` currently issues `BoardCommand::Delete(DeleteBoard { ... })`. Replace its body with explicit orchestration that wraps the atomic domain commands in a snapshot/rollback:\n\n```rust\n// crates/kanban-service/src/context.rs\nimpl KanbanContext {\n    pub async fn delete_board(&mut self, board_id: Uuid) -> KanbanResult<()> {\n        let snapshot = self.snapshot().await?;\n        let result = self.delete_board_inner(board_id).await;\n        if result.is_err() {\n            self.apply_snapshot(snapshot).await?;\n        }\n        result\n    }\n\n    async fn delete_board_inner(&mut self, board_id: Uuid) -> KanbanResult<()> {\n        // 1. Gather column + card IDs\n        let column_ids = self.list_column_ids_by_board(board_id).await?;\n        let mut all_card_ids: Vec<Uuid> = Vec::new();\n        for col_id in &column_ids {\n            all_card_ids.extend(self.list_card_ids_by_column(*col_id).await?);\n        }\n        all_card_ids.extend(self.list_archived_card_ids_by_columns(&column_ids).await?);\n\n        // 2. Remove graph edges via new atomic dependency command\n        self.execute(Command::Dependency(DependencyCommand::RemoveCards { ids: all_card_ids })).await?;\n\n        // 3. Atomic deletions, propagated outward\n        self.execute(Command::Card(CardCommand::DeleteCardsByColumns { column_ids: column_ids.clone() })).await?;\n        self.execute(Command::Card(CardCommand::DeleteArchivedCardsByColumns { column_ids })).await?;\n        self.execute(Command::Board(BoardCommand::DeleteColumnsByBoard { board_id })).await?;\n        self.execute(Command::Sprint(SprintCommand::DeleteSprintsByBoard { board_id })).await?;\n        self.execute(Command::Board(BoardCommand::Delete(DeleteBoard { board_id }))).await\n    }\n}\n```\n\n### Step 3 — Add `RemoveCards` to `DependencyCommand`\n\n```rust\n// crates/kanban-domain/src/commands/dependency_commands.rs\npub struct RemoveCards { pub ids: Vec<Uuid> }\nimpl RemoveCards {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        let ids = self.ids.clone();\n        context.store.modify_graph(Box::new(move |graph| {\n            for id in &ids { graph.cards.remove_card_edges(*id); }\n            Ok(())\n        }))\n    }\n}\n```\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/board_commands.rs` — simplify `DeleteBoard::execute` (lines 140-189)\n- `crates/kanban-domain/src/commands/dependency_commands.rs` — add `RemoveCards`\n- `crates/kanban-service/src/context.rs` — replace body of existing `delete_board()` at line 752, add private `delete_board_inner()`\n\n## Caller surfaces to verify\n\n- `crates/kanban-cli/src/handlers/board.rs:27-31` — CLI `BoardAction::Delete`\n- `crates/kanban-mcp/src/lib.rs:605-610` — MCP `tool_delete_board()`\n\nThese already call `KanbanContext::delete_board()` so no signature change needed — just verify behaviour after refactor.\n\n## Tests\n\n- Unit: `DeleteBoard` in isolation deletes only the board record\n- Unit: `RemoveCards` correctly removes all edges for given card IDs\n- Integration: `KanbanContext::delete_board()` with a real store verifies all associated entities are removed and the graph has no dangling edges (existing tests should pass unchanged)\n- Integration: Partial failure mid-cascade rolls back to snapshot (new test)",
+        "created_at": "2026-05-11T18:55:47.571166781Z",
+        "description": "Currently tracing is initialised in three separate, divergent places:\n\n1. init_tracing_cli() — kanban-cli/src/app.rs\n   - Writes to KANBAN_DEBUG_LOG file (if set) at debug level, otherwise stderr at warn level\n   - No in-memory layer\n\n2. init_tracing_tui() — kanban-cli/src/app.rs\n   - Same file/stderr branching as CLI\n   - Additionally layers InMemoryLogLayer (kanban-tui::error_log) for in-TUI error display\n   - Takes Arc<Mutex<ErrorLogState>> as parameter\n\n3. Inline in McpServer::run() — kanban-mcp/src/server.rs\n   - Simpler: stderr only, no file fallback, info default level (not warn/debug)\n   - No in-memory layer\n\nGoal: extract a single shared init_tracing() that all three paths call, so cross-cutting startup logging (e.g. build info) has one place to live.\n\nSuggested interface:\n  fn init_tracing(in_memory: Option<Arc<Mutex<ErrorLogState>>>)\n\n- None  -> CLI / MCP path (no in-memory layer)\n- Some  -> TUI path (adds InMemoryLogLayer)\n\nThe MCP default level (info) vs CLI/TUI default (warn/debug) can be handled via an additional parameter or RUST_LOG env var — worth deciding at implementation time.\n\nWhere to put it: kanban-cli/src/app.rs is fine if MCP imports it, but a better home may be a new kanban-tracing (or kanban-logging) crate, or kanban-core if the dependency is acceptable. Decide at implementation time.\n\nOnce consolidated, add log_build_info() as the last call inside the shared function — this was the original motivation (KAN-421 scoped it out because the shared root didn't exist yet).",
         "due_date": null,
-        "id": "e824cef5-14ba-4fe2-b4c3-d0cc73a5cc93",
-        "points": null,
-        "position": 30,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:13.846365052Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Todo",
-        "title": "Lift DeleteBoard cascade orchestration into service layer",
-        "updated_at": "2026-05-12T16:48:05.015150433Z"
-      },
-      {
-        "card_number": 428,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-05-11T21:52:16.841663592Z",
-        "description": "## Problem\n\n`MoveCards` in `kanban-domain` mixes two concerns: domain validation (WIP limit) and algorithmic orchestration (computing target positions by counting cards already in the column):\n\n```rust\n// crates/kanban-domain/src/commands/card_commands.rs:288-326\nlet base = context\n    .store\n    .list_cards_by_column(self.column_id)?\n    .iter()\n    .filter(|c| !id_set.contains(&c.id))\n    .count();\nfor (i, id) in valid_ids.iter().enumerate() {\n    let mut card = context.get_card(*id)?;\n    card.move_to_column(self.column_id, (base + i) as i32);\n    context.store.upsert_card(card)?;\n}\n```\n\nThe position calculation is orchestration — read state, derive values, drive a sequence of mutations. The WIP limit check IS a domain business rule and belongs in the domain.\n\n## Existing structure\n\nThe service layer already wraps this domain command:\n\n- `KanbanContext::move_cards_detailed()` at `crates/kanban-service/src/context.rs:455` — currently delegates to `CardCommand::MoveMultiple(MoveCards { ... })`\n\nThis refactor is **invert the wrap**: move the position calculation up into the existing service method and reduce `MoveCards` to atomic per-card moves (or replace its use with singular `MoveCard`).\n\n## SOLID Solution\n\n**Single Responsibility**: Position calculation becomes a pure function; WIP validation stays in domain; batch orchestration moves up into the service.\n\n**Interface Segregation**: Domain exposes `MoveCard` (singular, atomic) and a pure position helper. The service composes these.\n\n### Step 1 — Extract pure position function into domain\n\n```rust\n// crates/kanban-domain/src/card_lifecycle.rs\npub fn compute_move_positions(\n    existing_cards: &[Card],\n    moving_ids: &HashSet<Uuid>,\n) -> impl Iterator<Item = (Uuid, i32)> + '_ {\n    let base = existing_cards.iter().filter(|c| !moving_ids.contains(&c.id)).count();\n    moving_ids.iter().enumerate().map(move |(i, id)| (*id, (base + i) as i32))\n}\n```\n\nPure, no I/O, fully testable on any platform without a store.\n\n### Step 2 — Remove or reduce `MoveCards` in domain\n\nOption A (preferred): Remove `MoveCards` entirely. Service uses `MoveCard` (singular) in a loop.\nOption B: Keep `MoveCards` but reduce to accept pre-computed `Vec<(Uuid, i32)>` instead of `Vec<Uuid>`.\n\n### Step 3 — Replace body of existing `move_cards_detailed()`\n\n```rust\n// crates/kanban-service/src/context.rs\nimpl KanbanContext {\n    pub async fn move_cards_detailed(\n        &mut self,\n        ids: Vec<Uuid>,\n        column_id: Uuid,\n    ) -> KanbanResult<MoveResult> {\n        // 1. Validate IDs (existing helper)\n        let valid_ids = self.filter_valid_card_ids(&ids).await?;\n\n        // 2. WIP limit check (domain rule)\n        self.check_wip_limit(column_id, valid_ids.len(), &valid_ids).await?;\n\n        // 3. Compute positions (pure function, no I/O)\n        let existing = self.list_cards_by_column(column_id).await?;\n        let id_set: HashSet<Uuid> = valid_ids.iter().copied().collect();\n        let positions: Vec<_> = compute_move_positions(&existing, &id_set).collect();\n\n        // 4. Issue atomic MoveCard commands\n        for (card_id, position) in positions {\n            self.execute(Command::Card(CardCommand::MoveCard {\n                id: card_id,\n                column_id,\n                position,\n            })).await?;\n        }\n        Ok(MoveResult { /* aggregate */ })\n    }\n}\n```\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/card_commands.rs` — remove or reduce `MoveCards` (lines 288-326)\n- `crates/kanban-domain/src/card_lifecycle.rs` — add `compute_move_positions()` pure function\n- `crates/kanban-service/src/context.rs` — replace body of existing `move_cards_detailed()` at line 455\n\n## Caller surfaces to verify\n\n- `crates/kanban-service/src/context.rs:456, 510, 1049-1053` — internal service callers\n- `crates/kanban-cli/src/handlers/card.rs:166` — CLI `CardAction::MoveCards`\n- `crates/kanban-mcp/src/lib.rs:924-930` — MCP `tool_move_cards()`\n\nAll call `KanbanContext::move_cards_detailed()` — no signature change needed.\n\n## Tests\n\n- Unit: `compute_move_positions()` with various combinations of existing/moving cards\n- Unit: WIP limit rejection when batch exceeds column capacity\n- Integration: `KanbanContext::move_cards_detailed()` final positions contiguous and correct (existing tests should pass unchanged)\n\n## Cascade primitives note\n\nIf this lift produces any bulk, validation-bypassing operations that are only valid when executed in a specific sequence, those primitives belong in `cascade_commands` rather than their per-entity module — not because of the entity type, but because of the ordering invariant. Regular commands are self-contained and independently valid; cascade primitives are not.",
-        "due_date": null,
-        "id": "21272340-de01-49c2-89fa-65dfdabdd1ed",
+        "id": "2eafc218-88aa-4d51-80ef-b6055f7bbfe9",
         "points": null,
         "position": 31,
         "priority": "Medium",
@@ -4410,13 +4083,13 @@
             "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
             "sprint_name": "yarara-release",
             "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:13.846376575Z",
+            "started_at": "2026-05-11T23:24:13.846352853Z",
             "status": "Active"
           }
         ],
         "status": "Todo",
-        "title": "Lift MoveCards batch position calculation into service layer",
-        "updated_at": "2026-05-12T20:41:13.346294503Z"
+        "title": "Consolidate tracing init into a shared root function",
+        "updated_at": "2026-05-11T23:24:13.846353483Z"
       },
       {
         "card_number": 160,
@@ -4461,58 +4134,6 @@
         "updated_at": "2026-04-04T23:33:28.989090999Z"
       },
       {
-        "card_number": 422,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-05-11T18:55:47.571166781Z",
-        "description": "Currently tracing is initialised in three separate, divergent places:\n\n1. init_tracing_cli() — kanban-cli/src/app.rs\n   - Writes to KANBAN_DEBUG_LOG file (if set) at debug level, otherwise stderr at warn level\n   - No in-memory layer\n\n2. init_tracing_tui() — kanban-cli/src/app.rs\n   - Same file/stderr branching as CLI\n   - Additionally layers InMemoryLogLayer (kanban-tui::error_log) for in-TUI error display\n   - Takes Arc<Mutex<ErrorLogState>> as parameter\n\n3. Inline in McpServer::run() — kanban-mcp/src/server.rs\n   - Simpler: stderr only, no file fallback, info default level (not warn/debug)\n   - No in-memory layer\n\nGoal: extract a single shared init_tracing() that all three paths call, so cross-cutting startup logging (e.g. build info) has one place to live.\n\nSuggested interface:\n  fn init_tracing(in_memory: Option<Arc<Mutex<ErrorLogState>>>)\n\n- None  -> CLI / MCP path (no in-memory layer)\n- Some  -> TUI path (adds InMemoryLogLayer)\n\nThe MCP default level (info) vs CLI/TUI default (warn/debug) can be handled via an additional parameter or RUST_LOG env var — worth deciding at implementation time.\n\nWhere to put it: kanban-cli/src/app.rs is fine if MCP imports it, but a better home may be a new kanban-tracing (or kanban-logging) crate, or kanban-core if the dependency is acceptable. Decide at implementation time.\n\nOnce consolidated, add log_build_info() as the last call inside the shared function — this was the original motivation (KAN-421 scoped it out because the shared root didn't exist yet).",
-        "due_date": null,
-        "id": "2eafc218-88aa-4d51-80ef-b6055f7bbfe9",
-        "points": null,
-        "position": 31,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:13.846352853Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Todo",
-        "title": "Consolidate tracing init into a shared root function",
-        "updated_at": "2026-05-11T23:24:13.846353483Z"
-      },
-      {
-        "card_number": 429,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-05-11T21:52:19.453155076Z",
-        "description": "## Problem\n\n`ImportEntities` in `kanban-domain` is a 99-line command that does three distinct things: loads all existing entity IDs into HashSets (read orchestration), validates no duplicates (validation), and upserts all incoming entities in order (write orchestration). It has no rollback on partial failure — a mid-import store error leaves data in a partially-imported state.\n\n```rust\n// crates/kanban-domain/src/commands/board_commands.rs:214-319\nimpl ImportEntities {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        // Loads existing IDs for 5 entity types into HashSets\n        // Validates each import entity type for collisions (fail-fast per type)\n        // Upserts boards → columns → cards → archived cards → sprints → graph\n        // No rollback if any upsert fails\n    }\n}\n```\n\n## Existing structure\n\nThe service layer already wraps this domain command:\n\n- `KanbanContext::import_board()` at `crates/kanban-service/src/context.rs:1300` — currently delegates to `BoardCommand::Import(ImportEntities { ... })`\n- `KanbanContext::snapshot()` / `apply_snapshot()` at `context.rs:129-135` — existing rollback primitives, reusable for safe imports\n\nThis refactor is **invert the wrap**: pull the validation/upsert orchestration up into the existing service method, add snapshot-based rollback, and remove the `ImportEntities` command.\n\n## SOLID Solution\n\n**Single Responsibility**: Validation, deduplication, and upsert orchestration are three separate concerns — each independently testable.\n\n**Open-Closed**: New importable entity types should not require modifying the command — the service composes new steps.\n\n**Dependency Inversion**: Domain should not orchestrate bulk operations. Individual upsert operations are the domain interface; the service composes them.\n\n### Step 1 — Extract pure duplicate validator into new domain module\n\n```rust\n// crates/kanban-domain/src/import.rs (new file)\npub struct ImportPayload { ... }\npub struct ExistingIds { ... }\npub struct DuplicateError { pub entity_type: &'static str, pub id: Uuid }\n\npub fn validate_no_duplicates(\n    payload: &ImportPayload,\n    existing: &ExistingIds,\n) -> Result<(), DuplicateError> {\n    // pure function — no I/O, fully testable\n}\n```\n\n### Step 2 — Remove `ImportEntities` from domain\n\nRemove the struct and its execute impl from `board_commands.rs` (lines 214-319). Remove the variant from `BoardCommand` enum. The domain retains individual `upsert_*` operations on `DataStore`.\n\n### Step 3 — Replace body of existing `import_board()` with rollback-safe orchestration\n\n```rust\n// crates/kanban-service/src/context.rs\nimpl KanbanContext {\n    pub async fn import_board(&mut self, payload: ImportPayload) -> KanbanResult<()> {\n        let existing = self.load_existing_ids().await?;\n        validate_no_duplicates(&payload, &existing)\n            .map_err(|e| KanbanError::validation(...))?;\n        let snapshot = self.snapshot().await?;\n        let result = self.import_inner(payload).await;\n        if result.is_err() { self.apply_snapshot(snapshot).await?; }\n        result\n    }\n}\n```\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/board_commands.rs` — remove `ImportEntities` (lines 214-319)\n- `crates/kanban-domain/src/import.rs` — new file with payload types and validator\n- `crates/kanban-domain/src/lib.rs` — `pub mod import;`\n- `crates/kanban-service/src/context.rs` — replace body of existing `import_board()` at line 1300\n\n## Caller surfaces to verify\n\n- `crates/kanban-tui/src/app/mod.rs:2222-2277` — TUI `import_board_from_file()`\n- `crates/kanban-mcp/src/lib.rs:1091-1096` — MCP `tool_import_board()`\n\n## Tests\n\n- Unit: `validate_no_duplicates()` collision cases for each entity type\n- Integration: `KanbanContext::import_board()` end-to-end with real store\n- Integration: Partial failure mid-import rolls back to pre-import state (new test)\n\n## Cascade primitives note\n\nIf this lift produces any bulk, validation-bypassing operations that are only valid when executed in a specific sequence, those primitives belong in `cascade_commands` rather than their per-entity module — not because of the entity type, but because of the ordering invariant. Regular commands are self-contained and independently valid; cascade primitives are not.",
-        "due_date": null,
-        "id": "0a57a2f0-c5ae-4336-8725-5e08c4f16e1c",
-        "points": null,
-        "position": 32,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:13.846362448Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Todo",
-        "title": "Lift ImportEntities orchestration into service layer",
-        "updated_at": "2026-05-12T20:41:36.938588807Z"
-      },
-      {
         "card_number": 161,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -4555,6 +4176,32 @@
         "updated_at": "2026-04-04T23:33:28.989205394Z"
       },
       {
+        "card_number": 429,
+        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
+        "completed_at": null,
+        "created_at": "2026-05-11T21:52:19.453155076Z",
+        "description": "## Problem\n\n`ImportEntities` in `kanban-domain` is a 99-line command that does three distinct things: loads all existing entity IDs into HashSets (read orchestration), validates no duplicates (validation), and upserts all incoming entities in order (write orchestration). It has no rollback on partial failure — a mid-import store error leaves data in a partially-imported state.\n\n```rust\n// crates/kanban-domain/src/commands/board_commands.rs:214-319\nimpl ImportEntities {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        // Loads existing IDs for 5 entity types into HashSets\n        // Validates each import entity type for collisions (fail-fast per type)\n        // Upserts boards → columns → cards → archived cards → sprints → graph\n        // No rollback if any upsert fails\n    }\n}\n```\n\n## Existing structure\n\nThe service layer already wraps this domain command:\n\n- `KanbanContext::import_board()` at `crates/kanban-service/src/context.rs:1300` — currently delegates to `BoardCommand::Import(ImportEntities { ... })`\n- `KanbanContext::snapshot()` / `apply_snapshot()` at `context.rs:129-135` — existing rollback primitives, reusable for safe imports\n\nThis refactor is **invert the wrap**: pull the validation/upsert orchestration up into the existing service method, add snapshot-based rollback, and remove the `ImportEntities` command.\n\n## SOLID Solution\n\n**Single Responsibility**: Validation, deduplication, and upsert orchestration are three separate concerns — each independently testable.\n\n**Open-Closed**: New importable entity types should not require modifying the command — the service composes new steps.\n\n**Dependency Inversion**: Domain should not orchestrate bulk operations. Individual upsert operations are the domain interface; the service composes them.\n\n### Step 1 — Extract pure duplicate validator into new domain module\n\n```rust\n// crates/kanban-domain/src/import.rs (new file)\npub struct ImportPayload { ... }\npub struct ExistingIds { ... }\npub struct DuplicateError { pub entity_type: &'static str, pub id: Uuid }\n\npub fn validate_no_duplicates(\n    payload: &ImportPayload,\n    existing: &ExistingIds,\n) -> Result<(), DuplicateError> {\n    // pure function — no I/O, fully testable\n}\n```\n\n### Step 2 — Remove `ImportEntities` from domain\n\nRemove the struct and its execute impl from `board_commands.rs` (lines 214-319). Remove the variant from `BoardCommand` enum. The domain retains individual `upsert_*` operations on `DataStore`.\n\n### Step 3 — Replace body of existing `import_board()` with rollback-safe orchestration\n\n```rust\n// crates/kanban-service/src/context.rs\nimpl KanbanContext {\n    pub async fn import_board(&mut self, payload: ImportPayload) -> KanbanResult<()> {\n        let existing = self.load_existing_ids().await?;\n        validate_no_duplicates(&payload, &existing)\n            .map_err(|e| KanbanError::validation(...))?;\n        let snapshot = self.snapshot().await?;\n        let result = self.import_inner(payload).await;\n        if result.is_err() { self.apply_snapshot(snapshot).await?; }\n        result\n    }\n}\n```\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/board_commands.rs` — remove `ImportEntities` (lines 214-319)\n- `crates/kanban-domain/src/import.rs` — new file with payload types and validator\n- `crates/kanban-domain/src/lib.rs` — `pub mod import;`\n- `crates/kanban-service/src/context.rs` — replace body of existing `import_board()` at line 1300\n\n## Caller surfaces to verify\n\n- `crates/kanban-tui/src/app/mod.rs:2222-2277` — TUI `import_board_from_file()`\n- `crates/kanban-mcp/src/lib.rs:1091-1096` — MCP `tool_import_board()`\n\n## Tests\n\n- Unit: `validate_no_duplicates()` collision cases for each entity type\n- Integration: `KanbanContext::import_board()` end-to-end with real store\n- Integration: Partial failure mid-import rolls back to pre-import state (new test)\n\n## Cascade primitives note\n\nIf this lift produces any bulk, validation-bypassing operations that are only valid when executed in a specific sequence, those primitives belong in `cascade_commands` rather than their per-entity module — not because of the entity type, but because of the ordering invariant. Regular commands are self-contained and independently valid; cascade primitives are not.",
+        "due_date": null,
+        "id": "0a57a2f0-c5ae-4336-8725-5e08c4f16e1c",
+        "points": null,
+        "position": 32,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:24:13.846362448Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Todo",
+        "title": "Lift ImportEntities orchestration into service layer",
+        "updated_at": "2026-05-12T20:41:36.938588807Z"
+      },
+      {
         "card_number": 423,
         "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
         "completed_at": null,
@@ -4581,32 +4228,6 @@
         "updated_at": "2026-05-11T23:24:13.846374572Z"
       },
       {
-        "card_number": 430,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-05-11T21:52:21.397986813Z",
-        "description": "## Problem\n\n`MigrateSprintLogs` in `kanban-domain` is a data backfill utility masquerading as a domain command. It fetches all cards, calls a pure migration function, then upserts only modified cards. This is infrastructure-level orchestration — not a domain business rule.\n\n```rust\n// crates/kanban-domain/src/commands/card_commands.rs:439-462\nimpl MigrateSprintLogs {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        let mut cards = context.store.list_all_cards()?;\n        let sprints = context.store.list_all_sprints()?;\n        let boards = context.store.list_boards()?;\n        let before_lens: Vec<usize> = cards.iter().map(|c| c.sprint_logs.len()).collect();\n        let count = crate::card_lifecycle::migrate_sprint_logs(&mut cards, &sprints, &boards);\n        if count > 0 {\n            tracing::info!(\"Migrated sprint logs for {} card(s)\", count);\n            for (card, before_len) in cards.into_iter().zip(before_lens) {\n                if card.sprint_logs.len() != before_len {\n                    context.store.upsert_card(card)?;\n                }\n            }\n        }\n        Ok(())\n    }\n}\n```\n\nThe pure function `card_lifecycle::migrate_sprint_logs()` is correct domain logic and stays. Only the orchestration wrapper moves.\n\n## What to remove from domain\n\n- `pub struct MigrateSprintLogs;` and its `impl` block — `card_commands.rs:439-462`\n- `CardCommand::MigrateSprintLogs(MigrateSprintLogs)` variant — `card_commands.rs:23`\n- The two dispatch arms in `CardCommand::execute` and `CardCommand::description` — `card_commands.rs:40, 57`\n- The serde roundtrip test `test_command_serde_roundtrip_migrate_sprint_logs` — `commands/mod.rs:315-322`\n- The domain inline test `test_migrate_sprint_logs_backfills_cards_missing_sprint_log` — `card_commands.rs:984-1010` — move this coverage to the service integration test instead\n\n## What to add to service\n\nAdd directly on `KanbanContext` (not on `KanbanOperations` — this is a one-time backfill utility, not a regular operation):\n\n```rust\n// crates/kanban-service/src/context.rs\npub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {\n    let mut cards = self.backend.list_all_cards()?;\n    let sprints = self.backend.list_all_sprints()?;\n    let boards = self.backend.list_boards()?;\n    let before_lens: Vec<usize> = cards.iter().map(|c| c.sprint_logs.len()).collect();\n    let count = kanban_domain::card_lifecycle::migrate_sprint_logs(&mut cards, &sprints, &boards);\n    if count > 0 {\n        tracing::info!(\"Migrated sprint logs for {} card(s)\", count);\n        for (card, before_len) in cards.into_iter().zip(before_lens) {\n            if card.sprint_logs.len() != before_len {\n                self.backend.upsert_card(card)?;\n            }\n        }\n    }\n    Ok(count)\n}\n```\n\nNote: `self.backend.list_all_cards()`, `self.backend.list_all_sprints()`, `self.backend.list_boards()`, and `self.backend.upsert_card()` are the correct sync method names — verified from the existing context.rs patterns.\n\n## Undo stack — intentional behaviour change\n\nCurrently the TUI calls this via `execute_command` which routes through `KanbanContext::execute` and lands on the undo stack. After this refactor, the direct call bypasses the undo stack. This is correct — a data migration should not be undoable.\n\n## TUI update\n\n`crates/kanban-tui/src/app/mod.rs:2294-2303` — the private `migrate_sprint_logs` helper on `App` currently does:\n\n```rust\nfn migrate_sprint_logs(&mut self) {\n    let cmd = kanban_domain::commands::Command::Card(\n        kanban_domain::commands::CardCommand::MigrateSprintLogs(\n            kanban_domain::commands::MigrateSprintLogs,\n        ),\n    );\n    if let Err(e) = self.ctx.execute_command(cmd) {\n        tracing::error!(\"Failed to migrate sprint logs: {}\", e);\n    }\n}\n```\n\nReplace with:\n\n```rust\nfn migrate_sprint_logs(&mut self) {\n    if let Err(e) = self.ctx.inner.migrate_sprint_logs() {\n        tracing::error!(\"Failed to migrate sprint logs: {}\", e);\n    }\n}\n```\n\n`self.ctx` is `TuiContext`; `self.ctx.inner` is `KanbanContext`.\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/card_commands.rs` — remove struct, variant, dispatch arms, domain test\n- `crates/kanban-domain/src/commands/mod.rs` — remove serde roundtrip test\n- `crates/kanban-service/src/context.rs` — add `migrate_sprint_logs()`\n- `crates/kanban-tui/src/app/mod.rs:2294-2303` — update caller\n\n## Tests\n\n- Integration: `crates/kanban-service/tests/migrate_sprint_logs.rs` (new file) — two tests: backfill with a card that has `sprint_id` set but empty `sprint_logs`, and no-op when nothing to migrate. Use the same `open_json_ctx` / `open_sqlite_ctx` + macro pattern from `delete_board_cascade.rs`.\n- The pure `card_lifecycle::migrate_sprint_logs()` unit tests in `card_lifecycle.rs:613-660` are untouched.\n\n## Cascade primitives note\n\nIf this lift produces any bulk, validation-bypassing operations that are only valid when executed in a specific sequence, those primitives belong in `cascade_commands` rather than their per-entity module — not because of the entity type, but because of the ordering invariant. Regular commands are self-contained and independently valid; cascade primitives are not.",
-        "due_date": null,
-        "id": "e1edffa0-57f8-40b2-8408-cd23e1b39b6d",
-        "points": null,
-        "position": 33,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:13.846383984Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Todo",
-        "title": "Lift MigrateSprintLogs into service layer",
-        "updated_at": "2026-05-12T20:52:08.210099478Z"
-      },
-      {
         "card_number": 425,
         "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
         "completed_at": null,
@@ -4631,6 +4252,48 @@
         "status": "Todo",
         "title": "Fix minimum Rust version in CONTRIBUTING.md (1.74 is too low)",
         "updated_at": "2026-05-11T23:24:13.846372091Z"
+      },
+      {
+        "card_number": 163,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2025-12-23T00:31:01.453382Z",
+        "description": "## Context\nClaude is listed as a contributor. Transparency about AI-assisted development builds trust.\n\n## Content to Add to CONTRIBUTING.md\n\n### Section: \"AI-Assisted Development\"\n\nThis project uses AI assistance (Claude by Anthropic) for:\n- Code generation and refactoring\n- Documentation writing\n- Test case generation\n- Code review suggestions\n\n### Review Process for AI-Generated Code\nAll AI-generated code undergoes the same review as human contributions:\n1. Automated CI checks (clippy, tests, formatting)\n2. Human review for correctness and style\n3. Integration testing before merge\n\n### Patterns to Watch For\nAI-generated code may exhibit:\n- Over-abstraction (unnecessary traits/generics)\n- Verbose error handling\n- Missing edge cases in generated tests\n- Documentation that restates code instead of explaining intent\n\n### Attribution\nAI-assisted commits are attributed to the human who reviewed and approved them.\nThe AI tool is listed in commit trailers when significant generation occurred.\n\n## Files to Modify\n- `CONTRIBUTING.md` - add new section\n\n## Acceptance Criteria\n- [ ] Clear disclosure of AI tool usage\n- [ ] Review process documented\n- [ ] Common AI patterns listed for reviewers\n- [ ] Attribution policy clarified",
+        "due_date": null,
+        "id": "43cd8d8f-3ffa-4f8e-a0e1-4fc80cad4444",
+        "points": 1,
+        "position": 33,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": "2026-03-25T00:22:42.743041011Z",
+            "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
+            "sprint_name": "a-new-year",
+            "sprint_number": 11,
+            "started_at": "2025-12-23T00:31:51.248422Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": "2026-04-04T23:33:28.989115136Z",
+            "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
+            "sprint_name": "moonshot",
+            "sprint_number": 12,
+            "started_at": "2026-03-25T00:22:42.743041326Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:33:28.989115519Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Add AI contribution disclosure to CONTRIBUTING.md",
+        "updated_at": "2026-04-04T23:33:28.989116404Z"
       },
       {
         "card_number": 45,
@@ -4685,48 +4348,6 @@
         "updated_at": "2025-10-22T20:19:45.673371Z"
       },
       {
-        "card_number": 163,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2025-12-23T00:31:01.453382Z",
-        "description": "## Context\nClaude is listed as a contributor. Transparency about AI-assisted development builds trust.\n\n## Content to Add to CONTRIBUTING.md\n\n### Section: \"AI-Assisted Development\"\n\nThis project uses AI assistance (Claude by Anthropic) for:\n- Code generation and refactoring\n- Documentation writing\n- Test case generation\n- Code review suggestions\n\n### Review Process for AI-Generated Code\nAll AI-generated code undergoes the same review as human contributions:\n1. Automated CI checks (clippy, tests, formatting)\n2. Human review for correctness and style\n3. Integration testing before merge\n\n### Patterns to Watch For\nAI-generated code may exhibit:\n- Over-abstraction (unnecessary traits/generics)\n- Verbose error handling\n- Missing edge cases in generated tests\n- Documentation that restates code instead of explaining intent\n\n### Attribution\nAI-assisted commits are attributed to the human who reviewed and approved them.\nThe AI tool is listed in commit trailers when significant generation occurred.\n\n## Files to Modify\n- `CONTRIBUTING.md` - add new section\n\n## Acceptance Criteria\n- [ ] Clear disclosure of AI tool usage\n- [ ] Review process documented\n- [ ] Common AI patterns listed for reviewers\n- [ ] Attribution policy clarified",
-        "due_date": null,
-        "id": "43cd8d8f-3ffa-4f8e-a0e1-4fc80cad4444",
-        "points": 1,
-        "position": 33,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": "2026-03-25T00:22:42.743041011Z",
-            "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
-            "sprint_name": "a-new-year",
-            "sprint_number": 11,
-            "started_at": "2025-12-23T00:31:51.248422Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": "2026-04-04T23:33:28.989115136Z",
-            "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
-            "sprint_name": "moonshot",
-            "sprint_number": 12,
-            "started_at": "2026-03-25T00:22:42.743041326Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:33:28.989115519Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Add AI contribution disclosure to CONTRIBUTING.md",
-        "updated_at": "2026-04-04T23:33:28.989116404Z"
-      },
-      {
         "card_number": 164,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -4769,32 +4390,6 @@
         "updated_at": "2026-04-04T23:33:28.989179295Z"
       },
       {
-        "card_number": 431,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-05-11T21:52:23.673485610Z",
-        "description": "## Problem\n\n`UpdateSprint` in `kanban-domain` is 58 lines mixing three distinct concerns in a single `execute()` method: card_prefix lock checking, prefix uniqueness validation across siblings, and sprint name allocation with board mutation. This makes the method hard to test in isolation and difficult to read.\n\n```rust\n// crates/kanban-domain/src/commands/sprint_commands.rs\nimpl UpdateSprint {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        // 1. Check if card_prefix is being changed\n        //    → fetch sprint → check cards assigned → if locked, error\n        //    → if setting new prefix → fetch board → check board prefix collision\n        //    → fetch sibling sprints → check uniqueness collision\n        // 2. If name is being set\n        //    → fetch sprint → fetch board → allocate name index → upsert board\n        // 3. Fetch sprint → apply updates → upsert sprint\n    }\n}\n```\n\nThe validation logic is domain logic — it belongs in the domain. The problem is organisation, not placement.\n\n## SOLID Solution\n\n**Single Responsibility**: Each validation concern becomes a standalone pure function or method. `execute()` becomes a thin coordinator.\n\n**Open-Closed**: New validation rules (e.g. locked dates, status transitions) can be added as new functions without modifying existing ones.\n\n### Step 1 — Extract card_prefix lock check\n\n```rust\n// crates/kanban-domain/src/commands/sprint_commands.rs\n\nfn validate_card_prefix_not_locked(\n    sprint_id: Uuid,\n    context: &CommandContext,\n) -> KanbanResult<()> {\n    let has_active = !context.store.list_cards_by_sprint(sprint_id)?.is_empty();\n    let has_archived = context\n        .store\n        .list_archived_cards()?\n        .iter()\n        .any(|ac| ac.card.sprint_id == Some(sprint_id));\n    if has_active || has_archived {\n        return Err(KanbanError::validation(\n            \"sprint card_prefix cannot be changed after cards have been assigned\",\n        ));\n    }\n    Ok(())\n}\n```\n\n### Step 2 — Extract prefix uniqueness validation\n\n```rust\nfn validate_card_prefix_unique(\n    new_prefix: &str,\n    sprint_id: Uuid,\n    board_id: Uuid,\n    context: &CommandContext,\n) -> KanbanResult<()> {\n    let new_lower = new_prefix.to_lowercase();\n    let board = context.get_board(board_id)?;\n    if board.card_prefix.as_deref().map(|p| p.to_lowercase()).as_deref() == Some(new_lower.as_str()) {\n        return Err(KanbanError::validation(\n            \"sprint card_prefix must not match the board card_prefix\",\n        ));\n    }\n    let collision = context\n        .store\n        .list_sprints_by_board(board_id)?\n        .iter()\n        .filter(|s| s.id != sprint_id)\n        .any(|s| s.card_prefix.as_deref().map(|p| p.to_lowercase()).as_deref() == Some(new_lower.as_str()));\n    if collision {\n        return Err(KanbanError::validation(\"sprint card_prefix must be unique within the board\"));\n    }\n    Ok(())\n}\n```\n\n### Step 3 — Extract name allocation\n\n```rust\nfn allocate_sprint_name(\n    name: &str,\n    sprint_id: Uuid,\n    context: &CommandContext,\n    updates: &mut SprintUpdate,\n) -> KanbanResult<()> {\n    let sprint = context.get_sprint(sprint_id)?;\n    let mut board = context.get_board(sprint.board_id)?;\n    let idx = board.add_sprint_name_at_used_index(name.to_string());\n    updates.name_index = FieldUpdate::Set(idx);\n    context.store.upsert_board(board)?;\n    Ok(())\n}\n```\n\n### Step 4 — Slim `execute()` coordinates validators\n\n```rust\nimpl UpdateSprint {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        let mut updates = self.updates.clone();\n        let sprint = context.get_sprint(self.sprint_id)?;\n\n        if !matches!(updates.card_prefix, FieldUpdate::NoChange) {\n            validate_card_prefix_not_locked(self.sprint_id, context)?;\n            if let FieldUpdate::Set(ref prefix) = updates.card_prefix {\n                validate_card_prefix_unique(prefix, self.sprint_id, sprint.board_id, context)?;\n            }\n        }\n\n        if let Some(ref name) = updates.name {\n            allocate_sprint_name(name, self.sprint_id, context, &mut updates)?;\n        }\n\n        let mut sprint = context.get_sprint(self.sprint_id)?;\n        sprint.update(updates);\n        context.store.upsert_sprint(sprint)?;\n        Ok(())\n    }\n}\n```\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/sprint_commands.rs` — extract three private functions, slim `execute()`\n\n## Tests\n\n- Unit: `validate_card_prefix_not_locked` — sprint with cards returns error, sprint without cards passes\n- Unit: `validate_card_prefix_unique` — collision with board prefix, collision with sibling, no collision\n- Unit: `allocate_sprint_name` — correct name index allocated, board upserted\n- Existing integration tests should pass unchanged — behaviour is identical, only structure changes",
-        "due_date": null,
-        "id": "73a9ea39-0c3f-4f19-a4cb-3ea261fc444e",
-        "points": null,
-        "position": 34,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:13.846348055Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Todo",
-        "title": "Extract UpdateSprint validators into pure functions",
-        "updated_at": "2026-05-11T23:24:13.846349300Z"
-      },
-      {
         "card_number": 35,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-10-24T23:04:21.609543Z",
@@ -4819,6 +4414,32 @@
         "status": "Done",
         "title": "make j/k work for changing panels",
         "updated_at": "2025-10-24T23:04:21.609543Z"
+      },
+      {
+        "card_number": 94,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-24T23:09:57.868891Z",
+        "created_at": "2025-10-24T22:23:13.397578Z",
+        "description": "i just felt it was slow to put the selector where I wanted it when opening the ordering dialogue\n",
+        "due_date": null,
+        "id": "d67af0f9-644f-4c62-ba35-4ca087a3783d",
+        "points": 1,
+        "position": 35,
+        "priority": "Low",
+        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+            "sprint_name": "an-experience-to-remember",
+            "sprint_number": 6,
+            "started_at": "2025-11-01T09:30:06.155918Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "when opening a dialogue put selector on the currently selected item",
+        "updated_at": "2025-10-25T21:17:27.509711Z"
       },
       {
         "card_number": 168,
@@ -4871,58 +4492,6 @@
         "updated_at": "2026-04-04T23:44:57.075314435Z"
       },
       {
-        "card_number": 434,
-        "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
-        "completed_at": null,
-        "created_at": "2026-05-11T22:58:23.322907941Z",
-        "description": "## Why\n\nKAN-394's service-layer orchestration produced a recurring pattern:\nthe service exposes both a singular and a plural method for the same\nunderlying operation, with the singular doing its own small batch\nconstruction. Today:\n\n- `update_card` (singular) builds its own UpdateCard + chained\n  command batch *asymmetrically* (only `status → column` auto-sync).\n- `update_cards` (plural) builds the same per entry *symmetrically*\n  (both `status → column` and `column → status`), and adds per-batch\n  position offsets to avoid collisions.\n- `assign_card_to_sprint` (singular) wraps\n  `AssignCardsToSprint { ids: vec![id], sprint_id }`. Plain enough to\n  reduce to `assign_cards_to_sprint(vec![id], sprint_id)`.\n- `archive_card` (singular) is **already** a shorthand over\n  `archive_cards(vec![id])` (see `context.rs:950`).\n- `move_card` (singular) takes `position: Option<i32>` while\n  `move_cards` has no per-card position. **Blocked** — see Out of scope.\n\nThe duplication costs us three things:\n\n1. **Behavioural drift**: `update_card`'s asymmetric auto-sync silently\n   misses cases that `update_cards` handles. Any future tweak (e.g.\n   KAN-432's per-board opt-out) has to land in N places that must stay\n   in lock-step.\n2. **Conceptual noise**: two routes through the service for what should\n   be the same operation.\n3. **Wasted maintenance**: every time we touch the orchestration we have\n   to remember every singular/plural pair.\n\n## Design principle\n\n**Singular builds on plural, not the other way around.** The atomic\ntransaction (`KanbanContext::execute(Vec<Command>)`) is the fundamental\nunit at the service layer; the per-card operation lives one layer down\nin the domain commands. The plural method composes the transaction —\nincluding auto-sync chaining, per-batch position offsets, and (later)\nKAN-432's config-driven opt-out. The singular method is a convenience\nwrapper for the batch-of-one case.\n\nWhy this direction and not the reverse:\n\n- **Atomicity is the contract that matters most.** Multi-select 'c' on\n  5 cards must be one undo unit — pressing `u` once must revert all\n  five. If the plural looped the singular, every batch would be N\n  separate undo units. That defeats the purpose of `execute(Vec<Command>)`\n  and regresses the UX we just shipped in commit `d0a8ca9`.\n- **Single source of truth.** Auto-sync direction, position offset\n  tracking, future config flags all live in one place. The singular\n  cannot drift from the plural's semantics because it literally is\n  one entry into the plural.\n- **N = 1 is a clean special case.** A batch of one runs the same\n  orchestration; the position offset map has one entry that increments\n  to 1 and is discarded. No special-case code needed.\n- **Cost is negligible.** One `Vec::new()` + one `get_<entity>` per\n  singular call. We pay it once at construction; we gain a single\n  reasoning surface for every future change.\n\nWhen a future contributor adds another singular variant, the rule is:\ndelegate to the plural with `vec![one]` and (if the return type\nrequires it) trail with a `get_<entity>(id)`. Never invert this and\nhave the plural loop the singular.\n\n## What\n\nMake every eligible singular service method a one-line shorthand over\nits plural counterpart.\n\n### `update_card` → `update_cards`\n\n`crates/kanban-service/src/context.rs::update_card` (around line 843).\nNew body, full replacement:\n\n```rust\nfn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {\n    self.update_cards(vec![(id, updates)])?;\n    self.get_card(id)?\n        .ok_or_else(|| KanbanError::not_found(\"card\", id))\n}\n```\n\nThis deletes:\n\n- The asymmetric `match (updates.status, &updates.column_id)` block.\n- The local `MoveCard` import inside the function.\n- The per-call construction of the chained batch — `update_cards`\n  already does this symmetrically and with offset tracking.\n\n### `assign_card_to_sprint` → `assign_cards_to_sprint`\n\n`crates/kanban-service/src/context.rs::assign_card_to_sprint` (around\nline 1004). New body:\n\n```rust\nfn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {\n    self.assign_cards_to_sprint(vec![card_id], sprint_id)?;\n    self.get_card(card_id)?\n        .ok_or_else(|| KanbanError::not_found(\"card\", card_id))\n}\n```\n\nReplaces the explicit `AssignCardsToSprint { ids: vec![card_id], sprint_id }`\nconstruction and `execute` call with the trait-level shorthand.\n\n### `archive_card`\n\nNo change — it already delegates to `archive_cards(vec![id])` (see\n`context.rs:950–957`). Sanity-check it still looks right after this\nrefactor lands.\n\n## Where the wiring lives\n\n- `crates/kanban-service/src/context.rs::update_card` — collapse.\n- `crates/kanban-service/src/context.rs::assign_card_to_sprint` —\n  collapse.\n- No other files change. The trait signatures\n  (`KanbanOperations::update_card`, `::assign_card_to_sprint`) and\n  their return types are preserved.\n- `move_card`, `move_cards`, and the `*_detailed` inherent methods are\n  untouched — out of scope.\n- The pure helpers in `kanban_domain::card_lifecycle`\n  (`target_column_for_status`, `target_status_for_column_move`) and the\n  private bundling helpers on `KanbanContext` are unchanged.\n\n## Acceptance\n\nFor `update_card`:\n\n- All existing tests in `crates/kanban-service/tests/completion_sync.rs`\n  and `crates/kanban-mcp/tests/integration.rs` stay green.\n- Add three new tests covering the column-only path that previously\n  bypassed auto-sync:\n  - `test_update_card_column_only_to_completion_column_sets_status_done`\n  - `test_update_card_column_only_away_from_completion_clears_done`\n  - `test_update_card_column_only_to_non_completion_column_no_status_change`\n\nFor `assign_card_to_sprint`:\n\n- Existing tests (any in `kanban-service/tests/`, `kanban-mcp/tests/`,\n  `kanban-cli/tests/`) stay green. Behaviour is identical.\n- No new tests needed — it's a pure mechanical reduction with no\n  behaviour change.\n\nAcross both:\n\n- `cargo test --workspace`,\n  `cargo clippy --workspace --all-targets -- -D warnings`,\n  `cargo fmt --check` clean.\n- No callers change. Public signatures preserved.\n\n## Behaviour change for existing callers\n\n| Method | Caller-visible change |\n|---|---|\n| `update_card` | Closes the column-only auto-sync gap. Today no production caller uses this path (TUI uses status-only or both; CLI/MCP forward to `move_card` for column changes). Extension, not break. |\n| `assign_card_to_sprint` | None. Mechanical reduction. |\n| `archive_card` | None. Already a shorthand. |\n\n## Out of scope — `move_card` blocker\n\n`KanbanContext::move_card(id, column_id, position: Option<i32>)` cannot\ncleanly collapse into `move_cards(vec![id], column_id)` because:\n\n- `move_cards` accepts a single target `column_id` for all cards but\n  has no per-card `position` parameter.\n- The underlying `MoveCards` domain command in\n  `crates/kanban-domain/src/commands/card_commands.rs` does not carry\n  per-card positions — it appends.\n- Routing `move_card` through `update_cards(vec![(id, CardUpdate {\n  column_id: Some(col), position, .. })])` would bypass the WIP-limit\n  check that `MoveCard::execute` performs (`UpdateCard::execute` does\n  not check WIP limits — likely a separate latent bug).\n\nResolving this would require either:\n\n1. Adding per-card positions to `MoveCards` (signature + command +\n   storage change), OR\n2. Surfacing WIP-limit checking inside `UpdateCard::execute` so\n   `update_cards` can safely subsume column changes.\n\nBoth are non-trivial and worth a dedicated follow-up — not this card.\n\n## Commit shape\n\nOne `refactor(service)` commit covering both reductions + the three\nnew `update_card` column-only tests. Roughly:\n\n- `crates/kanban-service/src/context.rs` — ~50 lines deleted, ~10 added.\n- `crates/kanban-service/tests/completion_sync.rs` — ~80 lines added.\n\n## Notes\n\n- KAN-432 (per-board auto-sync config) lands cleanest *after* this\n  card: it only has to thread the flag through `update_cards` and\n  `move_cards`, not the singular variants too.\n- KAN-433 (drop dead lifecycle helpers) is independent — can land\n  before or after.\n- If the WIP-limit-on-update concern ends up mattering before the\n  `move_card` collapse is attempted, file as a separate card.\n\n## Risk\n\nVery low. The new `update_card` and `assign_card_to_sprint` behaviour\nis exactly what `update_cards(vec![(id, updates)])` and\n`assign_cards_to_sprint(vec![id], sprint_id)` already do today —\nlocked down by the existing batch tests.",
-        "due_date": null,
-        "id": "1791bdf5-4285-47ef-9b44-72dc3586c8d6",
-        "points": 3,
-        "position": 35,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:24.403406690Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Todo",
-        "title": "refactor(service): collapse singular service methods into shorthands over their plural counterparts",
-        "updated_at": "2026-05-11T23:24:24.403407416Z"
-      },
-      {
-        "card_number": 94,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-24T23:09:57.868891Z",
-        "created_at": "2025-10-24T22:23:13.397578Z",
-        "description": "i just felt it was slow to put the selector where I wanted it when opening the ordering dialogue\n",
-        "due_date": null,
-        "id": "d67af0f9-644f-4c62-ba35-4ca087a3783d",
-        "points": 1,
-        "position": 35,
-        "priority": "Low",
-        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-            "sprint_name": "an-experience-to-remember",
-            "sprint_number": 6,
-            "started_at": "2025-11-01T09:30:06.155918Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "when opening a dialogue put selector on the currently selected item",
-        "updated_at": "2025-10-25T21:17:27.509711Z"
-      },
-      {
         "card_number": 59,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-10-24T22:34:45.306759Z",
@@ -4940,82 +4509,21 @@
         "updated_at": "2025-10-24T22:34:45.306761Z"
       },
       {
-        "card_number": 34,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-24T23:04:30.736240Z",
-        "created_at": "2025-10-12T13:37:00.520483Z",
-        "description": "it currently does something else\n",
-        "due_date": null,
-        "id": "475bde99-0a3f-457c-9ea6-2fd51d1d7e73",
-        "points": 1,
-        "position": 36,
-        "priority": "High",
-        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-            "sprint_name": "an-experience-to-remember",
-            "sprint_number": 6,
-            "started_at": "2025-11-01T09:30:06.155912Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "when creating a task. set the cursor/selected task to the new task",
-        "updated_at": "2025-10-24T23:04:30.736240Z"
-      },
-      {
-        "card_number": 82,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-24T22:27:41.749434Z",
-        "created_at": "2025-10-22T15:46:45.372862Z",
-        "description": "When a sprint is completed\n\nDont clear the reference to said sprint when it has been marked as completed.\n\nWe would rather like to filter out cards from completed sprints from any card lists\n\n2025-10-22 17:52:51\n---\n\nI would also like to make the first addition to the sprint details interface\n\nI would like a panel showing tasks\n\nfor completed sprints the panel should be column split into two panels \n\nleft panel would show a card list with non completed cards\n\nright panel would show a card list with completed cards\n\nat the bottom of each of these column we would sum up the points for the cards in the list\n\n2025-10-22 21:45:54\n---\n\nTo the sprint details ui we also add editing of the sprint settings json. such as setting the sprint override prefix\n\nIn the sprint details we add starting date and ending date aswell as days left, tasks left.\n\n2025-10-22 22:19:35\n---\n\nhitting [x] to navigate to a column with a task list should automatically select the first item in the list\n\n2025-10-24 18:46:58\n---\n\nSomething is still off with the ordering behaviour.\n\nThe ordering doesnt apply at the moment of selecting an ordering. Only after `O` is hit to reverse the ordering the cards seem to align.\n",
-        "due_date": null,
-        "id": "10551177-bbc3-4096-89e7-0c40f324e0b4",
-        "points": 4,
-        "position": 36,
-        "priority": "High",
-        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-            "sprint_name": "an-experience-to-remember",
-            "sprint_number": 6,
-            "started_at": "2025-11-01T09:30:06.155916Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "when sprint completes, dont remove card -> sprint reference",
-        "updated_at": "2025-10-24T22:27:41.749436Z"
-      },
-      {
-        "card_number": 435,
+        "card_number": 450,
         "column_id": "db3aaee8-0f13-4afa-b000-592bac0bf364",
         "completed_at": null,
-        "created_at": "2026-05-11T23:24:55.116154968Z",
-        "description": "# KAN-435: sprint-detail card lists reuse the main-board CardListComponent\n\n## Original report\n\nThe narrow bug: scrolling didn't work inside the sprint-detail card lists. While planning the fix the scope expanded into \"sprint detail should behave like the main board\" — same renderer, same actions, same view modes.\n\n## Phase 1 — shipped (PR #261, branch `KAN-435/scrolling-in-the-card-lists-of-sprint-details`)\n\nSix commits, branch ready for merge:\n\n- `71cf133` `refactor(tui): align sprint-detail panel action configs with main-board card list` — both panels use `CardListComponentConfig::default()`; Completed gains multi-select, Uncompleted gains movement\n- `f61180e` `fix(tui): sprint-detail card lists scroll when selection passes viewport` — `SprintViewState::sync_scroll(uncompleted_viewport, completed_viewport)` called from `render_sprint_detail_with_tasks` with per-panel viewport heights\n- `8412f11` `refactor(tui): populate sprint-detail panels via CardQueryBuilder` — board's `task_sort_field` / `task_sort_order` apply on populate\n- `20cdf53` `chore: add changeset for KAN-435 partial implementation`\n- `1873230` `chore(tui): drop redundant comments on sprint-detail scroll and populate`\n- `0f40d2f` `test(tui): cover sort-on-populate and handler→raw-CardList sync in sprint detail`\n\nTests: 8 in `crates/kanban-tui/tests/sprint_detail_card_list_tests.rs` (scrolling, multi-select symmetry, movement enablement, default-panel focus, panel independence, sort-on-populate, handler→raw-CardList sync at `detail_view_handlers.rs:982`, status partitioning). Workspace tests 0 failures; clippy + fmt clean.\n\n## Phase 2 — not started\n\nPhase 1 fixed the literal bug + lifted action parity but kept the sprint-detail panels on a bespoke render path. The user's expanded intent: sprint detail should be the **same view-strategy machinery** the main board uses, just with different column definitions. Concretely:\n\n- **Kanban** in sprint detail = two side-by-side panels, columns = `[Uncompleted, Completed]`\n- **GroupedByColumn** = single list with `Uncompleted` / `Completed` section headers\n- **Flat** = single list of every sprint card\n\nSame key bindings as the main board (`h`/`l` switch panels, `H`/`L` move cards between *board* columns, `v`/`V` multi-select, `e` edit, `/` search, `o`/`O` sort, `V`-uppercase toggle view, Enter/Space open detail, `n` create, `d` archive). When a card is selected in the Uncompleted panel, the original board column it lives in shows as a label on the panel title. Completed cards get no extra label.\n\nThis is a substantial refactor of the view-strategy abstraction, not a bug fix.\n\n## Approach\n\n### 1. Make the view-strategy column-partition-agnostic\n\nToday the view strategy (`crates/kanban-tui/src/view_strategy.rs`, `layout_strategy.rs`) hardcodes board columns as the partition source. `ColumnListsLayout` builds one `CardList` per `board.column`; `VirtualUnifiedLayout` and `SingleListLayout` use the board's flat card list.\n\nIntroduce a `ColumnPartition` shape — minimal:\n\n```rust\n// new in crates/kanban-tui/src/view_strategy.rs\npub struct ColumnPartition {\n    pub title: String,\n    pub cards: Vec<Uuid>,  // pre-filtered, pre-sorted IDs\n}\n```\n\nThe layout strategy takes `Vec<ColumnPartition>` instead of computing from `board.columns`. Two adapters build these:\n\n- **Main board**: `build_board_partitions(board, ctx)` → one partition per board column, cards filtered/sorted via `CardQueryBuilder::in_column`.\n- **Sprint detail**: `build_sprint_partitions(sprint_id, board, ctx)` → two partitions, `Uncompleted` and `Completed`, each filtered+sorted via `CardQueryBuilder::in_sprints`, then post-partitioned by `card.is_completed()`.\n\n`ViewRefreshContext` gains a `partitions: Vec<ColumnPartition>` source field. The board chooses its source at `prepare_frame` time based on whether the active mode is `SprintDetail` or the normal board view.\n\n### 2. Sprint detail uses `ViewStrategy` end-to-end\n\nDelete `SprintViewState::{uncompleted_cards, completed_cards, sync_scroll, uncompleted_component, completed_component}`. Replace with one `view_strategy: Box<dyn ViewStrategy>` reflecting the current `task_list_view`. The strategy holds the layout (Flat / Grouped / Kanban) and the partitions.\n\n- `SprintViewState::panel` becomes the index into `Vec<ColumnPartition>` — `0 = Uncompleted, 1 = Completed`. h/l moves the panel index. In Flat or GroupedByColumn views, panel switching is a no-op (single list).\n- All key handling delegates to the active layout's selected `CardListComponent`, same as the main board.\n\n### 3. Render path collapses to the existing `RenderStrategy`\n\n`crates/kanban-tui/src/ui/sprint_detail.rs::render_sprint_detail_with_tasks` becomes:\n\n```rust\n// after sprint metadata at top, give the rest of `area` to the strategy\nlet view_area = ...;\napp.sprint_view.view_strategy.render(&app, frame, view_area);\n```\n\nSame as the main board's `render_tasks`. The `RenderStrategy` (`SinglePanelRenderer` / `MultiPanelRenderer`) renders into whatever `Rect` you give it. The bespoke `render_sprint_task_panel_with_selection` and its hand-rolled `Paragraph` loop are deleted.\n\nThis also brings **horizontal-truncation handling** along, since the renderer already truncates long card titles to fit `area.width` (it's the same `render_card_list_item` helper).\n\n### 4. Original-column label on the focused panel\n\nWhen the focused partition is `Uncompleted` (panel index 0), the selected card's board column name is shown in the panel title:\n\n```\n┌ Uncompleted (5) → InProgress ──────────────┐\n```\n\nImplementation: at render time, read `selected_card.column_id` from `app.model.cards()`, look up the column name in `app.model.columns()`, suffix the panel title. Completed (index 1) renders without the suffix per the user spec. The label is a render-time computation, not stored state.\n\n### 5. Original-column tracking on un-complete\n\nCarried over from phase 1's plan. `SprintViewState::original_columns: HashMap<Uuid, Uuid>`. When the user toggles `c` on a card in the Uncompleted partition, record `card_id → card.column_id` before issuing the status update. When toggling `c` on a Completed card with an entry in the map, route the move back to the recorded column (`update_card` with both `status` and `column_id` set — KAN-394's `(Some, Some) → respect both` branch).\n\nPre-existing Completed cards (no map entry) keep KAN-394's second-to-last fallback. In-memory only, resets when sprint detail closes.\n\n### 6. Search and `prepare_frame` integration\n\nThe board's existing `prepare_frame` (`crates/kanban-tui/src/app/mod.rs:1541`) rebuilds the main-board strategy each frame using a `ViewRefreshContext`. Extend it to also rebuild the sprint-detail strategy when `app.mode` (or the base mode) is `SprintDetail`. The sprint-specific `ViewRefreshContext` carries the same `search_query` and active sprint as the main board — search now propagates.\n\n### 7. Key parity verification\n\nAfter steps 1–3, every key the main board's `CardListComponent` responds to now works in sprint detail too because both routes through the same component and the same `render_strategy.handle_key` path. Specifically:\n\n| Key | Sprint detail behaviour after refactor |\n|---|---|\n| `j`/`k` | Navigate selection (with scroll already wired) |\n| `h`/`l` | Switch panel index in Kanban view; no-op in Flat/Grouped |\n| `H`/`L` | Move card between *board* columns (status auto-syncs via KAN-394) |\n| `v`/`V`-lower | Single-select / select all |\n| `V`-upper | Open view-mode picker dialog |\n| `e` | Edit card |\n| `/` | Search |\n| `o`/`O` | Sort dialog / toggle order |\n| `n` | Create card |\n| `d` | Archive selected |\n| `Enter`/`Space` | Open card detail |\n\nSprint-specific keys (`a` activate sprint, `M` carry over, `C` sprint card prefix, etc.) remain intercepted by the sprint-detail handler before the component delegation.\n\n## Files modified\n\n| File | Change |\n|---|---|\n| `crates/kanban-tui/src/view_strategy.rs` | Introduce `ColumnPartition`. `ViewRefreshContext` gains `partitions: Vec<ColumnPartition>`. Layouts consume partitions instead of looking up `board.columns` directly. |\n| `crates/kanban-tui/src/layout_strategy.rs` | `ColumnListsLayout` / `VirtualUnifiedLayout` / `SingleListLayout` rebuilt from partitions. `build_query` becomes a helper that yields a partition. |\n| `crates/kanban-tui/src/app/sprint_view.rs` | Replace dual `CardList` + `CardListComponent` fields with `view_strategy: Box<dyn ViewStrategy>` + `original_columns: HashMap<Uuid, Uuid>`. `panel: SprintTaskPanel` becomes `partition_index: usize`. `sync_scroll` is gone (strategy handles it). |\n| `crates/kanban-tui/src/app/mod.rs` | `prepare_frame` builds the sprint-detail strategy when in `AppMode::SprintDetail`. `populate_sprint_task_lists` and `apply_sort_to_sprint_lists` are deleted (subsumed by the strategy refresh). `partition_sprint_cards` no longer used here. |\n| `crates/kanban-tui/src/ui/sprint_detail.rs` | `render_sprint_detail_with_tasks` calls the strategy's render. `render_sprint_task_panel_with_selection` deleted. Title-suffix logic for the focused-partition original-column label lives here. |\n| `crates/kanban-tui/src/handlers/detail_view_handlers.rs` | Sprint-specific intercepts stay; everything else delegates to strategy. `c` toggle hooks `original_columns` for the round-trip behaviour. h/l swaps the partition index. |\n| `crates/kanban-tui/tests/sprint_detail_card_list_tests.rs` | Existing 5 tests update to the new state shape. Add: view-mode-toggle test, original-column-label test, original-column-roundtrip test, search-filter-propagation test, H/L card-move test. |\n\n## Reuse — already in place\n\n- `kanban_domain::CardQueryBuilder` for filter+sort (phase 1 already plumbed this in for populate)\n- `UnifiedViewStrategy::flat() / ::grouped() / ::kanban()`, `SinglePanelRenderer`, `MultiPanelRenderer`\n- `render_card_list_item` (handles truncation already)\n- `CardListComponent::handle_key` (full action set), `ensure_selected_visible`\n- KAN-394 service-layer auto-sync for status ↔ column on the un-complete round-trip\n\n## Verification\n\n```bash\ncargo test --workspace\ncargo clippy --workspace --all-targets -- -D warnings\ncargo fmt --check\n```\n\nNew tests in `crates/kanban-tui/tests/sprint_detail_card_list_tests.rs`:\n\n1. `test_sprint_detail_kanban_view_renders_two_panels`\n2. `test_sprint_detail_grouped_view_renders_single_list_with_status_headers`\n3. `test_sprint_detail_flat_view_renders_single_list_no_partition`\n4. `test_sprint_detail_focused_panel_title_shows_selected_card_original_column`\n5. `test_sprint_detail_completed_panel_title_has_no_extra_label`\n6. `test_sprint_detail_uncomplete_returns_card_to_original_column`\n7. `test_sprint_detail_uncomplete_falls_back_to_kan_394_for_pre_existing_completed_cards`\n8. `test_sprint_detail_search_filter_propagates_to_panels`\n9. `test_sprint_detail_capital_l_moves_card_right_between_board_columns`\n10. `test_sprint_detail_scroll_preserved_after_view_mode_switch`\n\nManual smoke (`kanban ~/notes/memes/kanban.json`):\n\n1. Enter sprint detail. Press uppercase `V` to open view picker. Pick Flat — sprint cards collapse into one list. Pick Grouped — section headers appear. Pick Kanban — two panels return.\n2. In Kanban view: select a card in Uncompleted. Panel title shows \" → <column-name>\". Press `H` — card moves left between board columns; auto-syncs status if it leaves the completion column.\n3. In Kanban view: `c` on Uncompleted card → moves to Completed panel (and to completion column on the underlying board). `c` again → returns to the column it came from (not the second-to-last fallback).\n4. Press `/`, type a query — both panels filter (in Kanban) or the single list filters (Flat/Grouped).\n\n## Commit strategy — additive, layered\n\nAiming to keep each commit independently green so bisect stays useful:\n\n1. **`refactor(tui): introduce ColumnPartition; main-board path unchanged`** — internal refactor of view-strategy/layout-strategy to accept partitions. Main board's adapter computes from `board.columns` (no behaviour change). Existing tests stay green.\n2. **`feat(tui): sprint detail builds its own ColumnPartitions`** — sprint-detail adapter; remove `populate_sprint_task_lists` and friends. Sprint detail still renders via bespoke path (next commit).\n3. **`refactor(tui): sprint detail delegates rendering to ViewStrategy`** — delete bespoke render; route through main-board renderer. Scrolling, action set, view modes all gained.\n4. **`feat(tui): focused-panel title shows selected card original column`** — render-time enrichment of the title.\n5. **`feat(tui): original-column tracking on un-complete in sprint detail`** — `original_columns` map + `c`-handler hook.\n6. **`feat(tui): prepare_frame propagates search filter to sprint detail`** — every-frame strategy rebuild when in `SprintDetail` mode.\n7. **`test(tui): expand sprint-detail coverage for view modes, label, round-trip, search, H/L`** — the 10 new tests above.\n8. **`chore: update KAN-435 changeset for phase 2`** — replace phase-1 wording with the full story.\n\n## Risk\n\nHigh. This is the largest single TUI refactor in this card line — view-strategy abstraction touches every render path. Mitigations:\n\n- Step 1 keeps main board behaviour byte-identical; verify by running existing tests untouched.\n- Steps 2–3 are scoped to sprint detail; main board can't regress because its adapter is unchanged.\n- Step 7 adds explicit regression tests for every claimed feature.\n\nIf steps 1–3 turn out to require a much bigger rewrite than estimated, fall back to: keep the bespoke sprint-detail render but add view-mode switching as a separate `SprintViewState` field, accept the duplication. That's a structurally weaker outcome but ships the user-visible features without the deep refactor.\n\n## Out of scope (file as separate cards if needed)\n\n- Per-panel independent view mode (Uncompleted in Flat while Completed in Grouped). Today's plan shares one view mode across both panels in Kanban; if independent modes turn out to matter, file separately.\n- Persisting `original_columns` across sessions. In-memory map suffices for the common workflow.\n- Card-position memory inside the column (returning to a *specific position* in the original column, not just the column itself). Today the card lands at the column's append position.",
+        "created_at": "2026-05-14T03:07:18.987941572Z",
+        "description": "## Background\n\nWe've had two near-misses with the same failure class — tests that pass on regular Linux CI but fail in the Nix build sandbox:\n\n1. **2026-05-07** — 5 tests in `crates/kanban-tui/tests/settings_config_edit_tests.rs` called `config::save()` which silently fell back to `$HOME/.config/kanban/config.toml`. In the nixpkgs build sandbox `$HOME` is non-writable (typically `/homeless-shelter`), so `create_dir_all` returned `EACCES` and the tests panicked. Fixed reactively by KAN-396 (PR #241).\n2. **2026-05-14** — a new test `test_apply_config_edit_with_non_default_content_writes_config` in PR #267 reintroduced the exact same pattern. Caught only by manual audit (KAN-449 / PR #269), not by CI. Would have blocked the next nixpkgs-update bump if not for the manual catch.\n\nThe pattern: any test that exercises `apply_config_edit` (or anything else that ends up calling `config::save()`) without explicitly setting `configuration_location` hits `dirs::config_dir()` and fails in a sandbox. Linux CI doesn't catch this because Linux CI has `$HOME` set to a writable path. Only the **Nix build sandbox** reproduces the failure.\n\nWe need CI to run a real Nix sandbox build with `doCheck = true` so this class of regression is caught before it ships.\n\n## Verified locally — end-to-end successful\n\nI built v0.5.1 in the actual Nix sandbox using an inline expression mirroring nixpkgs's `pkgs/by-name/ka/kanban/package.nix` and confirmed:\n\n- `nix-build` exit code **0**\n- Final store path: `/nix/store/503c486n3ycmz8gnrkhisk0w2jzlpnvd-kanban-0.5.1`\n- `cargoCheckHook` ran inside the sandbox with `--profile release --target x86_64-unknown-linux-gnu --offline`\n- Approximately **1400+ tests across 67 test binaries** all passed, zero FAILED, zero panics, zero `Permission denied`\n\nThis confirms the *derivation shape* (rustPlatform.buildRustPackage with doCheck = true, importCargoLock, the same nativeBuildInputs/buildInputs as `default.nix`) works end-to-end inside the sandbox. The CI job should adopt that same shape, exposed as a flake output so it integrates cleanly with `nix flake check`.\n\n## Recommended approach: flake output + `nix flake check`\n\nAdd a `checks.${system}.workspace-tests` output to `flake.nix` that overrides `default.nix` to flip `doCheck = true` and run the full workspace test suite:\n\n```nix\nchecks.${system}.workspace-tests =\n  (pkgs.callPackage ./default.nix { src = self; gitRev = self.rev or null; }).overrideAttrs (old: {\n    doCheck = true;\n    cargoBuildFlags = [];\n    cargoTestFlags = [ \"--workspace\" ];\n  });\n```\n\nCI step:\n\n```yaml\n- uses: cachix/install-nix-action@v27\n  with:\n    extra_nix_config: |\n      experimental-features = nix-command flakes\n      substituters = https://cache.nixos.org https://nix-community.cachix.org\n      trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=\n- run: nix flake check --print-build-logs\n```\n\n**Why this approach:**\n\n- One canonical hermetic-CI entry point (`nix flake check`) — same command developers can run locally.\n- Lives next to existing flake outputs in `flake.nix`, no separate file to maintain.\n- Equivalent sandbox semantics to the verified inline expression: the sandbox guarantees (non-writable `$HOME`, blocked network, ephemeral `/tmp`) come from the builder, not the derivation shape.\n\n**Verification gap to close before relying on this gate:**\n\nThe exact override path through `default.nix` was not run end-to-end during the v0.5.1 local verification — that used a standalone expression (see fallback below). Before marking the gate required, locally run `nix flake check` on current `develop` HEAD and confirm:\n\n1. It goes green when the codebase is healthy.\n2. It goes red when one of KAN-396 or KAN-449's test fixes is reverted (e.g. removing the `configuration_location` line from `test_apply_config_edit_with_non_default_content_writes_config`).\n\nThat regression-test-the-gate exercise is required by acceptance anyway; it doubles as the verification step for the override path.\n\n## Fallback: standalone `nix/nixpkgs-build.nix`\n\nIf the override path through `default.nix` proves fragile (cargoBuildFlags clearing, doCheck overriding, etc.), drop in a standalone file that mirrors nixpkgs's `pkgs/by-name/ka/kanban/package.nix` literally:\n\n```nix\n# nix/nixpkgs-build.nix\n{ pkgs ? import <nixpkgs> {}\n, src ? ./..\n}:\nlet\n  lockFile = \"${src}/Cargo.lock\";\nin\npkgs.rustPlatform.buildRustPackage {\n  pname = \"kanban\";\n  version = \"nixpkgs-sim\";\n\n  inherit src;\n\n  cargoDeps = pkgs.rustPlatform.importCargoLock { inherit lockFile; };\n\n  nativeBuildInputs = [ pkgs.pkg-config ];\n  buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [\n    pkgs.wayland\n    pkgs.xorg.libxcb\n  ];\n\n  env.GIT_COMMIT_HASH = \"0000000000000000000000000000000000000000\";\n\n  # doCheck defaults to true — DO NOT override; that's the whole point of this job.\n}\n```\n\nCI step:\n\n```yaml\n- run: nix-build nix/nixpkgs-build.nix --no-out-link -vvv\n```\n\nThis is the path that was verified end-to-end against v0.5.1. Reach for it only if the flake-output route doesn't hold up.\n\nThe exact expression I used (for reference, against a local nixpkgs checkout):\n\n```nix\nlet\n  pkgs = import /home/max/fulsomenko/nixpkgs {};\n  src = /tmp/kanban-v0.5.1;\nin\n  (pkgs.callPackage /home/max/fulsomenko/nixpkgs/pkgs/by-name/ka/kanban/package.nix {}).overrideAttrs (old: {\n    inherit src;\n    version = \"0.5.1\";\n    cargoDeps = pkgs.rustPlatform.importCargoLock { lockFile = \"${src}/Cargo.lock\"; };\n    env = (old.env or {}) // { GIT_COMMIT_HASH = \"5e54f85f0000000000000000000000000000000000\"; };\n  })\n```\n\n## Where it should run\n\n**Recommendation: PR-to-develop**, not just PR-to-master. The 2026-05-14 near-miss landed in develop via PR #267 and was only caught at release time. Gating develop merges catches it earlier and cheaper than gating only the release PR.\n\nWorkflow trigger:\n\n```yaml\non:\n  pull_request:\n    branches: [develop, master]\n```\n\nIf develop-gating proves too expensive on initial rollout, fall back to PR-to-master only — that still would have caught the 2026-05-14 issue at release time.\n\n## Cost / cache\n\n- **Cold runner**: ~30 minutes. The build does two cargo compiles (buildPhase in dev profile, checkPhase in release profile) plus ~600 crates of vendored deps. cargoCheckHook re-runs cargo with `--profile release`, which doesn't share artifacts with buildPhase's default profile.\n- **Warm cache**: 2–5 minutes for the deps (substituters do almost all the work); the workspace recompile is the dominant remaining cost.\n- **Substituters to enable**: `cache.nixos.org` (default) + `nix-community.cachix.org`. The local verification pulled ~80% of its dep store paths from those two caches.\n- **Optional**: project-owned Cachix or S3 cache (`cachix/cachix-action@v15`) for caching the kanban-* derivations between PRs. Not strictly needed initially.\n\n## Implementation tips / gotchas\n\n- **`nix-build` vs `nix build`** are different CLIs with different flags. The legacy `nix-build` does NOT accept `-L` (modern's verbose flag); use `-vvv` instead. `nix flake check` uses the new CLI, so `-L` / `--print-build-logs` is fine there.\n- **Disk pressure** — running this on a self-hosted runner with <50GB free space will fail mid-build (the vendoring + dep compile + workspace compile produces ~15-20GB of intermediate `/nix/store` paths). GitHub-hosted `ubuntu-latest` has ~14GB free which may not be enough — verify with `df -h` before committing to that runner.\n- **Soft-launch path**: land the workflow as a non-required check first. Tune it until it's reliably green on `develop` HEAD. Then mark it required.\n\n## Acceptance\n\n- A CI job exists that runs a Nix sandbox build with `doCheck = true`, exposed as `checks.${system}.workspace-tests` and invoked via `nix flake check` (preferred), or via `nix-build nix/nixpkgs-build.nix` if the fallback was needed.\n- The job runs on every PR to `develop` (preferred) or `master` (fallback).\n- **Regression test for the gate itself**: reverting either KAN-396 OR KAN-449 (just the test file changes, e.g. removing the `configuration_location` line from `test_apply_config_edit_with_non_default_content_writes_config`) and pushing as a PR causes the new CI job to fail red. Document this regression-test recipe so future maintainers can verify the gate is still meaningful.\n- Cache configured so steady-state CI time is acceptable (under 10 min for unchanged deps; ≤5 min preferred).\n- Document in `CONTRIBUTING.md` that this gate exists, what it catches, and how to reproduce locally:\n  ```\n  nix flake check --print-build-logs\n  ```\n\n## Why this matters beyond `apply_config_edit`\n\nThe class of bugs this catches is not limited to `config::save()` fallbacks. Anything that:\n\n- Writes under `$HOME` / `~/.config` / `~/.local/share` / `~/.cache` (any `dirs::*` lookup)\n- Requires network access (Nix sandbox blocks it)\n- Depends on `/tmp` lifetime semantics beyond the build\n- Assumes a TTY / terminal capabilities\n\n…will be caught by this single sandbox build. Currently **zero of these classes are caught pre-release** — we rely entirely on ryantm flagging it post-release, which delays the next nixpkgs bump until we land a reactive fix.\n\n## Related cards / PRs\n\n- **KAN-396 / PR #241** — first reactive fix for this failure class.\n- **KAN-445 / PR #267** — added the Windows CI job (precedent for adding platform-specific CI gates).\n- **KAN-449 / PR #269** — the 2026-05-14 near-miss this card prevents recurring.\n- **Verified store path**: `/nix/store/503c486n3ycmz8gnrkhisk0w2jzlpnvd-kanban-0.5.1`",
         "due_date": null,
-        "id": "26b740aa-b5d7-4a71-8b56-cd22b314e3e7",
-        "points": 1,
+        "id": "c8a25ac2-aa9d-4b44-83e5-50d48b748c7e",
+        "points": null,
         "position": 36,
-        "priority": "Low",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:25:47.767081947Z",
-            "status": "Active"
-          }
-        ],
+        "priority": "High",
+        "sprint_id": null,
+        "sprint_logs": [],
         "status": "Todo",
-        "title": "Scrolling in the card lists of sprint details",
-        "updated_at": "2026-05-12T05:57:15.818183493Z"
+        "title": "Add CI job: Nix sandbox build with tests (pre-release nixpkgs simulation)",
+        "updated_at": "2026-05-14T15:32:57.437315447Z"
       },
       {
         "card_number": 173,
@@ -5068,6 +4576,101 @@
         "updated_at": "2026-04-04T23:33:28.989132133Z"
       },
       {
+        "card_number": 82,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-24T22:27:41.749434Z",
+        "created_at": "2025-10-22T15:46:45.372862Z",
+        "description": "When a sprint is completed\n\nDont clear the reference to said sprint when it has been marked as completed.\n\nWe would rather like to filter out cards from completed sprints from any card lists\n\n2025-10-22 17:52:51\n---\n\nI would also like to make the first addition to the sprint details interface\n\nI would like a panel showing tasks\n\nfor completed sprints the panel should be column split into two panels \n\nleft panel would show a card list with non completed cards\n\nright panel would show a card list with completed cards\n\nat the bottom of each of these column we would sum up the points for the cards in the list\n\n2025-10-22 21:45:54\n---\n\nTo the sprint details ui we also add editing of the sprint settings json. such as setting the sprint override prefix\n\nIn the sprint details we add starting date and ending date aswell as days left, tasks left.\n\n2025-10-22 22:19:35\n---\n\nhitting [x] to navigate to a column with a task list should automatically select the first item in the list\n\n2025-10-24 18:46:58\n---\n\nSomething is still off with the ordering behaviour.\n\nThe ordering doesnt apply at the moment of selecting an ordering. Only after `O` is hit to reverse the ordering the cards seem to align.\n",
+        "due_date": null,
+        "id": "10551177-bbc3-4096-89e7-0c40f324e0b4",
+        "points": 4,
+        "position": 36,
+        "priority": "High",
+        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+            "sprint_name": "an-experience-to-remember",
+            "sprint_number": 6,
+            "started_at": "2025-11-01T09:30:06.155916Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "when sprint completes, dont remove card -> sprint reference",
+        "updated_at": "2025-10-24T22:27:41.749436Z"
+      },
+      {
+        "card_number": 34,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-24T23:04:30.736240Z",
+        "created_at": "2025-10-12T13:37:00.520483Z",
+        "description": "it currently does something else\n",
+        "due_date": null,
+        "id": "475bde99-0a3f-457c-9ea6-2fd51d1d7e73",
+        "points": 1,
+        "position": 36,
+        "priority": "High",
+        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+            "sprint_name": "an-experience-to-remember",
+            "sprint_number": 6,
+            "started_at": "2025-11-01T09:30:06.155912Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "when creating a task. set the cursor/selected task to the new task",
+        "updated_at": "2025-10-24T23:04:30.736240Z"
+      },
+      {
+        "card_number": 81,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-24T23:34:56.856533Z",
+        "created_at": "2025-10-22T15:41:13.773865Z",
+        "description": "2025-10-24 18:51:53\n---\n\nOn card lists that are empty hitting `j` or `k` seems to have no effect. \n\nFirst step\n\nReesearch if this is the case.\n",
+        "due_date": null,
+        "id": "a7b6cf8e-fa26-4625-ad97-18ed6095bca3",
+        "points": 1,
+        "position": 37,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "j / k doesnt work on empty columns",
+        "updated_at": "2025-10-24T23:35:12.094072Z"
+      },
+      {
+        "card_number": 90,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-26T08:17:50.126481Z",
+        "created_at": "2025-10-24T16:50:01.067630Z",
+        "description": "when a board has more than 1 column, moving it from the last column doesnt automatically uncomplete the card.\n\nit should\n\nand moving cards to the last column of a board that has more than 1 column doesnt complete the card\n",
+        "due_date": null,
+        "id": "3191fa04-c7ed-46e2-ae56-aba307f397f0",
+        "points": 1,
+        "position": 37,
+        "priority": "Medium",
+        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+            "sprint_name": "an-experience-to-remember",
+            "sprint_number": 6,
+            "started_at": "2025-11-01T09:30:06.155917Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "moving cards from last column doesnt uncomplete",
+        "updated_at": "2025-10-26T08:17:50.126483Z"
+      },
+      {
         "card_number": 174,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -5116,49 +4719,6 @@
         "status": "Todo",
         "title": "Add User-Visible Save Error Notifications",
         "updated_at": "2026-04-04T23:33:28.989118751Z"
-      },
-      {
-        "card_number": 81,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-24T23:34:56.856533Z",
-        "created_at": "2025-10-22T15:41:13.773865Z",
-        "description": "2025-10-24 18:51:53\n---\n\nOn card lists that are empty hitting `j` or `k` seems to have no effect. \n\nFirst step\n\nReesearch if this is the case.\n",
-        "due_date": null,
-        "id": "a7b6cf8e-fa26-4625-ad97-18ed6095bca3",
-        "points": 1,
-        "position": 37,
-        "priority": "Low",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "j / k doesnt work on empty columns",
-        "updated_at": "2025-10-24T23:35:12.094072Z"
-      },
-      {
-        "card_number": 90,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-26T08:17:50.126481Z",
-        "created_at": "2025-10-24T16:50:01.067630Z",
-        "description": "when a board has more than 1 column, moving it from the last column doesnt automatically uncomplete the card.\n\nit should\n\nand moving cards to the last column of a board that has more than 1 column doesnt complete the card\n",
-        "due_date": null,
-        "id": "3191fa04-c7ed-46e2-ae56-aba307f397f0",
-        "points": 1,
-        "position": 37,
-        "priority": "Medium",
-        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-            "sprint_name": "an-experience-to-remember",
-            "sprint_number": 6,
-            "started_at": "2025-11-01T09:30:06.155917Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "moving cards from last column doesnt uncomplete",
-        "updated_at": "2025-10-26T08:17:50.126483Z"
       },
       {
         "card_number": 175,
@@ -5508,6 +5068,32 @@
         "updated_at": "2025-10-26T11:38:57.923109Z"
       },
       {
+        "card_number": 77,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-27T22:27:09.272122Z",
+        "created_at": "2025-10-21T22:01:25.695703Z",
+        "description": "we can use the file creation date as the time stamp and make sure that the changelog update includes this\n\n",
+        "due_date": null,
+        "id": "00f1e6ee-435a-4f4a-b0d8-29e61e1b184b",
+        "points": 1,
+        "position": 43,
+        "priority": "Low",
+        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+            "sprint_name": "an-experience-to-remember",
+            "sprint_number": 6,
+            "started_at": "2025-11-01T09:30:06.155916Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "changeset script to add timestamp of changeset creation and card name",
+        "updated_at": "2025-10-27T22:27:09.272122Z"
+      },
+      {
         "card_number": 182,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -5548,32 +5134,6 @@
         "status": "Todo",
         "title": "Deduplicate query filter logic",
         "updated_at": "2026-04-04T23:44:57.145432657Z"
-      },
-      {
-        "card_number": 77,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-27T22:27:09.272122Z",
-        "created_at": "2025-10-21T22:01:25.695703Z",
-        "description": "we can use the file creation date as the time stamp and make sure that the changelog update includes this\n\n",
-        "due_date": null,
-        "id": "00f1e6ee-435a-4f4a-b0d8-29e61e1b184b",
-        "points": 1,
-        "position": 43,
-        "priority": "Low",
-        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-            "sprint_name": "an-experience-to-remember",
-            "sprint_number": 6,
-            "started_at": "2025-11-01T09:30:06.155916Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "changeset script to add timestamp of changeset creation and card name",
-        "updated_at": "2025-10-27T22:27:09.272122Z"
       },
       {
         "card_number": 183,
@@ -5644,23 +5204,6 @@
         "updated_at": "2025-10-27T22:27:15.912059Z"
       },
       {
-        "card_number": 104,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-10-30T10:19:35.665590Z",
-        "created_at": "2025-10-30T09:47:43.546359Z",
-        "description": "Putting this card on sleep as i dont have a repro of the case yet\n\nI think we solved this one by just updating the kanban app..\n",
-        "due_date": null,
-        "id": "a7deacc9-f9b0-4732-b2a8-b6af058ab319",
-        "points": 1,
-        "position": 45,
-        "priority": "Low",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "I cant seem to set points with the point setter dialogue anymore",
-        "updated_at": "2025-10-30T10:19:35.665590Z"
-      },
-      {
         "card_number": 184,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -5701,6 +5244,23 @@
         "status": "Todo",
         "title": "Cache branch names in BranchNameSearcher",
         "updated_at": "2026-04-04T23:44:57.192439714Z"
+      },
+      {
+        "card_number": 104,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-10-30T10:19:35.665590Z",
+        "created_at": "2025-10-30T09:47:43.546359Z",
+        "description": "Putting this card on sleep as i dont have a repro of the case yet\n\nI think we solved this one by just updating the kanban app..\n",
+        "due_date": null,
+        "id": "a7deacc9-f9b0-4732-b2a8-b6af058ab319",
+        "points": 1,
+        "position": 45,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "I cant seem to set points with the point setter dialogue anymore",
+        "updated_at": "2025-10-30T10:19:35.665590Z"
       },
       {
         "card_number": 185,
@@ -5745,48 +5305,6 @@
         "updated_at": "2026-04-04T23:44:57.215039759Z"
       },
       {
-        "card_number": 186,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-01-29T20:56:32.551632Z",
-        "description": "**File:** `crates/kanban-domain/src/card.rs:26-33`\n\n`AnimationType` is a UI/presentation concern living in the domain layer. Doc comment says \"visual feedback\", no Serialize/Deserialize derives, only used by TUI layer.\n\nOptions:\n1. Move to `kanban-tui` — cleanest separation\n2. Keep in domain, document rationale — pragmatic, enum is 5 lines with no behavior\n3. Move to `kanban-core` — if considered generic UI primitive like SelectionState/InputState",
-        "due_date": null,
-        "id": "1ee5488a-3c01-42cf-a5f9-b5d432287fcc",
-        "points": 1,
-        "position": 47,
-        "priority": "Low",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": "2026-03-25T00:22:42.743092975Z",
-            "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
-            "sprint_name": "a-new-year",
-            "sprint_number": 11,
-            "started_at": "2026-02-01T19:39:53.166308Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": "2026-04-04T23:33:28.989228799Z",
-            "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
-            "sprint_name": "moonshot",
-            "sprint_number": 12,
-            "started_at": "2026-03-25T00:22:42.743093255Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:33:28.989229064Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Decide on AnimationType placement",
-        "updated_at": "2026-04-04T23:44:57.238528205Z"
-      },
-      {
         "card_number": 110,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-11-01T16:40:40.994998Z",
@@ -5827,6 +5345,48 @@
         "status": "Done",
         "title": "in card metadata. show the sprint log for a card",
         "updated_at": "2025-11-01T16:40:40.994998Z"
+      },
+      {
+        "card_number": 186,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-01-29T20:56:32.551632Z",
+        "description": "**File:** `crates/kanban-domain/src/card.rs:26-33`\n\n`AnimationType` is a UI/presentation concern living in the domain layer. Doc comment says \"visual feedback\", no Serialize/Deserialize derives, only used by TUI layer.\n\nOptions:\n1. Move to `kanban-tui` — cleanest separation\n2. Keep in domain, document rationale — pragmatic, enum is 5 lines with no behavior\n3. Move to `kanban-core` — if considered generic UI primitive like SelectionState/InputState",
+        "due_date": null,
+        "id": "1ee5488a-3c01-42cf-a5f9-b5d432287fcc",
+        "points": 1,
+        "position": 47,
+        "priority": "Low",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": "2026-03-25T00:22:42.743092975Z",
+            "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
+            "sprint_name": "a-new-year",
+            "sprint_number": 11,
+            "started_at": "2026-02-01T19:39:53.166308Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": "2026-04-04T23:33:28.989228799Z",
+            "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
+            "sprint_name": "moonshot",
+            "sprint_number": 12,
+            "started_at": "2026-03-25T00:22:42.743093255Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:33:28.989229064Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Decide on AnimationType placement",
+        "updated_at": "2026-04-04T23:44:57.238528205Z"
       },
       {
         "card_number": 187,
@@ -5913,6 +5473,23 @@
         "updated_at": "2025-11-01T16:55:42.602259Z"
       },
       {
+        "card_number": 105,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-11-02T13:47:50.491755Z",
+        "created_at": "2025-10-30T09:50:19.618937Z",
+        "description": "sprint prefix should be a sprint setting and not a board setting as in the case we lose our sprint prefix after changing it \n\nthe board level sprint prefix setting should be an override for the application level sprint prefix\n\n2025-11-01 17:59:34\n---\n\nwe move sprint prefix from branch settings into sprint level settings so that we can have a sprint prefix per sprint\n\nsprint prefix should be a sprint setting and not a board setting as in the case we lose our sprint prefix after changing it \n\nthe board level sprint prefix setting should be an override for the application level sprint prefix\n\nwe dont have application level prefix yet, we have board and sprint. which are both configured from board settings. I want to move sprint prefix into sprint settings so that it can be unique for each sprint\n\nfallback order for prefix\n\ndefault prefix\n\napplication prefix (doesnt exist)\n\nboard prefix\n\nsprint prefix (configuration to be moved now, both in interface and data)\n\n2025-11-01 22:23:04\n---\n\nI think I made a slight mistake during the design of this addition\n\nthese are all for use with branch names to specific cards. that we got right.\n\nHere are the overrides with example prefixes\n\n```sh\ndefault prefix (DEFAULT)\n\n|\nv\n\n_application settings prefix (APP)_ [future]\n\n|\nv\n\nboard settings sprint prefix (BRANCH)\n\n|\nv\n\nsprint settings prefix (SPRINT)\n```\n\nCreating sprints with just the default prefix yields sprints of\n\n```sh\nsprint-1/first \nsprint-2/second \nsprint-3/third \n```\n\nThen adding branch prefix transforms these into \n\n```sh\nBRANCH-1/first \nBRANCH-2/second \nBRANCH-3/third \n```\n\nThen assigning the first sprint a sprint prefix\n\n```sh\nSPRINT-1/first \nBRANCH-2/second \nBRANCH-3/third \n```\n\nThen creating four cards and assigning them to each sprint\n\n```sh\ntask1 (SPRINT-1/first)\ntask2 (BRANCH-2/second)\ntask3 (BRANCH-3/third)\ntask4 (SPRINT-1/first)\n```\n\nThey get the following branch names\n\n```sh\ngit checkout -b SPRINT-1/task1\ngit checkout -b BRANCH-2/task2\ngit checkout -b BRANCH-3/task3\ngit checkout -b SPRINT-4/task4\n```\n\nThe branch naming sequence isnt unique for each prefix!\n\nIt is a global sequence where as the sequence for the cards should be unique to each\n\nSo. To clarify. There is a couple of sequences going on here.\n\nWe have one sequence for each new sprint of the same prefix.\n\nWe have a seperate sequence for each new card that also uses the sprint prefix.\n\nThere is an unfortunate collision in that the sprint names use the same prefix as the cards.\n\nThis was not supposed to be the case. The sprint prefix we had from before this feature was supposed to give us a way to customize the sprint name for each sprint sequence. we moved this into the sprint level definition. This was good for the tasks. but bad for the sprint sequence. I think we have identified all the issues here above. Can we come up with a good plan for resolution?\n",
+        "due_date": null,
+        "id": "287bab16-a102-4f4b-9aa1-bed70d1f3fbf",
+        "points": 1,
+        "position": 49,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "we probably should move sprint prefix into sprint level settings",
+        "updated_at": "2025-11-02T13:47:50.491755Z"
+      },
+      {
         "card_number": 188,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -5953,23 +5530,6 @@
         "status": "Todo",
         "title": "Remove ListRenderInfo type alias",
         "updated_at": "2026-04-04T23:44:57.292780667Z"
-      },
-      {
-        "card_number": 105,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-02T13:47:50.491755Z",
-        "created_at": "2025-10-30T09:50:19.618937Z",
-        "description": "sprint prefix should be a sprint setting and not a board setting as in the case we lose our sprint prefix after changing it \n\nthe board level sprint prefix setting should be an override for the application level sprint prefix\n\n2025-11-01 17:59:34\n---\n\nwe move sprint prefix from branch settings into sprint level settings so that we can have a sprint prefix per sprint\n\nsprint prefix should be a sprint setting and not a board setting as in the case we lose our sprint prefix after changing it \n\nthe board level sprint prefix setting should be an override for the application level sprint prefix\n\nwe dont have application level prefix yet, we have board and sprint. which are both configured from board settings. I want to move sprint prefix into sprint settings so that it can be unique for each sprint\n\nfallback order for prefix\n\ndefault prefix\n\napplication prefix (doesnt exist)\n\nboard prefix\n\nsprint prefix (configuration to be moved now, both in interface and data)\n\n2025-11-01 22:23:04\n---\n\nI think I made a slight mistake during the design of this addition\n\nthese are all for use with branch names to specific cards. that we got right.\n\nHere are the overrides with example prefixes\n\n```sh\ndefault prefix (DEFAULT)\n\n|\nv\n\n_application settings prefix (APP)_ [future]\n\n|\nv\n\nboard settings sprint prefix (BRANCH)\n\n|\nv\n\nsprint settings prefix (SPRINT)\n```\n\nCreating sprints with just the default prefix yields sprints of\n\n```sh\nsprint-1/first \nsprint-2/second \nsprint-3/third \n```\n\nThen adding branch prefix transforms these into \n\n```sh\nBRANCH-1/first \nBRANCH-2/second \nBRANCH-3/third \n```\n\nThen assigning the first sprint a sprint prefix\n\n```sh\nSPRINT-1/first \nBRANCH-2/second \nBRANCH-3/third \n```\n\nThen creating four cards and assigning them to each sprint\n\n```sh\ntask1 (SPRINT-1/first)\ntask2 (BRANCH-2/second)\ntask3 (BRANCH-3/third)\ntask4 (SPRINT-1/first)\n```\n\nThey get the following branch names\n\n```sh\ngit checkout -b SPRINT-1/task1\ngit checkout -b BRANCH-2/task2\ngit checkout -b BRANCH-3/task3\ngit checkout -b SPRINT-4/task4\n```\n\nThe branch naming sequence isnt unique for each prefix!\n\nIt is a global sequence where as the sequence for the cards should be unique to each\n\nSo. To clarify. There is a couple of sequences going on here.\n\nWe have one sequence for each new sprint of the same prefix.\n\nWe have a seperate sequence for each new card that also uses the sprint prefix.\n\nThere is an unfortunate collision in that the sprint names use the same prefix as the cards.\n\nThis was not supposed to be the case. The sprint prefix we had from before this feature was supposed to give us a way to customize the sprint name for each sprint sequence. we moved this into the sprint level definition. This was good for the tasks. but bad for the sprint sequence. I think we have identified all the issues here above. Can we come up with a good plan for resolution?\n",
-        "due_date": null,
-        "id": "287bab16-a102-4f4b-9aa1-bed70d1f3fbf",
-        "points": 1,
-        "position": 49,
-        "priority": "Low",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "we probably should move sprint prefix into sprint level settings",
-        "updated_at": "2025-11-02T13:47:50.491755Z"
       },
       {
         "card_number": 189,
@@ -6090,6 +5650,32 @@
         "updated_at": "2025-11-02T16:55:43.788200Z"
       },
       {
+        "card_number": 109,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-11-02T16:55:47.218723Z",
+        "created_at": "2025-10-31T18:31:12.437204Z",
+        "description": "I would like to see a dialogue letting me choose which sprint to filter card list by\n",
+        "due_date": null,
+        "id": "1e2b5781-00be-4351-a35e-ec32b86cbb94",
+        "points": 2,
+        "position": 52,
+        "priority": "Medium",
+        "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
+            "sprint_name": "a-hallowed-week",
+            "sprint_number": 7,
+            "started_at": "2025-11-01T09:30:06.155919Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Done",
+        "title": "choose which sprint to filter by",
+        "updated_at": "2025-11-02T16:55:47.218723Z"
+      },
+      {
         "card_number": 191,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -6132,49 +5718,6 @@
         "updated_at": "2026-04-04T23:44:57.379597781Z"
       },
       {
-        "card_number": 109,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-02T16:55:47.218723Z",
-        "created_at": "2025-10-31T18:31:12.437204Z",
-        "description": "I would like to see a dialogue letting me choose which sprint to filter card list by\n",
-        "due_date": null,
-        "id": "1e2b5781-00be-4351-a35e-ec32b86cbb94",
-        "points": 2,
-        "position": 52,
-        "priority": "Medium",
-        "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
-            "sprint_name": "a-hallowed-week",
-            "sprint_number": 7,
-            "started_at": "2025-11-01T09:30:06.155919Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Done",
-        "title": "choose which sprint to filter by",
-        "updated_at": "2025-11-02T16:55:47.218723Z"
-      },
-      {
-        "card_number": 87,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-02T17:00:33.469911Z",
-        "created_at": "2025-10-23T17:59:05.492972Z",
-        "description": "I think we do a select of the viewable sprint\n\neither in the main task list or the board details sprint list.\n\nare able to select the sprint which is viewed in the main task list\n",
-        "due_date": null,
-        "id": "ee315eb4-29f6-4ee7-bb13-e1a71f24bc51",
-        "points": 3,
-        "position": 53,
-        "priority": "Low",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "be able to select another sprint for viewing in the task list",
-        "updated_at": "2025-11-02T17:00:33.469911Z"
-      },
-      {
         "card_number": 192,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -6215,6 +5758,23 @@
         "status": "Todo",
         "title": "Board creation undo/redo loses columns due to split undo entries",
         "updated_at": "2026-04-04T23:44:57.408983492Z"
+      },
+      {
+        "card_number": 87,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-11-02T17:00:33.469911Z",
+        "created_at": "2025-10-23T17:59:05.492972Z",
+        "description": "I think we do a select of the viewable sprint\n\neither in the main task list or the board details sprint list.\n\nare able to select the sprint which is viewed in the main task list\n",
+        "due_date": null,
+        "id": "ee315eb4-29f6-4ee7-bb13-e1a71f24bc51",
+        "points": 3,
+        "position": 53,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "be able to select another sprint for viewing in the task list",
+        "updated_at": "2025-11-02T17:00:33.469911Z"
       },
       {
         "card_number": 195,
@@ -6388,32 +5948,6 @@
         "updated_at": "2026-04-04T23:44:57.487639960Z"
       },
       {
-        "card_number": 200,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-02-02T19:08:59.545866Z",
-        "description": "**From PR #165 review**\\n\\nThe same `parse_datetime` function exists in two places:\\n- `crates/kanban-mcp/src/lib.rs:87-102`\\n- `crates/kanban-cli/src/handlers/sprint.rs:5-18`\\n\\nThese are nearly identical implementations that parse both RFC 3339 and YYYY-MM-DD date formats. Should be extracted to a shared utility in `kanban-domain` or `kanban-core` to avoid drift between the two implementations.",
-        "due_date": null,
-        "id": "1a6eb20a-1228-40d7-b2d4-c92409c3e93b",
-        "points": 1,
-        "position": 57,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856433074Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Extract duplicated parse_datetime into shared utility",
-        "updated_at": "2026-04-04T23:44:57.516093378Z"
-      },
-      {
         "card_number": 120,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-11-03T16:53:08.185660Z",
@@ -6440,30 +5974,30 @@
         "updated_at": "2025-11-03T16:54:24.598198Z"
       },
       {
-        "card_number": 118,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-04T00:22:18.267021Z",
-        "created_at": "2025-11-02T17:01:58.592815Z",
-        "description": "now that we have per sprint filters for the card lists. lets remove the filtering of cards from the card lists\n",
+        "card_number": 200,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-02-02T19:08:59.545866Z",
+        "description": "**From PR #165 review**\\n\\nThe same `parse_datetime` function exists in two places:\\n- `crates/kanban-mcp/src/lib.rs:87-102`\\n- `crates/kanban-cli/src/handlers/sprint.rs:5-18`\\n\\nThese are nearly identical implementations that parse both RFC 3339 and YYYY-MM-DD date formats. Should be extracted to a shared utility in `kanban-domain` or `kanban-core` to avoid drift between the two implementations.",
         "due_date": null,
-        "id": "1d1a3739-8b40-47ec-9d17-90ed952df09c",
+        "id": "1a6eb20a-1228-40d7-b2d4-c92409c3e93b",
         "points": 1,
-        "position": 58,
-        "priority": "Low",
-        "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
+        "position": 57,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
-            "sprint_name": "a-hallowed-week",
-            "sprint_number": 7,
-            "started_at": "2025-11-02T17:02:08.460292Z",
-            "status": "Active"
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856433074Z",
+            "status": "Planning"
           }
         ],
-        "status": "Done",
-        "title": "unfilter tasks list on completed sprint",
-        "updated_at": "2025-11-04T00:22:18.267021Z"
+        "status": "Todo",
+        "title": "Extract duplicated parse_datetime into shared utility",
+        "updated_at": "2026-04-04T23:44:57.516093378Z"
       },
       {
         "card_number": 201,
@@ -6490,6 +6024,32 @@
         "status": "Todo",
         "title": "ArgsBuilder.add_field_str silently ignores FieldUpdate::Clear",
         "updated_at": "2026-04-04T23:44:57.543088871Z"
+      },
+      {
+        "card_number": 118,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-11-04T00:22:18.267021Z",
+        "created_at": "2025-11-02T17:01:58.592815Z",
+        "description": "now that we have per sprint filters for the card lists. lets remove the filtering of cards from the card lists\n",
+        "due_date": null,
+        "id": "1d1a3739-8b40-47ec-9d17-90ed952df09c",
+        "points": 1,
+        "position": 58,
+        "priority": "Low",
+        "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
+            "sprint_name": "a-hallowed-week",
+            "sprint_number": 7,
+            "started_at": "2025-11-02T17:02:08.460292Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "unfilter tasks list on completed sprint",
+        "updated_at": "2025-11-04T00:22:18.267021Z"
       },
       {
         "card_number": 121,
@@ -6544,14 +6104,14 @@
         "updated_at": "2026-04-04T23:44:57.568124444Z"
       },
       {
-        "card_number": 130,
+        "card_number": 111,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-15T00:16:54.870527Z",
-        "created_at": "2025-11-14T23:23:23.503523Z",
-        "description": "2025-11-15 00:23:43\n---\n\nStarting this one out from the unfiltered cards branch.\n\nThere are three card list component implementations. can we add an abstraction for the lists\n\nflat, grouped by column, and kanban view\n\na change to the card list require changes in three places.\n\nno good. lets fix it.\n\n",
+        "completed_at": "2025-11-17T17:05:22.697992Z",
+        "created_at": "2025-11-01T09:32:30.790965Z",
+        "description": "the help text for the sprint binding is showing the incorrect binding\n\nlets unify the help text, the card list and the card details view to use the same source for the sprint assignment bind\n",
         "due_date": null,
-        "id": "f6897495-f5ab-4c68-923f-025758a692fd",
-        "points": 5,
+        "id": "2c56bcac-b562-49f7-9b7d-1296b7c5011c",
+        "points": 2,
         "position": 60,
         "priority": "Low",
         "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
@@ -6561,13 +6121,13 @@
             "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
             "sprint_name": "a-hallowed-week",
             "sprint_number": 7,
-            "started_at": "2025-11-14T23:25:37.440976Z",
-            "status": "Active"
+            "started_at": "2025-11-01T09:33:32.897521Z",
+            "status": "Planning"
           }
         ],
         "status": "Done",
-        "title": "three card list components to become one",
-        "updated_at": "2025-11-15T00:16:54.870527Z"
+        "title": "sprint binding help is wrong",
+        "updated_at": "2025-11-17T17:05:22.698002Z"
       },
       {
         "card_number": 203,
@@ -6596,14 +6156,14 @@
         "updated_at": "2026-04-04T23:44:57.591177155Z"
       },
       {
-        "card_number": 111,
+        "card_number": 130,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-17T17:05:22.697992Z",
-        "created_at": "2025-11-01T09:32:30.790965Z",
-        "description": "the help text for the sprint binding is showing the incorrect binding\n\nlets unify the help text, the card list and the card details view to use the same source for the sprint assignment bind\n",
+        "completed_at": "2025-11-15T00:16:54.870527Z",
+        "created_at": "2025-11-14T23:23:23.503523Z",
+        "description": "2025-11-15 00:23:43\n---\n\nStarting this one out from the unfiltered cards branch.\n\nThere are three card list component implementations. can we add an abstraction for the lists\n\nflat, grouped by column, and kanban view\n\na change to the card list require changes in three places.\n\nno good. lets fix it.\n\n",
         "due_date": null,
-        "id": "2c56bcac-b562-49f7-9b7d-1296b7c5011c",
-        "points": 2,
+        "id": "f6897495-f5ab-4c68-923f-025758a692fd",
+        "points": 5,
         "position": 60,
         "priority": "Low",
         "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
@@ -6613,13 +6173,39 @@
             "sprint_id": "ce752be4-efce-40fe-bfa7-d0b313497feb",
             "sprint_name": "a-hallowed-week",
             "sprint_number": 7,
-            "started_at": "2025-11-01T09:33:32.897521Z",
-            "status": "Planning"
+            "started_at": "2025-11-14T23:25:37.440976Z",
+            "status": "Active"
           }
         ],
         "status": "Done",
-        "title": "sprint binding help is wrong",
-        "updated_at": "2025-11-17T17:05:22.698002Z"
+        "title": "three card list components to become one",
+        "updated_at": "2025-11-15T00:16:54.870527Z"
+      },
+      {
+        "card_number": 24,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-11-17T21:43:28.632944Z",
+        "created_at": "2025-10-11T20:30:09.214394Z",
+        "description": "In the stash somewhere there is a draft of CI\n\nWe have partly done this. Now to expand on what else needs to be done\n\n- [x] publish to crates.io on merge to master\n\nIssue\n---\n\nIt doesnt work to post minor. prob not major either. But patch works!\n\n### Error\n\n```sh\nbuilding '/nix/store/m7ja8jdxv0pnl6i7x6ybfb60abq6jsdx-bump-version.drv'...\nBumping version: 0.1.2 → 0.2.0 (type: minor)\n    Updating crates.io index\nerror: failed to select a version for the requirement `kanban-core = \"^0.1.0\"`\ncandidate versions found which didn't match: 0.2.0\nlocation searched: /home/runner/work/kanban/kanban/crates/kanban-core\nrequired by package `kanban-domain v0.2.0 (/home/runner/work/kanban/kanban/crates/kanban-domain)`\nError: Process completed with exit code 101.\n```\n\n2025-10-15 21:11:16\n---\n\nThere is also the question of wether my versioning is skipping to much. Maybe I should switch to the release branch model where releases are progressively built from feature branches accumulated during the spring\n\nIt doesnt feel so natural to bump the version for every feature branch. I wonder what would be the best strategy..\n",
+        "due_date": null,
+        "id": "1c2f3096-823b-4eb7-9345-b80a4c5d8693",
+        "points": 4,
+        "position": 61,
+        "priority": "Medium",
+        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2025-11-01T09:30:06.155909Z",
+            "status": "Completed"
+          }
+        ],
+        "status": "Done",
+        "title": "Add github ci",
+        "updated_at": "2025-11-17T21:43:28.632944Z"
       },
       {
         "card_number": 204,
@@ -6648,30 +6234,30 @@
         "updated_at": "2026-04-04T23:44:57.619851250Z"
       },
       {
-        "card_number": 24,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-17T21:43:28.632944Z",
-        "created_at": "2025-10-11T20:30:09.214394Z",
-        "description": "In the stash somewhere there is a draft of CI\n\nWe have partly done this. Now to expand on what else needs to be done\n\n- [x] publish to crates.io on merge to master\n\nIssue\n---\n\nIt doesnt work to post minor. prob not major either. But patch works!\n\n### Error\n\n```sh\nbuilding '/nix/store/m7ja8jdxv0pnl6i7x6ybfb60abq6jsdx-bump-version.drv'...\nBumping version: 0.1.2 → 0.2.0 (type: minor)\n    Updating crates.io index\nerror: failed to select a version for the requirement `kanban-core = \"^0.1.0\"`\ncandidate versions found which didn't match: 0.2.0\nlocation searched: /home/runner/work/kanban/kanban/crates/kanban-core\nrequired by package `kanban-domain v0.2.0 (/home/runner/work/kanban/kanban/crates/kanban-domain)`\nError: Process completed with exit code 101.\n```\n\n2025-10-15 21:11:16\n---\n\nThere is also the question of wether my versioning is skipping to much. Maybe I should switch to the release branch model where releases are progressively built from feature branches accumulated during the spring\n\nIt doesnt feel so natural to bump the version for every feature branch. I wonder what would be the best strategy..\n",
+        "card_number": 205,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-02-02T19:09:00.020734Z",
+        "description": "**From PR #165 review**\\n\\nThe integration tests in `crates/kanban-mcp/tests/integration.rs` cover happy paths thoroughly (13 tests for board CRUD, column CRUD, card lifecycle, sprint lifecycle, bulk ops, export/import). However, there are no tests for:\\n\\n- **Invalid UUID handling** — verify parse_uuid returns proper MCP error\\n- **Conflict retries** — verify execute_with_retry actually retries on ConflictDetected\\n- **Timeout behavior** — verify the 30s timeout fires and returns the right error\\n- **Operations on nonexistent entities** — only `board_get_nonexistent` is tested; missing column_get_nonexistent, card_get_nonexistent, sprint_get_nonexistent\\n- **Delete of nonexistent entity** — verify proper error propagation\\n- **Bulk operations with invalid IDs** — partial failure behavior\\n\\nUnit tests cover parser edge cases well (32 tests), but the integration layer needs error path coverage to prevent regressions.",
         "due_date": null,
-        "id": "1c2f3096-823b-4eb7-9345-b80a4c5d8693",
-        "points": 4,
-        "position": 61,
+        "id": "a130134c-08d8-4d56-ab07-e43acba95590",
+        "points": 3,
+        "position": 62,
         "priority": "Medium",
-        "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2025-11-01T09:30:06.155909Z",
-            "status": "Completed"
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856466577Z",
+            "status": "Planning"
           }
         ],
-        "status": "Done",
-        "title": "Add github ci",
-        "updated_at": "2025-11-17T21:43:28.632944Z"
+        "status": "Todo",
+        "title": "MCP integration tests lack error path coverage",
+        "updated_at": "2026-04-04T23:35:37.856467379Z"
       },
       {
         "card_number": 55,
@@ -6706,58 +6292,6 @@
         "status": "Done",
         "title": "Scroll in cards list",
         "updated_at": "2025-11-17T22:38:09.399815Z"
-      },
-      {
-        "card_number": 205,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-02-02T19:09:00.020734Z",
-        "description": "**From PR #165 review**\\n\\nThe integration tests in `crates/kanban-mcp/tests/integration.rs` cover happy paths thoroughly (13 tests for board CRUD, column CRUD, card lifecycle, sprint lifecycle, bulk ops, export/import). However, there are no tests for:\\n\\n- **Invalid UUID handling** — verify parse_uuid returns proper MCP error\\n- **Conflict retries** — verify execute_with_retry actually retries on ConflictDetected\\n- **Timeout behavior** — verify the 30s timeout fires and returns the right error\\n- **Operations on nonexistent entities** — only `board_get_nonexistent` is tested; missing column_get_nonexistent, card_get_nonexistent, sprint_get_nonexistent\\n- **Delete of nonexistent entity** — verify proper error propagation\\n- **Bulk operations with invalid IDs** — partial failure behavior\\n\\nUnit tests cover parser edge cases well (32 tests), but the integration layer needs error path coverage to prevent regressions.",
-        "due_date": null,
-        "id": "a130134c-08d8-4d56-ab07-e43acba95590",
-        "points": 3,
-        "position": 62,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856466577Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "MCP integration tests lack error path coverage",
-        "updated_at": "2026-04-04T23:35:37.856467379Z"
-      },
-      {
-        "card_number": 206,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-02-02T19:09:00.120396Z",
-        "description": "**From PR #165 review**\\n\\nIn `crates/kanban-mcp/src/context.rs:544-554`:\\n\\n```rust\\nlet tmp = tempfile::NamedTempFile::new()?;\\nstd::fs::write(tmp.path(), data)?;\\nlet path_str = tmp.path().to_string_lossy().to_string();\\nself.executor.execute_with_retry(&[\\\"import\\\", \\\"--file\\\", &path_str])\\n// tmp is dropped here, deleting the file\\n```\\n\\nThe `NamedTempFile` is dropped at end of function scope. Since `execute_with_retry` is synchronous and blocks until the CLI process completes, the file should still exist when read. However:\\n\\n1. If retry logic kicks in (conflict), the file could be read multiple times — which is fine since `NamedTempFile` isn't dropped until after all retries.\\n2. On some platforms, if the OS delays process cleanup, there could theoretically be a race.\\n\\nSafer alternative: use `tmp.into_temp_path()` or explicitly hold the handle, or pass data via stdin instead of a temp file.",
-        "due_date": null,
-        "id": "071f9152-1f2e-4ca8-85f1-795856751c0b",
-        "points": 2,
-        "position": 63,
-        "priority": "Low",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856377482Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Potential race in import_board temp file lifetime",
-        "updated_at": "2026-04-04T23:44:57.648621021Z"
       },
       {
         "card_number": 32,
@@ -6852,6 +6386,32 @@
         "updated_at": "2025-11-17T22:43:16.414879Z"
       },
       {
+        "card_number": 206,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-02-02T19:09:00.120396Z",
+        "description": "**From PR #165 review**\\n\\nIn `crates/kanban-mcp/src/context.rs:544-554`:\\n\\n```rust\\nlet tmp = tempfile::NamedTempFile::new()?;\\nstd::fs::write(tmp.path(), data)?;\\nlet path_str = tmp.path().to_string_lossy().to_string();\\nself.executor.execute_with_retry(&[\\\"import\\\", \\\"--file\\\", &path_str])\\n// tmp is dropped here, deleting the file\\n```\\n\\nThe `NamedTempFile` is dropped at end of function scope. Since `execute_with_retry` is synchronous and blocks until the CLI process completes, the file should still exist when read. However:\\n\\n1. If retry logic kicks in (conflict), the file could be read multiple times — which is fine since `NamedTempFile` isn't dropped until after all retries.\\n2. On some platforms, if the OS delays process cleanup, there could theoretically be a race.\\n\\nSafer alternative: use `tmp.into_temp_path()` or explicitly hold the handle, or pass data via stdin instead of a temp file.",
+        "due_date": null,
+        "id": "071f9152-1f2e-4ca8-85f1-795856751c0b",
+        "points": 2,
+        "position": 63,
+        "priority": "Low",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856377482Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Potential race in import_board temp file lifetime",
+        "updated_at": "2026-04-04T23:44:57.648621021Z"
+      },
+      {
         "card_number": 60,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-11-17T22:43:18.585541Z",
@@ -6876,32 +6436,6 @@
         "status": "Done",
         "title": "moving cards out of complete column doesnt unmark the card as complete",
         "updated_at": "2025-11-17T22:43:18.585541Z"
-      },
-      {
-        "card_number": 211,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-02-18T17:44:47.098855315Z",
-        "description": "The MCP seems to be lacking the graph implementation\n\nHow can we align the tui and the mcp to implement the interface?\n",
-        "due_date": null,
-        "id": "7d0b4c31-b762-4701-989d-86e699f23ddd",
-        "points": 4,
-        "position": 64,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856386301Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "MCP Lacks graph implementation",
-        "updated_at": "2026-04-04T23:44:57.699195623Z"
       },
       {
         "card_number": 14,
@@ -6930,6 +6464,32 @@
         "updated_at": "2025-11-26T23:26:45.563647Z"
       },
       {
+        "card_number": 211,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-02-18T17:44:47.098855315Z",
+        "description": "The MCP seems to be lacking the graph implementation\n\nHow can we align the tui and the mcp to implement the interface?\n",
+        "due_date": null,
+        "id": "7d0b4c31-b762-4701-989d-86e699f23ddd",
+        "points": 4,
+        "position": 64,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856386301Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "MCP Lacks graph implementation",
+        "updated_at": "2026-04-04T23:44:57.699195623Z"
+      },
+      {
         "card_number": 212,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -6954,6 +6514,23 @@
         "status": "Todo",
         "title": "Sprint names opt in",
         "updated_at": "2026-04-04T23:44:57.730640026Z"
+      },
+      {
+        "card_number": 132,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-11-17T22:45:25.590979Z",
+        "created_at": "2025-11-17T22:29:29.221286Z",
+        "description": null,
+        "due_date": null,
+        "id": "b03b1ea7-cf2b-4ce0-b3e0-aca8cfded23b",
+        "points": null,
+        "position": 65,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "urgent migrations",
+        "updated_at": "2025-11-17T22:45:25.590982Z"
       },
       {
         "card_number": 53,
@@ -6996,23 +6573,6 @@
         "status": "Done",
         "title": "pressing t then T always leads to an empty tasks list",
         "updated_at": "2025-11-27T00:41:37.400235Z"
-      },
-      {
-        "card_number": 132,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-17T22:45:25.590979Z",
-        "created_at": "2025-11-17T22:29:29.221286Z",
-        "description": null,
-        "due_date": null,
-        "id": "b03b1ea7-cf2b-4ce0-b3e0-aca8cfded23b",
-        "points": null,
-        "position": 65,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "urgent migrations",
-        "updated_at": "2025-11-17T22:45:25.590982Z"
       },
       {
         "card_number": 209,
@@ -7058,32 +6618,6 @@
         "updated_at": "2025-11-27T21:18:12.788856Z"
       },
       {
-        "card_number": 40,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-27T21:20:31.743113Z",
-        "created_at": "2025-10-12T15:45:29.530124Z",
-        "description": "Replicate the board details editing in the card details metadata\n\nOpen in subset of the JSON and edit those field and then after save update only that subset\n\n2025-10-30 19:48:40\n---\n\nthis seems out yeah\n\n",
-        "due_date": null,
-        "id": "ff2085d5-9304-423d-8169-6d3fb2a509d9",
-        "points": 3,
-        "position": 67,
-        "priority": "Critical",
-        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
-            "sprint_name": "an-experience-to-remember",
-            "sprint_number": 6,
-            "started_at": "2025-11-01T09:30:06.155913Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "Make card meta data editing like board settings edit",
-        "updated_at": "2025-11-27T21:20:31.743113Z"
-      },
-      {
         "card_number": 212,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -7110,21 +6644,30 @@
         "updated_at": "2026-04-04T23:44:57.795422883Z"
       },
       {
-        "card_number": 51,
+        "card_number": 40,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-11-27T21:20:53.581479Z",
-        "created_at": "2025-10-14T21:25:48.820829Z",
-        "description": "Any tests that are defined next to source code should be moved into their own files\n\non hold. raise this again if wanted\n",
+        "completed_at": "2025-11-27T21:20:31.743113Z",
+        "created_at": "2025-10-12T15:45:29.530124Z",
+        "description": "Replicate the board details editing in the card details metadata\n\nOpen in subset of the JSON and edit those field and then after save update only that subset\n\n2025-10-30 19:48:40\n---\n\nthis seems out yeah\n\n",
         "due_date": null,
-        "id": "a1576713-adde-4b20-9e28-ecb08226f8a7",
-        "points": 1,
-        "position": 68,
-        "priority": "Low",
-        "sprint_id": null,
-        "sprint_logs": [],
+        "id": "ff2085d5-9304-423d-8169-6d3fb2a509d9",
+        "points": 3,
+        "position": 67,
+        "priority": "Critical",
+        "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "737b04e6-52e2-4a40-bbaa-e2c9bcc84249",
+            "sprint_name": "an-experience-to-remember",
+            "sprint_number": 6,
+            "started_at": "2025-11-01T09:30:06.155913Z",
+            "status": "Active"
+          }
+        ],
         "status": "Done",
-        "title": "move in source test functions so spec files",
-        "updated_at": "2025-11-27T21:20:53.581479Z"
+        "title": "Make card meta data editing like board settings edit",
+        "updated_at": "2025-11-27T21:20:31.743113Z"
       },
       {
         "card_number": 213,
@@ -7151,6 +6694,23 @@
         "status": "Todo",
         "title": "Refactor TUI card list to use CardSummary and PaginatedList",
         "updated_at": "2026-04-04T23:44:57.820691064Z"
+      },
+      {
+        "card_number": 51,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-11-27T21:20:53.581479Z",
+        "created_at": "2025-10-14T21:25:48.820829Z",
+        "description": "Any tests that are defined next to source code should be moved into their own files\n\non hold. raise this again if wanted\n",
+        "due_date": null,
+        "id": "a1576713-adde-4b20-9e28-ecb08226f8a7",
+        "points": 1,
+        "position": 68,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "move in source test functions so spec files",
+        "updated_at": "2025-11-27T21:20:53.581479Z"
       },
       {
         "card_number": 133,
@@ -7273,32 +6833,6 @@
         "updated_at": "2025-12-04T21:59:09.071233Z"
       },
       {
-        "card_number": 228,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-22T22:03:03.499520786Z",
-        "description": "With kanban-service extracted, kanban-mcp no longer depends on kanban-cli, removing the original reason for the optional tui feature flag. Audit and clean up all related infrastructure:\n\n- Remove build-no-tui CI job (no longer tests a meaningful build path)\n- Remove the tui optional feature from kanban-cli (make TUI mandatory or drop the flag entirely)\n- Audit Nix build expressions for any no-tui / headless configurations\n- Audit Argo workflows/manifests for references to the no-tui build",
-        "due_date": null,
-        "id": "210bb7c2-3abc-4dc2-a060-4b22a3eb7724",
-        "points": 2,
-        "position": 71,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856410577Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Clean up build, CI, Nix, and Argo configs",
-        "updated_at": "2026-04-04T23:44:57.989400154Z"
-      },
-      {
         "card_number": 95,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-12-04T22:30:44.543435Z",
@@ -7325,30 +6859,30 @@
         "updated_at": "2025-12-04T22:31:39.181361Z"
       },
       {
-        "card_number": 124,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-12-04T22:36:45.823045Z",
-        "created_at": "2025-11-03T17:02:21.943472Z",
-        "description": "for the long card lists\n\nit would be beneficial to use `{` and `}` vim style bindings to skip sections. for now the grouped by columns flats list seems to be the best use of this bind\n\n2025-12-04 23:35:24\n---\n\nThis was done and I think I ended up pretty satisfied with it\n",
+        "card_number": 228,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-03-22T22:03:03.499520786Z",
+        "description": "With kanban-service extracted, kanban-mcp no longer depends on kanban-cli, removing the original reason for the optional tui feature flag. Audit and clean up all related infrastructure:\n\n- Remove build-no-tui CI job (no longer tests a meaningful build path)\n- Remove the tui optional feature from kanban-cli (make TUI mandatory or drop the flag entirely)\n- Audit Nix build expressions for any no-tui / headless configurations\n- Audit Argo workflows/manifests for references to the no-tui build",
         "due_date": null,
-        "id": "08be2710-da5a-4f32-9407-42de26969de1",
-        "points": 3,
-        "position": 72,
+        "id": "210bb7c2-3abc-4dc2-a060-4b22a3eb7724",
+        "points": 2,
+        "position": 71,
         "priority": "Medium",
-        "sprint_id": "98901eb9-91ab-43aa-8f82-b2a0b42c03cd",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "a61d4a55-5870-4493-9015-9854d8f583cf",
-            "sprint_name": "progression-is-progress",
-            "sprint_number": 8,
-            "started_at": "2025-11-17T22:46:16.108009Z",
-            "status": "Active"
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856410577Z",
+            "status": "Planning"
           }
         ],
-        "status": "Done",
-        "title": "implement { and } bindings",
-        "updated_at": "2025-12-04T22:36:45.823045Z"
+        "status": "Todo",
+        "title": "Clean up build, CI, Nix, and Argo configs",
+        "updated_at": "2026-04-04T23:44:57.989400154Z"
       },
       {
         "card_number": 227,
@@ -7377,6 +6911,32 @@
         "updated_at": "2026-04-04T23:44:57.950525247Z"
       },
       {
+        "card_number": 124,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-12-04T22:36:45.823045Z",
+        "created_at": "2025-11-03T17:02:21.943472Z",
+        "description": "for the long card lists\n\nit would be beneficial to use `{` and `}` vim style bindings to skip sections. for now the grouped by columns flats list seems to be the best use of this bind\n\n2025-12-04 23:35:24\n---\n\nThis was done and I think I ended up pretty satisfied with it\n",
+        "due_date": null,
+        "id": "08be2710-da5a-4f32-9407-42de26969de1",
+        "points": 3,
+        "position": 72,
+        "priority": "Medium",
+        "sprint_id": "98901eb9-91ab-43aa-8f82-b2a0b42c03cd",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "a61d4a55-5870-4493-9015-9854d8f583cf",
+            "sprint_name": "progression-is-progress",
+            "sprint_number": 8,
+            "started_at": "2025-11-17T22:46:16.108009Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "implement { and } bindings",
+        "updated_at": "2025-12-04T22:36:45.823045Z"
+      },
+      {
         "card_number": 125,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-12-04T22:36:48.606503Z",
@@ -7401,58 +6961,6 @@
         "status": "Done",
         "title": "implement `g` and `G` bindings",
         "updated_at": "2025-12-04T22:36:48.606504Z"
-      },
-      {
-        "card_number": 229,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-22T23:28:28.451012014Z",
-        "description": "kanban-service was missing from publish-crates.sh and kanban-mcp was listed before it. Fixed dependency order so kanban-service is published before kanban-mcp.",
-        "due_date": null,
-        "id": "248ecbc5-0ff9-43ca-9f6c-5ca66da55a0d",
-        "points": 1,
-        "position": 73,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856511404Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Fix publish-crates order: add kanban-service before kanban-mcp",
-        "updated_at": "2026-04-04T23:44:58.024691286Z"
-      },
-      {
-        "card_number": 234,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-25T23:26:46.166427431Z",
-        "description": "## Context\n\nKAN-216 added per-card ### grouping to CHANGELOG.md. Each bullet point is a commit subject line, but there is no link back to the actual commit on GitHub.\n\n## Current output\n\n### KAN-193 Bring MCP to full feature parity (2026-03-17)\n- feat: update MCP server tools for full CLI parity\n- feat: bring MCP context to full parity with CLI\n\n## Expected output\n\n### KAN-193 Bring MCP to full feature parity (2026-03-17)\n- feat: update MCP server tools for full CLI parity ([abc1234](https://github.com/owner/repo/commit/abc1234))\n- feat: bring MCP context to full parity with CLI ([def5678](https://github.com/owner/repo/commit/def5678))\n\n## Approach\n\nModify create-changeset.sh to capture commit hashes alongside subjects. Instead of:\n  git log ... --pretty=format:\"- %s\"\nUse:\n  git log ... --pretty=format:\"- %s (%H)\"\n\nThen in aggregate-changelog.sh, after deriving the repo URL (already done for PR links), replace bare hashes at end of bullet lines with Markdown links. Short hash (7 chars) shown in label.\n\n## Acceptance criteria\n\n- create-changeset.sh stores full commit hash alongside each subject line\n- aggregate-changelog.sh converts hashes to GitHub commit links using remote URL\n- Legacy changeset files without hashes are handled gracefully (lines left unchanged)\n- Short hash (7 chars) is shown in the link label",
-        "due_date": null,
-        "id": "c8a2272a-cda8-4e7f-bac2-47bd90edf41c",
-        "points": 2,
-        "position": 74,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856474296Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Add commit links to CHANGELOG entries",
-        "updated_at": "2026-04-04T23:35:37.856475133Z"
       },
       {
         "card_number": 67,
@@ -7497,6 +7005,49 @@
         "updated_at": "2025-12-04T22:37:18.340275Z"
       },
       {
+        "card_number": 234,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-03-25T23:26:46.166427431Z",
+        "description": "## Context\n\nKAN-216 added per-card ### grouping to CHANGELOG.md. Each bullet point is a commit subject line, but there is no link back to the actual commit on GitHub.\n\n## Current output\n\n### KAN-193 Bring MCP to full feature parity (2026-03-17)\n- feat: update MCP server tools for full CLI parity\n- feat: bring MCP context to full parity with CLI\n\n## Expected output\n\n### KAN-193 Bring MCP to full feature parity (2026-03-17)\n- feat: update MCP server tools for full CLI parity ([abc1234](https://github.com/owner/repo/commit/abc1234))\n- feat: bring MCP context to full parity with CLI ([def5678](https://github.com/owner/repo/commit/def5678))\n\n## Approach\n\nModify create-changeset.sh to capture commit hashes alongside subjects. Instead of:\n  git log ... --pretty=format:\"- %s\"\nUse:\n  git log ... --pretty=format:\"- %s (%H)\"\n\nThen in aggregate-changelog.sh, after deriving the repo URL (already done for PR links), replace bare hashes at end of bullet lines with Markdown links. Short hash (7 chars) shown in label.\n\n## Acceptance criteria\n\n- create-changeset.sh stores full commit hash alongside each subject line\n- aggregate-changelog.sh converts hashes to GitHub commit links using remote URL\n- Legacy changeset files without hashes are handled gracefully (lines left unchanged)\n- Short hash (7 chars) is shown in the link label",
+        "due_date": null,
+        "id": "c8a2272a-cda8-4e7f-bac2-47bd90edf41c",
+        "points": 2,
+        "position": 74,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856474296Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Add commit links to CHANGELOG entries",
+        "updated_at": "2026-04-04T23:35:37.856475133Z"
+      },
+      {
+        "card_number": 145,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-12-04T23:05:56.834091Z",
+        "created_at": "2025-12-04T22:39:36.658299Z",
+        "description": "Hitting `e` from the task list, on a card doesnt update its description\n\nI think this is also how we saw a conflict with the own instance\n\n2025-12-05 00:05:28\n---\n\nPatch applied\n\nWe add the pause call in the queue snapshot and resume after save\n",
+        "due_date": null,
+        "id": "abcdf9ab-c39e-4a65-a6b4-ba7828f6eae5",
+        "points": 5,
+        "position": 75,
+        "priority": "Critical",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "We broke the file watcher / having a conflict with one instance",
+        "updated_at": "2025-12-04T23:05:56.834093Z"
+      },
+      {
         "card_number": 239,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -7521,23 +7072,6 @@
         "status": "Todo",
         "title": "Replace KanbanError::Internal with panics for invariant violations",
         "updated_at": "2026-04-04T23:44:58.163134569Z"
-      },
-      {
-        "card_number": 145,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-12-04T23:05:56.834091Z",
-        "created_at": "2025-12-04T22:39:36.658299Z",
-        "description": "Hitting `e` from the task list, on a card doesnt update its description\n\nI think this is also how we saw a conflict with the own instance\n\n2025-12-05 00:05:28\n---\n\nPatch applied\n\nWe add the pause call in the queue snapshot and resume after save\n",
-        "due_date": null,
-        "id": "abcdf9ab-c39e-4a65-a6b4-ba7828f6eae5",
-        "points": 5,
-        "position": 75,
-        "priority": "Critical",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "We broke the file watcher / having a conflict with one instance",
-        "updated_at": "2025-12-04T23:05:56.834093Z"
       },
       {
         "card_number": 147,
@@ -7977,6 +7511,23 @@
         "updated_at": "2025-12-19T21:39:10.303390Z"
       },
       {
+        "card_number": 150,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-12-19T21:39:13.850088Z",
+        "created_at": "2025-12-16T02:04:22.114571Z",
+        "description": "There is a bug with starting the app and providing a file path to a non existant file\n",
+        "due_date": null,
+        "id": "da91abfd-e6bf-4a62-968c-24368f8b78bc",
+        "points": 2,
+        "position": 84,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "file path to a non existant file crashes the app",
+        "updated_at": "2025-12-19T21:39:13.850088Z"
+      },
+      {
         "card_number": 247,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -8003,21 +7554,21 @@
         "updated_at": "2026-04-04T23:44:58.447940983Z"
       },
       {
-        "card_number": 150,
+        "card_number": 146,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-12-19T21:39:13.850088Z",
-        "created_at": "2025-12-16T02:04:22.114571Z",
-        "description": "There is a bug with starting the app and providing a file path to a non existant file\n",
+        "completed_at": "2025-12-19T21:39:21.518507Z",
+        "created_at": "2025-12-04T23:03:58.581895Z",
+        "description": "Create an mcp server.\n\nDepends on kanban cli?\n\n",
         "due_date": null,
-        "id": "da91abfd-e6bf-4a62-968c-24368f8b78bc",
-        "points": 2,
-        "position": 84,
+        "id": "b8d92ecb-1f96-4d5d-8c37-18f13a31497b",
+        "points": 3,
+        "position": 85,
         "priority": "Medium",
         "sprint_id": null,
         "sprint_logs": [],
         "status": "Done",
-        "title": "file path to a non existant file crashes the app",
-        "updated_at": "2025-12-19T21:39:13.850088Z"
+        "title": "Kanban MCP",
+        "updated_at": "2025-12-19T21:39:21.518507Z"
       },
       {
         "card_number": 248,
@@ -8044,23 +7595,6 @@
         "status": "Todo",
         "title": "Use consistent lookup pattern in MoveCard column check",
         "updated_at": "2026-04-04T23:44:58.474995393Z"
-      },
-      {
-        "card_number": 146,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-12-19T21:39:21.518507Z",
-        "created_at": "2025-12-04T23:03:58.581895Z",
-        "description": "Create an mcp server.\n\nDepends on kanban cli?\n\n",
-        "due_date": null,
-        "id": "b8d92ecb-1f96-4d5d-8c37-18f13a31497b",
-        "points": 3,
-        "position": 85,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Kanban MCP",
-        "updated_at": "2025-12-19T21:39:21.518507Z"
       },
       {
         "card_number": 249,
@@ -8106,23 +7640,6 @@
         "updated_at": "2025-12-19T23:37:15.162391Z"
       },
       {
-        "card_number": 151,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2025-12-19T23:40:03.832086Z",
-        "created_at": "2025-12-17T00:57:48.068843Z",
-        "description": "2025-12-17 01:58:29\n---\n\nThe time has come.\n\nIt is time to initiate the kanban cli for command line kanbanning\n\nOur first order of business is to look for abstraction oppurtunity and general cleanup of the codebase so that we can reuse functions in both the tui and the cli. And eventual api or whatever consumer we wish.\n\n---\n\nThe goal of this feature is to have a cli matching the abilities of the tui\n",
-        "due_date": null,
-        "id": "89f6cb27-161b-496a-8736-e7467e8c48a9",
-        "points": null,
-        "position": 87,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "kanban cli",
-        "updated_at": "2025-12-19T23:40:03.832087Z"
-      },
-      {
         "card_number": 250,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -8147,6 +7664,23 @@
         "status": "Todo",
         "title": "Replace unwrap_or_default with required_str in SQLite upserts",
         "updated_at": "2026-04-04T23:44:58.529819733Z"
+      },
+      {
+        "card_number": 151,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2025-12-19T23:40:03.832086Z",
+        "created_at": "2025-12-17T00:57:48.068843Z",
+        "description": "2025-12-17 01:58:29\n---\n\nThe time has come.\n\nIt is time to initiate the kanban cli for command line kanbanning\n\nOur first order of business is to look for abstraction oppurtunity and general cleanup of the codebase so that we can reuse functions in both the tui and the cli. And eventual api or whatever consumer we wish.\n\n---\n\nThe goal of this feature is to have a cli matching the abilities of the tui\n",
+        "due_date": null,
+        "id": "89f6cb27-161b-496a-8736-e7467e8c48a9",
+        "points": null,
+        "position": 87,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "kanban cli",
+        "updated_at": "2025-12-19T23:40:03.832087Z"
       },
       {
         "card_number": 128,
@@ -8285,32 +7819,6 @@
         "updated_at": "2026-04-04T23:44:58.595348725Z"
       },
       {
-        "card_number": 253,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-29T23:41:00.196647244Z",
-        "description": "sync_table builds DELETE FROM x WHERE id NOT IN (?, ?...) with one placeholder per entity. Default limit is 999. Chunk deletes or use a temp table for large datasets.",
-        "due_date": null,
-        "id": "9575c91c-a5ad-4684-942a-0a0356817343",
-        "points": 2,
-        "position": 90,
-        "priority": "Low",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856396416Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Chunk sync_table deletes to avoid SQLITE_LIMIT_VARIABLE_NUMBER",
-        "updated_at": "2026-04-04T23:44:58.623542457Z"
-      },
-      {
         "card_number": 20,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2025-12-19T23:42:20.064240Z",
@@ -8361,15 +7869,15 @@
         "updated_at": "2025-12-19T23:42:20.064240Z"
       },
       {
-        "card_number": 254,
+        "card_number": 253,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
-        "created_at": "2026-03-29T23:41:01.196398430Z",
-        "description": "Currently dispatch priority is determined by factory registration order. Add a numeric priority field to StoreFactory to make this explicit and less fragile.",
+        "created_at": "2026-03-29T23:41:00.196647244Z",
+        "description": "sync_table builds DELETE FROM x WHERE id NOT IN (?, ?...) with one placeholder per entity. Default limit is 999. Chunk deletes or use a temp table for large datasets.",
         "due_date": null,
-        "id": "3afd25ac-95ca-423e-b13d-89c856d0fdb1",
+        "id": "9575c91c-a5ad-4684-942a-0a0356817343",
         "points": 2,
-        "position": 91,
+        "position": 90,
         "priority": "Low",
         "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
@@ -8378,13 +7886,13 @@
             "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
             "sprint_name": "a-catchy-spring",
             "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856459038Z",
+            "started_at": "2026-04-04T23:35:37.856396416Z",
             "status": "Planning"
           }
         ],
         "status": "Todo",
-        "title": "Make StoreRegistry priority explicit instead of registration order",
-        "updated_at": "2026-04-04T23:44:58.651973193Z"
+        "title": "Chunk sync_table deletes to avoid SQLITE_LIMIT_VARIABLE_NUMBER",
+        "updated_at": "2026-04-04T23:44:58.623542457Z"
       },
       {
         "card_number": 129,
@@ -8419,6 +7927,32 @@
         "status": "Done",
         "title": "include commit hash in -V",
         "updated_at": "2025-12-20T00:10:54.557845Z"
+      },
+      {
+        "card_number": 254,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-03-29T23:41:01.196398430Z",
+        "description": "Currently dispatch priority is determined by factory registration order. Add a numeric priority field to StoreFactory to make this explicit and less fragile.",
+        "due_date": null,
+        "id": "3afd25ac-95ca-423e-b13d-89c856d0fdb1",
+        "points": 2,
+        "position": 91,
+        "priority": "Low",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856459038Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Make StoreRegistry priority explicit instead of registration order",
+        "updated_at": "2026-04-04T23:44:58.651973193Z"
       },
       {
         "card_number": 255,
@@ -8636,32 +8170,6 @@
         "updated_at": "2025-12-23T00:37:14.657061Z"
       },
       {
-        "card_number": 267,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-31T01:21:07.816718755Z",
-        "description": "The import is duplicated in both handle() and default_output_path() function bodies. Move it to module level. Ref: PR #205 review.",
-        "due_date": null,
-        "id": "82a2447d-7478-457a-9ddb-9a7212203b99",
-        "points": 1,
-        "position": 96,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856408515Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Move use std::path::Path to module level in migrate handler",
-        "updated_at": "2026-04-04T23:44:58.924533686Z"
-      },
-      {
         "card_number": 6,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-01-09T01:11:28.387265Z",
@@ -8710,6 +8218,58 @@
         "status": "Done",
         "title": "Card dependencies",
         "updated_at": "2026-01-09T01:11:28.387265Z"
+      },
+      {
+        "card_number": 267,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-03-31T01:21:07.816718755Z",
+        "description": "The import is duplicated in both handle() and default_output_path() function bodies. Move it to module level. Ref: PR #205 review.",
+        "due_date": null,
+        "id": "82a2447d-7478-457a-9ddb-9a7212203b99",
+        "points": 1,
+        "position": 96,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856408515Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Move use std::path::Path to module level in migrate handler",
+        "updated_at": "2026-04-04T23:44:58.924533686Z"
+      },
+      {
+        "card_number": 265,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-03-31T00:50:20.386898562Z",
+        "description": "## Problem\n\n`TuiContext` maintains its own parallel domain state (`boards`, `columns`, `cards`, `archived_cards`, `sprints`, `graph`) and reimplements the entire `KanbanOperations` trait with 650+ lines of hand-rolled command construction and state reading. Both CLI (`CliContext`) and MCP (`McpContext`) instead wrap `KanbanContext` and delegate all operations in ~5 lines per method. The TUI should follow the same pattern.\n\nAdditionally, `StateManager` creates its own store via `kanban_service::make_store()` and has a `execute_with_context()` method that manually builds a `CommandContext` from individual mutable refs — this is redundant now that `KanbanContext.execute()` does the same thing.\n\n## Solution\n\nAfter KAN-264 lifts undo/redo into `KanbanContext`, refactor the TUI to delegate to it.\n\n## Changes Required\n\n### 1. Rewrite `TuiContext` to wrap `KanbanContext`\n\n**File:** `crates/kanban-tui/src/tui_context.rs` (currently 653 lines → ~150 lines)\n\nReplace parallel state:\n```rust\n// BEFORE\npub struct TuiContext {\n    pub boards: Vec<Board>,\n    pub columns: Vec<Column>,\n    pub cards: Vec<Card>,\n    pub archived_cards: Vec<ArchivedCard>,\n    pub sprints: Vec<Sprint>,\n    pub graph: DependencyGraph,\n    pub state_manager: StateManager,\n}\n\n// AFTER\npub struct TuiContext {\n    pub inner: KanbanContext,\n    pub state_manager: StateManager,\n}\n```\n\nNew constructor — store created externally, passed to both KanbanContext and StateManager:\n```rust\npub fn new(save_file: Option<String>) -> KanbanResult<(Self, ...)> {\n    let (store, state_manager, save_rx, completion_rx) = if let Some(ref path) = save_file {\n        let store = kanban_service::make_store(path)?;\n        let (sm, rx, crx) = StateManager::new(Some(store.clone()))?;\n        (Some(store), sm, Some(rx), Some(crx))\n    } else { ... };\n    let inner = if let Some(s) = store {\n        KanbanContext::empty(s)\n    } else { ... };\n    Ok((Self { inner, state_manager }, save_rx, completion_rx))\n}\n```\n\nKanbanOperations delegation with save queuing via helper:\n```rust\nfn with_save<F, R>(&mut self, f: F) -> KanbanResult<R>\nwhere F: FnOnce(&mut KanbanContext) -> KanbanResult<R> {\n    let result = f(&mut self.inner)?;\n    // KanbanContext.execute() already captured undo snapshot internally\n    let snapshot = Snapshot::from_context(&self.inner);\n    self.state_manager.queue_snapshot(snapshot);\n    Ok(result)\n}\n\n// Each mutating method becomes a one-liner:\nfn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {\n    self.with_save(|ctx| ctx.create_board(name, card_prefix))\n}\n\n// Read-only methods are direct delegation:\nfn list_boards(&self) -> KanbanResult<Vec<Board>> { self.inner.list_boards() }\n```\n\n### 2. Simplify `StateManager`\n\n**File:** `crates/kanban-tui/src/state/mod.rs`\n\n- **Remove** `execute_with_context()` and `execute()` methods (KanbanContext handles command execution)\n- **Remove** `create_store()` private method\n- **Change** `StateManager::new()` to accept `Option<Arc<dyn PersistenceStore>>` instead of `Option<String>`\n- **Keep** all of: `capture_before_command`, `queue_snapshot`, `save_completed`, `has_pending_saves`, `is_dirty`, `mark_dirty`, `mark_clean`, `clear_history`, `can_undo`, `can_redo`, `history_mut`, `set_file_watcher`, `force_overwrite`, `reload_from_disk`, `close_save_channel`, `store()`, `instance_id()`\n- **Update** `reload_from_disk` to use `KanbanContext::reload()` or `apply_snapshot()` instead of `Snapshot::apply_to_app`\n\n### 3. Update field accesses (mechanical bulk change)\n\n~262 references across ~15 files: `ctx.boards` → `ctx.inner.boards` (same for columns, cards, sprints, archived_cards, graph)\n\n**Affected files by reference count:**\n| File | ~Refs |\n|------|-------|\n| `app/mod.rs` | 58 |\n| `handlers/detail_view_handlers.rs` | 47 |\n| `handlers/card_handlers.rs` | 33 |\n| `ui.rs` | 26 |\n| `handlers/popup_handlers.rs` | 19 |\n| `handlers/dialog_handlers.rs` | 11 |\n| `handlers/sprint_handlers.rs` | 11 |\n| `handlers/column_handlers.rs` | 11 |\n| `components/selection_dialog.rs` | 7 |\n| `handlers/board_handlers.rs` | 6 |\n| `handlers/navigation_handlers.rs` | 6 |\n| `render_strategy.rs` | 6 |\n| `state/mod.rs` | 6 |\n| `state/snapshot.rs` | 13 |\n| `handlers/filter_handlers.rs` | 2 |\n\n### 4. Update `TuiSnapshot` trait\n\n**File:** `crates/kanban-tui/src/state/snapshot.rs`\n\n`Snapshot::from_app` and `apply_to_app` read/write through `app.ctx.inner`:\n```rust\nfn from_app(app: &App) -> Self {\n    app.ctx.inner.snapshot()  // uses new KanbanContext method from KAN-264\n}\nfn apply_to_app(&self, app: &mut App) {\n    app.ctx.inner.apply_snapshot(self.clone());\n    // keep the sort field sync logic for UX state\n}\n```\n\n### 5. Update initial load path\n\n**File:** `crates/kanban-tui/src/app/mod.rs`\n\n`App::load_initial_state()` changes from manual deserialization to:\n```rust\npub async fn load_initial_state(&mut self) {\n    if let Some(store) = self.ctx.inner.store().cloned() {\n        if store.exists().await {\n            match KanbanContext::load(store).await {\n                Ok(loaded_ctx) => {\n                    self.ctx.inner = loaded_ctx;\n                    self.ctx.state_manager.mark_clean();\n                    self.ctx.state_manager.clear_history();\n                }\n                Err(e) => { /* error handling */ }\n            }\n        }\n    }\n}\n```\n\n### 6. Handle direct mutations\n\nSeveral handlers mutate domain state directly via `get_mut()` (e.g., external editor edits, sprint counter initialization, imports). These are mechanical changes from `self.ctx.cards.get_mut()` → `self.ctx.inner.cards.get_mut()` — covered by the bulk rename in step 3. `KanbanContext` fields are `pub` so this works.\n\n### 7. Update `App::execute_command`\n\nKeep `execute_command`/`execute_commands_batch` on `TuiContext` but implement using `KanbanContext::execute()`:\n```rust\npub fn execute_command(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {\n    // KanbanContext.execute() handles undo capture internally (from KAN-264)\n    self.inner.execute(command)?;\n    self.state_manager.mark_dirty();\n    let snapshot = self.inner.snapshot();\n    self.state_manager.queue_snapshot(snapshot.into());\n    Ok(())\n}\n```\n\n## Tests\n\n**Update existing tests:**\n- `state/mod.rs`: `test_state_manager_creation`, `test_dirty_flag_after_execute` — adapt to new StateManager constructor and removal of `execute()`\n- `state/snapshot.rs`: update `ctx.inner.boards` paths\n- `tests/data_integrity_tests.rs`, `tests/conflict_detection_tests.rs`, `tests/import_failure_safety.rs`, `tests/export_import_tests.rs` — field path updates\n\n**New tests (TDD):**\n| Test | Description |\n|------|-------------|\n| `test_tui_context_delegates_create_board_to_inner` | Create board via TuiContext, verify it exists in inner.boards |\n| `test_tui_context_queues_save_after_mutation` | Verify save channel receives snapshot after operation |\n| `test_tui_context_read_operations_skip_save` | Verify read-only ops don't queue saves |\n| `test_state_manager_accepts_store_directly` | Construct StateManager with Arc store, verify it works |\n\n## Verification\n\n1. `cargo test --workspace` — all tests pass\n2. `cargo clippy --workspace` — no warnings\n3. Run TUI with `.json` and `.db` files — verify runtime behavior unchanged\n4. Verify undo/redo still works in TUI\n5. `grep -r \"execute_with_context\" crates/kanban-tui/` returns nothing (fully removed)\n\n## Files Modified\n\n| File | Change |\n|------|--------|\n| `crates/kanban-tui/src/tui_context.rs` | Rewrite: wrap KanbanContext, delegate KanbanOperations |\n| `crates/kanban-tui/src/state/mod.rs` | Remove execute methods, accept store directly |\n| `crates/kanban-tui/src/state/snapshot.rs` | Update field paths to ctx.inner |\n| `crates/kanban-tui/src/app/mod.rs` | Update field paths, initial load, ~58 refs |\n| `crates/kanban-tui/src/handlers/*.rs` | Update field paths (~140 refs across 8 files) |\n| `crates/kanban-tui/src/ui.rs` | Update field paths (~26 refs) |\n| `crates/kanban-tui/src/render_strategy.rs` | Update field paths (~6 refs) |\n| `crates/kanban-tui/src/components/selection_dialog.rs` | Update field paths (~7 refs) |\n| `crates/kanban-tui/Cargo.toml` | Remove `sqlite` feature, remove kanban-service feature forwarding |\n\n## Depends on\n\n- KAN-264 (Lift undo/redo into KanbanContext)\n\n## Prerequisite for\n\n- KAN-260 (Invert storage backend plugin architecture)\n\n## Additional Evidence (2026-04-03, KAN-274 settings branch)\n\nCommit `e1800ee` (\"fix: wire default_sprint_prefix from AppConfig into sprint creation\") is a clear example of the duplication tax this refactoring would eliminate. The fix had to be applied in **two places**:\n\n1. **`KanbanContext::create_sprint()`** (`kanban-service/src/context.rs`) — replaced hardcoded `\"sprint\"` with `self.app_config.effective_default_sprint_prefix()`.\n2. **`TuiContext::create_sprint()`** (`kanban-tui/src/tui_context.rs:522`) — identical logic, separately maintained, replaced `\"sprint\"` with `self.default_sprint_prefix.clone()`.\n\nAdditionally the TUI needed manual plumbing to stay in sync:\n- `TuiContext` gained a `default_sprint_prefix: String` field (`tui_context.rs`)\n- `App::new()` had to pass it through from `AppConfig` (`app/mod.rs`)\n- `settings_handlers.rs` had to sync it on config change (`self.ctx.default_sprint_prefix = ...`)\n- `sprint_handlers.rs` had its own fallback chain reading from `board.sprint_prefix` → `self.app_config.effective_default_sprint_prefix()`\n\nIf `TuiContext` simply wrapped `KanbanContext`, the service-layer fix would have been the only change needed — zero TUI modifications. This pattern repeats for every config-driven feature (card prefix, sprint prefix, storage backend) and will keep getting worse as more settings are added.",
+        "due_date": null,
+        "id": "88bd3f3c-5190-49bd-bdb8-94fbc58a2774",
+        "points": 3,
+        "position": 97,
+        "priority": "High",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856488811Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Simplify TuiContext to wrap KanbanContext like CLI/MCP",
+        "updated_at": "2026-04-04T23:44:58.841546799Z"
       },
       {
         "card_number": 12,
@@ -8762,58 +8322,6 @@
         "updated_at": "2026-01-10T00:49:29.134518Z"
       },
       {
-        "card_number": 265,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-31T00:50:20.386898562Z",
-        "description": "## Problem\n\n`TuiContext` maintains its own parallel domain state (`boards`, `columns`, `cards`, `archived_cards`, `sprints`, `graph`) and reimplements the entire `KanbanOperations` trait with 650+ lines of hand-rolled command construction and state reading. Both CLI (`CliContext`) and MCP (`McpContext`) instead wrap `KanbanContext` and delegate all operations in ~5 lines per method. The TUI should follow the same pattern.\n\nAdditionally, `StateManager` creates its own store via `kanban_service::make_store()` and has a `execute_with_context()` method that manually builds a `CommandContext` from individual mutable refs — this is redundant now that `KanbanContext.execute()` does the same thing.\n\n## Solution\n\nAfter KAN-264 lifts undo/redo into `KanbanContext`, refactor the TUI to delegate to it.\n\n## Changes Required\n\n### 1. Rewrite `TuiContext` to wrap `KanbanContext`\n\n**File:** `crates/kanban-tui/src/tui_context.rs` (currently 653 lines → ~150 lines)\n\nReplace parallel state:\n```rust\n// BEFORE\npub struct TuiContext {\n    pub boards: Vec<Board>,\n    pub columns: Vec<Column>,\n    pub cards: Vec<Card>,\n    pub archived_cards: Vec<ArchivedCard>,\n    pub sprints: Vec<Sprint>,\n    pub graph: DependencyGraph,\n    pub state_manager: StateManager,\n}\n\n// AFTER\npub struct TuiContext {\n    pub inner: KanbanContext,\n    pub state_manager: StateManager,\n}\n```\n\nNew constructor — store created externally, passed to both KanbanContext and StateManager:\n```rust\npub fn new(save_file: Option<String>) -> KanbanResult<(Self, ...)> {\n    let (store, state_manager, save_rx, completion_rx) = if let Some(ref path) = save_file {\n        let store = kanban_service::make_store(path)?;\n        let (sm, rx, crx) = StateManager::new(Some(store.clone()))?;\n        (Some(store), sm, Some(rx), Some(crx))\n    } else { ... };\n    let inner = if let Some(s) = store {\n        KanbanContext::empty(s)\n    } else { ... };\n    Ok((Self { inner, state_manager }, save_rx, completion_rx))\n}\n```\n\nKanbanOperations delegation with save queuing via helper:\n```rust\nfn with_save<F, R>(&mut self, f: F) -> KanbanResult<R>\nwhere F: FnOnce(&mut KanbanContext) -> KanbanResult<R> {\n    let result = f(&mut self.inner)?;\n    // KanbanContext.execute() already captured undo snapshot internally\n    let snapshot = Snapshot::from_context(&self.inner);\n    self.state_manager.queue_snapshot(snapshot);\n    Ok(result)\n}\n\n// Each mutating method becomes a one-liner:\nfn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {\n    self.with_save(|ctx| ctx.create_board(name, card_prefix))\n}\n\n// Read-only methods are direct delegation:\nfn list_boards(&self) -> KanbanResult<Vec<Board>> { self.inner.list_boards() }\n```\n\n### 2. Simplify `StateManager`\n\n**File:** `crates/kanban-tui/src/state/mod.rs`\n\n- **Remove** `execute_with_context()` and `execute()` methods (KanbanContext handles command execution)\n- **Remove** `create_store()` private method\n- **Change** `StateManager::new()` to accept `Option<Arc<dyn PersistenceStore>>` instead of `Option<String>`\n- **Keep** all of: `capture_before_command`, `queue_snapshot`, `save_completed`, `has_pending_saves`, `is_dirty`, `mark_dirty`, `mark_clean`, `clear_history`, `can_undo`, `can_redo`, `history_mut`, `set_file_watcher`, `force_overwrite`, `reload_from_disk`, `close_save_channel`, `store()`, `instance_id()`\n- **Update** `reload_from_disk` to use `KanbanContext::reload()` or `apply_snapshot()` instead of `Snapshot::apply_to_app`\n\n### 3. Update field accesses (mechanical bulk change)\n\n~262 references across ~15 files: `ctx.boards` → `ctx.inner.boards` (same for columns, cards, sprints, archived_cards, graph)\n\n**Affected files by reference count:**\n| File | ~Refs |\n|------|-------|\n| `app/mod.rs` | 58 |\n| `handlers/detail_view_handlers.rs` | 47 |\n| `handlers/card_handlers.rs` | 33 |\n| `ui.rs` | 26 |\n| `handlers/popup_handlers.rs` | 19 |\n| `handlers/dialog_handlers.rs` | 11 |\n| `handlers/sprint_handlers.rs` | 11 |\n| `handlers/column_handlers.rs` | 11 |\n| `components/selection_dialog.rs` | 7 |\n| `handlers/board_handlers.rs` | 6 |\n| `handlers/navigation_handlers.rs` | 6 |\n| `render_strategy.rs` | 6 |\n| `state/mod.rs` | 6 |\n| `state/snapshot.rs` | 13 |\n| `handlers/filter_handlers.rs` | 2 |\n\n### 4. Update `TuiSnapshot` trait\n\n**File:** `crates/kanban-tui/src/state/snapshot.rs`\n\n`Snapshot::from_app` and `apply_to_app` read/write through `app.ctx.inner`:\n```rust\nfn from_app(app: &App) -> Self {\n    app.ctx.inner.snapshot()  // uses new KanbanContext method from KAN-264\n}\nfn apply_to_app(&self, app: &mut App) {\n    app.ctx.inner.apply_snapshot(self.clone());\n    // keep the sort field sync logic for UX state\n}\n```\n\n### 5. Update initial load path\n\n**File:** `crates/kanban-tui/src/app/mod.rs`\n\n`App::load_initial_state()` changes from manual deserialization to:\n```rust\npub async fn load_initial_state(&mut self) {\n    if let Some(store) = self.ctx.inner.store().cloned() {\n        if store.exists().await {\n            match KanbanContext::load(store).await {\n                Ok(loaded_ctx) => {\n                    self.ctx.inner = loaded_ctx;\n                    self.ctx.state_manager.mark_clean();\n                    self.ctx.state_manager.clear_history();\n                }\n                Err(e) => { /* error handling */ }\n            }\n        }\n    }\n}\n```\n\n### 6. Handle direct mutations\n\nSeveral handlers mutate domain state directly via `get_mut()` (e.g., external editor edits, sprint counter initialization, imports). These are mechanical changes from `self.ctx.cards.get_mut()` → `self.ctx.inner.cards.get_mut()` — covered by the bulk rename in step 3. `KanbanContext` fields are `pub` so this works.\n\n### 7. Update `App::execute_command`\n\nKeep `execute_command`/`execute_commands_batch` on `TuiContext` but implement using `KanbanContext::execute()`:\n```rust\npub fn execute_command(&mut self, command: Box<dyn Command>) -> KanbanResult<()> {\n    // KanbanContext.execute() handles undo capture internally (from KAN-264)\n    self.inner.execute(command)?;\n    self.state_manager.mark_dirty();\n    let snapshot = self.inner.snapshot();\n    self.state_manager.queue_snapshot(snapshot.into());\n    Ok(())\n}\n```\n\n## Tests\n\n**Update existing tests:**\n- `state/mod.rs`: `test_state_manager_creation`, `test_dirty_flag_after_execute` — adapt to new StateManager constructor and removal of `execute()`\n- `state/snapshot.rs`: update `ctx.inner.boards` paths\n- `tests/data_integrity_tests.rs`, `tests/conflict_detection_tests.rs`, `tests/import_failure_safety.rs`, `tests/export_import_tests.rs` — field path updates\n\n**New tests (TDD):**\n| Test | Description |\n|------|-------------|\n| `test_tui_context_delegates_create_board_to_inner` | Create board via TuiContext, verify it exists in inner.boards |\n| `test_tui_context_queues_save_after_mutation` | Verify save channel receives snapshot after operation |\n| `test_tui_context_read_operations_skip_save` | Verify read-only ops don't queue saves |\n| `test_state_manager_accepts_store_directly` | Construct StateManager with Arc store, verify it works |\n\n## Verification\n\n1. `cargo test --workspace` — all tests pass\n2. `cargo clippy --workspace` — no warnings\n3. Run TUI with `.json` and `.db` files — verify runtime behavior unchanged\n4. Verify undo/redo still works in TUI\n5. `grep -r \"execute_with_context\" crates/kanban-tui/` returns nothing (fully removed)\n\n## Files Modified\n\n| File | Change |\n|------|--------|\n| `crates/kanban-tui/src/tui_context.rs` | Rewrite: wrap KanbanContext, delegate KanbanOperations |\n| `crates/kanban-tui/src/state/mod.rs` | Remove execute methods, accept store directly |\n| `crates/kanban-tui/src/state/snapshot.rs` | Update field paths to ctx.inner |\n| `crates/kanban-tui/src/app/mod.rs` | Update field paths, initial load, ~58 refs |\n| `crates/kanban-tui/src/handlers/*.rs` | Update field paths (~140 refs across 8 files) |\n| `crates/kanban-tui/src/ui.rs` | Update field paths (~26 refs) |\n| `crates/kanban-tui/src/render_strategy.rs` | Update field paths (~6 refs) |\n| `crates/kanban-tui/src/components/selection_dialog.rs` | Update field paths (~7 refs) |\n| `crates/kanban-tui/Cargo.toml` | Remove `sqlite` feature, remove kanban-service feature forwarding |\n\n## Depends on\n\n- KAN-264 (Lift undo/redo into KanbanContext)\n\n## Prerequisite for\n\n- KAN-260 (Invert storage backend plugin architecture)\n\n## Additional Evidence (2026-04-03, KAN-274 settings branch)\n\nCommit `e1800ee` (\"fix: wire default_sprint_prefix from AppConfig into sprint creation\") is a clear example of the duplication tax this refactoring would eliminate. The fix had to be applied in **two places**:\n\n1. **`KanbanContext::create_sprint()`** (`kanban-service/src/context.rs`) — replaced hardcoded `\"sprint\"` with `self.app_config.effective_default_sprint_prefix()`.\n2. **`TuiContext::create_sprint()`** (`kanban-tui/src/tui_context.rs:522`) — identical logic, separately maintained, replaced `\"sprint\"` with `self.default_sprint_prefix.clone()`.\n\nAdditionally the TUI needed manual plumbing to stay in sync:\n- `TuiContext` gained a `default_sprint_prefix: String` field (`tui_context.rs`)\n- `App::new()` had to pass it through from `AppConfig` (`app/mod.rs`)\n- `settings_handlers.rs` had to sync it on config change (`self.ctx.default_sprint_prefix = ...`)\n- `sprint_handlers.rs` had its own fallback chain reading from `board.sprint_prefix` → `self.app_config.effective_default_sprint_prefix()`\n\nIf `TuiContext` simply wrapped `KanbanContext`, the service-layer fix would have been the only change needed — zero TUI modifications. This pattern repeats for every config-driven feature (card prefix, sprint prefix, storage backend) and will keep getting worse as more settings are added.",
-        "due_date": null,
-        "id": "88bd3f3c-5190-49bd-bdb8-94fbc58a2774",
-        "points": 3,
-        "position": 97,
-        "priority": "High",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856488811Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Simplify TuiContext to wrap KanbanContext like CLI/MCP",
-        "updated_at": "2026-04-04T23:44:58.841546799Z"
-      },
-      {
-        "card_number": 268,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-31T01:21:10.203382414Z",
-        "description": "All 9 migrate integration tests in crates/kanban-cli/tests/migrate.rs go json -> sqlite. Add at least one test that migrates sqlite -> json to verify create_by_name(json, path) works when the locator has a non-json extension. This also exercises the sqlite backend as a source. Ref: PR #205 review.",
-        "due_date": null,
-        "id": "605a2d94-bbe3-4bbc-b156-453156fd0299",
-        "points": 2,
-        "position": 98,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856434902Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Add sqlite-to-json migration test",
-        "updated_at": "2026-04-04T23:44:58.966506274Z"
-      },
-      {
         "card_number": 134,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-01-10T02:34:01.947587Z",
@@ -8846,6 +8354,32 @@
         "status": "Done",
         "title": "undo action",
         "updated_at": "2026-01-10T02:34:01.947588Z"
+      },
+      {
+        "card_number": 268,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-03-31T01:21:10.203382414Z",
+        "description": "All 9 migrate integration tests in crates/kanban-cli/tests/migrate.rs go json -> sqlite. Add at least one test that migrates sqlite -> json to verify create_by_name(json, path) works when the locator has a non-json extension. This also exercises the sqlite backend as a source. Ref: PR #205 review.",
+        "due_date": null,
+        "id": "605a2d94-bbe3-4bbc-b156-453156fd0299",
+        "points": 2,
+        "position": 98,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856434902Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Add sqlite-to-json migration test",
+        "updated_at": "2026-04-04T23:44:58.966506274Z"
       },
       {
         "card_number": 170,
@@ -8891,32 +8425,6 @@
         "updated_at": "2026-04-04T23:44:59.009954827Z"
       },
       {
-        "card_number": 270,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-31T01:21:14.220029366Z",
-        "description": "The default impl falls back to self.name(), which is a footgun if a backend is named differently from its extension. Making it required forces explicit declaration. Ref: PR #205 review.",
-        "due_date": null,
-        "id": "c9e4800b-f0cd-4420-ba0b-4f5ebdce15fa",
-        "points": 1,
-        "position": 100,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856456923Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Make default_extension a required method on StoreFactory",
-        "updated_at": "2026-04-04T23:44:59.051440788Z"
-      },
-      {
         "card_number": 196,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-02-01T19:28:45.979587Z",
@@ -8941,6 +8449,32 @@
         "status": "Done",
         "title": "Redesign release workflow: defer version bump to master merge",
         "updated_at": "2026-02-01T19:28:45.979587Z"
+      },
+      {
+        "card_number": 270,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-03-31T01:21:14.220029366Z",
+        "description": "The default impl falls back to self.name(), which is a footgun if a backend is named differently from its extension. Making it required forces explicit declaration. Ref: PR #205 review.",
+        "due_date": null,
+        "id": "c9e4800b-f0cd-4420-ba0b-4f5ebdce15fa",
+        "points": 1,
+        "position": 100,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856456923Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Make default_extension a required method on StoreFactory",
+        "updated_at": "2026-04-04T23:44:59.051440788Z"
       },
       {
         "card_number": 197,
@@ -8995,6 +8529,32 @@
         "updated_at": "2026-04-04T23:44:59.091405512Z"
       },
       {
+        "card_number": 194,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-02-02T19:22:49.304523Z",
+        "created_at": "2026-02-01T13:41:03.481620Z",
+        "description": "## Bug\n\nWhen assigning a card to a sprint via the TUI ('a' key), the wrong sprint gets assigned. Cards end up on old Completed sprints instead of the intended one.\n\n## Root Cause\n\nIndex mismatch between the sprint selection dialog and the selection handler:\n\n**Dialog rendering** (`selection_dialog.rs:194-202`) filters OUT Completed/Cancelled sprints:\n```rust\n.filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)\n```\nShows: `[(None), Sprint #11 \"a-new-year\" (Planning)]`\n\n**Selection handler** (`popup_handlers.rs:209-215`) uses UNFILTERED list:\n```rust\nlet board_sprints: Vec<_> = self.ctx.sprints.iter()\n    .filter(|s| s.board_id == board_id)\n    .collect();\nif let Some(sprint) = board_sprints.get(selection_idx - 1) { ... }\n```\nUnfiltered: `[Sprint #1 (Completed), Sprint #6 (Completed), ..., Sprint #11 (Planning)]`\n\nUser selects index 1 (Sprint #11 in filtered list) -> handler does `get(0)` on unfiltered list -> gets Sprint #1 \"an-eventful-october\".\n\n## Affected Code\n\n- `crates/kanban-tui/src/handlers/popup_handlers.rs:209-215` -- single card assignment\n- `crates/kanban-tui/src/handlers/popup_handlers.rs:337-343` -- multi-card assignment (same bug)\n\n## Fix\n\nApply the same Completed/Cancelled filter in the handler that the dialog uses:\n```rust\nlet board_sprints: Vec<_> = self.ctx.sprints.iter()\n    .filter(|s| s.board_id == board_id)\n    .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)\n    .collect();\n```\n\nBoth single-card and multi-card paths need the fix.\n\n## Notes\n\n- CLI is not affected (uses UUID directly, no index-based selection)\n- MCP is not affected (no sprint assignment tool yet)",
+        "due_date": null,
+        "id": "54197834-f36b-453c-9c15-68de00f17186",
+        "points": 5,
+        "position": 102,
+        "priority": "Critical",
+        "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
+            "sprint_name": "a-new-year",
+            "sprint_number": 11,
+            "started_at": "2026-02-01T13:46:38.854326Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Done",
+        "title": "Fix TUI sprint assignment selecting wrong sprint (index mismatch)",
+        "updated_at": "2026-02-02T19:22:49.304524Z"
+      },
+      {
         "card_number": 272,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -9021,30 +8581,30 @@
         "updated_at": "2026-04-04T23:44:59.132480388Z"
       },
       {
-        "card_number": 194,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-02-02T19:22:49.304523Z",
-        "created_at": "2026-02-01T13:41:03.481620Z",
-        "description": "## Bug\n\nWhen assigning a card to a sprint via the TUI ('a' key), the wrong sprint gets assigned. Cards end up on old Completed sprints instead of the intended one.\n\n## Root Cause\n\nIndex mismatch between the sprint selection dialog and the selection handler:\n\n**Dialog rendering** (`selection_dialog.rs:194-202`) filters OUT Completed/Cancelled sprints:\n```rust\n.filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)\n```\nShows: `[(None), Sprint #11 \"a-new-year\" (Planning)]`\n\n**Selection handler** (`popup_handlers.rs:209-215`) uses UNFILTERED list:\n```rust\nlet board_sprints: Vec<_> = self.ctx.sprints.iter()\n    .filter(|s| s.board_id == board_id)\n    .collect();\nif let Some(sprint) = board_sprints.get(selection_idx - 1) { ... }\n```\nUnfiltered: `[Sprint #1 (Completed), Sprint #6 (Completed), ..., Sprint #11 (Planning)]`\n\nUser selects index 1 (Sprint #11 in filtered list) -> handler does `get(0)` on unfiltered list -> gets Sprint #1 \"an-eventful-october\".\n\n## Affected Code\n\n- `crates/kanban-tui/src/handlers/popup_handlers.rs:209-215` -- single card assignment\n- `crates/kanban-tui/src/handlers/popup_handlers.rs:337-343` -- multi-card assignment (same bug)\n\n## Fix\n\nApply the same Completed/Cancelled filter in the handler that the dialog uses:\n```rust\nlet board_sprints: Vec<_> = self.ctx.sprints.iter()\n    .filter(|s| s.board_id == board_id)\n    .filter(|s| s.status != SprintStatus::Completed && s.status != SprintStatus::Cancelled)\n    .collect();\n```\n\nBoth single-card and multi-card paths need the fix.\n\n## Notes\n\n- CLI is not affected (uses UUID directly, no index-based selection)\n- MCP is not affected (no sprint assignment tool yet)",
+        "card_number": 273,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-03-31T21:15:49.892549528Z",
+        "description": "## Problem\n\nEvery new keybinding must be added in two places:\n1. `keybindings/` registry (for footer display and help popup)\n2. `handle_key_event()` hardcoded match in `app/mod.rs` (for actual dispatch)\n\nThese can silently drift apart — a key can appear in help but do nothing, or work but not show in help.\n\n## Complications\n\n- **Context-dependent keys**: `n` creates board or card depending on focus; `e` edits board or card\n- **Multi-key sequences**: `gg` needs pending-key state\n- **Terminal access**: some handlers (`e`, card detail editing) need `terminal` + `event_handler` params that `execute_action()` doesn't receive\n- **Return value**: some branches set `should_restart_events = true`\n\n## Proposed Approach\n\n1. Extend `KeybindingAction` to carry context (e.g. `CreateItem` instead of separate `CreateBoard`/`CreateCard`, resolved at dispatch time by focus)\n2. Pass `terminal` and `event_handler` into `execute_action()` so all handlers can be dispatched uniformly\n3. Add a `needs_restart` return value from `execute_action()`\n4. Handle multi-key sequences (`gg`) as a pre-processing step before dispatch\n5. Make the registry the single source of truth — remove the hardcoded match in `handle_key_event` for Normal mode\n6. All other modes (CardDetail, BoardDetail, etc.) could follow the same pattern incrementally",
         "due_date": null,
-        "id": "54197834-f36b-453c-9c15-68de00f17186",
-        "points": 5,
-        "position": 102,
-        "priority": "Critical",
-        "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
+        "id": "2e8e1467-9f5a-4a8d-9739-80b849a2c231",
+        "points": 4,
+        "position": 103,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
-            "sprint_name": "a-new-year",
-            "sprint_number": 11,
-            "started_at": "2026-02-01T13:46:38.854326Z",
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856394290Z",
             "status": "Planning"
           }
         ],
-        "status": "Done",
-        "title": "Fix TUI sprint assignment selecting wrong sprint (index mismatch)",
-        "updated_at": "2026-02-02T19:22:49.304524Z"
+        "status": "Todo",
+        "title": "Unify keybinding dispatch with registry",
+        "updated_at": "2026-04-04T23:44:59.167261224Z"
       },
       {
         "card_number": 193,
@@ -9081,58 +8641,6 @@
         "updated_at": "2026-02-02T19:22:55.402436Z"
       },
       {
-        "card_number": 273,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-31T21:15:49.892549528Z",
-        "description": "## Problem\n\nEvery new keybinding must be added in two places:\n1. `keybindings/` registry (for footer display and help popup)\n2. `handle_key_event()` hardcoded match in `app/mod.rs` (for actual dispatch)\n\nThese can silently drift apart — a key can appear in help but do nothing, or work but not show in help.\n\n## Complications\n\n- **Context-dependent keys**: `n` creates board or card depending on focus; `e` edits board or card\n- **Multi-key sequences**: `gg` needs pending-key state\n- **Terminal access**: some handlers (`e`, card detail editing) need `terminal` + `event_handler` params that `execute_action()` doesn't receive\n- **Return value**: some branches set `should_restart_events = true`\n\n## Proposed Approach\n\n1. Extend `KeybindingAction` to carry context (e.g. `CreateItem` instead of separate `CreateBoard`/`CreateCard`, resolved at dispatch time by focus)\n2. Pass `terminal` and `event_handler` into `execute_action()` so all handlers can be dispatched uniformly\n3. Add a `needs_restart` return value from `execute_action()`\n4. Handle multi-key sequences (`gg`) as a pre-processing step before dispatch\n5. Make the registry the single source of truth — remove the hardcoded match in `handle_key_event` for Normal mode\n6. All other modes (CardDetail, BoardDetail, etc.) could follow the same pattern incrementally",
-        "due_date": null,
-        "id": "2e8e1467-9f5a-4a8d-9739-80b849a2c231",
-        "points": 4,
-        "position": 103,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856394290Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Unify keybinding dispatch with registry",
-        "updated_at": "2026-04-04T23:44:59.167261224Z"
-      },
-      {
-        "card_number": 275,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-03-31T21:22:38.967871171Z",
-        "description": "Remove futures and futures-util from workspace Cargo.toml - they are not used anywhere in the codebase and can be safely removed as a cleanup task.",
-        "due_date": null,
-        "id": "b66a0571-94e9-4972-9c42-a8450982d0a4",
-        "points": 1,
-        "position": 104,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856390298Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Remove unused futures dependencies",
-        "updated_at": "2026-04-04T23:44:59.224998615Z"
-      },
-      {
         "card_number": 178,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-02-02T19:22:59.769305Z",
@@ -9167,32 +8675,6 @@
         "updated_at": "2026-02-02T19:22:59.769305Z"
       },
       {
-        "card_number": 279,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-03T22:18:20.737115496Z",
-        "description": "config.rs is ~1000 lines. Split AppConfigDto, validate_branch_prefix, and tests into separate files to stay within the 300-line guideline.",
-        "due_date": null,
-        "id": "62cb2d6a-b8d5-4980-a0a0-2d929380480b",
-        "points": 2,
-        "position": 105,
-        "priority": "Low",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856406269Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Split config.rs into smaller modules",
-        "updated_at": "2026-04-04T23:44:59.281795149Z"
-      },
-      {
         "card_number": 208,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-02-17T22:28:04.426955436Z",
@@ -9219,16 +8701,16 @@
         "updated_at": "2026-02-17T22:28:14.638486382Z"
       },
       {
-        "card_number": 280,
+        "card_number": 279,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
-        "created_at": "2026-04-03T22:19:02.597703105Z",
-        "description": "SettingsViewProvider pushes 'e/Enter' inside Configuration match arm AND unconditionally pushes another 'e' at the bottom. 'e' appears twice in keybinding context for Configuration focus.",
+        "created_at": "2026-04-03T22:18:20.737115496Z",
+        "description": "config.rs is ~1000 lines. Split AppConfigDto, validate_branch_prefix, and tests into separate files to stay within the 300-line guideline.",
         "due_date": null,
-        "id": "c99e2784-db4a-49df-8ceb-382609bf74ab",
-        "points": 1,
-        "position": 106,
-        "priority": "Medium",
+        "id": "62cb2d6a-b8d5-4980-a0a0-2d929380480b",
+        "points": 2,
+        "position": 105,
+        "priority": "Low",
         "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
           {
@@ -9236,13 +8718,13 @@
             "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
             "sprint_name": "a-catchy-spring",
             "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856424543Z",
+            "started_at": "2026-04-04T23:35:37.856406269Z",
             "status": "Planning"
           }
         ],
         "status": "Todo",
-        "title": "Fix duplicate 'e' keybinding in settings provider",
-        "updated_at": "2026-04-04T23:44:59.314370892Z"
+        "title": "Split config.rs into smaller modules",
+        "updated_at": "2026-04-04T23:44:59.281795149Z"
       },
       {
         "card_number": 209,
@@ -9269,6 +8751,32 @@
         "status": "Done",
         "title": "Multi select cards",
         "updated_at": "2026-02-18T17:44:25.361826341Z"
+      },
+      {
+        "card_number": 280,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-03T22:19:02.597703105Z",
+        "description": "SettingsViewProvider pushes 'e/Enter' inside Configuration match arm AND unconditionally pushes another 'e' at the bottom. 'e' appears twice in keybinding context for Configuration focus.",
+        "due_date": null,
+        "id": "c99e2784-db4a-49df-8ceb-382609bf74ab",
+        "points": 1,
+        "position": 106,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856424543Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Fix duplicate 'e' keybinding in settings provider",
+        "updated_at": "2026-04-04T23:44:59.314370892Z"
       },
       {
         "card_number": 281,
@@ -9314,6 +8822,23 @@
         "updated_at": "2026-03-17T00:25:35.757864536Z"
       },
       {
+        "card_number": 208,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-03-17T00:25:38.583577859Z",
+        "created_at": "2026-02-21T11:47:26.405502Z",
+        "description": "# Create and Deploy Kanban Project Landing Page\n\n## Summary\nDesigned and implemented a landing page for the kanban terminal-based project management tool at kanban.yoon.se. The page showcases the   \nproject's capabilities, features, and installation methods using a terminal-inspired design that matches the yoon.se design system.       \n\n## What Was Done\n\n### 1. Landing Page Design & Content\n- Created semantic HTML5 structure with 5 main sections:\n  - **Hero**: Project title, tagline, demo GIF, installation CTAs (cargo + nix)\n  - **Features**: 6 feature cards highlighting vim-like power, speed, three interfaces, task management, developer workflow, and local-first approach\n  - **Installation**: Three installation methods (crates.io, nix, from source) with quick start guide\n  - **Roadmap**: v0.2.0 status with completed/in-progress/planned items\n  - **Footer**: Links to GitHub, Crates.io, docs, and author/license info\n\n### 2. Design System Integration\n- Matched yoon.se terminal-inspired dark theme:\n  - Colors: GitHub Dark (#0d1117 bg, #c9714a accent)\n  - Typography: SF Mono for headings, system sans for body\n  - Spacing: 8-point grid system\n  - No border-radius (sharp terminal aesthetic)\n- Terminal-style components:\n  - `$ ` prefix for install commands in accent color\n  - `> ` prefix for links (yoon design pattern)\n  - Monospace headings and code blocks\n- Fully responsive: desktop (3-col), tablet (2-col), mobile (1-col)\n\n### 3. Static Site Implementation\n- **index.html**: 158 lines, semantic HTML with proper meta tags\n- **styles.css**: 576 lines, complete design system with CSS variables and responsive layout\n- **demo.gif**: 997KB animated TUI demo (copied from project root)\n- No external dependencies, fast loading, SEO-friendly\n\n### 4. Nix Build Integration\n- Created `web/default.nix` for reproducible builds\n- Added `kanban-web` package to main `flake.nix`\n- Build command: `nix build .#kanban-web`\n- Output: Static files ready for deployment\n\n## Files Created\n- `/Users/max/memes/kanban/web/index.html`\n- `/Users/max/memes/kanban/web/styles.css`\n- `/Users/max/memes/kanban/web/demo.gif`\n- `/Users/max/memes/kanban/web/default.nix`\n\n## Deployment\nReady for deployment to kanban.yoon.se:\n\n```bash\nnix build .#kanban-web\ncp -r result/* /var/www/kanban.yoon.se/\n```\n\nSuccess Criteria\n\n✅ Landing page matches yoon.se design system (dark theme, terminal aesthetic)\n✅ All 5 content sections implemented with accurate project information\n✅ Responsive design works across desktop, tablet, and mobile\n✅ Demo GIF displays correctly and animates\n✅ Installation commands (cargo + nix) clearly presented\n✅ Nix build support added for reproducible deployment\n✅ Fast loading with minimal file size (20KB HTML+CSS)\n✅ SEO-optimized with proper meta tags and semantic HTML\n✅ Follows yoon BRAND_GUIDE principles (direct, humble, technical, authentic)\n✅ Files committed to git with proper commit message\n\nThis captures the full scope of work completed for the landing page project!\n",
+        "due_date": null,
+        "id": "4a2eb647-acbf-40f0-a03f-4c874e0d1c09",
+        "points": 3,
+        "position": 108,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "create a landing page for the project",
+        "updated_at": "2026-03-17T00:25:38.583578091Z"
+      },
+      {
         "card_number": 282,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -9340,21 +8865,21 @@
         "updated_at": "2026-04-04T23:44:59.401748374Z"
       },
       {
-        "card_number": 208,
+        "card_number": 215,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-17T00:25:38.583577859Z",
-        "created_at": "2026-02-21T11:47:26.405502Z",
-        "description": "# Create and Deploy Kanban Project Landing Page\n\n## Summary\nDesigned and implemented a landing page for the kanban terminal-based project management tool at kanban.yoon.se. The page showcases the   \nproject's capabilities, features, and installation methods using a terminal-inspired design that matches the yoon.se design system.       \n\n## What Was Done\n\n### 1. Landing Page Design & Content\n- Created semantic HTML5 structure with 5 main sections:\n  - **Hero**: Project title, tagline, demo GIF, installation CTAs (cargo + nix)\n  - **Features**: 6 feature cards highlighting vim-like power, speed, three interfaces, task management, developer workflow, and local-first approach\n  - **Installation**: Three installation methods (crates.io, nix, from source) with quick start guide\n  - **Roadmap**: v0.2.0 status with completed/in-progress/planned items\n  - **Footer**: Links to GitHub, Crates.io, docs, and author/license info\n\n### 2. Design System Integration\n- Matched yoon.se terminal-inspired dark theme:\n  - Colors: GitHub Dark (#0d1117 bg, #c9714a accent)\n  - Typography: SF Mono for headings, system sans for body\n  - Spacing: 8-point grid system\n  - No border-radius (sharp terminal aesthetic)\n- Terminal-style components:\n  - `$ ` prefix for install commands in accent color\n  - `> ` prefix for links (yoon design pattern)\n  - Monospace headings and code blocks\n- Fully responsive: desktop (3-col), tablet (2-col), mobile (1-col)\n\n### 3. Static Site Implementation\n- **index.html**: 158 lines, semantic HTML with proper meta tags\n- **styles.css**: 576 lines, complete design system with CSS variables and responsive layout\n- **demo.gif**: 997KB animated TUI demo (copied from project root)\n- No external dependencies, fast loading, SEO-friendly\n\n### 4. Nix Build Integration\n- Created `web/default.nix` for reproducible builds\n- Added `kanban-web` package to main `flake.nix`\n- Build command: `nix build .#kanban-web`\n- Output: Static files ready for deployment\n\n## Files Created\n- `/Users/max/memes/kanban/web/index.html`\n- `/Users/max/memes/kanban/web/styles.css`\n- `/Users/max/memes/kanban/web/demo.gif`\n- `/Users/max/memes/kanban/web/default.nix`\n\n## Deployment\nReady for deployment to kanban.yoon.se:\n\n```bash\nnix build .#kanban-web\ncp -r result/* /var/www/kanban.yoon.se/\n```\n\nSuccess Criteria\n\n✅ Landing page matches yoon.se design system (dark theme, terminal aesthetic)\n✅ All 5 content sections implemented with accurate project information\n✅ Responsive design works across desktop, tablet, and mobile\n✅ Demo GIF displays correctly and animates\n✅ Installation commands (cargo + nix) clearly presented\n✅ Nix build support added for reproducible deployment\n✅ Fast loading with minimal file size (20KB HTML+CSS)\n✅ SEO-optimized with proper meta tags and semantic HTML\n✅ Follows yoon BRAND_GUIDE principles (direct, humble, technical, authentic)\n✅ Files committed to git with proper commit message\n\nThis captures the full scope of work completed for the landing page project!\n",
+        "completed_at": "2026-03-17T00:34:23.120947Z",
+        "created_at": "2026-03-17T00:25:10.598013819Z",
+        "description": "---\n  Investigation: -V flag shows commit: unknown in release builds\n\n  Root Cause\n\n  The version string is constructed at compile time in crates/kanban-cli/src/cli.rs:4-8:\n\n  const VERSION: &str = concat!(\n      env!(\"CARGO_PKG_VERSION\"),\n      \"\\ncommit: \",\n      env!(\"GIT_COMMIT_HASH\")\n  );\n\n  The commit hash is resolved in crates/kanban-cli/build.rs:8-27 with this priority:\n\n  1. GIT_COMMIT_HASH env var (if set and not empty / not \"unknown\")\n  2. git rev-parse HEAD — works when .git is present\n  3. Falls back to \"unknown\"\n\n  Why It Fails in Release / Nix Builds\n\n  default.nix:14 uses lib.cleanSource ./. which strips the .git directory before building — standard Nix practice for reproducible builds. Without .git, step 2 fails and the fallback fires.\n\n  Neither the Nix derivation (default.nix, flake.nix), the dev shell (shell.nix), nor the CI workflows (ci.yml, release.yml) set GIT_COMMIT_HASH as an env var at build time.\n\n  Why cargo run -- -V Works\n\n  Running directly from the repo means .git exists on disk, so git rev-parse HEAD succeeds in the build script.\n\n  Proposed Fix\n\n  Two separate concerns:\n\n  1. Drop commit line when unknown — Change the version string construction so commit: unknown is never shown. This requires either:\n  - A build-time cfg flag (not possible with env! alone)\n  - Splitting the version into base + optional suffix evaluated at runtime via clap's .version() method with a String rather than a compile-time &str\n\n  2. Inject hash during Nix/release builds — In default.nix, pass the commit rev as an env var before the build:\n  preBuild = ''\n    export GIT_COMMIT_HASH=\"${self.rev or \"unknown\"}\"\n  '';\n  self.rev is available in flake context when the working tree is clean and committed. The or \"unknown\" handles dirty trees gracefully.\n\n  Files Involved\n\n  ┌───────────────────────────────────┬────────────────────────────────────────────┐\n  │               File                │                 Relevance                  │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ crates/kanban-cli/src/cli.rs:4-13 │ Version string constant + clap wiring      │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ crates/kanban-cli/build.rs:1-28   │ Build script that resolves GIT_COMMIT_HASH │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ default.nix:14                    │ lib.cleanSource strips .git                │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ flake.nix                         │ Has access to self.rev for injecting hash  │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ .github/workflows/release.yml     │ Does not set GIT_COMMIT_HASH               │\n  └───────────────────────────────────┴────────────────────────────────────────────┘\n\n  Acceptance Criteria\n\n  - kanban -V on a release/Nix build shows only the semver (e.g. 0.2.0), no commit: line\n  - kanban -V on a dev build (cargo run) still shows the commit hash\n  - kanban -V on a Nix build from a clean committed tree shows the correct short commit hash\n  - No commit: unknown output in any scenario\n",
         "due_date": null,
-        "id": "4a2eb647-acbf-40f0-a03f-4c874e0d1c09",
-        "points": 3,
-        "position": 108,
-        "priority": "Medium",
+        "id": "365980c0-14ec-4b38-aab6-5ac27e93d01a",
+        "points": null,
+        "position": 109,
+        "priority": "Low",
         "sprint_id": null,
         "sprint_logs": [],
         "status": "Done",
-        "title": "create a landing page for the project",
-        "updated_at": "2026-03-17T00:25:38.583578091Z"
+        "title": "version flag",
+        "updated_at": "2026-03-17T00:34:23.120947264Z"
       },
       {
         "card_number": 283,
@@ -9381,23 +8906,6 @@
         "status": "Todo",
         "title": "Log warning on config file deletion failure",
         "updated_at": "2026-04-04T23:44:59.442225194Z"
-      },
-      {
-        "card_number": 215,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-17T00:34:23.120947Z",
-        "created_at": "2026-03-17T00:25:10.598013819Z",
-        "description": "---\n  Investigation: -V flag shows commit: unknown in release builds\n\n  Root Cause\n\n  The version string is constructed at compile time in crates/kanban-cli/src/cli.rs:4-8:\n\n  const VERSION: &str = concat!(\n      env!(\"CARGO_PKG_VERSION\"),\n      \"\\ncommit: \",\n      env!(\"GIT_COMMIT_HASH\")\n  );\n\n  The commit hash is resolved in crates/kanban-cli/build.rs:8-27 with this priority:\n\n  1. GIT_COMMIT_HASH env var (if set and not empty / not \"unknown\")\n  2. git rev-parse HEAD — works when .git is present\n  3. Falls back to \"unknown\"\n\n  Why It Fails in Release / Nix Builds\n\n  default.nix:14 uses lib.cleanSource ./. which strips the .git directory before building — standard Nix practice for reproducible builds. Without .git, step 2 fails and the fallback fires.\n\n  Neither the Nix derivation (default.nix, flake.nix), the dev shell (shell.nix), nor the CI workflows (ci.yml, release.yml) set GIT_COMMIT_HASH as an env var at build time.\n\n  Why cargo run -- -V Works\n\n  Running directly from the repo means .git exists on disk, so git rev-parse HEAD succeeds in the build script.\n\n  Proposed Fix\n\n  Two separate concerns:\n\n  1. Drop commit line when unknown — Change the version string construction so commit: unknown is never shown. This requires either:\n  - A build-time cfg flag (not possible with env! alone)\n  - Splitting the version into base + optional suffix evaluated at runtime via clap's .version() method with a String rather than a compile-time &str\n\n  2. Inject hash during Nix/release builds — In default.nix, pass the commit rev as an env var before the build:\n  preBuild = ''\n    export GIT_COMMIT_HASH=\"${self.rev or \"unknown\"}\"\n  '';\n  self.rev is available in flake context when the working tree is clean and committed. The or \"unknown\" handles dirty trees gracefully.\n\n  Files Involved\n\n  ┌───────────────────────────────────┬────────────────────────────────────────────┐\n  │               File                │                 Relevance                  │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ crates/kanban-cli/src/cli.rs:4-13 │ Version string constant + clap wiring      │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ crates/kanban-cli/build.rs:1-28   │ Build script that resolves GIT_COMMIT_HASH │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ default.nix:14                    │ lib.cleanSource strips .git                │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ flake.nix                         │ Has access to self.rev for injecting hash  │\n  ├───────────────────────────────────┼────────────────────────────────────────────┤\n  │ .github/workflows/release.yml     │ Does not set GIT_COMMIT_HASH               │\n  └───────────────────────────────────┴────────────────────────────────────────────┘\n\n  Acceptance Criteria\n\n  - kanban -V on a release/Nix build shows only the semver (e.g. 0.2.0), no commit: line\n  - kanban -V on a dev build (cargo run) still shows the commit hash\n  - kanban -V on a Nix build from a clean committed tree shows the correct short commit hash\n  - No commit: unknown output in any scenario\n",
-        "due_date": null,
-        "id": "365980c0-14ec-4b38-aab6-5ac27e93d01a",
-        "points": null,
-        "position": 109,
-        "priority": "Low",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "version flag",
-        "updated_at": "2026-03-17T00:34:23.120947264Z"
       },
       {
         "card_number": 217,
@@ -9443,23 +8951,6 @@
         "updated_at": "2026-04-04T23:44:59.483115506Z"
       },
       {
-        "card_number": 221,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-20T22:50:04.423551030Z",
-        "created_at": "2026-03-20T21:07:39.419336697Z",
-        "description": "## Challenge\nWhen the terminal window was too small to show all keybindings in the help popup, entries were silently cut off with no scroll support.\n\n## Solution\nImplemented scrollable help menu by reusing the existing `ListComponent` infrastructure from the card lists, following the same patterns used throughout the rest of the TUI.\n\n## Changes\n\n### `crates/kanban-core/src/pagination.rs`\n- Added `Page::get_adjusted_viewport_height(raw)` — computes content rows after reserving lines for scroll indicators (above=1 if scrolled, below=1 if items extend past viewport).\n\n### `crates/kanban-tui/src/components/generic_list.rs`\n- `ListComponent::get_adjusted_viewport_height` now delegates to `Page::get_adjusted_viewport_height` (deduplication).\n\n### `crates/kanban-tui/src/app.rs`\n- Replaced `help_selection: SelectionState` + `help_page: Page` with `help_list: ListComponent`.\n- On help open: `help_list.update_item_count(bindings.len())` + `set_scroll_offset(0)`.\n- On help close (3 locations): `help_list.update_item_count(0)`.\n- Navigation (j/k): uses two-step `ensure_selected_visible` pattern matching `navigation_handlers.rs`.\n- Key-shortcut jump: uses `help_list.jump_to(index)` + `ensure_selected_visible`.\n\n### `crates/kanban-tui/src/ui.rs` — `render_help_popup`\n- Layout changed to `[Length(2), Min(0), Length(2)]`: fixed header, scrollable bindings body, fixed footer.\n- `all_lines` now contains only the N binding lines (no header/footer offset arithmetic needed).\n- Uses `help_list.get_adjusted_viewport_height` + `help_list.get_render_info` for correct scroll state.\n- Scroll indicators rendered via shared `render_scroll_indicators` helper with label `\"item\"` (fixes \"entrys\" pluralisation bug from `\"entry\"`).\n- Fixed footer (hint line) always visible regardless of scroll position.\n\n## Commits\n- `feat(pagination): add get_adjusted_viewport_height to Page`\n- `refactor(generic_list): delegate get_adjusted_viewport_height to Page`\n- `feat(help): replace help_selection+help_page with help_list ListComponent`\n- `feat(help): fixed header/footer layout with ListComponent scroll in render_help_popup`\n\n2026-03-21 00:20:17\n---\n\nPR #185 — KAN-221: Scrollable Help Menu\n\nOverview\n\nReplaces the static Paragraph-based help popup with a ListComponent-backed scrollable list. Fixes\nclipping on small terminals, pins the header/footer, and fixes a pluralisation bug (\"entrys\" →\n\"items\"). Also generalises render_scroll_indicators and extracts get_adjusted_viewport_height up to\n kanban-core.\n\n---\nCode Quality\n\nPositives:\n- The get_adjusted_viewport_height extraction to Page is a clean improvement — ListComponent now\njust delegates, eliminating duplication\n- render_scroll_indicators generalisation is well done; the split-call pattern (above and below\nseparately) is a bit awkward but avoids a larger API change\n- render_help_popup signature change to &mut App is appropriate given it now writes\nhelp_viewport_height\n- The two-step ensure_selected_visible pattern for navigation is consistent with the existing\nnavigation_handlers.rs approach\n\nIssues:\n\n1. help_viewport_height as mutable state on App is a design smell. Viewport height is a render-time\n concern, not application state. It's written during render_help_popup and read during event\nhandling (handle_help_keys). This creates a frame-lag: on the very first keypress after opening\nhelp, help_viewport_height is 0 (initialised in open_help via set_scroll_offset(0) but never set).\nThe adjusted height will be wrong until the first render frame completes.\n\n// app.rs:513\nself.help_list.update_item_count(context.bindings.len());\nself.help_list.set_scroll_offset(0);\n// help_viewport_height is still 0 here\n2. render_scroll_indicators called twice per render site for above/below. The split above/below\ncalls work but produce a confusing API — a caller passing show_above=false, items_above=0 just to\nget the below indicator feels wrong. A struct or two-field tuple would be cleaner, or the function\ncould take an Option for each side. Minor, but it was touched in this PR so it's worth noting.\n3. update_item_count(0) used for \"reset\" (lines 870, 884, 1707). The intent is clearing the list,\nbut zeroing total_items is semantically different from \"close/reset\". If ListComponent ever gains\ninvariants around total_items, this could silently break. A reset() method would be clearer.\n4. render_help_popup signature is now &mut App but it's called from the render path. Render\nfunctions mutating application state is an architectural concern — it makes render_* functions\nharder to reason about and test. The help_viewport_height field is the only reason for this; see\npoint 1.\n5. all_lines is built eagerly (iterating all bindings), then only page_info.visible_indices are\nrendered. For typical keybinding counts this is fine, but it's unnecessary work — the visible lines\n could be built directly from visible_indices.\n\n---\nPotential Issues / Risks\n\n- Frame-lag on first navigation: If the user opens help and immediately presses j before the first\nrender, help_viewport_height == 0 means get_adjusted_viewport_height(0) == 0, so\nensure_selected_visible(0) is a no-op. The selection will scroll correctly after the next render.\nLow severity but worth a comment.\n- render_help_popup not called if help mode is never rendered (unlikely in practice, but\ntheoretically help_viewport_height stays 0 if render is skipped for any reason).\n- No test coverage added for the new scroll logic in the help context — the existing pattern in the\n codebase seems to rely on manual testing, which is noted in the PR description.\n\n---\nSuggestions\n\n1. Pass viewport_height into handle_help_keys from the call site, or compute it from a\nterminal-size accessor, rather than caching it on App.\n2. Consider a ListComponent::reset() method instead of update_item_count(0).\n3. Add a render_scroll_indicators_pair variant or use a small struct to avoid the split above/below\n calls.\n4. Build rendered_lines directly from page_info.visible_indices to avoid the intermediate all_lines\n allocation.\n\n---\nVerdict\n\nThe core fix is correct and the approach is sound. The main concern is help_viewport_height on App\ncreating a render/event coupling — it works in practice due to the TUI render loop but is fragile.\nAll other issues are minor. Approve with nits — the frame-lag concern is worth addressing before\nmerge if there's appetite, otherwise it should at minimum be documented.\n",
-        "due_date": null,
-        "id": "36754f9e-14ed-4fab-812c-c8c66a164c6a",
-        "points": null,
-        "position": 111,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Help menu list doesnt scroll",
-        "updated_at": "2026-03-21T12:48:10.528702211Z"
-      },
-      {
         "card_number": 285,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -9484,6 +8975,23 @@
         "status": "Todo",
         "title": "Move has_data_file flag out of AppConfig",
         "updated_at": "2026-04-04T23:44:59.525472708Z"
+      },
+      {
+        "card_number": 221,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-03-20T22:50:04.423551030Z",
+        "created_at": "2026-03-20T21:07:39.419336697Z",
+        "description": "## Challenge\nWhen the terminal window was too small to show all keybindings in the help popup, entries were silently cut off with no scroll support.\n\n## Solution\nImplemented scrollable help menu by reusing the existing `ListComponent` infrastructure from the card lists, following the same patterns used throughout the rest of the TUI.\n\n## Changes\n\n### `crates/kanban-core/src/pagination.rs`\n- Added `Page::get_adjusted_viewport_height(raw)` — computes content rows after reserving lines for scroll indicators (above=1 if scrolled, below=1 if items extend past viewport).\n\n### `crates/kanban-tui/src/components/generic_list.rs`\n- `ListComponent::get_adjusted_viewport_height` now delegates to `Page::get_adjusted_viewport_height` (deduplication).\n\n### `crates/kanban-tui/src/app.rs`\n- Replaced `help_selection: SelectionState` + `help_page: Page` with `help_list: ListComponent`.\n- On help open: `help_list.update_item_count(bindings.len())` + `set_scroll_offset(0)`.\n- On help close (3 locations): `help_list.update_item_count(0)`.\n- Navigation (j/k): uses two-step `ensure_selected_visible` pattern matching `navigation_handlers.rs`.\n- Key-shortcut jump: uses `help_list.jump_to(index)` + `ensure_selected_visible`.\n\n### `crates/kanban-tui/src/ui.rs` — `render_help_popup`\n- Layout changed to `[Length(2), Min(0), Length(2)]`: fixed header, scrollable bindings body, fixed footer.\n- `all_lines` now contains only the N binding lines (no header/footer offset arithmetic needed).\n- Uses `help_list.get_adjusted_viewport_height` + `help_list.get_render_info` for correct scroll state.\n- Scroll indicators rendered via shared `render_scroll_indicators` helper with label `\"item\"` (fixes \"entrys\" pluralisation bug from `\"entry\"`).\n- Fixed footer (hint line) always visible regardless of scroll position.\n\n## Commits\n- `feat(pagination): add get_adjusted_viewport_height to Page`\n- `refactor(generic_list): delegate get_adjusted_viewport_height to Page`\n- `feat(help): replace help_selection+help_page with help_list ListComponent`\n- `feat(help): fixed header/footer layout with ListComponent scroll in render_help_popup`\n\n2026-03-21 00:20:17\n---\n\nPR #185 — KAN-221: Scrollable Help Menu\n\nOverview\n\nReplaces the static Paragraph-based help popup with a ListComponent-backed scrollable list. Fixes\nclipping on small terminals, pins the header/footer, and fixes a pluralisation bug (\"entrys\" →\n\"items\"). Also generalises render_scroll_indicators and extracts get_adjusted_viewport_height up to\n kanban-core.\n\n---\nCode Quality\n\nPositives:\n- The get_adjusted_viewport_height extraction to Page is a clean improvement — ListComponent now\njust delegates, eliminating duplication\n- render_scroll_indicators generalisation is well done; the split-call pattern (above and below\nseparately) is a bit awkward but avoids a larger API change\n- render_help_popup signature change to &mut App is appropriate given it now writes\nhelp_viewport_height\n- The two-step ensure_selected_visible pattern for navigation is consistent with the existing\nnavigation_handlers.rs approach\n\nIssues:\n\n1. help_viewport_height as mutable state on App is a design smell. Viewport height is a render-time\n concern, not application state. It's written during render_help_popup and read during event\nhandling (handle_help_keys). This creates a frame-lag: on the very first keypress after opening\nhelp, help_viewport_height is 0 (initialised in open_help via set_scroll_offset(0) but never set).\nThe adjusted height will be wrong until the first render frame completes.\n\n// app.rs:513\nself.help_list.update_item_count(context.bindings.len());\nself.help_list.set_scroll_offset(0);\n// help_viewport_height is still 0 here\n2. render_scroll_indicators called twice per render site for above/below. The split above/below\ncalls work but produce a confusing API — a caller passing show_above=false, items_above=0 just to\nget the below indicator feels wrong. A struct or two-field tuple would be cleaner, or the function\ncould take an Option for each side. Minor, but it was touched in this PR so it's worth noting.\n3. update_item_count(0) used for \"reset\" (lines 870, 884, 1707). The intent is clearing the list,\nbut zeroing total_items is semantically different from \"close/reset\". If ListComponent ever gains\ninvariants around total_items, this could silently break. A reset() method would be clearer.\n4. render_help_popup signature is now &mut App but it's called from the render path. Render\nfunctions mutating application state is an architectural concern — it makes render_* functions\nharder to reason about and test. The help_viewport_height field is the only reason for this; see\npoint 1.\n5. all_lines is built eagerly (iterating all bindings), then only page_info.visible_indices are\nrendered. For typical keybinding counts this is fine, but it's unnecessary work — the visible lines\n could be built directly from visible_indices.\n\n---\nPotential Issues / Risks\n\n- Frame-lag on first navigation: If the user opens help and immediately presses j before the first\nrender, help_viewport_height == 0 means get_adjusted_viewport_height(0) == 0, so\nensure_selected_visible(0) is a no-op. The selection will scroll correctly after the next render.\nLow severity but worth a comment.\n- render_help_popup not called if help mode is never rendered (unlikely in practice, but\ntheoretically help_viewport_height stays 0 if render is skipped for any reason).\n- No test coverage added for the new scroll logic in the help context — the existing pattern in the\n codebase seems to rely on manual testing, which is noted in the PR description.\n\n---\nSuggestions\n\n1. Pass viewport_height into handle_help_keys from the call site, or compute it from a\nterminal-size accessor, rather than caching it on App.\n2. Consider a ListComponent::reset() method instead of update_item_count(0).\n3. Add a render_scroll_indicators_pair variant or use a small struct to avoid the split above/below\n calls.\n4. Build rendered_lines directly from page_info.visible_indices to avoid the intermediate all_lines\n allocation.\n\n---\nVerdict\n\nThe core fix is correct and the approach is sound. The main concern is help_viewport_height on App\ncreating a render/event coupling — it works in practice due to the TUI render loop but is fragile.\nAll other issues are minor. Approve with nits — the frame-lag concern is worth addressing before\nmerge if there's appetite, otherwise it should at minimum be documented.\n",
+        "due_date": null,
+        "id": "36754f9e-14ed-4fab-812c-c8c66a164c6a",
+        "points": null,
+        "position": 111,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "Help menu list doesnt scroll",
+        "updated_at": "2026-03-21T12:48:10.528702211Z"
       },
       {
         "card_number": 218,
@@ -9641,23 +9149,6 @@
         "updated_at": "2026-04-04T23:44:59.695084759Z"
       },
       {
-        "card_number": 222,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-22T14:10:15.806698690Z",
-        "created_at": "2026-03-21T20:43:37.808747277Z",
-        "description": "Follow-up fixes from KAN-123 search improvements:\\n- `gg` didn't scroll view to top — added `ensure_selected_visible` to `handle_jump_to_top`\\n- Unicode panic risk in `build_title_spans` — byte offsets from `title_lower` could differ from `title` for chars that expand on lowercasing (e.g. Turkish İ)\\n- `search_query` expression repeated 3x in `render_strategy.rs` — added `SearchState::active_query()` helper\\n- Active-search footer only showed `ESC: clear search` — updated to `j/k: navigate | ESC: clear`\\n- `n`/`N` were wired to navigate when search active — removed, `n` is new card only",
-        "due_date": null,
-        "id": "1ef7eef8-ed9f-40f4-a218-eeec54638ef7",
-        "points": null,
-        "position": 116,
-        "priority": "Low",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Fix post-search UX issues (gg scroll, Unicode panic, footer hint, n/N nav)",
-        "updated_at": "2026-03-22T14:10:15.806699191Z"
-      },
-      {
         "card_number": 290,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -9684,21 +9175,21 @@
         "updated_at": "2026-04-04T23:44:59.737340918Z"
       },
       {
-        "card_number": 224,
+        "card_number": 222,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-22T14:10:33.688473711Z",
-        "created_at": "2026-03-21T22:21:32.129925564Z",
-        "description": "Plan: Decompose app.rs into Focused Modules\n\nContext\n\ncrates/kanban-tui/src/app.rs is a 2,060-line god object with 58 public fields spanning unrelated concerns: mode navigation, focus tracking, entity selection, filtering, multi-select, dialog state, sprint views, relationships, animations, persistence, and UI state. All 9 handler files (impl App) freely mutate any field. This makes it impossible to discover where to add/change something without reading the entire file, and causes constant merge conflicts.\n\nThe goal is purely structural: split fields and their co-located logic into focused sub-structs in named modules with zero behavioral change. After this refactor, adding a new sprint feature means editing sprint_view.rs. Adding a filter means editing filter.rs. The App struct becomes a thin orchestrator.\n\nTarget Structure\n\ncrates/kanban-tui/src/app/\n├── mod.rs          ← Thin App struct + new() + run() + handle_key_event() + execute_action()\n├── mode.rs         ← AppMode, DialogMode, ModeManager (push/pop/open_dialog/is_dialog/get_base_mode)\n├── focus.rs        ← Focus, CardFocus, BoardFocus, FocusState\n├── selection.rs    ← SelectionHub (board/card/sprint selection + active indices)\n├── filter.rs       ← FilterState (sprint filters, hide_assigned, sort field/order, search, filter_dialog)\n├── multi_select.rs ← MultiSelectState (selected_cards, selection_mode_active)\n├── dialog_input.rs ← DialogInputState (import, priority, column, sprint_assign, task_list_view selections)\n├── sprint_view.rs  ← SprintTaskPanel enum, SprintViewState (panel + card lists + components)\n├── relationship.rs ← RelationshipState (card_ids, selected, selection, search, parents/children lists)\n├── view.rs         ← ViewState (strategy, card_list_component, viewport_height, last_frame_area)\n├── animation.rs    ← CardAnimation, ANIMATION_DURATION_MS, AnimationState\n├── persistence.rs  ← PersistenceState (save_file, app_config, file_watcher, channels)\n└── ui_state.rs     ← UiState (banner, help_list, help_pending_action, card_navigation_history)\n\nMigration Steps (each must compile before proceeding)\n\nStep 1: app.rs → app/mod.rs (mkdir + mv). Files Touched: 0. Effort: 5 min\nStep 2: Extract enums to mode.rs, re-export. Files Touched: mod.rs. Effort: 20 min\nStep 3: Extract Focus/CardFocus/BoardFocus/SprintTaskPanel to focus.rs, sprint_view.rs. Files Touched: mod.rs. Effort: 15 min\nStep 4: Extract CardAnimation + constant to animation.rs. Files Touched: mod.rs. Effort: 10 min\nStep 5: Introduce ModeManager with Deref; mode+mode_stack → mode: ModeManager. Files Touched: mod.rs + ~20 write sites in handlers/ui.rs. Effort: 75 min\nStep 6: Introduce FocusState; 3 fields → focus: FocusState. Files Touched: 9 handler files, ui.rs, render_strategy.rs, keybindings/registry.rs. Effort: 45 min\nStep 7: Introduce SelectionHub; 5 fields → selection: SelectionHub. Files Touched: all 9 handlers, app.rs, ui.rs, state/snapshot.rs. Effort: 75 min\nStep 8: Introduce FilterState; 7 fields → filter: FilterState. Files Touched: app.rs, navigation/sprint/card/filter_handlers, state/snapshot.rs. Effort: 40 min\nStep 9: Introduce MultiSelectState; 2 fields → multi_select: MultiSelectState. Files Touched: navigation/popup/card_handlers, app.rs. Effort: 20 min\nStep 10: Introduce DialogInputState; 6 fields → dialog_input: DialogInputState. Files Touched: popup/card/column/detail_view/board_handlers. Effort: 25 min\nStep 11: Introduce SprintViewState; 5 fields → sprint_view: SprintViewState. Files Touched: app.rs, popup/card/detail_view_handlers, ui.rs. Effort: 35 min\nStep 12: Introduce RelationshipState; 7 fields → relationship: RelationshipState. Files Touched: navigation/popup/card/detail_view_handlers. Effort: 30 min\nStep 13: Introduce ViewState; 4 fields → view: ViewState. Files Touched: app.rs, navigation/card_handlers, ui.rs. Effort: 20 min\nStep 14: Introduce AnimationState; 1 field → animation: AnimationState. Files Touched: app.rs, card_handlers. Effort: 20 min\nStep 15: Introduce PersistenceState; 6 fields → persistence: PersistenceState. Files Touched: app.rs, state/mod.rs only. Effort: 20 min\nStep 16: Introduce UiState; 4 fields → ui: UiState; keep App shims. Files Touched: app.rs, detail_view_handlers. Effort: 20 min\nStep 17: Move method bodies into sub-struct impls (populate, apply_sort, sync, switch_strategy, animation tick). Files Touched: app.rs + sprint_view/view/animation modules. Effort: 45 min\n\nTotal: ~8 hours\n\nCritical Files\n\n- crates/kanban-tui/src/app.rs → becomes app/mod.rs\n- crates/kanban-tui/src/ui.rs — updated in steps 6, 11, 13, 16\n- crates/kanban-tui/src/state/snapshot.rs — apply_to_app accesses active_board_index + current_sort_field; updated in steps 7 and 8\n- crates/kanban-tui/src/keybindings/registry.rs — reads app.mode, app.focus, app.card_focus, app.board_focus; updated in steps 5 and 6\n- crates/kanban-tui/src/handlers/detail_view_handlers.rs — touches the most sub-struct categories; use as integration canary\n\nVerification\n\nAfter each step: cargo check --package kanban-tui\nAfter all steps: cargo build && cargo test --package kanban-tui && cargo clippy -- -D warnings",
+        "completed_at": "2026-03-22T14:10:15.806698690Z",
+        "created_at": "2026-03-21T20:43:37.808747277Z",
+        "description": "Follow-up fixes from KAN-123 search improvements:\\n- `gg` didn't scroll view to top — added `ensure_selected_visible` to `handle_jump_to_top`\\n- Unicode panic risk in `build_title_spans` — byte offsets from `title_lower` could differ from `title` for chars that expand on lowercasing (e.g. Turkish İ)\\n- `search_query` expression repeated 3x in `render_strategy.rs` — added `SearchState::active_query()` helper\\n- Active-search footer only showed `ESC: clear search` — updated to `j/k: navigate | ESC: clear`\\n- `n`/`N` were wired to navigate when search active — removed, `n` is new card only",
         "due_date": null,
-        "id": "0409ba2d-72a0-47d9-8909-9138be67090c",
+        "id": "1ef7eef8-ed9f-40f4-a218-eeec54638ef7",
         "points": null,
-        "position": 117,
-        "priority": "Medium",
+        "position": 116,
+        "priority": "Low",
         "sprint_id": null,
         "sprint_logs": [],
         "status": "Done",
-        "title": "Decompose app.rs into Focused Modules",
-        "updated_at": "2026-03-22T14:10:33.688473789Z"
+        "title": "Fix post-search UX issues (gg scroll, Unicode panic, footer hint, n/N nav)",
+        "updated_at": "2026-03-22T14:10:15.806699191Z"
       },
       {
         "card_number": 291,
@@ -9727,6 +9218,40 @@
         "updated_at": "2026-04-04T23:44:59.778401899Z"
       },
       {
+        "card_number": 224,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-03-22T14:10:33.688473711Z",
+        "created_at": "2026-03-21T22:21:32.129925564Z",
+        "description": "Plan: Decompose app.rs into Focused Modules\n\nContext\n\ncrates/kanban-tui/src/app.rs is a 2,060-line god object with 58 public fields spanning unrelated concerns: mode navigation, focus tracking, entity selection, filtering, multi-select, dialog state, sprint views, relationships, animations, persistence, and UI state. All 9 handler files (impl App) freely mutate any field. This makes it impossible to discover where to add/change something without reading the entire file, and causes constant merge conflicts.\n\nThe goal is purely structural: split fields and their co-located logic into focused sub-structs in named modules with zero behavioral change. After this refactor, adding a new sprint feature means editing sprint_view.rs. Adding a filter means editing filter.rs. The App struct becomes a thin orchestrator.\n\nTarget Structure\n\ncrates/kanban-tui/src/app/\n├── mod.rs          ← Thin App struct + new() + run() + handle_key_event() + execute_action()\n├── mode.rs         ← AppMode, DialogMode, ModeManager (push/pop/open_dialog/is_dialog/get_base_mode)\n├── focus.rs        ← Focus, CardFocus, BoardFocus, FocusState\n├── selection.rs    ← SelectionHub (board/card/sprint selection + active indices)\n├── filter.rs       ← FilterState (sprint filters, hide_assigned, sort field/order, search, filter_dialog)\n├── multi_select.rs ← MultiSelectState (selected_cards, selection_mode_active)\n├── dialog_input.rs ← DialogInputState (import, priority, column, sprint_assign, task_list_view selections)\n├── sprint_view.rs  ← SprintTaskPanel enum, SprintViewState (panel + card lists + components)\n├── relationship.rs ← RelationshipState (card_ids, selected, selection, search, parents/children lists)\n├── view.rs         ← ViewState (strategy, card_list_component, viewport_height, last_frame_area)\n├── animation.rs    ← CardAnimation, ANIMATION_DURATION_MS, AnimationState\n├── persistence.rs  ← PersistenceState (save_file, app_config, file_watcher, channels)\n└── ui_state.rs     ← UiState (banner, help_list, help_pending_action, card_navigation_history)\n\nMigration Steps (each must compile before proceeding)\n\nStep 1: app.rs → app/mod.rs (mkdir + mv). Files Touched: 0. Effort: 5 min\nStep 2: Extract enums to mode.rs, re-export. Files Touched: mod.rs. Effort: 20 min\nStep 3: Extract Focus/CardFocus/BoardFocus/SprintTaskPanel to focus.rs, sprint_view.rs. Files Touched: mod.rs. Effort: 15 min\nStep 4: Extract CardAnimation + constant to animation.rs. Files Touched: mod.rs. Effort: 10 min\nStep 5: Introduce ModeManager with Deref; mode+mode_stack → mode: ModeManager. Files Touched: mod.rs + ~20 write sites in handlers/ui.rs. Effort: 75 min\nStep 6: Introduce FocusState; 3 fields → focus: FocusState. Files Touched: 9 handler files, ui.rs, render_strategy.rs, keybindings/registry.rs. Effort: 45 min\nStep 7: Introduce SelectionHub; 5 fields → selection: SelectionHub. Files Touched: all 9 handlers, app.rs, ui.rs, state/snapshot.rs. Effort: 75 min\nStep 8: Introduce FilterState; 7 fields → filter: FilterState. Files Touched: app.rs, navigation/sprint/card/filter_handlers, state/snapshot.rs. Effort: 40 min\nStep 9: Introduce MultiSelectState; 2 fields → multi_select: MultiSelectState. Files Touched: navigation/popup/card_handlers, app.rs. Effort: 20 min\nStep 10: Introduce DialogInputState; 6 fields → dialog_input: DialogInputState. Files Touched: popup/card/column/detail_view/board_handlers. Effort: 25 min\nStep 11: Introduce SprintViewState; 5 fields → sprint_view: SprintViewState. Files Touched: app.rs, popup/card/detail_view_handlers, ui.rs. Effort: 35 min\nStep 12: Introduce RelationshipState; 7 fields → relationship: RelationshipState. Files Touched: navigation/popup/card/detail_view_handlers. Effort: 30 min\nStep 13: Introduce ViewState; 4 fields → view: ViewState. Files Touched: app.rs, navigation/card_handlers, ui.rs. Effort: 20 min\nStep 14: Introduce AnimationState; 1 field → animation: AnimationState. Files Touched: app.rs, card_handlers. Effort: 20 min\nStep 15: Introduce PersistenceState; 6 fields → persistence: PersistenceState. Files Touched: app.rs, state/mod.rs only. Effort: 20 min\nStep 16: Introduce UiState; 4 fields → ui: UiState; keep App shims. Files Touched: app.rs, detail_view_handlers. Effort: 20 min\nStep 17: Move method bodies into sub-struct impls (populate, apply_sort, sync, switch_strategy, animation tick). Files Touched: app.rs + sprint_view/view/animation modules. Effort: 45 min\n\nTotal: ~8 hours\n\nCritical Files\n\n- crates/kanban-tui/src/app.rs → becomes app/mod.rs\n- crates/kanban-tui/src/ui.rs — updated in steps 6, 11, 13, 16\n- crates/kanban-tui/src/state/snapshot.rs — apply_to_app accesses active_board_index + current_sort_field; updated in steps 7 and 8\n- crates/kanban-tui/src/keybindings/registry.rs — reads app.mode, app.focus, app.card_focus, app.board_focus; updated in steps 5 and 6\n- crates/kanban-tui/src/handlers/detail_view_handlers.rs — touches the most sub-struct categories; use as integration canary\n\nVerification\n\nAfter each step: cargo check --package kanban-tui\nAfter all steps: cargo build && cargo test --package kanban-tui && cargo clippy -- -D warnings",
+        "due_date": null,
+        "id": "0409ba2d-72a0-47d9-8909-9138be67090c",
+        "points": null,
+        "position": 117,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "Decompose app.rs into Focused Modules",
+        "updated_at": "2026-03-22T14:10:33.688473789Z"
+      },
+      {
+        "card_number": 220,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-03-22T14:10:38.745731756Z",
+        "created_at": "2026-03-18T03:09:45.873764937Z",
+        "description": "kanban_bin() now searches CARGO_TARGET_DIR across all subdirs and profiles (release before debug) so nix sandbox builds with cross-compiled target triples are found without KANBAN_BIN injection. KANBAN_BIN override preserved.",
+        "due_date": null,
+        "id": "12e6437f-8295-40ca-b0d5-1c89cbfd85eb",
+        "points": null,
+        "position": 118,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "Fix kanban binary discovery in MCP integration tests for nix builds",
+        "updated_at": "2026-03-22T14:10:38.745731835Z"
+      },
+      {
         "card_number": 292,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -9751,23 +9276,6 @@
         "status": "Todo",
         "title": "Document move_config cross-device fallback crash window",
         "updated_at": "2026-04-04T23:44:59.820460535Z"
-      },
-      {
-        "card_number": 220,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-22T14:10:38.745731756Z",
-        "created_at": "2026-03-18T03:09:45.873764937Z",
-        "description": "kanban_bin() now searches CARGO_TARGET_DIR across all subdirs and profiles (release before debug) so nix sandbox builds with cross-compiled target triples are found without KANBAN_BIN injection. KANBAN_BIN override preserved.",
-        "due_date": null,
-        "id": "12e6437f-8295-40ca-b0d5-1c89cbfd85eb",
-        "points": null,
-        "position": 118,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Fix kanban binary discovery in MCP integration tests for nix builds",
-        "updated_at": "2026-03-22T14:10:38.745731835Z"
       },
       {
         "card_number": 293,
@@ -9960,30 +9468,30 @@
         "updated_at": "2026-04-04T23:45:00.024564443Z"
       },
       {
-        "card_number": 303,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-05T00:01:03.632059484Z",
-        "description": "The current bulk-update pattern (bulk-archive, bulk-move) feels like an afterthought. A more natural API would be `kanban cards update` (plural) supporting heterogeneous field updates across multiple cards in one command, e.g. different points per card. This mirrors how users think: 'update cards' rather than 'card bulk-update'.",
+        "card_number": 233,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-03-28T17:07:24.153426440Z",
+        "created_at": "2026-03-25T01:29:43.793638242Z",
+        "description": "Added 'Attachments, adding files to cards' as the first planned item in the Roadmap section of web/index.html to match README.md.",
         "due_date": null,
-        "id": "aa5af110-c68b-4662-a7e0-41c8446b713d",
-        "points": 3,
+        "id": "84e739f8-171a-431d-8fcf-eec4884d9710",
+        "points": 1,
         "position": 124,
         "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541932090Z",
-            "status": "Planning"
+            "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
+            "sprint_name": "moonshot",
+            "sprint_number": 12,
+            "started_at": "2026-03-31T22:20:35.403926901Z",
+            "status": "Active"
           }
         ],
-        "status": "Todo",
-        "title": "Add 'kanban cards update' plural subcommand for bulk heterogeneous updates",
-        "updated_at": "2026-04-06T21:44:46.541951939Z"
+        "status": "Done",
+        "title": "Sync web/index.html roadmap with README.md",
+        "updated_at": "2026-03-31T22:20:35.403930561Z"
       },
       {
         "card_number": 232,
@@ -10046,30 +9554,54 @@
         "updated_at": "2026-03-28T17:03:59.246079417Z"
       },
       {
-        "card_number": 233,
+        "card_number": 123,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-28T17:07:24.153426440Z",
-        "created_at": "2026-03-25T01:29:43.793638242Z",
-        "description": "Added 'Attachments, adding files to cards' as the first planned item in the Roadmap section of web/index.html to match README.md.",
+        "completed_at": "2026-03-21T18:06:08.092387619Z",
+        "created_at": "2025-11-03T16:58:06.579445Z",
+        "description": "It would be cool to emulate the vim search binding with `escape` to clear search, `enter` to apply search and `n` to go to next hit. ofcourse with highlighting of the search string on the hit element\n\nlike I hit c to complete the task and it took me away from the search results. search should only clear explicitly by hitting escape\n\ncurrently. searching and then hitting escape escape the user out of the board\n\nalso actions taken after the search has been made clears the search. I would like to keep the search results until the users explictly exits search mode\n",
         "due_date": null,
-        "id": "84e739f8-171a-431d-8fcf-eec4884d9710",
+        "id": "c401de4c-5d33-4fb3-a955-05074785c28d",
         "points": 1,
         "position": 124,
         "priority": "Medium",
-        "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
+        "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
         "sprint_logs": [
           {
-            "ended_at": null,
-            "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
-            "sprint_name": "moonshot",
-            "sprint_number": 12,
-            "started_at": "2026-03-31T22:20:35.403926901Z",
+            "ended_at": "2025-12-15T20:35:57.264719Z",
+            "sprint_id": "a61d4a55-5870-4493-9015-9854d8f583cf",
+            "sprint_name": "progression-is-progress",
+            "sprint_number": 8,
+            "started_at": "2025-11-17T22:46:16.108008Z",
             "status": "Active"
+          },
+          {
+            "ended_at": "2026-01-10T15:31:10.374955Z",
+            "sprint_id": "63d7a91a-cd0f-42fa-8fac-73ae015431f8",
+            "sprint_name": "a-merry-christmas",
+            "sprint_number": 10,
+            "started_at": "2025-12-15T20:35:57.264720Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": "2026-02-01T13:46:57.678266Z",
+            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
+            "sprint_name": "an-eventful-october",
+            "sprint_number": 1,
+            "started_at": "2026-01-10T15:31:10.374956Z",
+            "status": "Completed"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
+            "sprint_name": "a-new-year",
+            "sprint_number": 11,
+            "started_at": "2026-02-01T13:46:57.678268Z",
+            "status": "Planning"
           }
         ],
         "status": "Done",
-        "title": "Sync web/index.html roadmap with README.md",
-        "updated_at": "2026-03-31T22:20:35.403930561Z"
+        "title": "escape bind to clear search, enter to apply",
+        "updated_at": "2026-03-28T17:03:59.235889171Z"
       },
       {
         "card_number": 122,
@@ -10122,54 +9654,30 @@
         "updated_at": "2026-03-28T17:03:59.225291075Z"
       },
       {
-        "card_number": 123,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-21T18:06:08.092387619Z",
-        "created_at": "2025-11-03T16:58:06.579445Z",
-        "description": "It would be cool to emulate the vim search binding with `escape` to clear search, `enter` to apply search and `n` to go to next hit. ofcourse with highlighting of the search string on the hit element\n\nlike I hit c to complete the task and it took me away from the search results. search should only clear explicitly by hitting escape\n\ncurrently. searching and then hitting escape escape the user out of the board\n\nalso actions taken after the search has been made clears the search. I would like to keep the search results until the users explictly exits search mode\n",
+        "card_number": 303,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-05T00:01:03.632059484Z",
+        "description": "The current bulk-update pattern (bulk-archive, bulk-move) feels like an afterthought. A more natural API would be `kanban cards update` (plural) supporting heterogeneous field updates across multiple cards in one command, e.g. different points per card. This mirrors how users think: 'update cards' rather than 'card bulk-update'.",
         "due_date": null,
-        "id": "c401de4c-5d33-4fb3-a955-05074785c28d",
-        "points": 1,
+        "id": "aa5af110-c68b-4662-a7e0-41c8446b713d",
+        "points": 3,
         "position": 124,
         "priority": "Medium",
-        "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
           {
-            "ended_at": "2025-12-15T20:35:57.264719Z",
-            "sprint_id": "a61d4a55-5870-4493-9015-9854d8f583cf",
-            "sprint_name": "progression-is-progress",
-            "sprint_number": 8,
-            "started_at": "2025-11-17T22:46:16.108008Z",
-            "status": "Active"
-          },
-          {
-            "ended_at": "2026-01-10T15:31:10.374955Z",
-            "sprint_id": "63d7a91a-cd0f-42fa-8fac-73ae015431f8",
-            "sprint_name": "a-merry-christmas",
-            "sprint_number": 10,
-            "started_at": "2025-12-15T20:35:57.264720Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": "2026-02-01T13:46:57.678266Z",
-            "sprint_id": "5fffb1a7-facb-4461-b0f1-13ec3e4d3f3a",
-            "sprint_name": "an-eventful-october",
-            "sprint_number": 1,
-            "started_at": "2026-01-10T15:31:10.374956Z",
-            "status": "Completed"
-          },
-          {
             "ended_at": null,
-            "sprint_id": "3b98dc57-7c28-4724-9b80-e4dcb3421acd",
-            "sprint_name": "a-new-year",
-            "sprint_number": 11,
-            "started_at": "2026-02-01T13:46:57.678268Z",
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541932090Z",
             "status": "Planning"
           }
         ],
-        "status": "Done",
-        "title": "escape bind to clear search, enter to apply",
-        "updated_at": "2026-03-28T17:03:59.235889171Z"
+        "status": "Todo",
+        "title": "Add 'kanban cards update' plural subcommand for bulk heterogeneous updates",
+        "updated_at": "2026-04-06T21:44:46.541951939Z"
       },
       {
         "card_number": 298,
@@ -10267,30 +9775,30 @@
         "updated_at": "2026-04-06T21:44:46.541944404Z"
       },
       {
-        "card_number": 314,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-06T11:43:32.930113058Z",
-        "description": "Avoid vec![Box::new(cmd) as Box<dyn Command>] at every single-command call site",
+        "card_number": 235,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-03-29T00:08:26.243089260Z",
+        "created_at": "2026-03-25T23:43:21.977203118Z",
+        "description": "## Goal\n\nReplace the single flat `KanbanError` enum (in `kanban-core`) with per-layer error types that have precise, minimal responsibility. This is the foundation for all future error handling across the codebase.\n\n## Current Problem\n\n`KanbanError` in `kanban-core` is used by every crate, meaning:\n- Persistence concepts (`ConflictDetected`, `Io`) sit next to domain concepts (`CycleDetected`, `NotFound`)\n- The core crate couples upward to higher-layer concerns\n- Callers cannot match precisely — `NotFound(String)` loses type information\n- Graph errors (`CycleDetected`, `SelfReference`, `EdgeNotFound`) are domain-specific but in core\n\n## Target Architecture\n\n```\nkanban-core        → KanbanError (thin top-level wrapper, used by service + CLI + TUI + MCP)\nkanban-domain      → DomainError (NotFound, Validation, DependencyError)\nkanban-persistence → PersistenceError (Io, Serialization, ConflictDetected)\n```\n\nEach layer only knows its own error type. Boundaries convert via `#[from]`.\n\n## Layer Design\n\n### kanban-domain: DomainError\n\n```rust\n#[derive(Error, Debug)]\npub enum DomainError {\n    #[error(\"{entity} {id} not found\")]\n    NotFound { entity: &'static str, id: Uuid },\n\n    #[error(\"validation error: {0}\")]\n    Validation(String),\n\n    #[error(transparent)]\n    Dependency(#[from] DependencyError),\n}\n\n#[derive(Error, Debug)]\npub enum DependencyError {\n    #[error(\"cycle detected: adding this edge would create a circular dependency\")]\n    CycleDetected,\n\n    #[error(\"self-reference not allowed\")]\n    SelfReference,\n\n    #[error(\"edge not found\")]\n    EdgeNotFound,\n}\n```\n\n`NotFound { entity: &'static str, id: Uuid }` — typed id, readable message, no enum bloat as domain grows.\n\nHelper constructors on `DomainError` keep call sites clean:\n```rust\nimpl DomainError {\n    pub fn board_not_found(id: Uuid) -> Self { Self::NotFound { entity: \"board\", id } }\n    pub fn card_not_found(id: Uuid)  -> Self { Self::NotFound { entity: \"card\",  id } }\n    pub fn column_not_found(id: Uuid)-> Self { Self::NotFound { entity: \"column\",id } }\n    pub fn sprint_not_found(id: Uuid)-> Self { Self::NotFound { entity: \"sprint\",id } }\n    pub fn archived_card_not_found(id: Uuid) -> Self { Self::NotFound { entity: \"archived card\", id } }\n}\n```\n\n### kanban-persistence: PersistenceError\n\n```rust\n#[derive(Error, Debug)]\npub enum PersistenceError {\n    #[error(\"IO error: {0}\")]\n    Io(#[from] std::io::Error),\n\n    #[error(\"serialization error: {0}\")]\n    Serialization(String),\n\n    #[error(\"file conflict: {path} was modified by another instance\")]\n    ConflictDetected {\n        path: String,\n        #[source]\n        source: Option<Box<dyn std::error::Error + Send + Sync>>,\n    },\n}\n```\n\n### kanban-core: KanbanError (top-level wrapper)\n\n```rust\n#[derive(Error, Debug)]\npub enum KanbanError {\n    #[error(transparent)]\n    Domain(#[from] DomainError),\n\n    #[error(transparent)]\n    Persistence(#[from] PersistenceError),\n\n    #[error(\"internal error: {0}\")]\n    Internal(String),\n}\n```\n\nTUI, CLI, and MCP work with `KanbanError`. They can match on `KanbanError::Domain(DomainError::NotFound { entity, id })` when they need precision, or treat all errors uniformly for display.\n\n## Migration Steps\n\n1. **Add `DomainError` + `DependencyError` to `kanban-domain`**\n   - New file: `crates/kanban-domain/src/error.rs`\n   - Export from `crates/kanban-domain/src/lib.rs`\n\n2. **Add `PersistenceError` to `kanban-persistence`**\n   - New file: `crates/kanban-persistence/src/error.rs`\n   - Export from `crates/kanban-persistence/src/lib.rs`\n\n3. **Update `kanban-core` KanbanError**\n   - Depends on `kanban-domain` and `kanban-persistence` (check if circular — may need to move KanbanError out of core entirely, or keep core as the aggregator crate)\n   - Remove `NotFound`, `Validation`, `Io`, `Serialization`, `ConflictDetected`, `CycleDetected`, `SelfReference`, `EdgeNotFound`, `Connection`\n\n4. **Update `kanban-domain` command and graph code**\n   - All commands return `DomainResult<()>` (type alias for `Result<T, DomainError>`)\n   - Graph errors return `DependencyError`\n\n5. **Update `kanban-persistence`**\n   - All persistence code returns `PersistenceResult<T>`\n\n6. **Update `kanban-service`**\n   - Service methods return `KanbanResult<T>` as today\n   - `?` operator handles conversion via `#[from]`\n\n7. **Update TUI, CLI, MCP**\n   - Match arms updated where needed\n   - `cargo check` drives this mechanically\n\n## Watch Out For\n\n- `kanban-core` currently has no dependencies on other workspace crates — if `KanbanError` wraps `DomainError`, core would need to depend on domain, inverting the dependency flow. Consider making `kanban-service` own the top-level error instead, with `kanban-core` remaining a pure abstractions crate (traits + result type only).\n- `KanbanResult<T>` type alias must be updated at its definition site\n\n## Acceptance Criteria\n\n- [ ] `DomainError` defined in `kanban-domain` with `NotFound { entity, id }`, `Validation`, `Dependency` variants\n- [ ] `DependencyError` sub-enum with `CycleDetected`, `SelfReference`, `EdgeNotFound`\n- [ ] `PersistenceError` defined in `kanban-persistence`\n- [ ] `KanbanError` in core (or service) wraps both via `#[from]`\n- [ ] No stringly-typed `NotFound(String)` anywhere in the codebase\n- [ ] `cargo test --workspace` passes\n- [ ] `cargo clippy --workspace` passes clean\n- [ ] KAN-171 can use `DomainError::card_not_found(id)` directly in CommandContext helpers",
         "due_date": null,
-        "id": "0d44531b-cb7a-4f51-bfeb-47bfe8b08134",
-        "points": null,
+        "id": "4ceaaf1c-e27d-4f67-ae60-9cda1e8a627c",
+        "points": 5,
         "position": 128,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "priority": "High",
+        "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541919760Z",
-            "status": "Planning"
+            "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
+            "sprint_name": "moonshot",
+            "sprint_number": 12,
+            "started_at": "2026-03-28T21:44:41.511381383Z",
+            "status": "Active"
           }
         ],
-        "status": "Todo",
-        "title": "Add execute_one(Box<dyn Command>) convenience method to KanbanContext",
-        "updated_at": "2026-04-06T21:44:46.541941832Z"
+        "status": "Done",
+        "title": "Per-layer error types: DomainError, PersistenceError, KanbanError",
+        "updated_at": "2026-03-29T13:21:24.343853066Z"
       },
       {
         "card_number": 262,
@@ -10319,30 +9827,30 @@
         "updated_at": "2026-03-31T22:19:39.943232014Z"
       },
       {
-        "card_number": 235,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-03-29T00:08:26.243089260Z",
-        "created_at": "2026-03-25T23:43:21.977203118Z",
-        "description": "## Goal\n\nReplace the single flat `KanbanError` enum (in `kanban-core`) with per-layer error types that have precise, minimal responsibility. This is the foundation for all future error handling across the codebase.\n\n## Current Problem\n\n`KanbanError` in `kanban-core` is used by every crate, meaning:\n- Persistence concepts (`ConflictDetected`, `Io`) sit next to domain concepts (`CycleDetected`, `NotFound`)\n- The core crate couples upward to higher-layer concerns\n- Callers cannot match precisely — `NotFound(String)` loses type information\n- Graph errors (`CycleDetected`, `SelfReference`, `EdgeNotFound`) are domain-specific but in core\n\n## Target Architecture\n\n```\nkanban-core        → KanbanError (thin top-level wrapper, used by service + CLI + TUI + MCP)\nkanban-domain      → DomainError (NotFound, Validation, DependencyError)\nkanban-persistence → PersistenceError (Io, Serialization, ConflictDetected)\n```\n\nEach layer only knows its own error type. Boundaries convert via `#[from]`.\n\n## Layer Design\n\n### kanban-domain: DomainError\n\n```rust\n#[derive(Error, Debug)]\npub enum DomainError {\n    #[error(\"{entity} {id} not found\")]\n    NotFound { entity: &'static str, id: Uuid },\n\n    #[error(\"validation error: {0}\")]\n    Validation(String),\n\n    #[error(transparent)]\n    Dependency(#[from] DependencyError),\n}\n\n#[derive(Error, Debug)]\npub enum DependencyError {\n    #[error(\"cycle detected: adding this edge would create a circular dependency\")]\n    CycleDetected,\n\n    #[error(\"self-reference not allowed\")]\n    SelfReference,\n\n    #[error(\"edge not found\")]\n    EdgeNotFound,\n}\n```\n\n`NotFound { entity: &'static str, id: Uuid }` — typed id, readable message, no enum bloat as domain grows.\n\nHelper constructors on `DomainError` keep call sites clean:\n```rust\nimpl DomainError {\n    pub fn board_not_found(id: Uuid) -> Self { Self::NotFound { entity: \"board\", id } }\n    pub fn card_not_found(id: Uuid)  -> Self { Self::NotFound { entity: \"card\",  id } }\n    pub fn column_not_found(id: Uuid)-> Self { Self::NotFound { entity: \"column\",id } }\n    pub fn sprint_not_found(id: Uuid)-> Self { Self::NotFound { entity: \"sprint\",id } }\n    pub fn archived_card_not_found(id: Uuid) -> Self { Self::NotFound { entity: \"archived card\", id } }\n}\n```\n\n### kanban-persistence: PersistenceError\n\n```rust\n#[derive(Error, Debug)]\npub enum PersistenceError {\n    #[error(\"IO error: {0}\")]\n    Io(#[from] std::io::Error),\n\n    #[error(\"serialization error: {0}\")]\n    Serialization(String),\n\n    #[error(\"file conflict: {path} was modified by another instance\")]\n    ConflictDetected {\n        path: String,\n        #[source]\n        source: Option<Box<dyn std::error::Error + Send + Sync>>,\n    },\n}\n```\n\n### kanban-core: KanbanError (top-level wrapper)\n\n```rust\n#[derive(Error, Debug)]\npub enum KanbanError {\n    #[error(transparent)]\n    Domain(#[from] DomainError),\n\n    #[error(transparent)]\n    Persistence(#[from] PersistenceError),\n\n    #[error(\"internal error: {0}\")]\n    Internal(String),\n}\n```\n\nTUI, CLI, and MCP work with `KanbanError`. They can match on `KanbanError::Domain(DomainError::NotFound { entity, id })` when they need precision, or treat all errors uniformly for display.\n\n## Migration Steps\n\n1. **Add `DomainError` + `DependencyError` to `kanban-domain`**\n   - New file: `crates/kanban-domain/src/error.rs`\n   - Export from `crates/kanban-domain/src/lib.rs`\n\n2. **Add `PersistenceError` to `kanban-persistence`**\n   - New file: `crates/kanban-persistence/src/error.rs`\n   - Export from `crates/kanban-persistence/src/lib.rs`\n\n3. **Update `kanban-core` KanbanError**\n   - Depends on `kanban-domain` and `kanban-persistence` (check if circular — may need to move KanbanError out of core entirely, or keep core as the aggregator crate)\n   - Remove `NotFound`, `Validation`, `Io`, `Serialization`, `ConflictDetected`, `CycleDetected`, `SelfReference`, `EdgeNotFound`, `Connection`\n\n4. **Update `kanban-domain` command and graph code**\n   - All commands return `DomainResult<()>` (type alias for `Result<T, DomainError>`)\n   - Graph errors return `DependencyError`\n\n5. **Update `kanban-persistence`**\n   - All persistence code returns `PersistenceResult<T>`\n\n6. **Update `kanban-service`**\n   - Service methods return `KanbanResult<T>` as today\n   - `?` operator handles conversion via `#[from]`\n\n7. **Update TUI, CLI, MCP**\n   - Match arms updated where needed\n   - `cargo check` drives this mechanically\n\n## Watch Out For\n\n- `kanban-core` currently has no dependencies on other workspace crates — if `KanbanError` wraps `DomainError`, core would need to depend on domain, inverting the dependency flow. Consider making `kanban-service` own the top-level error instead, with `kanban-core` remaining a pure abstractions crate (traits + result type only).\n- `KanbanResult<T>` type alias must be updated at its definition site\n\n## Acceptance Criteria\n\n- [ ] `DomainError` defined in `kanban-domain` with `NotFound { entity, id }`, `Validation`, `Dependency` variants\n- [ ] `DependencyError` sub-enum with `CycleDetected`, `SelfReference`, `EdgeNotFound`\n- [ ] `PersistenceError` defined in `kanban-persistence`\n- [ ] `KanbanError` in core (or service) wraps both via `#[from]`\n- [ ] No stringly-typed `NotFound(String)` anywhere in the codebase\n- [ ] `cargo test --workspace` passes\n- [ ] `cargo clippy --workspace` passes clean\n- [ ] KAN-171 can use `DomainError::card_not_found(id)` directly in CommandContext helpers",
+        "card_number": 314,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-06T11:43:32.930113058Z",
+        "description": "Avoid vec![Box::new(cmd) as Box<dyn Command>] at every single-command call site",
         "due_date": null,
-        "id": "4ceaaf1c-e27d-4f67-ae60-9cda1e8a627c",
-        "points": 5,
+        "id": "0d44531b-cb7a-4f51-bfeb-47bfe8b08134",
+        "points": null,
         "position": 128,
-        "priority": "High",
-        "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "0c3867d9-7ed8-4ac4-90c8-d7f8eebb17d0",
-            "sprint_name": "moonshot",
-            "sprint_number": 12,
-            "started_at": "2026-03-28T21:44:41.511381383Z",
-            "status": "Active"
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541919760Z",
+            "status": "Planning"
           }
         ],
-        "status": "Done",
-        "title": "Per-layer error types: DomainError, PersistenceError, KanbanError",
-        "updated_at": "2026-03-29T13:21:24.343853066Z"
+        "status": "Todo",
+        "title": "Add execute_one(Box<dyn Command>) convenience method to KanbanContext",
+        "updated_at": "2026-04-06T21:44:46.541941832Z"
       },
       {
         "card_number": 259,
@@ -10371,32 +9879,6 @@
         "updated_at": "2026-03-31T22:19:48.638724848Z"
       },
       {
-        "card_number": 306,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-05T11:43:27.299929945Z",
-        "description": "In apply_config_edit, the inline path resolution (is_absolute / current_dir().join) duplicates logic from resolve_storage_location. Extract a private is_same_location(loc: &str, resolved: &str) -> bool helper that delegates to resolve_storage_location to eliminate the duplication and the hidden dependency on from_config serialising absolute paths.",
-        "due_date": null,
-        "id": "4c374d7e-5600-4675-80f5-5d4ce72c58db",
-        "points": null,
-        "position": 129,
-        "priority": "Low",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541931189Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Extract strip_storage path resolution into helper",
-        "updated_at": "2026-04-06T21:44:46.541951117Z"
-      },
-      {
         "card_number": 258,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-03-31T00:28:05.528006166Z",
@@ -10423,15 +9905,15 @@
         "updated_at": "2026-03-31T22:20:28.012633240Z"
       },
       {
-        "card_number": 307,
+        "card_number": 306,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
-        "created_at": "2026-04-05T11:47:42.730243629Z",
-        "description": "test_open_config_editor_skips_apply_when_content_matches only validates the trim() comparison in isolation — it does not assert that apply_config_edit is actually not called. Replace with an integration-level assertion that verifies the absence of side effects (e.g. config file not written, migration_state stays Idle) when the editor returns unchanged content.",
+        "created_at": "2026-04-05T11:43:27.299929945Z",
+        "description": "In apply_config_edit, the inline path resolution (is_absolute / current_dir().join) duplicates logic from resolve_storage_location. Extract a private is_same_location(loc: &str, resolved: &str) -> bool helper that delegates to resolve_storage_location to eliminate the duplication and the hidden dependency on from_config serialising absolute paths.",
         "due_date": null,
-        "id": "84ad89f7-f5d0-4b2a-a84b-db1f90ebae02",
+        "id": "4c374d7e-5600-4675-80f5-5d4ce72c58db",
         "points": null,
-        "position": 130,
+        "position": 129,
         "priority": "Low",
         "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
@@ -10440,13 +9922,13 @@
             "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
             "sprint_name": "a-catchy-spring",
             "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541920709Z",
+            "started_at": "2026-04-06T21:44:46.541931189Z",
             "status": "Planning"
           }
         ],
         "status": "Todo",
-        "title": "Strengthen open_config_editor no-op guard test",
-        "updated_at": "2026-04-06T21:44:46.541942662Z"
+        "title": "Extract strip_storage path resolution into helper",
+        "updated_at": "2026-04-06T21:44:46.541951117Z"
       },
       {
         "card_number": 263,
@@ -10473,6 +9955,32 @@
         "status": "Done",
         "title": "Rework migrate CLI: backend as positional arg, filename as option",
         "updated_at": "2026-03-31T22:19:34.634197710Z"
+      },
+      {
+        "card_number": 307,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-05T11:47:42.730243629Z",
+        "description": "test_open_config_editor_skips_apply_when_content_matches only validates the trim() comparison in isolation — it does not assert that apply_config_edit is actually not called. Replace with an integration-level assertion that verifies the absence of side effects (e.g. config file not written, migration_state stays Idle) when the editor returns unchanged content.",
+        "due_date": null,
+        "id": "84ad89f7-f5d0-4b2a-a84b-db1f90ebae02",
+        "points": null,
+        "position": 130,
+        "priority": "Low",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541920709Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Strengthen open_config_editor no-op guard test",
+        "updated_at": "2026-04-06T21:44:46.541942662Z"
       },
       {
         "card_number": 315,
@@ -10579,6 +10087,23 @@
         "updated_at": "2026-04-06T21:44:46.541950269Z"
       },
       {
+        "card_number": 300,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-04-04T23:19:06.810027693Z",
+        "created_at": "2026-04-04T23:11:47.844701277Z",
+        "description": null,
+        "due_date": null,
+        "id": "95ee70a6-29c1-46f6-99f0-b8c37cffa196",
+        "points": null,
+        "position": 133,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "make version readout of web/landing dynamic",
+        "updated_at": "2026-04-04T23:19:06.810027997Z"
+      },
+      {
         "card_number": 316,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -10603,23 +10128,6 @@
         "status": "Todo",
         "title": "Skip save() I/O when context is not dirty",
         "updated_at": "2026-04-06T21:44:46.541943588Z"
-      },
-      {
-        "card_number": 300,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-04-04T23:19:06.810027693Z",
-        "created_at": "2026-04-04T23:11:47.844701277Z",
-        "description": null,
-        "due_date": null,
-        "id": "95ee70a6-29c1-46f6-99f0-b8c37cffa196",
-        "points": null,
-        "position": 133,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "make version readout of web/landing dynamic",
-        "updated_at": "2026-04-04T23:19:06.810027997Z"
       },
       {
         "card_number": 171,
@@ -10742,6 +10250,32 @@
         "updated_at": "2026-04-06T21:43:06.253364696Z"
       },
       {
+        "card_number": 318,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-06T13:28:54.200998180Z",
+        "description": "From PR #213 review. The execute() API now takes Vec<Box<dyn Command>>, which requires wrapping every single-command call site with vec\\![Box::new(cmd) as Box<dyn Command>]. There are ~100 such sites in kanban-tui alone. Consider a cmd\\!() macro or a single() helper fn: fn cmd(c: impl Command + 'static) -> Vec<Box<dyn Command>> { vec\\![Box::new(c)] }. Low priority cleanup.",
+        "due_date": null,
+        "id": "22209f66-0f52-45c5-b8a6-4e5576287630",
+        "points": 2,
+        "position": 136,
+        "priority": "Low",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541932998Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Add helper to reduce vec\\![Box::new(...) as Box<dyn Command>] boilerplate",
+        "updated_at": "2026-04-06T21:44:46.541952888Z"
+      },
+      {
         "card_number": 274,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-04-06T21:43:36.139853390Z",
@@ -10774,58 +10308,6 @@
         "status": "Done",
         "title": "Settings page UI",
         "updated_at": "2026-04-06T21:43:36.139853931Z"
-      },
-      {
-        "card_number": 318,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-06T13:28:54.200998180Z",
-        "description": "From PR #213 review. The execute() API now takes Vec<Box<dyn Command>>, which requires wrapping every single-command call site with vec\\![Box::new(cmd) as Box<dyn Command>]. There are ~100 such sites in kanban-tui alone. Consider a cmd\\!() macro or a single() helper fn: fn cmd(c: impl Command + 'static) -> Vec<Box<dyn Command>> { vec\\![Box::new(c)] }. Low priority cleanup.",
-        "due_date": null,
-        "id": "22209f66-0f52-45c5-b8a6-4e5576287630",
-        "points": 2,
-        "position": 136,
-        "priority": "Low",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541932998Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Add helper to reduce vec\\![Box::new(...) as Box<dyn Command>] boilerplate",
-        "updated_at": "2026-04-06T21:44:46.541952888Z"
-      },
-      {
-        "card_number": 310,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-05T11:47:42.770230452Z",
-        "description": "Both annotate_storage_fields and comment_storage_fields use Vec::join(\"\\n\") which silently drops any trailing newline from the input. Most text tools expect a trailing newline; stripping it on round-trip could cause spurious diffs. Also: the hardcoded 2-space indent on the JSON comment will misalign if the file uses a different indent width.",
-        "due_date": null,
-        "id": "29b84203-4bb1-4c31-9827-c288ef838367",
-        "points": null,
-        "position": 137,
-        "priority": "Low",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541916968Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Fix trailing newline drop in annotate/comment_storage_fields",
-        "updated_at": "2026-04-06T21:44:46.541939348Z"
       },
       {
         "card_number": 159,
@@ -10870,21 +10352,30 @@
         "updated_at": "2026-04-06T21:43:27.331824726Z"
       },
       {
-        "card_number": 317,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-04-06T20:55:26.754926950Z",
-        "created_at": "2026-04-06T13:28:50.806409179Z",
-        "description": "Confirmed bug from PR #213 review. The mutating_op! macro in crates/kanban-mcp/src/lib.rs calls reload() after every mutation to refresh state, but does not call clear_history() afterward. This causes undo/redo history to accumulate across reloads in MCP — the TUI file watcher path correctly calls clear_history() after reload(), but MCP does not. Fix: add ctx.clear_history() call inside mutating_op! after the reload() call.",
+        "card_number": 310,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-05T11:47:42.770230452Z",
+        "description": "Both annotate_storage_fields and comment_storage_fields use Vec::join(\"\\n\") which silently drops any trailing newline from the input. Most text tools expect a trailing newline; stripping it on round-trip could cause spurious diffs. Also: the hardcoded 2-space indent on the JSON comment will misalign if the file uses a different indent width.",
         "due_date": null,
-        "id": "572eac31-61c6-4094-b2c5-8c99efc06580",
-        "points": 1,
-        "position": 138,
-        "priority": "High",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Fix: MCP mutating_op! calls reload() without clear_history()",
-        "updated_at": "2026-04-06T20:55:26.754927912Z"
+        "id": "29b84203-4bb1-4c31-9827-c288ef838367",
+        "points": null,
+        "position": 137,
+        "priority": "Low",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541916968Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Fix trailing newline drop in annotate/comment_storage_fields",
+        "updated_at": "2026-04-06T21:44:46.541939348Z"
       },
       {
         "card_number": 321,
@@ -10911,6 +10402,23 @@
         "status": "Todo",
         "title": "Expose list_assignable_sprints on KanbanContext",
         "updated_at": "2026-04-06T21:44:46.541937728Z"
+      },
+      {
+        "card_number": 317,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-04-06T20:55:26.754926950Z",
+        "created_at": "2026-04-06T13:28:50.806409179Z",
+        "description": "Confirmed bug from PR #213 review. The mutating_op! macro in crates/kanban-mcp/src/lib.rs calls reload() after every mutation to refresh state, but does not call clear_history() afterward. This causes undo/redo history to accumulate across reloads in MCP — the TUI file watcher path correctly calls clear_history() after reload(), but MCP does not. Fix: add ctx.clear_history() call inside mutating_op! after the reload() call.",
+        "due_date": null,
+        "id": "572eac31-61c6-4094-b2c5-8c99efc06580",
+        "points": 1,
+        "position": 138,
+        "priority": "High",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "Fix: MCP mutating_op! calls reload() without clear_history()",
+        "updated_at": "2026-04-06T20:55:26.754927912Z"
       },
       {
         "card_number": 264,
@@ -10965,6 +10473,32 @@
         "updated_at": "2026-04-06T21:44:46.541945264Z"
       },
       {
+        "card_number": 322,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-06T20:15:05.321353767Z",
+        "description": "## Problem\n\n`next_sprint_number` on `Board` is stored state that has drifted out of use:\n- `allocate_sprint_number()` (the only method that reads/writes it) is **never called** anywhere in the codebase\n- Sprint numbers are actually assigned via `sprint_counters: HashMap<String, u32>` (keyed by prefix) through `get_next_sprint_number(prefix: &str)` in `board.rs`\n\n`sprint_counters` has the same fundamental problem — it is stored state that can diverge from reality when the file is hand-edited or migrated. `ensure_sprint_counter_initialized()` already derives the correct starting value from existing sprints (max sprint_number for the prefix + 1), proving the information is fully derivable.\n\nThis caused a concrete bug: `demo/fixtures/demo.json` ended up with two sprints both labelled KAN 1 because `sprint_counters` fell out of sync during manual editing.\n\n## Options\n\n1. **Remove `next_sprint_number` only** — dead field cleanup. Low risk, small change.\n2. **Remove both `next_sprint_number` and `sprint_counters`** — replace with a computed function `next_sprint_number_for(prefix, sprints) -> u32` that returns `max(sprint.sprint_number where sprint.prefix == prefix) + 1`, defaulting to 1. Eliminates the entire class of drift bugs.\n\nOption 2 is preferred. The max-scan cost is negligible at this scale.\n\n## Affected files\n\n- `crates/kanban-domain/src/board.rs` — remove field + `allocate_sprint_number()`, replace `get_next_sprint_number()` with pure function\n- `crates/kanban-domain/src/commands/sprint_commands.rs` — pass sprints slice to the new function instead of mutating board counter\n- `crates/kanban-persistence-sqlite/src/upserts.rs` — drop `next_sprint_number` column writes\n- `crates/kanban-persistence-sqlite/src/builders.rs` — drop `next_sprint_number` field read\n- `crates/kanban-persistence-json/` — field will naturally stop being serialized once removed from struct\n- Tests in `kanban-service`, `kanban-persistence-sqlite` that reference `next_sprint_number`\n- `demo/fixtures/demo.json` — fix the duplicate KAN 1 sprint_number while touching this",
+        "due_date": null,
+        "id": "5e68c015-7af8-447d-a12c-14d57d518e5b",
+        "points": null,
+        "position": 140,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541912935Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Remove next_sprint_number and derive sprint counters from sprints",
+        "updated_at": "2026-04-06T21:44:46.541936624Z"
+      },
+      {
         "card_number": 165,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-04-06T21:43:38.809285354Z",
@@ -11007,15 +10541,15 @@
         "updated_at": "2026-04-06T21:43:38.809285755Z"
       },
       {
-        "card_number": 322,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-06T20:15:05.321353767Z",
-        "description": "## Problem\n\n`next_sprint_number` on `Board` is stored state that has drifted out of use:\n- `allocate_sprint_number()` (the only method that reads/writes it) is **never called** anywhere in the codebase\n- Sprint numbers are actually assigned via `sprint_counters: HashMap<String, u32>` (keyed by prefix) through `get_next_sprint_number(prefix: &str)` in `board.rs`\n\n`sprint_counters` has the same fundamental problem — it is stored state that can diverge from reality when the file is hand-edited or migrated. `ensure_sprint_counter_initialized()` already derives the correct starting value from existing sprints (max sprint_number for the prefix + 1), proving the information is fully derivable.\n\nThis caused a concrete bug: `demo/fixtures/demo.json` ended up with two sprints both labelled KAN 1 because `sprint_counters` fell out of sync during manual editing.\n\n## Options\n\n1. **Remove `next_sprint_number` only** — dead field cleanup. Low risk, small change.\n2. **Remove both `next_sprint_number` and `sprint_counters`** — replace with a computed function `next_sprint_number_for(prefix, sprints) -> u32` that returns `max(sprint.sprint_number where sprint.prefix == prefix) + 1`, defaulting to 1. Eliminates the entire class of drift bugs.\n\nOption 2 is preferred. The max-scan cost is negligible at this scale.\n\n## Affected files\n\n- `crates/kanban-domain/src/board.rs` — remove field + `allocate_sprint_number()`, replace `get_next_sprint_number()` with pure function\n- `crates/kanban-domain/src/commands/sprint_commands.rs` — pass sprints slice to the new function instead of mutating board counter\n- `crates/kanban-persistence-sqlite/src/upserts.rs` — drop `next_sprint_number` column writes\n- `crates/kanban-persistence-sqlite/src/builders.rs` — drop `next_sprint_number` field read\n- `crates/kanban-persistence-json/` — field will naturally stop being serialized once removed from struct\n- Tests in `kanban-service`, `kanban-persistence-sqlite` that reference `next_sprint_number`\n- `demo/fixtures/demo.json` — fix the duplicate KAN 1 sprint_number while touching this",
+        "card_number": 278,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-04-06T20:52:22.971633349Z",
+        "created_at": "2026-04-03T18:42:07.915128523Z",
+        "description": null,
         "due_date": null,
-        "id": "5e68c015-7af8-447d-a12c-14d57d518e5b",
-        "points": null,
-        "position": 140,
+        "id": "07571a07-b569-4aa0-bf1e-fc1459775fc9",
+        "points": 2,
+        "position": 141,
         "priority": "Medium",
         "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
@@ -11024,13 +10558,13 @@
             "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
             "sprint_name": "a-catchy-spring",
             "sprint_number": 13,
-            "started_at": "2026-04-06T21:44:46.541912935Z",
+            "started_at": "2026-04-04T23:35:37.856429077Z",
             "status": "Planning"
           }
         ],
-        "status": "Todo",
-        "title": "Remove next_sprint_number and derive sprint counters from sprints",
-        "updated_at": "2026-04-06T21:44:46.541936624Z"
+        "status": "Done",
+        "title": "Improve demo workflow",
+        "updated_at": "2026-04-06T20:52:22.971633417Z"
       },
       {
         "card_number": 327,
@@ -11057,32 +10591,6 @@
         "status": "Todo",
         "title": "Warn when storage falls back to implicit CWD kanban.json",
         "updated_at": "2026-04-06T21:44:46.541938571Z"
-      },
-      {
-        "card_number": 278,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-04-06T20:52:22.971633349Z",
-        "created_at": "2026-04-03T18:42:07.915128523Z",
-        "description": null,
-        "due_date": null,
-        "id": "07571a07-b569-4aa0-bf1e-fc1459775fc9",
-        "points": 2,
-        "position": 141,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856429077Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Done",
-        "title": "Improve demo workflow",
-        "updated_at": "2026-04-06T20:52:22.971633417Z"
       },
       {
         "card_number": 312,
@@ -11189,6 +10697,23 @@
         "updated_at": "2026-04-06T21:42:53.464085340Z"
       },
       {
+        "card_number": 333,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-04-19T22:40:48.384278386Z",
+        "created_at": "2026-04-07T20:27:51.974031824Z",
+        "description": "## What was done\n\n### Root README\n- Reordered sections: Quick Start → Installation → Features\n- New tagline: \"Keyboard-first kanban for the terminal.\"\n- Dropped \"Normal Mode\" jargon from key binding headers\n- Fixed inaccuracies: removed 'due date' from sort options (not implemented), removed story points range (1–5)\n- Removed V1→V2 migration bullet (no users had v1)\n- Simplified Storage & Sync copy\n\n### Crate READMEs\n- kanban-core: fixed MAX_PAGE_SIZE documented as 1000, actual is 500\n- kanban-domain: fixed field name card_counters → prefix_counters\n\n### Web Landing Page (web/)\n- New hero: value headline, install command as primary CTA, secondary nav links\n- Added Why Kanban? section with differentiator bullets\n- Rewrote feature cards: no emojis, specific copy, stronger differentiators\n- Reordered: Features before Installation\n- Added demo GIF embed\n- New CSS sections: hero-brand, hero-cta, demo, why\n- Added web/README.md\n\n### Demo Infrastructure\n- Packaged agentstation/vhs fork (v0.11.1) in demo/vhs.nix — adds SVG output support\n- Added devShells.demo to root flake (imports demo/shell.nix with flake pkgs)\n- Added ttyd to demo dev shell (required by VHS at runtime)\n- Injected version via ldflags in vhs.nix\n- Fixed malformed PS1 via PROMPT_COMMAND='PS1=\"> \"' in record.sh\n- Set Framerate 16 for natural playback speed\n- record.sh: outputs demo.gif and demo.svg, clean prompt, fixture reset\n- web/default.nix: serves demo.gif (SVG too large at 33MB uncompressed)\n- Updated demo/README.md and added web/README.md\n\n### Tracked separately\n- KAN-332: Require explicit file path — no implicit kanban.json default (TODO)",
+        "due_date": null,
+        "id": "e479f448-45c4-4cc6-88c5-49f9da962501",
+        "points": null,
+        "position": 145,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "README, web landing page, and demo infrastructure revamp",
+        "updated_at": "2026-04-19T22:40:48.384284513Z"
+      },
+      {
         "card_number": 335,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -11223,40 +10748,6 @@
         "updated_at": "2026-05-07T22:06:15.245101226Z"
       },
       {
-        "card_number": 333,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-04-19T22:40:48.384278386Z",
-        "created_at": "2026-04-07T20:27:51.974031824Z",
-        "description": "## What was done\n\n### Root README\n- Reordered sections: Quick Start → Installation → Features\n- New tagline: \"Keyboard-first kanban for the terminal.\"\n- Dropped \"Normal Mode\" jargon from key binding headers\n- Fixed inaccuracies: removed 'due date' from sort options (not implemented), removed story points range (1–5)\n- Removed V1→V2 migration bullet (no users had v1)\n- Simplified Storage & Sync copy\n\n### Crate READMEs\n- kanban-core: fixed MAX_PAGE_SIZE documented as 1000, actual is 500\n- kanban-domain: fixed field name card_counters → prefix_counters\n\n### Web Landing Page (web/)\n- New hero: value headline, install command as primary CTA, secondary nav links\n- Added Why Kanban? section with differentiator bullets\n- Rewrote feature cards: no emojis, specific copy, stronger differentiators\n- Reordered: Features before Installation\n- Added demo GIF embed\n- New CSS sections: hero-brand, hero-cta, demo, why\n- Added web/README.md\n\n### Demo Infrastructure\n- Packaged agentstation/vhs fork (v0.11.1) in demo/vhs.nix — adds SVG output support\n- Added devShells.demo to root flake (imports demo/shell.nix with flake pkgs)\n- Added ttyd to demo dev shell (required by VHS at runtime)\n- Injected version via ldflags in vhs.nix\n- Fixed malformed PS1 via PROMPT_COMMAND='PS1=\"> \"' in record.sh\n- Set Framerate 16 for natural playback speed\n- record.sh: outputs demo.gif and demo.svg, clean prompt, fixture reset\n- web/default.nix: serves demo.gif (SVG too large at 33MB uncompressed)\n- Updated demo/README.md and added web/README.md\n\n### Tracked separately\n- KAN-332: Require explicit file path — no implicit kanban.json default (TODO)",
-        "due_date": null,
-        "id": "e479f448-45c4-4cc6-88c5-49f9da962501",
-        "points": null,
-        "position": 145,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "README, web landing page, and demo infrastructure revamp",
-        "updated_at": "2026-04-19T22:40:48.384284513Z"
-      },
-      {
-        "card_number": 348,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-04-19T21:25:32.826098046Z",
-        "created_at": "2026-04-15T20:36:40.945047314Z",
-        "description": "Currently KanbanContext loads the entire dataset into Vec<T> fields on startup. PersistenceStore is a snapshot interface (load/save blobs). This makes storage backends interchangeable serialization formats only — SQLite's query engine goes unused. Goal: PersistenceStore becomes a query interface (list_boards, list_cards(filter), get_card, upsert_card, delete_card, etc.). KanbanContext becomes a thin coordinator that delegates reads/writes to the store. SQLite then runs real WHERE clauses. JSON backend becomes honest: loads everything, queries in memory. Undo/redo needs rethinking without full-world clones.",
-        "due_date": null,
-        "id": "c2aefb17-3426-4bb9-ae0b-bb3164fe6ab0",
-        "points": null,
-        "position": 146,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Refactor storage to on-demand querying instead of full snapshot in memory",
-        "updated_at": "2026-04-19T21:25:32.826099246Z"
-      },
-      {
         "card_number": 336,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -11289,6 +10780,23 @@
         "status": "Todo",
         "title": "Add test for Completions subcommand early-return path",
         "updated_at": "2026-05-07T22:06:15.245104097Z"
+      },
+      {
+        "card_number": 348,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-04-19T21:25:32.826098046Z",
+        "created_at": "2026-04-15T20:36:40.945047314Z",
+        "description": "Currently KanbanContext loads the entire dataset into Vec<T> fields on startup. PersistenceStore is a snapshot interface (load/save blobs). This makes storage backends interchangeable serialization formats only — SQLite's query engine goes unused. Goal: PersistenceStore becomes a query interface (list_boards, list_cards(filter), get_card, upsert_card, delete_card, etc.). KanbanContext becomes a thin coordinator that delegates reads/writes to the store. SQLite then runs real WHERE clauses. JSON backend becomes honest: loads everything, queries in memory. Undo/redo needs rethinking without full-world clones.",
+        "due_date": null,
+        "id": "c2aefb17-3426-4bb9-ae0b-bb3164fe6ab0",
+        "points": null,
+        "position": 146,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "Refactor storage to on-demand querying instead of full snapshot in memory",
+        "updated_at": "2026-04-19T21:25:32.826099246Z"
       },
       {
         "card_number": 337,
@@ -11342,23 +10850,6 @@
         "updated_at": "2026-04-19T22:41:41.847302658Z"
       },
       {
-        "card_number": 331,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-04-06T22:56:06.190782490Z",
-        "created_at": "2026-04-06T22:46:10.777694184Z",
-        "description": "## Documentation Revamp — Root README + 9 Crate READMEs\n\nComplete rewrite of all project documentation to be accurate, dense, and compelling.\n\n### Files Modified\n\n| File | Lines | Notes |\n|------|-------|-------|\n| `README.md` | 373 | Full rewrite: hero tagline, feature grid, installation, quick start, full keybinding tables for all 5 contexts, architecture diagram + crate table, persistence details, roadmap |\n| `crates/kanban-mcp/README.md` | 182 | All 40 tools documented (was 14); organized by section with parameter types |\n| `crates/kanban-domain/README.md` | 307 | All models fully documented: Board, Column, Card (every field), Sprint, SprintLog, ArchivedCard, FieldUpdate, DependencyGraph, HistoryManager, error hierarchy, business rules |\n| `crates/kanban-tui/README.md` | 321 | New: module structure, AppMode/DialogMode enums (all 26 dialogs), focus system, view strategies, event loop, full keybinding tables, editor integration, clipboard, components |\n| `crates/kanban-service/README.md` | 236 | Expanded: all KanbanContext fields, complete method tables for all operation groups, undo/redo API, state accessors, utility functions, command execution flow |\n| `crates/kanban-cli/README.md` | 180 | New: full command reference for board/column/card/sprint/top-level, card identifier resolution, JSON output format, BatchOperationResult, shell completions, env vars |\n| `crates/kanban-core/README.md` | 174 | Fixed phantom traits (removed Repository/Service/Loggable that don't exist); documented AppConfig, PaginatedList, Page/PageInfo, InputState, SelectionState, Editable, Graph |\n| `crates/kanban-persistence/README.md` | 159 | New: PersistenceStore, StoreFactory, StoreRegistry, ChangeDetector, Serializer, MigrationStrategy, all shared types |\n| `crates/kanban-persistence-json/README.md` | 101 | New: V2 envelope format, save/load flows, atomic writes, conflict detection, debounced saving, JsonStoreFactory match logic |\n| `crates/kanban-persistence-sqlite/README.md` | 112 | New: SqliteStore, connection pool config, all 14 tables, transactional save/load, schema versioning, SqliteStoreFactory magic-byte detection |\n\n### Key Fixes\n- MCP README previously listed 14 tools; now documents all 40\n- kanban-core previously referenced phantom `Repository`, `Service`, `Loggable` traits not present in source\n- kanban-tui and kanban-cli had no READMEs\n- Card model was missing `sprint_logs`, `completed_at`, `assigned_prefix`, `card_prefix` field docs\n- Status transition semantics (Done <-> completed_at) were undocumented\n- All keybinding tables verified against `crates/kanban-tui/src/keybindings/` source",
-        "due_date": null,
-        "id": "4de75dc6-a711-4771-80b5-9e9a252e15b2",
-        "points": null,
-        "position": 148,
-        "priority": "High",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Revamp all documentation — root README + 9 crate READMEs",
-        "updated_at": "2026-04-27T08:30:39.252429340Z"
-      },
-      {
         "card_number": 338,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -11393,30 +10884,21 @@
         "updated_at": "2026-05-07T22:06:15.245108198Z"
       },
       {
-        "card_number": 231,
+        "card_number": 331,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-10T15:13:34.214698980Z",
-        "created_at": "2026-03-22T23:43:10.286586719Z",
-        "description": "The release workflow continued to the tag/GitHub release steps even after publish-crates.sh exited with code 1. Add safeguards so a partial publish causes the entire job to abort and surface a clear failure, preventing tag/version mismatches and orphaned crates on crates.io.\n\n## Resolution\n\nAlready implemented. publish-crates.sh has `set -uo pipefail` and the publish loop explicitly calls `exit 1` on failure (lines 43-45). The CI job will abort on any crate publish failure.\n\nNo code change needed.",
+        "completed_at": "2026-04-06T22:56:06.190782490Z",
+        "created_at": "2026-04-06T22:46:10.777694184Z",
+        "description": "## Documentation Revamp — Root README + 9 Crate READMEs\n\nComplete rewrite of all project documentation to be accurate, dense, and compelling.\n\n### Files Modified\n\n| File | Lines | Notes |\n|------|-------|-------|\n| `README.md` | 373 | Full rewrite: hero tagline, feature grid, installation, quick start, full keybinding tables for all 5 contexts, architecture diagram + crate table, persistence details, roadmap |\n| `crates/kanban-mcp/README.md` | 182 | All 40 tools documented (was 14); organized by section with parameter types |\n| `crates/kanban-domain/README.md` | 307 | All models fully documented: Board, Column, Card (every field), Sprint, SprintLog, ArchivedCard, FieldUpdate, DependencyGraph, HistoryManager, error hierarchy, business rules |\n| `crates/kanban-tui/README.md` | 321 | New: module structure, AppMode/DialogMode enums (all 26 dialogs), focus system, view strategies, event loop, full keybinding tables, editor integration, clipboard, components |\n| `crates/kanban-service/README.md` | 236 | Expanded: all KanbanContext fields, complete method tables for all operation groups, undo/redo API, state accessors, utility functions, command execution flow |\n| `crates/kanban-cli/README.md` | 180 | New: full command reference for board/column/card/sprint/top-level, card identifier resolution, JSON output format, BatchOperationResult, shell completions, env vars |\n| `crates/kanban-core/README.md` | 174 | Fixed phantom traits (removed Repository/Service/Loggable that don't exist); documented AppConfig, PaginatedList, Page/PageInfo, InputState, SelectionState, Editable, Graph |\n| `crates/kanban-persistence/README.md` | 159 | New: PersistenceStore, StoreFactory, StoreRegistry, ChangeDetector, Serializer, MigrationStrategy, all shared types |\n| `crates/kanban-persistence-json/README.md` | 101 | New: V2 envelope format, save/load flows, atomic writes, conflict detection, debounced saving, JsonStoreFactory match logic |\n| `crates/kanban-persistence-sqlite/README.md` | 112 | New: SqliteStore, connection pool config, all 14 tables, transactional save/load, schema versioning, SqliteStoreFactory magic-byte detection |\n\n### Key Fixes\n- MCP README previously listed 14 tools; now documents all 40\n- kanban-core previously referenced phantom `Repository`, `Service`, `Loggable` traits not present in source\n- kanban-tui and kanban-cli had no READMEs\n- Card model was missing `sprint_logs`, `completed_at`, `assigned_prefix`, `card_prefix` field docs\n- Status transition semantics (Done <-> completed_at) were undocumented\n- All keybinding tables verified against `crates/kanban-tui/src/keybindings/` source",
         "due_date": null,
-        "id": "042d74e3-e975-4662-8cdb-aa64021b2d7e",
-        "points": 1,
-        "position": 149,
-        "priority": "Medium",
-        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
-            "sprint_name": "a-catchy-spring",
-            "sprint_number": 13,
-            "started_at": "2026-04-04T23:35:37.856371057Z",
-            "status": "Planning"
-          }
-        ],
+        "id": "4de75dc6-a711-4771-80b5-9e9a252e15b2",
+        "points": null,
+        "position": 148,
+        "priority": "High",
+        "sprint_id": null,
+        "sprint_logs": [],
         "status": "Done",
-        "title": "Fail release job immediately if any crate publish fails",
-        "updated_at": "2026-05-10T15:13:34.214699796Z"
+        "title": "Revamp all documentation — root README + 9 crate READMEs",
+        "updated_at": "2026-04-27T08:30:39.252429340Z"
       },
       {
         "card_number": 340,
@@ -11453,6 +10935,58 @@
         "updated_at": "2026-05-07T22:06:15.245110654Z"
       },
       {
+        "card_number": 231,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-10T15:13:34.214698980Z",
+        "created_at": "2026-03-22T23:43:10.286586719Z",
+        "description": "The release workflow continued to the tag/GitHub release steps even after publish-crates.sh exited with code 1. Add safeguards so a partial publish causes the entire job to abort and surface a clear failure, preventing tag/version mismatches and orphaned crates on crates.io.\n\n## Resolution\n\nAlready implemented. publish-crates.sh has `set -uo pipefail` and the publish loop explicitly calls `exit 1` on failure (lines 43-45). The CI job will abort on any crate publish failure.\n\nNo code change needed.",
+        "due_date": null,
+        "id": "042d74e3-e975-4662-8cdb-aa64021b2d7e",
+        "points": 1,
+        "position": 149,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856371057Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Done",
+        "title": "Fail release job immediately if any crate publish fails",
+        "updated_at": "2026-05-10T15:13:34.214699796Z"
+      },
+      {
+        "card_number": 384,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-07T22:06:09.412138272Z",
+        "created_at": "2026-04-28T08:54:01.006886168Z",
+        "description": "Goal: open_context() establishes a connection with zero I/O. Data is loaded lazily on first DataStore/CommandStore call. Eliminates the is_sqlite fork across all three apps (TUI, CLI, MCP).\n\n# Challenge\n\nKanbanContext::load() today: (1) calls PersistenceStore::load() fetching full snapshot blob, (2) deserializes everything into InMemoryStore, (3) loads command log. This is eager-load-everything. All three apps fork on is_sqlite because JSON and SQLite have different initialization contracts.\n\n# TARGET ARCHITECTURE\n\nDataStore + CommandStore are the sole runtime interface. PersistenceStore (blob) is used only for import/export/migration. KanbanBackend gains lifecycle methods: flush(), reload(), needs_flush(), needs_save_worker(), on_undo_state_changed(), instance_id().\n\n### STEP 1 — KanbanBackend lifecycle methods [DONE]\n\nAdd flush/reload/needs_flush/needs_save_worker/on_undo_state_changed/instance_id to KanbanBackend with default no-op impls. SQLite impl: flush()=WAL checkpoint, reload()=no-op, needs_flush()=false. InMemoryStore uses all defaults.\nFiles: crates/kanban-service/src/backend.rs, crates/kanban-persistence-sqlite/src/sqlite_store.rs, crates/kanban-domain/src/data_store.rs\n\n### STEP 2 — JsonDataStore lazy JSON backend [DONE]\n\nNew type in crates/kanban-service/src/json_backend.rs wrapping Arc<dyn PersistenceStore> + RwLock<Option<InMemoryStore>> + AtomicBool dirty. Construction is zero-I/O. ensure_loaded() reads file on first access using block_in_place (requires multi_thread runtime). flush() serialises cache to disk. reload() sets inner=None so next access re-reads. needs_save_worker()=true (background flush worker needed). on_undo_state_changed() caches cursor+baseline for next flush.\n\n### STEP 3 — Simplify KanbanContext [DONE]\n\nSingle constructor KanbanContext::open(backend, config) — zero I/O. baseline_snapshot: Option<Snapshot> starts None, captured lazily on first execute(). command_count restored lazily on first undo/redo via ensure_undo_state_initialized(). save() delegates to backend.flush().await. reload() delegates to backend.reload().await and clears baseline_snapshot. Removed store: Option<Arc<dyn PersistenceStore>> field, replace_store(), store() getter.\nFile: crates/kanban-service/src/context.rs\n\n### STEP 4 — StoreManager::make_backend() [DONE]\n\nNew method returning Arc<dyn KanbanBackend>. If is_sqlite → SqliteStore::open(). Else → JsonDataStore::new(make_store()). Also make_backend_sync() for sync contexts (uses block_on internally).\nFile: crates/kanban-service/src/store_manager.rs\n\n### STEP 5 — kanban_service::open_context() [DONE]\n\nSingle public entry point: sync_backend_with_file() + make_backend() + KanbanContext::open(). All three apps can call this instead of duplicating the StoreManager dance.\nFile: crates/kanban-service/src/lib.rs\n\n### STEP 6 — Wire FileWatcher to backend.reload() [DONE]\n\nauto_reload_from_external_change() in app/mod.rs now calls ctx.reload() → backend.reload() instead of store.load().await directly. SaveCoordinator sends () flush signals instead of Snapshot blobs; save worker calls backend.flush().await on each signal. TuiContext uses needs_save_worker() to decide whether to spawn the background worker.\nFiles: crates/kanban-tui/src/app/mod.rs, crates/kanban-tui/src/state/mod.rs, crates/kanban-tui/src/tui_context.rs, crates/kanban-tui/src/handlers/settings_handlers.rs\n\n### STEP 7 — Unify App Initialization [PENDING]\n\nReplace divergent is_sqlite forks in all three apps with open_context().\n\nTUI: Collapse App::new_with_store() + App::open_sqlite() into App::new(ctx: KanbanContext). Remove TuiContext::from_context(); TuiContext::new(ctx) is the only constructor. SaveCoordinator::new() uses ctx.backend().needs_flush() instead of store.is_some().\n\nCLI: Remove if is_sqlite { App::open_sqlite() } else { App::new_with_store() } fork in app.rs. CliContext::load() calls kanban_service::open_context() directly. Remove StoreManager parameter.\n\nMCP: McpContext::new() calls kanban_service::open_context() directly. Remove StoreManager parameter.\n\nDelete dead code: App::open_sqlite(), App::new_with_store(), TuiContext::from_context(), resolve_is_sqlite() helper.\n\nTDD tests to write first:\n\n- test_tui_context_single_constructor_json (save_rx is Some)\n- test_tui_context_single_constructor_sqlite (save_rx is None)\n- test_cli_init_and_run_json_unified_path\n- test_cli_init_and_run_sqlite_unified_path\n- test_mcp_list_boards_json_unified_path\n- test_mcp_list_boards_sqlite_unified_path\n\nFiles to modify:\n\n- crates/kanban-cli/src/app.rs\n- crates/kanban-cli/src/context.rs\n- crates/kanban-mcp/src/context.rs\n- crates/kanban-mcp/src/server.rs\n- crates/kanban-tui/src/app/mod.rs\n- crates/kanban-tui/src/tui_context.rs\n\nVERIFICATION (all steps)\n\n1. cargo test --workspace — all tests pass\n2. cargo run -- init --name Test test.json && cargo run test.json — JSON path works\n3. cargo run -- init --name Test test.sqlite && cargo run test.sqlite — SQLite path works\n4. Modify test.json externally while TUI open → conflict banner appears\n5. Modify test.sqlite externally → next read reflects new state transparently\n6. MCP tool calls persist for both backends\n7. Undo/redo works on both backends after lazy baseline change\n\n---\n\n\nPlan to implement\n\n### Create Kanban Card: Step 7 — Unify App Initialization\n\nContext\n\nSteps 1–6 of the \"Unified Backends via True Deferred Reads\" architecture are complete and committed.\nStep 7 (unifying CLI, MCP, and TUI initialization paths) has not been done yet and needs to be tracked\nas a kanban card so it can be planned and scheduled.\n\nTask\n\nRun a single CLI command to create the card in ~/notes/memes/kanban.json.\n\nBoard Info\n\n- File: ~/notes/memes/kanban.json\n- Board ID: e119c091-e1fa-4596-9bc7-038ceab6adec\n- Column: TODO → ID: 591afb61-7289-46bf-ba07-21758afd44fe\n\nCommand\n\nkanban ~/notes/memes/kanban.json card create \\\n  --board-id e119c091-e1fa-4596-9bc7-038ceab6adec \\\n  --column-id 591afb61-7289-46bf-ba07-21758afd44fe \\\n  --title \"Architecture: Unified Backends via True Deferred Reads\" \\\n  --description \"Goal: open_context() establishes a connection with zero I/O. Data is loaded lazily on first\nDataStore/CommandStore call. Eliminates the is_sqlite fork across all three apps (TUI, CLI, MCP).\n\nPROBLEM\nKanbanContext::load() today: (1) calls PersistenceStore::load() fetching full snapshot blob, (2) deserializes everything into\nInMemoryStore, (3) loads command log. This is eager-load-everything. All three apps fork on is_sqlite because JSON and SQLite\nhave different initialization contracts.\n\nTARGET ARCHITECTURE\nDataStore + CommandStore are the sole runtime interface. PersistenceStore (blob) is used only for import/export/migration.\nKanbanBackend gains lifecycle methods: flush(), reload(), needs_flush(), needs_save_worker(), on_undo_state_changed(),\ninstance_id().\n\nSTEP 1 — KanbanBackend lifecycle methods [DONE]\nAdd flush/reload/needs_flush/needs_save_worker/on_undo_state_changed/instance_id to KanbanBackend with default no-op impls.\nSQLite impl: flush()=WAL checkpoint, reload()=no-op, needs_flush()=false. InMemoryStore uses all defaults.\nFiles: crates/kanban-service/src/backend.rs, crates/kanban-persistence-sqlite/src/sqlite_store.rs,\ncrates/kanban-domain/src/data_store.rs\n\nSTEP 2 — JsonDataStore lazy JSON backend [DONE]\nNew type in crates/kanban-service/src/json_backend.rs wrapping Arc<dyn PersistenceStore> + RwLock<Option<InMemoryStore>> +\nAtomicBool dirty. Construction is zero-I/O. ensure_loaded() reads file on first access using block_in_place (requires\nmulti_thread runtime). flush() serialises cache to disk. reload() sets inner=None so next access re-reads.\nneeds_save_worker()=true (background flush worker needed). on_undo_state_changed() caches cursor+baseline for next flush.\n\nSTEP 3 — Simplify KanbanContext [DONE]\nSingle constructor KanbanContext::open(backend, config) — zero I/O. baseline_snapshot: Option<Snapshot> starts None, captured\nlazily on first execute(). command_count restored lazily on first undo/redo via ensure_undo_state_initialized(). save()\ndelegates to backend.flush().await. reload() delegates to backend.reload().await and clears baseline_snapshot. Removed store:\nOption<Arc<dyn PersistenceStore>> field, replace_store(), store() getter.\nFile: crates/kanban-service/src/context.rs\n\nSTEP 4 — StoreManager::make_backend() [DONE]\nNew method returning Arc<dyn KanbanBackend>. If is_sqlite → SqliteStore::open(). Else → JsonDataStore::new(make_store()). Also\n make_backend_sync() for sync contexts (uses block_on internally).\nFile: crates/kanban-service/src/store_manager.rs\n\nSTEP 5 — kanban_service::open_context() [DONE]\nSingle public entry point: sync_backend_with_file() + make_backend() + KanbanContext::open(). All three apps can call this\ninstead of duplicating the StoreManager dance.\nFile: crates/kanban-service/src/lib.rs\n\nSTEP 6 — Wire FileWatcher to backend.reload() [DONE]\nauto_reload_from_external_change() in app/mod.rs now calls ctx.reload() → backend.reload() instead of store.load().await\ndirectly. SaveCoordinator sends () flush signals instead of Snapshot blobs; save worker calls backend.flush().await on each\nsignal. TuiContext uses needs_save_worker() to decide whether to spawn the background worker.\nFiles: crates/kanban-tui/src/app/mod.rs, crates/kanban-tui/src/state/mod.rs, crates/kanban-tui/src/tui_context.rs,\ncrates/kanban-tui/src/handlers/settings_handlers.rs\n\nSTEP 7 — Unify App Initialization [PENDING]\nReplace divergent is_sqlite forks in all three apps with open_context().\n\nTUI: Collapse App::new_with_store() + App::open_sqlite() into App::new(ctx: KanbanContext). Remove TuiContext::from_context();\n TuiContext::new(ctx) is the only constructor. SaveCoordinator::new() uses ctx.backend().needs_save_worker() instead of\nstore.is_some().\n\nCLI: Remove if is_sqlite { App::open_sqlite() } else { App::new_with_store() } fork in app.rs. CliContext::load() calls\nkanban_service::open_context() directly. Remove StoreManager parameter.\n\nMCP: McpContext::new() calls kanban_service::open_context() directly. Remove StoreManager parameter.\n\nDelete dead code: App::open_sqlite(), App::new_with_store(), TuiContext::from_context(), resolve_is_sqlite() helper.\n\nTDD tests to write first:\n- test_tui_context_single_constructor_json (save_rx is Some)\n- test_tui_context_single_constructor_sqlite (save_rx is None)\n- test_cli_init_and_run_json_unified_path\n- test_cli_init_and_run_sqlite_unified_path\n- test_mcp_list_boards_json_unified_path\n- test_mcp_list_boards_sqlite_unified_path\n\nFiles to modify:\n- crates/kanban-cli/src/app.rs\n- crates/kanban-cli/src/context.rs\n- crates/kanban-mcp/src/context.rs\n- crates/kanban-mcp/src/server.rs\n- crates/kanban-tui/src/app/mod.rs\n- crates/kanban-tui/src/tui_context.rs\n\nVERIFICATION (all steps)\n1. cargo test --workspace — all tests pass\n2. cargo run -- init --name Test test.json && cargo run test.json — JSON path works\n3. cargo run -- init --name Test test.sqlite && cargo run test.sqlite — SQLite path works\n4. Modify test.json externally while TUI open → conflict banner appears\n5. Modify test.sqlite externally → next read reflects new state transparently\n6. MCP tool calls persist for both backends\n7. Undo/redo works on both backends after lazy baseline change\" \\\n  --priority High\n\nVerification\n\nAfter running the command, open the TUI (kanban ~/notes/memes/kanban.json) and confirm the card\nappears in the TODO column.\n\nContext\n\nThe project has two backends (JSON, SQLite) and three apps (TUI, CLI, MCP) with divergent initialization paths. The goal is\nnot just a surface unification — the underlying requirement is true deferred reads: open_context() should establish a\nconnection and do zero I/O. Data is only read from disk/DB when a specific entity is first requested.\n\nThis solves all three pain points simultaneously:\n- Startup time: nothing loaded until the UI actually renders\n- Staleness: reload() on file-watch event is well-defined per backend\n- Extensibility: remote backends (PostgreSQL, HTTP API) are natural — each DataStore method becomes a network call\n\n---\nCurrent State: Why the Model Is Wrong\n\nThe Snapshot Bootstrap Problem\n\nKanbanContext::load(store, config) today:\n1. Calls PersistenceStore::load() → fetches full snapshot blob\n2. Deserializes everything into InMemoryStore (all boards, columns, cards, sprints)\n3. Loads the entire command log\n4. Takes a baseline_snapshot of the full state\n\nThis is eager-load-everything regardless of what the user actually needs to see.\n\nThe Two-Path Problem\n\nJSON path:   KanbanContext::load(store) → InMemoryStore (full eager hydration)\nSQLite path: KanbanContext::open_sqlite() → SqliteStore (bypasses snapshot, but\n             still loads command log state upfront)\n\nAll three apps fork on is_sqlite. The fork exists because the two paths have fundamentally different initialization contracts.\n\nWhy SQLite Is Already Half-Right\n\nSqliteStore already implements DataStore with real SQL queries — list_boards() is SELECT * FROM boards,\nlist_columns_by_board(id) is SELECT ... WHERE board_id = ?. There is no pre-load. The problem is that\nKanbanContext::open_sqlite() still loads command log state eagerly, and the rest of the codebase bypasses this with the\nsnapshot model anyway.\n\n---\n\nThe PersistenceStore blob interface (load/save full snapshot) is used as the initialization protocol for KanbanContext. This\nforces everything through a full-load. The correct initialization protocol is: establish a connection, do nothing else.\n\nThe fine-grained DataStore trait (already defined in kanban-domain) is the right lazy interface. KanbanContext should always\nread through DataStore methods, never through blob snapshots during normal operation. Snapshots become a utility for\nimport/export/migration only.\n\nTarget Architecture\n---\n\nPrinciple: DataStore + CommandStore as the Sole Runtime Interface\n\nNormal operation:   KanbanContext → DataStore / CommandStore methods (lazy, per-entity)\nImport/Export:      KanbanContext → PersistenceStore (snapshot blob, on demand)\n\nExtend KanbanBackend with Lifecycle Methods\n\nKanbanBackend (in kanban-service/src/backend.rs) gains three methods:\n\npub trait KanbanBackend: DataStore + CommandStore + Send + Sync {\n    fn as_data_store(&self) -> &dyn DataStore;\n\n    // New lifecycle:\n    async fn flush(&self) -> KanbanResult<()> { Ok(()) }   // default no-op\n    async fn reload(&self) -> KanbanResult<()> { Ok(()) }  // default no-op\n    fn needs_flush(&self) -> bool { false }                 // default: always in sync\n}\n\n- SQLite: flush() = WAL checkpoint, reload() = no-op (reads are always live), needs_flush() = false\n- JsonDataStore (new): flush() = serialize cache to file, reload() = re-read file + clear cache, needs_flush() = tracks dirty\nstate\n\nJsonDataStore (New Type)\n\nLives in crates/kanban-service/src/json_backend.rs (has access to both InMemoryStore and JsonFileStore).\n\nJsonDataStore {\n    path: PathBuf,\n    inner: RwLock<Option<InMemoryStore>>,   // None until first access\n    file_store: Arc<JsonFileStore>,\n    dirty: AtomicBool,\n}\n\n- Any DataStore or CommandStore method call checks inner.is_none() → if so, reads the JSON file and populates InMemoryStore\n(the one-time lazy load)\n- Subsequent calls are served from the in-memory cache\n- Writes update the cache + set dirty = true\n- flush() serializes the in-memory state to JSON via JsonFileStore\n- reload() sets inner = None → next access re-reads the file\n\nThis is the one place where \"lazy\" still reads the full JSON file — because JSON is a single blob, there's no way to partially\n read it. But the load is deferred until something actually needs data, making open_context() instantaneous even for large\nfiles.\n\nKanbanContext — Single Constructor, Zero Initial I/O\n\npub struct KanbanContext {\n    backend: Arc<dyn KanbanBackend>,\n    app_config: AppConfig,\n    baseline_snapshot: Option<Snapshot>,    // None until first write\n    undo_cursor: usize,\n    command_count: usize,\n    dirty: bool,\n    conflict_pending: bool,\n}\n\nimpl KanbanContext {\n    pub async fn open(backend: Arc<dyn KanbanBackend>, config: AppConfig) -> KanbanResult<Self> {\n        // Zero I/O. Just wraps the backend.\n        Ok(Self {\n            backend,\n            app_config: config,\n            baseline_snapshot: None,    // lazy: captured on first write\n            undo_cursor: 0,\n            command_count: 0,           // lazy: read from CommandStore on first undo/redo\n            dirty: false,\n            conflict_pending: false,\n        })\n    }\n}\n\nUndo baseline captured lazily:\nOn first execute(commands) call, if baseline_snapshot.is_none(), take a snapshot of current backend state and store it. The\nbaseline is the state at the time of first write, which is the correct semantic anyway.\n\nCommand count restored lazily:\nOn first undo/redo, if needed, call backend.command_count() to restore cursor position from the backend.\n\nUnified Public Entry Point\n\nIn crates/kanban-service/src/lib.rs:\n\npub async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanContext> {\n    let mut config = config;\n    let sm = StoreManager::new(default_registry());\n    sm.sync_backend_with_file(locator, &mut config);\n    let backend: Arc<dyn KanbanBackend> = sm.make_backend(locator, &config).await?;\n    KanbanContext::open(backend, config).await\n}\n\nAll three apps:\nlet ctx = kanban_service::open_context(&file_path, config).await?;\n// Zero I/O has happened. First render triggers actual data reads.\n\nStoreManager::make_backend()\n\nNew method in StoreManager that returns Arc<dyn KanbanBackend>:\n\npub async fn make_backend(\n    &self,\n    locator: &str,\n    config: &AppConfig,\n) -> KanbanResult<Arc<dyn KanbanBackend>> {\n    if self.is_sqlite(locator) {\n        Ok(Arc::new(SqliteStore::open(locator).await?))\n    } else {\n        let store = self.make_store(\"json\", locator)?;    // existing PersistenceStore\n        Ok(Arc::new(JsonDataStore::new(store)))\n    }\n}\n\n---\nStaleness / External Change Handling\n\nWith reload() on KanbanBackend:\n- FileWatcher fires → KanbanContext calls backend.reload()\n- For JSON: clears the in-memory cache. Next DataStore call re-reads the file.\n- For SQLite: no-op. Reads are always live against the DB.\n- If dirty is true when reload fires → conflict_pending = true (existing conflict UI)\n\nThis replaces the current FileMetadata mtime/hash conflict detection in JsonFileStore with a cleaner model: the context owns\nconflict state, not the store.\n\n---\nWhat Happens to PersistenceStore\n\nPersistenceStore trait and its implementations stay. Their role narrows:\n- Import: load a snapshot blob and call backend.apply_snapshot()\n- Export: call backend.snapshot() and pass to PersistenceStore::save()\n- Migration: blob-level version upgrades (V1→V2 JSON envelope etc.)\n- NOT used: for normal app startup or runtime reads\n\nStoreFactory / StoreRegistry stay for this purpose. StoreManager::make_store() stays for import/export flows.\n\n---\n### TDD Workflow (Mandatory for Every Step)\n\nEach step follows Red → Green → Refactor:\n1. Red: Write failing tests that specify the expected behaviour. Present for review before implementing.\n2. Green: Minimum implementation to make tests pass.\n3. Refactor: Clean up without breaking tests.\n\ncargo test --workspace must pass at the end of every step.\n\n---\nRecommended Order of Work\n\n### Step 1 — Extend KanbanBackend with lifecycle methods\n\nWhy: KanbanBackend (backend.rs:8) currently has only as_data_store(). We need flush, reload, needs_flush so that KanbanContext\n can delegate persistence without knowing which backend it holds.\n\nRed — tests to write first (crates/kanban-persistence-sqlite/src/sqlite_store.rs, inline #[cfg(test)]):\ntest_sqlite_backend_needs_flush_returns_false\ntest_sqlite_backend_flush_executes_wal_checkpoint\ntest_sqlite_backend_reload_is_noop  (list_boards before and after reload returns same data)\ntest_in_memory_store_lifecycle_defaults_are_noop\nUse real TempDir SQLite file. Pattern: SqliteStore::open(tmp.path()).await?.\n\nGreen — changes:\n\ncrates/kanban-service/src/backend.rs:\n- Line 9 (after as_data_store): add three methods with default no-op impls:\nasync fn flush(&self) -> KanbanResult<()> { Ok(()) }\nasync fn reload(&self) -> KanbanResult<()> { Ok(()) }\nfn needs_flush(&self) -> bool { false }\n\ncrates/kanban-persistence-sqlite/src/sqlite_store.rs:\n- Locate the impl KanbanBackend for SqliteStore block (currently only has as_data_store)\n- Add concrete impls:\n  - flush(): call self.checkpoint().await (checkpoint method already exists at ~line 1654)\n  - reload(): Ok(()) — SQLite reads are always live\n  - needs_flush(): false — write-through\n\ncrates/kanban-domain/src/in_memory_store.rs:\n- InMemoryStore will use the default no-op impls (no explicit impl needed; covered by blanket impl on KanbanBackend)\n\nRefactor: Confirm the blanket impl at backend.rs:13-17 still compiles with the new default methods.\n\n---\n### Step 2 — Create JsonDataStore\n\nWhy: Currently the JSON path requires creating InMemoryStore + JsonFileStore separately, wired together inside\nKanbanContext::load(). This forces eager loading on construction. JsonDataStore encapsulates this pair and makes loading lazy\n— the file is not read until the first DataStore method call.\n\nRed — tests to write first (inline #[cfg(test)] in new crates/kanban-service/src/json_backend.rs):\ntest_json_data_store_construction_does_no_io\n  (assert file not read: create store pointing at non-existent path, construction succeeds)\ntest_json_data_store_list_boards_triggers_load\n  (create JSON file with 1 board; construction ok; assert inner is None; call list_boards(); assert returns 1 board)\ntest_json_data_store_needs_flush_false_when_clean\ntest_json_data_store_needs_flush_true_after_upsert\ntest_json_data_store_flush_writes_to_disk\n  (upsert board; flush(); create new JsonDataStore at same path; list_boards() returns the board)\ntest_json_data_store_reload_clears_cache\n  (load; modify file externally; reload(); list_boards() returns updated data)\ntest_json_data_store_command_log_round_trip\n  (append commands; flush(); create fresh store; command_count() returns correct value)\nUse real TempDir JSON files via kanban_persistence_json::JsonStoreFactory.\n\nGreen — new file crates/kanban-service/src/json_backend.rs:\npub struct JsonDataStore {\n    file_store: Arc<dyn PersistenceStore + Send + Sync>,\n    inner: RwLock<Option<InMemoryStore>>,\n    dirty: AtomicBool,\n}\n- fn new(store: Arc<dyn PersistenceStore + Send + Sync>) -> Self — stores only, no I/O\n- Private fn ensure_loaded(&self) -> KanbanResult<()>:\n  - Acquires write lock on inner\n  - If None: calls file_store.load() (or returns empty InMemoryStore if !file_store.exists())\n  - Deserializes StoreSnapshot.data into Snapshot\n\n  - Calls InMemoryStore::apply_snapshot(snapshot)\n  - Restores command log from file_store.get_command_log() into InMemoryStore\n  - Sets inner = Some(store)\n- Every DataStore and CommandStore method: calls ensure_loaded() then delegates to inner\n- Write methods additionally set dirty.store(true, Ordering::Release)\n- flush(): if dirty, serialize snapshot + command log → call file_store.save() + file_store.sync_command_log(); clear dirty\n- reload(): set inner = None (next access re-reads file); clear dirty\n- needs_flush(): return dirty.load(Ordering::Acquire)\n\nAlso add impl KanbanBackend for JsonDataStore (delegates to above lifecycle methods). Add to crates/kanban-service/src/lib.rs\nmodule declaration.\n\nRefactor: Extract snapshot serialization helper (reuse snapshot_to_json_bytes / snapshot_from_json_bytes from existing\nkanban-persistence crate).\n\n---\n### Step 3 — Simplify KanbanContext\n\nWhy: KanbanContext currently has a store: Option<Arc<dyn PersistenceStore>> field (context.rs:45) whose presence/absence\nencodes which backend path we're on. save() (lines 422-445) and reload() (lines 398-410) both have let Some(store) =\n&self.store else { return Ok(()) } guards. baseline_snapshot (line 46) is eagerly set on construction, forcing a snapshot\nread. All of this disappears with the new model.\n\nRed — integration tests in new crates/kanban-service/tests/context_open.rs:\ntest_open_context_json_does_no_io_at_construction\n  (point at non-existent path; KanbanContext::open(JsonDataStore::new(...), cfg) succeeds immediately)\ntest_open_context_sqlite_does_no_io_at_construction\n  (same for SqliteStore)\ntest_open_context_first_list_boards_triggers_load\n  (create JSON with 1 board; open context; list_boards() returns 1)\ntest_open_context_baseline_is_none_before_first_execute\n  (ctx.baseline_snapshot is None before any execute)\ntest_open_context_baseline_captured_on_first_execute\n  (create_board; ctx.baseline_snapshot is Some)\ntest_open_context_save_flushes_json_not_sqlite\n  (JSON: save() causes dirty=false; SQLite: save() is no-op, no-op is fine)\ntest_open_context_reload_delegates_to_backend\n  (modify JSON externally; ctx.reload(); list_boards() returns updated data)\ntest_undo_redo_still_work_after_lazy_baseline\n\nGreen — changes to crates/kanban-service/src/context.rs:\n\nStruct (lines 42-51):\n- Line 45: REMOVE store: Option<Arc<dyn PersistenceStore + Send + Sync>>\n- Line 46: CHANGE baseline_snapshot: Snapshot → baseline_snapshot: Option<Snapshot>\n\nNew constructor (replaces load, open_sqlite, open_json, empty):\n// Replaces lines 54-147\npub async fn open(backend: Arc<dyn KanbanBackend>, config: AppConfig) -> KanbanResult<Self> {\n    Ok(Self {\n        backend,\n        app_config: config,\n        baseline_snapshot: None,   // lazy: set on first execute()\n        undo_cursor: 0,            // lazy: restored on first undo/redo\n        command_count: 0,          // lazy: restored from backend.command_count() on first undo/redo\n        dirty: false,\n        conflict_pending: false,\n    })\n}\nRemove load() (lines 54-99), open_sqlite() (lines 108-124), open_json() (lines 127-131), empty() (lines 133-147).\n\nexecute() — lazy baseline (lines 199-259):\n- Lines 205-209: Before capturing pre-execution snapshot, if baseline_snapshot.is_none():\nif self.baseline_snapshot.is_none() {\n    self.baseline_snapshot = Some(self.backend.snapshot()?);\n    self.command_count = self.backend.command_count() as usize;\n    self.undo_cursor = self.command_count;\n}\n\nundo() — lazy command count (lines 267-300):\n- If self.command_count == 0 and undo_cursor == 0 at start, restore from backend:\nif self.command_count == 0 {\n    self.command_count = self.backend.command_count() as usize;\n    self.undo_cursor = self.command_count;\n    self.baseline_snapshot = Some(self.backend.snapshot()?);\n}\n\nsave() (lines 422-445):\n- Remove let Some(store) = &self.store else { return Ok(()) } guard (lines 423-425)\n- Remove the entire body; replace with:\npub async fn save(&self) -> KanbanResult<()> {\n    self.backend.flush().await\n}\n\nreload() (lines 398-410):\n- Remove let Some(store) = &self.store else { return Ok(()) } guard (lines 399-401)\n- Replace body with:\npub async fn reload(&mut self) -> KanbanResult<()> {\n    self.backend.reload().await?;\n    self.baseline_snapshot = None;\n    self.undo_cursor = 0;\n    self.command_count = 0;\n    self.dirty = false;\n    Ok(())\n}\n\nRemove or adapt:\n- replace_store() method (line 391) — REMOVE (no more store field)\n- store() getter (line 395) — REMOVE\n\nRefactor: All callers of ctx.store() and ctx.replace_store() — grep and fix. The is_dirty(), mark_dirty(), mark_clean() (lines\n 367-375) remain unchanged.\n\n---\n### Step 4 — StoreManager::make_backend()\n\nWhy: StoreManager::make_store() (lines 106-112) returns Arc<dyn PersistenceStore>. We need make_backend() that returns Arc<dyn\n KanbanBackend>, hiding the JSON vs SQLite construction difference.\n\nRed — tests (inline in store_manager.rs):\ntest_make_backend_json_path_returns_json_data_store\ntest_make_backend_sqlite_path_returns_sqlite_store\ntest_make_backend_detects_sqlite_by_magic_bytes\n  (write a real SQLite file without extension; make_backend detects it correctly)\ntest_make_backend_detects_json_by_content\n  (write a JSON file without extension; make_backend detects it correctly)\nAll use TempDir.\n\nGreen — add to crates/kanban-service/src/store_manager.rs after make_store() (line 112):\npub async fn make_backend(\n    &self,\n    locator: &str,\n    config: &AppConfig,\n) -> KanbanResult<Arc<dyn KanbanBackend>> {\n    if self.is_sqlite(locator) {\n        #[cfg(feature = \"sqlite\")]\n        return Ok(Arc::new(SqliteStore::open(locator).await\n            .map_err(|e| KanbanError::Database(e.to_string()))?));\n        #[cfg(not(feature = \"sqlite\"))]\n        return Err(KanbanError::Internal(\"SQLite feature not enabled\".into()));\n    }\n    let store = self.make_store(\n        config.effective_storage_backend(),\n        locator\n    )?;\n    Ok(Arc::new(JsonDataStore::new(store)))\n}\n\nRefactor: Reuse is_sqlite() (lines 56-66) and detect_backend() (lines 71-90) — no duplication.\n\n---\n### Step 5 — kanban_service::open_context()\n\nWhy: This is the single public entry point that all three apps will call. It replaces the\nStoreManager::sync_backend_with_file() + KanbanContext::load() / open_sqlite() dance that is currently duplicated in\nCliContext::load() (context.rs:17-33), McpContext::new() (mcp/context.rs:15-31), and App::new_with_store() /\nApp::open_sqlite() (tui/app/mod.rs:198-361).\n\nRed — integration tests in crates/kanban-service/tests/open_context.rs:\ntest_open_context_json_end_to_end\n  (init JSON file; open_context(); create_board(); save(); reopen; list_boards() returns board)\ntest_open_context_sqlite_end_to_end\n  (same for SQLite)\ntest_open_context_auto_detects_backend_from_magic_bytes\n  (create unlabelled SQLite file; open_context detects SQLite; CRUD works)\ntest_open_context_new_file_starts_empty\n  (point at non-existent path; open_context(); list_boards() returns [])\n\nGreen — add to crates/kanban-service/src/lib.rs (after default_registry() at line 39):\npub async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanContext> {\n    let mut config = config;\n    let sm = StoreManager::new(default_registry());\n    sm.sync_backend_with_file(locator, &mut config);\n    let backend = sm.make_backend(locator, &config).await?;\n    KanbanContext::open(backend, config).await\n}\n\nRefactor: Nothing to delete yet — keep old exports until Step 7.\n\n---\n### Step 6 — Wire FileWatcher to backend.reload()\n\nWhy: Currently App::auto_reload_from_external_change() (app/mod.rs:2210) loads from disk by calling store.load().await\ndirectly — it knows about the PersistenceStore. After this step, external change handling goes through ctx.reload() →\nbackend.reload(), which works for both JSON (clears cache) and SQLite (no-op, reads are live). The FileMetadata mtime/hash\npath in JsonFileStore can be retired.\n\nRed — TUI integration test in crates/kanban-tui/tests/:\ntest_external_json_change_triggers_reload_when_clean\n  (open JSON ctx; write new board to file externally; simulate watcher event;\n   assert list_boards() returns the new board without manual reload)\ntest_external_json_change_sets_conflict_when_dirty\n  (open JSON ctx; create board (dirty=true); write file externally; simulate watcher event;\n   assert ctx.conflict_pending == true)\ntest_external_sqlite_change_is_transparent\n  (open SQLite ctx; insert row externally; list_boards() immediately returns new row — no reload needed)\n\nGreen — changes to crates/kanban-tui/src/app/mod.rs:\n\nauto_reload_from_external_change() (line 2210):\n- Replace the current store.load().await call with:\nasync fn auto_reload_from_external_change(&mut self) -> KanbanResult<()> {\n    if self.ctx.is_dirty() {\n        self.ctx.set_conflict_pending(true);\n        return Ok(());\n    }\n    self.ctx.reload().await?;   // delegates to backend.reload()\n    Ok(())\n}\n- Remove store reference; no more PersistenceStore access in TUI\n\nRefactor: Remove FileMetadata import from JsonFileStore if it's no longer used externally. The conflict detection logic (mtime\n + size + hash) inside JsonFileStore::save() can remain as an internal guard — it's not the reload trigger anymore.\n\n---\n### Step 7 — Unify App Initialization\n\nWhy: After Steps 1-6, KanbanContext::open() is the correct single entry point. The if is_sqlite forks in all three apps become\n dead code.\n\nTUI changes (crates/kanban-tui/src/app/mod.rs and tui_context.rs):\n\nTuiContext::new(store) (tui_context.rs:22-39) and TuiContext::from_context(ctx) (tui_context.rs:45-58):\n- Collapse to single TuiContext::new(ctx: KanbanContext) -> (Self, Option<Receiver<Snapshot>>, ...):\n  - SaveCoordinator::new(ctx.backend().needs_flush()) — replaces store.is_some() at tui_context.rs:31\n  - If needs_flush(): create save channel and return Some(rx)\n  - If not: return None\n\nApp::new_with_store() (app/mod.rs:198-286) and App::open_sqlite() (app/mod.rs:293-361):\n- Replace with single App::new(ctx: KanbanContext, config: AppConfig) -> KanbanResult<(Self, Option<Receiver<Snapshot>>)>\n- No more store_manager.make_store() inside App; App just takes a pre-built KanbanContext\n\nCLI fork (app.rs:285-301):\n- Remove the if is_sqlite { App::open_sqlite(...) } else { App::new_with_store(...) } block\n- Replace with:\nlet ctx = kanban_service::open_context(&effective_file, config).await?;\nlet (mut app, save_rx) = App::new(ctx, app_config)?;\napp.set_error_log(error_log);\napp.run(save_rx).await?;\n\nCliContext::load() (kanban-cli/src/context.rs:17-33):\n- Replace body with:\npub async fn load(locator: &str, config: AppConfig) -> KanbanResult<Self> {\n    Ok(Self { inner: kanban_service::open_context(locator, config).await? })\n}\n- Remove store_manager parameter — no longer needed\n\nMcpContext::new() (kanban-mcp/src/context.rs:15-31):\n- Replace body with:\npub async fn new(data_file: &str, config: AppConfig) -> KanbanResult<Self> {\n    Ok(Self { inner: kanban_service::open_context(data_file, config).await? })\n}\n- Remove store_manager parameter\n\nRed — tests to write first:\n// kanban-cli/tests/\ntest_cli_init_and_run_json_unified_path\ntest_cli_init_and_run_sqlite_unified_path\n// kanban-mcp/tests/\ntest_mcp_list_boards_json_unified_path\ntest_mcp_list_boards_sqlite_unified_path\n// kanban-tui/tests/\ntest_tui_context_single_constructor_json\ntest_tui_context_single_constructor_sqlite\n  (assert save_rx is Some for JSON, None for SQLite)\n\nRefactor — delete dead code:\n- App::open_sqlite() (app/mod.rs:293-361) — entire method\n- App::new_with_store() (app/mod.rs:198-286) — entire method (replaced by App::new())\n- TuiContext::from_context() (tui_context.rs:45-58) — entire method\n- resolve_is_sqlite() helper in kanban-cli (wherever defined)\n- KanbanContext::open_sqlite() (context.rs:108-124) — already removed in Step 3\n- StoreManager parameter from CliContext::load and McpContext::new call sites\n\n---\nWhat This Unlocks\n\n- Startup is instant: open_context() = connection only. First render triggers first read.\n- Staleness handled uniformly: reload() is well-defined on both backends.\n- Remote backends trivial: implement DataStore + CommandStore + KanbanBackend. Each method = a network call. needs_flush() =\nfalse (write-through). flush() = no-op.\n- Pagination path clear: DataStore methods already take no limit/offset, but they can be extended. The lazy model means adding\n list_cards_paginated(column_id, page, size) doesn't require rethinking the initialization protocol.\n- No SQLite special-casing: both backends implement the same interface.\n\n---\nFiles to Modify\n\n┌──────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐\n│                         File                         │                            Change                            │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/backend.rs                 │ Add flush, reload, needs_flush to KanbanBackend              │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/json_backend.rs            │ New: JsonDataStore (lazy InMemory + JsonFileStore)           │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/context.rs                 │ Single open() constructor, lazy baseline, remove store field │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/store_manager.rs           │ Add make_backend() method                                    │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/lib.rs                     │ Expose open_context()                                        │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-persistence-sqlite/src/sqlite_store.rs │ Impl KanbanBackend lifecycle methods                         │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-cli/src/app.rs                         │ Remove is_sqlite fork                                        │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-cli/src/context.rs                     │ Call open_context()                                          │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-mcp/src/server.rs                      │ Call open_context()                                          │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-mcp/src/context.rs                     │ Call open_context()                                          │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-tui/src/app/mod.rs                     │ Collapse two constructors                                    │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-tui/src/tui_context.rs                 │ Remove from_context() vs new() split                         │\n└──────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘\n\n---\nNon-Goals / Deferred\n\n- Pagination / streaming: DataStore API stays as-is for now. The lazy model is a prerequisite — do this first.\n- StoreFactory::create() async wart (block_in_place): separate concern, leave for later.\n- Command log protocol divergence (JSON envelope vs SQLite tables): JsonDataStore handles this internally. No protocol\nunification needed.\n- ID type aliases vs newtypes, TOCTOU in modify_graph: out of scope.\n\n---\nVerification\n\n1. cargo test --workspace — all existing tests pass\n2. cargo run -- init --name \"Test\" test.json && cargo run test.json — JSON works, first render triggers file read\n3. cargo run -- init --name \"Test\" test.sqlite && cargo run test.sqlite — SQLite works, each view triggers DB query\n4. Modify test.json externally while TUI is open → conflict banner appears\n5. Modify test.sqlite externally while TUI is open → next read reflects new state transparently\n6. MCP tool calls persist correctly for both backends (write-through for SQLite, flush for JSON)\n7. Undo/redo works correctly on both backends after the lazy baseline change\n─────────────────────────────────────────────────────────────────────────────────\n",
+        "due_date": null,
+        "id": "6cbed515-7e76-41ce-9449-e045891c9092",
+        "points": null,
+        "position": 150,
+        "priority": "High",
+        "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+            "sprint_name": "sphinx-centered",
+            "sprint_number": 14,
+            "started_at": "2026-04-29T04:53:26.701583312Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Done",
+        "title": "Architecture: Unified Backends via True Deferred Reads",
+        "updated_at": "2026-05-07T22:06:09.412139502Z"
+      },
+      {
         "card_number": 343,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -11485,49 +11019,6 @@
         "status": "Todo",
         "title": "Unify card identifier prefix resolution via Sprint::effective_card_prefix()",
         "updated_at": "2026-05-07T22:06:15.245112967Z"
-      },
-      {
-        "card_number": 384,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-07T22:06:09.412138272Z",
-        "created_at": "2026-04-28T08:54:01.006886168Z",
-        "description": "Goal: open_context() establishes a connection with zero I/O. Data is loaded lazily on first DataStore/CommandStore call. Eliminates the is_sqlite fork across all three apps (TUI, CLI, MCP).\n\n# Challenge\n\nKanbanContext::load() today: (1) calls PersistenceStore::load() fetching full snapshot blob, (2) deserializes everything into InMemoryStore, (3) loads command log. This is eager-load-everything. All three apps fork on is_sqlite because JSON and SQLite have different initialization contracts.\n\n# TARGET ARCHITECTURE\n\nDataStore + CommandStore are the sole runtime interface. PersistenceStore (blob) is used only for import/export/migration. KanbanBackend gains lifecycle methods: flush(), reload(), needs_flush(), needs_save_worker(), on_undo_state_changed(), instance_id().\n\n### STEP 1 — KanbanBackend lifecycle methods [DONE]\n\nAdd flush/reload/needs_flush/needs_save_worker/on_undo_state_changed/instance_id to KanbanBackend with default no-op impls. SQLite impl: flush()=WAL checkpoint, reload()=no-op, needs_flush()=false. InMemoryStore uses all defaults.\nFiles: crates/kanban-service/src/backend.rs, crates/kanban-persistence-sqlite/src/sqlite_store.rs, crates/kanban-domain/src/data_store.rs\n\n### STEP 2 — JsonDataStore lazy JSON backend [DONE]\n\nNew type in crates/kanban-service/src/json_backend.rs wrapping Arc<dyn PersistenceStore> + RwLock<Option<InMemoryStore>> + AtomicBool dirty. Construction is zero-I/O. ensure_loaded() reads file on first access using block_in_place (requires multi_thread runtime). flush() serialises cache to disk. reload() sets inner=None so next access re-reads. needs_save_worker()=true (background flush worker needed). on_undo_state_changed() caches cursor+baseline for next flush.\n\n### STEP 3 — Simplify KanbanContext [DONE]\n\nSingle constructor KanbanContext::open(backend, config) — zero I/O. baseline_snapshot: Option<Snapshot> starts None, captured lazily on first execute(). command_count restored lazily on first undo/redo via ensure_undo_state_initialized(). save() delegates to backend.flush().await. reload() delegates to backend.reload().await and clears baseline_snapshot. Removed store: Option<Arc<dyn PersistenceStore>> field, replace_store(), store() getter.\nFile: crates/kanban-service/src/context.rs\n\n### STEP 4 — StoreManager::make_backend() [DONE]\n\nNew method returning Arc<dyn KanbanBackend>. If is_sqlite → SqliteStore::open(). Else → JsonDataStore::new(make_store()). Also make_backend_sync() for sync contexts (uses block_on internally).\nFile: crates/kanban-service/src/store_manager.rs\n\n### STEP 5 — kanban_service::open_context() [DONE]\n\nSingle public entry point: sync_backend_with_file() + make_backend() + KanbanContext::open(). All three apps can call this instead of duplicating the StoreManager dance.\nFile: crates/kanban-service/src/lib.rs\n\n### STEP 6 — Wire FileWatcher to backend.reload() [DONE]\n\nauto_reload_from_external_change() in app/mod.rs now calls ctx.reload() → backend.reload() instead of store.load().await directly. SaveCoordinator sends () flush signals instead of Snapshot blobs; save worker calls backend.flush().await on each signal. TuiContext uses needs_save_worker() to decide whether to spawn the background worker.\nFiles: crates/kanban-tui/src/app/mod.rs, crates/kanban-tui/src/state/mod.rs, crates/kanban-tui/src/tui_context.rs, crates/kanban-tui/src/handlers/settings_handlers.rs\n\n### STEP 7 — Unify App Initialization [PENDING]\n\nReplace divergent is_sqlite forks in all three apps with open_context().\n\nTUI: Collapse App::new_with_store() + App::open_sqlite() into App::new(ctx: KanbanContext). Remove TuiContext::from_context(); TuiContext::new(ctx) is the only constructor. SaveCoordinator::new() uses ctx.backend().needs_flush() instead of store.is_some().\n\nCLI: Remove if is_sqlite { App::open_sqlite() } else { App::new_with_store() } fork in app.rs. CliContext::load() calls kanban_service::open_context() directly. Remove StoreManager parameter.\n\nMCP: McpContext::new() calls kanban_service::open_context() directly. Remove StoreManager parameter.\n\nDelete dead code: App::open_sqlite(), App::new_with_store(), TuiContext::from_context(), resolve_is_sqlite() helper.\n\nTDD tests to write first:\n\n- test_tui_context_single_constructor_json (save_rx is Some)\n- test_tui_context_single_constructor_sqlite (save_rx is None)\n- test_cli_init_and_run_json_unified_path\n- test_cli_init_and_run_sqlite_unified_path\n- test_mcp_list_boards_json_unified_path\n- test_mcp_list_boards_sqlite_unified_path\n\nFiles to modify:\n\n- crates/kanban-cli/src/app.rs\n- crates/kanban-cli/src/context.rs\n- crates/kanban-mcp/src/context.rs\n- crates/kanban-mcp/src/server.rs\n- crates/kanban-tui/src/app/mod.rs\n- crates/kanban-tui/src/tui_context.rs\n\nVERIFICATION (all steps)\n\n1. cargo test --workspace — all tests pass\n2. cargo run -- init --name Test test.json && cargo run test.json — JSON path works\n3. cargo run -- init --name Test test.sqlite && cargo run test.sqlite — SQLite path works\n4. Modify test.json externally while TUI open → conflict banner appears\n5. Modify test.sqlite externally → next read reflects new state transparently\n6. MCP tool calls persist for both backends\n7. Undo/redo works on both backends after lazy baseline change\n\n---\n\n\nPlan to implement\n\n### Create Kanban Card: Step 7 — Unify App Initialization\n\nContext\n\nSteps 1–6 of the \"Unified Backends via True Deferred Reads\" architecture are complete and committed.\nStep 7 (unifying CLI, MCP, and TUI initialization paths) has not been done yet and needs to be tracked\nas a kanban card so it can be planned and scheduled.\n\nTask\n\nRun a single CLI command to create the card in ~/notes/memes/kanban.json.\n\nBoard Info\n\n- File: ~/notes/memes/kanban.json\n- Board ID: e119c091-e1fa-4596-9bc7-038ceab6adec\n- Column: TODO → ID: 591afb61-7289-46bf-ba07-21758afd44fe\n\nCommand\n\nkanban ~/notes/memes/kanban.json card create \\\n  --board-id e119c091-e1fa-4596-9bc7-038ceab6adec \\\n  --column-id 591afb61-7289-46bf-ba07-21758afd44fe \\\n  --title \"Architecture: Unified Backends via True Deferred Reads\" \\\n  --description \"Goal: open_context() establishes a connection with zero I/O. Data is loaded lazily on first\nDataStore/CommandStore call. Eliminates the is_sqlite fork across all three apps (TUI, CLI, MCP).\n\nPROBLEM\nKanbanContext::load() today: (1) calls PersistenceStore::load() fetching full snapshot blob, (2) deserializes everything into\nInMemoryStore, (3) loads command log. This is eager-load-everything. All three apps fork on is_sqlite because JSON and SQLite\nhave different initialization contracts.\n\nTARGET ARCHITECTURE\nDataStore + CommandStore are the sole runtime interface. PersistenceStore (blob) is used only for import/export/migration.\nKanbanBackend gains lifecycle methods: flush(), reload(), needs_flush(), needs_save_worker(), on_undo_state_changed(),\ninstance_id().\n\nSTEP 1 — KanbanBackend lifecycle methods [DONE]\nAdd flush/reload/needs_flush/needs_save_worker/on_undo_state_changed/instance_id to KanbanBackend with default no-op impls.\nSQLite impl: flush()=WAL checkpoint, reload()=no-op, needs_flush()=false. InMemoryStore uses all defaults.\nFiles: crates/kanban-service/src/backend.rs, crates/kanban-persistence-sqlite/src/sqlite_store.rs,\ncrates/kanban-domain/src/data_store.rs\n\nSTEP 2 — JsonDataStore lazy JSON backend [DONE]\nNew type in crates/kanban-service/src/json_backend.rs wrapping Arc<dyn PersistenceStore> + RwLock<Option<InMemoryStore>> +\nAtomicBool dirty. Construction is zero-I/O. ensure_loaded() reads file on first access using block_in_place (requires\nmulti_thread runtime). flush() serialises cache to disk. reload() sets inner=None so next access re-reads.\nneeds_save_worker()=true (background flush worker needed). on_undo_state_changed() caches cursor+baseline for next flush.\n\nSTEP 3 — Simplify KanbanContext [DONE]\nSingle constructor KanbanContext::open(backend, config) — zero I/O. baseline_snapshot: Option<Snapshot> starts None, captured\nlazily on first execute(). command_count restored lazily on first undo/redo via ensure_undo_state_initialized(). save()\ndelegates to backend.flush().await. reload() delegates to backend.reload().await and clears baseline_snapshot. Removed store:\nOption<Arc<dyn PersistenceStore>> field, replace_store(), store() getter.\nFile: crates/kanban-service/src/context.rs\n\nSTEP 4 — StoreManager::make_backend() [DONE]\nNew method returning Arc<dyn KanbanBackend>. If is_sqlite → SqliteStore::open(). Else → JsonDataStore::new(make_store()). Also\n make_backend_sync() for sync contexts (uses block_on internally).\nFile: crates/kanban-service/src/store_manager.rs\n\nSTEP 5 — kanban_service::open_context() [DONE]\nSingle public entry point: sync_backend_with_file() + make_backend() + KanbanContext::open(). All three apps can call this\ninstead of duplicating the StoreManager dance.\nFile: crates/kanban-service/src/lib.rs\n\nSTEP 6 — Wire FileWatcher to backend.reload() [DONE]\nauto_reload_from_external_change() in app/mod.rs now calls ctx.reload() → backend.reload() instead of store.load().await\ndirectly. SaveCoordinator sends () flush signals instead of Snapshot blobs; save worker calls backend.flush().await on each\nsignal. TuiContext uses needs_save_worker() to decide whether to spawn the background worker.\nFiles: crates/kanban-tui/src/app/mod.rs, crates/kanban-tui/src/state/mod.rs, crates/kanban-tui/src/tui_context.rs,\ncrates/kanban-tui/src/handlers/settings_handlers.rs\n\nSTEP 7 — Unify App Initialization [PENDING]\nReplace divergent is_sqlite forks in all three apps with open_context().\n\nTUI: Collapse App::new_with_store() + App::open_sqlite() into App::new(ctx: KanbanContext). Remove TuiContext::from_context();\n TuiContext::new(ctx) is the only constructor. SaveCoordinator::new() uses ctx.backend().needs_save_worker() instead of\nstore.is_some().\n\nCLI: Remove if is_sqlite { App::open_sqlite() } else { App::new_with_store() } fork in app.rs. CliContext::load() calls\nkanban_service::open_context() directly. Remove StoreManager parameter.\n\nMCP: McpContext::new() calls kanban_service::open_context() directly. Remove StoreManager parameter.\n\nDelete dead code: App::open_sqlite(), App::new_with_store(), TuiContext::from_context(), resolve_is_sqlite() helper.\n\nTDD tests to write first:\n- test_tui_context_single_constructor_json (save_rx is Some)\n- test_tui_context_single_constructor_sqlite (save_rx is None)\n- test_cli_init_and_run_json_unified_path\n- test_cli_init_and_run_sqlite_unified_path\n- test_mcp_list_boards_json_unified_path\n- test_mcp_list_boards_sqlite_unified_path\n\nFiles to modify:\n- crates/kanban-cli/src/app.rs\n- crates/kanban-cli/src/context.rs\n- crates/kanban-mcp/src/context.rs\n- crates/kanban-mcp/src/server.rs\n- crates/kanban-tui/src/app/mod.rs\n- crates/kanban-tui/src/tui_context.rs\n\nVERIFICATION (all steps)\n1. cargo test --workspace — all tests pass\n2. cargo run -- init --name Test test.json && cargo run test.json — JSON path works\n3. cargo run -- init --name Test test.sqlite && cargo run test.sqlite — SQLite path works\n4. Modify test.json externally while TUI open → conflict banner appears\n5. Modify test.sqlite externally → next read reflects new state transparently\n6. MCP tool calls persist for both backends\n7. Undo/redo works on both backends after lazy baseline change\" \\\n  --priority High\n\nVerification\n\nAfter running the command, open the TUI (kanban ~/notes/memes/kanban.json) and confirm the card\nappears in the TODO column.\n\nContext\n\nThe project has two backends (JSON, SQLite) and three apps (TUI, CLI, MCP) with divergent initialization paths. The goal is\nnot just a surface unification — the underlying requirement is true deferred reads: open_context() should establish a\nconnection and do zero I/O. Data is only read from disk/DB when a specific entity is first requested.\n\nThis solves all three pain points simultaneously:\n- Startup time: nothing loaded until the UI actually renders\n- Staleness: reload() on file-watch event is well-defined per backend\n- Extensibility: remote backends (PostgreSQL, HTTP API) are natural — each DataStore method becomes a network call\n\n---\nCurrent State: Why the Model Is Wrong\n\nThe Snapshot Bootstrap Problem\n\nKanbanContext::load(store, config) today:\n1. Calls PersistenceStore::load() → fetches full snapshot blob\n2. Deserializes everything into InMemoryStore (all boards, columns, cards, sprints)\n3. Loads the entire command log\n4. Takes a baseline_snapshot of the full state\n\nThis is eager-load-everything regardless of what the user actually needs to see.\n\nThe Two-Path Problem\n\nJSON path:   KanbanContext::load(store) → InMemoryStore (full eager hydration)\nSQLite path: KanbanContext::open_sqlite() → SqliteStore (bypasses snapshot, but\n             still loads command log state upfront)\n\nAll three apps fork on is_sqlite. The fork exists because the two paths have fundamentally different initialization contracts.\n\nWhy SQLite Is Already Half-Right\n\nSqliteStore already implements DataStore with real SQL queries — list_boards() is SELECT * FROM boards,\nlist_columns_by_board(id) is SELECT ... WHERE board_id = ?. There is no pre-load. The problem is that\nKanbanContext::open_sqlite() still loads command log state eagerly, and the rest of the codebase bypasses this with the\nsnapshot model anyway.\n\n---\n\nThe PersistenceStore blob interface (load/save full snapshot) is used as the initialization protocol for KanbanContext. This\nforces everything through a full-load. The correct initialization protocol is: establish a connection, do nothing else.\n\nThe fine-grained DataStore trait (already defined in kanban-domain) is the right lazy interface. KanbanContext should always\nread through DataStore methods, never through blob snapshots during normal operation. Snapshots become a utility for\nimport/export/migration only.\n\nTarget Architecture\n---\n\nPrinciple: DataStore + CommandStore as the Sole Runtime Interface\n\nNormal operation:   KanbanContext → DataStore / CommandStore methods (lazy, per-entity)\nImport/Export:      KanbanContext → PersistenceStore (snapshot blob, on demand)\n\nExtend KanbanBackend with Lifecycle Methods\n\nKanbanBackend (in kanban-service/src/backend.rs) gains three methods:\n\npub trait KanbanBackend: DataStore + CommandStore + Send + Sync {\n    fn as_data_store(&self) -> &dyn DataStore;\n\n    // New lifecycle:\n    async fn flush(&self) -> KanbanResult<()> { Ok(()) }   // default no-op\n    async fn reload(&self) -> KanbanResult<()> { Ok(()) }  // default no-op\n    fn needs_flush(&self) -> bool { false }                 // default: always in sync\n}\n\n- SQLite: flush() = WAL checkpoint, reload() = no-op (reads are always live), needs_flush() = false\n- JsonDataStore (new): flush() = serialize cache to file, reload() = re-read file + clear cache, needs_flush() = tracks dirty\nstate\n\nJsonDataStore (New Type)\n\nLives in crates/kanban-service/src/json_backend.rs (has access to both InMemoryStore and JsonFileStore).\n\nJsonDataStore {\n    path: PathBuf,\n    inner: RwLock<Option<InMemoryStore>>,   // None until first access\n    file_store: Arc<JsonFileStore>,\n    dirty: AtomicBool,\n}\n\n- Any DataStore or CommandStore method call checks inner.is_none() → if so, reads the JSON file and populates InMemoryStore\n(the one-time lazy load)\n- Subsequent calls are served from the in-memory cache\n- Writes update the cache + set dirty = true\n- flush() serializes the in-memory state to JSON via JsonFileStore\n- reload() sets inner = None → next access re-reads the file\n\nThis is the one place where \"lazy\" still reads the full JSON file — because JSON is a single blob, there's no way to partially\n read it. But the load is deferred until something actually needs data, making open_context() instantaneous even for large\nfiles.\n\nKanbanContext — Single Constructor, Zero Initial I/O\n\npub struct KanbanContext {\n    backend: Arc<dyn KanbanBackend>,\n    app_config: AppConfig,\n    baseline_snapshot: Option<Snapshot>,    // None until first write\n    undo_cursor: usize,\n    command_count: usize,\n    dirty: bool,\n    conflict_pending: bool,\n}\n\nimpl KanbanContext {\n    pub async fn open(backend: Arc<dyn KanbanBackend>, config: AppConfig) -> KanbanResult<Self> {\n        // Zero I/O. Just wraps the backend.\n        Ok(Self {\n            backend,\n            app_config: config,\n            baseline_snapshot: None,    // lazy: captured on first write\n            undo_cursor: 0,\n            command_count: 0,           // lazy: read from CommandStore on first undo/redo\n            dirty: false,\n            conflict_pending: false,\n        })\n    }\n}\n\nUndo baseline captured lazily:\nOn first execute(commands) call, if baseline_snapshot.is_none(), take a snapshot of current backend state and store it. The\nbaseline is the state at the time of first write, which is the correct semantic anyway.\n\nCommand count restored lazily:\nOn first undo/redo, if needed, call backend.command_count() to restore cursor position from the backend.\n\nUnified Public Entry Point\n\nIn crates/kanban-service/src/lib.rs:\n\npub async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanContext> {\n    let mut config = config;\n    let sm = StoreManager::new(default_registry());\n    sm.sync_backend_with_file(locator, &mut config);\n    let backend: Arc<dyn KanbanBackend> = sm.make_backend(locator, &config).await?;\n    KanbanContext::open(backend, config).await\n}\n\nAll three apps:\nlet ctx = kanban_service::open_context(&file_path, config).await?;\n// Zero I/O has happened. First render triggers actual data reads.\n\nStoreManager::make_backend()\n\nNew method in StoreManager that returns Arc<dyn KanbanBackend>:\n\npub async fn make_backend(\n    &self,\n    locator: &str,\n    config: &AppConfig,\n) -> KanbanResult<Arc<dyn KanbanBackend>> {\n    if self.is_sqlite(locator) {\n        Ok(Arc::new(SqliteStore::open(locator).await?))\n    } else {\n        let store = self.make_store(\"json\", locator)?;    // existing PersistenceStore\n        Ok(Arc::new(JsonDataStore::new(store)))\n    }\n}\n\n---\nStaleness / External Change Handling\n\nWith reload() on KanbanBackend:\n- FileWatcher fires → KanbanContext calls backend.reload()\n- For JSON: clears the in-memory cache. Next DataStore call re-reads the file.\n- For SQLite: no-op. Reads are always live against the DB.\n- If dirty is true when reload fires → conflict_pending = true (existing conflict UI)\n\nThis replaces the current FileMetadata mtime/hash conflict detection in JsonFileStore with a cleaner model: the context owns\nconflict state, not the store.\n\n---\nWhat Happens to PersistenceStore\n\nPersistenceStore trait and its implementations stay. Their role narrows:\n- Import: load a snapshot blob and call backend.apply_snapshot()\n- Export: call backend.snapshot() and pass to PersistenceStore::save()\n- Migration: blob-level version upgrades (V1→V2 JSON envelope etc.)\n- NOT used: for normal app startup or runtime reads\n\nStoreFactory / StoreRegistry stay for this purpose. StoreManager::make_store() stays for import/export flows.\n\n---\n### TDD Workflow (Mandatory for Every Step)\n\nEach step follows Red → Green → Refactor:\n1. Red: Write failing tests that specify the expected behaviour. Present for review before implementing.\n2. Green: Minimum implementation to make tests pass.\n3. Refactor: Clean up without breaking tests.\n\ncargo test --workspace must pass at the end of every step.\n\n---\nRecommended Order of Work\n\n### Step 1 — Extend KanbanBackend with lifecycle methods\n\nWhy: KanbanBackend (backend.rs:8) currently has only as_data_store(). We need flush, reload, needs_flush so that KanbanContext\n can delegate persistence without knowing which backend it holds.\n\nRed — tests to write first (crates/kanban-persistence-sqlite/src/sqlite_store.rs, inline #[cfg(test)]):\ntest_sqlite_backend_needs_flush_returns_false\ntest_sqlite_backend_flush_executes_wal_checkpoint\ntest_sqlite_backend_reload_is_noop  (list_boards before and after reload returns same data)\ntest_in_memory_store_lifecycle_defaults_are_noop\nUse real TempDir SQLite file. Pattern: SqliteStore::open(tmp.path()).await?.\n\nGreen — changes:\n\ncrates/kanban-service/src/backend.rs:\n- Line 9 (after as_data_store): add three methods with default no-op impls:\nasync fn flush(&self) -> KanbanResult<()> { Ok(()) }\nasync fn reload(&self) -> KanbanResult<()> { Ok(()) }\nfn needs_flush(&self) -> bool { false }\n\ncrates/kanban-persistence-sqlite/src/sqlite_store.rs:\n- Locate the impl KanbanBackend for SqliteStore block (currently only has as_data_store)\n- Add concrete impls:\n  - flush(): call self.checkpoint().await (checkpoint method already exists at ~line 1654)\n  - reload(): Ok(()) — SQLite reads are always live\n  - needs_flush(): false — write-through\n\ncrates/kanban-domain/src/in_memory_store.rs:\n- InMemoryStore will use the default no-op impls (no explicit impl needed; covered by blanket impl on KanbanBackend)\n\nRefactor: Confirm the blanket impl at backend.rs:13-17 still compiles with the new default methods.\n\n---\n### Step 2 — Create JsonDataStore\n\nWhy: Currently the JSON path requires creating InMemoryStore + JsonFileStore separately, wired together inside\nKanbanContext::load(). This forces eager loading on construction. JsonDataStore encapsulates this pair and makes loading lazy\n— the file is not read until the first DataStore method call.\n\nRed — tests to write first (inline #[cfg(test)] in new crates/kanban-service/src/json_backend.rs):\ntest_json_data_store_construction_does_no_io\n  (assert file not read: create store pointing at non-existent path, construction succeeds)\ntest_json_data_store_list_boards_triggers_load\n  (create JSON file with 1 board; construction ok; assert inner is None; call list_boards(); assert returns 1 board)\ntest_json_data_store_needs_flush_false_when_clean\ntest_json_data_store_needs_flush_true_after_upsert\ntest_json_data_store_flush_writes_to_disk\n  (upsert board; flush(); create new JsonDataStore at same path; list_boards() returns the board)\ntest_json_data_store_reload_clears_cache\n  (load; modify file externally; reload(); list_boards() returns updated data)\ntest_json_data_store_command_log_round_trip\n  (append commands; flush(); create fresh store; command_count() returns correct value)\nUse real TempDir JSON files via kanban_persistence_json::JsonStoreFactory.\n\nGreen — new file crates/kanban-service/src/json_backend.rs:\npub struct JsonDataStore {\n    file_store: Arc<dyn PersistenceStore + Send + Sync>,\n    inner: RwLock<Option<InMemoryStore>>,\n    dirty: AtomicBool,\n}\n- fn new(store: Arc<dyn PersistenceStore + Send + Sync>) -> Self — stores only, no I/O\n- Private fn ensure_loaded(&self) -> KanbanResult<()>:\n  - Acquires write lock on inner\n  - If None: calls file_store.load() (or returns empty InMemoryStore if !file_store.exists())\n  - Deserializes StoreSnapshot.data into Snapshot\n\n  - Calls InMemoryStore::apply_snapshot(snapshot)\n  - Restores command log from file_store.get_command_log() into InMemoryStore\n  - Sets inner = Some(store)\n- Every DataStore and CommandStore method: calls ensure_loaded() then delegates to inner\n- Write methods additionally set dirty.store(true, Ordering::Release)\n- flush(): if dirty, serialize snapshot + command log → call file_store.save() + file_store.sync_command_log(); clear dirty\n- reload(): set inner = None (next access re-reads file); clear dirty\n- needs_flush(): return dirty.load(Ordering::Acquire)\n\nAlso add impl KanbanBackend for JsonDataStore (delegates to above lifecycle methods). Add to crates/kanban-service/src/lib.rs\nmodule declaration.\n\nRefactor: Extract snapshot serialization helper (reuse snapshot_to_json_bytes / snapshot_from_json_bytes from existing\nkanban-persistence crate).\n\n---\n### Step 3 — Simplify KanbanContext\n\nWhy: KanbanContext currently has a store: Option<Arc<dyn PersistenceStore>> field (context.rs:45) whose presence/absence\nencodes which backend path we're on. save() (lines 422-445) and reload() (lines 398-410) both have let Some(store) =\n&self.store else { return Ok(()) } guards. baseline_snapshot (line 46) is eagerly set on construction, forcing a snapshot\nread. All of this disappears with the new model.\n\nRed — integration tests in new crates/kanban-service/tests/context_open.rs:\ntest_open_context_json_does_no_io_at_construction\n  (point at non-existent path; KanbanContext::open(JsonDataStore::new(...), cfg) succeeds immediately)\ntest_open_context_sqlite_does_no_io_at_construction\n  (same for SqliteStore)\ntest_open_context_first_list_boards_triggers_load\n  (create JSON with 1 board; open context; list_boards() returns 1)\ntest_open_context_baseline_is_none_before_first_execute\n  (ctx.baseline_snapshot is None before any execute)\ntest_open_context_baseline_captured_on_first_execute\n  (create_board; ctx.baseline_snapshot is Some)\ntest_open_context_save_flushes_json_not_sqlite\n  (JSON: save() causes dirty=false; SQLite: save() is no-op, no-op is fine)\ntest_open_context_reload_delegates_to_backend\n  (modify JSON externally; ctx.reload(); list_boards() returns updated data)\ntest_undo_redo_still_work_after_lazy_baseline\n\nGreen — changes to crates/kanban-service/src/context.rs:\n\nStruct (lines 42-51):\n- Line 45: REMOVE store: Option<Arc<dyn PersistenceStore + Send + Sync>>\n- Line 46: CHANGE baseline_snapshot: Snapshot → baseline_snapshot: Option<Snapshot>\n\nNew constructor (replaces load, open_sqlite, open_json, empty):\n// Replaces lines 54-147\npub async fn open(backend: Arc<dyn KanbanBackend>, config: AppConfig) -> KanbanResult<Self> {\n    Ok(Self {\n        backend,\n        app_config: config,\n        baseline_snapshot: None,   // lazy: set on first execute()\n        undo_cursor: 0,            // lazy: restored on first undo/redo\n        command_count: 0,          // lazy: restored from backend.command_count() on first undo/redo\n        dirty: false,\n        conflict_pending: false,\n    })\n}\nRemove load() (lines 54-99), open_sqlite() (lines 108-124), open_json() (lines 127-131), empty() (lines 133-147).\n\nexecute() — lazy baseline (lines 199-259):\n- Lines 205-209: Before capturing pre-execution snapshot, if baseline_snapshot.is_none():\nif self.baseline_snapshot.is_none() {\n    self.baseline_snapshot = Some(self.backend.snapshot()?);\n    self.command_count = self.backend.command_count() as usize;\n    self.undo_cursor = self.command_count;\n}\n\nundo() — lazy command count (lines 267-300):\n- If self.command_count == 0 and undo_cursor == 0 at start, restore from backend:\nif self.command_count == 0 {\n    self.command_count = self.backend.command_count() as usize;\n    self.undo_cursor = self.command_count;\n    self.baseline_snapshot = Some(self.backend.snapshot()?);\n}\n\nsave() (lines 422-445):\n- Remove let Some(store) = &self.store else { return Ok(()) } guard (lines 423-425)\n- Remove the entire body; replace with:\npub async fn save(&self) -> KanbanResult<()> {\n    self.backend.flush().await\n}\n\nreload() (lines 398-410):\n- Remove let Some(store) = &self.store else { return Ok(()) } guard (lines 399-401)\n- Replace body with:\npub async fn reload(&mut self) -> KanbanResult<()> {\n    self.backend.reload().await?;\n    self.baseline_snapshot = None;\n    self.undo_cursor = 0;\n    self.command_count = 0;\n    self.dirty = false;\n    Ok(())\n}\n\nRemove or adapt:\n- replace_store() method (line 391) — REMOVE (no more store field)\n- store() getter (line 395) — REMOVE\n\nRefactor: All callers of ctx.store() and ctx.replace_store() — grep and fix. The is_dirty(), mark_dirty(), mark_clean() (lines\n 367-375) remain unchanged.\n\n---\n### Step 4 — StoreManager::make_backend()\n\nWhy: StoreManager::make_store() (lines 106-112) returns Arc<dyn PersistenceStore>. We need make_backend() that returns Arc<dyn\n KanbanBackend>, hiding the JSON vs SQLite construction difference.\n\nRed — tests (inline in store_manager.rs):\ntest_make_backend_json_path_returns_json_data_store\ntest_make_backend_sqlite_path_returns_sqlite_store\ntest_make_backend_detects_sqlite_by_magic_bytes\n  (write a real SQLite file without extension; make_backend detects it correctly)\ntest_make_backend_detects_json_by_content\n  (write a JSON file without extension; make_backend detects it correctly)\nAll use TempDir.\n\nGreen — add to crates/kanban-service/src/store_manager.rs after make_store() (line 112):\npub async fn make_backend(\n    &self,\n    locator: &str,\n    config: &AppConfig,\n) -> KanbanResult<Arc<dyn KanbanBackend>> {\n    if self.is_sqlite(locator) {\n        #[cfg(feature = \"sqlite\")]\n        return Ok(Arc::new(SqliteStore::open(locator).await\n            .map_err(|e| KanbanError::Database(e.to_string()))?));\n        #[cfg(not(feature = \"sqlite\"))]\n        return Err(KanbanError::Internal(\"SQLite feature not enabled\".into()));\n    }\n    let store = self.make_store(\n        config.effective_storage_backend(),\n        locator\n    )?;\n    Ok(Arc::new(JsonDataStore::new(store)))\n}\n\nRefactor: Reuse is_sqlite() (lines 56-66) and detect_backend() (lines 71-90) — no duplication.\n\n---\n### Step 5 — kanban_service::open_context()\n\nWhy: This is the single public entry point that all three apps will call. It replaces the\nStoreManager::sync_backend_with_file() + KanbanContext::load() / open_sqlite() dance that is currently duplicated in\nCliContext::load() (context.rs:17-33), McpContext::new() (mcp/context.rs:15-31), and App::new_with_store() /\nApp::open_sqlite() (tui/app/mod.rs:198-361).\n\nRed — integration tests in crates/kanban-service/tests/open_context.rs:\ntest_open_context_json_end_to_end\n  (init JSON file; open_context(); create_board(); save(); reopen; list_boards() returns board)\ntest_open_context_sqlite_end_to_end\n  (same for SQLite)\ntest_open_context_auto_detects_backend_from_magic_bytes\n  (create unlabelled SQLite file; open_context detects SQLite; CRUD works)\ntest_open_context_new_file_starts_empty\n  (point at non-existent path; open_context(); list_boards() returns [])\n\nGreen — add to crates/kanban-service/src/lib.rs (after default_registry() at line 39):\npub async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanContext> {\n    let mut config = config;\n    let sm = StoreManager::new(default_registry());\n    sm.sync_backend_with_file(locator, &mut config);\n    let backend = sm.make_backend(locator, &config).await?;\n    KanbanContext::open(backend, config).await\n}\n\nRefactor: Nothing to delete yet — keep old exports until Step 7.\n\n---\n### Step 6 — Wire FileWatcher to backend.reload()\n\nWhy: Currently App::auto_reload_from_external_change() (app/mod.rs:2210) loads from disk by calling store.load().await\ndirectly — it knows about the PersistenceStore. After this step, external change handling goes through ctx.reload() →\nbackend.reload(), which works for both JSON (clears cache) and SQLite (no-op, reads are live). The FileMetadata mtime/hash\npath in JsonFileStore can be retired.\n\nRed — TUI integration test in crates/kanban-tui/tests/:\ntest_external_json_change_triggers_reload_when_clean\n  (open JSON ctx; write new board to file externally; simulate watcher event;\n   assert list_boards() returns the new board without manual reload)\ntest_external_json_change_sets_conflict_when_dirty\n  (open JSON ctx; create board (dirty=true); write file externally; simulate watcher event;\n   assert ctx.conflict_pending == true)\ntest_external_sqlite_change_is_transparent\n  (open SQLite ctx; insert row externally; list_boards() immediately returns new row — no reload needed)\n\nGreen — changes to crates/kanban-tui/src/app/mod.rs:\n\nauto_reload_from_external_change() (line 2210):\n- Replace the current store.load().await call with:\nasync fn auto_reload_from_external_change(&mut self) -> KanbanResult<()> {\n    if self.ctx.is_dirty() {\n        self.ctx.set_conflict_pending(true);\n        return Ok(());\n    }\n    self.ctx.reload().await?;   // delegates to backend.reload()\n    Ok(())\n}\n- Remove store reference; no more PersistenceStore access in TUI\n\nRefactor: Remove FileMetadata import from JsonFileStore if it's no longer used externally. The conflict detection logic (mtime\n + size + hash) inside JsonFileStore::save() can remain as an internal guard — it's not the reload trigger anymore.\n\n---\n### Step 7 — Unify App Initialization\n\nWhy: After Steps 1-6, KanbanContext::open() is the correct single entry point. The if is_sqlite forks in all three apps become\n dead code.\n\nTUI changes (crates/kanban-tui/src/app/mod.rs and tui_context.rs):\n\nTuiContext::new(store) (tui_context.rs:22-39) and TuiContext::from_context(ctx) (tui_context.rs:45-58):\n- Collapse to single TuiContext::new(ctx: KanbanContext) -> (Self, Option<Receiver<Snapshot>>, ...):\n  - SaveCoordinator::new(ctx.backend().needs_flush()) — replaces store.is_some() at tui_context.rs:31\n  - If needs_flush(): create save channel and return Some(rx)\n  - If not: return None\n\nApp::new_with_store() (app/mod.rs:198-286) and App::open_sqlite() (app/mod.rs:293-361):\n- Replace with single App::new(ctx: KanbanContext, config: AppConfig) -> KanbanResult<(Self, Option<Receiver<Snapshot>>)>\n- No more store_manager.make_store() inside App; App just takes a pre-built KanbanContext\n\nCLI fork (app.rs:285-301):\n- Remove the if is_sqlite { App::open_sqlite(...) } else { App::new_with_store(...) } block\n- Replace with:\nlet ctx = kanban_service::open_context(&effective_file, config).await?;\nlet (mut app, save_rx) = App::new(ctx, app_config)?;\napp.set_error_log(error_log);\napp.run(save_rx).await?;\n\nCliContext::load() (kanban-cli/src/context.rs:17-33):\n- Replace body with:\npub async fn load(locator: &str, config: AppConfig) -> KanbanResult<Self> {\n    Ok(Self { inner: kanban_service::open_context(locator, config).await? })\n}\n- Remove store_manager parameter — no longer needed\n\nMcpContext::new() (kanban-mcp/src/context.rs:15-31):\n- Replace body with:\npub async fn new(data_file: &str, config: AppConfig) -> KanbanResult<Self> {\n    Ok(Self { inner: kanban_service::open_context(data_file, config).await? })\n}\n- Remove store_manager parameter\n\nRed — tests to write first:\n// kanban-cli/tests/\ntest_cli_init_and_run_json_unified_path\ntest_cli_init_and_run_sqlite_unified_path\n// kanban-mcp/tests/\ntest_mcp_list_boards_json_unified_path\ntest_mcp_list_boards_sqlite_unified_path\n// kanban-tui/tests/\ntest_tui_context_single_constructor_json\ntest_tui_context_single_constructor_sqlite\n  (assert save_rx is Some for JSON, None for SQLite)\n\nRefactor — delete dead code:\n- App::open_sqlite() (app/mod.rs:293-361) — entire method\n- App::new_with_store() (app/mod.rs:198-286) — entire method (replaced by App::new())\n- TuiContext::from_context() (tui_context.rs:45-58) — entire method\n- resolve_is_sqlite() helper in kanban-cli (wherever defined)\n- KanbanContext::open_sqlite() (context.rs:108-124) — already removed in Step 3\n- StoreManager parameter from CliContext::load and McpContext::new call sites\n\n---\nWhat This Unlocks\n\n- Startup is instant: open_context() = connection only. First render triggers first read.\n- Staleness handled uniformly: reload() is well-defined on both backends.\n- Remote backends trivial: implement DataStore + CommandStore + KanbanBackend. Each method = a network call. needs_flush() =\nfalse (write-through). flush() = no-op.\n- Pagination path clear: DataStore methods already take no limit/offset, but they can be extended. The lazy model means adding\n list_cards_paginated(column_id, page, size) doesn't require rethinking the initialization protocol.\n- No SQLite special-casing: both backends implement the same interface.\n\n---\nFiles to Modify\n\n┌──────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐\n│                         File                         │                            Change                            │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/backend.rs                 │ Add flush, reload, needs_flush to KanbanBackend              │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/json_backend.rs            │ New: JsonDataStore (lazy InMemory + JsonFileStore)           │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/context.rs                 │ Single open() constructor, lazy baseline, remove store field │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/store_manager.rs           │ Add make_backend() method                                    │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-service/src/lib.rs                     │ Expose open_context()                                        │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-persistence-sqlite/src/sqlite_store.rs │ Impl KanbanBackend lifecycle methods                         │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-cli/src/app.rs                         │ Remove is_sqlite fork                                        │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-cli/src/context.rs                     │ Call open_context()                                          │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-mcp/src/server.rs                      │ Call open_context()                                          │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-mcp/src/context.rs                     │ Call open_context()                                          │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-tui/src/app/mod.rs                     │ Collapse two constructors                                    │\n├──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤\n│ crates/kanban-tui/src/tui_context.rs                 │ Remove from_context() vs new() split                         │\n└──────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘\n\n---\nNon-Goals / Deferred\n\n- Pagination / streaming: DataStore API stays as-is for now. The lazy model is a prerequisite — do this first.\n- StoreFactory::create() async wart (block_in_place): separate concern, leave for later.\n- Command log protocol divergence (JSON envelope vs SQLite tables): JsonDataStore handles this internally. No protocol\nunification needed.\n- ID type aliases vs newtypes, TOCTOU in modify_graph: out of scope.\n\n---\nVerification\n\n1. cargo test --workspace — all existing tests pass\n2. cargo run -- init --name \"Test\" test.json && cargo run test.json — JSON works, first render triggers file read\n3. cargo run -- init --name \"Test\" test.sqlite && cargo run test.sqlite — SQLite works, each view triggers DB query\n4. Modify test.json externally while TUI is open → conflict banner appears\n5. Modify test.sqlite externally while TUI is open → next read reflects new state transparently\n6. MCP tool calls persist correctly for both backends (write-through for SQLite, flush for JSON)\n7. Undo/redo works correctly on both backends after the lazy baseline change\n─────────────────────────────────────────────────────────────────────────────────\n",
-        "due_date": null,
-        "id": "6cbed515-7e76-41ce-9449-e045891c9092",
-        "points": null,
-        "position": 150,
-        "priority": "High",
-        "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-            "sprint_name": "sphinx-centered",
-            "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:26.701583312Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Done",
-        "title": "Architecture: Unified Backends via True Deferred Reads",
-        "updated_at": "2026-05-07T22:06:09.412139502Z"
-      },
-      {
-        "card_number": 406,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-08T00:44:07.871029832Z",
-        "created_at": "2026-05-07T22:35:49.026848073Z",
-        "description": "# Sprint assignment dialog: group sprints by status with completed sprints in separate section\n\n## Status: ✅ Implemented — PR #245\n\nPR: https://github.com/fulsomenko/kanban/pull/245\nBranch: `KAN-406/sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section`\nPlan file: `/home/max/.claude/plans/checkout-339-and-plan-parsed-pony.md`\n\n---\n\n## Goal (original)\n\nThe sprint assignment dialog showed all assignable sprints in a flat list, filtered to `Planning + Active` only by `Sprint::assignable`. This blocked valid retrospective workflows (\"this bug was actually fixed in sprint 12 — let me record that\") and gave no visual distinction between historical and currently-active sprints.\n\n## Final shipped behaviour\n\nThe dialog now renders two headed sections:\n\n```\n  (None)                  ← unassign option\nActive / Planned          ← yellow-bold header\n  > sprint-15/yarara\n    sprint-14/sphinx-centered\nCompleted / Ended         ← yellow-bold header\n    sprint-13/a-catchy-spring   (green — Completed)\n    sprint-12/moonshot          (green — Completed)\n    sprint-11/a-new-year        (red   — Ended: Active w/ end_date in past)\n    sprint-10/a-merry-christmas (green — Completed)\n```\n\n- **Active / Planned** = `Planning` status OR (`Active` AND `end_date` is `None` or in the future). Default white style.\n- **Completed / Ended** = `Completed` status (green) OR `Active` with `end_date <= now` (red, \"ended without formal completion\").\n- **Cancelled** sprints stay hidden — out of scope for this card.\n- Section headers appear only when their section is non-empty.\n- `j`/`k` skip headers and clamp at section boundaries. Selection starts at the `(None)` entry.\n- The dialog scrolls (`Paragraph::scroll`) to keep the selected entry on-screen when the entry list overflows the viewport.\n- The \"current sprint\" marker now uses a status-aware rule:\n  - In the top section: bold green + ` (current)` suffix (existing behaviour).\n  - In the bottom section: ` (current)` suffix only — the green/red status colour wins, no bold-current override. This lets a card assigned to a completed sprint still read as \"completed\" first.\n\n## Path chosen\n\nWhen the user pivoted from \"Cancelled = ended\" to \"ended = `end_date` in the past, regardless of status\", we settled on:\n\n- **Cancelled stays hidden** (option (i) from the design discussion). Cleanest scope; the green/red distinction the user asked for is purely about Completed-vs-overdue-Active.\n- **Status colour wins over current-marker** in the bottom section. Reasoning: the `(current)` suffix already identifies the card's current assignment; the colour is the more important signal in this dialog.\n\n## Implementation summary\n\n### Domain layer — `crates/kanban-domain/src/sprint.rs`\n\n- **Refactored** `Sprint::is_ended` from `&self -> bool` (which used `Utc::now()` internally) to `&self, now: DateTime<Utc> -> bool`. Three call sites updated to pass `chrono::Utc::now()`:\n  - `crates/kanban-tui/src/ui/sprint_detail.rs:83`\n  - `crates/kanban-tui/src/ui/board_detail.rs:182`\n  - `crates/kanban-tui/src/app/mod.rs:1472`\n- **Added** `Sprint::for_assignment_dialog(sprints: &[Sprint], board_id: Uuid, now: DateTime<Utc>) -> (Vec<&Sprint>, Vec<&Sprint>)`. Returns `(active_or_planned, completed_or_ended)`. Each section sorted by `sprint_number` descending. Cancelled and other-board sprints excluded.\n- **Removed** the now-unused `Sprint::assignable`. Fully superseded.\n\n### TUI builder — `crates/kanban-tui/src/components/sprint_assign_list.rs` (new)\n\nPure-logic module the dialog renders/handlers consume. Re-exported via `crates/kanban-tui/src/components/mod.rs`.\n\n```rust\npub enum SprintAssignEntry<'a> {\n    Header(&'static str),\n    None,\n    ActiveOrPlanned(&'a Sprint),\n    Completed(&'a Sprint),\n    Ended(&'a Sprint),\n}\n\npub const ACTIVE_PLANNED_HEADER:  &str = \"Active / Planned\";\npub const COMPLETED_ENDED_HEADER: &str = \"Completed / Ended\";\n\npub fn build_entries<'a>(sprints, board_id, now) -> Vec<SprintAssignEntry<'a>>;\npub fn next_selectable(entries, cur)  -> Option<usize>;\npub fn prev_selectable(entries, cur)  -> Option<usize>;\npub fn sprint_id_of(entry)            -> Option<Uuid>;\npub fn scroll_offset_to_show(selected, total, height) -> usize;\n```\n\n`scroll_offset_to_show` is stateless — given (selected, total, height), it returns the row offset that keeps `selected` inside the viewport. No persisted scroll state.\n\n### Single-card render — `crates/kanban-tui/src/components/selection_dialog.rs`\n\n`SprintAssignDialog::render` iterates `build_entries(...)`, dispatches each entry to `render_entry_line`, then applies `Paragraph::new(lines).scroll((scroll_offset_to_show(...) as u16, 0))`. `options_count` returns `entries.len()` so the surrounding selection plumbing keeps working.\n\n### Multi-card render — `crates/kanban-tui/src/ui/dialogs/cards.rs`\n\n`render_assign_multiple_cards_popup` got the same treatment for symmetric behaviour when multi-selecting cards and bulk-assigning to a sprint.\n\n### Handlers — `crates/kanban-tui/src/handlers/popup_handlers.rs`\n\nBoth `handle_assign_card_to_sprint_popup` and `handle_assign_multiple_cards_to_sprint_popup`:\n\n- `j`/`k` call `next_selectable / prev_selectable` and write the result back to `dialog_input.sprint_assign_selection`.\n- `Enter` matches on `entries[selection_idx]`:\n  - `None` → existing unassign command.\n  - `ActiveOrPlanned(_) | Completed(_) | Ended(_)` → existing `AssignCardsToSprint` with `sprint_id_of(entry)`.\n  - `Header(_)` → unreachable (selection never points at a header).\n- Both handlers share a small `sprint_assign_entries(&self) -> Vec<SprintAssignEntry<'_>>` helper that builds the entry vec from current `(board, sprints)` state.\n\n### Open-dialog gate — `crates/kanban-tui/src/handlers/card_handlers.rs`\n\nReplaced the `Sprint::assignable(...).len() > 0` precheck with an `entries.iter().any(|e| matches!(e, ActiveOrPlanned | Completed | Ended))` check. The dialog is now reachable on boards that have only Completed sprints (the retrospective case).\n\n### Current-sprint lookup — `crates/kanban-tui/src/app/mod.rs:2143`\n\n`get_current_sprint_selection_index` rewritten: scans `build_entries(...)` and returns the first index whose `sprint_id_of(entry) == Some(card_sprint_id)`. Falls through to `0` (the `(None)` entry) when not found.\n\n## Test coverage\n\n- **11 inline domain tests** in `crates/kanban-domain/src/sprint.rs` covering `is_ended` semantics, the bucket logic across all four sprint states, sort ordering, and other-board exclusion.\n- **16 inline TUI builder tests** in `crates/kanban-tui/src/components/sprint_assign_list.rs`:\n  - `build_entries` always emits `(None)` at index 0; section headers appear only when populated; Completed and Ended share the lower section.\n  - `next_selectable`/`prev_selectable` skip headers and clamp at section boundaries.\n  - `sprint_id_of` for each variant.\n  - `scroll_offset_to_show`: list-fits / selected-in-first-viewport / selected-below-viewport / clamps-at-last-full-viewport / zero-height / empty-list.\n- **9 integration tests** in `crates/kanban-tui/tests/sprint_assign_dialog_tests.rs`:\n  - Active / Planned and Completed / Ended headers render conditionally.\n  - Completed renders green, Ended renders red (cell-level `Color` inspection).\n  - `j` skips the Active / Planned header.\n  - End-to-end assigning to a Completed sprint via the single-card handler.\n  - Same for Ended.\n  - Same for the bulk-assign handler.\n  - Current-sprint marker preserves status colour in the lower section.\n  - Scroll: 30 planning sprints, navigate to the oldest, rendered output still contains its name.\n- `cargo clippy --all-targets --workspace -- -D warnings` clean.\n- `cargo fmt --check` clean.\n\n## Cross-references / supersedes\n\n- **KAN-1** (filter out completed from sprint assign) — superseded by this work; intent inverted (group, don't hide).\n- **KAN-118** (unfilter tasks list on completed sprint) — partial overlap; close pending verification.\n- **KAN-140** (filter out completed sprints from assign list) — superseded.\n- **KAN-1**'s scope (and the dropped \"Cancelled excluded for now\" semantics) leaves the Cancelled-bucket question open as a follow-up.\n\n## Commit log on the branch\n\n```\ne737c09 refactor(domain): remove unused Sprint::assignable and run cargo fmt\n11a0882 feat(tui): scroll sprint assign dialog so the selected entry stays visible\nd13d4f9 test(tui): assert card state via ctx.get_card after sprint assign handler\n0bb5a60 feat(tui): map current sprint to its sprint_assign_list entry index\nb541d1e feat(tui): include completed and ended sprints in sprint-assign dialog open gate\nfecce66 feat(tui): wire sprint assign handlers to skip-aware nav and entry-typed enter\n6279c73 feat(tui): render multi-card sprint assign dialog with grouped sections\n42d8144 feat(tui): render single-card sprint assign dialog with grouped sections\n9c1774f test(tui): add failing integration tests for sprint assign dialog\n4cd5e80 feat(tui): implement sprint_assign_list build_entries and nav helpers\n5dac94a test(tui): add failing tests and stub sprint_assign_list module\n633b16e feat(domain): implement Sprint::for_assignment_dialog\n4dab89b test(domain): add failing tests for Sprint::for_assignment_dialog and is_ended\nff10e76 refactor(domain): inject now into Sprint::is_ended for testability\n006743b chore: add changeset for KAN-406\n```",
-        "due_date": null,
-        "id": "83199428-d1b3-4cd8-99c9-78b87078d30a",
-        "points": null,
-        "position": 151,
-        "priority": "Medium",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Done",
-        "title": "Sprint assignment dialog: group sprints by status with completed sprints in separate section",
-        "updated_at": "2026-05-08T00:44:07.871030153Z"
       },
       {
         "card_number": 345,
@@ -11564,21 +11055,21 @@
         "updated_at": "2026-05-07T22:06:15.245115240Z"
       },
       {
-        "card_number": 418,
+        "card_number": 406,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-10T15:13:14.159744912Z",
-        "created_at": "2026-05-10T15:03:05.184738297Z",
-        "description": "## Reproduction\n\nToday \\`kanban -V\\` (and \\`kanban --version\\`) prints:\n\n```\n$ kanban -V\nError: kanban 0.4.0\ncommit: 7b56f00e9dff6f7e9a738c9e0eae4d8e1caef7dc\n                                ← extra blank line\n$\n```\n\nTwo distinct bugs:\n\n1. **\\`Error:\\` prefix** — version is being treated as a fatal error and\n   sent to stderr with exit code 1.\n2. **Trailing blank line** — output ends with two newlines instead of one.\n\nExpected:\n\n```\n$ kanban -V\nkanban 0.4.0\ncommit: 7b56f00e9dff6f7e9a738c9e0eae4d8e1caef7dc\n$\n```\n\n…on stdout, exit code 0, single trailing newline.\n\n## Root cause\n\n### 1. \\`Error:\\` prefix\n\n\\`crates/kanban-cli/src/main.rs:6-12\\`:\n\n\\`\\`\\`rust\n#[tokio::main]\nasync fn main() {\n    if let Err(e) = CliApp::with_defaults().run().await {\n        eprintln!(\\\"Error: {e}\\\");\n        std::process::exit(1);\n    }\n}\n\\`\\`\\`\n\n\\`crates/kanban-cli/src/app.rs:96\\`:\n\n\\`\\`\\`rust\nlet matches = cmd.try_get_matches_from_mut(args)?;\n\\`\\`\\`\n\nWhen the user passes \\`-V\\` / \\`--version\\`, clap returns a\n\\`clap::Error\\` with \\`ErrorKind::DisplayVersion\\`.\n\\`try_get_matches_from_mut\\` surfaces it as \\`Err\\`; the \\`?\\` in\n\\`parse_cli\\` re-wraps it via \\`anyhow\\`; \\`main\\`'s generic error\nhandler prints \\`\\\"Error: {e}\\\"\\` to **stderr** with exit code **1**.\n\nThe same pitfall affects \\`--help\\` (\\`ErrorKind::DisplayHelp\\`).\n\n### 2. Extra trailing newline\n\n\\`crates/kanban-core/src/version.rs:4-8\\`:\n\n\\`\\`\\`rust\npub const VERSION: &str = concat!(\n    env!(\\\"CARGO_PKG_VERSION\\\"),\n    \\\"\\\\ncommit: \\\",\n    env!(\\\"GIT_COMMIT_HASH\\\")\n);\n\\`\\`\\`\n\nclap's \\`Display\\` for \\`DisplayVersion\\` already appends \\`\\\\n\\`. The\n\\`eprintln!\\` in \\`main.rs:9\\` then appends **another** \\`\\\\n\\`,\nproducing the trailing blank line. Both bugs collapse to the same root\ncause: clap's exit-style errors should never reach \\`eprintln!(\\\"Error:\n{e}\\\")\\`.\n\n## Proposed fix\n\n\\`\\`\\`rust\n// crates/kanban-cli/src/app.rs\nlet matches = cmd\n    .try_get_matches_from_mut(args)\n    .unwrap_or_else(|e| e.exit());   // help/version → stdout, exit 0\n\\`\\`\\`\n\n…or, to preserve the \\`anyhow::Result\\` return type for \\`parse_cli\\`,\npattern-match on \\`e.kind()\\` and call \\`e.exit()\\` only for\n\\`DisplayHelp\\` / \\`DisplayVersion\\`. Both shapes resolve both bugs\nbecause \\`clap::Error::exit\\`:\n\n- writes to **stdout** for \\`DisplayHelp\\` / \\`DisplayVersion\\` (no\n  \\`Error:\\` prefix),\n- uses \\`print!\\` (single trailing newline, no double newline),\n- exits **0** for help/version, with the appropriate code for real\n  errors,\n- routes real errors (\\`InvalidValue\\`, \\`UnknownArgument\\`, …) to\n  stderr with exit code 2.\n\n## Build-path constraint\n\n**Principle**: when \\`GIT_COMMIT_HASH\\` is unset (or \\`git rev-parse\nHEAD\\` fails), the \\`commit:\\` line is **omitted** from the output\nentirely. This is already correctly implemented via the\n\\`has_git_commit\\` cfg gate in \\`crates/kanban-core/build.rs:9-31\\`\nand the matching \\`#[cfg(has_git_commit)]\\` /\n\\`#[cfg(not(has_git_commit))]\\` branches in\n\\`crates/kanban-core/src/version.rs\\`. The clap-error fix must not break\nthis gate — both \\`VERSION\\` variants must continue to render correctly.\n\n| # | Path | \\`GIT_COMMIT_HASH\\` source | \\`has_git_commit\\` | \\`commit:\\` line |\n|---|------|----------------------------|--------------------|------------------|\n| 1 | Cargo dev build inside the repo | \\`build.rs\\` falls back to \\`git rev-parse HEAD\\` | yes | included |\n| 2 | Local Nix flake (\\`~/fulsomenko/kanban/default.nix:31-33\\`) | \\`preBuild\\` exports from \\`flake.nix\\`'s \\`self.rev\\` | yes | included |\n| 3 | Nixpkgs (\\`~/fulsomenko/nixpkgs/pkgs/by-name/ka/kanban/package.nix:19\\`) | \\`env.GIT_COMMIT_HASH = finalAttrs.src.rev\\` | yes | included |\n| 4 | **Unpinned build** — e.g. \\`cargo install kanban\\` from crates.io, source extract with no git tree | env unset + \\`git rev-parse\\` fails → fallback \\`\\\"unknown\\\"\\` | **no** | **omitted** |\n\nSo \\`-V\\` output should be \\`kanban X.Y.Z\\\\ncommit: <hash>\\\\n\\` in\npaths 1–3 and just \\`kanban X.Y.Z\\\\n\\` in path 4 — both with a single\ntrailing newline and no \\`Error:\\` prefix.\n\n## Acceptance criteria\n\n- \\`kanban -V\\` writes to **stdout**, exits **0**, prints\n  \\`kanban X.Y.Z[\\\\ncommit: <hash>]\\\\n\\` with a single trailing newline.\n- \\`kanban --version\\` behaves identically.\n- \\`kanban --help\\` writes to stdout, exits 0, no \\`Error:\\` prefix.\n- Invalid args (e.g. \\`kanban --no-such-flag\\`) still route through the\n  existing \\`eprintln!(\\\"Error: {e}\\\")\\` path with non-zero exit.\n- All four build paths in the table above produce clean output. In path\n  4 the \\`commit:\\` line is omitted entirely.\n- Integration test asserting on the format (probably in\n  \\`crates/kanban-cli/tests/cli_integration.rs\\` using \\`assert_cmd\\`)\n  for both stdout content and exit code, against both VERSION variants\n  (with and without the commit line).\n\n## Discovery\n\nKAN-3 (\\`add -v flag\\`) is the original feature request that introduced\n\\`-V\\` / \\`--version\\` — already **Done**, empty description, unrelated\nto this regression. KAN-38 (\\`branch name doesnt reflected the used\nversion\\`) is a separate concern about branch-name generation, not\nversion output. No existing card covers the bugs reported here.\n\n\n## Review notes (PR #250)\n\nSix review items raised on PR #250. Status of each:\n\n### 1. \\`e.exit()\\` is \\`-> !\\` — \\`parse_cli\\`'s Result is now leakier than it looks\n\n**Status: not addressed (theoretical).**\n\nAfter the fix, the only path that can return \\`Err\\` from \\`parse_cli\\`\nis \\`Cli::from_arg_matches(&matches)?\\` (clap-derive mismatch — basically\nimpossible in practice). Every other clap error terminates the process\ndirectly via \\`std::process::exit\\`.\n\nConsequence: any in-process embedder of \\`CliApp::run_with_args\\` loses\nthe ability to handle a malformed arg list gracefully; they get a hard\n\\`exit(2)\\` mid-test. Today there are no such embedders (all integration\ntests spawn subprocesses via \\`assert_cmd\\`), so this is purely\ntheoretical. If it ever matters, options are:\n\n- Document on \\`run_with_args\\`'s docstring that this entry point may\n  \\`exit()\\` for invalid args.\n- Pattern-match \\`e.kind()\\` and convert real-error kinds back into\n  \\`anyhow::Error\\` so the Result remains the source of truth for\n  in-process callers.\n\n### 2. Comment reads as if it explains a \\`match\\` that isn't there\n\n**Status: addressed in commit \\`16ce3a5\\`.**\n\nComment now reads \"\\`e.exit()\\` dispatches per-kind internally — no\n\\`match e.kind()\\` needed here\" so a reader doesn't go hunting for a\nmatch arm that isn't there.\n\n### 3. Failure messages on the long-version test are sparser\n\n**Status: addressed in commit \\`16ce3a5\\`.**\n\n\\`test_long_version_flag_writes_clean_to_stdout\\` now has the same\n\\`\"got: {:?}\"\\` failure annotations as the short-version test for\nstderr emptiness, the \\`\"kanban \"\\` prefix, the \\`\"Error:\"\\`\nnon-prefix, and the trailing-newline shape.\n\n### 4. \\`kanban_no_config\\` is duplicated between two test modules\n\n**Status: not addressed.**\n\n\\`mod no_file_tests\\` (KAN-332) and \\`mod version_and_help_tests\\`\n(this PR) each define a byte-identical \\`kanban_no_config(dir)\\`\nhelper. Five lines of duplication. Could lift to module level and\nhave both inner modules \\`use super::kanban_no_config;\\`. Defensible\neither way — keeping each test module self-contained vs. DRY. Held\nbecause (a) only two call sites today, (b) collapses naturally when a\nthird module appears.\n\n### 5. \\`--help\\` text contains \\`Usage:\\` — assertion format-coupled\n\n**Status: not addressed (acceptable risk).**\n\n\\`assert!(stdout.contains(\"Usage:\"))\\` is fragile in the sense that a\nclap major bump could re-case it to \\`usage:\\` or \\`USAGE:\\`. The\nproject pins clap and \"Usage:\" has been the convention for years, so\nthe assertion is meaningful as written. Any clap upgrade should re-run\nthis test as part of the upgrade checklist.\n\n### 6. No explicit assertion on exit code 0\n\n**Status: not addressed (low value).**\n\n\\`.success()\\` from assert_cmd accepts any successful exit on the\nhost platform. Could tighten to \\`.success().code(0)\\` for explicit\nverification, but \\`success()\\` is the codebase convention and the\ndistinction is academic on Unix where success means exit 0. Held;\nwould just add visual noise.\n\n## Summary\n\n- Addressed in this branch: **#2, #3** (commit \\`16ce3a5\\`).\n- Held as acceptable: **#4, #5, #6** (style / theoretical).\n- Held with documented option: **#1** (in-process embedder concern;\n  no consumers today).",
+        "completed_at": "2026-05-08T00:44:07.871029832Z",
+        "created_at": "2026-05-07T22:35:49.026848073Z",
+        "description": "# Sprint assignment dialog: group sprints by status with completed sprints in separate section\n\n## Status: ✅ Implemented — PR #245\n\nPR: https://github.com/fulsomenko/kanban/pull/245\nBranch: `KAN-406/sprint-assignment-dialog-group-sprints-by-status-with-completed-sprints-in-separate-section`\nPlan file: `/home/max/.claude/plans/checkout-339-and-plan-parsed-pony.md`\n\n---\n\n## Goal (original)\n\nThe sprint assignment dialog showed all assignable sprints in a flat list, filtered to `Planning + Active` only by `Sprint::assignable`. This blocked valid retrospective workflows (\"this bug was actually fixed in sprint 12 — let me record that\") and gave no visual distinction between historical and currently-active sprints.\n\n## Final shipped behaviour\n\nThe dialog now renders two headed sections:\n\n```\n  (None)                  ← unassign option\nActive / Planned          ← yellow-bold header\n  > sprint-15/yarara\n    sprint-14/sphinx-centered\nCompleted / Ended         ← yellow-bold header\n    sprint-13/a-catchy-spring   (green — Completed)\n    sprint-12/moonshot          (green — Completed)\n    sprint-11/a-new-year        (red   — Ended: Active w/ end_date in past)\n    sprint-10/a-merry-christmas (green — Completed)\n```\n\n- **Active / Planned** = `Planning` status OR (`Active` AND `end_date` is `None` or in the future). Default white style.\n- **Completed / Ended** = `Completed` status (green) OR `Active` with `end_date <= now` (red, \"ended without formal completion\").\n- **Cancelled** sprints stay hidden — out of scope for this card.\n- Section headers appear only when their section is non-empty.\n- `j`/`k` skip headers and clamp at section boundaries. Selection starts at the `(None)` entry.\n- The dialog scrolls (`Paragraph::scroll`) to keep the selected entry on-screen when the entry list overflows the viewport.\n- The \"current sprint\" marker now uses a status-aware rule:\n  - In the top section: bold green + ` (current)` suffix (existing behaviour).\n  - In the bottom section: ` (current)` suffix only — the green/red status colour wins, no bold-current override. This lets a card assigned to a completed sprint still read as \"completed\" first.\n\n## Path chosen\n\nWhen the user pivoted from \"Cancelled = ended\" to \"ended = `end_date` in the past, regardless of status\", we settled on:\n\n- **Cancelled stays hidden** (option (i) from the design discussion). Cleanest scope; the green/red distinction the user asked for is purely about Completed-vs-overdue-Active.\n- **Status colour wins over current-marker** in the bottom section. Reasoning: the `(current)` suffix already identifies the card's current assignment; the colour is the more important signal in this dialog.\n\n## Implementation summary\n\n### Domain layer — `crates/kanban-domain/src/sprint.rs`\n\n- **Refactored** `Sprint::is_ended` from `&self -> bool` (which used `Utc::now()` internally) to `&self, now: DateTime<Utc> -> bool`. Three call sites updated to pass `chrono::Utc::now()`:\n  - `crates/kanban-tui/src/ui/sprint_detail.rs:83`\n  - `crates/kanban-tui/src/ui/board_detail.rs:182`\n  - `crates/kanban-tui/src/app/mod.rs:1472`\n- **Added** `Sprint::for_assignment_dialog(sprints: &[Sprint], board_id: Uuid, now: DateTime<Utc>) -> (Vec<&Sprint>, Vec<&Sprint>)`. Returns `(active_or_planned, completed_or_ended)`. Each section sorted by `sprint_number` descending. Cancelled and other-board sprints excluded.\n- **Removed** the now-unused `Sprint::assignable`. Fully superseded.\n\n### TUI builder — `crates/kanban-tui/src/components/sprint_assign_list.rs` (new)\n\nPure-logic module the dialog renders/handlers consume. Re-exported via `crates/kanban-tui/src/components/mod.rs`.\n\n```rust\npub enum SprintAssignEntry<'a> {\n    Header(&'static str),\n    None,\n    ActiveOrPlanned(&'a Sprint),\n    Completed(&'a Sprint),\n    Ended(&'a Sprint),\n}\n\npub const ACTIVE_PLANNED_HEADER:  &str = \"Active / Planned\";\npub const COMPLETED_ENDED_HEADER: &str = \"Completed / Ended\";\n\npub fn build_entries<'a>(sprints, board_id, now) -> Vec<SprintAssignEntry<'a>>;\npub fn next_selectable(entries, cur)  -> Option<usize>;\npub fn prev_selectable(entries, cur)  -> Option<usize>;\npub fn sprint_id_of(entry)            -> Option<Uuid>;\npub fn scroll_offset_to_show(selected, total, height) -> usize;\n```\n\n`scroll_offset_to_show` is stateless — given (selected, total, height), it returns the row offset that keeps `selected` inside the viewport. No persisted scroll state.\n\n### Single-card render — `crates/kanban-tui/src/components/selection_dialog.rs`\n\n`SprintAssignDialog::render` iterates `build_entries(...)`, dispatches each entry to `render_entry_line`, then applies `Paragraph::new(lines).scroll((scroll_offset_to_show(...) as u16, 0))`. `options_count` returns `entries.len()` so the surrounding selection plumbing keeps working.\n\n### Multi-card render — `crates/kanban-tui/src/ui/dialogs/cards.rs`\n\n`render_assign_multiple_cards_popup` got the same treatment for symmetric behaviour when multi-selecting cards and bulk-assigning to a sprint.\n\n### Handlers — `crates/kanban-tui/src/handlers/popup_handlers.rs`\n\nBoth `handle_assign_card_to_sprint_popup` and `handle_assign_multiple_cards_to_sprint_popup`:\n\n- `j`/`k` call `next_selectable / prev_selectable` and write the result back to `dialog_input.sprint_assign_selection`.\n- `Enter` matches on `entries[selection_idx]`:\n  - `None` → existing unassign command.\n  - `ActiveOrPlanned(_) | Completed(_) | Ended(_)` → existing `AssignCardsToSprint` with `sprint_id_of(entry)`.\n  - `Header(_)` → unreachable (selection never points at a header).\n- Both handlers share a small `sprint_assign_entries(&self) -> Vec<SprintAssignEntry<'_>>` helper that builds the entry vec from current `(board, sprints)` state.\n\n### Open-dialog gate — `crates/kanban-tui/src/handlers/card_handlers.rs`\n\nReplaced the `Sprint::assignable(...).len() > 0` precheck with an `entries.iter().any(|e| matches!(e, ActiveOrPlanned | Completed | Ended))` check. The dialog is now reachable on boards that have only Completed sprints (the retrospective case).\n\n### Current-sprint lookup — `crates/kanban-tui/src/app/mod.rs:2143`\n\n`get_current_sprint_selection_index` rewritten: scans `build_entries(...)` and returns the first index whose `sprint_id_of(entry) == Some(card_sprint_id)`. Falls through to `0` (the `(None)` entry) when not found.\n\n## Test coverage\n\n- **11 inline domain tests** in `crates/kanban-domain/src/sprint.rs` covering `is_ended` semantics, the bucket logic across all four sprint states, sort ordering, and other-board exclusion.\n- **16 inline TUI builder tests** in `crates/kanban-tui/src/components/sprint_assign_list.rs`:\n  - `build_entries` always emits `(None)` at index 0; section headers appear only when populated; Completed and Ended share the lower section.\n  - `next_selectable`/`prev_selectable` skip headers and clamp at section boundaries.\n  - `sprint_id_of` for each variant.\n  - `scroll_offset_to_show`: list-fits / selected-in-first-viewport / selected-below-viewport / clamps-at-last-full-viewport / zero-height / empty-list.\n- **9 integration tests** in `crates/kanban-tui/tests/sprint_assign_dialog_tests.rs`:\n  - Active / Planned and Completed / Ended headers render conditionally.\n  - Completed renders green, Ended renders red (cell-level `Color` inspection).\n  - `j` skips the Active / Planned header.\n  - End-to-end assigning to a Completed sprint via the single-card handler.\n  - Same for Ended.\n  - Same for the bulk-assign handler.\n  - Current-sprint marker preserves status colour in the lower section.\n  - Scroll: 30 planning sprints, navigate to the oldest, rendered output still contains its name.\n- `cargo clippy --all-targets --workspace -- -D warnings` clean.\n- `cargo fmt --check` clean.\n\n## Cross-references / supersedes\n\n- **KAN-1** (filter out completed from sprint assign) — superseded by this work; intent inverted (group, don't hide).\n- **KAN-118** (unfilter tasks list on completed sprint) — partial overlap; close pending verification.\n- **KAN-140** (filter out completed sprints from assign list) — superseded.\n- **KAN-1**'s scope (and the dropped \"Cancelled excluded for now\" semantics) leaves the Cancelled-bucket question open as a follow-up.\n\n## Commit log on the branch\n\n```\ne737c09 refactor(domain): remove unused Sprint::assignable and run cargo fmt\n11a0882 feat(tui): scroll sprint assign dialog so the selected entry stays visible\nd13d4f9 test(tui): assert card state via ctx.get_card after sprint assign handler\n0bb5a60 feat(tui): map current sprint to its sprint_assign_list entry index\nb541d1e feat(tui): include completed and ended sprints in sprint-assign dialog open gate\nfecce66 feat(tui): wire sprint assign handlers to skip-aware nav and entry-typed enter\n6279c73 feat(tui): render multi-card sprint assign dialog with grouped sections\n42d8144 feat(tui): render single-card sprint assign dialog with grouped sections\n9c1774f test(tui): add failing integration tests for sprint assign dialog\n4cd5e80 feat(tui): implement sprint_assign_list build_entries and nav helpers\n5dac94a test(tui): add failing tests and stub sprint_assign_list module\n633b16e feat(domain): implement Sprint::for_assignment_dialog\n4dab89b test(domain): add failing tests for Sprint::for_assignment_dialog and is_ended\nff10e76 refactor(domain): inject now into Sprint::is_ended for testability\n006743b chore: add changeset for KAN-406\n```",
         "due_date": null,
-        "id": "ce17b2f6-4ac8-4475-9e9e-1fe5bf3572cb",
+        "id": "83199428-d1b3-4cd8-99c9-78b87078d30a",
         "points": null,
-        "position": 152,
-        "priority": "Low",
+        "position": 151,
+        "priority": "Medium",
         "sprint_id": null,
         "sprint_logs": [],
         "status": "Done",
-        "title": "Fix `kanban -V` output: drop `Error:` prefix and stray trailing newline",
-        "updated_at": "2026-05-10T15:22:02.322817396Z"
+        "title": "Sprint assignment dialog: group sprints by status with completed sprints in separate section",
+        "updated_at": "2026-05-08T00:44:07.871030153Z"
       },
       {
         "card_number": 346,
@@ -11613,6 +11104,23 @@
         "status": "Todo",
         "title": "Guard SQLite migration board_prefix_counters query against missing table",
         "updated_at": "2026-05-07T22:06:15.245117457Z"
+      },
+      {
+        "card_number": 418,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-10T15:13:14.159744912Z",
+        "created_at": "2026-05-10T15:03:05.184738297Z",
+        "description": "## Reproduction\n\nToday \\`kanban -V\\` (and \\`kanban --version\\`) prints:\n\n```\n$ kanban -V\nError: kanban 0.4.0\ncommit: 7b56f00e9dff6f7e9a738c9e0eae4d8e1caef7dc\n                                ← extra blank line\n$\n```\n\nTwo distinct bugs:\n\n1. **\\`Error:\\` prefix** — version is being treated as a fatal error and\n   sent to stderr with exit code 1.\n2. **Trailing blank line** — output ends with two newlines instead of one.\n\nExpected:\n\n```\n$ kanban -V\nkanban 0.4.0\ncommit: 7b56f00e9dff6f7e9a738c9e0eae4d8e1caef7dc\n$\n```\n\n…on stdout, exit code 0, single trailing newline.\n\n## Root cause\n\n### 1. \\`Error:\\` prefix\n\n\\`crates/kanban-cli/src/main.rs:6-12\\`:\n\n\\`\\`\\`rust\n#[tokio::main]\nasync fn main() {\n    if let Err(e) = CliApp::with_defaults().run().await {\n        eprintln!(\\\"Error: {e}\\\");\n        std::process::exit(1);\n    }\n}\n\\`\\`\\`\n\n\\`crates/kanban-cli/src/app.rs:96\\`:\n\n\\`\\`\\`rust\nlet matches = cmd.try_get_matches_from_mut(args)?;\n\\`\\`\\`\n\nWhen the user passes \\`-V\\` / \\`--version\\`, clap returns a\n\\`clap::Error\\` with \\`ErrorKind::DisplayVersion\\`.\n\\`try_get_matches_from_mut\\` surfaces it as \\`Err\\`; the \\`?\\` in\n\\`parse_cli\\` re-wraps it via \\`anyhow\\`; \\`main\\`'s generic error\nhandler prints \\`\\\"Error: {e}\\\"\\` to **stderr** with exit code **1**.\n\nThe same pitfall affects \\`--help\\` (\\`ErrorKind::DisplayHelp\\`).\n\n### 2. Extra trailing newline\n\n\\`crates/kanban-core/src/version.rs:4-8\\`:\n\n\\`\\`\\`rust\npub const VERSION: &str = concat!(\n    env!(\\\"CARGO_PKG_VERSION\\\"),\n    \\\"\\\\ncommit: \\\",\n    env!(\\\"GIT_COMMIT_HASH\\\")\n);\n\\`\\`\\`\n\nclap's \\`Display\\` for \\`DisplayVersion\\` already appends \\`\\\\n\\`. The\n\\`eprintln!\\` in \\`main.rs:9\\` then appends **another** \\`\\\\n\\`,\nproducing the trailing blank line. Both bugs collapse to the same root\ncause: clap's exit-style errors should never reach \\`eprintln!(\\\"Error:\n{e}\\\")\\`.\n\n## Proposed fix\n\n\\`\\`\\`rust\n// crates/kanban-cli/src/app.rs\nlet matches = cmd\n    .try_get_matches_from_mut(args)\n    .unwrap_or_else(|e| e.exit());   // help/version → stdout, exit 0\n\\`\\`\\`\n\n…or, to preserve the \\`anyhow::Result\\` return type for \\`parse_cli\\`,\npattern-match on \\`e.kind()\\` and call \\`e.exit()\\` only for\n\\`DisplayHelp\\` / \\`DisplayVersion\\`. Both shapes resolve both bugs\nbecause \\`clap::Error::exit\\`:\n\n- writes to **stdout** for \\`DisplayHelp\\` / \\`DisplayVersion\\` (no\n  \\`Error:\\` prefix),\n- uses \\`print!\\` (single trailing newline, no double newline),\n- exits **0** for help/version, with the appropriate code for real\n  errors,\n- routes real errors (\\`InvalidValue\\`, \\`UnknownArgument\\`, …) to\n  stderr with exit code 2.\n\n## Build-path constraint\n\n**Principle**: when \\`GIT_COMMIT_HASH\\` is unset (or \\`git rev-parse\nHEAD\\` fails), the \\`commit:\\` line is **omitted** from the output\nentirely. This is already correctly implemented via the\n\\`has_git_commit\\` cfg gate in \\`crates/kanban-core/build.rs:9-31\\`\nand the matching \\`#[cfg(has_git_commit)]\\` /\n\\`#[cfg(not(has_git_commit))]\\` branches in\n\\`crates/kanban-core/src/version.rs\\`. The clap-error fix must not break\nthis gate — both \\`VERSION\\` variants must continue to render correctly.\n\n| # | Path | \\`GIT_COMMIT_HASH\\` source | \\`has_git_commit\\` | \\`commit:\\` line |\n|---|------|----------------------------|--------------------|------------------|\n| 1 | Cargo dev build inside the repo | \\`build.rs\\` falls back to \\`git rev-parse HEAD\\` | yes | included |\n| 2 | Local Nix flake (\\`~/fulsomenko/kanban/default.nix:31-33\\`) | \\`preBuild\\` exports from \\`flake.nix\\`'s \\`self.rev\\` | yes | included |\n| 3 | Nixpkgs (\\`~/fulsomenko/nixpkgs/pkgs/by-name/ka/kanban/package.nix:19\\`) | \\`env.GIT_COMMIT_HASH = finalAttrs.src.rev\\` | yes | included |\n| 4 | **Unpinned build** — e.g. \\`cargo install kanban\\` from crates.io, source extract with no git tree | env unset + \\`git rev-parse\\` fails → fallback \\`\\\"unknown\\\"\\` | **no** | **omitted** |\n\nSo \\`-V\\` output should be \\`kanban X.Y.Z\\\\ncommit: <hash>\\\\n\\` in\npaths 1–3 and just \\`kanban X.Y.Z\\\\n\\` in path 4 — both with a single\ntrailing newline and no \\`Error:\\` prefix.\n\n## Acceptance criteria\n\n- \\`kanban -V\\` writes to **stdout**, exits **0**, prints\n  \\`kanban X.Y.Z[\\\\ncommit: <hash>]\\\\n\\` with a single trailing newline.\n- \\`kanban --version\\` behaves identically.\n- \\`kanban --help\\` writes to stdout, exits 0, no \\`Error:\\` prefix.\n- Invalid args (e.g. \\`kanban --no-such-flag\\`) still route through the\n  existing \\`eprintln!(\\\"Error: {e}\\\")\\` path with non-zero exit.\n- All four build paths in the table above produce clean output. In path\n  4 the \\`commit:\\` line is omitted entirely.\n- Integration test asserting on the format (probably in\n  \\`crates/kanban-cli/tests/cli_integration.rs\\` using \\`assert_cmd\\`)\n  for both stdout content and exit code, against both VERSION variants\n  (with and without the commit line).\n\n## Discovery\n\nKAN-3 (\\`add -v flag\\`) is the original feature request that introduced\n\\`-V\\` / \\`--version\\` — already **Done**, empty description, unrelated\nto this regression. KAN-38 (\\`branch name doesnt reflected the used\nversion\\`) is a separate concern about branch-name generation, not\nversion output. No existing card covers the bugs reported here.\n\n\n## Review notes (PR #250)\n\nSix review items raised on PR #250. Status of each:\n\n### 1. \\`e.exit()\\` is \\`-> !\\` — \\`parse_cli\\`'s Result is now leakier than it looks\n\n**Status: not addressed (theoretical).**\n\nAfter the fix, the only path that can return \\`Err\\` from \\`parse_cli\\`\nis \\`Cli::from_arg_matches(&matches)?\\` (clap-derive mismatch — basically\nimpossible in practice). Every other clap error terminates the process\ndirectly via \\`std::process::exit\\`.\n\nConsequence: any in-process embedder of \\`CliApp::run_with_args\\` loses\nthe ability to handle a malformed arg list gracefully; they get a hard\n\\`exit(2)\\` mid-test. Today there are no such embedders (all integration\ntests spawn subprocesses via \\`assert_cmd\\`), so this is purely\ntheoretical. If it ever matters, options are:\n\n- Document on \\`run_with_args\\`'s docstring that this entry point may\n  \\`exit()\\` for invalid args.\n- Pattern-match \\`e.kind()\\` and convert real-error kinds back into\n  \\`anyhow::Error\\` so the Result remains the source of truth for\n  in-process callers.\n\n### 2. Comment reads as if it explains a \\`match\\` that isn't there\n\n**Status: addressed in commit \\`16ce3a5\\`.**\n\nComment now reads \"\\`e.exit()\\` dispatches per-kind internally — no\n\\`match e.kind()\\` needed here\" so a reader doesn't go hunting for a\nmatch arm that isn't there.\n\n### 3. Failure messages on the long-version test are sparser\n\n**Status: addressed in commit \\`16ce3a5\\`.**\n\n\\`test_long_version_flag_writes_clean_to_stdout\\` now has the same\n\\`\"got: {:?}\"\\` failure annotations as the short-version test for\nstderr emptiness, the \\`\"kanban \"\\` prefix, the \\`\"Error:\"\\`\nnon-prefix, and the trailing-newline shape.\n\n### 4. \\`kanban_no_config\\` is duplicated between two test modules\n\n**Status: not addressed.**\n\n\\`mod no_file_tests\\` (KAN-332) and \\`mod version_and_help_tests\\`\n(this PR) each define a byte-identical \\`kanban_no_config(dir)\\`\nhelper. Five lines of duplication. Could lift to module level and\nhave both inner modules \\`use super::kanban_no_config;\\`. Defensible\neither way — keeping each test module self-contained vs. DRY. Held\nbecause (a) only two call sites today, (b) collapses naturally when a\nthird module appears.\n\n### 5. \\`--help\\` text contains \\`Usage:\\` — assertion format-coupled\n\n**Status: not addressed (acceptable risk).**\n\n\\`assert!(stdout.contains(\"Usage:\"))\\` is fragile in the sense that a\nclap major bump could re-case it to \\`usage:\\` or \\`USAGE:\\`. The\nproject pins clap and \"Usage:\" has been the convention for years, so\nthe assertion is meaningful as written. Any clap upgrade should re-run\nthis test as part of the upgrade checklist.\n\n### 6. No explicit assertion on exit code 0\n\n**Status: not addressed (low value).**\n\n\\`.success()\\` from assert_cmd accepts any successful exit on the\nhost platform. Could tighten to \\`.success().code(0)\\` for explicit\nverification, but \\`success()\\` is the codebase convention and the\ndistinction is academic on Unix where success means exit 0. Held;\nwould just add visual noise.\n\n## Summary\n\n- Addressed in this branch: **#2, #3** (commit \\`16ce3a5\\`).\n- Held as acceptable: **#4, #5, #6** (style / theoretical).\n- Held with documented option: **#1** (in-process embedder concern;\n  no consumers today).",
+        "due_date": null,
+        "id": "ce17b2f6-4ac8-4475-9e9e-1fe5bf3572cb",
+        "points": null,
+        "position": 152,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "Fix `kanban -V` output: drop `Error:` prefix and stray trailing newline",
+        "updated_at": "2026-05-10T15:22:02.322817396Z"
       },
       {
         "card_number": 347,
@@ -11853,6 +11361,32 @@
         "updated_at": "2026-05-07T22:06:15.245132509Z"
       },
       {
+        "card_number": 393,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-10T16:06:19.252866742Z",
+        "created_at": "2026-05-04T21:16:26.498956728Z",
+        "description": "Closed as cannot-reproduce on 2026-05-10. Empirical probe via MCP against ./test/boards.sqlite (ext4, Linux): single writes and 5-write bursts all leave WAL at 0 bytes immediately after the tool returns; main .sqlite mtime advances and bytes are physically present. External sqlite3 reader sees writes immediately. The full chain mutating_op! → save() → flush() → wal_checkpoint(TRUNCATE) is intact across MCP, CLI, and TUI (all converge on the same KanbanContext::save → backend.flush primitive). If a real symptom resurfaces, file a new card with the exact filesystem and reproduction.",
+        "due_date": null,
+        "id": "d4f41303-3a6b-4066-b8d3-fc7c0473e3af",
+        "points": null,
+        "position": 157,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T21:58:57.806926614Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Done",
+        "title": "bug: MCP server does not flush writes to SQLite db immediately",
+        "updated_at": "2026-05-10T16:06:19.252867149Z"
+      },
+      {
         "card_number": 352,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -11887,30 +11421,38 @@
         "updated_at": "2026-05-07T22:06:15.245135106Z"
       },
       {
-        "card_number": 393,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-10T16:06:19.252866742Z",
-        "created_at": "2026-05-04T21:16:26.498956728Z",
-        "description": "Closed as cannot-reproduce on 2026-05-10. Empirical probe via MCP against ./test/boards.sqlite (ext4, Linux): single writes and 5-write bursts all leave WAL at 0 bytes immediately after the tool returns; main .sqlite mtime advances and bytes are physically present. External sqlite3 reader sees writes immediately. The full chain mutating_op! → save() → flush() → wal_checkpoint(TRUNCATE) is intact across MCP, CLI, and TUI (all converge on the same KanbanContext::save → backend.flush primitive). If a real symptom resurfaces, file a new card with the exact filesystem and reproduction.",
+        "card_number": 353,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-18T08:32:16.449138219Z",
+        "description": "SqliteStore uses WAL mode with a max-2-connection pool. Add integration tests that verify: (1) multiple concurrent readers can query without blocking, (2) writes are serialised correctly under concurrent load, (3) no data races or deadlocks under rapid undo/redo interleaved with writes. Use tokio::test(flavor = \"multi_thread\") and spawn tasks via tokio::spawn.",
         "due_date": null,
-        "id": "d4f41303-3a6b-4066-b8d3-fc7c0473e3af",
+        "id": "6545ead0-1eec-4783-8b11-abd2b599da8f",
         "points": null,
-        "position": 157,
+        "position": 158,
         "priority": "Medium",
         "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
         "sprint_logs": [
+          {
+            "ended_at": "2026-05-07T22:06:15.245136470Z",
+            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+            "sprint_name": "sphinx-centered",
+            "sprint_number": 14,
+            "started_at": "2026-04-29T04:53:21.126561895Z",
+            "status": "Planning"
+          },
           {
             "ended_at": null,
             "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
             "sprint_name": "yarara-release",
             "sprint_number": 15,
-            "started_at": "2026-05-07T21:58:57.806926614Z",
+            "started_at": "2026-05-07T22:06:15.245136930Z",
             "status": "Planning"
           }
         ],
-        "status": "Done",
-        "title": "bug: MCP server does not flush writes to SQLite db immediately",
-        "updated_at": "2026-05-10T16:06:19.252867149Z"
+        "status": "Todo",
+        "title": "Add SQLite concurrent access tests (multi-reader, single-writer)",
+        "updated_at": "2026-05-07T22:06:15.245137250Z"
       },
       {
         "card_number": 332,
@@ -11945,40 +11487,6 @@
         "status": "Done",
         "title": "Require explicit file path — no implicit kanban.json default",
         "updated_at": "2026-05-11T20:21:30.116244057Z"
-      },
-      {
-        "card_number": 353,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-18T08:32:16.449138219Z",
-        "description": "SqliteStore uses WAL mode with a max-2-connection pool. Add integration tests that verify: (1) multiple concurrent readers can query without blocking, (2) writes are serialised correctly under concurrent load, (3) no data races or deadlocks under rapid undo/redo interleaved with writes. Use tokio::test(flavor = \"multi_thread\") and spawn tasks via tokio::spawn.",
-        "due_date": null,
-        "id": "6545ead0-1eec-4783-8b11-abd2b599da8f",
-        "points": null,
-        "position": 158,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": "2026-05-07T22:06:15.245136470Z",
-            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-            "sprint_name": "sphinx-centered",
-            "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:21.126561895Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T22:06:15.245136930Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Add SQLite concurrent access tests (multi-reader, single-writer)",
-        "updated_at": "2026-05-07T22:06:15.245137250Z"
       },
       {
         "card_number": 354,
@@ -12117,40 +11625,6 @@
         "updated_at": "2026-05-07T22:06:15.245140991Z"
       },
       {
-        "card_number": 356,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-04-18T14:34:17.215849305Z",
-        "description": "The 32-method DataStore trait violates Interface Segregation. Split into per-entity repository traits. DataStore becomes a supertrait combining them.",
-        "due_date": null,
-        "id": "7c1ea781-1ccf-475d-bc72-f2a1586782b1",
-        "points": null,
-        "position": 161,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": "2026-05-07T22:06:15.245142213Z",
-            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-            "sprint_name": "sphinx-centered",
-            "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:21.126633883Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T22:06:15.245142667Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Split DataStore god trait (ISP violation)",
-        "updated_at": "2026-05-07T22:06:15.245142930Z"
-      },
-      {
         "card_number": 365,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": "2026-05-11T20:21:30.248664582Z",
@@ -12185,24 +11659,24 @@
         "updated_at": "2026-05-11T20:21:30.274473428Z"
       },
       {
-        "card_number": 366,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-11T20:21:30.302593784Z",
-        "created_at": "2026-04-20T19:19:12.256447265Z",
-        "description": "MVC refactor: single Model with lazy loading replaces triple-copy data flow.\n\nPreviously the TUI maintained three copies of domain data per frame: InMemoryStore (RwLock<StoreState>), TuiContext cloning accessors (~180 sites), and RenderData (rebuilt every frame). Now a single Model struct with Option<Vec<T>> lazy slots serves as the cached read layer. The View reads via zero-clone &[T] slices, and card lookup is O(1) via HashMap index.\n\nChanges:\n- Introduced Model struct (app/model.rs) with load_from_snapshot, invalidate_*, and &-reference accessors\n- Wired Model into App, populated in prepare_frame() from snapshot\n- Migrated all UI rendering (~37 sites across 9 files) from render_data to model\n- Migrated all event handlers (~180 sites across 11 files) from ctx cloning accessors to model\n- Removed RenderData struct entirely\n- Removed 4 of 6 TuiContext cloning accessors (kept boards/sprints for pre-prepare_frame startup)\n- Prepared lazy loading slots for future SQLite on-demand path",
+        "card_number": 356,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-04-18T14:34:17.215849305Z",
+        "description": "The 32-method DataStore trait violates Interface Segregation. Split into per-entity repository traits. DataStore becomes a supertrait combining them.",
         "due_date": null,
-        "id": "626f228c-2598-4a52-b022-9133e185c43f",
+        "id": "7c1ea781-1ccf-475d-bc72-f2a1586782b1",
         "points": null,
-        "position": 162,
+        "position": 161,
         "priority": "Medium",
         "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
         "sprint_logs": [
           {
-            "ended_at": "2026-05-07T22:06:15.245076439Z",
+            "ended_at": "2026-05-07T22:06:15.245142213Z",
             "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
             "sprint_name": "sphinx-centered",
             "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:21.126619123Z",
+            "started_at": "2026-04-29T04:53:21.126633883Z",
             "status": "Planning"
           },
           {
@@ -12210,13 +11684,13 @@
             "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
             "sprint_name": "yarara-release",
             "sprint_number": 15,
-            "started_at": "2026-05-07T22:06:15.245076851Z",
+            "started_at": "2026-05-07T22:06:15.245142667Z",
             "status": "Planning"
           }
         ],
-        "status": "Done",
-        "title": "description doesnt load in card details",
-        "updated_at": "2026-05-11T20:21:30.329236740Z"
+        "status": "Todo",
+        "title": "Split DataStore god trait (ISP violation)",
+        "updated_at": "2026-05-07T22:06:15.245142930Z"
       },
       {
         "card_number": 357,
@@ -12253,6 +11727,66 @@
         "updated_at": "2026-05-07T22:06:15.245145103Z"
       },
       {
+        "card_number": 366,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-11T20:21:30.302593784Z",
+        "created_at": "2026-04-20T19:19:12.256447265Z",
+        "description": "MVC refactor: single Model with lazy loading replaces triple-copy data flow.\n\nPreviously the TUI maintained three copies of domain data per frame: InMemoryStore (RwLock<StoreState>), TuiContext cloning accessors (~180 sites), and RenderData (rebuilt every frame). Now a single Model struct with Option<Vec<T>> lazy slots serves as the cached read layer. The View reads via zero-clone &[T] slices, and card lookup is O(1) via HashMap index.\n\nChanges:\n- Introduced Model struct (app/model.rs) with load_from_snapshot, invalidate_*, and &-reference accessors\n- Wired Model into App, populated in prepare_frame() from snapshot\n- Migrated all UI rendering (~37 sites across 9 files) from render_data to model\n- Migrated all event handlers (~180 sites across 11 files) from ctx cloning accessors to model\n- Removed RenderData struct entirely\n- Removed 4 of 6 TuiContext cloning accessors (kept boards/sprints for pre-prepare_frame startup)\n- Prepared lazy loading slots for future SQLite on-demand path",
+        "due_date": null,
+        "id": "626f228c-2598-4a52-b022-9133e185c43f",
+        "points": null,
+        "position": 162,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": "2026-05-07T22:06:15.245076439Z",
+            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+            "sprint_name": "sphinx-centered",
+            "sprint_number": 14,
+            "started_at": "2026-04-29T04:53:21.126619123Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T22:06:15.245076851Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Done",
+        "title": "description doesnt load in card details",
+        "updated_at": "2026-05-11T20:21:30.329236740Z"
+      },
+      {
+        "card_number": 391,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-11T20:21:30.357738977Z",
+        "created_at": "2026-05-04T02:53:22.798067658Z",
+        "description": "# UPDATE 2026-05-04 — Implementation outcome\n\n**Shipped (Part A + drift-prevention CI invariant):**\n- New `scripts/list-crates.sh` derives the workspace crate list from `cargo metadata` + `jq` + `tsort`. Filters dev-deps via `kind == null` so the dependency cycle (kanban-persistence-json dev-deps on kanban-service which normal-deps on kanban-persistence-json) doesn't break the topo-sort.\n- `scripts/validate-release.sh` and `scripts/publish-crates.sh` refactored to populate `CRATES` via `mapfile -t CRATES < <(list-crates --paths)`. Hardcoded arrays gone.\n- New `scripts/check-crate-list-sync.sh` invariant: fails CI if either script regresses to a hardcoded array literal, or if `list-crates` output disagrees with `crates/*/Cargo.toml` workspace members.\n- Wired into `flake.nix`, `shell.nix`, and `.github/workflows/ci.yml` (new step in `release-validation` job).\n- Changeset `kan-391-fix-validate-release-staleness.md` added with `bump: patch`.\n\n**Reverted (Part B): the original review's \"drop --no-verify\" recommendation was a misdiagnosis.**\n\nEmpirical verification during implementation showed this. When `cargo publish --dry-run` (without `--no-verify`) packages a workspace crate, it resolves path-deps to their **crates.io** versions and tries to compile against those. Concrete evidence: `kanban-domain 0.3.5` on crates.io defines `pub trait Command`, but local develop has refactored to `pub enum Command` (KAN-260/KAN-348). Compile fails with E0782 (\"expected a type, found a trait\") because new code is being built against old published API. This is the inherent chicken-and-egg of workspace publishing — every API-changing release fails dry-run until each crate is republished in dependency order, which can only happen during the actual release run.\n\nThe original `--no-verify --offline` flags weren't a defect — they were a deliberate workaround for this constraint. Step 4 (`cargo check --workspace --all-features`) already verifies compile against local source; Step 5 with `--no-verify --offline` adds manifest/package-shape verification, which is what it can do without the published siblings being available. Added an explanatory comment in `validate-release.sh` Step 5 so the next reviewer doesn't make the same mistake.\n\n**Net effect:** the dynamic crate list alone resolves the missing-3-crates drift bug (the actual blocker called out in this card). The deeper fix for \"we want real compile validation pre-publish\" requires either a workspace-aware tool (cargo-workspaces / release-plz — sibling card) or staging the publish across multiple commits.\n\n**Files changed:**\n- `scripts/list-crates.sh` (new)\n- `scripts/check-crate-list-sync.sh` (new)\n- `scripts/validate-release.sh` (CRATES + INTERNAL_DEPS now dynamic; Step 5 commented to explain --no-verify)\n- `scripts/publish-crates.sh` (CRATES now dynamic)\n- `flake.nix` (listCrates + checkCrateListSync derivations exposed)\n- `shell.nix` (parameters + buildInputs)\n- `.github/workflows/ci.yml` (new step in release-validation job)\n- `.changeset/kan-391-fix-validate-release-staleness.md` (new, bump: patch)\n\n---\n\n# PR #208 (release 0.4.0) — Pre-merge review action items\n\nThis card tracks code-review findings from PR #208 (develop → master, 0.4.0 release). 38 commits, 283 files, +45,171/-13,065. Per-feature PRs were already gated; this review focuses on the merge-to-master boundary.\n\n## Summary verdict\n\nAfter deep investigation, **most of the initial review concerns turned out to be non-issues** — the release pipeline is fully wired, tempfile placements are legitimate, bump-version regex coverage is complete, and the KAN-339 changeset is real follow-up work. The only **actionable findings** are:\n\n- **Blocker:** `scripts/validate-release.sh` is stale — its CRATES and INTERNAL_DEPS arrays don't include the 3 new/missing crates (`kanban-service`, `kanban-persistence-json`, `kanban-persistence-sqlite`).\n- **Medium:** Step 5 of validate-release.sh uses `--no-verify --offline`, which means it doesn't actually compile crates against published deps; only manifest shape is checked.\n\nEverything else flagged in the original review (release wiring, tempfile placement, bump-version regex, KAN-339 leftover, CHANGELOG) was confirmed safe via investigation.\n\n---\n\n## Original review (delivered in chat 2026-05-04)\n\n### Overview\n\nThis is the 0.4.0 release PR merging 38 feature/fix PRs from `develop` into `master`. It's a bundle of already-reviewed-and-merged work: SQLite backend, sprint carry-over, settings UI, undo/redo lift, per-layer error types, AUR packaging, and major architectural changes (KAN-260 inverted backend plugin architecture, KAN-348 deferred reads, KAN-384 unified backends, KAN-341 card identifier redesign).\n\n**Scope:** 283 files, +45,171/-13,065. Diff too large to review line-by-line via `gh pr diff`, so the review focused on release readiness.\n\n**CI:** All 7 required checks pass; merge state is `CLEAN`/`MERGEABLE`. Individual feature PRs were reviewed prior to merging into `develop`.\n\n### What ships\n\n- **New crates** (`kanban-persistence-json`, `kanban-persistence-sqlite`) added to workspace; backends register through `StoreFactory`/`StoreRegistry` (`crates/kanban-cli/src/lib.rs`, `crates/kanban-service/src/lib.rs:1`).\n- **CLI restructured into a lib + thin bin** so third-party backends can reuse `CliApp` (`crates/kanban-cli/src/lib.rs`, `crates/kanban-cli/src/main.rs:1`). `compile_error!` enforces at least one backend feature is enabled.\n- **Default features** for `kanban-cli`, `kanban-service`, `kanban-mcp` are `[\"json\", \"sqlite\"]`. JSON remains the default file format, but SQLite is compiled in.\n- **AUR workflow** rewrites `pkgver`/`pkgrel`/`sha256` on each `release: published` event.\n- **34 changesets** in `.changeset/` will drive `bump-version.sh` + `aggregate-changelog.sh` on merge.\n\n---\n\n## Findings — actionable\n\n### 1. BLOCKER — `scripts/validate-release.sh` is stale\n\n**Evidence (origin/develop):**\n\nCRATES array (lines 4-11) — only 6 of 9 crates:\n```\ncrates/kanban-core\ncrates/kanban-domain\ncrates/kanban-mcp\ncrates/kanban-persistence\ncrates/kanban-tui\ncrates/kanban-cli\n```\n\nINTERNAL_DEPS array (line 40) — only 5 entries:\n```\nkanban-core, kanban-mcp, kanban-domain, kanban-persistence, kanban-tui\n```\n\n**Missing from both arrays:**\n- `kanban-service`\n- `kanban-persistence-json`\n- `kanban-persistence-sqlite`\n\n**Why this matters:**\n\n`scripts/publish-crates.sh` (correctly) lists all 9 crates and publishes them in dependency order (with a 10s pacing sleep, and a \"skip if version exists\" check via the crates.io API). But `release.yml` runs `validate-release` *before* the push to master and *before* `publish-crates` (release.yml line ~80). If a future change introduces a malformed manifest (missing `version =` next to a `path =` dep) in any of the 3 missing crates, the validator silently passes, the release commits, and the publish step fails halfway through — leaving crates.io in a partially-published state.\n\n**Fix:**\n\nUpdate both arrays in `scripts/validate-release.sh` to match `publish-crates.sh`:\n\n```bash\nCRATES=(\n  \"crates/kanban-core\"\n  \"crates/kanban-domain\"\n  \"crates/kanban-persistence\"\n  \"crates/kanban-persistence-json\"\n  \"crates/kanban-persistence-sqlite\"\n  \"crates/kanban-service\"\n  \"crates/kanban-tui\"\n  \"crates/kanban-mcp\"\n  \"crates/kanban-cli\"\n)\n\nINTERNAL_DEPS=(\n  \"kanban-core\"\n  \"kanban-domain\"\n  \"kanban-persistence\"\n  \"kanban-persistence-json\"\n  \"kanban-persistence-sqlite\"\n  \"kanban-service\"\n  \"kanban-tui\"\n  \"kanban-mcp\"\n)\n```\n\n**Better fix (DRY / SOLID — Single Source of Truth):**\n\nBoth scripts duplicate the crate list. Extract to a shared file (`scripts/crates.txt` or a sourced shell helper) and have both scripts read from it. This eliminates the class of bug where one script gets updated and the other doesn't (which is exactly what happened here).\n\n**TDD plan (Red → Green → Refactor):**\n\n- **Red:** Add a CI check (`scripts/check-crate-list-sync.sh`) that fails when `validate-release.sh` and `publish-crates.sh` disagree on the crate list. Wire it into `ci.yml` so the test is visible. Run it now — it must FAIL before any fix is applied (proving the test is real). Also wire a self-test that fails if a crate exists in `crates/` but isn't in either array.\n- **Green:** Apply the array updates above. Re-run `check-crate-list-sync.sh` — it passes.\n- **Refactor:** Extract the crate list into `scripts/crate-list.sh` (a single sourced array) and have both scripts source it. Re-run the CI check; it should still pass and the synchronization invariant is now structurally enforced. Delete the duplicate-detection script if the shared-source approach makes it obsolete, OR keep it as a regression guard against accidental future divergence (recommended — defense in depth).\n\n---\n\n### 2. MEDIUM — `validate-release.sh` Step 5 doesn't actually verify\n\n**Evidence:**\n\nStep 5 (line 65 of `scripts/validate-release.sh`) runs:\n```bash\ncargo publish --dry-run --no-verify --offline --quiet --allow-dirty\n```\n\nWhat each flag disables:\n- `--no-verify`: skips the actual build of the package (the most important check)\n- `--offline`: no network → can't validate against published versions of inter-crate deps\n- `--quiet`: hides warnings\n- `--allow-dirty`: ignores uncommitted changes\n\nSo this step only checks that the manifest parses and that `cargo publish` is willing to *attempt* to publish. It does NOT check that the crate compiles in isolation against its declared deps as they exist on crates.io.\n\n**Why this matters:**\n\nThe 0.4.0 release introduces fresh workspace topology (two new published crates, mcp/tui/service/cli all rewired). The risk of a broken inter-crate version pin only becoming visible at actual publish time is real — and once a crate is published to crates.io it cannot be yanked silently (yanking is observable, and version numbers can never be reused). A failed mid-pipeline publish leaves the registry in a half-published state.\n\nThe CI Build job covers compilation against path deps within the workspace, but doesn't simulate \"kanban-cli compiled standalone, pulling kanban-service from crates.io\". Those are different graphs.\n\n**Fix (low effort, high value):**\n\nDrop `--no-verify` from Step 5. This makes the dry-run actually compile each crate. `--offline` should also go (or be replaced with an explicit registry-access guard) so dep resolution against published versions is exercised.\n\n```bash\ncargo publish --dry-run --quiet --allow-dirty\n```\n\nIf the dry-run becomes too slow, parallelize across crates rather than skipping verification.\n\n**Why not address it in a separate PR:** The release fires *immediately* on merge of #208. Any validate-release improvement applied later only protects 0.5.0 onwards — 0.4.0 ships with whatever validation runs at merge time.\n\n**TDD plan (Red → Green → Refactor):**\n\n- **Red:** Construct a deliberately broken state: locally edit one of the new crate manifests to point to a non-existent inter-crate version (e.g. `kanban-core = \"^99.0\"`). Run `validate-release.sh` — Step 5 currently passes (because of `--no-verify`). That's the failing test: the validator says \"OK\" when it should say \"broken\".\n- **Green:** Drop `--no-verify` (and ideally `--offline`). Re-run; Step 5 now fails on the broken manifest.\n- **Refactor:** Reset the manifest. Confirm a clean tree still validates. Optionally parallelize the per-crate dry-run with `xargs -P` if duration becomes a problem on the runner.\n\n---\n\n## Findings — investigated, no action needed\n\nThe following items were flagged in the initial review but **investigation cleared them**.\n\n### 3. Tempfile as runtime dependency (kanban-persistence-json, kanban-service)\n\n**Initial concern:** Both crates declare `tempfile.workspace = true` in `[dependencies]`, not `[dev-dependencies]`.\n\n**Investigation result: legitimate runtime dependency.**\n\n- `crates/kanban-persistence-json/src/atomic_writer.rs:16` uses `tempfile::NamedTempFile::new_in()` in production code for atomic JSON writes (write to temp + rename — prevents corruption on crash mid-write). This is the correct pattern.\n- `crates/kanban-service/src/config.rs:366,377` uses `tempfile::NamedTempFile::new_in()` in `write_config_file()` (called by public `save_to()`/`save()`) for the same atomic-write pattern.\n- `crates/kanban-persistence/Cargo.toml` correctly gates tempfile under `optional = true` + `test-helpers` feature; runtime usages there are all `#[cfg(test)]` or behind the feature flag.\n\n**Conclusion:** placement is correct. No change needed.\n\n**Motivation for documenting:** future contributors will inevitably wonder the same thing. A brief code comment near the atomic-write helpers (\"uses tempfile for atomic write — production dependency, not test-only\") would prevent the same false alarm next time. *Optional, not required.*\n\n---\n\n### 4. `bump-version.sh` regex coverage on inter-crate deps\n\n**Initial concern:** the sed pattern `version = \"^${MAJOR}.${MINOR}\"` only matches exact `^0.3` — anything else (e.g. `0.3` without caret, `0.3.5` exact pin, `*`) would silently not be rewritten on a minor bump.\n\n**Investigation result: all 9 crate manifests on origin/develop use exactly `version = \"^0.3\"` for every kanban-* path dep.** Verified across:\n- `kanban-domain`, `kanban-persistence`, `kanban-persistence-json`, `kanban-persistence-sqlite`, `kanban-service`, `kanban-tui`, `kanban-cli`, `kanban-mcp`\n\nNo outliers. The 0.3 → 0.4 minor bump will rewrite all path deps cleanly.\n\n**Conclusion:** safe.\n\n**Optional hardening (not required for 0.4.0):** add a CI check that greps for any `kanban-* = .* version = \"[^^]` (i.e., a version pin that doesn't start with a caret) and fails. This protects future contributors from silently pinning wrong.\n\n---\n\n### 5. KAN-339 changeset (\"Address PR 208 0 4 0 code review feedback\")\n\n**Initial concern:** changeset title sounded like it might be a leftover, double-counting old feedback.\n\n**Investigation result: real follow-up work.** The changeset (commit c634491, 6 files changed) implements concrete domain-layer fixes from a prior review round:\n\n- `feat(domain)`: `WipLimitExceeded` error variant + predicate\n- `feat(domain)`: enforce WIP limits in `CreateCard`, `MoveCard`, `MoveCards`, `RestoreCard`\n- `fix(domain)`: cap redo stack at `MAX_HISTORY_DEPTH`\n- `fix(domain)`: validate column exists before restoring card\n- `fix(ci)`: validate release tag and fix sed delimiter in aur-publish\n\nAll accompanied by red-green-refactor tests (`test(domain): add failing WIP limit enforcement tests` etc.), consistent with the TDD discipline in CLAUDE.md.\n\n**Conclusion:** legitimate, ship it.\n\n---\n\n### 6. Release pipeline downstream of `release.yml`\n\n**Initial concern:** PR description claims \"version bump, CHANGELOG update, crates.io publish, GitHub release\" but the visible portion of `release.yml` only showed bump + changelog + push.\n\n**Investigation result: pipeline is fully wired.** Beyond what was visible:\n\n- `release.yml` line ~108 calls `nix run .#publish-crates` (which runs `publish-crates.sh` against crates.io)\n- `release.yml` line ~121 calls `softprops/action-gh-release` to create the GitHub Release with tag `v$VERSION`\n- `aur-publish.yml` triggers on `release: published` (the event the GitHub Release creation emits) and runs the AUR rewrite workflow\n- A \"sync develop\" step closes the loop after master is updated\n\n**Conclusion:** end-to-end automation is complete and correct.\n\n---\n\n### 7. AUR PKGBUILD placeholder values\n\n**Initial concern:** `aur/PKGBUILD` shows `pkgver=0.3.5` — would this ship stale?\n\n**Investigation result: by design.** `aur-publish.yml` lines 18-31 dynamically rewrite `pkgver`, `pkgrel`, and `sha256sums` on each release event. The static value is just a starting point for `sed`. The tag regex `^[0-9]+\\.[0-9]+(\\.[0-9]+)?(-[a-zA-Z0-9]+)?$` validates input before substitution (mitigates tag injection). The sha256 is computed from the GitHub-served tarball at workflow time, not trusted from inputs.\n\n**Conclusion:** correct.\n\n---\n\n### 8. PR draft state\n\n**Status:** PR is currently in `Draft`. Mark Ready for Review before merging.\n\n**Why:** `release.yml` triggers on `pull_request: closed` with `merged == true`. This works for a draft that's marked ready and then merged via the normal flow, but if the PR is force-merged via GitHub API or CLI while still in draft, some integrations (status checks, notifications) may not behave consistently. Marking ready is the documented happy path.\n\n**Action:** flip the toggle on GitHub before clicking merge.\n\n---\n\n### 9. CHANGELOG.md not yet updated for 0.4.0\n\n**Status:** by design — `aggregate-changelog.sh` runs post-merge inside `release.yml`, reads `.changeset/*.md`, writes the new section to `CHANGELOG.md`, and *deletes the changesets*. Don't pre-populate.\n\n**Conclusion:** no action.\n\n---\n\n## Conventions / style\n\n- 38 commits follow `type(scope): msg` with `kanban-` prefix dropped on scope. Consistent with project convention.\n- New `kanban-cli/src/lib.rs` doc comment follows \"no comments unless documenting public API\" guideline.\n- `compile_error!` in `kanban-cli/src/main.rs:1` enforces at least one backend feature — good defensive design at the build boundary.\n\n## Test coverage\n\n- New `crates/kanban-persistence/tests/store_contract_smoke.rs` provides cross-backend contract tests gated on `test-helpers` feature.\n- Properly scoped via `required-features` so contract tests only run when helpers compile in.\n- CI Test job passes (3m6s).\n\n## Security\n\n- AUR workflow uses pinned action SHA (`KSXGitHub/github-actions-deploy-aur@2ac5a4c1...`).\n- Tag input validated with regex before `sed`.\n- SHA256 computed from authoritative source at runtime, not input.\n\n---\n\n## SOLID principles applied to fixes\n\nThe proposed fixes themselves should be evaluated against SOLID:\n\n- **Single Responsibility:** the shared `scripts/crate-list.sh` (refactor step in fix #1) has the single responsibility of being the source of truth for the workspace crate list. Both `validate-release.sh` and `publish-crates.sh` continue to have their own single responsibility (validation vs. publishing) and merely delegate the \"what crates exist\" question to the new file.\n- **Open/Closed:** when a 10th crate is added in the future, contributors edit one file (`crate-list.sh`), not two. The validator and publisher are closed for modification, open for the extension that \"the workspace gained a crate.\"\n- **Liskov / Interface Segregation:** N/A at this script-shell level.\n- **Dependency Inversion:** both scripts depend on the abstraction (the sourced list) rather than each holding its own concrete copy. Currently they each redeclare the list — that's the inversion failure being corrected.\n\n## Recommendation\n\n**Block merge until fix #1 ships.** Strongly consider also applying fix #2 in the same PR — both are small, both target `scripts/validate-release.sh`, and 0.4.0 is the release where the workspace topology change makes the staleness most likely to cause a partial-publish incident.\n\nItems 3–9 are non-actionable; merge as-is once 1 and 2 are addressed.",
+        "due_date": null,
+        "id": "36716ee1-f014-4fc0-b8e1-856613d3e8e8",
+        "points": 2,
+        "position": 163,
+        "priority": "High",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T21:58:57.806920747Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Done",
+        "title": "PR #208 (release 0.4.0) — fix validate-release.sh staleness before merge",
+        "updated_at": "2026-05-11T20:21:30.393827659Z"
+      },
+      {
         "card_number": 358,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -12285,32 +11819,6 @@
         "status": "Todo",
         "title": "Refactor sqlite_store.rs into submodules",
         "updated_at": "2026-05-07T22:06:15.245146777Z"
-      },
-      {
-        "card_number": 391,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-11T20:21:30.357738977Z",
-        "created_at": "2026-05-04T02:53:22.798067658Z",
-        "description": "# UPDATE 2026-05-04 — Implementation outcome\n\n**Shipped (Part A + drift-prevention CI invariant):**\n- New `scripts/list-crates.sh` derives the workspace crate list from `cargo metadata` + `jq` + `tsort`. Filters dev-deps via `kind == null` so the dependency cycle (kanban-persistence-json dev-deps on kanban-service which normal-deps on kanban-persistence-json) doesn't break the topo-sort.\n- `scripts/validate-release.sh` and `scripts/publish-crates.sh` refactored to populate `CRATES` via `mapfile -t CRATES < <(list-crates --paths)`. Hardcoded arrays gone.\n- New `scripts/check-crate-list-sync.sh` invariant: fails CI if either script regresses to a hardcoded array literal, or if `list-crates` output disagrees with `crates/*/Cargo.toml` workspace members.\n- Wired into `flake.nix`, `shell.nix`, and `.github/workflows/ci.yml` (new step in `release-validation` job).\n- Changeset `kan-391-fix-validate-release-staleness.md` added with `bump: patch`.\n\n**Reverted (Part B): the original review's \"drop --no-verify\" recommendation was a misdiagnosis.**\n\nEmpirical verification during implementation showed this. When `cargo publish --dry-run` (without `--no-verify`) packages a workspace crate, it resolves path-deps to their **crates.io** versions and tries to compile against those. Concrete evidence: `kanban-domain 0.3.5` on crates.io defines `pub trait Command`, but local develop has refactored to `pub enum Command` (KAN-260/KAN-348). Compile fails with E0782 (\"expected a type, found a trait\") because new code is being built against old published API. This is the inherent chicken-and-egg of workspace publishing — every API-changing release fails dry-run until each crate is republished in dependency order, which can only happen during the actual release run.\n\nThe original `--no-verify --offline` flags weren't a defect — they were a deliberate workaround for this constraint. Step 4 (`cargo check --workspace --all-features`) already verifies compile against local source; Step 5 with `--no-verify --offline` adds manifest/package-shape verification, which is what it can do without the published siblings being available. Added an explanatory comment in `validate-release.sh` Step 5 so the next reviewer doesn't make the same mistake.\n\n**Net effect:** the dynamic crate list alone resolves the missing-3-crates drift bug (the actual blocker called out in this card). The deeper fix for \"we want real compile validation pre-publish\" requires either a workspace-aware tool (cargo-workspaces / release-plz — sibling card) or staging the publish across multiple commits.\n\n**Files changed:**\n- `scripts/list-crates.sh` (new)\n- `scripts/check-crate-list-sync.sh` (new)\n- `scripts/validate-release.sh` (CRATES + INTERNAL_DEPS now dynamic; Step 5 commented to explain --no-verify)\n- `scripts/publish-crates.sh` (CRATES now dynamic)\n- `flake.nix` (listCrates + checkCrateListSync derivations exposed)\n- `shell.nix` (parameters + buildInputs)\n- `.github/workflows/ci.yml` (new step in release-validation job)\n- `.changeset/kan-391-fix-validate-release-staleness.md` (new, bump: patch)\n\n---\n\n# PR #208 (release 0.4.0) — Pre-merge review action items\n\nThis card tracks code-review findings from PR #208 (develop → master, 0.4.0 release). 38 commits, 283 files, +45,171/-13,065. Per-feature PRs were already gated; this review focuses on the merge-to-master boundary.\n\n## Summary verdict\n\nAfter deep investigation, **most of the initial review concerns turned out to be non-issues** — the release pipeline is fully wired, tempfile placements are legitimate, bump-version regex coverage is complete, and the KAN-339 changeset is real follow-up work. The only **actionable findings** are:\n\n- **Blocker:** `scripts/validate-release.sh` is stale — its CRATES and INTERNAL_DEPS arrays don't include the 3 new/missing crates (`kanban-service`, `kanban-persistence-json`, `kanban-persistence-sqlite`).\n- **Medium:** Step 5 of validate-release.sh uses `--no-verify --offline`, which means it doesn't actually compile crates against published deps; only manifest shape is checked.\n\nEverything else flagged in the original review (release wiring, tempfile placement, bump-version regex, KAN-339 leftover, CHANGELOG) was confirmed safe via investigation.\n\n---\n\n## Original review (delivered in chat 2026-05-04)\n\n### Overview\n\nThis is the 0.4.0 release PR merging 38 feature/fix PRs from `develop` into `master`. It's a bundle of already-reviewed-and-merged work: SQLite backend, sprint carry-over, settings UI, undo/redo lift, per-layer error types, AUR packaging, and major architectural changes (KAN-260 inverted backend plugin architecture, KAN-348 deferred reads, KAN-384 unified backends, KAN-341 card identifier redesign).\n\n**Scope:** 283 files, +45,171/-13,065. Diff too large to review line-by-line via `gh pr diff`, so the review focused on release readiness.\n\n**CI:** All 7 required checks pass; merge state is `CLEAN`/`MERGEABLE`. Individual feature PRs were reviewed prior to merging into `develop`.\n\n### What ships\n\n- **New crates** (`kanban-persistence-json`, `kanban-persistence-sqlite`) added to workspace; backends register through `StoreFactory`/`StoreRegistry` (`crates/kanban-cli/src/lib.rs`, `crates/kanban-service/src/lib.rs:1`).\n- **CLI restructured into a lib + thin bin** so third-party backends can reuse `CliApp` (`crates/kanban-cli/src/lib.rs`, `crates/kanban-cli/src/main.rs:1`). `compile_error!` enforces at least one backend feature is enabled.\n- **Default features** for `kanban-cli`, `kanban-service`, `kanban-mcp` are `[\"json\", \"sqlite\"]`. JSON remains the default file format, but SQLite is compiled in.\n- **AUR workflow** rewrites `pkgver`/`pkgrel`/`sha256` on each `release: published` event.\n- **34 changesets** in `.changeset/` will drive `bump-version.sh` + `aggregate-changelog.sh` on merge.\n\n---\n\n## Findings — actionable\n\n### 1. BLOCKER — `scripts/validate-release.sh` is stale\n\n**Evidence (origin/develop):**\n\nCRATES array (lines 4-11) — only 6 of 9 crates:\n```\ncrates/kanban-core\ncrates/kanban-domain\ncrates/kanban-mcp\ncrates/kanban-persistence\ncrates/kanban-tui\ncrates/kanban-cli\n```\n\nINTERNAL_DEPS array (line 40) — only 5 entries:\n```\nkanban-core, kanban-mcp, kanban-domain, kanban-persistence, kanban-tui\n```\n\n**Missing from both arrays:**\n- `kanban-service`\n- `kanban-persistence-json`\n- `kanban-persistence-sqlite`\n\n**Why this matters:**\n\n`scripts/publish-crates.sh` (correctly) lists all 9 crates and publishes them in dependency order (with a 10s pacing sleep, and a \"skip if version exists\" check via the crates.io API). But `release.yml` runs `validate-release` *before* the push to master and *before* `publish-crates` (release.yml line ~80). If a future change introduces a malformed manifest (missing `version =` next to a `path =` dep) in any of the 3 missing crates, the validator silently passes, the release commits, and the publish step fails halfway through — leaving crates.io in a partially-published state.\n\n**Fix:**\n\nUpdate both arrays in `scripts/validate-release.sh` to match `publish-crates.sh`:\n\n```bash\nCRATES=(\n  \"crates/kanban-core\"\n  \"crates/kanban-domain\"\n  \"crates/kanban-persistence\"\n  \"crates/kanban-persistence-json\"\n  \"crates/kanban-persistence-sqlite\"\n  \"crates/kanban-service\"\n  \"crates/kanban-tui\"\n  \"crates/kanban-mcp\"\n  \"crates/kanban-cli\"\n)\n\nINTERNAL_DEPS=(\n  \"kanban-core\"\n  \"kanban-domain\"\n  \"kanban-persistence\"\n  \"kanban-persistence-json\"\n  \"kanban-persistence-sqlite\"\n  \"kanban-service\"\n  \"kanban-tui\"\n  \"kanban-mcp\"\n)\n```\n\n**Better fix (DRY / SOLID — Single Source of Truth):**\n\nBoth scripts duplicate the crate list. Extract to a shared file (`scripts/crates.txt` or a sourced shell helper) and have both scripts read from it. This eliminates the class of bug where one script gets updated and the other doesn't (which is exactly what happened here).\n\n**TDD plan (Red → Green → Refactor):**\n\n- **Red:** Add a CI check (`scripts/check-crate-list-sync.sh`) that fails when `validate-release.sh` and `publish-crates.sh` disagree on the crate list. Wire it into `ci.yml` so the test is visible. Run it now — it must FAIL before any fix is applied (proving the test is real). Also wire a self-test that fails if a crate exists in `crates/` but isn't in either array.\n- **Green:** Apply the array updates above. Re-run `check-crate-list-sync.sh` — it passes.\n- **Refactor:** Extract the crate list into `scripts/crate-list.sh` (a single sourced array) and have both scripts source it. Re-run the CI check; it should still pass and the synchronization invariant is now structurally enforced. Delete the duplicate-detection script if the shared-source approach makes it obsolete, OR keep it as a regression guard against accidental future divergence (recommended — defense in depth).\n\n---\n\n### 2. MEDIUM — `validate-release.sh` Step 5 doesn't actually verify\n\n**Evidence:**\n\nStep 5 (line 65 of `scripts/validate-release.sh`) runs:\n```bash\ncargo publish --dry-run --no-verify --offline --quiet --allow-dirty\n```\n\nWhat each flag disables:\n- `--no-verify`: skips the actual build of the package (the most important check)\n- `--offline`: no network → can't validate against published versions of inter-crate deps\n- `--quiet`: hides warnings\n- `--allow-dirty`: ignores uncommitted changes\n\nSo this step only checks that the manifest parses and that `cargo publish` is willing to *attempt* to publish. It does NOT check that the crate compiles in isolation against its declared deps as they exist on crates.io.\n\n**Why this matters:**\n\nThe 0.4.0 release introduces fresh workspace topology (two new published crates, mcp/tui/service/cli all rewired). The risk of a broken inter-crate version pin only becoming visible at actual publish time is real — and once a crate is published to crates.io it cannot be yanked silently (yanking is observable, and version numbers can never be reused). A failed mid-pipeline publish leaves the registry in a half-published state.\n\nThe CI Build job covers compilation against path deps within the workspace, but doesn't simulate \"kanban-cli compiled standalone, pulling kanban-service from crates.io\". Those are different graphs.\n\n**Fix (low effort, high value):**\n\nDrop `--no-verify` from Step 5. This makes the dry-run actually compile each crate. `--offline` should also go (or be replaced with an explicit registry-access guard) so dep resolution against published versions is exercised.\n\n```bash\ncargo publish --dry-run --quiet --allow-dirty\n```\n\nIf the dry-run becomes too slow, parallelize across crates rather than skipping verification.\n\n**Why not address it in a separate PR:** The release fires *immediately* on merge of #208. Any validate-release improvement applied later only protects 0.5.0 onwards — 0.4.0 ships with whatever validation runs at merge time.\n\n**TDD plan (Red → Green → Refactor):**\n\n- **Red:** Construct a deliberately broken state: locally edit one of the new crate manifests to point to a non-existent inter-crate version (e.g. `kanban-core = \"^99.0\"`). Run `validate-release.sh` — Step 5 currently passes (because of `--no-verify`). That's the failing test: the validator says \"OK\" when it should say \"broken\".\n- **Green:** Drop `--no-verify` (and ideally `--offline`). Re-run; Step 5 now fails on the broken manifest.\n- **Refactor:** Reset the manifest. Confirm a clean tree still validates. Optionally parallelize the per-crate dry-run with `xargs -P` if duration becomes a problem on the runner.\n\n---\n\n## Findings — investigated, no action needed\n\nThe following items were flagged in the initial review but **investigation cleared them**.\n\n### 3. Tempfile as runtime dependency (kanban-persistence-json, kanban-service)\n\n**Initial concern:** Both crates declare `tempfile.workspace = true` in `[dependencies]`, not `[dev-dependencies]`.\n\n**Investigation result: legitimate runtime dependency.**\n\n- `crates/kanban-persistence-json/src/atomic_writer.rs:16` uses `tempfile::NamedTempFile::new_in()` in production code for atomic JSON writes (write to temp + rename — prevents corruption on crash mid-write). This is the correct pattern.\n- `crates/kanban-service/src/config.rs:366,377` uses `tempfile::NamedTempFile::new_in()` in `write_config_file()` (called by public `save_to()`/`save()`) for the same atomic-write pattern.\n- `crates/kanban-persistence/Cargo.toml` correctly gates tempfile under `optional = true` + `test-helpers` feature; runtime usages there are all `#[cfg(test)]` or behind the feature flag.\n\n**Conclusion:** placement is correct. No change needed.\n\n**Motivation for documenting:** future contributors will inevitably wonder the same thing. A brief code comment near the atomic-write helpers (\"uses tempfile for atomic write — production dependency, not test-only\") would prevent the same false alarm next time. *Optional, not required.*\n\n---\n\n### 4. `bump-version.sh` regex coverage on inter-crate deps\n\n**Initial concern:** the sed pattern `version = \"^${MAJOR}.${MINOR}\"` only matches exact `^0.3` — anything else (e.g. `0.3` without caret, `0.3.5` exact pin, `*`) would silently not be rewritten on a minor bump.\n\n**Investigation result: all 9 crate manifests on origin/develop use exactly `version = \"^0.3\"` for every kanban-* path dep.** Verified across:\n- `kanban-domain`, `kanban-persistence`, `kanban-persistence-json`, `kanban-persistence-sqlite`, `kanban-service`, `kanban-tui`, `kanban-cli`, `kanban-mcp`\n\nNo outliers. The 0.3 → 0.4 minor bump will rewrite all path deps cleanly.\n\n**Conclusion:** safe.\n\n**Optional hardening (not required for 0.4.0):** add a CI check that greps for any `kanban-* = .* version = \"[^^]` (i.e., a version pin that doesn't start with a caret) and fails. This protects future contributors from silently pinning wrong.\n\n---\n\n### 5. KAN-339 changeset (\"Address PR 208 0 4 0 code review feedback\")\n\n**Initial concern:** changeset title sounded like it might be a leftover, double-counting old feedback.\n\n**Investigation result: real follow-up work.** The changeset (commit c634491, 6 files changed) implements concrete domain-layer fixes from a prior review round:\n\n- `feat(domain)`: `WipLimitExceeded` error variant + predicate\n- `feat(domain)`: enforce WIP limits in `CreateCard`, `MoveCard`, `MoveCards`, `RestoreCard`\n- `fix(domain)`: cap redo stack at `MAX_HISTORY_DEPTH`\n- `fix(domain)`: validate column exists before restoring card\n- `fix(ci)`: validate release tag and fix sed delimiter in aur-publish\n\nAll accompanied by red-green-refactor tests (`test(domain): add failing WIP limit enforcement tests` etc.), consistent with the TDD discipline in CLAUDE.md.\n\n**Conclusion:** legitimate, ship it.\n\n---\n\n### 6. Release pipeline downstream of `release.yml`\n\n**Initial concern:** PR description claims \"version bump, CHANGELOG update, crates.io publish, GitHub release\" but the visible portion of `release.yml` only showed bump + changelog + push.\n\n**Investigation result: pipeline is fully wired.** Beyond what was visible:\n\n- `release.yml` line ~108 calls `nix run .#publish-crates` (which runs `publish-crates.sh` against crates.io)\n- `release.yml` line ~121 calls `softprops/action-gh-release` to create the GitHub Release with tag `v$VERSION`\n- `aur-publish.yml` triggers on `release: published` (the event the GitHub Release creation emits) and runs the AUR rewrite workflow\n- A \"sync develop\" step closes the loop after master is updated\n\n**Conclusion:** end-to-end automation is complete and correct.\n\n---\n\n### 7. AUR PKGBUILD placeholder values\n\n**Initial concern:** `aur/PKGBUILD` shows `pkgver=0.3.5` — would this ship stale?\n\n**Investigation result: by design.** `aur-publish.yml` lines 18-31 dynamically rewrite `pkgver`, `pkgrel`, and `sha256sums` on each release event. The static value is just a starting point for `sed`. The tag regex `^[0-9]+\\.[0-9]+(\\.[0-9]+)?(-[a-zA-Z0-9]+)?$` validates input before substitution (mitigates tag injection). The sha256 is computed from the GitHub-served tarball at workflow time, not trusted from inputs.\n\n**Conclusion:** correct.\n\n---\n\n### 8. PR draft state\n\n**Status:** PR is currently in `Draft`. Mark Ready for Review before merging.\n\n**Why:** `release.yml` triggers on `pull_request: closed` with `merged == true`. This works for a draft that's marked ready and then merged via the normal flow, but if the PR is force-merged via GitHub API or CLI while still in draft, some integrations (status checks, notifications) may not behave consistently. Marking ready is the documented happy path.\n\n**Action:** flip the toggle on GitHub before clicking merge.\n\n---\n\n### 9. CHANGELOG.md not yet updated for 0.4.0\n\n**Status:** by design — `aggregate-changelog.sh` runs post-merge inside `release.yml`, reads `.changeset/*.md`, writes the new section to `CHANGELOG.md`, and *deletes the changesets*. Don't pre-populate.\n\n**Conclusion:** no action.\n\n---\n\n## Conventions / style\n\n- 38 commits follow `type(scope): msg` with `kanban-` prefix dropped on scope. Consistent with project convention.\n- New `kanban-cli/src/lib.rs` doc comment follows \"no comments unless documenting public API\" guideline.\n- `compile_error!` in `kanban-cli/src/main.rs:1` enforces at least one backend feature — good defensive design at the build boundary.\n\n## Test coverage\n\n- New `crates/kanban-persistence/tests/store_contract_smoke.rs` provides cross-backend contract tests gated on `test-helpers` feature.\n- Properly scoped via `required-features` so contract tests only run when helpers compile in.\n- CI Test job passes (3m6s).\n\n## Security\n\n- AUR workflow uses pinned action SHA (`KSXGitHub/github-actions-deploy-aur@2ac5a4c1...`).\n- Tag input validated with regex before `sed`.\n- SHA256 computed from authoritative source at runtime, not input.\n\n---\n\n## SOLID principles applied to fixes\n\nThe proposed fixes themselves should be evaluated against SOLID:\n\n- **Single Responsibility:** the shared `scripts/crate-list.sh` (refactor step in fix #1) has the single responsibility of being the source of truth for the workspace crate list. Both `validate-release.sh` and `publish-crates.sh` continue to have their own single responsibility (validation vs. publishing) and merely delegate the \"what crates exist\" question to the new file.\n- **Open/Closed:** when a 10th crate is added in the future, contributors edit one file (`crate-list.sh`), not two. The validator and publisher are closed for modification, open for the extension that \"the workspace gained a crate.\"\n- **Liskov / Interface Segregation:** N/A at this script-shell level.\n- **Dependency Inversion:** both scripts depend on the abstraction (the sourced list) rather than each holding its own concrete copy. Currently they each redeclare the list — that's the inversion failure being corrected.\n\n## Recommendation\n\n**Block merge until fix #1 ships.** Strongly consider also applying fix #2 in the same PR — both are small, both target `scripts/validate-release.sh`, and 0.4.0 is the release where the workspace topology change makes the staleness most likely to cause a partial-publish incident.\n\nItems 3–9 are non-actionable; merge as-is once 1 and 2 are addressed.",
-        "due_date": null,
-        "id": "36716ee1-f014-4fc0-b8e1-856613d3e8e8",
-        "points": 2,
-        "position": 163,
-        "priority": "High",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T21:58:57.806920747Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Done",
-        "title": "PR #208 (release 0.4.0) — fix validate-release.sh staleness before merge",
-        "updated_at": "2026-05-11T20:21:30.393827659Z"
       },
       {
         "card_number": 359,
@@ -12519,40 +12027,6 @@
         "updated_at": "2026-05-11T20:21:30.586206622Z"
       },
       {
-        "card_number": 330,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-11T20:24:34.663664934Z",
-        "created_at": "2026-04-06T22:24:07.225850794Z",
-        "description": "# Problem\n\nStarting the TUI and immediately exiting silently creates an empty `kanban.json` in the current working directory, even though no explicit board creation was requested. It also emits a confusing warning:\n\n```\nWARN kanban_tui::app: Failed to start file watching for /path/to/kanban.json: IO err: No such file or directory (os error 2)\n```\n\nCreating a board should be an explicit user action (via the export/import flow).\n\n---\n\n# Root Cause Analysis\n\n## Trigger chain\n\nThe issue is in `load_initial_state()` in `crates/kanban-tui/src/app/mod.rs` (~line 1585):\n\n```rust\nasync fn load_initial_state(&mut self) {\n    if self.persistence.save_file.is_some() {\n        let store = self.ctx.store().clone();\n        if store.exists().await {\n            // ... loads data from file ...\n        }\n        // store does NOT exist — falls through\n    }\n    self.migrate_sprint_logs(); // ALWAYS called, even on empty/missing store\n    self.check_ended_sprints();\n    // ...\n}\n```\n\n`migrate_sprint_logs()` always calls `execute_command`:\n\n```rust\n// crates/kanban-tui/src/app/mod.rs ~line 1940\nfn migrate_sprint_logs(&mut self) {\n    let cmd = Box::new(kanban_domain::commands::MigrateSprintLogs);\n    if let Err(e) = self.ctx.execute_command(cmd) {\n        tracing::error!(\"Failed to migrate sprint logs: {}\", e);\n    }\n}\n```\n\n`TuiContext::execute_commands_batch` unconditionally queues a snapshot save:\n\n```rust\n// crates/kanban-tui/src/tui_context.rs ~line 59\npub fn execute_commands_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {\n    self.inner.execute(commands)?;\n    let snapshot = self.inner.snapshot();\n    self.save_coordinator.queue_snapshot(snapshot); // always queued\n    Ok(())\n}\n```\n\nAnd `KanbanContext::execute` always marks dirty:\n\n```rust\n// crates/kanban-service/src/context.rs ~line 180\npub fn execute(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {\n    self.history.capture_before_command(self.snapshot());\n    for command in commands { /* ... */ }\n    self.dirty = true; // always set, even for no-op commands\n    Ok(())\n}\n```\n\nSo even with no boards, `migrate_sprint_logs()` queues an empty snapshot write, which the save worker flushes to disk — creating `kanban.json`.\n\n## Why the file watcher error appears\n\nFile watching is initialized in `App::run()` after `load_initial_state()` but before the save worker runs. Since `kanban.json` doesn't exist yet, `start_watching` fails with `ENOENT`:\n\n```rust\n// crates/kanban-tui/src/app/mod.rs ~line 1601\nif let Some(ref save_file) = self.persistence.save_file {\n    let watcher = kanban_persistence::FileWatcher::new();\n    let path = std::path::PathBuf::from(save_file);\n    if let Err(e) = watcher.start_watching(path.clone()).await {\n        tracing::warn!(\"Failed to start file watching for {}: {}\", path.display(), e);\n    }\n}\n```\n\n---\n\n# Proposed Solutions\n\n## Option A — Guard `migrate_sprint_logs` behind the store-exists check (minimal fix)\n\nMove the call inside the `store.exists()` block so it only runs when there is actual data to migrate:\n\n```rust\nasync fn load_initial_state(&mut self) {\n    if self.persistence.save_file.is_some() {\n        let store = self.ctx.store().clone();\n        if store.exists().await {\n            match store.load().await {\n                Ok((snapshot, _)) => { /* apply snapshot */ }\n                Err(e) => { /* error handling */ }\n            }\n            self.migrate_sprint_logs(); // only when data was loaded\n        }\n    }\n    self.check_ended_sprints();\n    // ...\n}\n```\n\n**Pros:** Minimal, targeted, low risk.\n**Cons:** Does not fix the underlying issue that execute always queues a save.\n\n## Option B — Only queue save when snapshot actually changed (robust fix)\n\n```rust\n// crates/kanban-tui/src/tui_context.rs\npub fn execute_commands_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {\n    let before = self.inner.snapshot();\n    self.inner.execute(commands)?;\n    let after = self.inner.snapshot();\n    if before != after {\n        self.save_coordinator.queue_snapshot(after);\n    }\n    Ok(())\n}\n```\n\nRequires `Snapshot` to implement `PartialEq`. Alternatively, `MigrateSprintLogs` could return a boolean indicating whether it applied any changes.\n\n**Pros:** Prevents spurious writes from any no-op command, not just `MigrateSprintLogs`.\n**Cons:** More invasive; snapshot diff has overhead on every command.\n\n## Option C — Skip save when snapshot is empty (quick guard)\n\n```rust\n// crates/kanban-tui/src/state/mod.rs\npub fn queue_snapshot(&mut self, snapshot: Snapshot) {\n    if snapshot.boards.is_empty() {\n        return;\n    }\n    // ... existing logic ...\n}\n```\n\n**Pros:** Very simple one-liner.\n**Cons:** Semantically wrong — masks the bug rather than fixing it.\n\n## Recommendation\n\n**Option A** as immediate fix, **Option B** as proper follow-up.",
-        "due_date": null,
-        "id": "abd67c7e-efa2-4c46-950f-fa25c2aa78a0",
-        "points": null,
-        "position": 168,
-        "priority": "High",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": "2026-05-07T22:06:15.245094512Z",
-            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
-            "sprint_name": "sphinx-centered",
-            "sprint_number": 14,
-            "started_at": "2026-04-29T04:53:21.126558826Z",
-            "status": "Planning"
-          },
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T22:06:15.245095232Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Done",
-        "title": "TUI creates kanban.json on startup even when no data file exists",
-        "updated_at": "2026-05-11T20:24:34.690814778Z"
-      },
-      {
         "card_number": 362,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -12587,30 +12061,38 @@
         "updated_at": "2026-05-07T22:06:15.245156805Z"
       },
       {
-        "card_number": 407,
+        "card_number": 330,
         "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-11T20:24:34.716659410Z",
-        "created_at": "2026-05-07T22:39:12.996045407Z",
-        "description": "# fix(cli): require explicit kanban file — no implicit cwd kanban.json fallback\n\n## Stakeholder motivation\n\nFor the nixpkgs (and AUR) release, the *first interaction* a brand-new user has with `kanban` will almost always be a CLI invocation from their `$HOME` or some unrelated cwd. Today, that interaction silently lies to them:\n\n- `kanban card list` succeeds with `[]` even though no kanban file exists\n- `kanban card get KAN-12` returns \"Card not found\" — implying the card was deleted, when actually no file is being read at all\n- The TUI silently *creates* an empty `kanban.json` in cwd (KAN-330)\n\nThe user has no signal that `kanban` is operating on a phantom empty store at `$PWD/kanban.json`. For someone with their real board at `~/notes/memes/kanban.json`, this looks like total data loss. For a packaged-distro user evaluating the tool for thirty seconds, it looks like a broken app.\n\nGoal for the 0.4.x release window: **every command must produce data the user can trust, or fail fast with actionable guidance**. Implicit cwd fallback is incompatible with that goal.\n\nThis card implements the **fail-fast** stance from KAN-332 for the CLI specifically. (KAN-330 covers the parallel TUI fix.)\n\n---\n\n## Reproducer (observed)\n\n```\n$ pwd\n/home/max/fulsomenko/kanban/demo\n\n$ ls kanban.json\nls: cannot access 'kanban.json': No such file or directory\n\n$ kanban card get KAN-12\n{\"success\":false,\"api_version\":\"0.4.0\",\"error\":\"Card not found: 'KAN-12'\"}\nError: Card not found: 'KAN-12'\n\n$ kanban card list\n{\"success\":true,\"api_version\":\"0.4.0\",\"data\":{\"items\":[],\"total\":0,\"page\":1,\"page_size\":50,\"total_pages\":0}}\n```\n\nNote that `card list` returns **success** with an empty result. There is nothing in the output to indicate the user's real data lives at a different path.\n\n---\n\n## Where the bug is\n\n### 1. CLI entry resolves a default when no file is specified\n\n`crates/kanban-cli/src/app.rs:243-253`\n\n```rust\nlet validated_file: Option<String> = match file {\n    Some(ref p) => Some(\n        kanban_service::validate_path(std::path::Path::new(p))?\n            .to_string_lossy()\n            .to_string(),\n    ),\n    None => None,\n};\nlet effective_file = validated_file\n    .clone()\n    .unwrap_or_else(|| kanban_service::config::resolve_storage_location(&config));\n```\n\nWhen the positional `FILE` arg is absent **and** the `KANBAN_FILE` env var is absent (clap's `env = \"KANBAN_FILE\"` covers both via `file: Option<String>`), the code falls through to `resolve_storage_location`.\n\n### 2. resolve_storage_location joins cwd with a hardcoded default name\n\n`crates/kanban-service/src/config.rs:130-140`\n\n```rust\npub fn resolve_storage_location(config: &AppConfig) -> String {\n    let raw = config.effective_storage_location();\n    let path = Path::new(&raw);\n    if path.is_absolute() {\n        raw\n    } else {\n        std::env::current_dir()\n            .map(|cwd| cwd.join(path).display().to_string())\n            .unwrap_or(raw)\n    }\n}\n```\n\n### 3. effective_storage_location invents a filename if none is configured\n\n`crates/kanban-core/src/config.rs:73-81`\n\n```rust\npub fn effective_storage_location(&self) -> String {\n    self.storage_location.clone().unwrap_or_else(|| {\n        match self.effective_storage_backend() {\n            \"sqlite\" => DEFAULT_SQLITE_FILENAME,  // \"kanban.sqlite\"\n            _ => DEFAULT_JSON_FILENAME,            // \"kanban.json\"\n        }\n        .to_string()\n    })\n}\n```\n\nThe chain (CLI arg | env var | config.storage_location | hardcoded default) silently produces `$PWD/kanban.json` whenever the first three are missing. Step 4 is the root cause — there should be no step 4.\n\n---\n\n## Decision: Option A — fail fast\n\nThree sources of file location are accepted (in order of precedence):\n\n1. CLI positional `FILE` arg (also picks up `KANBAN_FILE` env var via clap's `env`)\n2. `storage_location` field in the user's `~/.config/kanban/config.toml`\n3. (rejected) implicit `$PWD/kanban.json`\n\nIf **none of (1) or (2)** is set, the CLI must exit non-zero with a clear, actionable error. No silent phantom file. No auto-creation.\n\n### Why Option A over Option B (preserve cwd default but error if missing)\n\n- The intent of \"implicit cwd file\" is fundamentally ambiguous: is the user expecting an existing file, or asking us to create one? A clean refusal is unambiguous.\n- One-time inconvenience for repeat users is solved permanently by setting `KANBAN_FILE` in `~/.zshrc` or `storage_location` in their config.\n- Eliminates the \"where did my data go?\" support burden in one stroke.\n- KAN-332 was already filed for exactly this stance — this card is its concrete CLI implementation.\n\n---\n\n## Concrete fix\n\n### A. Add a non-defaulting accessor on `AppConfig`\n\n`crates/kanban-core/src/config.rs` — add alongside `effective_storage_location`:\n\n```rust\n/// Returns the user-configured storage location, if any.\n/// Unlike `effective_storage_location`, this never falls back to a hardcoded filename.\npub fn explicit_storage_location(&self) -> Option<&str> {\n    self.storage_location.as_deref()\n}\n```\n\n### B. Add a non-defaulting resolver in `kanban-service`\n\n`crates/kanban-service/src/config.rs`:\n\n```rust\n/// Like `resolve_storage_location`, but returns `None` when nothing is configured\n/// instead of inventing `$PWD/kanban.json`.\npub fn resolve_explicit_storage_location(config: &AppConfig) -> Option<String> {\n    let raw = config.explicit_storage_location()?;\n    let path = Path::new(raw);\n    Some(if path.is_absolute() {\n        raw.to_string()\n    } else {\n        std::env::current_dir()\n            .map(|cwd| cwd.join(path).display().to_string())\n            .unwrap_or_else(|_| raw.to_string())\n    })\n}\n```\n\n### C. Switch CLI `app.rs` to fail when both sources are absent\n\n`crates/kanban-cli/src/app.rs` — replace the `effective_file` resolution (currently lines 251-253) with:\n\n```rust\nlet resolved_file: Option<String> = validated_file\n    .clone()\n    .or_else(|| kanban_service::config::resolve_explicit_storage_location(&config));\n\nlet effective_file = match resolved_file {\n    Some(f) => f,\n    None => anyhow::bail!(\n        \"no kanban file specified\\n\\\n         \\n\\\n         Provide a path one of three ways:\\n  \\\n         1. As a positional arg:  kanban /path/to/board.json card list\\n  \\\n         2. Via environment var:  export KANBAN_FILE=/path/to/board.json\\n  \\\n         3. In your config file:  set `storage_location = \\\"/path/to/board.json\\\"`\\n     \\\n            in {}\\n\\\n         \\n\\\n         To create a new board, run:\\n  \\\n         kanban /path/to/new-board.json board create --name \\\"My Board\\\"\"\n        , kanban_service::config::config_path()\n            .map(|p| p.display().to_string())\n            .unwrap_or_else(|| \"your platform's config dir\".to_string())\n    ),\n};\n```\n\n(The `None => TUI launch` arm in `match command` already passes `validated_file` through to `App::new_with_store`, which has its own fallback path — that is **out of scope** here and tracked by KAN-330. We do not change TUI behavior in this card.)\n\nWait — re-reading `app.rs:255-273`: the TUI arm uses `validated_file: Option<String>`, not `effective_file`. But the subcommand arm at `app.rs:281` uses `effective_file`. So the `bail!` above lives only on the subcommand path, leaving TUI untouched. \n\n### D. Leave `effective_storage_location` / `resolve_storage_location` alone\n\nOther callers (TUI, MCP, tests, migrate) may still rely on the defaulting behaviour. We add a sibling accessor rather than break the existing one. KAN-330 will revisit the TUI fallback separately.\n\n### E. Migrate command exception\n\n`Commands::Migrate` does its own argument parsing (source/target paths are explicit args), so it must run **before** the `effective_file` requirement. Verify `app.rs:275-278` already short-circuits before the subcommand arm — it does. No additional work needed.\n\n---\n\n## Tests (TDD — write red first, present before implementing)\n\nIn `crates/kanban-cli/tests/cli_integration.rs`, add a new module `mod no_file_specified_tests`:\n\n1. **`test_subcommand_without_file_arg_or_env_fails_with_helpful_error`**\n   - `kanban().env_clear().env(\"PATH\", ...).args([\"card\", \"list\"])` from a tempdir cwd\n   - Assert exit code != 0\n   - Assert stderr contains \"no kanban file specified\"\n   - Assert stderr mentions all three remediation paths (positional arg, `KANBAN_FILE`, config)\n   - Assert no `kanban.json` was created in the tempdir cwd\n\n2. **`test_subcommand_with_kanban_file_env_var_succeeds`**\n   - Same setup, but `.env(\"KANBAN_FILE\", file_path)`\n   - Assert success\n\n3. **`test_subcommand_with_positional_file_arg_succeeds`**\n   - Existing pattern, just confirm we didn't regress it\n\n4. **`test_subcommand_with_config_storage_location_succeeds`**\n   - Set `XDG_CONFIG_HOME` (or `HOME`, depending on platform) to a tempdir\n   - Write `kanban/config.toml` with `storage_location = \"/path/to/file.json\"`\n   - Run `card list` with no args\n   - Assert success and that the configured path was used (create the board there first as setup)\n\n5. **`test_migrate_subcommand_does_not_require_default_file`**\n   - `kanban migrate src.json sqlite -o out.sqlite` runs without invoking the file-required check\n   - This is a regression guard for the short-circuit at `app.rs:275-278`\n\n### Test environment hygiene\n\nThe CLI reads `KANBAN_FILE` via clap and `~/.config/kanban/config.toml` via `dirs`. Tests must:\n- Use `Command::env_clear()` then re-add only `PATH` to prevent host `KANBAN_FILE` leaking in\n- Set `XDG_CONFIG_HOME` (Linux) / `HOME` (macOS) to a tempdir so `dirs::config_dir()` is sandboxed\n- Set `current_dir(tempdir)` so any cwd-relative behaviour is observable\n\nExisting tests at `crates/kanban-cli/tests/cli_integration.rs` use `tempdir()` + positional file args; copy that scaffold and add the env hygiene above for the new module.\n\n---\n\n## Acceptance criteria\n\n- [ ] Running any non-`migrate`, non-`completions` subcommand without a file arg, without `KANBAN_FILE` set, and without `storage_location` in config exits non-zero with the multi-line guidance message above.\n- [ ] No `kanban.json` (or `kanban.sqlite`) is created in cwd as a side effect of failure.\n- [ ] `KANBAN_FILE` env var alone is sufficient to satisfy the requirement (no positional arg needed).\n- [ ] `storage_location` in `~/.config/kanban/config.toml` alone is sufficient to satisfy the requirement.\n- [ ] The error message names the actual config file path on the user's platform (via `config_path()`).\n- [ ] `kanban migrate` continues to work without an implicit default file.\n- [ ] TUI behaviour (no subcommand) is unchanged in this card. TUI fallback is KAN-330's responsibility.\n- [ ] All existing tests pass; new tests in `no_file_specified_tests` pass.\n\n---\n\n## Cross-references\n\n- **KAN-332** — original \"Require explicit file path\" card. This card is its concrete CLI implementation. Consider closing KAN-332 when this lands.\n- **KAN-330** — parallel issue in the TUI (\"creates kanban.json on startup\"). Out of scope here.\n- **KAN-399** — improve CLI error messages. The error wording added here should match KAN-399's tone/format guidelines once that lands.\n- Demo tape (`demo/demo.tape`) currently passes `demo.json` explicitly to every command — already correct, no demo update needed.\n\n## Effort estimate\n\n**3 points.** Small surface area (one new accessor, one new resolver, one bail), but the test setup for sandboxed config + env-cleared invocations is fiddly enough to be the bulk of the work.",
+        "completed_at": "2026-05-11T20:24:34.663664934Z",
+        "created_at": "2026-04-06T22:24:07.225850794Z",
+        "description": "# Problem\n\nStarting the TUI and immediately exiting silently creates an empty `kanban.json` in the current working directory, even though no explicit board creation was requested. It also emits a confusing warning:\n\n```\nWARN kanban_tui::app: Failed to start file watching for /path/to/kanban.json: IO err: No such file or directory (os error 2)\n```\n\nCreating a board should be an explicit user action (via the export/import flow).\n\n---\n\n# Root Cause Analysis\n\n## Trigger chain\n\nThe issue is in `load_initial_state()` in `crates/kanban-tui/src/app/mod.rs` (~line 1585):\n\n```rust\nasync fn load_initial_state(&mut self) {\n    if self.persistence.save_file.is_some() {\n        let store = self.ctx.store().clone();\n        if store.exists().await {\n            // ... loads data from file ...\n        }\n        // store does NOT exist — falls through\n    }\n    self.migrate_sprint_logs(); // ALWAYS called, even on empty/missing store\n    self.check_ended_sprints();\n    // ...\n}\n```\n\n`migrate_sprint_logs()` always calls `execute_command`:\n\n```rust\n// crates/kanban-tui/src/app/mod.rs ~line 1940\nfn migrate_sprint_logs(&mut self) {\n    let cmd = Box::new(kanban_domain::commands::MigrateSprintLogs);\n    if let Err(e) = self.ctx.execute_command(cmd) {\n        tracing::error!(\"Failed to migrate sprint logs: {}\", e);\n    }\n}\n```\n\n`TuiContext::execute_commands_batch` unconditionally queues a snapshot save:\n\n```rust\n// crates/kanban-tui/src/tui_context.rs ~line 59\npub fn execute_commands_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {\n    self.inner.execute(commands)?;\n    let snapshot = self.inner.snapshot();\n    self.save_coordinator.queue_snapshot(snapshot); // always queued\n    Ok(())\n}\n```\n\nAnd `KanbanContext::execute` always marks dirty:\n\n```rust\n// crates/kanban-service/src/context.rs ~line 180\npub fn execute(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {\n    self.history.capture_before_command(self.snapshot());\n    for command in commands { /* ... */ }\n    self.dirty = true; // always set, even for no-op commands\n    Ok(())\n}\n```\n\nSo even with no boards, `migrate_sprint_logs()` queues an empty snapshot write, which the save worker flushes to disk — creating `kanban.json`.\n\n## Why the file watcher error appears\n\nFile watching is initialized in `App::run()` after `load_initial_state()` but before the save worker runs. Since `kanban.json` doesn't exist yet, `start_watching` fails with `ENOENT`:\n\n```rust\n// crates/kanban-tui/src/app/mod.rs ~line 1601\nif let Some(ref save_file) = self.persistence.save_file {\n    let watcher = kanban_persistence::FileWatcher::new();\n    let path = std::path::PathBuf::from(save_file);\n    if let Err(e) = watcher.start_watching(path.clone()).await {\n        tracing::warn!(\"Failed to start file watching for {}: {}\", path.display(), e);\n    }\n}\n```\n\n---\n\n# Proposed Solutions\n\n## Option A — Guard `migrate_sprint_logs` behind the store-exists check (minimal fix)\n\nMove the call inside the `store.exists()` block so it only runs when there is actual data to migrate:\n\n```rust\nasync fn load_initial_state(&mut self) {\n    if self.persistence.save_file.is_some() {\n        let store = self.ctx.store().clone();\n        if store.exists().await {\n            match store.load().await {\n                Ok((snapshot, _)) => { /* apply snapshot */ }\n                Err(e) => { /* error handling */ }\n            }\n            self.migrate_sprint_logs(); // only when data was loaded\n        }\n    }\n    self.check_ended_sprints();\n    // ...\n}\n```\n\n**Pros:** Minimal, targeted, low risk.\n**Cons:** Does not fix the underlying issue that execute always queues a save.\n\n## Option B — Only queue save when snapshot actually changed (robust fix)\n\n```rust\n// crates/kanban-tui/src/tui_context.rs\npub fn execute_commands_batch(&mut self, commands: Vec<Box<dyn Command>>) -> KanbanResult<()> {\n    let before = self.inner.snapshot();\n    self.inner.execute(commands)?;\n    let after = self.inner.snapshot();\n    if before != after {\n        self.save_coordinator.queue_snapshot(after);\n    }\n    Ok(())\n}\n```\n\nRequires `Snapshot` to implement `PartialEq`. Alternatively, `MigrateSprintLogs` could return a boolean indicating whether it applied any changes.\n\n**Pros:** Prevents spurious writes from any no-op command, not just `MigrateSprintLogs`.\n**Cons:** More invasive; snapshot diff has overhead on every command.\n\n## Option C — Skip save when snapshot is empty (quick guard)\n\n```rust\n// crates/kanban-tui/src/state/mod.rs\npub fn queue_snapshot(&mut self, snapshot: Snapshot) {\n    if snapshot.boards.is_empty() {\n        return;\n    }\n    // ... existing logic ...\n}\n```\n\n**Pros:** Very simple one-liner.\n**Cons:** Semantically wrong — masks the bug rather than fixing it.\n\n## Recommendation\n\n**Option A** as immediate fix, **Option B** as proper follow-up.",
         "due_date": null,
-        "id": "d546ea9c-afad-4144-a342-3c8904efacd7",
-        "points": 3,
-        "position": 169,
+        "id": "abd67c7e-efa2-4c46-950f-fa25c2aa78a0",
+        "points": null,
+        "position": 168,
         "priority": "High",
         "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
         "sprint_logs": [
+          {
+            "ended_at": "2026-05-07T22:06:15.245094512Z",
+            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+            "sprint_name": "sphinx-centered",
+            "sprint_number": 14,
+            "started_at": "2026-04-29T04:53:21.126558826Z",
+            "status": "Planning"
+          },
           {
             "ended_at": null,
             "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
             "sprint_name": "yarara-release",
             "sprint_number": 15,
-            "started_at": "2026-05-07T22:39:17.340821858Z",
+            "started_at": "2026-05-07T22:06:15.245095232Z",
             "status": "Planning"
           }
         ],
         "status": "Done",
-        "title": "fix(cli): require explicit kanban file — no implicit cwd kanban.json fallback",
-        "updated_at": "2026-05-11T20:24:34.744234961Z"
+        "title": "TUI creates kanban.json on startup even when no data file exists",
+        "updated_at": "2026-05-11T20:24:34.690814778Z"
       },
       {
         "card_number": 372,
@@ -12645,6 +12127,32 @@
         "status": "Todo",
         "title": "SQLite PersistenceStore: replace JSON snapshot round-trip with native atomic SQL operations",
         "updated_at": "2026-05-07T22:06:15.245158825Z"
+      },
+      {
+        "card_number": 407,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-11T20:24:34.716659410Z",
+        "created_at": "2026-05-07T22:39:12.996045407Z",
+        "description": "# fix(cli): require explicit kanban file — no implicit cwd kanban.json fallback\n\n## Stakeholder motivation\n\nFor the nixpkgs (and AUR) release, the *first interaction* a brand-new user has with `kanban` will almost always be a CLI invocation from their `$HOME` or some unrelated cwd. Today, that interaction silently lies to them:\n\n- `kanban card list` succeeds with `[]` even though no kanban file exists\n- `kanban card get KAN-12` returns \"Card not found\" — implying the card was deleted, when actually no file is being read at all\n- The TUI silently *creates* an empty `kanban.json` in cwd (KAN-330)\n\nThe user has no signal that `kanban` is operating on a phantom empty store at `$PWD/kanban.json`. For someone with their real board at `~/notes/memes/kanban.json`, this looks like total data loss. For a packaged-distro user evaluating the tool for thirty seconds, it looks like a broken app.\n\nGoal for the 0.4.x release window: **every command must produce data the user can trust, or fail fast with actionable guidance**. Implicit cwd fallback is incompatible with that goal.\n\nThis card implements the **fail-fast** stance from KAN-332 for the CLI specifically. (KAN-330 covers the parallel TUI fix.)\n\n---\n\n## Reproducer (observed)\n\n```\n$ pwd\n/home/max/fulsomenko/kanban/demo\n\n$ ls kanban.json\nls: cannot access 'kanban.json': No such file or directory\n\n$ kanban card get KAN-12\n{\"success\":false,\"api_version\":\"0.4.0\",\"error\":\"Card not found: 'KAN-12'\"}\nError: Card not found: 'KAN-12'\n\n$ kanban card list\n{\"success\":true,\"api_version\":\"0.4.0\",\"data\":{\"items\":[],\"total\":0,\"page\":1,\"page_size\":50,\"total_pages\":0}}\n```\n\nNote that `card list` returns **success** with an empty result. There is nothing in the output to indicate the user's real data lives at a different path.\n\n---\n\n## Where the bug is\n\n### 1. CLI entry resolves a default when no file is specified\n\n`crates/kanban-cli/src/app.rs:243-253`\n\n```rust\nlet validated_file: Option<String> = match file {\n    Some(ref p) => Some(\n        kanban_service::validate_path(std::path::Path::new(p))?\n            .to_string_lossy()\n            .to_string(),\n    ),\n    None => None,\n};\nlet effective_file = validated_file\n    .clone()\n    .unwrap_or_else(|| kanban_service::config::resolve_storage_location(&config));\n```\n\nWhen the positional `FILE` arg is absent **and** the `KANBAN_FILE` env var is absent (clap's `env = \"KANBAN_FILE\"` covers both via `file: Option<String>`), the code falls through to `resolve_storage_location`.\n\n### 2. resolve_storage_location joins cwd with a hardcoded default name\n\n`crates/kanban-service/src/config.rs:130-140`\n\n```rust\npub fn resolve_storage_location(config: &AppConfig) -> String {\n    let raw = config.effective_storage_location();\n    let path = Path::new(&raw);\n    if path.is_absolute() {\n        raw\n    } else {\n        std::env::current_dir()\n            .map(|cwd| cwd.join(path).display().to_string())\n            .unwrap_or(raw)\n    }\n}\n```\n\n### 3. effective_storage_location invents a filename if none is configured\n\n`crates/kanban-core/src/config.rs:73-81`\n\n```rust\npub fn effective_storage_location(&self) -> String {\n    self.storage_location.clone().unwrap_or_else(|| {\n        match self.effective_storage_backend() {\n            \"sqlite\" => DEFAULT_SQLITE_FILENAME,  // \"kanban.sqlite\"\n            _ => DEFAULT_JSON_FILENAME,            // \"kanban.json\"\n        }\n        .to_string()\n    })\n}\n```\n\nThe chain (CLI arg | env var | config.storage_location | hardcoded default) silently produces `$PWD/kanban.json` whenever the first three are missing. Step 4 is the root cause — there should be no step 4.\n\n---\n\n## Decision: Option A — fail fast\n\nThree sources of file location are accepted (in order of precedence):\n\n1. CLI positional `FILE` arg (also picks up `KANBAN_FILE` env var via clap's `env`)\n2. `storage_location` field in the user's `~/.config/kanban/config.toml`\n3. (rejected) implicit `$PWD/kanban.json`\n\nIf **none of (1) or (2)** is set, the CLI must exit non-zero with a clear, actionable error. No silent phantom file. No auto-creation.\n\n### Why Option A over Option B (preserve cwd default but error if missing)\n\n- The intent of \"implicit cwd file\" is fundamentally ambiguous: is the user expecting an existing file, or asking us to create one? A clean refusal is unambiguous.\n- One-time inconvenience for repeat users is solved permanently by setting `KANBAN_FILE` in `~/.zshrc` or `storage_location` in their config.\n- Eliminates the \"where did my data go?\" support burden in one stroke.\n- KAN-332 was already filed for exactly this stance — this card is its concrete CLI implementation.\n\n---\n\n## Concrete fix\n\n### A. Add a non-defaulting accessor on `AppConfig`\n\n`crates/kanban-core/src/config.rs` — add alongside `effective_storage_location`:\n\n```rust\n/// Returns the user-configured storage location, if any.\n/// Unlike `effective_storage_location`, this never falls back to a hardcoded filename.\npub fn explicit_storage_location(&self) -> Option<&str> {\n    self.storage_location.as_deref()\n}\n```\n\n### B. Add a non-defaulting resolver in `kanban-service`\n\n`crates/kanban-service/src/config.rs`:\n\n```rust\n/// Like `resolve_storage_location`, but returns `None` when nothing is configured\n/// instead of inventing `$PWD/kanban.json`.\npub fn resolve_explicit_storage_location(config: &AppConfig) -> Option<String> {\n    let raw = config.explicit_storage_location()?;\n    let path = Path::new(raw);\n    Some(if path.is_absolute() {\n        raw.to_string()\n    } else {\n        std::env::current_dir()\n            .map(|cwd| cwd.join(path).display().to_string())\n            .unwrap_or_else(|_| raw.to_string())\n    })\n}\n```\n\n### C. Switch CLI `app.rs` to fail when both sources are absent\n\n`crates/kanban-cli/src/app.rs` — replace the `effective_file` resolution (currently lines 251-253) with:\n\n```rust\nlet resolved_file: Option<String> = validated_file\n    .clone()\n    .or_else(|| kanban_service::config::resolve_explicit_storage_location(&config));\n\nlet effective_file = match resolved_file {\n    Some(f) => f,\n    None => anyhow::bail!(\n        \"no kanban file specified\\n\\\n         \\n\\\n         Provide a path one of three ways:\\n  \\\n         1. As a positional arg:  kanban /path/to/board.json card list\\n  \\\n         2. Via environment var:  export KANBAN_FILE=/path/to/board.json\\n  \\\n         3. In your config file:  set `storage_location = \\\"/path/to/board.json\\\"`\\n     \\\n            in {}\\n\\\n         \\n\\\n         To create a new board, run:\\n  \\\n         kanban /path/to/new-board.json board create --name \\\"My Board\\\"\"\n        , kanban_service::config::config_path()\n            .map(|p| p.display().to_string())\n            .unwrap_or_else(|| \"your platform's config dir\".to_string())\n    ),\n};\n```\n\n(The `None => TUI launch` arm in `match command` already passes `validated_file` through to `App::new_with_store`, which has its own fallback path — that is **out of scope** here and tracked by KAN-330. We do not change TUI behavior in this card.)\n\nWait — re-reading `app.rs:255-273`: the TUI arm uses `validated_file: Option<String>`, not `effective_file`. But the subcommand arm at `app.rs:281` uses `effective_file`. So the `bail!` above lives only on the subcommand path, leaving TUI untouched. \n\n### D. Leave `effective_storage_location` / `resolve_storage_location` alone\n\nOther callers (TUI, MCP, tests, migrate) may still rely on the defaulting behaviour. We add a sibling accessor rather than break the existing one. KAN-330 will revisit the TUI fallback separately.\n\n### E. Migrate command exception\n\n`Commands::Migrate` does its own argument parsing (source/target paths are explicit args), so it must run **before** the `effective_file` requirement. Verify `app.rs:275-278` already short-circuits before the subcommand arm — it does. No additional work needed.\n\n---\n\n## Tests (TDD — write red first, present before implementing)\n\nIn `crates/kanban-cli/tests/cli_integration.rs`, add a new module `mod no_file_specified_tests`:\n\n1. **`test_subcommand_without_file_arg_or_env_fails_with_helpful_error`**\n   - `kanban().env_clear().env(\"PATH\", ...).args([\"card\", \"list\"])` from a tempdir cwd\n   - Assert exit code != 0\n   - Assert stderr contains \"no kanban file specified\"\n   - Assert stderr mentions all three remediation paths (positional arg, `KANBAN_FILE`, config)\n   - Assert no `kanban.json` was created in the tempdir cwd\n\n2. **`test_subcommand_with_kanban_file_env_var_succeeds`**\n   - Same setup, but `.env(\"KANBAN_FILE\", file_path)`\n   - Assert success\n\n3. **`test_subcommand_with_positional_file_arg_succeeds`**\n   - Existing pattern, just confirm we didn't regress it\n\n4. **`test_subcommand_with_config_storage_location_succeeds`**\n   - Set `XDG_CONFIG_HOME` (or `HOME`, depending on platform) to a tempdir\n   - Write `kanban/config.toml` with `storage_location = \"/path/to/file.json\"`\n   - Run `card list` with no args\n   - Assert success and that the configured path was used (create the board there first as setup)\n\n5. **`test_migrate_subcommand_does_not_require_default_file`**\n   - `kanban migrate src.json sqlite -o out.sqlite` runs without invoking the file-required check\n   - This is a regression guard for the short-circuit at `app.rs:275-278`\n\n### Test environment hygiene\n\nThe CLI reads `KANBAN_FILE` via clap and `~/.config/kanban/config.toml` via `dirs`. Tests must:\n- Use `Command::env_clear()` then re-add only `PATH` to prevent host `KANBAN_FILE` leaking in\n- Set `XDG_CONFIG_HOME` (Linux) / `HOME` (macOS) to a tempdir so `dirs::config_dir()` is sandboxed\n- Set `current_dir(tempdir)` so any cwd-relative behaviour is observable\n\nExisting tests at `crates/kanban-cli/tests/cli_integration.rs` use `tempdir()` + positional file args; copy that scaffold and add the env hygiene above for the new module.\n\n---\n\n## Acceptance criteria\n\n- [ ] Running any non-`migrate`, non-`completions` subcommand without a file arg, without `KANBAN_FILE` set, and without `storage_location` in config exits non-zero with the multi-line guidance message above.\n- [ ] No `kanban.json` (or `kanban.sqlite`) is created in cwd as a side effect of failure.\n- [ ] `KANBAN_FILE` env var alone is sufficient to satisfy the requirement (no positional arg needed).\n- [ ] `storage_location` in `~/.config/kanban/config.toml` alone is sufficient to satisfy the requirement.\n- [ ] The error message names the actual config file path on the user's platform (via `config_path()`).\n- [ ] `kanban migrate` continues to work without an implicit default file.\n- [ ] TUI behaviour (no subcommand) is unchanged in this card. TUI fallback is KAN-330's responsibility.\n- [ ] All existing tests pass; new tests in `no_file_specified_tests` pass.\n\n---\n\n## Cross-references\n\n- **KAN-332** — original \"Require explicit file path\" card. This card is its concrete CLI implementation. Consider closing KAN-332 when this lands.\n- **KAN-330** — parallel issue in the TUI (\"creates kanban.json on startup\"). Out of scope here.\n- **KAN-399** — improve CLI error messages. The error wording added here should match KAN-399's tone/format guidelines once that lands.\n- Demo tape (`demo/demo.tape`) currently passes `demo.json` explicitly to every command — already correct, no demo update needed.\n\n## Effort estimate\n\n**3 points.** Small surface area (one new accessor, one new resolver, one bail), but the test setup for sandboxed config + env-cleared invocations is fiddly enough to be the bulk of the work.",
+        "due_date": null,
+        "id": "d546ea9c-afad-4144-a342-3c8904efacd7",
+        "points": 3,
+        "position": 169,
+        "priority": "High",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T22:39:17.340821858Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Done",
+        "title": "fix(cli): require explicit kanban file — no implicit cwd kanban.json fallback",
+        "updated_at": "2026-05-11T20:24:34.744234961Z"
       },
       {
         "card_number": 389,
@@ -12767,6 +12275,58 @@
         "updated_at": "2026-05-07T22:06:15.245164546Z"
       },
       {
+        "card_number": 420,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-10T19:04:37.971098598Z",
+        "created_at": "2026-05-10T18:19:45.801380053Z",
+        "description": "1.70.0 is too low — edition2024 support requires a higher minimum. Update prerequisites section to reflect the actual minimum version.",
+        "due_date": null,
+        "id": "2a48e22c-b200-425a-ae14-8a91a8034af1",
+        "points": null,
+        "position": 172,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:24:13.846381150Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "Bump minimum cargo version in CONTRIBUTING.md",
+        "updated_at": "2026-05-11T23:57:10.634462725Z"
+      },
+      {
+        "card_number": 421,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-11T18:37:56.670106654Z",
+        "created_at": "2026-05-10T18:19:50.920880150Z",
+        "description": "Add two structured log lines to EventHandler in kanban-tui/src/events.rs to aid cross-platform debugging:\n\n1. debug! on startup — logs target_os, target_arch, target_family, target_endian, target_pointer_width once per process start. Visible with RUST_LOG=debug or KANBAN_DEBUG_LOG.\n\n2. trace! per raw key event — fires immediately after event::read() succeeds, before the #[cfg(target_os = \"windows\")] filter. Logs code, kind (Press/Release/Repeat), and modifiers. On Windows this captures both Press and Release events before the filter drops Release, giving the exact signal needed to diagnose key-doubling issues like PR #247.\n\nNo build script. No changes to the filter or any other code.",
+        "due_date": null,
+        "id": "5424e618-16f5-45ff-af4c-1a374100a152",
+        "points": null,
+        "position": 172,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:24:13.846378884Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Done",
+        "title": "Add build-time debug info for target OS and cfg flags",
+        "updated_at": "2026-05-11T23:57:10.634466498Z"
+      },
+      {
         "card_number": 375,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -12801,58 +12361,6 @@
         "updated_at": "2026-05-07T22:06:15.245167505Z"
       },
       {
-        "card_number": 421,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-11T18:37:56.670106654Z",
-        "created_at": "2026-05-10T18:19:50.920880150Z",
-        "description": "Add two structured log lines to EventHandler in kanban-tui/src/events.rs to aid cross-platform debugging:\n\n1. debug! on startup — logs target_os, target_arch, target_family, target_endian, target_pointer_width once per process start. Visible with RUST_LOG=debug or KANBAN_DEBUG_LOG.\n\n2. trace! per raw key event — fires immediately after event::read() succeeds, before the #[cfg(target_os = \"windows\")] filter. Logs code, kind (Press/Release/Repeat), and modifiers. On Windows this captures both Press and Release events before the filter drops Release, giving the exact signal needed to diagnose key-doubling issues like PR #247.\n\nNo build script. No changes to the filter or any other code.",
-        "due_date": null,
-        "id": "5424e618-16f5-45ff-af4c-1a374100a152",
-        "points": null,
-        "position": 172,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:13.846378884Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "Add build-time debug info for target OS and cfg flags",
-        "updated_at": "2026-05-11T23:57:10.634466498Z"
-      },
-      {
-        "card_number": 420,
-        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
-        "completed_at": "2026-05-10T19:04:37.971098598Z",
-        "created_at": "2026-05-10T18:19:45.801380053Z",
-        "description": "1.70.0 is too low — edition2024 support requires a higher minimum. Update prerequisites section to reflect the actual minimum version.",
-        "due_date": null,
-        "id": "2a48e22c-b200-425a-ae14-8a91a8034af1",
-        "points": null,
-        "position": 172,
-        "priority": "Medium",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-11T23:24:13.846381150Z",
-            "status": "Active"
-          }
-        ],
-        "status": "Done",
-        "title": "Bump minimum cargo version in CONTRIBUTING.md",
-        "updated_at": "2026-05-11T23:57:10.634462725Z"
-      },
-      {
         "card_number": 376,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -12885,6 +12393,32 @@
         "status": "Todo",
         "title": "Document prepare_frame() precondition on auto_save() and export methods",
         "updated_at": "2026-05-07T22:06:15.245169880Z"
+      },
+      {
+        "card_number": 210,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-02-17T22:22:00.293786995Z",
+        "description": "When a sprint is ended it is currently a repetetive process to transfer cards over to a new sprint\n\nyou have to\n\n- end the sprint\n- create a new sprint (come up with a name)\n- go back to cards list\n- filter by the ended sprint\n- select all unfinished cards\n- assign to new sprint\n\nCould be made better with a carry over option when ending a sprint\n\nIf no sprint names are available, dialog to give otherwise consume sprint names",
+        "due_date": null,
+        "id": "b849870a-252f-477f-96d2-bd633e54a6d3",
+        "points": 3,
+        "position": 174,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856523368Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Carry over cards from ended sprint",
+        "updated_at": "2026-05-14T10:57:05.237239005Z"
       },
       {
         "card_number": 377,
@@ -12955,6 +12489,32 @@
         "updated_at": "2026-05-07T22:06:15.245175686Z"
       },
       {
+        "card_number": 256,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-03-30T00:10:04.739056992Z",
+        "description": "## Problem\n\n`App::new()` always loaded files via `import_board_from_file()`, which calls `std::fs::read_to_string()`. This fails on binary SQLite `.db` files with:\n\n```\nstream did not contain valid UTF-8\n```\n\nThe `StateManager` correctly created a SQLite store via the `StoreRegistry`, but the initial data load bypassed it entirely, going through the JSON-only import path.\n\n## Root Cause\n\nIn `crates/kanban-tui/src/app/mod.rs`, `App::new()` unconditionally called `import_board_from_file(filename)` for any existing file, regardless of backend type.\n\n## Fix\n\nTwo changes in `crates/kanban-tui/src/app/mod.rs`:\n\n1. **`App::new()`** — skip `import_board_from_file` for `.db`/`.sqlite`/`.sqlite3` extensions, since those require async store loading\n2. **`run()`** — added async initial state loading via `store.load()` at the start of the method (before terminal setup), using the same pattern as `auto_reload_from_external_change`\n\nJSON files continue using the existing sync import path unchanged.",
+        "due_date": null,
+        "id": "a30bf99a-dc77-4aa8-b307-c163bc6afb8a",
+        "points": 1,
+        "position": 175,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856496808Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Fix SQLite .db file loading (read_to_string on binary file)",
+        "updated_at": "2026-05-14T10:57:05.237239763Z"
+      },
+      {
         "card_number": 379,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -12987,6 +12547,58 @@
         "status": "Todo",
         "title": "Harden build_tasks_panel_title test against card-count coupling",
         "updated_at": "2026-05-07T22:06:15.245177515Z"
+      },
+      {
+        "card_number": 403,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-07T21:45:57.299426314Z",
+        "description": "## Behaviour\n\nAfter creating a new card in the TUI, the selector stays on whichever card was previously selected instead of jumping to the newly created card. Any action taken immediately after creation (edit, move, open details) acts on the wrong card.\n\n## Expected\n\nThe selector should move to the newly created card immediately after creation, matching the pre-regression behaviour.\n\n## When it broke\n\nIntroduced in one of the recent large releases (v0.4.x range). The releases were substantial with many changes so the exact commit is unclear — bisect if needed.\n\n## Impact\n\nBlocks the demo recording (Beat 2 creates a card then immediately edits it in Beat 3 — the edit lands on the wrong card). Workaround for demo: manually navigate to the new card before editing.\n\n## Investigation starting point\n\nLook at the handler that processes card creation confirmation and the code path that refreshes the card list state. The selector position after list refresh is likely not being set to the new card's index.",
+        "due_date": null,
+        "id": "a41509b7-4ff6-4557-bd87-be5a83005b73",
+        "points": null,
+        "position": 176,
+        "priority": "High",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T21:58:57.806941614Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Regression: card selector does not jump to newly created card",
+        "updated_at": "2026-05-14T10:57:05.237240173Z"
+      },
+      {
+        "card_number": 427,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-11T21:52:13.395460114Z",
+        "description": "## Problem\n\n`DeleteBoard` in `kanban-domain` violates SRP. It knows how to cascade-delete across columns, active cards, archived cards, sprints, and the dependency graph — that is orchestration, not domain logic.\n\n```\n// crates/kanban-domain/src/commands/board_commands.rs:140-189\nimpl DeleteBoard {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        // collects column IDs → gathers active card IDs per column →\n        // fetches archived cards → removes graph edges →\n        // deletes active cards, archived cards, columns, sprints, board\n    }\n}\n```\n\nAdding any new entity type associated with a board (e.g. checklists, labels) requires modifying `DeleteBoard` — a violation of OCP.\n\n## Existing structure\n\nThe service layer already wraps this domain command:\n\n- `KanbanContext::delete_board()` at `crates/kanban-service/src/context.rs:752` — currently delegates to `BoardCommand::Delete(DeleteBoard { ... })`\n- `KanbanContext::snapshot()` / `apply_snapshot()` at `context.rs:129-135` — existing rollback primitives, reusable\n\nThis refactor is **invert the wrap**: pull the cascade orchestration up into the existing service method and reduce the domain command to atomic. The service method already exists — we are reshaping the boundary, not creating new orchestration entrypoints.\n\n## SOLID Solution\n\n**Single Responsibility / Open-Closed**: The domain command does one thing — delete the board record. Cascade orchestration belongs in the service layer, where composition is expected.\n\n**Dependency Inversion**: Service composes atomic domain commands; domain command no longer knows about siblings.\n\n### Step 1 — Make `DeleteBoard` atomic in the domain\n\n```rust\n// crates/kanban-domain/src/commands/board_commands.rs\nimpl DeleteBoard {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        context.store.delete_board(self.board_id)\n    }\n}\n```\n\n### Step 2 — Move cascade orchestration into existing `KanbanContext::delete_board()`\n\nThe existing wrapper at `context.rs:752` currently issues `BoardCommand::Delete(DeleteBoard { ... })`. Replace its body with explicit orchestration that wraps the atomic domain commands in a snapshot/rollback:\n\n```rust\n// crates/kanban-service/src/context.rs\nimpl KanbanContext {\n    pub async fn delete_board(&mut self, board_id: Uuid) -> KanbanResult<()> {\n        let snapshot = self.snapshot().await?;\n        let result = self.delete_board_inner(board_id).await;\n        if result.is_err() {\n            self.apply_snapshot(snapshot).await?;\n        }\n        result\n    }\n\n    async fn delete_board_inner(&mut self, board_id: Uuid) -> KanbanResult<()> {\n        // 1. Gather column + card IDs\n        let column_ids = self.list_column_ids_by_board(board_id).await?;\n        let mut all_card_ids: Vec<Uuid> = Vec::new();\n        for col_id in &column_ids {\n            all_card_ids.extend(self.list_card_ids_by_column(*col_id).await?);\n        }\n        all_card_ids.extend(self.list_archived_card_ids_by_columns(&column_ids).await?);\n\n        // 2. Remove graph edges via new atomic dependency command\n        self.execute(Command::Dependency(DependencyCommand::RemoveCards { ids: all_card_ids })).await?;\n\n        // 3. Atomic deletions, propagated outward\n        self.execute(Command::Card(CardCommand::DeleteCardsByColumns { column_ids: column_ids.clone() })).await?;\n        self.execute(Command::Card(CardCommand::DeleteArchivedCardsByColumns { column_ids })).await?;\n        self.execute(Command::Board(BoardCommand::DeleteColumnsByBoard { board_id })).await?;\n        self.execute(Command::Sprint(SprintCommand::DeleteSprintsByBoard { board_id })).await?;\n        self.execute(Command::Board(BoardCommand::Delete(DeleteBoard { board_id }))).await\n    }\n}\n```\n\n### Step 3 — Add `RemoveCards` to `DependencyCommand`\n\n```rust\n// crates/kanban-domain/src/commands/dependency_commands.rs\npub struct RemoveCards { pub ids: Vec<Uuid> }\nimpl RemoveCards {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        let ids = self.ids.clone();\n        context.store.modify_graph(Box::new(move |graph| {\n            for id in &ids { graph.cards.remove_card_edges(*id); }\n            Ok(())\n        }))\n    }\n}\n```\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/board_commands.rs` — simplify `DeleteBoard::execute` (lines 140-189)\n- `crates/kanban-domain/src/commands/dependency_commands.rs` — add `RemoveCards`\n- `crates/kanban-service/src/context.rs` — replace body of existing `delete_board()` at line 752, add private `delete_board_inner()`\n\n## Caller surfaces to verify\n\n- `crates/kanban-cli/src/handlers/board.rs:27-31` — CLI `BoardAction::Delete`\n- `crates/kanban-mcp/src/lib.rs:605-610` — MCP `tool_delete_board()`\n\nThese already call `KanbanContext::delete_board()` so no signature change needed — just verify behaviour after refactor.\n\n## Tests\n\n- Unit: `DeleteBoard` in isolation deletes only the board record\n- Unit: `RemoveCards` correctly removes all edges for given card IDs\n- Integration: `KanbanContext::delete_board()` with a real store verifies all associated entities are removed and the graph has no dangling edges (existing tests should pass unchanged)\n- Integration: Partial failure mid-cascade rolls back to snapshot (new test)",
+        "due_date": null,
+        "id": "e824cef5-14ba-4fe2-b4c3-d0cc73a5cc93",
+        "points": null,
+        "position": 177,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:24:13.846365052Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Todo",
+        "title": "Lift DeleteBoard cascade orchestration into service layer",
+        "updated_at": "2026-05-14T10:57:05.237248364Z"
       },
       {
         "card_number": 380,
@@ -13057,6 +12669,58 @@
         "updated_at": "2026-05-07T22:06:15.245185168Z"
       },
       {
+        "card_number": 428,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-11T21:52:16.841663592Z",
+        "description": "## Problem\n\n`MoveCards` in `kanban-domain` mixes two concerns: domain validation (WIP limit) and algorithmic orchestration (computing target positions by counting cards already in the column):\n\n```rust\n// crates/kanban-domain/src/commands/card_commands.rs:288-326\nlet base = context\n    .store\n    .list_cards_by_column(self.column_id)?\n    .iter()\n    .filter(|c| !id_set.contains(&c.id))\n    .count();\nfor (i, id) in valid_ids.iter().enumerate() {\n    let mut card = context.get_card(*id)?;\n    card.move_to_column(self.column_id, (base + i) as i32);\n    context.store.upsert_card(card)?;\n}\n```\n\nThe position calculation is orchestration — read state, derive values, drive a sequence of mutations. The WIP limit check IS a domain business rule and belongs in the domain.\n\n## Existing structure\n\nThe service layer already wraps this domain command:\n\n- `KanbanContext::move_cards_detailed()` at `crates/kanban-service/src/context.rs:455` — currently delegates to `CardCommand::MoveMultiple(MoveCards { ... })`\n\nThis refactor is **invert the wrap**: move the position calculation up into the existing service method and reduce `MoveCards` to atomic per-card moves (or replace its use with singular `MoveCard`).\n\n## SOLID Solution\n\n**Single Responsibility**: Position calculation becomes a pure function; WIP validation stays in domain; batch orchestration moves up into the service.\n\n**Interface Segregation**: Domain exposes `MoveCard` (singular, atomic) and a pure position helper. The service composes these.\n\n### Step 1 — Extract pure position function into domain\n\n```rust\n// crates/kanban-domain/src/card_lifecycle.rs\npub fn compute_move_positions(\n    existing_cards: &[Card],\n    moving_ids: &HashSet<Uuid>,\n) -> impl Iterator<Item = (Uuid, i32)> + '_ {\n    let base = existing_cards.iter().filter(|c| !moving_ids.contains(&c.id)).count();\n    moving_ids.iter().enumerate().map(move |(i, id)| (*id, (base + i) as i32))\n}\n```\n\nPure, no I/O, fully testable on any platform without a store.\n\n### Step 2 — Remove or reduce `MoveCards` in domain\n\nOption A (preferred): Remove `MoveCards` entirely. Service uses `MoveCard` (singular) in a loop.\nOption B: Keep `MoveCards` but reduce to accept pre-computed `Vec<(Uuid, i32)>` instead of `Vec<Uuid>`.\n\n### Step 3 — Replace body of existing `move_cards_detailed()`\n\n```rust\n// crates/kanban-service/src/context.rs\nimpl KanbanContext {\n    pub async fn move_cards_detailed(\n        &mut self,\n        ids: Vec<Uuid>,\n        column_id: Uuid,\n    ) -> KanbanResult<MoveResult> {\n        // 1. Validate IDs (existing helper)\n        let valid_ids = self.filter_valid_card_ids(&ids).await?;\n\n        // 2. WIP limit check (domain rule)\n        self.check_wip_limit(column_id, valid_ids.len(), &valid_ids).await?;\n\n        // 3. Compute positions (pure function, no I/O)\n        let existing = self.list_cards_by_column(column_id).await?;\n        let id_set: HashSet<Uuid> = valid_ids.iter().copied().collect();\n        let positions: Vec<_> = compute_move_positions(&existing, &id_set).collect();\n\n        // 4. Issue atomic MoveCard commands\n        for (card_id, position) in positions {\n            self.execute(Command::Card(CardCommand::MoveCard {\n                id: card_id,\n                column_id,\n                position,\n            })).await?;\n        }\n        Ok(MoveResult { /* aggregate */ })\n    }\n}\n```\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/card_commands.rs` — remove or reduce `MoveCards` (lines 288-326)\n- `crates/kanban-domain/src/card_lifecycle.rs` — add `compute_move_positions()` pure function\n- `crates/kanban-service/src/context.rs` — replace body of existing `move_cards_detailed()` at line 455\n\n## Caller surfaces to verify\n\n- `crates/kanban-service/src/context.rs:456, 510, 1049-1053` — internal service callers\n- `crates/kanban-cli/src/handlers/card.rs:166` — CLI `CardAction::MoveCards`\n- `crates/kanban-mcp/src/lib.rs:924-930` — MCP `tool_move_cards()`\n\nAll call `KanbanContext::move_cards_detailed()` — no signature change needed.\n\n## Tests\n\n- Unit: `compute_move_positions()` with various combinations of existing/moving cards\n- Unit: WIP limit rejection when batch exceeds column capacity\n- Integration: `KanbanContext::move_cards_detailed()` final positions contiguous and correct (existing tests should pass unchanged)\n\n## Cascade primitives note\n\nIf this lift produces any bulk, validation-bypassing operations that are only valid when executed in a specific sequence, those primitives belong in `cascade_commands` rather than their per-entity module — not because of the entity type, but because of the ordering invariant. Regular commands are self-contained and independently valid; cascade primitives are not.",
+        "due_date": null,
+        "id": "21272340-de01-49c2-89fa-65dfdabdd1ed",
+        "points": null,
+        "position": 178,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:24:13.846376575Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Todo",
+        "title": "Lift MoveCards batch position calculation into service layer",
+        "updated_at": "2026-05-14T10:57:05.237248996Z"
+      },
+      {
+        "card_number": 430,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-11T21:52:21.397986813Z",
+        "description": "## Problem\n\n`MigrateSprintLogs` in `kanban-domain` is a data backfill utility masquerading as a domain command. It fetches all cards, calls a pure migration function, then upserts only modified cards. This is infrastructure-level orchestration — not a domain business rule.\n\n```rust\n// crates/kanban-domain/src/commands/card_commands.rs:439-462\nimpl MigrateSprintLogs {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        let mut cards = context.store.list_all_cards()?;\n        let sprints = context.store.list_all_sprints()?;\n        let boards = context.store.list_boards()?;\n        let before_lens: Vec<usize> = cards.iter().map(|c| c.sprint_logs.len()).collect();\n        let count = crate::card_lifecycle::migrate_sprint_logs(&mut cards, &sprints, &boards);\n        if count > 0 {\n            tracing::info!(\"Migrated sprint logs for {} card(s)\", count);\n            for (card, before_len) in cards.into_iter().zip(before_lens) {\n                if card.sprint_logs.len() != before_len {\n                    context.store.upsert_card(card)?;\n                }\n            }\n        }\n        Ok(())\n    }\n}\n```\n\nThe pure function `card_lifecycle::migrate_sprint_logs()` is correct domain logic and stays. Only the orchestration wrapper moves.\n\n## What to remove from domain\n\n- `pub struct MigrateSprintLogs;` and its `impl` block — `card_commands.rs:439-462`\n- `CardCommand::MigrateSprintLogs(MigrateSprintLogs)` variant — `card_commands.rs:23`\n- The two dispatch arms in `CardCommand::execute` and `CardCommand::description` — `card_commands.rs:40, 57`\n- The serde roundtrip test `test_command_serde_roundtrip_migrate_sprint_logs` — `commands/mod.rs:315-322`\n- The domain inline test `test_migrate_sprint_logs_backfills_cards_missing_sprint_log` — `card_commands.rs:984-1010` — move this coverage to the service integration test instead\n\n## What to add to service\n\nAdd directly on `KanbanContext` (not on `KanbanOperations` — this is a one-time backfill utility, not a regular operation):\n\n```rust\n// crates/kanban-service/src/context.rs\npub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {\n    let mut cards = self.backend.list_all_cards()?;\n    let sprints = self.backend.list_all_sprints()?;\n    let boards = self.backend.list_boards()?;\n    let before_lens: Vec<usize> = cards.iter().map(|c| c.sprint_logs.len()).collect();\n    let count = kanban_domain::card_lifecycle::migrate_sprint_logs(&mut cards, &sprints, &boards);\n    if count > 0 {\n        tracing::info!(\"Migrated sprint logs for {} card(s)\", count);\n        for (card, before_len) in cards.into_iter().zip(before_lens) {\n            if card.sprint_logs.len() != before_len {\n                self.backend.upsert_card(card)?;\n            }\n        }\n    }\n    Ok(count)\n}\n```\n\nNote: `self.backend.list_all_cards()`, `self.backend.list_all_sprints()`, `self.backend.list_boards()`, and `self.backend.upsert_card()` are the correct sync method names — verified from the existing context.rs patterns.\n\n## Undo stack — intentional behaviour change\n\nCurrently the TUI calls this via `execute_command` which routes through `KanbanContext::execute` and lands on the undo stack. After this refactor, the direct call bypasses the undo stack. This is correct — a data migration should not be undoable.\n\n## TUI update\n\n`crates/kanban-tui/src/app/mod.rs:2294-2303` — the private `migrate_sprint_logs` helper on `App` currently does:\n\n```rust\nfn migrate_sprint_logs(&mut self) {\n    let cmd = kanban_domain::commands::Command::Card(\n        kanban_domain::commands::CardCommand::MigrateSprintLogs(\n            kanban_domain::commands::MigrateSprintLogs,\n        ),\n    );\n    if let Err(e) = self.ctx.execute_command(cmd) {\n        tracing::error!(\"Failed to migrate sprint logs: {}\", e);\n    }\n}\n```\n\nReplace with:\n\n```rust\nfn migrate_sprint_logs(&mut self) {\n    if let Err(e) = self.ctx.inner.migrate_sprint_logs() {\n        tracing::error!(\"Failed to migrate sprint logs: {}\", e);\n    }\n}\n```\n\n`self.ctx` is `TuiContext`; `self.ctx.inner` is `KanbanContext`.\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/card_commands.rs` — remove struct, variant, dispatch arms, domain test\n- `crates/kanban-domain/src/commands/mod.rs` — remove serde roundtrip test\n- `crates/kanban-service/src/context.rs` — add `migrate_sprint_logs()`\n- `crates/kanban-tui/src/app/mod.rs:2294-2303` — update caller\n\n## Tests\n\n- Integration: `crates/kanban-service/tests/migrate_sprint_logs.rs` (new file) — two tests: backfill with a card that has `sprint_id` set but empty `sprint_logs`, and no-op when nothing to migrate. Use the same `open_json_ctx` / `open_sqlite_ctx` + macro pattern from `delete_board_cascade.rs`.\n- The pure `card_lifecycle::migrate_sprint_logs()` unit tests in `card_lifecycle.rs:613-660` are untouched.\n\n## Cascade primitives note\n\nIf this lift produces any bulk, validation-bypassing operations that are only valid when executed in a specific sequence, those primitives belong in `cascade_commands` rather than their per-entity module — not because of the entity type, but because of the ordering invariant. Regular commands are self-contained and independently valid; cascade primitives are not.",
+        "due_date": null,
+        "id": "e1edffa0-57f8-40b2-8408-cd23e1b39b6d",
+        "points": null,
+        "position": 179,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:24:13.846383984Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Todo",
+        "title": "Lift MigrateSprintLogs into service layer",
+        "updated_at": "2026-05-14T10:57:05.237249483Z"
+      },
+      {
         "card_number": 385,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -13125,6 +12789,32 @@
         "updated_at": "2026-05-07T22:06:15.245190796Z"
       },
       {
+        "card_number": 431,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-11T21:52:23.673485610Z",
+        "description": "## Problem\n\n`UpdateSprint` in `kanban-domain` is 58 lines mixing three distinct concerns in a single `execute()` method: card_prefix lock checking, prefix uniqueness validation across siblings, and sprint name allocation with board mutation. This makes the method hard to test in isolation and difficult to read.\n\n```rust\n// crates/kanban-domain/src/commands/sprint_commands.rs\nimpl UpdateSprint {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        // 1. Check if card_prefix is being changed\n        //    → fetch sprint → check cards assigned → if locked, error\n        //    → if setting new prefix → fetch board → check board prefix collision\n        //    → fetch sibling sprints → check uniqueness collision\n        // 2. If name is being set\n        //    → fetch sprint → fetch board → allocate name index → upsert board\n        // 3. Fetch sprint → apply updates → upsert sprint\n    }\n}\n```\n\nThe validation logic is domain logic — it belongs in the domain. The problem is organisation, not placement.\n\n## SOLID Solution\n\n**Single Responsibility**: Each validation concern becomes a standalone pure function or method. `execute()` becomes a thin coordinator.\n\n**Open-Closed**: New validation rules (e.g. locked dates, status transitions) can be added as new functions without modifying existing ones.\n\n### Step 1 — Extract card_prefix lock check\n\n```rust\n// crates/kanban-domain/src/commands/sprint_commands.rs\n\nfn validate_card_prefix_not_locked(\n    sprint_id: Uuid,\n    context: &CommandContext,\n) -> KanbanResult<()> {\n    let has_active = !context.store.list_cards_by_sprint(sprint_id)?.is_empty();\n    let has_archived = context\n        .store\n        .list_archived_cards()?\n        .iter()\n        .any(|ac| ac.card.sprint_id == Some(sprint_id));\n    if has_active || has_archived {\n        return Err(KanbanError::validation(\n            \"sprint card_prefix cannot be changed after cards have been assigned\",\n        ));\n    }\n    Ok(())\n}\n```\n\n### Step 2 — Extract prefix uniqueness validation\n\n```rust\nfn validate_card_prefix_unique(\n    new_prefix: &str,\n    sprint_id: Uuid,\n    board_id: Uuid,\n    context: &CommandContext,\n) -> KanbanResult<()> {\n    let new_lower = new_prefix.to_lowercase();\n    let board = context.get_board(board_id)?;\n    if board.card_prefix.as_deref().map(|p| p.to_lowercase()).as_deref() == Some(new_lower.as_str()) {\n        return Err(KanbanError::validation(\n            \"sprint card_prefix must not match the board card_prefix\",\n        ));\n    }\n    let collision = context\n        .store\n        .list_sprints_by_board(board_id)?\n        .iter()\n        .filter(|s| s.id != sprint_id)\n        .any(|s| s.card_prefix.as_deref().map(|p| p.to_lowercase()).as_deref() == Some(new_lower.as_str()));\n    if collision {\n        return Err(KanbanError::validation(\"sprint card_prefix must be unique within the board\"));\n    }\n    Ok(())\n}\n```\n\n### Step 3 — Extract name allocation\n\n```rust\nfn allocate_sprint_name(\n    name: &str,\n    sprint_id: Uuid,\n    context: &CommandContext,\n    updates: &mut SprintUpdate,\n) -> KanbanResult<()> {\n    let sprint = context.get_sprint(sprint_id)?;\n    let mut board = context.get_board(sprint.board_id)?;\n    let idx = board.add_sprint_name_at_used_index(name.to_string());\n    updates.name_index = FieldUpdate::Set(idx);\n    context.store.upsert_board(board)?;\n    Ok(())\n}\n```\n\n### Step 4 — Slim `execute()` coordinates validators\n\n```rust\nimpl UpdateSprint {\n    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {\n        let mut updates = self.updates.clone();\n        let sprint = context.get_sprint(self.sprint_id)?;\n\n        if !matches!(updates.card_prefix, FieldUpdate::NoChange) {\n            validate_card_prefix_not_locked(self.sprint_id, context)?;\n            if let FieldUpdate::Set(ref prefix) = updates.card_prefix {\n                validate_card_prefix_unique(prefix, self.sprint_id, sprint.board_id, context)?;\n            }\n        }\n\n        if let Some(ref name) = updates.name {\n            allocate_sprint_name(name, self.sprint_id, context, &mut updates)?;\n        }\n\n        let mut sprint = context.get_sprint(self.sprint_id)?;\n        sprint.update(updates);\n        context.store.upsert_sprint(sprint)?;\n        Ok(())\n    }\n}\n```\n\n## Files to modify\n\n- `crates/kanban-domain/src/commands/sprint_commands.rs` — extract three private functions, slim `execute()`\n\n## Tests\n\n- Unit: `validate_card_prefix_not_locked` — sprint with cards returns error, sprint without cards passes\n- Unit: `validate_card_prefix_unique` — collision with board prefix, collision with sibling, no collision\n- Unit: `allocate_sprint_name` — correct name index allocated, board upserted\n- Existing integration tests should pass unchanged — behaviour is identical, only structure changes",
+        "due_date": null,
+        "id": "73a9ea39-0c3f-4f19-a4cb-3ea261fc444e",
+        "points": null,
+        "position": 180,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:24:13.846348055Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Todo",
+        "title": "Extract UpdateSprint validators into pure functions",
+        "updated_at": "2026-05-14T10:57:05.237249922Z"
+      },
+      {
         "card_number": 387,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -13159,6 +12849,32 @@
         "updated_at": "2026-05-07T22:06:15.245193452Z"
       },
       {
+        "card_number": 434,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-11T22:58:23.322907941Z",
+        "description": "## Why\n\nKAN-394's service-layer orchestration produced a recurring pattern:\nthe service exposes both a singular and a plural method for the same\nunderlying operation, with the singular doing its own small batch\nconstruction. Today:\n\n- `update_card` (singular) builds its own UpdateCard + chained\n  command batch *asymmetrically* (only `status → column` auto-sync).\n- `update_cards` (plural) builds the same per entry *symmetrically*\n  (both `status → column` and `column → status`), and adds per-batch\n  position offsets to avoid collisions.\n- `assign_card_to_sprint` (singular) wraps\n  `AssignCardsToSprint { ids: vec![id], sprint_id }`. Plain enough to\n  reduce to `assign_cards_to_sprint(vec![id], sprint_id)`.\n- `archive_card` (singular) is **already** a shorthand over\n  `archive_cards(vec![id])` (see `context.rs:950`).\n- `move_card` (singular) takes `position: Option<i32>` while\n  `move_cards` has no per-card position. **Blocked** — see Out of scope.\n\nThe duplication costs us three things:\n\n1. **Behavioural drift**: `update_card`'s asymmetric auto-sync silently\n   misses cases that `update_cards` handles. Any future tweak (e.g.\n   KAN-432's per-board opt-out) has to land in N places that must stay\n   in lock-step.\n2. **Conceptual noise**: two routes through the service for what should\n   be the same operation.\n3. **Wasted maintenance**: every time we touch the orchestration we have\n   to remember every singular/plural pair.\n\n## Design principle\n\n**Singular builds on plural, not the other way around.** The atomic\ntransaction (`KanbanContext::execute(Vec<Command>)`) is the fundamental\nunit at the service layer; the per-card operation lives one layer down\nin the domain commands. The plural method composes the transaction —\nincluding auto-sync chaining, per-batch position offsets, and (later)\nKAN-432's config-driven opt-out. The singular method is a convenience\nwrapper for the batch-of-one case.\n\nWhy this direction and not the reverse:\n\n- **Atomicity is the contract that matters most.** Multi-select 'c' on\n  5 cards must be one undo unit — pressing `u` once must revert all\n  five. If the plural looped the singular, every batch would be N\n  separate undo units. That defeats the purpose of `execute(Vec<Command>)`\n  and regresses the UX we just shipped in commit `d0a8ca9`.\n- **Single source of truth.** Auto-sync direction, position offset\n  tracking, future config flags all live in one place. The singular\n  cannot drift from the plural's semantics because it literally is\n  one entry into the plural.\n- **N = 1 is a clean special case.** A batch of one runs the same\n  orchestration; the position offset map has one entry that increments\n  to 1 and is discarded. No special-case code needed.\n- **Cost is negligible.** One `Vec::new()` + one `get_<entity>` per\n  singular call. We pay it once at construction; we gain a single\n  reasoning surface for every future change.\n\nWhen a future contributor adds another singular variant, the rule is:\ndelegate to the plural with `vec![one]` and (if the return type\nrequires it) trail with a `get_<entity>(id)`. Never invert this and\nhave the plural loop the singular.\n\n## What\n\nMake every eligible singular service method a one-line shorthand over\nits plural counterpart.\n\n### `update_card` → `update_cards`\n\n`crates/kanban-service/src/context.rs::update_card` (around line 843).\nNew body, full replacement:\n\n```rust\nfn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {\n    self.update_cards(vec![(id, updates)])?;\n    self.get_card(id)?\n        .ok_or_else(|| KanbanError::not_found(\"card\", id))\n}\n```\n\nThis deletes:\n\n- The asymmetric `match (updates.status, &updates.column_id)` block.\n- The local `MoveCard` import inside the function.\n- The per-call construction of the chained batch — `update_cards`\n  already does this symmetrically and with offset tracking.\n\n### `assign_card_to_sprint` → `assign_cards_to_sprint`\n\n`crates/kanban-service/src/context.rs::assign_card_to_sprint` (around\nline 1004). New body:\n\n```rust\nfn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {\n    self.assign_cards_to_sprint(vec![card_id], sprint_id)?;\n    self.get_card(card_id)?\n        .ok_or_else(|| KanbanError::not_found(\"card\", card_id))\n}\n```\n\nReplaces the explicit `AssignCardsToSprint { ids: vec![card_id], sprint_id }`\nconstruction and `execute` call with the trait-level shorthand.\n\n### `archive_card`\n\nNo change — it already delegates to `archive_cards(vec![id])` (see\n`context.rs:950–957`). Sanity-check it still looks right after this\nrefactor lands.\n\n## Where the wiring lives\n\n- `crates/kanban-service/src/context.rs::update_card` — collapse.\n- `crates/kanban-service/src/context.rs::assign_card_to_sprint` —\n  collapse.\n- No other files change. The trait signatures\n  (`KanbanOperations::update_card`, `::assign_card_to_sprint`) and\n  their return types are preserved.\n- `move_card`, `move_cards`, and the `*_detailed` inherent methods are\n  untouched — out of scope.\n- The pure helpers in `kanban_domain::card_lifecycle`\n  (`target_column_for_status`, `target_status_for_column_move`) and the\n  private bundling helpers on `KanbanContext` are unchanged.\n\n## Acceptance\n\nFor `update_card`:\n\n- All existing tests in `crates/kanban-service/tests/completion_sync.rs`\n  and `crates/kanban-mcp/tests/integration.rs` stay green.\n- Add three new tests covering the column-only path that previously\n  bypassed auto-sync:\n  - `test_update_card_column_only_to_completion_column_sets_status_done`\n  - `test_update_card_column_only_away_from_completion_clears_done`\n  - `test_update_card_column_only_to_non_completion_column_no_status_change`\n\nFor `assign_card_to_sprint`:\n\n- Existing tests (any in `kanban-service/tests/`, `kanban-mcp/tests/`,\n  `kanban-cli/tests/`) stay green. Behaviour is identical.\n- No new tests needed — it's a pure mechanical reduction with no\n  behaviour change.\n\nAcross both:\n\n- `cargo test --workspace`,\n  `cargo clippy --workspace --all-targets -- -D warnings`,\n  `cargo fmt --check` clean.\n- No callers change. Public signatures preserved.\n\n## Behaviour change for existing callers\n\n| Method | Caller-visible change |\n|---|---|\n| `update_card` | Closes the column-only auto-sync gap. Today no production caller uses this path (TUI uses status-only or both; CLI/MCP forward to `move_card` for column changes). Extension, not break. |\n| `assign_card_to_sprint` | None. Mechanical reduction. |\n| `archive_card` | None. Already a shorthand. |\n\n## Out of scope — `move_card` blocker\n\n`KanbanContext::move_card(id, column_id, position: Option<i32>)` cannot\ncleanly collapse into `move_cards(vec![id], column_id)` because:\n\n- `move_cards` accepts a single target `column_id` for all cards but\n  has no per-card `position` parameter.\n- The underlying `MoveCards` domain command in\n  `crates/kanban-domain/src/commands/card_commands.rs` does not carry\n  per-card positions — it appends.\n- Routing `move_card` through `update_cards(vec![(id, CardUpdate {\n  column_id: Some(col), position, .. })])` would bypass the WIP-limit\n  check that `MoveCard::execute` performs (`UpdateCard::execute` does\n  not check WIP limits — likely a separate latent bug).\n\nResolving this would require either:\n\n1. Adding per-card positions to `MoveCards` (signature + command +\n   storage change), OR\n2. Surfacing WIP-limit checking inside `UpdateCard::execute` so\n   `update_cards` can safely subsume column changes.\n\nBoth are non-trivial and worth a dedicated follow-up — not this card.\n\n## Commit shape\n\nOne `refactor(service)` commit covering both reductions + the three\nnew `update_card` column-only tests. Roughly:\n\n- `crates/kanban-service/src/context.rs` — ~50 lines deleted, ~10 added.\n- `crates/kanban-service/tests/completion_sync.rs` — ~80 lines added.\n\n## Notes\n\n- KAN-432 (per-board auto-sync config) lands cleanest *after* this\n  card: it only has to thread the flag through `update_cards` and\n  `move_cards`, not the singular variants too.\n- KAN-433 (drop dead lifecycle helpers) is independent — can land\n  before or after.\n- If the WIP-limit-on-update concern ends up mattering before the\n  `move_card` collapse is attempted, file as a separate card.\n\n## Risk\n\nVery low. The new `update_card` and `assign_card_to_sprint` behaviour\nis exactly what `update_cards(vec![(id, updates)])` and\n`assign_cards_to_sprint(vec![id], sprint_id)` already do today —\nlocked down by the existing batch tests.",
+        "due_date": null,
+        "id": "1791bdf5-4285-47ef-9b44-72dc3586c8d6",
+        "points": 3,
+        "position": 181,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:24:24.403406690Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Todo",
+        "title": "refactor(service): collapse singular service methods into shorthands over their plural counterparts",
+        "updated_at": "2026-05-14T10:57:05.237250580Z"
+      },
+      {
         "card_number": 388,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -13183,6 +12899,49 @@
         "status": "Todo",
         "title": "feat: add sprint rename — MCP tool, CLI command, and TUI action",
         "updated_at": "2026-05-07T21:58:57.806935960Z"
+      },
+      {
+        "card_number": 435,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-11T23:24:55.116154968Z",
+        "description": "# KAN-435: sprint-detail card lists reuse the main-board CardListComponent\n\n## Original report\n\nThe narrow bug: scrolling didn't work inside the sprint-detail card lists. While planning the fix the scope expanded into \"sprint detail should behave like the main board\" — same renderer, same actions, same view modes.\n\n## Phase 1 — shipped (PR #261, branch `KAN-435/scrolling-in-the-card-lists-of-sprint-details`)\n\nSix commits, branch ready for merge:\n\n- `71cf133` `refactor(tui): align sprint-detail panel action configs with main-board card list` — both panels use `CardListComponentConfig::default()`; Completed gains multi-select, Uncompleted gains movement\n- `f61180e` `fix(tui): sprint-detail card lists scroll when selection passes viewport` — `SprintViewState::sync_scroll(uncompleted_viewport, completed_viewport)` called from `render_sprint_detail_with_tasks` with per-panel viewport heights\n- `8412f11` `refactor(tui): populate sprint-detail panels via CardQueryBuilder` — board's `task_sort_field` / `task_sort_order` apply on populate\n- `20cdf53` `chore: add changeset for KAN-435 partial implementation`\n- `1873230` `chore(tui): drop redundant comments on sprint-detail scroll and populate`\n- `0f40d2f` `test(tui): cover sort-on-populate and handler→raw-CardList sync in sprint detail`\n\nTests: 8 in `crates/kanban-tui/tests/sprint_detail_card_list_tests.rs` (scrolling, multi-select symmetry, movement enablement, default-panel focus, panel independence, sort-on-populate, handler→raw-CardList sync at `detail_view_handlers.rs:982`, status partitioning). Workspace tests 0 failures; clippy + fmt clean.\n\n## Phase 2 — not started\n\nPhase 1 fixed the literal bug + lifted action parity but kept the sprint-detail panels on a bespoke render path. The user's expanded intent: sprint detail should be the **same view-strategy machinery** the main board uses, just with different column definitions. Concretely:\n\n- **Kanban** in sprint detail = two side-by-side panels, columns = `[Uncompleted, Completed]`\n- **GroupedByColumn** = single list with `Uncompleted` / `Completed` section headers\n- **Flat** = single list of every sprint card\n\nSame key bindings as the main board (`h`/`l` switch panels, `H`/`L` move cards between *board* columns, `v`/`V` multi-select, `e` edit, `/` search, `o`/`O` sort, `V`-uppercase toggle view, Enter/Space open detail, `n` create, `d` archive). When a card is selected in the Uncompleted panel, the original board column it lives in shows as a label on the panel title. Completed cards get no extra label.\n\nThis is a substantial refactor of the view-strategy abstraction, not a bug fix.\n\n## Approach\n\n### 1. Make the view-strategy column-partition-agnostic\n\nToday the view strategy (`crates/kanban-tui/src/view_strategy.rs`, `layout_strategy.rs`) hardcodes board columns as the partition source. `ColumnListsLayout` builds one `CardList` per `board.column`; `VirtualUnifiedLayout` and `SingleListLayout` use the board's flat card list.\n\nIntroduce a `ColumnPartition` shape — minimal:\n\n```rust\n// new in crates/kanban-tui/src/view_strategy.rs\npub struct ColumnPartition {\n    pub title: String,\n    pub cards: Vec<Uuid>,  // pre-filtered, pre-sorted IDs\n}\n```\n\nThe layout strategy takes `Vec<ColumnPartition>` instead of computing from `board.columns`. Two adapters build these:\n\n- **Main board**: `build_board_partitions(board, ctx)` → one partition per board column, cards filtered/sorted via `CardQueryBuilder::in_column`.\n- **Sprint detail**: `build_sprint_partitions(sprint_id, board, ctx)` → two partitions, `Uncompleted` and `Completed`, each filtered+sorted via `CardQueryBuilder::in_sprints`, then post-partitioned by `card.is_completed()`.\n\n`ViewRefreshContext` gains a `partitions: Vec<ColumnPartition>` source field. The board chooses its source at `prepare_frame` time based on whether the active mode is `SprintDetail` or the normal board view.\n\n### 2. Sprint detail uses `ViewStrategy` end-to-end\n\nDelete `SprintViewState::{uncompleted_cards, completed_cards, sync_scroll, uncompleted_component, completed_component}`. Replace with one `view_strategy: Box<dyn ViewStrategy>` reflecting the current `task_list_view`. The strategy holds the layout (Flat / Grouped / Kanban) and the partitions.\n\n- `SprintViewState::panel` becomes the index into `Vec<ColumnPartition>` — `0 = Uncompleted, 1 = Completed`. h/l moves the panel index. In Flat or GroupedByColumn views, panel switching is a no-op (single list).\n- All key handling delegates to the active layout's selected `CardListComponent`, same as the main board.\n\n### 3. Render path collapses to the existing `RenderStrategy`\n\n`crates/kanban-tui/src/ui/sprint_detail.rs::render_sprint_detail_with_tasks` becomes:\n\n```rust\n// after sprint metadata at top, give the rest of `area` to the strategy\nlet view_area = ...;\napp.sprint_view.view_strategy.render(&app, frame, view_area);\n```\n\nSame as the main board's `render_tasks`. The `RenderStrategy` (`SinglePanelRenderer` / `MultiPanelRenderer`) renders into whatever `Rect` you give it. The bespoke `render_sprint_task_panel_with_selection` and its hand-rolled `Paragraph` loop are deleted.\n\nThis also brings **horizontal-truncation handling** along, since the renderer already truncates long card titles to fit `area.width` (it's the same `render_card_list_item` helper).\n\n### 4. Original-column label on the focused panel\n\nWhen the focused partition is `Uncompleted` (panel index 0), the selected card's board column name is shown in the panel title:\n\n```\n┌ Uncompleted (5) → InProgress ──────────────┐\n```\n\nImplementation: at render time, read `selected_card.column_id` from `app.model.cards()`, look up the column name in `app.model.columns()`, suffix the panel title. Completed (index 1) renders without the suffix per the user spec. The label is a render-time computation, not stored state.\n\n### 5. Original-column tracking on un-complete\n\nCarried over from phase 1's plan. `SprintViewState::original_columns: HashMap<Uuid, Uuid>`. When the user toggles `c` on a card in the Uncompleted partition, record `card_id → card.column_id` before issuing the status update. When toggling `c` on a Completed card with an entry in the map, route the move back to the recorded column (`update_card` with both `status` and `column_id` set — KAN-394's `(Some, Some) → respect both` branch).\n\nPre-existing Completed cards (no map entry) keep KAN-394's second-to-last fallback. In-memory only, resets when sprint detail closes.\n\n### 6. Search and `prepare_frame` integration\n\nThe board's existing `prepare_frame` (`crates/kanban-tui/src/app/mod.rs:1541`) rebuilds the main-board strategy each frame using a `ViewRefreshContext`. Extend it to also rebuild the sprint-detail strategy when `app.mode` (or the base mode) is `SprintDetail`. The sprint-specific `ViewRefreshContext` carries the same `search_query` and active sprint as the main board — search now propagates.\n\n### 7. Key parity verification\n\nAfter steps 1–3, every key the main board's `CardListComponent` responds to now works in sprint detail too because both routes through the same component and the same `render_strategy.handle_key` path. Specifically:\n\n| Key | Sprint detail behaviour after refactor |\n|---|---|\n| `j`/`k` | Navigate selection (with scroll already wired) |\n| `h`/`l` | Switch panel index in Kanban view; no-op in Flat/Grouped |\n| `H`/`L` | Move card between *board* columns (status auto-syncs via KAN-394) |\n| `v`/`V`-lower | Single-select / select all |\n| `V`-upper | Open view-mode picker dialog |\n| `e` | Edit card |\n| `/` | Search |\n| `o`/`O` | Sort dialog / toggle order |\n| `n` | Create card |\n| `d` | Archive selected |\n| `Enter`/`Space` | Open card detail |\n\nSprint-specific keys (`a` activate sprint, `M` carry over, `C` sprint card prefix, etc.) remain intercepted by the sprint-detail handler before the component delegation.\n\n## Files modified\n\n| File | Change |\n|---|---|\n| `crates/kanban-tui/src/view_strategy.rs` | Introduce `ColumnPartition`. `ViewRefreshContext` gains `partitions: Vec<ColumnPartition>`. Layouts consume partitions instead of looking up `board.columns` directly. |\n| `crates/kanban-tui/src/layout_strategy.rs` | `ColumnListsLayout` / `VirtualUnifiedLayout` / `SingleListLayout` rebuilt from partitions. `build_query` becomes a helper that yields a partition. |\n| `crates/kanban-tui/src/app/sprint_view.rs` | Replace dual `CardList` + `CardListComponent` fields with `view_strategy: Box<dyn ViewStrategy>` + `original_columns: HashMap<Uuid, Uuid>`. `panel: SprintTaskPanel` becomes `partition_index: usize`. `sync_scroll` is gone (strategy handles it). |\n| `crates/kanban-tui/src/app/mod.rs` | `prepare_frame` builds the sprint-detail strategy when in `AppMode::SprintDetail`. `populate_sprint_task_lists` and `apply_sort_to_sprint_lists` are deleted (subsumed by the strategy refresh). `partition_sprint_cards` no longer used here. |\n| `crates/kanban-tui/src/ui/sprint_detail.rs` | `render_sprint_detail_with_tasks` calls the strategy's render. `render_sprint_task_panel_with_selection` deleted. Title-suffix logic for the focused-partition original-column label lives here. |\n| `crates/kanban-tui/src/handlers/detail_view_handlers.rs` | Sprint-specific intercepts stay; everything else delegates to strategy. `c` toggle hooks `original_columns` for the round-trip behaviour. h/l swaps the partition index. |\n| `crates/kanban-tui/tests/sprint_detail_card_list_tests.rs` | Existing 5 tests update to the new state shape. Add: view-mode-toggle test, original-column-label test, original-column-roundtrip test, search-filter-propagation test, H/L card-move test. |\n\n## Reuse — already in place\n\n- `kanban_domain::CardQueryBuilder` for filter+sort (phase 1 already plumbed this in for populate)\n- `UnifiedViewStrategy::flat() / ::grouped() / ::kanban()`, `SinglePanelRenderer`, `MultiPanelRenderer`\n- `render_card_list_item` (handles truncation already)\n- `CardListComponent::handle_key` (full action set), `ensure_selected_visible`\n- KAN-394 service-layer auto-sync for status ↔ column on the un-complete round-trip\n\n## Verification\n\n```bash\ncargo test --workspace\ncargo clippy --workspace --all-targets -- -D warnings\ncargo fmt --check\n```\n\nNew tests in `crates/kanban-tui/tests/sprint_detail_card_list_tests.rs`:\n\n1. `test_sprint_detail_kanban_view_renders_two_panels`\n2. `test_sprint_detail_grouped_view_renders_single_list_with_status_headers`\n3. `test_sprint_detail_flat_view_renders_single_list_no_partition`\n4. `test_sprint_detail_focused_panel_title_shows_selected_card_original_column`\n5. `test_sprint_detail_completed_panel_title_has_no_extra_label`\n6. `test_sprint_detail_uncomplete_returns_card_to_original_column`\n7. `test_sprint_detail_uncomplete_falls_back_to_kan_394_for_pre_existing_completed_cards`\n8. `test_sprint_detail_search_filter_propagates_to_panels`\n9. `test_sprint_detail_capital_l_moves_card_right_between_board_columns`\n10. `test_sprint_detail_scroll_preserved_after_view_mode_switch`\n\nManual smoke (`kanban ~/notes/memes/kanban.json`):\n\n1. Enter sprint detail. Press uppercase `V` to open view picker. Pick Flat — sprint cards collapse into one list. Pick Grouped — section headers appear. Pick Kanban — two panels return.\n2. In Kanban view: select a card in Uncompleted. Panel title shows \" → <column-name>\". Press `H` — card moves left between board columns; auto-syncs status if it leaves the completion column.\n3. In Kanban view: `c` on Uncompleted card → moves to Completed panel (and to completion column on the underlying board). `c` again → returns to the column it came from (not the second-to-last fallback).\n4. Press `/`, type a query — both panels filter (in Kanban) or the single list filters (Flat/Grouped).\n\n## Commit strategy — additive, layered\n\nAiming to keep each commit independently green so bisect stays useful:\n\n1. **`refactor(tui): introduce ColumnPartition; main-board path unchanged`** — internal refactor of view-strategy/layout-strategy to accept partitions. Main board's adapter computes from `board.columns` (no behaviour change). Existing tests stay green.\n2. **`feat(tui): sprint detail builds its own ColumnPartitions`** — sprint-detail adapter; remove `populate_sprint_task_lists` and friends. Sprint detail still renders via bespoke path (next commit).\n3. **`refactor(tui): sprint detail delegates rendering to ViewStrategy`** — delete bespoke render; route through main-board renderer. Scrolling, action set, view modes all gained.\n4. **`feat(tui): focused-panel title shows selected card original column`** — render-time enrichment of the title.\n5. **`feat(tui): original-column tracking on un-complete in sprint detail`** — `original_columns` map + `c`-handler hook.\n6. **`feat(tui): prepare_frame propagates search filter to sprint detail`** — every-frame strategy rebuild when in `SprintDetail` mode.\n7. **`test(tui): expand sprint-detail coverage for view modes, label, round-trip, search, H/L`** — the 10 new tests above.\n8. **`chore: update KAN-435 changeset for phase 2`** — replace phase-1 wording with the full story.\n\n## Risk\n\nHigh. This is the largest single TUI refactor in this card line — view-strategy abstraction touches every render path. Mitigations:\n\n- Step 1 keeps main board behaviour byte-identical; verify by running existing tests untouched.\n- Steps 2–3 are scoped to sprint detail; main board can't regress because its adapter is unchanged.\n- Step 7 adds explicit regression tests for every claimed feature.\n\nIf steps 1–3 turn out to require a much bigger rewrite than estimated, fall back to: keep the bespoke sprint-detail render but add view-mode switching as a separate `SprintViewState` field, accept the duplication. That's a structurally weaker outcome but ships the user-visible features without the deep refactor.\n\n## Out of scope (file as separate cards if needed)\n\n- Per-panel independent view mode (Uncompleted in Flat while Completed in Grouped). Today's plan shares one view mode across both panels in Kanban; if independent modes turn out to matter, file separately.\n- Persisting `original_columns` across sessions. In-memory map suffices for the common workflow.\n- Card-position memory inside the column (returning to a *specific position* in the original column, not just the column itself). Today the card lands at the column's append position.",
+        "due_date": null,
+        "id": "26b740aa-b5d7-4a71-8b56-cd22b314e3e7",
+        "points": 1,
+        "position": 182,
+        "priority": "Low",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-11T23:25:47.767081947Z",
+            "status": "Active"
+          }
+        ],
+        "status": "Todo",
+        "title": "Scrolling in the card lists of sprint details",
+        "updated_at": "2026-05-14T10:57:05.237251340Z"
+      },
+      {
+        "card_number": 445,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-13T23:04:21.997580929Z",
+        "description": "Origin: surfaced in PR #255 conversation as \"It's related to the changes from #249, in that it breaks my ability to launch kanban with a file I've just created, at least on Windows.\" Independent of #255 itself — separate bug, separate fix.\n\n## Summary\n\nPR #249 introduced kanban-service/src/path.rs::validate_path, which is now called from kanban-cli/src/app.rs before opening the data file. On Windows, validate_path rejects valid in-cwd paths whenever the target file actually exists, with the misleading error \"Path traversal not allowed\".\n\n## Offending code (crates/kanban-service/src/path.rs, lines 22-35)\n\n    if path.is_absolute() {\n        Ok(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()))\n    } else {\n        let resolved = cwd.join(path);\n        let canonical = resolved\n            .canonicalize()\n            .unwrap_or_else(|_| normalize_path(&resolved));\n        if !canonical.starts_with(cwd) {\n            return Err(KanbanError::validation(format!(\n                \"Path traversal not allowed: '{}' resolves outside current directory\",\n                path.display()\n            )));\n        }\n        Ok(canonical)\n    }\n\n## Root cause\n\nstd::fs::canonicalize on Windows always returns a UNC long-path: \\\\?\\C:\\Users\\foo\\kanban.json. This is a long-standing Rust stdlib quirk; the stdlib docs explicitly warn about it, and the `dunce` crate exists solely to strip the prefix.\n\nstd::env::current_dir() returns a non-UNC path: C:\\Users\\foo.\n\nOn the relative-path branch:\n\n    cwd       = C:\\Users\\foo\\proj\n    canonical = \\\\?\\C:\\Users\\foo\\proj\\kanban.json\n    canonical.starts_with(cwd) -> false\n\nPath::starts_with is component-based, and the UNC prefix introduces an extra \\\\?\\ component. The traversal check rejects the path even though it resolves to a file literally inside cwd. The user sees \"Path traversal not allowed: 'kanban.json' resolves outside current directory\" — a false positive.\n\n## Why only \"file I just created\" triggers it\n\ncanonicalize requires the target to exist. When the file does not exist yet, the unwrap_or_else fallback to normalize_path runs, which produces a non-UNC path; starts_with succeeds and the call returns OK.\n\nSo the reproduction is sensitive to whether the file was created before launch:\n\n    kanban kanban.json     (file doesn't exist) -> works (creates new, no UNC produced)\n    New-Item kanban.json\n    kanban kanban.json     (file now exists)    -> \"Path traversal not allowed\"\n\nThe absolute-path branch (line 23) is also affected but in a different way: canonicalize succeeds, the UNC-prefixed PathBuf is returned, and the prefix leaks downstream to whichever store opens the file. Whether that breaks depends on the downstream consumer's tolerance for UNC paths; in practice many Windows APIs handle both, so this branch may be silently fine — but it is still wrong-shaped.\n\n## Why CI did not catch it\n\n- .github/workflows/ci.yml runs only on ubuntu-latest. No Windows job. On Linux/macOS canonicalize does not UNC-prefix, so the bug is invisible to CI.\n- The unit test test_validate_path_relative_within_cwd_returns_resolved uses Path::new(\"some/nested/file.json\") inside a fresh TempDir — the file does not exist, so the test hits the normalize_path fallback, not the canonicalize branch. Same on every OS.\n- test_validate_path_absolute_passes_through uses dir.path().join(\"file.json\") which also does not exist. Same fallback.\n\nThere is literally zero coverage of \"the file exists\" on the canonicalize branch.\n\n## Suggested fixes (three options)\n\n1. Use `dunce::canonicalize` instead of Path::canonicalize. The dunce crate is ~150 LOC, single-purpose, and returns \\\\?\\C:\\... -> C:\\.... Drop-in:\n\n       let canonical = dunce::canonicalize(&resolved).unwrap_or_else(|_| normalize_path(&resolved));\n\n   Apply on both the absolute-path and relative-path branches. This is the conventional Rust answer for this exact bug.\n\n2. Strip the prefix manually on Windows, no new dep:\n\n       fn strip_unc(p: PathBuf) -> PathBuf {\n           #[cfg(windows)] {\n               if let Some(s) = p.to_str().and_then(|s| s.strip_prefix(r\"\\\\?\\\")) {\n                   return PathBuf::from(s);\n               }\n           }\n           p\n       }\n\n   Wrap both canonicalize calls.\n\n3. Canonicalize both sides before comparing. Canonicalize cwd too on the relative-path branch; both have UNC, starts_with works. Does not address the absolute-path branch leaking UNC downstream.\n\nOption 1 is the cleanest and matches what the rest of the Rust ecosystem does.\n\n## Tests to add (regardless of fix shape)\n\n- test_validate_path_relative_within_cwd_existing_file_returns_resolved — create the file inside TempDir before calling validate_path_with_cwd. Currently this would panic on Windows (and only Windows) due to the bug. With the fix it should pass everywhere.\n- test_validate_path_absolute_existing_file_returns_non_unc — same idea for the absolute branch.\n- Add a Windows job to CI (or at minimum a cargo test --target x86_64-pc-windows-msvc cross-check in a separate matrix entry) so this class of bug is caught next time.\n\n## Severity\n\nHigh-ish. It is a hard \"I can't open my data\" failure for Windows users who pre-create their kanban file. Workaround is to delete the file and let kanban (re)create it, which only works if the file is empty.\n",
+        "due_date": null,
+        "id": "9adc4dd2-b9cd-4984-8272-2a7169ed70ad",
+        "points": null,
+        "position": 183,
+        "priority": "High",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "bug(service): validate_path rejects existing files on Windows (canonicalize UNC prefix)",
+        "updated_at": "2026-05-14T10:57:05.237251799Z"
       },
       {
         "card_number": 390,
@@ -13211,6 +12970,49 @@
         "updated_at": "2026-05-07T21:58:57.806938498Z"
       },
       {
+        "card_number": 449,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-14T02:29:47.894356833Z",
+        "description": "Follow-up to PR #267 (KAN-445) — `test_apply_config_edit_with_non_default_content_writes_config` at `crates/kanban-tui/tests/settings_ui_tests.rs:357` reintroduces the nixpkgs sandbox failure class that KAN-396 closed for the other `apply_config_edit` tests. Discovered during the post-merge audit of the 0.5.0 release (PR #251).\n\n## Where\n\n`crates/kanban-tui/tests/settings_ui_tests.rs:357-368`\n\n## Failure mode\n\nThe test builds a DTO from `AppConfig::default()`. `AppConfigDto::from_config` populates `configuration_location` via `effective_configuration_location(entity)`, which falls back to `config_path()` → `dirs::config_dir().join(\"kanban/config.toml\")` when the entity's `configuration_location` is `None`.\n\nIn a Nix build sandbox `$HOME` is a non-writable stub (typically `/homeless-shelter`), so `config::save`'s `create_dir_all` returns `EACCES`, `apply_config_edit` returns `Err`, and `assert!(result.is_ok())` panics.\n\nSame shape as the [2026-05-07 nixpkgs-update log](https://nixpkgs-update-logs.nix-community.org/kanban/2026-05-07.log) that KAN-396 fixed for the five tests in `settings_config_edit_tests.rs`.\n\n## Fix\n\nPin `app.app_config.configuration_location` to a `tempfile::tempdir()` path **before** building the DTO, so `effective_configuration_location` returns the tempdir path instead of the OS config dir.\n\n```rust\nlet dir = tempfile::tempdir().unwrap();\nlet config_path = dir.path().join(\"config.toml\");\nlet mut app = App::test_default();\napp.app_config = kanban_core::AppConfig {\n    default_card_prefix: Some(\"feat\".into()),\n    configuration_location: Some(config_path.to_string_lossy().into_owned()),\n    ..Default::default()\n};\n```\n\n## Verification\n\nReproduced the failure end-to-end on the dev machine by running the **pre-fix** test binary with `env -u XDG_CONFIG_HOME HOME=/var/empty` (forces `dirs::config_dir()` to resolve to an unwritable path, simulating the Nix sandbox).\n\n- Pre-fix binary: **FAILED** at `settings_ui_tests.rs:367:5` (the `assert!(result.is_ok())` line).\n- Post-fix binary, same environment: **PASSED**.\n\n## Status\n\n- PR #269 against `develop` (branch `KAN-449/make-apply-config-edit-test-sandbox-safe`). Replaces closed PR #268 (renamed branch to follow naming convention).\n- Two commits: the test fix + a changeset.\n\n## Latent risk NOT addressed in this card\n\nTwo other tests in `settings_config_edit_tests.rs` (the `_ = app.apply_config_edit(...)` pattern at lines 274 and 294) currently pass on Nix only by accident — `save()` fails early, `self.app_config` is never updated, and the assertions hold for the wrong reason. They are not panicking today, so they ride along. The durable fix is to make `config::save()` return an explicit error when `configuration_location` is unset, rather than silently falling back to `dirs::config_dir()`. That is a production-code change, separate card if/when it comes up.\n\n## Acceptance\n\n- PR #269 merged into `develop`.\n- The fix is verified by running the test binary with `env -u XDG_CONFIG_HOME HOME=/var/empty`.\n- The next nixpkgs-update bump survives without hitting this failure class.",
+        "due_date": null,
+        "id": "69918467-09bc-4d57-a6fe-d50632f7e2d7",
+        "points": null,
+        "position": 184,
+        "priority": "High",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "Make apply_config_edit non-default-content test sandbox-safe",
+        "updated_at": "2026-05-14T10:57:05.237252149Z"
+      },
+      {
+        "card_number": 394,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-05-04T21:17:06.109506890Z",
+        "description": "## Issue\n\nWhen an MCP agent sets a card's status to 'done', the card is marked complete but remains in its current column. It is not automatically moved to the board's completion column.\n\nThis creates a three-step manual workaround in the TUI:\n1. Open the TUI\n2. Navigate to the card\n3. Move it to the Complete column manually\n\nAdditionally, pressing 'c' in the TUI on an already-completed card does not move it — it unmarks it as complete instead.\n\n## Observed (2026-05-05) — inverse direction also broken\n\nMoving a card to the last column via MCP (tool_move_card) does NOT set the card's status to 'done' or populate completed_at. The completion column has no special meaning to the MCP layer — it treats it as an ordinary column move.\n\nThis confirms the bug is bidirectional: the status field and column position are not kept in sync in either direction by the MCP server.\n\n## Expected behaviour\n\nWhen a card's status is set to 'done' (via MCP or TUI), it should be automatically moved to the board's designated completion column (if one is configured). Conversely, when a card is moved to the completion column (via MCP or TUI), its status should be set to 'done' and completed_at populated. 'c' in the TUI should move a done card to the completion column, not toggle completion off.\n\n## Suggested fix\n\n- MCP move_card: after moving, check if destination is completion_column_id; if so, call the same lifecycle hook that sets status=done and completed_at\n- MCP update_card status=done: after updating, move card to completion_column_id if set\n- TUI 'c': on an already-done card in a non-completion column, move it to completion column rather than unmarking it\n- Root fix: see card 324 — remove CardStatus entirely and derive completion state solely from column position\n\n---\n\n# Implementation discussion (2026-05-11)\n\n## What was implemented (branch `KAN-394/bug-marking-card-done-via-mcp-...`)\n\nAuto-sync of the status ↔ completion-column invariant baked into the **domain command layer**:\n\n**Files changed (382 lines added, 1 removed):**\n- `crates/kanban-domain/src/card_lifecycle.rs` — two new pure helpers:\n  - `target_column_for_status(card, new_status, board, columns, cards) -> Option<(Uuid, i32)>`\n  - `target_status_for_column_move(card, new_column_id, board, columns) -> Option<CardStatus>`\n- `crates/kanban-domain/src/commands/card_commands.rs` — auto-sync wired into `UpdateCard::execute` and `MoveCard::execute`; 6 inline unit tests + a `CompletionFixture` helper\n- `crates/kanban-mcp/tests/integration.rs` — 3 end-to-end MCP integration tests\n- `.changeset/kan-394-mcp-sync-card-status-with-completion-column.md` — patch bump\n\n**Behaviour:**\n- `UpdateCard { status: Done }` (no column_id) → auto-moves card to `Board::resolve_completion_column` (which falls back to the last column when `completion_column_id` is unset), sets `completed_at`\n- `UpdateCard { status: Todo }` on a card in the completion column (no column_id) → moves to second-to-last column, clears `completed_at`\n- `MoveCard` to the completion column → sets `status=Done`, populates `completed_at`\n- `MoveCard` away from the completion column on a Done card → sets `status=Todo`, clears `completed_at`\n- When the caller passes **both** `column_id` and `status` (e.g. the TUI's atomic toggle), explicit caller intent wins; auto-sync is bypassed\n\n**Verification:**\n- 6 new unit tests in `card_commands.rs::tests` — all green\n- 3 new MCP integration tests (`mcp_update_card_status_to_done_moves_to_completion_column`, `mcp_move_card_to_completion_column_sets_status_done`, `mcp_move_card_away_from_completion_column_clears_done_status`) — all green\n- Full workspace test suite green (no regressions in TUI h/l/c handlers)\n- `cargo clippy --workspace --all-targets -- -D warnings` clean\n- `cargo fmt --check` clean\n\n## Open design questions raised in review (not yet committed)\n\n### Q1. Is the TUI now doing redundant work?\n\nThe TUI `toggle_card_completion` (in `crates/kanban-tui/src/handlers/card_handlers.rs`) still pre-computes target column + status via `compute_completion_toggle`, then issues `UpdateCard` with **both** fields populated. The auto-sync's \"respects_both\" branch lets these pass through untouched, so the TUI is unaffected — but the pre-computation is now duplicate work relative to a simplified TUI that just sends `status: Some(Done)`.\n\n**Trade-off:**\n- Simplified TUI = less code, single source of truth\n- But TUI already has board/columns/cards in `Model`; the domain auto-sync re-queries the store (3 extra reads per op)\n\n**Decision (tentative):** leave TUI as-is; file a separate \"simplify TUI completion handlers\" follow-up if pursued. Per CLAUDE.md \"a bug fix doesn't need surrounding cleanup.\"\n\n### Q2. Is auto-sync the right default? Should it be configurable?\n\nThe \"last column = completion\" assumption was already baked into the codebase via:\n- `Board::resolve_completion_column` falling back to last column\n- TUI 'c' key, h/l with completion-column transitions\n- `Card::update_status` setting `completed_at`\n\nThe change makes that pre-existing opinion **consistent** across entry points rather than introducing a new one — but it does so on *any* status/column change, not just on user gestures in the TUI. A user setting `status=Done` programmatically (CLI, MCP) without intending a column move would be surprised.\n\n**Real concern:** some workflows treat \"Done\" column as a stage (e.g. \"Done by dev, awaiting review\") rather than a completion gate. Auto-syncing forces a stronger semantic than those users want.\n\n**Proposed config knob (deferred):**\n- `Board.auto_sync_completion: bool` (default true), or\n- App-level `AppConfig.completion_sync_mode: { Strict | Suggest | Off }`\n\n**Decision (tentative):** ship default-on behaviour to fix the filed bug; file a follow-up card for configurability if real demand emerges.\n\n### Q3. Would chained commands be a cleaner architecture?\n\nYes — and likely the right long-term design. Instead of baking the side-effect into `UpdateCard::execute()`, the cleaner pattern is to compose at the service layer:\n\n```rust\n// In KanbanContext::update_card or a command-builder helper\nlet mut cmds = vec![UpdateCard { status: Done, .. }];\nif board.auto_sync_completion {\n    if let Some((col, pos)) = target_column_for_status(...) {\n        cmds.push(MoveCard { card_id, column_id: col, new_position: pos });\n    }\n}\nself.execute(cmds)?;  // already executes batches as a single undo unit\n```\n\n**Benefits:**\n- Each command stays single-purpose (SRP — the principle CLAUDE.md cites)\n- Auto-sync is observable in the command log (better for debugging and the eventual cross-client undo work in KAN-409/410)\n- Config gates the chain at one place, not deep inside each command\n- Undo already works on batches, so atomicity is preserved\n- The pure helpers (`target_column_for_status`, `target_status_for_column_move`) remain reusable regardless of where they are called\n\n**Cost:**\n- Composition logic moves to a higher layer (service or a builder helper)\n- Two call sites need to opt into the chain (UpdateCard path + MoveCard path)\n\n**Decision (pending):** the current branch implements the in-command approach. A refactor to chained commands at the service layer (`KanbanContext::update_card` and `KanbanContext::move_card`) is feasible without throwing away the work: keep the pure helpers, move the orchestration up. The unit tests on the commands would migrate to service-layer integration tests; the MCP integration tests stay valid since they test end-to-end behaviour.\n\n## Status\n\n- **Branch:** `KAN-394/bug-marking-card-done-via-mcp-does-not-move-it-to-the-completion-column`\n- **Tests passing:** yes (workspace-wide)\n- **Not yet committed:** working tree changes pending decision on Q3 (chained-commands refactor or ship as-is)\n- **Out of scope for this card:** Q2 config knob, Q1 TUI simplification, `MoveCards` batch path, TUI 'c' edge case for legacy-data Done-not-in-completion-column state",
+        "due_date": null,
+        "id": "ab7cfd7d-5dd8-4840-9371-f2d7732fbe0a",
+        "points": null,
+        "position": 185,
+        "priority": "High",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T21:58:57.806908436Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "bug: marking card done via MCP does not move it to the completion column",
+        "updated_at": "2026-05-14T10:57:05.237252659Z"
+      },
+      {
         "card_number": 392,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -13237,30 +13039,82 @@
         "updated_at": "2026-05-07T21:58:57.806912858Z"
       },
       {
-        "card_number": 394,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "card_number": 229,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
         "completed_at": null,
-        "created_at": "2026-05-04T21:17:06.109506890Z",
-        "description": "## Issue\n\nWhen an MCP agent sets a card's status to 'done', the card is marked complete but remains in its current column. It is not automatically moved to the board's completion column.\n\nThis creates a three-step manual workaround in the TUI:\n1. Open the TUI\n2. Navigate to the card\n3. Move it to the Complete column manually\n\nAdditionally, pressing 'c' in the TUI on an already-completed card does not move it — it unmarks it as complete instead.\n\n## Observed (2026-05-05) — inverse direction also broken\n\nMoving a card to the last column via MCP (tool_move_card) does NOT set the card's status to 'done' or populate completed_at. The completion column has no special meaning to the MCP layer — it treats it as an ordinary column move.\n\nThis confirms the bug is bidirectional: the status field and column position are not kept in sync in either direction by the MCP server.\n\n## Expected behaviour\n\nWhen a card's status is set to 'done' (via MCP or TUI), it should be automatically moved to the board's designated completion column (if one is configured). Conversely, when a card is moved to the completion column (via MCP or TUI), its status should be set to 'done' and completed_at populated. 'c' in the TUI should move a done card to the completion column, not toggle completion off.\n\n## Suggested fix\n\n- MCP move_card: after moving, check if destination is completion_column_id; if so, call the same lifecycle hook that sets status=done and completed_at\n- MCP update_card status=done: after updating, move card to completion_column_id if set\n- TUI 'c': on an already-done card in a non-completion column, move it to completion column rather than unmarking it\n- Root fix: see card 324 — remove CardStatus entirely and derive completion state solely from column position\n\n---\n\n# Implementation discussion (2026-05-11)\n\n## What was implemented (branch `KAN-394/bug-marking-card-done-via-mcp-...`)\n\nAuto-sync of the status ↔ completion-column invariant baked into the **domain command layer**:\n\n**Files changed (382 lines added, 1 removed):**\n- `crates/kanban-domain/src/card_lifecycle.rs` — two new pure helpers:\n  - `target_column_for_status(card, new_status, board, columns, cards) -> Option<(Uuid, i32)>`\n  - `target_status_for_column_move(card, new_column_id, board, columns) -> Option<CardStatus>`\n- `crates/kanban-domain/src/commands/card_commands.rs` — auto-sync wired into `UpdateCard::execute` and `MoveCard::execute`; 6 inline unit tests + a `CompletionFixture` helper\n- `crates/kanban-mcp/tests/integration.rs` — 3 end-to-end MCP integration tests\n- `.changeset/kan-394-mcp-sync-card-status-with-completion-column.md` — patch bump\n\n**Behaviour:**\n- `UpdateCard { status: Done }` (no column_id) → auto-moves card to `Board::resolve_completion_column` (which falls back to the last column when `completion_column_id` is unset), sets `completed_at`\n- `UpdateCard { status: Todo }` on a card in the completion column (no column_id) → moves to second-to-last column, clears `completed_at`\n- `MoveCard` to the completion column → sets `status=Done`, populates `completed_at`\n- `MoveCard` away from the completion column on a Done card → sets `status=Todo`, clears `completed_at`\n- When the caller passes **both** `column_id` and `status` (e.g. the TUI's atomic toggle), explicit caller intent wins; auto-sync is bypassed\n\n**Verification:**\n- 6 new unit tests in `card_commands.rs::tests` — all green\n- 3 new MCP integration tests (`mcp_update_card_status_to_done_moves_to_completion_column`, `mcp_move_card_to_completion_column_sets_status_done`, `mcp_move_card_away_from_completion_column_clears_done_status`) — all green\n- Full workspace test suite green (no regressions in TUI h/l/c handlers)\n- `cargo clippy --workspace --all-targets -- -D warnings` clean\n- `cargo fmt --check` clean\n\n## Open design questions raised in review (not yet committed)\n\n### Q1. Is the TUI now doing redundant work?\n\nThe TUI `toggle_card_completion` (in `crates/kanban-tui/src/handlers/card_handlers.rs`) still pre-computes target column + status via `compute_completion_toggle`, then issues `UpdateCard` with **both** fields populated. The auto-sync's \"respects_both\" branch lets these pass through untouched, so the TUI is unaffected — but the pre-computation is now duplicate work relative to a simplified TUI that just sends `status: Some(Done)`.\n\n**Trade-off:**\n- Simplified TUI = less code, single source of truth\n- But TUI already has board/columns/cards in `Model`; the domain auto-sync re-queries the store (3 extra reads per op)\n\n**Decision (tentative):** leave TUI as-is; file a separate \"simplify TUI completion handlers\" follow-up if pursued. Per CLAUDE.md \"a bug fix doesn't need surrounding cleanup.\"\n\n### Q2. Is auto-sync the right default? Should it be configurable?\n\nThe \"last column = completion\" assumption was already baked into the codebase via:\n- `Board::resolve_completion_column` falling back to last column\n- TUI 'c' key, h/l with completion-column transitions\n- `Card::update_status` setting `completed_at`\n\nThe change makes that pre-existing opinion **consistent** across entry points rather than introducing a new one — but it does so on *any* status/column change, not just on user gestures in the TUI. A user setting `status=Done` programmatically (CLI, MCP) without intending a column move would be surprised.\n\n**Real concern:** some workflows treat \"Done\" column as a stage (e.g. \"Done by dev, awaiting review\") rather than a completion gate. Auto-syncing forces a stronger semantic than those users want.\n\n**Proposed config knob (deferred):**\n- `Board.auto_sync_completion: bool` (default true), or\n- App-level `AppConfig.completion_sync_mode: { Strict | Suggest | Off }`\n\n**Decision (tentative):** ship default-on behaviour to fix the filed bug; file a follow-up card for configurability if real demand emerges.\n\n### Q3. Would chained commands be a cleaner architecture?\n\nYes — and likely the right long-term design. Instead of baking the side-effect into `UpdateCard::execute()`, the cleaner pattern is to compose at the service layer:\n\n```rust\n// In KanbanContext::update_card or a command-builder helper\nlet mut cmds = vec![UpdateCard { status: Done, .. }];\nif board.auto_sync_completion {\n    if let Some((col, pos)) = target_column_for_status(...) {\n        cmds.push(MoveCard { card_id, column_id: col, new_position: pos });\n    }\n}\nself.execute(cmds)?;  // already executes batches as a single undo unit\n```\n\n**Benefits:**\n- Each command stays single-purpose (SRP — the principle CLAUDE.md cites)\n- Auto-sync is observable in the command log (better for debugging and the eventual cross-client undo work in KAN-409/410)\n- Config gates the chain at one place, not deep inside each command\n- Undo already works on batches, so atomicity is preserved\n- The pure helpers (`target_column_for_status`, `target_status_for_column_move`) remain reusable regardless of where they are called\n\n**Cost:**\n- Composition logic moves to a higher layer (service or a builder helper)\n- Two call sites need to opt into the chain (UpdateCard path + MoveCard path)\n\n**Decision (pending):** the current branch implements the in-command approach. A refactor to chained commands at the service layer (`KanbanContext::update_card` and `KanbanContext::move_card`) is feasible without throwing away the work: keep the pure helpers, move the orchestration up. The unit tests on the commands would migrate to service-layer integration tests; the MCP integration tests stay valid since they test end-to-end behaviour.\n\n## Status\n\n- **Branch:** `KAN-394/bug-marking-card-done-via-mcp-does-not-move-it-to-the-completion-column`\n- **Tests passing:** yes (workspace-wide)\n- **Not yet committed:** working tree changes pending decision on Q3 (chained-commands refactor or ship as-is)\n- **Out of scope for this card:** Q2 config knob, Q1 TUI simplification, `MoveCards` batch path, TUI 'c' edge case for legacy-data Done-not-in-completion-column state",
+        "created_at": "2026-03-22T23:28:28.451012014Z",
+        "description": "kanban-service was missing from publish-crates.sh and kanban-mcp was listed before it. Fixed dependency order so kanban-service is published before kanban-mcp.",
         "due_date": null,
-        "id": "ab7cfd7d-5dd8-4840-9371-f2d7732fbe0a",
-        "points": null,
-        "position": 187,
-        "priority": "High",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "id": "248ecbc5-0ff9-43ca-9f6c-5ca66da55a0d",
+        "points": 1,
+        "position": 186,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
         "sprint_logs": [
           {
             "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-07T21:58:57.806908436Z",
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856511404Z",
             "status": "Planning"
           }
         ],
         "status": "Todo",
-        "title": "bug: marking card done via MCP does not move it to the completion column",
-        "updated_at": "2026-05-11T21:06:04.546076804Z"
+        "title": "Fix publish-crates order: add kanban-service before kanban-mcp",
+        "updated_at": "2026-05-14T10:57:05.237253062Z"
+      },
+      {
+        "card_number": 245,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-03-29T14:54:57.405559892Z",
+        "description": "TUI handlers catch command execution errors with tracing::error! but never call set_error() to show them to the user. Wire up Banner display for NotFound and other domain errors so the user gets visible feedback when an action fails silently. See PR #200 review for context.",
+        "due_date": null,
+        "id": "a498add8-d3a4-44f7-8372-450c956de89f",
+        "points": 3,
+        "position": 187,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856507373Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Surface command errors to user via Banner in TUI handlers",
+        "updated_at": "2026-05-14T11:00:27.556031048Z"
+      },
+      {
+        "card_number": 260,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-03-30T23:00:15.657707871Z",
+        "description": "## Problem\n\nThe current storage backend system requires compile-time feature flags threaded through 3 crates (`kanban-service` → `kanban-cli` → `kanban-tui`) for each backend. Third-party backends cannot be added without forking or rebuilding the app. This defeats the pluggable storage goal.\n\nDynamic plugin approaches (.so/dlopen, WASM, process-based IPC) all introduce significant complexity and tradeoffs (ABI instability, latency, unsafe code, heavy dependencies).\n\n## Solution: Inverted Dependency Model\n\nInstead of kanban loading plugins, **the plugin builds kanban**. The third-party backend owns `main()` and depends on kanban as a library.\n\n### Third-party usage\n\n```rust\n// kanban-s3/src/main.rs\nuse kanban_cli::App;\nuse kanban_s3_backend::S3StoreFactory;\n\nfn main() {\n    let mut app = App::default();\n    app.register_backend(S3StoreFactory);\n    app.run();\n}\n```\n\nUsers install with: `cargo install kanban-s3`\n\n### Changes Required\n\n#### 1. `kanban-cli` — expose as library + binary\n- Add `lib.rs` alongside `main.rs`\n- Export an `App` struct (or `AppBuilder`) with:\n  - `App::default()` — creates app with no backends\n  - `App::with_defaults()` — creates app with in-tree backends (JSON + SQLite)\n  - `app.register_backend(impl StoreFactory)` — register additional backends\n  - `app.run()` — starts the TUI/CLI\n- `main.rs` just calls `App::with_defaults().run()`\n\n#### 2. `kanban-mcp` — same pattern\n- Expose `KanbanMcpServer` builder with `register_backend`\n- Third parties can build a custom MCP server binary with their backend\n\n#### 3. `kanban-service` — simplify\n- Remove `default_registry()` and feature-gated backend registration\n- Accept a `StoreRegistry` from the caller (passed down from `App`)\n- Make all in-tree backends default deps (no more feature flags for JSON/SQLite)\n\n#### 4. `kanban-persistence` — add Tier 1 contract tests\n- Move persistence-level contract tests into `kanban-persistence` behind `test-helpers` feature\n- Tests operate at `StoreSnapshot` save/load level only (no `KanbanContext` dependency)\n- Third-party backends depend only on `kanban-persistence` for traits + test suite\n- Keep existing Tier 2 roundtrip tests in `kanban-service` for in-tree backends\n\n#### 5. Remove feature flag wiring\n- Remove `sqlite` feature from `kanban-cli`, `kanban-tui`, `kanban-mcp`\n- Remove `sqlite-storage`/`json-storage` features from `kanban-service`\n- Both backends become unconditional dependencies\n\n### Third-party backend developer experience\n\n1. Create crate, depend on `kanban-persistence` (for traits) and `kanban-cli` (for `App`)\n2. Implement `PersistenceStore` + `StoreFactory`\n3. Run `kanban_persistence::contract_tests!(my_factory)` in tests (Tier 1 — persistence level)\n4. Build binary: `App::default().register_backend(MyFactory).run()`\n5. Publish to crates.io\n\n### Multi-client compatibility (TUI, CLI, MCP)\n\nAll three client surfaces accept backends through the same pattern — they all flow to StoreRegistry -> KanbanContext:\n\n```rust\n// TUI\nApp::default().register_backend(PostgresStoreFactory).run();\n\n// CLI (headless)\nApp::default().register_backend(PostgresStoreFactory).run_cli();\n\n// MCP server\nMcpServer::default().register_backend(PostgresStoreFactory).serve();\n```\n\nThird-party crates can ship multiple binaries from one crate:\n\n```toml\n# kanban-postgres/Cargo.toml\n[[bin]]\nname = \"kanban-postgres\"\npath = \"src/main.rs\"         # TUI with Postgres\n\n[[bin]]\nname = \"kanban-postgres-mcp\"\npath = \"src/mcp.rs\"          # MCP server with Postgres\n```\n\nThis requires both kanban-cli and kanban-mcp to expose their runners as library APIs that accept a StoreRegistry. The internal flow is unchanged — stores are created before any client-specific code runs, so TUI/CLI/MCP never need to know which backend is in use.\n\n### What stays the same\n- `PersistenceStore` and `StoreFactory` trait definitions unchanged\n- `StoreRegistry` matching logic unchanged\n- All existing domain/service/TUI code unchanged\n- Default `kanban` binary ships with JSON + SQLite as today\n\n### Precedent\nThis is the same pattern used by axum, bevy, mdbook — the \"plugin\" owns main(), the framework is a library dependency.\n\n## Reference Implementation: PostgreSQL Backend (`kanban-persistence-postgres`)\n\nBuild a PostgreSQL storage backend as the first third-party-style plugin to validate the architecture. This serves as both a useful backend and a reference for third-party developers.\n\n### Why PostgreSQL\n- Validates the plugin model end-to-end with a real networked database (vs SQLite's embedded model)\n- Exercises the `StoreFactory` pattern with connection strings (`postgres://...`) instead of file paths\n- Proves the architecture works for backends where the locator is a URI, not a filesystem path\n- High demand use case: shared/team kanban boards backed by a central database\n\n### Implementation\n- New crate: `kanban-persistence-postgres` — lives in-tree under `crates/` like JSON and SQLite (same workspace, same code patterns, same quality bar)\n- **But wired as a plugin**: not registered in `default_registry()`, no feature flags in `kanban-service`/`kanban-cli`. Instead ships its own binary entrypoint using `App::default().register_backend(PostgresStoreFactory).run()`\n- This is the dogfooding constraint: if the in-tree Postgres crate can integrate purely through the plugin API, any external crate can too\n- Depends on `kanban-persistence` for traits, `sqlx` with `postgres` feature\n- `PostgresStoreFactory` matches `postgres://` and `postgresql://` URI schemes\n- Relational schema similar to SQLite backend but using PostgreSQL types (JSONB, TIMESTAMPTZ, etc.)\n- Must pass all Tier 1 contract tests from `kanban-persistence`\n- Must pass Tier 2 roundtrip tests from `kanban-service`\n- Integration tests run against a real PostgreSQL instance (docker-compose or testcontainers)\n\n### Validation criteria\n- A third-party developer can look at this crate and replicate the pattern for their own backend\n- The crate works both in-tree (as a default backend in the main binary) and as a standalone `cargo install kanban-postgres` binary\n- Documentation in the crate serves as a plugin development guide",
+        "due_date": null,
+        "id": "f78d2716-636a-49bc-b88f-c5b5329c84ae",
+        "points": 4,
+        "position": 188,
+        "priority": "High",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856462903Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Invert storage backend plugin architecture",
+        "updated_at": "2026-05-14T11:00:27.556040531Z"
       },
       {
         "card_number": 395,
@@ -13287,6 +13141,40 @@
         "status": "Todo",
         "title": "MCP server holds stale file descriptor when git replaces the database file on disk",
         "updated_at": "2026-05-07T21:58:57.806917611Z"
+      },
+      {
+        "card_number": 341,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-04-13T20:27:32.244827437Z",
+        "description": "## Problem\n\nWhen a card is created, `assigned_prefix` is set from `board.card_prefix` at creation time. If the board prefix later changes, or the card is assigned to a sprint with its own `card_prefix`, the identifier lookup uses the stale `assigned_prefix` (it ranks above `sprint.card_prefix` in the hierarchy), making the card unreachable by its sprint prefix.\n\n---\n\n## Design Discussion\n\n### Why multi-alias (track all historical prefixes) does not work\n\n`prefix_counters` is per-prefix per-board. Two sprints can independently use the same `card_prefix`. If Card A (sprint 1, prefix SPR) and Card B (sprint 3, prefix SPR) both have card_number=5, `SPR-5` is genuinely ambiguous. The KAN-211 multi-match return handles ambiguity gracefully but does not eliminate it — two legitimately different cards with the same identifier is worse than a lookup oddity.\n\n### Why hierarchy reorder has the same collision risk\n\nReordering to `sprint.card_prefix → card.assigned_prefix → board.card_prefix` shifts which scenario causes the collision but does not eliminate it. A card created as KAN-5 assigned to sprint SPR resolves as SPR-5. A card created as SPR-5 (board prefix was SPR at creation) also resolves as SPR-5. Same collision, different trigger.\n\n### Sprint prefix uniqueness closes the collision\n\nAll constraints are scoped to a single board — `prefix_counters`, sprint `card_prefix` values, `assigned_prefix` values, and card numbers all live within one board. Cross-board sprints are not a realistic Scrum/Kanban scenario (that is program-level coordination, not sprint sharing).\n\nIf sprint `card_prefix` is enforced unique against `board.prefix_counters` (all historical board prefixes) AND against other sprints on the same board, then no sprint prefix can ever equal any card's `assigned_prefix`. The collision is structurally impossible.\n\n### card.card_prefix is dead weight\n\n`card.card_prefix` (the per-card override field) is always `None` at creation (card_commands.rs:154). The CLI handler hardcodes `card_prefix: FieldUpdate::NoChange`. The TUI has no UI for it. It has never been set in any code path. It adds a fourth level to the hierarchy with no practical benefit.\n\n### card.assigned_prefix should also be dropped\n\n`assigned_prefix` only exists to preserve the prefix a card was created under if `board.card_prefix` later changes. If the board prefix is locked (immutable once cards exist), `assigned_prefix` is always equal to `board.card_prefix` — redundant by definition. It can be dropped entirely and prefix resolved purely by function.\n\n---\n\n## Target Model\n\n**Prefix resolution (fully functional, nothing stored on card):**\n`sprint.card_prefix → board.card_prefix`\n\n- Card created on board → board prefix + board counter → e.g. KAN-5\n- Card assigned to sprint with prefix SPR → resolves as SPR-5 (same number, prefix is dynamic)\n- Card dropped from sprint → resolves as KAN-5 again\n- Card number is stable (assigned once at creation, never changes)\n\n**Locking rules:**\n- `board.card_prefix` is immutable once the first card is created\n- `sprint.card_prefix` is immutable once the first card is assigned to the sprint\n- Sprint `card_prefix` must not appear in `board.prefix_counters` (all historical board prefixes)\n- Sprint `card_prefix` must not match any other sprint's `card_prefix` on the same board\n\n**Counters:**\n- Board: `card_counter: u32` — single value, replaces `prefix_counters: HashMap<String, u32>` (since prefix is now locked, the HashMap always had one meaningful key)\n- Sprint: no card counter — sprint prefix is a label only, card numbers come from the board counter\n- Sprint numbering counter (`sprint_counters`) unchanged\n\n---\n\n## Migration Required (both backends)\n\n### Key insight: assigned_prefix IS the prefix change history\n\n`card.assigned_prefix` on existing cards already records exactly what prefix each card was created under — it is the historical record of board prefix changes, just stored per-card rather than per-board. The migration can use it precisely:\n\n1. Bucket all cards by `assigned_prefix` value\n2. Each bucket's `max(card_number) + 1` is the correct counter for that prefix\n3. The bucket matching `board.card_prefix` becomes `board.card_counter`\n4. Collision detection: if card_numbers overlap across buckets, those cards would become ambiguous post-migration — surface as errors before dropping the field\n\nThis makes the migration fully deterministic. No guessing, no heuristics. The existing field contains exactly the information needed to reconstruct counters correctly and detect every collision case. After the migration, the field is dropped and locking prevents the situation from recurring.\n\nSimilarly, `sprint_logs` on cards already tracks which sprints a card has been assigned to with timestamps — the same pattern applied to boards would reconstruct the full prefix history if needed.\n\n### JSON: V2 → V3\n\n1. For each board: bucket cards by `assigned_prefix`, find bucket matching `board.card_prefix`, set `board.card_counter` to `max(card_number) + 1` from that bucket\n2. Collision check: if any card_number appears in more than one `assigned_prefix` bucket, abort with an error listing the conflicting identifiers\n3. Drop `card.assigned_prefix` on every card\n4. Drop `card.card_prefix` on every card\n\n### SQLite: schema v1 → v2\n\n1. Same bucketing and collision check logic in a migration transaction\n2. Populate `card_counter` on boards table from the above\n3. `ALTER TABLE cards DROP COLUMN assigned_prefix`\n4. `ALTER TABLE cards DROP COLUMN card_prefix`\n5. Wrap in a single transaction — abort entirely on collision rather than partial migrate\n\n### Hard edge case\n\nIf a board changed prefix mid-life (KAN-1..50, then PROJ-1..30), card_numbers 1-30 exist in both buckets. Migration aborts with:\n```\nMigration error: board \"My Board\" has ambiguous card numbers after prefix change.\n  KAN-1..30 and PROJ-1..30 cannot both be identified post-migration.\n  Resolve by deleting or re-numbering cards in one prefix group before migrating.\n```\n\n---\n\n## Files Affected\n\n- `crates/kanban-domain/src/card.rs` — drop `card_prefix`, `assigned_prefix` fields; update `CardUpdate`, `branch_name()`\n- `crates/kanban-domain/src/board.rs` — replace `prefix_counters: HashMap` with `card_counter: u32`; add prefix lock enforcement\n- `crates/kanban-domain/src/commands/card_commands.rs` — update `CreateCard` to use `board.card_counter`\n- `crates/kanban-domain/src/commands/sprint_commands.rs` — enforce sprint prefix uniqueness and immutability\n- `crates/kanban-domain/src/search/mod.rs` — simplify hierarchy to two levels\n- `crates/kanban-persistence-json/src/lib.rs` — V2→V3 migration\n- `crates/kanban-persistence-sqlite/src/` — schema v1→v2 migration\n- `crates/kanban-mcp/src/lib.rs` — remove `card_prefix` from card update tool\n- `crates/kanban-cli/src/cli.rs` — remove `card_prefix` from card update command\n",
+        "due_date": null,
+        "id": "fa821ce3-4db2-4967-9c3a-b78b1117633a",
+        "points": null,
+        "position": 189,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": "2026-05-10T15:14:10.272419081Z",
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-13T23:43:22.006627035Z",
+            "status": "Active"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-10T15:14:10.272419913Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Redesign card identifier model: drop stored prefixes, lock board/sprint prefix, simplify counters",
+        "updated_at": "2026-05-14T11:00:27.556041205Z"
       },
       {
         "card_number": 344,
@@ -13323,6 +13211,32 @@
         "updated_at": "2026-05-07T22:06:15.245195960Z"
       },
       {
+        "card_number": 302,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-04-04T23:50:48.834116789Z",
+        "description": "When starting the tui. A board is not preselected making the ui look very empty and stale.\n\nI think we should at the very least preselect the first board. or if we really wanted to.\n\nRemember the last board selected and select that\n",
+        "due_date": null,
+        "id": "ef22e57d-924a-432c-81dd-1b9b22bba4b4",
+        "points": 1,
+        "position": 190,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:51:55.287301384Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Starting the tui doesnt select a board",
+        "updated_at": "2026-05-14T11:00:27.556041507Z"
+      },
+      {
         "card_number": 402,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -13347,6 +13261,134 @@
         "status": "Todo",
         "title": "Add AUR and nixpkgs version badges to README",
         "updated_at": "2026-05-07T21:58:57.806905172Z"
+      },
+      {
+        "card_number": 334,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-04-11T08:39:51.832815833Z",
+        "description": "**Bug:** When a card is assigned to a sprint with a prefix override (e.g. `CAT`), the card gets a new identifier (`CAT-260`). However, looking up the card using that identifier returns \"Card not found\" — only the original identifier (`KAN-260`) works.\n\n**Observed:**\n```\nkanban card get CAT-260  →  Error: Card not found: 'CAT-260'\nkanban card get KAN-260  →  success\n```\n\n**Expected:** The card should be retrievable by its sprint-assigned identifier (`CAT-260`).\n\n**Steps to reproduce:**\n1. Create a card on a board with prefix `KAN` — gets ID `KAN-260`\n2. Assign the card to a sprint with prefix override `CAT` — branch name becomes `CAT-260`\n3. Run `kanban card get CAT-260`\n4. Observe \"Card not found\" error\n\n**Root cause area:** Card lookup likely only indexes by the canonical `assigned_prefix` + `card_number`, not by the sprint-assigned prefix.",
+        "due_date": null,
+        "id": "0015392b-e4a8-4c6f-bfba-895c5e2f1f86",
+        "points": 3,
+        "position": 191,
+        "priority": "High",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": "2026-05-07T22:06:15.245065172Z",
+            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+            "sprint_name": "sphinx-centered",
+            "sprint_number": 14,
+            "started_at": "2026-04-29T04:53:21.126609766Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T22:06:15.245067047Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Card not found when looked up by sprint-assigned prefix identifier",
+        "updated_at": "2026-05-14T11:07:38.156519134Z"
+      },
+      {
+        "card_number": 369,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-04-27T07:12:25.392072773Z",
+        "description": null,
+        "due_date": null,
+        "id": "c4658b76-e0dd-41a5-86c7-f84334259f6b",
+        "points": null,
+        "position": 192,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": "2026-05-07T22:06:15.245078306Z",
+            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+            "sprint_name": "sphinx-centered",
+            "sprint_number": 14,
+            "started_at": "2026-04-29T04:53:21.126606635Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T22:06:15.245078745Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Implement StoreFactory for SQLite backend",
+        "updated_at": "2026-05-14T11:07:38.156520014Z"
+      },
+      {
+        "card_number": 370,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-04-27T08:24:12.170416957Z",
+        "description": "Register SqliteStoreFactory in the StoreRegistry so MCP/CLI route SQLite files through the registry like JSON, instead of the old open_sqlite bypass.\n\n## Done\n- Added `path`/`instance_id` fields to `SqliteStore`; implemented `PersistenceStore`\n- Added `SqliteStoreFactory` (magic-byte content sniffing, `create()` via registry)\n- Registered factory in `default_registry()` (sqlite first, then json)\n- Removed `is_sqlite`/`open_sqlite` bypass from `McpContext::new` and `CliContext::load`\n- Added unit tests for all new behaviour\n\nBranch: KAN-366/description-doesnt-load-in-card-details",
+        "due_date": null,
+        "id": "200e9bcd-9654-49a0-affc-cab1866ab223",
+        "points": null,
+        "position": 193,
+        "priority": "Medium",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": "2026-05-07T22:06:15.245080262Z",
+            "sprint_id": "124ae046-2368-4334-b5f7-c64a47cdeca4",
+            "sprint_name": "sphinx-centered",
+            "sprint_number": 14,
+            "started_at": "2026-04-29T04:53:21.126605275Z",
+            "status": "Planning"
+          },
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-07T22:06:15.245080694Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "SQLite backend registry integration",
+        "updated_at": "2026-05-14T11:07:38.156520444Z"
+      },
+      {
+        "card_number": 275,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-03-31T21:22:38.967871171Z",
+        "description": "Remove futures and futures-util from workspace Cargo.toml - they are not used anywhere in the codebase and can be safely removed as a cleanup task.",
+        "due_date": null,
+        "id": "b66a0571-94e9-4972-9c42-a8450982d0a4",
+        "points": 1,
+        "position": 194,
+        "priority": "Medium",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-04T23:35:37.856390298Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Remove unused futures dependencies",
+        "updated_at": "2026-05-14T11:09:21.268637793Z"
       },
       {
         "card_number": 408,
@@ -13401,6 +13443,32 @@
         "updated_at": "2026-05-10T17:33:14.477269439Z"
       },
       {
+        "card_number": 323,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": null,
+        "created_at": "2026-04-06T20:36:22.081954307Z",
+        "description": "## Problem\n\nWhen a non-existent file path is passed to the CLI (e.g. `kanban demo.json card get KAN-12` when the correct path is `fixtures/demo.json`), the user sees:\n\n```\n{\"success\":false,\"api_version\":\"0.3.5\",\"error\":\"Card not found: 'KAN-12'\"}\nError: Card not found: 'KAN-12'\n```\n\nThis is wrong. The file doesn't exist — the card lookup never had a chance. The real error is a missing file.\n\n## Root Cause\n\n`KanbanContext::load` in `kanban-service/src/context.rs` is designed to support the TUI's \"new board\" flow — it silently returns an empty context when the file doesn't exist:\n\n```rust\n// kanban-service/src/context.rs:44-46\npub async fn load(...) -> KanbanResult<Self> {\n    if !store.exists().await {\n        return Ok(Self::empty(store, config));  // ← silent empty context\n    }\n    ...\n}\n```\n\nThe CLI loads via `CliContext::load` in `kanban-cli/src/context.rs`, which delegates directly without checking existence first:\n\n```rust\n// kanban-cli/src/context.rs:17-28\npub async fn load(file_path: &str, mut config: AppConfig) -> KanbanResult<Self> {\n    ...\n    Ok(Self {\n        inner: KanbanContext::load(make_store(&backend, file_path)?, config).await?,\n    })\n}\n```\n\nThe empty context has no cards, so any card operation then fails with a misleading domain-level error.\n\n## Proposed Fix\n\nAdd a file existence check in `CliContext::load` before delegating to `KanbanContext::load`:\n\n```rust\n// kanban-cli/src/context.rs\npub async fn load(file_path: &str, mut config: AppConfig) -> KanbanResult<Self> {\n    if !std::path::Path::new(file_path).exists() {\n        return Err(KanbanError::NotFound(format!(\n            \"Board file not found: '{}'\",\n            file_path\n        )));\n    }\n    ...\n}\n```\n\nThis keeps the TUI's empty-context path untouched (TUI uses `KanbanContext::load` directly via `App::new`) while giving CLI users a clear, actionable error message.\n\n## Steps to Resolution\n\n1. Add existence check at the top of `CliContext::load` in `kanban-cli/src/context.rs`\n2. Verify the error surfaces as a `{\"success\":false,...,\"error\":\"Board file not found: 'demo.json'\"}` JSON response\n3. Add a CLI integration test in `kanban-cli/tests/cli_integration.rs` asserting the correct error message on a missing file path\n4. Confirm the TUI is unaffected (it never calls `CliContext::load`)",
+        "due_date": null,
+        "id": "d9db775c-f075-4d9d-b3a7-9e8404dd0383",
+        "points": null,
+        "position": 195,
+        "priority": "High",
+        "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "3e05b869-e1d8-49b4-a0b9-7fdb668684f9",
+            "sprint_name": "a-catchy-spring",
+            "sprint_number": 13,
+            "started_at": "2026-04-06T21:44:46.541917904Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Fix misleading 'Card not found' error when board file does not exist",
+        "updated_at": "2026-05-14T18:38:13.134127739Z"
+      },
+      {
         "card_number": 410,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -13453,30 +13521,21 @@
         "updated_at": "2026-05-11T23:24:13.846356360Z"
       },
       {
-        "card_number": 411,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-05-08T22:21:52.554877234Z",
-        "description": "## Concept\n\nThe command log lives in-memory and is session-scoped (KAN-405). For users who want cross-session undo without sacrificing a clean data file, we can borrow nvim's approach: a separate, optional undo file that stores the command log independently from the data layer. The data file stays clean and human-readable; the undo file is an ephemeral sidecar that the user can opt into, delete freely, and version-control separately or ignore entirely.\n\n## How nvim does it\n\nnvim writes a .un~ file alongside each edited file. It stores a tree of undo/redo branches. The file is silently ignored if missing or corrupted. Kanban should follow the same contract: the undo file is opt-in, best-effort, and never required for correct operation.\n\n## Proposed design\n\n### File location and naming\n\n- Default: same directory as the data file with a suffix, e.g. board.json -> board.json.undo\n- Configurable via AppConfig: undo_dir = ~/.local/share/kanban/undo/ with filenames derived from the data file path hash\n- If the undo file cannot be read or is malformed, silently discard it and start with a clean slate\n\n### File format\n\nJSON Lines or a simple binary envelope (baseline snapshot + ordered command batches):\n\n{\n  format_version: 1,\n  data_file_hash: sha256 of the data file path (for validation),\n  session_id: uuid of the session that wrote this file,\n  baseline: <Snapshot as JSON>,\n  commands: [ [batch0_cmd0, ...], [batch1_cmd0, ...], ... ]\n}\n\nThe baseline is the snapshot at the time the undo file was started. Commands are the ordered batches applied after that baseline. This is exactly the in-memory state of KanbanContext serialised to disk — so loading it is a straightforward deserialise and populate.\n\n### UndoStore trait (new, in kanban-persistence or kanban-service)\n\npub trait UndoStore: Send + Sync {\n    fn load(&self) -> KanbanResult<Option<UndoState>>;\n    fn save(&self, state: &UndoState) -> KanbanResult<()>;\n    fn clear(&self) -> KanbanResult<()>;\n}\n\npub struct UndoState {\n    pub baseline: Snapshot,\n    pub commands: Vec<Vec<Command>>,\n    pub cursor: usize,\n}\n\nImplementations:\n- NullUndoStore: no-op (default, current behaviour)\n- FileUndoStore: reads/writes the sidecar file described above\n\n### Integration in KanbanContext\n\nOn open: if an UndoStore is configured, call load(). If it returns Some(state), populate baseline_snapshot, command log, and undo_cursor from it. If it returns None or errors, fall back to a clean session.\n\nOn execute/undo/redo: after any state change, call save() asynchronously (debounced, same as the main save worker). Errors are logged but not fatal.\n\nOn session close / clear_history: call clear() to delete the undo file so it does not accumulate stale state.\n\n### Activation\n\nOpt-in via config:\n\n[undo]\nenabled = true          # default: false\ndir = ~/.local/share/kanban/undo   # optional, defaults to data file directory\n\nOr via CLI flag: kanban --undo-file board.json.undo\n\n### Safety properties\n\n- The undo file is never required for data integrity. Deleting it is always safe.\n- If the data file changes between sessions (e.g. external edit, migration), the baseline hash check fails and the undo file is discarded.\n- The undo file is not committed to version control (add *.undo to .gitignore in project templates).\n- Undo file writes use atomic rename, same as the main JSON file.\n\n## Relationship to other cards\n\n- KAN-405: established that the command log must not be in the data file. This card is the opt-in escape hatch for users who want cross-session undo without polluting kanban.json.\n- KAN-410: message-based bus for cross-client undo — complementary, not competing. Bus = live sync; undo file = crash recovery and single-user cross-session undo.",
+        "card_number": 455,
+        "column_id": "289b85d8-a199-49fa-9d77-5ad892d87ef8",
+        "completed_at": "2026-05-14T20:04:09.440314840Z",
+        "created_at": "2026-05-14T19:13:14.579263490Z",
+        "description": "## Observed\n\nTwo places in the TUI have lists that support j/k navigation but do not scroll, making items below the visible area unreachable.\n\n### 1. Board edit view — Sprints [4] and Columns [5] panels\n\nrender_board_sprints_list and render_board_columns_list in kanban-tui/src/ui/board_detail.rs both render a Paragraph::new(lines) with no scroll offset. The selection highlight (app.selection.sprint.get() / app.dialog_input.column_selection.get()) moves, but the paragraph never scrolls.\n\n### 2. Card list sprint filter popup\n\nThe sprint list in the filter popup (kanban-tui/src/components/filter_popup.rs line 119) also renders Paragraph::new(sprint_lines) with no scroll offset. On boards with many sprints the list clips at the popup boundary.\n\n## Root cause (shared)\n\nAll three Paragraph widgets clip at their widget boundary. A viewport offset must be passed explicitly via .scroll((row, 0)). The selection index is tracked in all cases but never used to derive an offset.\n\n## Implementation — PR #273\n\nhttps://github.com/fulsomenko/kanban/pull/273\n\nThe fix went deeper than the original \"fix direction\" suggested. Rather than re-deriving a sticky-bottom offset on every render, the PR matches the minimal-scroll behavior of the main card list:\n\n- Extracted the pure scroll-math primitive `scroll_offset_to_keep_visible(current_offset, selected, viewport_height) -> usize` into `kanban_core::pagination`. `Page::scroll_to_visible` now delegates to it, so `ListComponent`, `card_list`, and every other Page-based list reuse the same logic with no behavior change.\n- Added `Cell<usize>` scroll-offset fields alongside the existing selections: `SelectionHub.sprint_scroll`, `DialogInputState.column_scroll`, `FilterDialogState.item_scroll` (the last is reset on `next_section`/`prev_section`). Each renderer reads the cell, calls the pure function, writes back, and applies the offset via `Paragraph::scroll`.\n- Filter popup uses a translated `selected_line_idx` to account for the title, unassigned-sprints checkbox, and separator that precede the sprint rows.\n\nTests added: 6 unit tests for the pure function in `kanban-core::pagination`, plus 4 integration tests in `kanban-tui/tests/scroll_board_edit_lists.rs` — including `test_board_sprints_scroll_offset_is_stable_when_selection_moves_within_viewport`, which verifies the property that distinguishes minimal-scroll from sticky-bottom.\n\nFollow-up tracked in **KAN-456** — \"Migrate all SelectionState-backed lists to ListComponent for unified scrolling\". That card consumes the pure function added here and finishes the architectural unification across the ~10 other `SelectionState` fields in the app.",
         "due_date": null,
-        "id": "6df0d7be-7dc3-4a25-8b8e-850c692a7f20",
+        "id": "503e1702-9398-4ea6-b002-08305d1ce1ea",
         "points": null,
         "position": 197,
-        "priority": "Low",
-        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-        "sprint_logs": [
-          {
-            "ended_at": null,
-            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
-            "sprint_name": "yarara-release",
-            "sprint_number": 15,
-            "started_at": "2026-05-10T17:33:14.477270845Z",
-            "status": "Planning"
-          }
-        ],
-        "status": "Todo",
-        "title": "Design: separate undo file for optional cross-session command log persistence",
-        "updated_at": "2026-05-10T17:33:14.477271146Z"
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Done",
+        "title": "No scrolling in board edit view sprint and column lists",
+        "updated_at": "2026-05-14T20:09:30.570705642Z"
       },
       {
         "card_number": 433,
@@ -13505,6 +13564,49 @@
         "updated_at": "2026-05-11T23:24:13.846369317Z"
       },
       {
+        "card_number": 411,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-08T22:21:52.554877234Z",
+        "description": "## Concept\n\nThe command log lives in-memory and is session-scoped (KAN-405). For users who want cross-session undo without sacrificing a clean data file, we can borrow nvim's approach: a separate, optional undo file that stores the command log independently from the data layer. The data file stays clean and human-readable; the undo file is an ephemeral sidecar that the user can opt into, delete freely, and version-control separately or ignore entirely.\n\n## How nvim does it\n\nnvim writes a .un~ file alongside each edited file. It stores a tree of undo/redo branches. The file is silently ignored if missing or corrupted. Kanban should follow the same contract: the undo file is opt-in, best-effort, and never required for correct operation.\n\n## Proposed design\n\n### File location and naming\n\n- Default: same directory as the data file with a suffix, e.g. board.json -> board.json.undo\n- Configurable via AppConfig: undo_dir = ~/.local/share/kanban/undo/ with filenames derived from the data file path hash\n- If the undo file cannot be read or is malformed, silently discard it and start with a clean slate\n\n### File format\n\nJSON Lines or a simple binary envelope (baseline snapshot + ordered command batches):\n\n{\n  format_version: 1,\n  data_file_hash: sha256 of the data file path (for validation),\n  session_id: uuid of the session that wrote this file,\n  baseline: <Snapshot as JSON>,\n  commands: [ [batch0_cmd0, ...], [batch1_cmd0, ...], ... ]\n}\n\nThe baseline is the snapshot at the time the undo file was started. Commands are the ordered batches applied after that baseline. This is exactly the in-memory state of KanbanContext serialised to disk — so loading it is a straightforward deserialise and populate.\n\n### UndoStore trait (new, in kanban-persistence or kanban-service)\n\npub trait UndoStore: Send + Sync {\n    fn load(&self) -> KanbanResult<Option<UndoState>>;\n    fn save(&self, state: &UndoState) -> KanbanResult<()>;\n    fn clear(&self) -> KanbanResult<()>;\n}\n\npub struct UndoState {\n    pub baseline: Snapshot,\n    pub commands: Vec<Vec<Command>>,\n    pub cursor: usize,\n}\n\nImplementations:\n- NullUndoStore: no-op (default, current behaviour)\n- FileUndoStore: reads/writes the sidecar file described above\n\n### Integration in KanbanContext\n\nOn open: if an UndoStore is configured, call load(). If it returns Some(state), populate baseline_snapshot, command log, and undo_cursor from it. If it returns None or errors, fall back to a clean session.\n\nOn execute/undo/redo: after any state change, call save() asynchronously (debounced, same as the main save worker). Errors are logged but not fatal.\n\nOn session close / clear_history: call clear() to delete the undo file so it does not accumulate stale state.\n\n### Activation\n\nOpt-in via config:\n\n[undo]\nenabled = true          # default: false\ndir = ~/.local/share/kanban/undo   # optional, defaults to data file directory\n\nOr via CLI flag: kanban --undo-file board.json.undo\n\n### Safety properties\n\n- The undo file is never required for data integrity. Deleting it is always safe.\n- If the data file changes between sessions (e.g. external edit, migration), the baseline hash check fails and the undo file is discarded.\n- The undo file is not committed to version control (add *.undo to .gitignore in project templates).\n- Undo file writes use atomic rename, same as the main JSON file.\n\n## Relationship to other cards\n\n- KAN-405: established that the command log must not be in the data file. This card is the opt-in escape hatch for users who want cross-session undo without polluting kanban.json.\n- KAN-410: message-based bus for cross-client undo — complementary, not competing. Bus = live sync; undo file = crash recovery and single-user cross-session undo.",
+        "due_date": null,
+        "id": "6df0d7be-7dc3-4a25-8b8e-850c692a7f20",
+        "points": null,
+        "position": 197,
+        "priority": "Low",
+        "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+        "sprint_logs": [
+          {
+            "ended_at": null,
+            "sprint_id": "6927495b-f63e-4260-8bb7-4ba44b964be8",
+            "sprint_name": "yarara-release",
+            "sprint_number": 15,
+            "started_at": "2026-05-10T17:33:14.477270845Z",
+            "status": "Planning"
+          }
+        ],
+        "status": "Todo",
+        "title": "Design: separate undo file for optional cross-session command log persistence",
+        "updated_at": "2026-05-10T17:33:14.477271146Z"
+      },
+      {
+        "card_number": 436,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-11T23:39:08.420337295Z",
+        "description": "## Why\n\nAfter KAN-434 collapsed `update_card` and `assign_card_to_sprint` into\nshorthands over their plural counterparts, code review surfaced an\ninefficiency in the underlying pattern: three batch service methods on\n`KanbanContext` compute their `KanbanResult<usize>` return value by\n**reading the backend twice** (before-the-mutation count and\nafter-the-mutation count), then returning the delta.\n\nThe three offenders, all in `crates/kanban-service/src/context.rs`:\n\n```\n:1048  fn archive_cards            — list_archived_cards() × 2\n:1057  fn move_cards               — list_cards_by_column(column_id) × 2\n:1145  fn assign_cards_to_sprint   — list_cards_by_sprint(sprint_id) × 2\n```\n\nThe before/after pattern is the only honest way to compute \"how many\ncards were actually changed\" given today's command surface — some of\nthe input IDs may already be on the sprint / already archived /\nalready in the target column (no-ops), and some may be invalid (the\ndomain commands' `filter_valid_card_ids` helper silently skips them).\nCounting the delta on the backend is correct, but each of those\n`list_*` calls is wasted work that the underlying domain command\nalready knows the answer to.\n\nThere's a second cost surfaced specifically by KAN-434's collapse:\nthe singular wrappers (`assign_card_to_sprint`, and the pre-existing\n`archive_card`) call the plural to get the `usize`, discard it, then\nfetch the card. So for the single-card path the two reads are pure\noverhead — the singular doesn't even use the count.\n\nOn in-memory and JSON backends the cost is microseconds. On SQLite\nit's two additional indexed queries per call. Negligible per\noperation; becomes measurable at high frequency or large boards.\n\n## What\n\nPush the mutation count down into the domain command's execute path\nso the service can return it directly without re-reading the backend.\n\n### Domain-layer change (the load-bearing part)\n\nIn `crates/kanban-domain/src/commands/card_commands.rs`, change the\nthree offending commands' `execute` from `KanbanResult<()>` to\n`KanbanResult<usize>`:\n\n- `ArchiveCards::execute`         (line ~254)\n- `MoveCards::execute`            (line ~294)\n- `AssignCardsToSprint::execute`  (line ~336)\n\nEach command already knows which IDs it actually mutated (it calls\n`filter_valid_card_ids` and iterates them). Returning that count is a\nlocal change inside each `execute` body — `Ok(valid_ids.len())`\ntypically.\n\n### CardCommand enum dispatch\n\n`crates/kanban-domain/src/commands/card_commands.rs:27` —\n`CardCommand::execute` currently returns `KanbanResult<()>`. It needs\nto either (a) also become `KanbanResult<usize>` with non-batch arms\nreturning `Ok(0)` or `Ok(1)`, or (b) keep its `()` return and add a\nseparate `executed_count` method per command. Option (a) is more\nhonest — every mutation is \"n entities affected\" — but it touches the\ncommand-log replay path. Option (b) keeps the existing replay code\npath untouched.\n\n**Recommendation: Option (a).** It generalises naturally: `CreateCard`\nreturns 1, `DeleteCard` returns 1, `UpdateCard` returns 1, etc. Both\noptions are tracked here so the implementer can pick.\n\n### Service-layer cleanup\n\nIn `crates/kanban-service/src/context.rs::execute(Vec<Command>)`\n(line 158), propagate the per-command count out so callers can sum it.\nThen rewrite the three plurals:\n\n```rust\nfn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {\n    let counts = self.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards { ids }))])?;\n    Ok(counts.into_iter().sum())  // exactly one command, one count\n}\n\nfn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {\n    let chained_status_updates = self.chained_status_updates_for_batch_move(&ids, column_id)?;\n    let mut batch = vec![Command::Card(CardCommand::MoveMultiple(MoveCards { ids, column_id }))];\n    for (card_id, new_status) in chained_status_updates {\n        batch.push(/* chained UpdateCard */);\n    }\n    let counts = self.execute(batch)?;\n    Ok(counts[0])  // first command is the MoveCards batch; status flips are not \"moves\"\n}\n\nfn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {\n    let counts = self.execute(vec![Command::Card(CardCommand::AssignToSprint(\n        AssignCardsToSprint { ids, sprint_id }\n    ))])?;\n    Ok(counts.into_iter().sum())\n}\n```\n\nThe `KanbanContext::execute` signature changes from\n`fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<()>`\nto\n`fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<Vec<usize>>`.\n\nThat return shape lets the caller pick whichever index they care about\n(the first command, the sum, etc.) without forcing every caller to\ncare about the count.\n\n### `archive_card` and the singulars naturally cheapen\n\nAfter this change, `assign_card_to_sprint` (a shorthand over\n`assign_cards_to_sprint` post-KAN-434) and `archive_card` (a shorthand\nover `archive_cards`) no longer pay for the wasted reads. The count\nthey discard was the wasted work; removing the source of the count\nremoves the waste.\n\n## Where the wiring lives\n\n| File | Change |\n|---|---|\n| `crates/kanban-domain/src/commands/card_commands.rs` | `ArchiveCards::execute`, `MoveCards::execute`, `AssignCardsToSprint::execute` return `KanbanResult<usize>`. Same change propagates to the `CardCommand::execute` dispatch arm depending on Option (a) vs (b). |\n| `crates/kanban-domain/src/commands/mod.rs` | If Option (a): `Command::execute` returns `KanbanResult<usize>` from its match. |\n| `crates/kanban-service/src/context.rs` | `execute(Vec<Command>)` returns `KanbanResult<Vec<usize>>` (or `KanbanResult<usize>` if collapsed at the service boundary — caller's choice). Plurals at `:1048`, `:1057`, `:1145` use the returned counts instead of before/after delta queries. |\n\nThe command-log replay machinery on the persistence side\n(`kanban-persistence-*` crates) shouldn't care about the count —\nreplay applies commands for their side effects, not their return\nvalues. Confirm by `grep`ping for callers of `Command::execute` /\n`CardCommand::execute` outside `KanbanContext` to make sure the\nsignature change doesn't break them.\n\n## Reuse — already in place\n\n- `filter_valid_card_ids` at\n  `crates/kanban-domain/src/commands/mod.rs::CommandContext` — every\n  affected command already calls this to compute the actually-mutated\n  ID set. The count is literally `valid_ids.len()` at the point each\n  command finishes its body.\n- `KanbanContext::execute` infrastructure — atomic batch, rollback,\n  undo cursor. Unchanged in behaviour; only the return type widens.\n\n## Acceptance\n\n- The three plurals (`archive_cards`, `move_cards`,\n  `assign_cards_to_sprint`) no longer call `list_*` for the count.\n- Existing tests in `crates/kanban-service/tests/`,\n  `crates/kanban-mcp/tests/`, and the contract-test helpers continue\n  to pass without modification — the count semantics are preserved.\n- Add a microbench or instrumented log assertion (optional) showing\n  that a single-card `assign_card_to_sprint` makes one backend\n  mutation call and zero count-queries.\n- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,\n  and `cargo fmt --check` all clean.\n\n## Behaviour change for existing callers\n\n**None.** The return value (`usize`, count of cards actually mutated)\nis identical to what the before/after delta produced. Pure\nperformance refactor.\n\n## Risk\n\nMedium. Touches the `Command::execute` signature, which is a\nload-bearing trait used by:\n\n- `KanbanContext::execute` (the atomic batch executor)\n- The undo/redo replay path\n- Any future cross-client command-log work\n\nThe change is mechanical but wide. Recommended approach:\n\n1. Start with Option (b) on a feature branch: add per-command\n   `executed_count()` methods alongside the existing `()` returns.\n   This is additive — no existing caller breaks.\n2. Switch the three service plurals to use the new method.\n3. Verify all tests + the undo/redo path still work.\n4. **Then** consider whether to converge on Option (a) (uniform\n   `KanbanResult<usize>` from every `execute`) as a second step.\n\nDoing Option (a) directly is shorter overall but harder to bisect if\nsomething breaks.\n\n## Notes / Out of scope\n\n- This card does **not** address the `move_card` collapse blocker\n  from KAN-434 (the `position: Option<i32>` mismatch with `move_cards`).\n  That's a separate concern.\n- This card does **not** introduce per-card success/failure detail —\n  the `BatchOperationResult` returned by `*_detailed` inherent methods\n  on `KanbanContext` already covers that case. Those methods have\n  their own pattern and are out of scope unless the implementer\n  decides to unify.\n- The `update_cards` plural (post-KAN-394) does NOT have this issue —\n  it returns `count = updates.len()` upfront because each input maps\n  one-to-one to an `UpdateCard` command. Don't touch it.\n\n## Relationship to other cards\n\n- **KAN-434** (just merged) is the reason this gap is visible — the\n  singular shorthands discard the count and pay for two extra reads\n  per call. Resolving this card eliminates that overhead.\n- **KAN-432** (per-board auto-sync opt-out) is independent. Both\n  changes touch `update_cards` but in different ways.\n- **KAN-433** (drop dead lifecycle helpers) is independent.\n\n## Commit shape\n\nIf Option (b) (additive):\n\n1. `feat(domain): card batch commands expose executed_count()` — add\n   the new method to `ArchiveCards`, `MoveCards`,\n   `AssignCardsToSprint`. Default to `0` for non-batch commands.\n2. `refactor(service): replace before/after delta with command\n   executed_count()` — switch the three plurals.\n3. `chore: add changeset for KAN-43x`\n\nIf Option (a) (signature change):\n\n1. `refactor(domain): Command::execute returns KanbanResult<usize>` —\n   wide mechanical change.\n2. `refactor(service): plurals use returned counts instead of\n   before/after delta` — switch the three plurals.\n3. `chore: add changeset for KAN-43x`\n\nEither way: write the test commit first when introducing the new\nreturn shape, per the project TDD convention.",
+        "due_date": null,
+        "id": "96355729-f423-4d63-9b82-2ac75160c3c1",
+        "points": 3,
+        "position": 198,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "refactor(domain): commands return mutation count to remove before/after delta queries in service plurals",
+        "updated_at": "2026-05-11T23:39:08.421237072Z"
+      },
+      {
         "card_number": 412,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -13531,21 +13633,21 @@
         "updated_at": "2026-05-10T17:33:14.477276009Z"
       },
       {
-        "card_number": 436,
+        "card_number": 437,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
-        "created_at": "2026-05-11T23:39:08.420337295Z",
-        "description": "## Why\n\nAfter KAN-434 collapsed `update_card` and `assign_card_to_sprint` into\nshorthands over their plural counterparts, code review surfaced an\ninefficiency in the underlying pattern: three batch service methods on\n`KanbanContext` compute their `KanbanResult<usize>` return value by\n**reading the backend twice** (before-the-mutation count and\nafter-the-mutation count), then returning the delta.\n\nThe three offenders, all in `crates/kanban-service/src/context.rs`:\n\n```\n:1048  fn archive_cards            — list_archived_cards() × 2\n:1057  fn move_cards               — list_cards_by_column(column_id) × 2\n:1145  fn assign_cards_to_sprint   — list_cards_by_sprint(sprint_id) × 2\n```\n\nThe before/after pattern is the only honest way to compute \"how many\ncards were actually changed\" given today's command surface — some of\nthe input IDs may already be on the sprint / already archived /\nalready in the target column (no-ops), and some may be invalid (the\ndomain commands' `filter_valid_card_ids` helper silently skips them).\nCounting the delta on the backend is correct, but each of those\n`list_*` calls is wasted work that the underlying domain command\nalready knows the answer to.\n\nThere's a second cost surfaced specifically by KAN-434's collapse:\nthe singular wrappers (`assign_card_to_sprint`, and the pre-existing\n`archive_card`) call the plural to get the `usize`, discard it, then\nfetch the card. So for the single-card path the two reads are pure\noverhead — the singular doesn't even use the count.\n\nOn in-memory and JSON backends the cost is microseconds. On SQLite\nit's two additional indexed queries per call. Negligible per\noperation; becomes measurable at high frequency or large boards.\n\n## What\n\nPush the mutation count down into the domain command's execute path\nso the service can return it directly without re-reading the backend.\n\n### Domain-layer change (the load-bearing part)\n\nIn `crates/kanban-domain/src/commands/card_commands.rs`, change the\nthree offending commands' `execute` from `KanbanResult<()>` to\n`KanbanResult<usize>`:\n\n- `ArchiveCards::execute`         (line ~254)\n- `MoveCards::execute`            (line ~294)\n- `AssignCardsToSprint::execute`  (line ~336)\n\nEach command already knows which IDs it actually mutated (it calls\n`filter_valid_card_ids` and iterates them). Returning that count is a\nlocal change inside each `execute` body — `Ok(valid_ids.len())`\ntypically.\n\n### CardCommand enum dispatch\n\n`crates/kanban-domain/src/commands/card_commands.rs:27` —\n`CardCommand::execute` currently returns `KanbanResult<()>`. It needs\nto either (a) also become `KanbanResult<usize>` with non-batch arms\nreturning `Ok(0)` or `Ok(1)`, or (b) keep its `()` return and add a\nseparate `executed_count` method per command. Option (a) is more\nhonest — every mutation is \"n entities affected\" — but it touches the\ncommand-log replay path. Option (b) keeps the existing replay code\npath untouched.\n\n**Recommendation: Option (a).** It generalises naturally: `CreateCard`\nreturns 1, `DeleteCard` returns 1, `UpdateCard` returns 1, etc. Both\noptions are tracked here so the implementer can pick.\n\n### Service-layer cleanup\n\nIn `crates/kanban-service/src/context.rs::execute(Vec<Command>)`\n(line 158), propagate the per-command count out so callers can sum it.\nThen rewrite the three plurals:\n\n```rust\nfn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {\n    let counts = self.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards { ids }))])?;\n    Ok(counts.into_iter().sum())  // exactly one command, one count\n}\n\nfn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {\n    let chained_status_updates = self.chained_status_updates_for_batch_move(&ids, column_id)?;\n    let mut batch = vec![Command::Card(CardCommand::MoveMultiple(MoveCards { ids, column_id }))];\n    for (card_id, new_status) in chained_status_updates {\n        batch.push(/* chained UpdateCard */);\n    }\n    let counts = self.execute(batch)?;\n    Ok(counts[0])  // first command is the MoveCards batch; status flips are not \"moves\"\n}\n\nfn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {\n    let counts = self.execute(vec![Command::Card(CardCommand::AssignToSprint(\n        AssignCardsToSprint { ids, sprint_id }\n    ))])?;\n    Ok(counts.into_iter().sum())\n}\n```\n\nThe `KanbanContext::execute` signature changes from\n`fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<()>`\nto\n`fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<Vec<usize>>`.\n\nThat return shape lets the caller pick whichever index they care about\n(the first command, the sum, etc.) without forcing every caller to\ncare about the count.\n\n### `archive_card` and the singulars naturally cheapen\n\nAfter this change, `assign_card_to_sprint` (a shorthand over\n`assign_cards_to_sprint` post-KAN-434) and `archive_card` (a shorthand\nover `archive_cards`) no longer pay for the wasted reads. The count\nthey discard was the wasted work; removing the source of the count\nremoves the waste.\n\n## Where the wiring lives\n\n| File | Change |\n|---|---|\n| `crates/kanban-domain/src/commands/card_commands.rs` | `ArchiveCards::execute`, `MoveCards::execute`, `AssignCardsToSprint::execute` return `KanbanResult<usize>`. Same change propagates to the `CardCommand::execute` dispatch arm depending on Option (a) vs (b). |\n| `crates/kanban-domain/src/commands/mod.rs` | If Option (a): `Command::execute` returns `KanbanResult<usize>` from its match. |\n| `crates/kanban-service/src/context.rs` | `execute(Vec<Command>)` returns `KanbanResult<Vec<usize>>` (or `KanbanResult<usize>` if collapsed at the service boundary — caller's choice). Plurals at `:1048`, `:1057`, `:1145` use the returned counts instead of before/after delta queries. |\n\nThe command-log replay machinery on the persistence side\n(`kanban-persistence-*` crates) shouldn't care about the count —\nreplay applies commands for their side effects, not their return\nvalues. Confirm by `grep`ping for callers of `Command::execute` /\n`CardCommand::execute` outside `KanbanContext` to make sure the\nsignature change doesn't break them.\n\n## Reuse — already in place\n\n- `filter_valid_card_ids` at\n  `crates/kanban-domain/src/commands/mod.rs::CommandContext` — every\n  affected command already calls this to compute the actually-mutated\n  ID set. The count is literally `valid_ids.len()` at the point each\n  command finishes its body.\n- `KanbanContext::execute` infrastructure — atomic batch, rollback,\n  undo cursor. Unchanged in behaviour; only the return type widens.\n\n## Acceptance\n\n- The three plurals (`archive_cards`, `move_cards`,\n  `assign_cards_to_sprint`) no longer call `list_*` for the count.\n- Existing tests in `crates/kanban-service/tests/`,\n  `crates/kanban-mcp/tests/`, and the contract-test helpers continue\n  to pass without modification — the count semantics are preserved.\n- Add a microbench or instrumented log assertion (optional) showing\n  that a single-card `assign_card_to_sprint` makes one backend\n  mutation call and zero count-queries.\n- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,\n  and `cargo fmt --check` all clean.\n\n## Behaviour change for existing callers\n\n**None.** The return value (`usize`, count of cards actually mutated)\nis identical to what the before/after delta produced. Pure\nperformance refactor.\n\n## Risk\n\nMedium. Touches the `Command::execute` signature, which is a\nload-bearing trait used by:\n\n- `KanbanContext::execute` (the atomic batch executor)\n- The undo/redo replay path\n- Any future cross-client command-log work\n\nThe change is mechanical but wide. Recommended approach:\n\n1. Start with Option (b) on a feature branch: add per-command\n   `executed_count()` methods alongside the existing `()` returns.\n   This is additive — no existing caller breaks.\n2. Switch the three service plurals to use the new method.\n3. Verify all tests + the undo/redo path still work.\n4. **Then** consider whether to converge on Option (a) (uniform\n   `KanbanResult<usize>` from every `execute`) as a second step.\n\nDoing Option (a) directly is shorter overall but harder to bisect if\nsomething breaks.\n\n## Notes / Out of scope\n\n- This card does **not** address the `move_card` collapse blocker\n  from KAN-434 (the `position: Option<i32>` mismatch with `move_cards`).\n  That's a separate concern.\n- This card does **not** introduce per-card success/failure detail —\n  the `BatchOperationResult` returned by `*_detailed` inherent methods\n  on `KanbanContext` already covers that case. Those methods have\n  their own pattern and are out of scope unless the implementer\n  decides to unify.\n- The `update_cards` plural (post-KAN-394) does NOT have this issue —\n  it returns `count = updates.len()` upfront because each input maps\n  one-to-one to an `UpdateCard` command. Don't touch it.\n\n## Relationship to other cards\n\n- **KAN-434** (just merged) is the reason this gap is visible — the\n  singular shorthands discard the count and pay for two extra reads\n  per call. Resolving this card eliminates that overhead.\n- **KAN-432** (per-board auto-sync opt-out) is independent. Both\n  changes touch `update_cards` but in different ways.\n- **KAN-433** (drop dead lifecycle helpers) is independent.\n\n## Commit shape\n\nIf Option (b) (additive):\n\n1. `feat(domain): card batch commands expose executed_count()` — add\n   the new method to `ArchiveCards`, `MoveCards`,\n   `AssignCardsToSprint`. Default to `0` for non-batch commands.\n2. `refactor(service): replace before/after delta with command\n   executed_count()` — switch the three plurals.\n3. `chore: add changeset for KAN-43x`\n\nIf Option (a) (signature change):\n\n1. `refactor(domain): Command::execute returns KanbanResult<usize>` —\n   wide mechanical change.\n2. `refactor(service): plurals use returned counts instead of\n   before/after delta` — switch the three plurals.\n3. `chore: add changeset for KAN-43x`\n\nEither way: write the test commit first when introducing the new\nreturn shape, per the project TDD convention.",
+        "created_at": "2026-05-11T23:58:32.501238350Z",
+        "description": "## Behaviour\n\nIn ColumnView and GroupedByColumn views, pressing `h` or `l` to move a\ncard across columns leaves the selector on whatever card was previously\nselected in the **target** column, instead of following the moved card.\nEquivalently, multi-selecting cards and pressing `h`/`l` to move them\nleaves the selector in the wrong place.\n\n## Expected\n\nAfter `h`/`l`, the selector follows the moved card into its new column.\nFor the multi-select case, the selector follows the *first* selected\ncard (matching the existing implementation intent at\n`crates/kanban-tui/src/handlers/card_handlers.rs:535` —\n`first_card_id` is computed precisely for this purpose).\n\n## Why it happens\n\nSame root cause as KAN-403, just at the move-card handlers:\n\n- `crates/kanban-tui/src/handlers/card_handlers.rs:404::handle_move_card`\n  ends with `self.select_card_by_id(card_id);` at line 480.\n- `crates/kanban-tui/src/handlers/card_handlers.rs::move_selected_cards`\n  ends with `self.select_card_by_id(card_id);` at line 536.\n\nBy the time `select_card_by_id` runs:\n\n1. `self.ctx.move_card(card_id, target_column_id, None)` has updated the\n   model — the card lives in `target_column_id` now.\n2. The column-selection navigation block (lines 487–514) has shifted\n   `self.dialog_input.column_selection` to the target column in\n   ColumnView, so the *active task list* is now the target column's.\n3. But the target column's `CardList::cards` vec is the cached one from\n   the previous `prepare_frame()` — it does NOT yet contain the moved\n   card's ID.\n4. `select_card_by_id` → `task_list.select_card(card_id)` searches\n   `self.cards`, doesn't find it, returns `false` silently.\n5. The next render-loop `prepare_frame()` refreshes the task list and\n   `CardList::update_cards` re-applies the saved `current_card` (the\n   previously selected card in the target column). The moved card is\n   ignored.\n\nIn **Flat** view this bug doesn't manifest — the active task list is\nglobal and the card is in it before and after the move.\n\n## Reproduction\n\n```rust\n// Add to crates/kanban-tui/tests/stale_model_regression_tests.rs\n#[test]\nfn test_move_card_right_selects_moved_card_in_kanban_view() {\n    let mut app = App::test_default();\n    let board = app.ctx.create_board(\"Board\".to_string(), None).unwrap();\n    let _todo = app.ctx.create_column(board.id, \"Todo\".to_string(), Some(0)).unwrap();\n    let _doing = app.ctx.create_column(board.id, \"Doing\".to_string(), Some(1)).unwrap();\n    let _done = app.ctx.create_column(board.id, \"Done\".to_string(), Some(2)).unwrap();\n    app.prepare_frame();\n    app.selection.board.set(Some(0));\n    app.selection.active_board_index = Some(0);\n    app.focus.active = Focus::Cards;\n\n    // Two cards in Todo so there's a \"prior selection\" in Doing's\n    // post-move task list to clobber the moved card's selection.\n    app.input.set(\"Anchor\".to_string());\n    app.create_card();\n    app.prepare_frame();\n    app.input.set(\"Mover\".to_string());\n    app.create_card();\n    app.prepare_frame();\n    let mover_id = app.get_selected_card_id().unwrap();\n\n    // Move \"Mover\" right: Todo → Doing.\n    app.handle_move_card_right();\n    app.prepare_frame();\n\n    let selected = app.get_selected_card_id().expect(\"a card is selected\");\n    assert_eq!(\n        selected, mover_id,\n        \"selector must follow the moved card into the target column, not stay on a prior card\"\n    );\n}\n```\n\nA symmetric test should exist for `move_selected_cards` (multi-select\n+ `l`).\n\n## Fix — option 1: mirror KAN-403 per-handler\n\nInsert `self.prepare_frame()` right before each `select_card_by_id`\ncall at the two sites above. One-line change per call site, two total.\nMirrors the fix landed for `create_card` in\n[KAN-403 PR](https://github.com/fulsomenko/kanban/pull/260).\n\n```rust\n// handle_move_card, around line 480:\nself.prepare_frame();\nself.select_card_by_id(card_id);\n\n// move_selected_cards, around line 536:\nif let Some(card_id) = first_card_id {\n    self.prepare_frame();\n    self.select_card_by_id(card_id);\n}\n```\n\n## Fix — option 2: centralize in `select_card_by_id` (preferred)\n\nSee companion card (filed alongside this one) for refactoring\n`crates/kanban-tui/src/app/mod.rs:1454::select_card_by_id` to refresh\nthe task list internally. That eliminates every per-handler workaround,\nincluding the one already in `create_card`. Both this card's bug and\nKAN-403's are subsumed.\n\nIf the companion card lands first, this card is automatically\nresolved — close it as a duplicate.\n\n## Acceptance\n\n- Test `test_move_card_right_selects_moved_card_in_kanban_view` (and a\n  matching `test_move_selected_cards_right_selects_first_moved_card`)\n  passes.\n- The existing `test_create_card_selects_newly_created_card_when_prior_selection_exists`\n  (added in KAN-403) stays green.\n- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,\n  `cargo fmt --check` all clean.\n- Manual sanity: `kanban /tmp/test.json`, create two cards in Todo,\n  select the second, press `l`. Expected: focus follows to Doing\n  column, the moved card stays selected.\n\n## Files modified\n\n| File | Change |\n|---|---|\n| `crates/kanban-tui/src/handlers/card_handlers.rs` | Insert `self.prepare_frame()` before `select_card_by_id` at line 480 (`handle_move_card`) and line 536 (`move_selected_cards`). Two lines added. |\n| `crates/kanban-tui/tests/stale_model_regression_tests.rs` | Two new tests (single-card and multi-select). |\n\n## Architectural principle\n\nSelection / cursor logic stays inside the TUI app. The fix lives in\n`crates/kanban-tui/src/handlers/card_handlers.rs`; nothing leaks into\n`kanban-service` or `kanban-domain`. Verified during KAN-403 — no\nservice- or domain-layer code references `select_card_by_id`,\n`active_card`, or `selected_card`.\n\n## Risk\n\nVery low. Same shape as the KAN-403 fix that just merged. The added\n`prepare_frame` call is idempotent — the next render-loop call is\nredundant but harmless.\n\n## Relationship to other cards\n\n- **KAN-403** (PR #260): identical bug at `create_card`, now fixed.\n  This card is the natural follow-up surfaced by KAN-403's plan\n  (\"`handle_move_card` may have a related bug in ColumnView\").\n- **Companion refactor card** (filed alongside): centralize the\n  refresh in `select_card_by_id`. Implementing the companion subsumes\n  this card.\n\n## Commit shape\n\nIf going with option 1 (per-handler):\n\n1. `test(tui): cover selector-follows-card on h/l move (red)` — two new\n   tests, both failing.\n2. `fix(tui): refresh task list before selecting moved card` —\n   two-line insertion.\n3. `chore: add changeset for KAN-NNN`.\n\nIf going with option 2: see companion card.",
         "due_date": null,
-        "id": "96355729-f423-4d63-9b82-2ac75160c3c1",
-        "points": 3,
-        "position": 198,
-        "priority": "Low",
+        "id": "8da7af03-a2c7-4acc-ac47-44380f829620",
+        "points": 2,
+        "position": 199,
+        "priority": "High",
         "sprint_id": null,
         "sprint_logs": [],
         "status": "Todo",
-        "title": "refactor(domain): commands return mutation count to remove before/after delta queries in service plurals",
-        "updated_at": "2026-05-11T23:39:08.421237072Z"
+        "title": "fix(tui): selector does not follow card after move across columns in kanban view",
+        "updated_at": "2026-05-11T23:58:32.501409979Z"
       },
       {
         "card_number": 413,
@@ -13574,40 +13676,6 @@
         "updated_at": "2026-05-10T17:33:14.477272926Z"
       },
       {
-        "card_number": 437,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-05-11T23:58:32.501238350Z",
-        "description": "## Behaviour\n\nIn ColumnView and GroupedByColumn views, pressing `h` or `l` to move a\ncard across columns leaves the selector on whatever card was previously\nselected in the **target** column, instead of following the moved card.\nEquivalently, multi-selecting cards and pressing `h`/`l` to move them\nleaves the selector in the wrong place.\n\n## Expected\n\nAfter `h`/`l`, the selector follows the moved card into its new column.\nFor the multi-select case, the selector follows the *first* selected\ncard (matching the existing implementation intent at\n`crates/kanban-tui/src/handlers/card_handlers.rs:535` —\n`first_card_id` is computed precisely for this purpose).\n\n## Why it happens\n\nSame root cause as KAN-403, just at the move-card handlers:\n\n- `crates/kanban-tui/src/handlers/card_handlers.rs:404::handle_move_card`\n  ends with `self.select_card_by_id(card_id);` at line 480.\n- `crates/kanban-tui/src/handlers/card_handlers.rs::move_selected_cards`\n  ends with `self.select_card_by_id(card_id);` at line 536.\n\nBy the time `select_card_by_id` runs:\n\n1. `self.ctx.move_card(card_id, target_column_id, None)` has updated the\n   model — the card lives in `target_column_id` now.\n2. The column-selection navigation block (lines 487–514) has shifted\n   `self.dialog_input.column_selection` to the target column in\n   ColumnView, so the *active task list* is now the target column's.\n3. But the target column's `CardList::cards` vec is the cached one from\n   the previous `prepare_frame()` — it does NOT yet contain the moved\n   card's ID.\n4. `select_card_by_id` → `task_list.select_card(card_id)` searches\n   `self.cards`, doesn't find it, returns `false` silently.\n5. The next render-loop `prepare_frame()` refreshes the task list and\n   `CardList::update_cards` re-applies the saved `current_card` (the\n   previously selected card in the target column). The moved card is\n   ignored.\n\nIn **Flat** view this bug doesn't manifest — the active task list is\nglobal and the card is in it before and after the move.\n\n## Reproduction\n\n```rust\n// Add to crates/kanban-tui/tests/stale_model_regression_tests.rs\n#[test]\nfn test_move_card_right_selects_moved_card_in_kanban_view() {\n    let mut app = App::test_default();\n    let board = app.ctx.create_board(\"Board\".to_string(), None).unwrap();\n    let _todo = app.ctx.create_column(board.id, \"Todo\".to_string(), Some(0)).unwrap();\n    let _doing = app.ctx.create_column(board.id, \"Doing\".to_string(), Some(1)).unwrap();\n    let _done = app.ctx.create_column(board.id, \"Done\".to_string(), Some(2)).unwrap();\n    app.prepare_frame();\n    app.selection.board.set(Some(0));\n    app.selection.active_board_index = Some(0);\n    app.focus.active = Focus::Cards;\n\n    // Two cards in Todo so there's a \"prior selection\" in Doing's\n    // post-move task list to clobber the moved card's selection.\n    app.input.set(\"Anchor\".to_string());\n    app.create_card();\n    app.prepare_frame();\n    app.input.set(\"Mover\".to_string());\n    app.create_card();\n    app.prepare_frame();\n    let mover_id = app.get_selected_card_id().unwrap();\n\n    // Move \"Mover\" right: Todo → Doing.\n    app.handle_move_card_right();\n    app.prepare_frame();\n\n    let selected = app.get_selected_card_id().expect(\"a card is selected\");\n    assert_eq!(\n        selected, mover_id,\n        \"selector must follow the moved card into the target column, not stay on a prior card\"\n    );\n}\n```\n\nA symmetric test should exist for `move_selected_cards` (multi-select\n+ `l`).\n\n## Fix — option 1: mirror KAN-403 per-handler\n\nInsert `self.prepare_frame()` right before each `select_card_by_id`\ncall at the two sites above. One-line change per call site, two total.\nMirrors the fix landed for `create_card` in\n[KAN-403 PR](https://github.com/fulsomenko/kanban/pull/260).\n\n```rust\n// handle_move_card, around line 480:\nself.prepare_frame();\nself.select_card_by_id(card_id);\n\n// move_selected_cards, around line 536:\nif let Some(card_id) = first_card_id {\n    self.prepare_frame();\n    self.select_card_by_id(card_id);\n}\n```\n\n## Fix — option 2: centralize in `select_card_by_id` (preferred)\n\nSee companion card (filed alongside this one) for refactoring\n`crates/kanban-tui/src/app/mod.rs:1454::select_card_by_id` to refresh\nthe task list internally. That eliminates every per-handler workaround,\nincluding the one already in `create_card`. Both this card's bug and\nKAN-403's are subsumed.\n\nIf the companion card lands first, this card is automatically\nresolved — close it as a duplicate.\n\n## Acceptance\n\n- Test `test_move_card_right_selects_moved_card_in_kanban_view` (and a\n  matching `test_move_selected_cards_right_selects_first_moved_card`)\n  passes.\n- The existing `test_create_card_selects_newly_created_card_when_prior_selection_exists`\n  (added in KAN-403) stays green.\n- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,\n  `cargo fmt --check` all clean.\n- Manual sanity: `kanban /tmp/test.json`, create two cards in Todo,\n  select the second, press `l`. Expected: focus follows to Doing\n  column, the moved card stays selected.\n\n## Files modified\n\n| File | Change |\n|---|---|\n| `crates/kanban-tui/src/handlers/card_handlers.rs` | Insert `self.prepare_frame()` before `select_card_by_id` at line 480 (`handle_move_card`) and line 536 (`move_selected_cards`). Two lines added. |\n| `crates/kanban-tui/tests/stale_model_regression_tests.rs` | Two new tests (single-card and multi-select). |\n\n## Architectural principle\n\nSelection / cursor logic stays inside the TUI app. The fix lives in\n`crates/kanban-tui/src/handlers/card_handlers.rs`; nothing leaks into\n`kanban-service` or `kanban-domain`. Verified during KAN-403 — no\nservice- or domain-layer code references `select_card_by_id`,\n`active_card`, or `selected_card`.\n\n## Risk\n\nVery low. Same shape as the KAN-403 fix that just merged. The added\n`prepare_frame` call is idempotent — the next render-loop call is\nredundant but harmless.\n\n## Relationship to other cards\n\n- **KAN-403** (PR #260): identical bug at `create_card`, now fixed.\n  This card is the natural follow-up surfaced by KAN-403's plan\n  (\"`handle_move_card` may have a related bug in ColumnView\").\n- **Companion refactor card** (filed alongside): centralize the\n  refresh in `select_card_by_id`. Implementing the companion subsumes\n  this card.\n\n## Commit shape\n\nIf going with option 1 (per-handler):\n\n1. `test(tui): cover selector-follows-card on h/l move (red)` — two new\n   tests, both failing.\n2. `fix(tui): refresh task list before selecting moved card` —\n   two-line insertion.\n3. `chore: add changeset for KAN-NNN`.\n\nIf going with option 2: see companion card.",
-        "due_date": null,
-        "id": "8da7af03-a2c7-4acc-ac47-44380f829620",
-        "points": 2,
-        "position": 199,
-        "priority": "High",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Todo",
-        "title": "fix(tui): selector does not follow card after move across columns in kanban view",
-        "updated_at": "2026-05-11T23:58:32.501409979Z"
-      },
-      {
-        "card_number": 438,
-        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
-        "completed_at": null,
-        "created_at": "2026-05-11T23:58:32.539930381Z",
-        "description": "## Why\n\nKAN-403 fixed a TUI regression where `create_card` left the selector on\nthe prior card instead of jumping to the new one. The root cause was a\nstale view-layer task list at the moment `select_card_by_id` ran. The\ncompanion card (filed alongside this one) calls out the same shape at\n`handle_move_card` and `move_selected_cards`.\n\nThe pattern recurs every time a handler:\n\n1. Mutates the model in a way that adds a card to (or moves a card\n   between) view-layer task lists, AND\n2. Calls `select_card_by_id(card_id)` before the next render-loop\n   `prepare_frame()` has refreshed the task list.\n\nToday the workaround is local to each handler: insert\n`self.prepare_frame()` right before `self.select_card_by_id(...)`.\nThat works but it duplicates the same fix across N handlers, and any\nfuture handler that forgets to add it will silently regress the\nselection behaviour.\n\nThe cleaner architecture: make `select_card_by_id` itself responsible\nfor ensuring the active task list is fresh. Selection / cursor logic\nalready lives entirely inside the TUI app (verified during KAN-403 —\nno other crate touches it) and `select_card_by_id` is the canonical\nentry point for \"the user wants card `X` selected\". Refreshing the\ntask list before searching for `X` is part of that contract.\n\n## What\n\nModify `crates/kanban-tui/src/app/mod.rs:1454::select_card_by_id` to\ncall `self.prepare_frame()` before delegating to\n`task_list.select_card(card_id)`:\n\n```rust\npub fn select_card_by_id(&mut self, card_id: uuid::Uuid) {\n    self.prepare_frame();\n    if let Some(task_list) = self.view.strategy.get_active_task_list_mut() {\n        task_list.select_card(card_id);\n    }\n}\n```\n\nThen remove the now-redundant `self.prepare_frame()` calls from:\n\n- `crates/kanban-tui/src/handlers/card_handlers.rs::create_card` (the\n  one inserted by KAN-403 at line 390).\n- `crates/kanban-tui/src/handlers/card_handlers.rs::handle_move_card`\n  and `move_selected_cards` (only if the companion card landed first\n  and added them — otherwise they were never inserted).\n\n## Where the wiring lives\n\n- `crates/kanban-tui/src/app/mod.rs:1454` — single method change. ~3\n  lines added (the `prepare_frame()` call + a brief doc comment if\n  warranted).\n- `crates/kanban-tui/src/handlers/card_handlers.rs:390` — remove the\n  redundant call inserted by KAN-403.\n- Any other handler that's accumulated the same workaround over time.\n\nThe `prepare_frame()` method (`app/mod.rs:1541`) and the\n`select_card_by_id` method (`app/mod.rs:1454`) both live in\n`impl App` in the `kanban-tui` crate. Service and domain layers are\nuntouched. The selection-logic-stays-in-TUI principle is preserved.\n\n## Existing call sites\n\n`select_card_by_id` is called from 8 handler sites in\n`crates/kanban-tui/src/handlers/`:\n\n- `card_handlers.rs:252` (`toggle_card_completion`)\n- `card_handlers.rs:297` (`toggle_selected_cards_completion`)\n- `card_handlers.rs:391` (`create_card` — KAN-403's fix is the\n  `prepare_frame` above this line)\n- `card_handlers.rs:480` (`handle_move_card`)\n- `card_handlers.rs:536` (`move_selected_cards`)\n- `card_handlers.rs:603`/`612` (next/prev navigation — card is\n  already in the list)\n- `column_handlers.rs:537`\n\nFor the navigation cases (next/prev, line 603/612), the card is\nalready in the active task list — calling `prepare_frame` is wasted\nwork but doesn't change behaviour. For everything else, the refresh\neither is the bug fix (create/move) or is a no-op (toggle).\n\n## Performance consideration\n\nEvery `select_card_by_id` call now triggers a snapshot load + a\ntask-list rebuild. For the in-memory backend this is microseconds.\nFor SQLite it's a single indexed query. Negligible at user-driven\ncadence. If a future hot path emerges that calls `select_card_by_id`\nin a tight loop, that loop should batch via direct task-list access\nanyway, not through this entry point.\n\n## Acceptance\n\n- The redundant `prepare_frame` call removed from `create_card` —\n  `test_create_card_selects_newly_created_card_when_prior_selection_exists`\n  still passes.\n- If the companion card's tests exist:\n  `test_move_card_right_selects_moved_card_in_kanban_view` and the\n  multi-select variant still pass with the per-handler fixes removed.\n- No new tests required — both bug-fix cards already pin down the\n  behaviour. A negative test (e.g.\n  `test_toggle_completion_does_not_drop_selection`) is optional belt-\n  and-braces.\n- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,\n  `cargo fmt --check` all clean.\n\n## Files modified\n\n| File | Change |\n|---|---|\n| `crates/kanban-tui/src/app/mod.rs` | `select_card_by_id` calls `self.prepare_frame()` first. |\n| `crates/kanban-tui/src/handlers/card_handlers.rs` | Remove the redundant `self.prepare_frame()` call from `create_card` (and from any other handler that accumulated the same workaround pre-merge). |\n\n## Risk\n\nLow.\n\n- The change is purely additive at the entry point and removes\n  duplication at the call sites — no behaviour change for working\n  flows.\n- Calls `prepare_frame` once on every selection update across all 8\n  call sites. For toggle / navigation that's wasted work, but cheap.\n- If a future bug surfaces where `select_card_by_id` is called from a\n  context where `prepare_frame` would be wrong (e.g. mid-frame, with\n  a partially-applied state), revisit with a `select_card_by_id_raw`\n  escape hatch.\n\n## Relationship to other cards\n\n- **KAN-403** (merged in #260): introduced the first per-handler\n  workaround in `create_card`. The redundant call goes away when this\n  card lands.\n- **Companion bug card** (filed alongside): adds per-handler\n  workarounds at `handle_move_card` and `move_selected_cards`. Either\n  card landing alone is fine; if both land, the order is:\n  1. Companion lands first → this card removes its workaround too.\n  2. This card lands first → companion is auto-resolved, close as dup.\n\n## Commit shape\n\n1. `refactor(tui): select_card_by_id refreshes task list before\n   selecting` — change `select_card_by_id` body, remove the redundant\n   `prepare_frame` call(s) from handlers.\n2. `chore: add changeset for KAN-NNN` — user-facing description noting\n   that the underlying flakiness is gone (most users won't notice\n   anything since KAN-403 + the companion bug card already covered\n   the visible cases).\n\n## Out of scope\n\n- A \"deferred selection intent\" mechanism (storing\n  `pending_card_selection: Option<Uuid>` on the app and applying it\n  during the next `update_cards`) is an alternative that avoids the\n  extra `prepare_frame` call but adds plumbing across two layers. Not\n  worth the complexity unless `prepare_frame` cost becomes measurable.",
-        "due_date": null,
-        "id": "a7ac3b3f-055e-49b8-b918-b8a4fc3740e4",
-        "points": 2,
-        "position": 200,
-        "priority": "Low",
-        "sprint_id": null,
-        "sprint_logs": [],
-        "status": "Todo",
-        "title": "refactor(tui): centralize task-list refresh in select_card_by_id",
-        "updated_at": "2026-05-11T23:58:32.540105738Z"
-      },
-      {
         "card_number": 414,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
@@ -13632,6 +13700,23 @@
         "status": "Todo",
         "title": "Update CONTRIBUTING.md to explicitly welcome bug fixes",
         "updated_at": "2026-05-10T17:33:14.477267740Z"
+      },
+      {
+        "card_number": 438,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-11T23:58:32.539930381Z",
+        "description": "## Why\n\nKAN-403 fixed a TUI regression where `create_card` left the selector on\nthe prior card instead of jumping to the new one. The root cause was a\nstale view-layer task list at the moment `select_card_by_id` ran. The\ncompanion card (filed alongside this one) calls out the same shape at\n`handle_move_card` and `move_selected_cards`.\n\nThe pattern recurs every time a handler:\n\n1. Mutates the model in a way that adds a card to (or moves a card\n   between) view-layer task lists, AND\n2. Calls `select_card_by_id(card_id)` before the next render-loop\n   `prepare_frame()` has refreshed the task list.\n\nToday the workaround is local to each handler: insert\n`self.prepare_frame()` right before `self.select_card_by_id(...)`.\nThat works but it duplicates the same fix across N handlers, and any\nfuture handler that forgets to add it will silently regress the\nselection behaviour.\n\nThe cleaner architecture: make `select_card_by_id` itself responsible\nfor ensuring the active task list is fresh. Selection / cursor logic\nalready lives entirely inside the TUI app (verified during KAN-403 —\nno other crate touches it) and `select_card_by_id` is the canonical\nentry point for \"the user wants card `X` selected\". Refreshing the\ntask list before searching for `X` is part of that contract.\n\n## What\n\nModify `crates/kanban-tui/src/app/mod.rs:1454::select_card_by_id` to\ncall `self.prepare_frame()` before delegating to\n`task_list.select_card(card_id)`:\n\n```rust\npub fn select_card_by_id(&mut self, card_id: uuid::Uuid) {\n    self.prepare_frame();\n    if let Some(task_list) = self.view.strategy.get_active_task_list_mut() {\n        task_list.select_card(card_id);\n    }\n}\n```\n\nThen remove the now-redundant `self.prepare_frame()` calls from:\n\n- `crates/kanban-tui/src/handlers/card_handlers.rs::create_card` (the\n  one inserted by KAN-403 at line 390).\n- `crates/kanban-tui/src/handlers/card_handlers.rs::handle_move_card`\n  and `move_selected_cards` (only if the companion card landed first\n  and added them — otherwise they were never inserted).\n\n## Where the wiring lives\n\n- `crates/kanban-tui/src/app/mod.rs:1454` — single method change. ~3\n  lines added (the `prepare_frame()` call + a brief doc comment if\n  warranted).\n- `crates/kanban-tui/src/handlers/card_handlers.rs:390` — remove the\n  redundant call inserted by KAN-403.\n- Any other handler that's accumulated the same workaround over time.\n\nThe `prepare_frame()` method (`app/mod.rs:1541`) and the\n`select_card_by_id` method (`app/mod.rs:1454`) both live in\n`impl App` in the `kanban-tui` crate. Service and domain layers are\nuntouched. The selection-logic-stays-in-TUI principle is preserved.\n\n## Existing call sites\n\n`select_card_by_id` is called from 8 handler sites in\n`crates/kanban-tui/src/handlers/`:\n\n- `card_handlers.rs:252` (`toggle_card_completion`)\n- `card_handlers.rs:297` (`toggle_selected_cards_completion`)\n- `card_handlers.rs:391` (`create_card` — KAN-403's fix is the\n  `prepare_frame` above this line)\n- `card_handlers.rs:480` (`handle_move_card`)\n- `card_handlers.rs:536` (`move_selected_cards`)\n- `card_handlers.rs:603`/`612` (next/prev navigation — card is\n  already in the list)\n- `column_handlers.rs:537`\n\nFor the navigation cases (next/prev, line 603/612), the card is\nalready in the active task list — calling `prepare_frame` is wasted\nwork but doesn't change behaviour. For everything else, the refresh\neither is the bug fix (create/move) or is a no-op (toggle).\n\n## Performance consideration\n\nEvery `select_card_by_id` call now triggers a snapshot load + a\ntask-list rebuild. For the in-memory backend this is microseconds.\nFor SQLite it's a single indexed query. Negligible at user-driven\ncadence. If a future hot path emerges that calls `select_card_by_id`\nin a tight loop, that loop should batch via direct task-list access\nanyway, not through this entry point.\n\n## Acceptance\n\n- The redundant `prepare_frame` call removed from `create_card` —\n  `test_create_card_selects_newly_created_card_when_prior_selection_exists`\n  still passes.\n- If the companion card's tests exist:\n  `test_move_card_right_selects_moved_card_in_kanban_view` and the\n  multi-select variant still pass with the per-handler fixes removed.\n- No new tests required — both bug-fix cards already pin down the\n  behaviour. A negative test (e.g.\n  `test_toggle_completion_does_not_drop_selection`) is optional belt-\n  and-braces.\n- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,\n  `cargo fmt --check` all clean.\n\n## Files modified\n\n| File | Change |\n|---|---|\n| `crates/kanban-tui/src/app/mod.rs` | `select_card_by_id` calls `self.prepare_frame()` first. |\n| `crates/kanban-tui/src/handlers/card_handlers.rs` | Remove the redundant `self.prepare_frame()` call from `create_card` (and from any other handler that accumulated the same workaround pre-merge). |\n\n## Risk\n\nLow.\n\n- The change is purely additive at the entry point and removes\n  duplication at the call sites — no behaviour change for working\n  flows.\n- Calls `prepare_frame` once on every selection update across all 8\n  call sites. For toggle / navigation that's wasted work, but cheap.\n- If a future bug surfaces where `select_card_by_id` is called from a\n  context where `prepare_frame` would be wrong (e.g. mid-frame, with\n  a partially-applied state), revisit with a `select_card_by_id_raw`\n  escape hatch.\n\n## Relationship to other cards\n\n- **KAN-403** (merged in #260): introduced the first per-handler\n  workaround in `create_card`. The redundant call goes away when this\n  card lands.\n- **Companion bug card** (filed alongside): adds per-handler\n  workarounds at `handle_move_card` and `move_selected_cards`. Either\n  card landing alone is fine; if both land, the order is:\n  1. Companion lands first → this card removes its workaround too.\n  2. This card lands first → companion is auto-resolved, close as dup.\n\n## Commit shape\n\n1. `refactor(tui): select_card_by_id refreshes task list before\n   selecting` — change `select_card_by_id` body, remove the redundant\n   `prepare_frame` call(s) from handlers.\n2. `chore: add changeset for KAN-NNN` — user-facing description noting\n   that the underlying flakiness is gone (most users won't notice\n   anything since KAN-403 + the companion bug card already covered\n   the visible cases).\n\n## Out of scope\n\n- A \"deferred selection intent\" mechanism (storing\n  `pending_card_selection: Option<Uuid>` on the app and applying it\n  during the next `update_cards`) is an alternative that avoids the\n  extra `prepare_frame` call but adds plumbing across two layers. Not\n  worth the complexity unless `prepare_frame` cost becomes measurable.",
+        "due_date": null,
+        "id": "a7ac3b3f-055e-49b8-b918-b8a4fc3740e4",
+        "points": 2,
+        "position": 200,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "refactor(tui): centralize task-list refresh in select_card_by_id",
+        "updated_at": "2026-05-11T23:58:32.540105738Z"
       },
       {
         "card_number": 415,
@@ -13784,7 +13869,7 @@
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
         "created_at": "2026-05-13T20:43:16.361663614Z",
-        "description": "shell_words uses POSIX quoting rules where backslash is an escape character. A Windows user who sets EDITOR=C:\\Users\\foo\\vim.exe (no quotes, backslashes) will have their path silently mangled — the backslashes are interpreted as escapes. The quoted-path tests in the PR use forward slashes only. Options: (1) document in README that Windows users must use forward slashes or quote the path; (2) gate on cfg!(target_os='windows') and use a simpler whitespace split when unquoted. At minimum, add a test case with a raw backslash Windows path to make the failure visible.",
+        "description": "shell_words follows POSIX quoting rules where \\ is an escape character. A Windows user who sets EDITOR to a backslash path (the natural cmd/PowerShell syntax) has the path silently mangled before it ever reaches Command::new.\n\nVerified empirically against shell-words 1.1.1:\n\n  EDITOR=C:\\Program Files\\vim.exe        -> [\"C:Program\", \"Filesvim.exe\"]   (two tokens, path mangled)\n  EDITOR=C:\\Users\\foo\\nvim.exe           -> [\"C:Usersfoonvim.exe\"]          (entirely nonsense path)\n  EDITOR=C:\\tools\\code.exe --wait        -> [\"C:toolscode.exe\", \"--wait\"]   (path mangled, args OK)\n  EDITOR=\"C:\\Program Files\\vim.exe\"      -> [\"C:\\\\Program Files\\\\vim.exe\"]  (quoted works)\n  EDITOR=\"C:\\Program Files\\vim.exe\" --x  -> [\"C:\\\\Program Files\\\\vim.exe\", \"--x\"] (quoted+arg works)\n\nScope is broader than \"users with spaces in the path\": anyone on Windows whose EDITOR is an absolute path (rather than a binary name relying on PATH) is affected. Before the refactor, EDITOR flowed straight into Command::new(&editor) and the OS path APIs accepted a literal Windows path with backslashes. After the refactor, the string is fed through shell_words::split first, backslashes are eaten as escapes, and which::which / Command::new are then handed a nonsense path that doesn't exist.\n\nPossible fixes:\n1. Gate on cfg!(target_os = \"windows\") and skip shell-words parsing for the unquoted case (preserves backslash-path behavior but gives up multi-word args on Windows).\n2. Use a Windows-aware command-line parser (more invasive, but correct for both quoted and unquoted inputs and arg-bearing EDITORs).\n3. Minimum viable: keep current parsing but document the requirement to quote backslash paths in the README VS Code limitations note.\n\nAlso add a test case that exercises a raw-backslash Windows path so the limitation is visible at the test level.\n\nCaptured during review of #255; bundled into #266 as a follow-up.",
         "due_date": null,
         "id": "74b0c073-f4f2-4042-a91b-14e707b5c0da",
         "points": null,
@@ -13794,14 +13879,14 @@
         "sprint_logs": [],
         "status": "Todo",
         "title": "editor: document/handle Windows backslash paths in EDITOR",
-        "updated_at": "2026-05-13T20:43:16.361921765Z"
+        "updated_at": "2026-05-13T21:31:49.992042248Z"
       },
       {
         "card_number": 444,
         "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
         "completed_at": null,
         "created_at": "2026-05-13T20:43:24.338020743Z",
-        "description": "resolve_editor_uses_env_var and resolve_editor_handles_multiword_editor both check that the returned path ends_with('vim') or ends_with('code'), but which::which falls back to PathBuf::from(program) on failure — meaning PathBuf::from('vim').ends_with('vim') is true even when vim is not on PATH. The tests pass vacuously on machines without the editors installed. Fix: assert that the path is absolute (path.is_absolute()) as a proxy for 'which actually resolved it', or split into two cases: when the binary is present assert absolute, when absent assert the program name passthrough.",
+        "description": "resolve_editor_uses_env_var (line 152) and resolve_editor_handles_multiword_editor (line 163) assert path.ends_with(\"vim\") or path.ends_with(\"code\"). which::which falls back to PathBuf::from(&program) on failure (editor.rs:41), so PathBuf::from(\"vim\").ends_with(\"vim\") is true regardless of whether which actually resolved anything. On a CI runner without vim, the test passes — but verifies nothing about the resolution behavior. Same for code, which is even less likely to be on a CI runner.\n\nAmanda was aware of the issue but had no good answer (\"I don't have a good solution out the gate ... one lazy fix could be to install vim on the GHA runner, but that creates a dependency/coupling that shouldn't exist\").\n\nRecommended approach: drop vim and code as test fixtures and use cargo (or rustc) instead. cargo is guaranteed to be on PATH whenever cargo test is running the test — by definition. Then path.is_absolute() becomes a non-vacuous check: it is only true if which::which actually resolved the binary.\n\nSuggested test rewrite (assumes commit 1's resolve_editor_with(Option<&str>) extraction is in place):\n\n  #[test]\n  fn resolve_editor_resolves_program_via_which() {\n      let (path, args) = resolve_editor_with(Some(\"cargo\"));\n      assert!(path.is_absolute(), \"which() should have resolved cargo to an absolute path\");\n      assert!(args.is_empty());\n  }\n\n  #[test]\n  fn resolve_editor_extracts_args_from_program() {\n      let (path, args) = resolve_editor_with(Some(\"cargo --verbose\"));\n      assert!(path.is_absolute());\n      assert_eq!(args, vec![\"--verbose\"]);\n  }\n\nWhy cargo rather than sh/cmd or installing vim:\n- cargo is cross-platform: no cfg-gating needed, no Git Bash / WSL assumption on Windows\n- No CI config change required (no GHA apt-get install vim, no shell.nix change)\n- No coupling to optional system packages\n- The binary is by definition present, since it's running the test\n\nCaptured during review of #255; bundled into #266 as a follow-up.",
         "due_date": null,
         "id": "afb4e39f-a608-4115-9de9-daf0ec9edd21",
         "points": null,
@@ -13811,7 +13896,126 @@
         "sprint_logs": [],
         "status": "Todo",
         "title": "editor: strengthen resolve_editor test assertions",
-        "updated_at": "2026-05-13T20:43:24.338177656Z"
+        "updated_at": "2026-05-13T22:53:05.774970695Z"
+      },
+      {
+        "card_number": 446,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-14T01:23:55.078171066Z",
+        "description": "Follow-up from PR #251 (Release 0.5.0) review. The AUR section of release.yml works for the obvious failure modes but has three latent risks worth addressing before they bite.\n\n## Where\n\n`.github/workflows/release.yml`, the \"Update PKGBUILD version and sha256\" + \"Generate .SRCINFO\" + \"Commit and push AUR files\" + \"Deploy to AUR\" steps (lines ~126-171).\n\n## Risks (in order of likelihood)\n\n### 1. Tag-push → tarball-fetch race\n\nThe \"Tag version\" step pushes `v$VERSION` to origin, then \"Update PKGBUILD\" curls `https://github.com/fulsomenko/kanban/archive/v$VERSION.tar.gz`. The archive endpoint is tag-based and usually serves immediately, but GitHub's CDN can transiently 404 right after a tag push. With `set -e` + `curl -fsL`, a single transient 404 fails the whole release **after** crates.io has already published — no clean retry path, requires manual re-tag or running the `aur-publish.yml` workflow_dispatch fallback.\n\nFix: wrap the curl in a retry loop with exponential backoff.\n\n```bash\nfor i in 1 2 3 4 5; do\n  if SHA256=$(curl -fsL \"$URL\" | sha256sum | cut -d' ' -f1); then break; fi\n  sleep $((i*5))\ndone\n```\n\n### 2. No end-to-end SHA validation before AUR push\n\n`makepkg --printsrcinfo` parses metadata only — it does not download or verify sources. So if the recorded sha is ever wrong (truncated body, sed regex miss, GitHub archive format drift), CI is green and the broken PKGBUILD ships to AUR. End users see `==> ERROR: One or more files did not pass the validity check!` at `pacman -S` time.\n\nFix: replace (or augment) the `--printsrcinfo` step with `makepkg -od --nocheck` inside the same nix shell. That re-downloads via makepkg's own logic and verifies against the sha we just wrote — closes the loop on the exact artifact end users will pull.\n\n### 3. GitHub auto-generated tarballs aren't contractually byte-stable\n\nGitHub has historically changed git's `archive` defaults (notably 2023-01 / 2023-09 gzip default changes), invalidating hashes across nixpkgs and AUR. When that happens, our recorded sha drifts even though the upstream commit is unchanged.\n\nTwo ways out:\n- (a) Upload a built tarball as a GH Release asset (via `softprops/action-gh-release` `files:` input) and source the PKGBUILD from `.../releases/download/...` (immutable artifact).\n- (b) Source from `git+https://...#tag=v$pkgver` and let makepkg verify by ref instead of by sha.\n\n(b) is lower-effort. Slow-burning, no urgency.\n\n### 4. sed assumes single-line sha256sums array\n\n`sed \"s|sha256sums=.*|...|\"` works on the current `aur/PKGBUILD:11` which has `sha256sums=(\"...\")` on one line. The moment anyone canonicalises to the multi-line form, the sed silently leaves the array half-replaced and the **old** sha survives. Pin the format with a `# do not reformat — release.yml depends on single-line` comment in the PKGBUILD, or rewrite the field with a tool that parses arrays.\n\n### 5. Hardcoded pkgrel=1\n\nIf anyone ever pushes an AUR-only fix manually (standard convention is bumping `pkgrel` between upstream releases), the next release.yml run resets it to 1. Probably fine for this fully-automated flow, but worth a comment in the PKGBUILD header so a future maintainer isn't surprised.\n\n## Recommended order\n\n1. **Add curl retry** — addresses #1, ~4 lines, no semantic change.\n2. **Add `makepkg -od --nocheck` validation step** — addresses #2, single nix-shell invocation.\n3. **Pin sha256sums single-line format with a comment** — addresses #4, one-line change.\n4. **Decide on (a) vs (b) for tarball stability** — addresses #3, larger change, can wait.\n\n## Context\n\nThis is the first release that exercises the wired-up AUR pipe end-to-end (KAN-397 only just landed in 0.5.0). Decided to ship 0.5.0 with the current pipe and iterate based on what actually happens on the first real run, rather than pre-harden everything blind.\n\n## Acceptance\n\n- Curl retry implemented and tested via a manual `workflow_dispatch` run.\n- `makepkg -od --nocheck` runs against the freshly-written PKGBUILD before commit/push.\n- PKGBUILD has a header comment about sha256sums single-line format and pkgrel reset.\n- Decision recorded on (a) vs (b) for #3 (can be left as a deferred sub-card).",
+        "due_date": null,
+        "id": "0fb3bd53-c640-412b-8db9-25f8268e6de0",
+        "points": null,
+        "position": 207,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "Harden release.yml AUR publish pipeline",
+        "updated_at": "2026-05-14T01:23:55.080341526Z"
+      },
+      {
+        "card_number": 451,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-14T16:47:31.372532845Z",
+        "description": "## Problem\n\n`board create` currently has an implicit dual responsibility:\n\n1. Creates a board (domain entity)\n2. Initialises the storage file if it does not already exist\n\nThis is a separation-of-concerns violation. Storage bootstrapping is an infrastructure concern, not a domain concern. The result is a UX jagged edge: `board create` silently creates a new file, while every other CLI command requires the file to exist (enforced by the existence check added in KAN-323).\n\n## Context\n\nDiscovered while implementing KAN-323 (fix misleading 'Card not found' error when board file does not exist). The fix gates all commands on file existence — but had to exempt `board create` to preserve the only CLI path to bootstrap a new file. This exemption is itself a design smell.\n\nThe CLAUDE.md historically showed `cargo run -- init --name \"My Board\"` as the initialisation command, suggesting an `init` subcommand was once planned or has since been removed.\n\n## Proposed Fix\n\n1. Add a top-level `init` subcommand:\n   ```\n   kanban <file> init [--name <board-name>]\n   ```\n   - Creates the file with an empty context (no board required)\n   - Optionally accepts `--name` to also create a first board in one step\n   - Errors if the file already exists (to avoid accidental overwrites)\n\n2. Remove the `board create` exemption from the file-existence check in `kanban-cli/src/app.rs`:\n   ```rust\n   // Before: special-cased board create to bypass existence check\n   let is_bootstrap = matches!(&cmd, Commands::Board(b) if matches!(b.action, BoardAction::Create { .. }));\n   // After: all commands require the file to exist\n   ```\n\n3. Update CLAUDE.md to document `kanban <file> init` as the canonical initialisation flow.\n\n## Files to Modify\n\n- `crates/kanban-cli/src/cli.rs` — add `Init` variant to `Commands` enum with optional `--name` arg\n- `crates/kanban-cli/src/app.rs` — handle `Commands::Init` before the existence check; remove `is_bootstrap` exemption\n- `crates/kanban-cli/src/handlers/` — add `init.rs` handler that creates the file and optionally a board\n- `crates/kanban-cli/tests/cli_integration.rs` — add `init_tests` module; update `test_board_create_on_new_file_succeeds` to use `init` instead",
+        "due_date": null,
+        "id": "89c73b19-3b8c-4eb9-831f-461ffbd43f3f",
+        "points": null,
+        "position": 207,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "add cli init subcommand to decouple storage bootstrapping from board create",
+        "updated_at": "2026-05-14T16:47:31.373293925Z"
+      },
+      {
+        "card_number": 447,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-14T02:11:10.818576565Z",
+        "description": "Follow-up from the 0.5.0 release audit (PR #251). The KAN-405 SQLite migration that drops the legacy `command_log` and `undo_state` tables works correctly in practice but has two hardening gaps worth closing.\n\n## Where\n\n`crates/kanban-persistence-sqlite/src/sqlite_store.rs:300-366` — the `migrate()` method on the SQLite store.\n\n## What's there today\n\n- Two sequential `DROP TABLE` statements, each guarded by a `COUNT(*) > 0` check against `sqlite_master`.\n- No explicit `BEGIN`/`COMMIT` wrapping the pair.\n- The `schema_version` column exists in the metadata table but is **not consulted** by the migration logic — it relies entirely on table-existence checks.\n\n## Why it's a nice-to-have, not a blocker\n\nIf the process crashes between dropping `command_log` and `undo_state`, the database is left half-migrated (one table gone, the other not). However, the migration is idempotent: the next 0.5.0 open sees the dropped table missing, skips it, sees the surviving one, drops it. End state converges to correct.\n\nSo shipping 0.5.0 without this fix is fine. But making it transactional removes the brief half-migrated window entirely, and adopting `schema_version` is a prerequisite for any future migration that can't rely on table-existence as the sentinel.\n\n## Fix\n\n1. Wrap both DROPs in a single transaction:\n\n```rust\nlet mut tx = self.pool.begin().await?;\nsqlx::query(\"DROP TABLE IF EXISTS command_log\").execute(&mut *tx).await?;\nsqlx::query(\"DROP TABLE IF EXISTS undo_state\").execute(&mut *tx).await?;\nsqlx::query(\"UPDATE metadata SET schema_version = 2 WHERE id = 1\").execute(&mut *tx).await?;\ntx.commit().await?;\n```\n\n2. Gate the migration on `schema_version < 2`, not on table existence. Bump `schema_version` to 2 in the same transaction.\n\n3. The fresh-install path (schema.sql) should set `schema_version = 2` so we never run the migration on a brand-new DB.\n\n## Tests\n\n- Existing test at `crates/kanban-persistence-sqlite/tests/data_store.rs:362-423` should continue to pass.\n- Add: fresh-install path (no legacy tables, `schema_version = 2`) does not attempt the migration.\n- Add: migration is no-op when `schema_version >= 2` even if legacy tables somehow exist (defensive).\n- Consider documenting the half-migrated recovery scenario in a comment so future readers don't worry about it.\n\n## Acceptance\n\n- Both DROPs and the `schema_version` bump run in one transaction.\n- The migration is gated on `schema_version`, not table existence.\n- All existing migration tests pass; new tests cover fresh install and schema-version gating.\n- The audit comment in `sqlite_store.rs` notes that this closes the half-migrated window.",
+        "due_date": null,
+        "id": "f5fe3bf4-008f-432a-860a-3346d47cee92",
+        "points": null,
+        "position": 208,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "Wrap SQLite KAN-405 legacy-table drop in a transaction + use schema_version",
+        "updated_at": "2026-05-14T02:11:10.820168134Z"
+      },
+      {
+        "card_number": 452,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-14T17:45:02.127919353Z",
+        "description": "## Background\n\nThe project currently ships to crates.io, AUR, GitHub Releases (notes only, no binaries), and nixpkgs (via ryantm). Three large user populations have no first-class install path today:\n\n- **macOS users** — no Homebrew formula, no install path other than `cargo install kanban-cli` or building from source.\n- **Windows users** — Windows CI binary exists (PR #267 / KAN-445) but it isn't packaged or published anywhere consumers look (Chocolatey, winget).\n- **Discoverability on Linux beyond Arch** — AUR covers Arch, nixpkgs covers Nix, but no Homebrew-on-Linux path exists.\n\nThis card covers publishing to **Homebrew (tap)**, **Chocolatey**, and **winget**, restructuring all packaging under a unified `packaging/` directory, and updating the release workflow to drive all of them.\n\n## Prerequisites (blockers — must land before any registry work)\n\n### P1. Add macOS to CI\n\n`.github/workflows/ci.yml` currently runs only `ubuntu-latest` and `windows-latest`. The TUI uses crossterm (cross-platform) and the Linux-only deps in `default.nix:22-25` are gated on `pkgs.stdenv.isLinux`, so the project *should* build on macOS, but this is unverified. Required before Homebrew because the tap is meaningless if it can't actually compile on macOS.\n\n- Add `macos-latest` (Intel) and `macos-14` (Apple Silicon) to the test matrix.\n- Run `cargo test --workspace` on both.\n- Address any platform-specific failures that surface.\n\n### P2. Build and upload release binaries\n\n`.github/workflows/release.yml` currently only creates a GitHub Release with auto-generated notes — no artifacts. Chocolatey and winget both expect a downloadable binary from a stable URL. Required before either of those.\n\nAdd a build matrix step to `release.yml` (after `Create GitHub Release`) that produces and uploads:\n\n- `kanban-v${VERSION}-x86_64-pc-windows-msvc.zip` — Windows binary (cross-compile from Ubuntu via `cross`, or use a `windows-latest` job)\n- `kanban-v${VERSION}-x86_64-apple-darwin.tar.gz` — macOS Intel\n- `kanban-v${VERSION}-aarch64-apple-darwin.tar.gz` — macOS ARM\n- `kanban-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz` — Linux (useful for non-Arch, non-Nix users; also enables Homebrew-on-Linux)\n\nEach archive contains just the `kanban` binary plus `LICENSE` and `README.md`. Use `softprops/action-gh-release@v2` (already in use) with the `files:` field to attach them.\n\nGenerate and publish SHA256 checksums alongside (a single `SHA256SUMS` file is the conventional shape).\n\n## Repo restructure: `packaging/` directory\n\nMove everything packaging-related under a unified `packaging/` directory. Current `aur/` becomes `packaging/aur/`, and new homes are created for the new registries.\n\nTarget layout:\n\n```\npackaging/\n├── aur/\n│   ├── PKGBUILD\n│   └── .SRCINFO\n├── homebrew/\n│   └── Formula/\n│       └── kanban.rb\n├── chocolatey/\n│   ├── kanban.nuspec\n│   └── tools/\n│       ├── chocolateyinstall.ps1\n│       ├── chocolateyuninstall.ps1\n│       ├── LICENSE.txt\n│       └── VERIFICATION.txt\n└── winget/\n    └── manifests/\n        └── f/\n            └── fulsomenko/\n                └── kanban/\n                    ├── fulsomenko.kanban.installer.yaml\n                    ├── fulsomenko.kanban.locale.en-US.yaml\n                    └── fulsomenko.kanban.yaml\n```\n\nCI references to `./aur/...` in `release.yml` must be updated to `./packaging/aur/...` in the same PR that does the move, or the AUR pipeline breaks at next release.\n\n## Task 1: Homebrew tap\n\n### Scope: tap first, core later\n\nShip a Homebrew tap (`fulsomenko/homebrew-kanban`) as the initial deliverable. Migrating to homebrew-core is a separate future card — the Formula written here is designed to port cleanly when notability allows it (license is already SPDX `Apache-2.0`, test block goes beyond `--version`, etc.).\n\n### Tap repo\n\nCreate a separate GitHub repo `fulsomenko/homebrew-kanban`. The Formula's source of truth lives at `packaging/homebrew/Formula/kanban.rb` in this repo; release.yml mirrors it to the tap repo on each release.\n\n### Formula skeleton\n\n```ruby\nclass Kanban < Formula\n  desc \"Terminal-based kanban board inspired by lazygit\"\n  homepage \"https://github.com/fulsomenko/kanban\"\n  url \"https://github.com/fulsomenko/kanban/archive/refs/tags/v#{VERSION}.tar.gz\"\n  sha256 \"<filled in by release.yml>\"\n  license \"Apache-2.0\"\n  head \"https://github.com/fulsomenko/kanban.git\", branch: \"develop\"\n\n  depends_on \"rust\" => :build\n  depends_on \"pkg-config\" => :build\n\n  on_linux do\n    depends_on \"wayland\"\n    depends_on \"libxcb\"\n  end\n\n  def install\n    system \"cargo\", \"install\", *std_cargo_args(path: \"crates/kanban-cli\")\n  end\n\n  test do\n    assert_match \"kanban\", shell_output(\"#{bin}/kanban --version\")\n    system bin/\"kanban\", \"init\", \"--name\", \"Test\", testpath/\"test.json\"\n    assert_predicate testpath/\"test.json\", :exist?\n  end\nend\n```\n\nNotes on the formula:\n\n- `std_cargo_args(path: \"crates/kanban-cli\")` builds only `kanban-cli`, matching `default.nix:27`.\n- `on_linux` mirrors the Wayland/libxcb deps from `default.nix:22-25`.\n- The `test do` block must exercise actual behavior, not just `--version`, to satisfy homebrew-core audit when we eventually port. Initializing a board file is a cheap, meaningful test.\n\n### User-facing UX\n\n```sh\nbrew install fulsomenko/kanban/kanban\n# or\nbrew tap fulsomenko/kanban\nbrew install kanban\n```\n\nCompile-from-source on install will take a few minutes per machine. Self-hosting bottles is out of scope for this card.\n\n### README\n\nAdd a \"Homebrew\" section under installation alongside the AUR and Nix sections.\n\n## Task 2: Chocolatey\n\n### Files\n\n`packaging/chocolatey/kanban.nuspec`:\n\n```xml\n<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<package xmlns=\"http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd\">\n  <metadata>\n    <id>kanban</id>\n    <version>$version$</version>\n    <title>kanban</title>\n    <authors>Max Blomstervall</authors>\n    <projectUrl>https://github.com/fulsomenko/kanban</projectUrl>\n    <licenseUrl>https://github.com/fulsomenko/kanban/blob/master/LICENSE</licenseUrl>\n    <requireLicenseAcceptance>false</requireLicenseAcceptance>\n    <projectSourceUrl>https://github.com/fulsomenko/kanban</projectSourceUrl>\n    <packageSourceUrl>https://github.com/fulsomenko/kanban/tree/master/packaging/chocolatey</packageSourceUrl>\n    <docsUrl>https://github.com/fulsomenko/kanban#readme</docsUrl>\n    <bugTrackerUrl>https://github.com/fulsomenko/kanban/issues</bugTrackerUrl>\n    <tags>kanban tui terminal productivity rust</tags>\n    <summary>Terminal-based kanban board inspired by lazygit</summary>\n    <description><![CDATA[\nA terminal-based kanban/project management tool written in Rust,\ninspired by lazygit's interface design.\n    ]]></description>\n  </metadata>\n  <files>\n    <file src=\"tools\\**\" target=\"tools\" />\n  </files>\n</package>\n```\n\n`packaging/chocolatey/tools/chocolateyinstall.ps1`:\n\n```powershell\n$ErrorActionPreference = 'Stop'\n$toolsDir = \"$(Split-Path -parent $MyInvocation.MyCommand.Definition)\"\n$version  = '$version$'\n$url      = \"https://github.com/fulsomenko/kanban/releases/download/v$version/kanban-v$version-x86_64-pc-windows-msvc.zip\"\n\n$packageArgs = @{\n  packageName    = 'kanban'\n  unzipLocation  = $toolsDir\n  url64bit       = $url\n  checksum64     = '$checksum64$'\n  checksumType64 = 'sha256'\n}\n\nInstall-ChocolateyZipPackage @packageArgs\n```\n\n`packaging/chocolatey/tools/chocolateyuninstall.ps1`:\n\n```powershell\n$ErrorActionPreference = 'Stop'\n$toolsDir = \"$(Split-Path -parent $MyInvocation.MyCommand.Definition)\"\nUninstall-ChocolateyZipPackage -PackageName 'kanban' -ZipFileName \"kanban-*-x86_64-pc-windows-msvc.zip\"\n```\n\n`packaging/chocolatey/tools/LICENSE.txt` — copy of the project LICENSE (chocolatey audit requires this be redistributed alongside the binary).\n\n`packaging/chocolatey/tools/VERIFICATION.txt`:\n\n```\nVERIFICATION\n\nThe binary in this package is the official kanban release for Windows,\ndownloaded from the project's GitHub release page:\n\n  https://github.com/fulsomenko/kanban/releases\n\nThe SHA256 checksum is recorded in the chocolateyinstall.ps1 file via\nthe `$checksum64` substitution variable, populated at package build time\nfrom the release artifact.\n\nTo verify manually:\n  1. Download the release zip from the URL above.\n  2. Compute its SHA256:  Get-FileHash -Algorithm SHA256 <file>.zip\n  3. Confirm it matches the checksum embedded in chocolateyinstall.ps1.\n```\n\n### Build/publish process\n\nThe `$version$` and `$checksum64$` placeholders are substituted at release time. release.yml:\n\n1. After building Windows release artifact and computing SHA256.\n2. `sed`-replace `$version$` and `$checksum64$` in copies under a build directory.\n3. Run `choco pack` against the build directory.\n4. Run `choco push kanban.<version>.nupkg --api-key=$CHOCO_API_KEY --source=https://push.chocolatey.org/`.\n5. Wait for moderation (out-of-band; can take days to weeks for first version).\n\nNeed to obtain a Chocolatey community API key and add it to repository secrets as `CHOCO_API_KEY`.\n\n### Moderation expectations\n\nFirst version typically reviewed within 1-7 days. Common feedback: tighten the description, fix metadata, ensure LICENSE.txt and VERIFICATION.txt are present and accurate. Subsequent versions usually auto-pass once the maintainer relationship is established.\n\n## Task 3: winget\n\n### Files\n\n`packaging/winget/manifests/f/fulsomenko/kanban/fulsomenko.kanban.yaml` (version manifest):\n\n```yaml\nPackageIdentifier: fulsomenko.kanban\nPackageVersion: $version\nDefaultLocale: en-US\nManifestType: version\nManifestVersion: 1.6.0\n```\n\n`packaging/winget/manifests/f/fulsomenko/kanban/fulsomenko.kanban.locale.en-US.yaml`:\n\n```yaml\nPackageIdentifier: fulsomenko.kanban\nPackageVersion: $version\nPackageLocale: en-US\nPublisher: Fulsomenko\nPublisherUrl: https://github.com/fulsomenko\nPublisherSupportUrl: https://github.com/fulsomenko/kanban/issues\nAuthor: Max Blomstervall\nPackageName: kanban\nPackageUrl: https://github.com/fulsomenko/kanban\nLicense: Apache-2.0\nLicenseUrl: https://github.com/fulsomenko/kanban/blob/master/LICENSE\nShortDescription: Terminal-based kanban board inspired by lazygit\nDescription: |\n  A terminal-based kanban/project management tool written in Rust,\n  inspired by lazygit's interface design.\nTags:\n  - kanban\n  - tui\n  - terminal\n  - productivity\n  - rust\nManifestType: defaultLocale\nManifestVersion: 1.6.0\n```\n\n`packaging/winget/manifests/f/fulsomenko/kanban/fulsomenko.kanban.installer.yaml`:\n\n```yaml\nPackageIdentifier: fulsomenko.kanban\nPackageVersion: $version\nInstallerType: zip\nNestedInstallerType: portable\nNestedInstallerFiles:\n  - RelativeFilePath: kanban.exe\n    PortableCommandAlias: kanban\nInstallers:\n  - Architecture: x64\n    InstallerUrl: https://github.com/fulsomenko/kanban/releases/download/v$version/kanban-v$version-x86_64-pc-windows-msvc.zip\n    InstallerSha256: $sha256\nManifestType: installer\nManifestVersion: 1.6.0\n```\n\n### Publish process\n\n1. `winget` manifests cannot live in your repo as their canonical home — they must be submitted as a PR to `microsoft/winget-pkgs`.\n2. The in-repo `packaging/winget/manifests/` is a dev/staging copy. release.yml uses `microsoft/winget-create` (or the `vedantmgoyal2009/winget-releaser@v2` action) to auto-generate the PR upstream on each release.\n3. Validate locally with `winget validate --manifest packaging/winget/manifests/f/fulsomenko/kanban/` before submitting.\n\n### Why use `vedantmgoyal2009/winget-releaser`\n\nIt abstracts away the manifest generation, PR creation, and authentication-via-PAT-token dance. Inputs are: GitHub release tag, installer regex, PackageIdentifier, GitHub token with `public_repo` scope on a fork of `microsoft/winget-pkgs`. Needs a fork of `microsoft/winget-pkgs` under `fulsomenko/`.\n\n### Validation\n\n`winget` does an automated validation pass on each PR (manifest schema, installer reachability, SHA256 match). Manual review by Microsoft maintainers typically merges within 1-3 days for well-formed PRs.\n\n## Task 4: CI changes (`release.yml`)\n\nAll AUR path references currently point at `./aur/...` (`release.yml:81-100`). Update in the move PR:\n\n```diff\n- sed -i \"s|...|...|\" ./aur/PKGBUILD\n+ sed -i \"s|...|...|\" ./packaging/aur/PKGBUILD\n```\n\nAnd:\n\n```diff\n- cd aur && makepkg --printsrcinfo > .SRCINFO\n+ cd packaging/aur && makepkg --printsrcinfo > .SRCINFO\n```\n\nAnd:\n\n```diff\n- git add aur/PKGBUILD aur/.SRCINFO\n+ git add packaging/aur/PKGBUILD packaging/aur/.SRCINFO\n```\n\nAnd the `KSXGitHub/github-actions-deploy-aur` action's `pkgbuild` input:\n\n```diff\n- pkgbuild: ./aur/PKGBUILD\n+ pkgbuild: ./packaging/aur/PKGBUILD\n```\n\n### New release.yml steps to add\n\nAfter \"Push release commit\" and before \"Create GitHub Release\":\n\n1. **Build release binaries** (matrix job): Linux/macOS Intel/macOS ARM/Windows, each producing a tarball or zip + SHA256.\n\nAfter \"Create GitHub Release\":\n\n2. **Update Homebrew formula**: substitute version + SHA256 in `packaging/homebrew/Formula/kanban.rb`, push to `fulsomenko/homebrew-kanban` repo via deploy key.\n3. **Publish to Chocolatey**: substitute version + checksum, `choco pack`, `choco push` with `CHOCO_API_KEY` secret.\n4. **Submit to winget**: invoke `vedantmgoyal2009/winget-releaser@v2` with the release tag and a `WINGET_TOKEN` secret (PAT scoped to a `fulsomenko/winget-pkgs` fork).\n\n### New repository secrets needed\n\n- `CHOCO_API_KEY` — Chocolatey community API key.\n- `WINGET_TOKEN` — GitHub PAT with `public_repo` scope on `fulsomenko/winget-pkgs` (fork of upstream).\n- `HOMEBREW_TAP_DEPLOY_KEY` — SSH deploy key with write access to `fulsomenko/homebrew-kanban`.\n\n## Documentation\n\nUpdate `README.md` installation section to list all install paths:\n\n```\n### Install\n\n- macOS / Linux:    brew install fulsomenko/kanban/kanban\n- Windows (choco):  choco install kanban\n- Windows (winget): winget install fulsomenko.kanban\n- Arch (AUR):       yay -S kanban\n- Nix:              nix profile install nixpkgs#kanban\n- crates.io:        cargo install kanban-cli\n```\n\nUpdate `CONTRIBUTING.md` packaging section (if it doesn't exist, create one) listing each registry, its packaging file location under `packaging/`, and where in `release.yml` the publish step lives.\n\n## Acceptance\n\n- `packaging/` directory exists with subdirectories for `aur/`, `homebrew/`, `chocolatey/`, `winget/`.\n- Existing AUR pipeline still works after the path move (verify by triggering a release or dry-running `release.yml` against a fork).\n- macOS CI matrix entries are green on `develop` HEAD.\n- Release artifacts (Linux, macOS x2, Windows zip + SHA256) are attached to v0.5.2 (or the next release after this card lands).\n- Homebrew tap `fulsomenko/homebrew-kanban` exists; `brew install fulsomenko/kanban/kanban` installs the current version on macOS and Linux.\n- Chocolatey package `kanban` exists on community.chocolatey.org; `choco install kanban` works on Windows (after first moderation passes).\n- winget manifest merged into `microsoft/winget-pkgs`; `winget install fulsomenko.kanban` works on Windows.\n- `release.yml` automates publishing to all four registries (AUR, Homebrew tap, Chocolatey, winget) on each release.\n- README and CONTRIBUTING.md updated.\n\n## Out of scope (separate future cards)\n\n- Migrating Homebrew tap → homebrew-core (gated on notability; track separately).\n- Self-hosting Homebrew bottles to avoid compile-from-source.\n- Publishing to Scoop (third Windows package manager, less ubiquitous than choco/winget).\n- Publishing to apt/dpkg or rpm/yum repositories.\n- Snap or Flatpak packaging.\n\n## Related cards / PRs\n\n- **KAN-445 / PR #267** — added Windows CI; the Windows binary it produces is reused here.\n- **KAN-450** — Nix sandbox CI gate; orthogonal but lives in the same \"make releases hermetic and broadly available\" theme.\n- **AUR pipeline** — already automated in `release.yml:81-115`; this card preserves and relocates it, doesn't replace it.",
+        "due_date": null,
+        "id": "21b2e425-f160-4331-bc61-2cbb4e882cd3",
+        "points": null,
+        "position": 208,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "Publish to Homebrew, Chocolatey, winget; consolidate packaging/ directory",
+        "updated_at": "2026-05-14T17:45:02.128480656Z"
+      },
+      {
+        "card_number": 448,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-14T02:11:21.104578663Z",
+        "description": "Follow-up from the 0.5.0 release audit (PR #251). The Windows key-doubling fix (windows/fix-keyevent-handling) + its generalisation to all platforms (KAN-426) is currently only exercised by integration tests on platforms where the filter is reachable (Windows CI), and is unreachable code on Linux/macOS where crossterm only emits `Press` events in standard terminal mode.\n\n## Where\n\n`crates/kanban-tui/src/events.rs:38-40` — the `if key.kind != KeyEventKind::Press { continue; }` filter inside the event loop.\n\n## Why it matters\n\nIf the filter logic is ever broken (e.g. inverted condition, wrong `KeyEventKind` variant compared), on Linux/macOS we wouldn't notice — the filter is a no-op there. The only safety net today is the new `windows-latest` CI job; an inline unit test would catch regressions on any platform.\n\nThis is genuinely a no-op for runtime behaviour today, but cheap insurance against a future refactor flipping the predicate.\n\n## Fix\n\nAdd a unit test under `#[cfg(test)]` in `events.rs` (or a small new test file if `events.rs` is already large). The test should:\n\n1. Construct `KeyEvent { kind: KeyEventKind::Press, ... }` and verify the filter passes it through.\n2. Construct `KeyEvent { kind: KeyEventKind::Release, ... }` and `KeyEventKind::Repeat` and verify both are filtered out.\n3. Ideally exercise the filter as a pure function, not via the full event loop — refactor the predicate into a helper like `fn should_process_key(kind: KeyEventKind) -> bool` if needed.\n\n## Acceptance\n\n- A test in `crates/kanban-tui/src/events.rs` (or `crates/kanban-tui/tests/event_filter_tests.rs`) that proves Press → kept, Release/Repeat → filtered.\n- The test passes on Linux (where the filter is unreachable in normal operation), giving us coverage that doesn't depend on Windows CI being healthy.\n- No production behaviour change.\n\n## Priority\n\nLow. The fix shipped in 0.5.0 is correct on paper and validated by integration tests on Windows CI. This is hardening, not a blocker.",
+        "due_date": null,
+        "id": "a9ad8d6f-4468-4be3-b11b-dcdc1ad2f174",
+        "points": null,
+        "position": 209,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "Add unit test for KeyEventKind::Press filter (events.rs)",
+        "updated_at": "2026-05-14T02:11:21.105637037Z"
+      },
+      {
+        "card_number": 453,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-14T19:08:14.873490471Z",
+        "description": "## Context\n\nFollow-up to KAN-328 (PR #272). The error banner system in `crates/kanban-tui/src/components/banner.rs` is set via `App::set_error(...)` (`crates/kanban-tui/src/app/mod.rs:663-669`) but is not cleared by success paths. Once an error banner appears, it persists until either:\n\n1. Another call to `set_error` / `set_success` overwrites it, or\n2. The banner TTL expires (see `Banner::is_expired`, but verify it is actually consulted from the render path — at the time of writing this card it does not appear to be wired up).\n\nThe result is that an error from a failed action stays visible on screen through subsequent successful actions, confusing the user.\n\n## Reproduction\n\n1. On a board with `active_sprint_id == None`, focus the Cards panel.\n2. Press `t` — red banner appears: \"No active sprint set for filtering\". (KAN-328 behaviour, working as intended.)\n3. Open sprint details, activate a sprint, return to cards.\n4. Press `t` — toggle succeeds (info log: \"Enabled sprint filter - showing active sprint only\"), but the red banner from step 2 is still visible on screen.\n\nThe same issue affects every handler that emits ``tracing::info!`` on success while a prior error banner is on screen — ``handle_toggle_sprint_filter`` is just where it was noticed during PR review.\n\n## Code references\n\n- ``crates/kanban-tui/src/handlers/card_handlers.rs:180-204`` — ``handle_toggle_sprint_filter``; the two ``tracing::info!`` branches (toggle on / toggle off) do not touch the banner.\n- ``crates/kanban-tui/src/app/mod.rs:663-669`` — ``set_error``, ``set_success``, ``clear_banner``.\n- ``crates/kanban-tui/src/components/banner.rs`` — ``Banner::is_expired(ttl)`` exists but the render path (``crates/kanban-tui/src/ui/mod.rs`` near line 129) currently renders unconditionally on ``ui_state.banner.is_some()``, no TTL check.\n\n## Approach options\n\n1. Per-handler clears (narrow). Add ``self.clear_banner()`` (or set a fresh ``set_success`` where appropriate) at the success branches of state-mutating handlers. Minimal change but fragile: every new handler has to remember.\n2. TTL-driven auto-dismiss (systemic). Wire ``Banner::is_expired`` into the render path so banners self-dismiss after a fixed duration (3-5 seconds feels right). Independent of handler discipline.\n3. Both. Auto-dismiss with TTL plus an explicit clear on each success path so visible feedback always matches the latest action.\n\nPreferred: option 2 first (one place, broad coverage). Layer option 1 on top only if specific flows still feel laggy after TTL is in.\n\n## Acceptance criteria\n\n- [ ] Pressing ``t`` with no active sprint still shows the error banner (regression check for KAN-328).\n- [ ] After activating a sprint and pressing ``t`` again, the stale banner is gone — either immediately on the next successful action, or via TTL within a defined window.\n- [ ] Integration test in ``crates/kanban-tui/tests/`` reproducing the sequence above and asserting the banner is cleared after the success step.\n- [ ] If the TTL approach is taken: a test that advances time (or uses a small TTL) and asserts ``ui_state.banner`` becomes ``None`` after render once expired.\n\n## Out of scope\n\n- New banner variants (Info / Warning).\n- Redesign of banner UI placement or styling.",
+        "due_date": null,
+        "id": "e9783f4c-df16-4a3d-a225-c3097f3473ea",
+        "points": 1,
+        "position": 209,
+        "priority": "Low",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "Clear stale error banner when subsequent action succeeds",
+        "updated_at": "2026-05-14T19:08:14.874125980Z"
+      },
+      {
+        "card_number": 456,
+        "column_id": "591afb61-7289-46bf-ba07-21758afd44fe",
+        "completed_at": null,
+        "created_at": "2026-05-14T19:47:37.243343790Z",
+        "description": "## Goal\n\nUnify the in-app selectable lists so they all share a single component (`ListComponent`) with consistent scroll behavior, navigation, and (optionally) above/below indicators. KAN-455 (#272-ish) introduced the *pure scroll math* (`pagination::scroll_offset_to_keep_visible`) and applied it to three lists; this card finishes the architectural migration.\n\n## Background\n\n`ListComponent` (`crates/kanban-tui/src/components/generic_list.rs`) wraps a `kanban_core::SelectionState` plus a `kanban_core::pagination::Page` and exposes `navigate_up/down`, `ensure_selected_visible`, `get_render_info`, multi-select, and adjusted viewport math. The above/below indicators are NOT rendered by `ListComponent` itself — they're an opt-in caller concern handled via `scroll_indicators::render_above_indicator/below_indicator`. So adopting `ListComponent` does not force the indicator UX.\n\nToday many lists use bare `kanban_core::SelectionState` instead. Some pair it with an ad-hoc scroll offset (after KAN-455). The result: inconsistent behavior, scroll math repeated in renderers, no easy way to add features like adjusted viewport or multi-select.\n\n## Current consumers to migrate\n\nBare `SelectionState` fields (no scroll, scroll math handled externally if at all):\n\n- `app/selection.rs` — `SelectionHub`\n  - `board: SelectionState`\n  - `sprint: SelectionState` *(KAN-455 added `sprint_scroll: Cell<usize>` alongside)*\n  - `settings_config: SelectionState`\n  - `settings_config_file: SelectionState`\n  - `settings_storage: SelectionState`\n- `app/dialog_input.rs` — `DialogInputState`\n  - `import_selection: SelectionState`\n  - `priority_selection: SelectionState`\n  - `column_selection: SelectionState` *(KAN-455 added `column_scroll: Cell<usize>` alongside)*\n  - `sprint_assign_selection: SelectionState`\n  - `task_list_view_selection: SelectionState`\n  - `carry_over_sprint_selection: SelectionState`\n- `app/filter.rs` — `FilterState`\n  - `sort_field_selection: SelectionState`\n- `app/relationship.rs` — `RelationshipState`\n  - `selection: SelectionState`\n\nRaw `usize` selection that should also adopt `ListComponent`:\n\n- `filters.rs` — `FilterDialogState.item_selection: usize` *(KAN-455 added `item_scroll: Cell<usize>` alongside)*\n\nFor each, the migration replaces the `SelectionState`/`usize` with a `ListComponent`, then updates handler call sites (`.get()/.set()/.next()/.prev()` → `ListComponent` equivalents) and ensures `ensure_selected_visible(viewport_height)` is called wherever navigation happens.\n\n## Suggested refactor steps\n\n1. For each list, replace the existing selection field with a `ListComponent`. Where a `Cell<usize>` scroll offset was added by KAN-455, remove it (now subsumed by `ListComponent`).\n2. Migrate handler call sites (see `grep -rn 'selection\\.sprint\\|column_selection\\|sprint_assign_selection\\|item_selection'` etc.).\n3. Add `.ensure_selected_visible(viewport_height)` after navigation. For lists whose viewport height is only known at render time, store it the way `app.view.viewport_height` is stored for the main card list.\n4. Renderers: replace ad-hoc scroll-offset reads with `list.get_scroll_offset()` or use `list.get_render_info(viewport_height)`.\n5. Decide per-list whether to render above/below indicators (they exist already as `scroll_indicators::render_above_indicator/below_indicator`).\n6. Remove now-unused helpers — `scroll_offset_to_show` in `components/sprint_assign_list.rs:214` if no longer referenced. Consider also moving any remaining pure scroll math to `kanban_core::pagination`.\n\n## What KAN-455 left in place that this card should consume\n\n- Pure function `kanban_core::pagination::scroll_offset_to_keep_visible(current, selected, viewport_height) -> usize` (added in KAN-455). `Page::scroll_to_visible` already delegates to it. `ListComponent` transitively uses it via `Page`.\n\n## Out of scope\n\n- Visual redesign of any list.\n- Adding above/below indicators where they don't already appear.\n- Changing keybindings or navigation semantics.\n\n## Acceptance\n\n- No `SelectionState` field remains for lists rendered as a paragraph or list widget. (Standalone single-selection state — e.g. radio dialogs — may stay if they have no scroll.)\n- All lists scroll with the same minimal-scroll behavior already used by the main card list.\n- All existing tests pass; new tests cover at least one migration per state struct touched.\n\n## Notes from KAN-455 review\n\nIssues raised during review of KAN-455 (PR #273) that were deferred here because the `ListComponent` migration supersedes them:\n\n- **Renderer duplication.** `board_detail.rs::render_board_sprints_list/render_board_columns_list` and `filter_popup.rs::render_filter_sprints_section` each contain ~8 lines of identical scroll boilerplate (read `Cell` → call `scroll_offset_to_keep_visible` → write `Cell` → `Paragraph::scroll`). Migrating to `ListComponent` removes this duplication wholesale.\n- **Heterogeneous list in filter popup — design decision needed.** The sprints section in the filter popup is not a flat list: it has a title line, an unassigned-sprints checkbox row, a separator, then the sprint rows. Today this is handled by a `selected_line_idx` translation inside the renderer (item_selection 0 → line 1, k ≥ 1 → line k+2). When migrating, decide how to model this in `ListComponent`:\n  - Option A: one `ListComponent` for the sprints only; render decorative rows (title, separator, unassigned) outside the list. Cleanest, requires a small change to which `Paragraph` block gets `.scroll(...)`.\n  - Option B: a single `ListComponent` over all rows (treating decorative rows as non-selectable). Requires extending `ListComponent` to support non-selectable entries.\n  Option A is recommended.\n- **`as u16` cast on scroll offset.** All three renderers (and the prior-art sites in `ui/dialogs/cards.rs:104` and `components/selection_dialog.rs:369`) cast `usize` → `u16` when feeding `Paragraph::scroll((scroll, 0))`. For lists > 65535 items this truncates silently. The migration should pick a consistent strategy — likely `u16::try_from(scroll).unwrap_or(u16::MAX)` — and apply it across every site that ends up calling `Paragraph::scroll`.\n- **Section-reset test.** `FilterDialogState::next_section/prev_section` reset `item_scroll` to 0 today. The migration removes `item_scroll` (it becomes the `ListComponent`'s internal scroll offset), but the *behavior* — section changes reset the sprints panel to top — must be preserved. Add a test that exercises this through the new abstraction.",
+        "due_date": null,
+        "id": "2eda4bc3-f03d-4a26-acbc-d7ccb5a44dd7",
+        "points": null,
+        "position": 210,
+        "priority": "Medium",
+        "sprint_id": null,
+        "sprint_logs": [],
+        "status": "Todo",
+        "title": "Migrate all SelectionState-backed lists to ListComponent",
+        "updated_at": "2026-05-14T20:07:41.393131408Z"
       }
     ],
     "columns": [


### PR DESCRIPTION
Release **0.6.0** from `develop` to `master`. Consumes 4 changesets accumulated since 0.5.1.

Highest changeset bump is **minor** (editor robustness refactor) so 0.5.1 goes to 0.6.0.

## What

### Minor (drives the version bump)

- **editor/improve-robustness** ([#255](https://github.com/fulsomenko/kanban/pull/255)) by @amanda-amy-frost. Rewrites editor launching to handle arbitrary `EDITOR` strings via `shell_words` parsing and `which`-based path resolution, instead of the previous hard-coded editor names. Fallback to `notepad` on Windows / `vi` elsewhere is preserved. Error message for a missing editor is now shell-aware (PowerShell vs POSIX). Vim-like terminal editors are the best-tested path. VS Code (`code --wait`) at least resolves and launches now, but the temp-file handling is still flaky, so terminal editors remain preferred. README adds Windows + WSL setup notes recommending `EDITOR` be a program in `PATH` (for example `$env:EDITOR = "vim.exe"`) rather than a full Windows-style path.

### Patch (bug fixes and small UX wins)

- **KAN-323** ([#271](https://github.com/fulsomenko/kanban/pull/271)). `kanban missing.json card get KAN-1` (or any subcommand) when the file does not exist now reports `Board file not found: 'missing.json'` instead of the misleading `Card not found: 'KAN-1'`. The check covers every path that can supply the file: positional argument, `KANBAN_FILE` env var, and `storage_location` in the config. **Behaviour change**: `board create` no longer doubles as a storage-file initialiser. That responsibility moves to `kanban <file>` with no subcommand, which now creates an empty storage file if one does not exist and exits cleanly, making it safe to use in scripts and CI without a TTY. In a TTY, the TUI still launches as before.
- **KAN-328** ([#272](https://github.com/fulsomenko/kanban/pull/272)). Pressing `t` to toggle the active-sprint filter on a board with no active sprint now surfaces an error banner reading "No active sprint set for filtering" instead of failing silently. Previously the keypress quietly emitted a warning to the trace log, leaving users unsure why the card list did not change.
- **KAN-455** ([#273](https://github.com/fulsomenko/kanban/pull/273)). Sprint and column lists in the board edit view, and the sprint section of the card list filter popup, now scroll to keep the selected item visible. Previously these three lists tracked the `j`/`k` cursor but never scrolled, so items past the visible area were unreachable on small terminals or boards with many sprints or columns. Scroll behaviour matches the minimal-scroll pattern of the main card list: the viewport only shifts when the cursor crosses an edge, so navigating back and forth inside the visible area no longer reshuffles the list. Internally extracts `scroll_offset_to_keep_visible` from `Page::scroll_to_visible` as a reusable pure helper.

### Chore (no changeset, no user-visible change)

- **chore** ([#274](https://github.com/fulsomenko/kanban/pull/274)). Updates the personal kanban todo file tracked in-repo.

## Why

Periodic release per CONTRIBUTING.md release cadence (`develop` to `master`). Four changesets have accumulated since 0.5.1 and each was reviewed individually as it landed in `develop`. One coordinated bump per release rather than per feature.

The editor refactor is the only minor bump, so it drives the version. The other three are small, isolated fixes that round out the release without adding scope.

## How

Standard release flow:

1. Merge this PR to `master`.
2. CI's `release.yml` runs `validate-release.sh`, bumps versions to 0.6.0 across the workspace, publishes each crate to crates.io in dependency order (`kanban-core` then `kanban-domain` then `kanban-persistence` and its backends then `kanban-service` then `kanban-tui` / `kanban-mcp` then `kanban-cli`), creates a GitHub Release using the consumed changeset notes, and pushes the new PKGBUILD to AUR.
3. The four `.changeset/*.md` files are deleted by the release workflow once consumed.

## Notable behaviour changes (read before merging)

- **`board create` no longer auto-creates the storage file** (KAN-323). Existing scripts that depended on `kanban newfile.json board create --name X` to also create the file will need to either run `kanban newfile.json` first, or rely on the existing config / env var path. Bare `kanban <file>` is the new way to init a storage file headlessly.
- **Subcommands always require an existing file** (KAN-323). Running any subcommand against a non-existent file now fails with `Board file not found: ...` rather than producing misleading downstream errors. Pair with the bare-`kanban` init above to provision in scripts.
- **`EDITOR` parsing changed from name-matching to shell-words + `which`** (#255). Most users see no change. Windows users with a fully-qualified Windows path in `EDITOR` should switch to a program name in `PATH` (`vim.exe`, `nvim.exe`) until the Windows path-resolution edge cases are sorted out. VS Code is still not recommended even though it now launches.

## Testing

- All four feature/fix PRs were tested individually as they landed in `develop` (#255, #271, #272, #273).
- `validate-release.sh` runs in CI on every PR to `develop` and `master`. It checks workspace versioning, no hardcoded path-dep versions, full workspace build, dry-run publish for each crate, and dependency resolution.
- `test-windows` CI job (added in 0.5.0) continues to run `cargo test --all-features --workspace` on `windows-latest`, so the editor refactor was exercised on Windows before merge.
- New integration / unit tests landed alongside their changesets:
  - `crates/kanban-tui/src/editor.rs` unit tests for `parse_editor`, `resolve_editor_with`, and `editor_env_hint` (#255).
  - `crates/kanban-cli/tests/cli_integration.rs` `missing_file_tests` covering the new "file required" error and the bare-`kanban <file>` init path (KAN-323).
  - `crates/kanban-tui/tests/...` for the sprint filter toast (KAN-328).
  - `crates/kanban-tui/tests/...` for board edit + filter popup scrolling, including the minimal-scroll stability property (KAN-455).
  - `crates/kanban-core/...` unit tests for `scroll_offset_to_keep_visible` covering zero viewport, already-visible selection, selection above / below viewport, and both viewport edges.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` all pass on `develop` HEAD.
