### PR TITLE
KAN-466 chore(mcp): pass gitRev to nix build so -V includes commit hash

### DIFF
--- a/.changeset/kan-466-kanban-mcp-v-should-include-git-commit-hash.md
+++ b/.changeset/kan-466-kanban-mcp-v-should-include-git-commit-hash.md
@@ -2,4 +2,11 @@
 bump: patch
 ---
 
-pass gitRev to kanban-mcp nix build so -V includes commit hash
+`kanban-mcp -V` now includes the git commit hash, matching the output of `kanban -V`:
+
+```
+kanban-mcp 0.6.0
+commit: 1e2200b91bf854ca7dac456923fb38d903b67d28
+```
+
+Previously the commit line was missing because the `kanban-mcp` Nix build did not forward the `gitRev` parameter to the compiler environment. The nixpkgs package was already correct.

--- a/.changeset/kan-466-kanban-mcp-v-should-include-git-commit-hash.md
+++ b/.changeset/kan-466-kanban-mcp-v-should-include-git-commit-hash.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+pass gitRev to kanban-mcp nix build so -V includes commit hash

--- a/crates/kanban-mcp/default.nix
+++ b/crates/kanban-mcp/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , src
+, gitRev ? null
 }:
 
 let
@@ -15,6 +16,10 @@ rustPlatform.buildRustPackage {
   cargoLock = {
     lockFile = ../../Cargo.lock;
   };
+
+  preBuild = lib.optionalString (gitRev != null) ''
+    export GIT_COMMIT_HASH="${gitRev}"
+  '';
 
   # Only build the kanban-mcp binary
   cargoBuildFlags = [ "--package" "kanban-mcp" ];

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
         in {
           default = kanban;
           kanban-cli = kanban-cli;
-          kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix { src = self; };
+          kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix { src = self; gitRev = self.rev or null; };
           kanban-web = pkgs.callPackage ./web/default.nix {};
           mcp-server-git = servers.packages.${system}.mcp-server-git;
           aggregate-changelog = aggregateChangelog;


### PR DESCRIPTION
Pass `gitRev` to the `kanban-mcp` Nix build so `kanban-mcp -V` includes the git commit hash:

- Add `gitRev ? null` parameter to `crates/kanban-mcp/default.nix`
- Add `preBuild` step that exports `GIT_COMMIT_HASH` when `gitRev` is provided
- Pass `gitRev = self.rev or null` in `flake.nix`, matching the pattern used for `kanban` and `kanban-cli`

**What**: `kanban-mcp -V` now prints the commit hash alongside the version, identical to `kanban -V`.

**Why**: The `kanban-mcp` Nix derivation was missing the `gitRev` wiring that the CLI derivation already had. Both binaries use `kanban_core::VERSION` which conditionally embeds the hash — the Rust side was already correct, only the Nix build was missing the env var.

**How**: Mirrors the existing pattern in `default.nix` (`preBuild = lib.optionalString (gitRev != null) ''export GIT_COMMIT_HASH=...''`). No Rust changes needed. The nixpkgs package was already correct (whole-workspace build with `env.GIT_COMMIT_HASH = finalAttrs.src.rev`).

**Testing**: `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean).