### PR TITLE
ci: auto-bump Homebrew tap formula on each release

### DIFF
--- a/.changeset/kan-465-publish-to-homebrew-via-personal-tap-fulsomenko-homebrew-kanban.md
+++ b/.changeset/kan-465-publish-to-homebrew-via-personal-tap-fulsomenko-homebrew-kanban.md
@@ -2,4 +2,12 @@
 bump: minor
 ---
 
-Add Homebrew tap distribution for macOS and Linux. Install kanban and kanban-mcp with `brew install fulsomenko/tap/kanban`. Both binaries are included — the TUI/CLI and the 40-tool MCP server. The formula is maintained in the `fulsomenko/homebrew-tap` repository and automatically updated on each release via CI.
+**Homebrew tap now available.** Install kanban and kanban-mcp on macOS and Linux via Homebrew:
+
+```bash
+brew install fulsomenko/tap/kanban
+```
+
+Both the TUI/CLI binary (`kanban`) and the 40-tool MCP server (`kanban-mcp`) are included. The formula is maintained in the `fulsomenko/homebrew-tap` repository, and the release workflow automatically updates it on each version bump — no manual maintenance required.
+
+This is **Phase 1** of Homebrew distribution (personal tap). Phase 2 (homebrew-core submission) will follow once the project meets Homebrew's notability requirements (≥225 stars for self-submitted software).

--- a/.changeset/kan-465-publish-to-homebrew-via-personal-tap-fulsomenko-homebrew-kanban.md
+++ b/.changeset/kan-465-publish-to-homebrew-via-personal-tap-fulsomenko-homebrew-kanban.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Add Homebrew tap distribution for macOS and Linux. Install kanban and kanban-mcp with `brew install fulsomenko/tap/kanban`. Both binaries are included — the TUI/CLI and the 40-tool MCP server. The formula is maintained in the `fulsomenko/homebrew-tap` repository and automatically updated on each release via CI.

--- a/.changeset/kan-465-publish-to-homebrew-via-personal-tap-fulsomenko-homebrew-kanban.md
+++ b/.changeset/kan-465-publish-to-homebrew-via-personal-tap-fulsomenko-homebrew-kanban.md
@@ -2,12 +2,4 @@
 bump: minor
 ---
 
-**Homebrew tap now available.** Install kanban and kanban-mcp on macOS and Linux via Homebrew:
-
-```bash
-brew install fulsomenko/tap/kanban
-```
-
-Both the TUI/CLI binary (`kanban`) and the 40-tool MCP server (`kanban-mcp`) are included. The formula is maintained in the `fulsomenko/homebrew-tap` repository, and the release workflow automatically updates it on each version bump — no manual maintenance required.
-
-This is **Phase 1** of Homebrew distribution (personal tap). Phase 2 (homebrew-core submission) will follow once the project meets Homebrew's notability requirements (≥225 stars for self-submitted software).
+Release workflow now auto-bumps the Homebrew tap formula on each version bump. The `release.yml` CI job computes the tarball SHA256, clones the `fulsomenko/homebrew-tap` repository, updates the formula's `url` and `sha256` fields, and pushes the changes — no manual intervention required. Updated README and web landing page with Homebrew install instructions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,49 @@ jobs:
           updpkgsums: false
           allow_empty_commits: false
 
+      - name: Compute upstream tarball SHA256 for Homebrew
+        if: steps.check.outputs.has_changesets == 'true'
+        id: brew-sha
+        env:
+          VERSION: ${{ steps.release.outputs.new }}
+        run: |
+          set -euo pipefail
+          URL="https://github.com/fulsomenko/kanban/archive/refs/tags/v${VERSION}.tar.gz"
+          SHA256=$(curl -fsL "$URL" | sha256sum | cut -d' ' -f1)
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Homebrew tap SSH key
+        if: steps.check.outputs.has_changesets == 'true'
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}" > ~/.ssh/homebrew_tap_key
+          chmod 600 ~/.ssh/homebrew_tap_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Bump formula in homebrew-kanban tap
+        if: steps.check.outputs.has_changesets == 'true'
+        env:
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/homebrew_tap_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+          VERSION: ${{ steps.release.outputs.new }}
+          SHA: ${{ steps.brew-sha.outputs.sha256 }}
+          URL: ${{ steps.brew-sha.outputs.url }}
+        run: |
+          set -euo pipefail
+          git clone git@github.com:fulsomenko/homebrew-kanban.git /tmp/homebrew-kanban
+          sed -i "s|^  url \".*\"|  url \"${URL}\"|" /tmp/homebrew-kanban/Formula/kanban.rb
+          sed -i "s|^  sha256 \".*\"|  sha256 \"${SHA}\"|" /tmp/homebrew-kanban/Formula/kanban.rb
+          cd /tmp/homebrew-kanban
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/kanban.rb
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "kanban ${VERSION}"
+            git push origin master
+          fi
+
       - name: Sync develop with master
         if: steps.check.outputs.has_changesets == 'true'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
           chmod 600 ~/.ssh/homebrew_tap_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-      - name: Bump formula in homebrew-kanban tap
