### PR TITLE
KAN-469 refactor(web): collapse installation methods into single code block

### DIFF
--- a/.changeset/kan-469-refactor-web-installation.md
+++ b/.changeset/kan-469-refactor-web-installation.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Web landing page installation section refactored to collapse five separate install method blocks into a single unified code block. All methods (Cargo, Homebrew, Nix, AUR, from source) are now presented together with inline comments for clarity. Nix installation simplified from multi-step instructions to a single command: `nix run nixpkgs/nixpkgs-unstable#kanban`.

--- a/web/index.html
+++ b/web/index.html
@@ -98,30 +98,16 @@
 <span class="prompt">$</span> cargo install kanban-cli
 
 <span class="comment"># Homebrew</span>
-<span class="prompt">$</span> brew install fulsomenko/tap/kanban</code></pre>
-        </div>
+<span class="prompt">$</span> brew install fulsomenko/tap/kanban
 
-        <div class="install-method">
-          <h3>From Crates.io</h3>
-          <pre><code class="code-block nohighlight"><span class="prompt">$</span> cargo install kanban-cli</code></pre>
-        </div>
+<span class="comment"># Nix</span>
+<span class="prompt">$</span> nix run nixpkgs/nixpkgs-unstable#kanban
 
-        <div class="install-method">
-          <h3>Using Nix</h3>
-          <pre><code class="code-block nohighlight"><span class="prompt">$</span> nix run github:fulsomenko/kanban
-<span class="prompt">$</span> <span class="comment"># or</span>
-<span class="prompt">$</span> nix run github:nixos/nixpkgs/nixpkgs-unstable#kanban
-</code></pre>
-        </div>
+<span class="comment"># AUR (Arch Linux)</span>
+<span class="prompt">$</span> yay -S kanban
 
-        <div class="install-method">
-          <h3>Arch Linux (AUR)</h3>
-          <pre><code class="code-block nohighlight"><span class="prompt">$</span> yay -S kanban</code></pre>
-        </div>
-
-        <div class="install-method">
-          <h3>From Source</h3>
-          <pre><code class="code-block nohighlight"><span class="prompt">$</span> git clone https://github.com/fulsomenko/kanban
+<span class="comment"># From source</span>
+<span class="prompt">$</span> git clone https://github.com/fulsomenko/kanban
 <span class="prompt">$</span> cd kanban
 <span class="prompt">$</span> cargo install --path crates/kanban-cli</code></pre>
         </div>


### PR DESCRIPTION
Collapse web landing page installation section from five separate method blocks into a single unified code block with inline comments:

- Consolidate Cargo, Homebrew, Nix, AUR, and from-source instructions into one pre block
- Add inline comment headers for each installation method for clarity
- Simplify Nix installation to single command: `nix run nixpkgs/nixpkgs-unstable#kanban`
- Remove redundant "From Crates.io" and "Using Nix" section duplicates

**What**: Unified installation code block on landing page with all package managers shown together.

**Why**: Cleaner presentation reduces visual clutter and makes it obvious to users that multiple installation paths are available. The collapse from five sections to one makes the page more scannable.

**How**: Merged multiple install-method divs into a single pre block with commented headers. Simplified Nix from dual-command format to the standard nixpkgs unstable pinning.

**Testing**: `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean).