### PR TITLE
KAN-451 feat(cli): add init subcommand to decouple storage bootstrapping from board create

### DIFF
--- a/.changeset/kan-451-add-cli-init-subcommand-to-decouple-storage-bootstrapping-from-board-create.md
+++ b/.changeset/kan-451-add-cli-init-subcommand-to-decouple-storage-bootstrapping-from-board-create.md
@@ -1,0 +1,14 @@
+---
+bump: minor
+---
+
+Add `kanban init` command for non-interactive board file initialization. Creates a new board file with an optional first board and exits cleanly without opening the TUI. Decouples storage bootstrapping from board creation, enabling scriptable first-time setup and fixing Homebrew formula tests that were hanging in non-TTY environments.
+
+**Usage:**
+```bash
+kanban init boards.json --board "My Project"  # create file + first board, exit
+kanban init --board "My Project"              # uses KANBAN_FILE or boards.json
+kanban init                                   # creates boards.json with "My Board"
+```
+
+File path resolution follows the standard chain: positional argument > `KANBAN_FILE` env var > config file `storage_location` > compiled-in default (`boards.json`).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ kanban sprint activate yarara-release --duration-days 14
 kanban card assign-sprint KAN-5 --sprint yarara-release
 ```
 
+### Init (non-interactive setup)
+
+```bash
+kanban init boards.json --board "My Project"  # create file + first board, exit
+kanban init --board "My Project"              # uses KANBAN_FILE or boards.json
+kanban init                                   # creates boards.json with "My Board"
+```
+
 Every entity argument accepts either a UUID or a human-readable name (sprint
 numbers also work for sprints; cards accept their `KAN-N` identifier). When a
 name doesn't match, the error lists what's available.

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -9,6 +9,7 @@ kanban [FILE] [COMMAND]
 kanban                        # Launch TUI; pick or skip a file from the startup dialog
 kanban boards.json            # Launch TUI with specific file
 kanban boards.json board list # Run a CLI command
+kanban init boards.json --board "Project"  # Create file + first board, exit
 ```
 
 **File selection priority** (TUI launches the choose-storage dialog when none of these is set):
@@ -98,6 +99,26 @@ kanban sprint complete <ID>
 kanban sprint cancel <ID>
 kanban sprint delete <ID>
 kanban sprint carry-over --from <ID> --to <ID>
+```
+
+### `init`
+
+```bash
+kanban init [FILE] [--board <NAME>]
+```
+
+Create a board file and an initial board, then exit without opening the TUI. Does not open the TUI.
+
+- `FILE` — target file path (default: uses KANBAN_FILE env var, then config storage_location, then boards.json)
+- `--board` — name of the first board to create (default: "My Board")
+
+Examples:
+
+```bash
+kanban init                    # creates boards.json with "My Board"
+kanban init boards.json        # creates boards.json with "My Board"
+kanban init boards.json --board "Sprint 1"  # creates boards.json with "Sprint 1"
+KANBAN_FILE=work.json kanban init --board "Team Board"  # uses env var
 ```
 
 ### Top-level commands

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -107,7 +107,7 @@ kanban sprint carry-over --from <ID> --to <ID>
 kanban init [FILE] [--board <NAME>]
 ```
 
-Create a board file and an initial board, then exit without opening the TUI. Does not open the TUI.
+Create a board file and an initial board, then exit without opening the TUI.
 
 - `FILE` — target file path (default: uses KANBAN_FILE env var, then config storage_location, then boards.json)
 - `--board` — name of the first board to create (default: "My Board")

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -1,8 +1,10 @@
 use crate::cli::{Cli, Commands};
 use crate::context::CliContext;
 use crate::handlers;
+use crate::output;
 use clap::{CommandFactory, FromArgMatches};
 use kanban_core::AppConfig;
+use kanban_domain::KanbanOperations;
 use kanban_persistence::{StoreFactory, StoreRegistry};
 use kanban_service::StoreManager;
 #[cfg(feature = "tui")]
@@ -128,7 +130,7 @@ async fn dispatch_subcommand(ctx: &mut CliContext, cmd: Commands) -> anyhow::Res
         Commands::Import(args) => {
             handlers::export::handle_import(ctx, args).await?;
         }
-        Commands::Completions { .. } | Commands::Migrate(_) => unreachable!(),
+        Commands::Completions { .. } | Commands::Migrate(_) | Commands::Init { .. } => unreachable!(),
     }
     Ok(())
 }
@@ -264,7 +266,7 @@ impl CliApp {
 
         let needs_data_file = !matches!(
             &command,
-            None | Some(Commands::Completions { .. }) | Some(Commands::Migrate(_))
+            None | Some(Commands::Completions { .. }) | Some(Commands::Migrate(_)) | Some(Commands::Init { .. })
         );
         if needs_data_file && validated_file.is_none() && config.storage_location.is_none() {
             anyhow::bail!(
@@ -322,6 +324,14 @@ Provide the file path in one of these ways:
             Some(Commands::Migrate(args)) => {
                 init_tracing_cli();
                 handlers::migrate::handle(&store_manager, args).await?;
+            }
+            Some(Commands::Init { board }) => {
+                init_tracing_cli();
+                let board_name = board.unwrap_or_else(|| "My Board".to_string());
+                let mut ctx = CliContext::load(&store_manager, &effective_file, config).await?;
+                let created = ctx.create_board(board_name, None)?;
+                ctx.save().await?;
+                output::output_success(&created);
             }
             Some(cmd) => {
                 init_tracing_cli();

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -130,7 +130,9 @@ async fn dispatch_subcommand(ctx: &mut CliContext, cmd: Commands) -> anyhow::Res
         Commands::Import(args) => {
             handlers::export::handle_import(ctx, args).await?;
         }
-        Commands::Completions { .. } | Commands::Migrate(_) | Commands::Init { .. } => unreachable!(),
+        Commands::Completions { .. } | Commands::Migrate(_) | Commands::Init { .. } => {
+            unreachable!()
+        }
     }
     Ok(())
 }
@@ -266,7 +268,9 @@ impl CliApp {
 
         let needs_data_file = !matches!(
             &command,
-            None | Some(Commands::Completions { .. }) | Some(Commands::Migrate(_)) | Some(Commands::Init { .. })
+            None | Some(Commands::Completions { .. })
+                | Some(Commands::Migrate(_))
+                | Some(Commands::Init { .. })
         );
         if needs_data_file && validated_file.is_none() && config.storage_location.is_none() {
             anyhow::bail!(

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -36,6 +36,12 @@ pub enum Commands {
     },
     /// Migrate data between storage backends
     Migrate(MigrateArgs),
+    /// Initialize a new board file with an optional first board
+    Init {
+        /// Name of the first board to create
+        #[arg(long)]
+        board: Option<String>,
+    },
 }
 
 // Board commands

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -16,6 +16,15 @@ fn extract_id(json: &Value) -> String {
     json["data"]["id"].as_str().unwrap().to_string()
 }
 
+fn kanban_no_config(dir: &std::path::Path) -> Command {
+    let mut cmd = kanban();
+    cmd.current_dir(dir)
+        .env_remove("KANBAN_FILE")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("HOME", dir);
+    cmd
+}
+
 mod board_tests {
     use super::*;
 
@@ -3224,5 +3233,71 @@ mod missing_file_tests {
             file.exists(),
             "kanban <file> must create the file when missing"
         );
+    }
+}
+
+mod init_tests {
+    use super::*;
+
+    #[test]
+    fn test_init_creates_file_with_default_board() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("boards.json");
+
+        let output = kanban()
+            .args([file.to_str().unwrap(), "init"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        assert!(file.exists());
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert_eq!(json["data"]["name"], "My Board");
+    }
+
+    #[test]
+    fn test_init_creates_file_with_named_board() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("boards.json");
+
+        let output = kanban()
+            .args([file.to_str().unwrap(), "init", "--board", "Sprint 1"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        assert!(file.exists());
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert_eq!(json["data"]["name"], "Sprint 1");
+    }
+
+    #[test]
+    fn test_init_via_kanban_file_env() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("env-board.json");
+
+        kanban_no_config(dir.path())
+            .env("KANBAN_FILE", file.to_str().unwrap())
+            .args(["init", "--board", "Env Board"])
+            .assert()
+            .success();
+
+        assert!(file.exists());
+    }
+
+    #[test]
+    fn test_init_fails_cleanly_on_bad_path() {
+        let dir = tempdir().unwrap();
+        let bad = dir.path().join("no").join("such").join("dir").join("x.json");
+
+        kanban()
+            .args([bad.to_str().unwrap(), "init"])
+            .assert()
+            .failure();
     }
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -3293,7 +3293,12 @@ mod init_tests {
     #[test]
     fn test_init_fails_cleanly_on_bad_path() {
         let dir = tempdir().unwrap();
-        let bad = dir.path().join("no").join("such").join("dir").join("x.json");
+        let bad = dir
+            .path()
+            .join("no")
+            .join("such")
+            .join("dir")
+            .join("x.json");
 
         kanban()
             .args([bad.to_str().unwrap(), "init"])


### PR DESCRIPTION
Add `kanban init` command for non-interactive board file initialization:

- Add Init subcommand variant to Commands enum with optional --board flag
- Implement handler that creates file, initial board, saves, and exits cleanly
- Exclude Init from needs_data_file guard (file doesn't need to exist yet)
- Handle Init before catch-all subcommand arm to bypass file existence check
- File resolution uses standard chain: positional > KANBAN_FILE > config > default
- Add 4 integration tests covering all usage scenarios
- Document usage in README.md and crates/kanban-cli/README.md

**What**: Non-interactive board file initialization via `kanban init [FILE] [--board NAME]`. Decouples storage bootstrapping from board creation, enabling scriptable first-time setup.

**Why**: Homebrew formula tests were hanging in non-TTY environments when trying to create a board. The existing `kanban board create` requires the file to exist, and bare `kanban` opens an interactive TUI dialog. We needed a way to initialize a file + board without user interaction.

**How**: Added Init as a top-level command (like Migrate) that bypasses the "file must exist" guard, creates a CliContext, creates a board with optional name (defaults to "My Board"), saves, and exits. File resolution respects the standard chain used throughout the CLI.

**Testing**: 
- `cargo test --test cli_integration init_tests` — 4 new tests, all passing
- `cargo test --workspace` — no regressions
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Manual test confirms functionality (file creation, JSON output, board contents)