+      - name: Bump formula in homebrew-tap
         if: steps.check.outputs.has_changesets == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/homebrew_tap_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
@@ -199,10 +199,10 @@ jobs:
           URL: ${{ steps.brew-sha.outputs.url }}
         run: |
           set -euo pipefail
-          git clone git@github.com:fulsomenko/homebrew-kanban.git /tmp/homebrew-kanban
-          sed -i "s|^  url \".*\"|  url \"${URL}\"|" /tmp/homebrew-kanban/Formula/kanban.rb
-          sed -i "s|^  sha256 \".*\"|  sha256 \"${SHA}\"|" /tmp/homebrew-kanban/Formula/kanban.rb
-          cd /tmp/homebrew-kanban
+          git clone git@github.com:fulsomenko/homebrew-tap.git /tmp/homebrew-tap
+          sed -i "s|^  url \".*\"|  url \"${URL}\"|" /tmp/homebrew-tap/Formula/kanban.rb
+          sed -i "s|^  sha256 \".*\"|  sha256 \"${SHA}\"|" /tmp/homebrew-tap/Formula/kanban.rb
+          cd /tmp/homebrew-tap
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/kanban.rb

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cd kanban
 cargo install --path crates/kanban-cli
 ```
 
-### Homebrew (macOS & Linux)
+### Homebrew
 ```bash
 brew install fulsomenko/tap/kanban
 ```

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cargo install --path crates/kanban-cli
 
 ### Homebrew (macOS & Linux)
 ```bash
-brew install fulsomenko/kanban/kanban
+brew install fulsomenko/tap/kanban
 ```
 
 ### Using Nix

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ cd kanban
 cargo install --path crates/kanban-cli
 ```
 
+### Homebrew (macOS & Linux)
+```bash
+brew install fulsomenko/kanban/kanban
+```
+
 ### Using Nix
 ```bash
 nix run github:fulsomenko/kanban

--- a/web/index.html
+++ b/web/index.html
@@ -93,6 +93,15 @@
       <h2>Getting Started</h2>
       <div class="install-methods">
         <div class="install-method">
+          <h3>Installation</h3>
+          <pre><code class="code-block nohighlight"><span class="comment"># Cargo</span>
+<span class="prompt">$</span> cargo install kanban-cli
+
+<span class="comment"># Homebrew (macOS & Linux)</span>
+<span class="prompt">$</span> brew install fulsomenko/tap/kanban</code></pre>
+        </div>
+
+        <div class="install-method">
           <h3>From Crates.io</h3>
           <pre><code class="code-block nohighlight"><span class="prompt">$</span> cargo install kanban-cli</code></pre>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -97,7 +97,7 @@
           <pre><code class="code-block nohighlight"><span class="comment"># Cargo</span>
 <span class="prompt">$</span> cargo install kanban-cli
 
-<span class="comment"># Homebrew (macOS & Linux)</span>
+<span class="comment"># Homebrew</span>
 <span class="prompt">$</span> brew install fulsomenko/tap/kanban</code></pre>
         </div>
 


### PR DESCRIPTION
## Summary

Add Homebrew tap distribution with automated formula updates on each release. Users can now install kanban via `brew install fulsomenko/tap/kanban` (macOS and Linux). The release workflow automatically bumps the formula's version and SHA256 — no manual maintenance required.

## Changes

- **CI**: Three new jobs in release.yml (after AUR, before sync):
  - Compute upstream tarball SHA256 for the release
  - Setup SSH authentication to the tap repo
  - Clone tap, sed-bump formula url/sha256, commit, and push
  
- **Documentation**: 
  - README: Added Homebrew install section
  - Web landing page: Added unified "Installation" section with Cargo + Homebrew options (styled with terminal comments)

- **Changeset**: Minor bump, focused on the CI automation this repo adds

## Design Approach

Reused the proven AUR automation pattern from release.yml — same SHA256 computation idiom (curl | sha256sum), same SSH key setup, same conditional gating on changesets. Keeps packaging strategies consistent.

Formula lives only in the tap repo (fulsomenko/homebrew-kanban); no formula files in this repo. Single source of truth avoids maintenance overhead.

## Testing

- ✅ macOS pre-flight (gate before merge): brew install, brew test, brew audit --strict --new, brew style all pass
- ✅ Both binaries included: kanban (CLI/TUI) and kanban-mcp (40-tool MCP server)
- ✅ Cargo checks: fmt, clippy -D warnings, test --workspace all clean
- ✅ All commits GPG signed

## Known Deferred

- SHA256 validation (KAN-468): Add non-empty check before sed-bump
- Web UX refactor (KAN-469): Collapse all install methods into single code block (currently creates redundancy with "From Crates.io")