### PR TITLE
KAN-474 feat(service): SqliteBackend persists the audit log on disk

### DIFF
--- a/.changeset/kan-474-audit-log-on-disk.md
+++ b/.changeset/kan-474-audit-log-on-disk.md
@@ -1,0 +1,27 @@
+---
+bump: patch
+---
+
+The SQLite backend's audit log now lives on disk. Earlier releases
+kept a per-session in-memory log on SQLite even though a
+`command_log` table existed in the schema, so the audit history was
+lost on every session close. From this release, every batch of
+commands executed against a SQLite-backed kanban file is appended to
+`command_log` immediately and survives reopen. The append uses an
+auto-allocated `batch_index`, so concurrent writers stay consistent
+without a pre-read.
+
+JSON files and the no-persistence in-memory backend are unchanged —
+their audit log was already per-session and remains so. This release
+just makes the SQLite story honest.
+
+There is no audit-log UI yet. This change is foundation work for the
+upcoming audit-log view (KAN-36). Existing SQLite files are picked up
+seamlessly; nothing in the schema or on-disk layout changes apart
+from the fact that rows now actually get inserted into the table that
+has existed since v0.6.
+
+Library users: the `CommandStore` programmatic interface returns
+`Vec<CommandBatch>` instead of `Vec<Vec<Command>>` — same data, named
+type. The `load_all_commands` convenience was removed; use
+`command_count` followed by `load_commands` instead.

--- a/crates/kanban-domain/src/command_store.rs
+++ b/crates/kanban-domain/src/command_store.rs
@@ -1,5 +1,43 @@
 use crate::commands::Command;
 use crate::KanbanResult;
+use serde::{Deserialize, Serialize};
+
+/// One audit-log entry — the commands submitted as a single
+/// `KanbanContext::execute` call.
+///
+/// Most user actions are a single command; some (animated archive,
+/// cascade flows) are multiple. The batch boundary distinguishes
+/// "one user action" from "many user actions" and is what an
+/// audit-log UI renders per row.
+///
+/// `#[serde(transparent)]` keeps the on-disk JSON encoding identical
+/// to a bare `Vec<Command>`, so existing SQLite `command_log` rows
+/// deserialize unchanged.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CommandBatch {
+    pub commands: Vec<Command>,
+}
+
+impl CommandBatch {
+    pub fn new(commands: Vec<Command>) -> Self {
+        Self { commands }
+    }
+
+    pub fn len(&self) -> usize {
+        self.commands.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+}
+
+impl From<Vec<Command>> for CommandBatch {
+    fn from(commands: Vec<Command>) -> Self {
+        Self { commands }
+    }
+}
 
 /// Append-only chronological log of executed command batches.
 /// Backend-defined persistence (JSON in-memory, SQLite on disk).
@@ -10,11 +48,11 @@ pub trait CommandStore: Send + Sync {
     fn command_count(&self) -> KanbanResult<u64>;
 
     /// Half-open range `[from, to)`.
-    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<Vec<Command>>>;
+    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>>;
 
     /// Atomic count + load. Default is non-atomic; backends with
     /// interior locks should override.
-    fn load_all_commands(&self) -> KanbanResult<(Vec<Vec<Command>>, u64)> {
+    fn load_all_commands(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
         let count = self.command_count()?;
         let batches = self.load_commands(0, count)?;
         Ok((batches, count))

--- a/crates/kanban-domain/src/command_store.rs
+++ b/crates/kanban-domain/src/command_store.rs
@@ -49,14 +49,6 @@ pub trait CommandStore: Send + Sync {
 
     /// Half-open range `[from, to)`.
     fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>>;
-
-    /// Atomic count + load. Default is non-atomic; backends with
-    /// interior locks should override.
-    fn load_all_commands(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
-        let count = self.command_count()?;
-        let batches = self.load_commands(0, count)?;
-        Ok((batches, count))
-    }
 }
 
 #[cfg(test)]
@@ -116,18 +108,6 @@ mod tests {
 
         let batches = store.load_commands(0, 2).unwrap();
         assert_eq!(batches.len(), 2);
-    }
-
-    #[test]
-    fn test_load_all_commands_returns_consistent_count_and_data() {
-        let store = InMemoryStore::new();
-        store.append_commands(&[make_board_cmd("B1")]).unwrap();
-        store.append_commands(&[make_board_cmd("B2")]).unwrap();
-        store.append_commands(&[make_board_cmd("B3")]).unwrap();
-
-        let (batches, count) = store.load_all_commands().unwrap();
-        assert_eq!(count, 3);
-        assert_eq!(batches.len(), 3);
     }
 
     #[test]

--- a/crates/kanban-domain/src/in_memory_store.rs
+++ b/crates/kanban-domain/src/in_memory_store.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 use crate::command_store::CommandStore;
 use crate::commands::Command;
 use crate::data_store::DataStore;
+use crate::session_command_log::SessionCommandLog;
 use crate::{
     ArchivedCard, Board, Card, Column, DependencyGraph, KanbanError, KanbanResult, Snapshot, Sprint,
 };
@@ -68,14 +69,14 @@ impl StoreState {
 
 pub struct InMemoryStore {
     state: RwLock<StoreState>,
-    command_log: RwLock<Vec<Vec<Command>>>,
+    command_log: SessionCommandLog,
 }
 
 impl InMemoryStore {
     pub fn new() -> Self {
         Self {
             state: RwLock::new(StoreState::new()),
-            command_log: RwLock::new(Vec::new()),
+            command_log: SessionCommandLog::new(),
         }
     }
 
@@ -89,18 +90,6 @@ impl InMemoryStore {
         self.state
             .write()
             .map_err(|e| KanbanError::Internal(format!("State RwLock poisoned (write): {e}")))
-    }
-
-    fn read_log(&self) -> KanbanResult<std::sync::RwLockReadGuard<'_, Vec<Vec<Command>>>> {
-        self.command_log
-            .read()
-            .map_err(|e| KanbanError::Internal(format!("Command log RwLock poisoned (read): {e}")))
-    }
-
-    fn write_log(&self) -> KanbanResult<std::sync::RwLockWriteGuard<'_, Vec<Vec<Command>>>> {
-        self.command_log
-            .write()
-            .map_err(|e| KanbanError::Internal(format!("Command log RwLock poisoned (write): {e}")))
     }
 }
 
@@ -462,25 +451,19 @@ impl DataStore for InMemoryStore {
 
 impl CommandStore for InMemoryStore {
     fn append_commands(&self, cmds: &[Command]) -> KanbanResult<u64> {
-        let mut log = self.write_log()?;
-        log.push(cmds.to_vec());
-        Ok(log.len() as u64)
+        self.command_log.append(cmds)
     }
 
     fn command_count(&self) -> KanbanResult<u64> {
-        Ok(self.read_log()?.len() as u64)
+        self.command_log.count()
     }
 
     fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<Vec<Command>>> {
-        let log = self.read_log()?;
-        let from = (from as usize).min(log.len());
-        let to = (to as usize).min(log.len());
-        Ok(log[from..to].to_vec())
+        self.command_log.load(from, to)
     }
 
     fn load_all_commands(&self) -> KanbanResult<(Vec<Vec<Command>>, u64)> {
-        let log = self.read_log()?;
-        Ok((log.clone(), log.len() as u64))
+        self.command_log.load_all()
     }
 }
 

--- a/crates/kanban-domain/src/in_memory_store.rs
+++ b/crates/kanban-domain/src/in_memory_store.rs
@@ -461,10 +461,6 @@ impl CommandStore for InMemoryStore {
     fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
         self.command_log.load(from, to)
     }
-
-    fn load_all_commands(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
-        self.command_log.load_all()
-    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-domain/src/in_memory_store.rs
+++ b/crates/kanban-domain/src/in_memory_store.rs
@@ -3,7 +3,7 @@ use std::sync::RwLock;
 
 use uuid::Uuid;
 
-use crate::command_store::CommandStore;
+use crate::command_store::{CommandBatch, CommandStore};
 use crate::commands::Command;
 use crate::data_store::DataStore;
 use crate::session_command_log::SessionCommandLog;
@@ -458,11 +458,11 @@ impl CommandStore for InMemoryStore {
         self.command_log.count()
     }
 
-    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<Vec<Command>>> {
+    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
         self.command_log.load(from, to)
     }
 
-    fn load_all_commands(&self) -> KanbanResult<(Vec<Vec<Command>>, u64)> {
+    fn load_all_commands(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
         self.command_log.load_all()
     }
 }

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -17,6 +17,7 @@ pub mod in_memory_store;
 pub mod operations;
 pub mod query;
 pub mod search;
+pub mod session_command_log;
 pub mod snapshot;
 pub mod sort;
 pub mod sprint;
@@ -62,6 +63,7 @@ pub use task_list_view::TaskListView;
 pub use command_store::CommandStore;
 pub use data_store::{DataStore, GraphMutFn};
 pub use in_memory_store::InMemoryStore;
+pub use session_command_log::SessionCommandLog;
 
 pub use error::{
     AmbiguousMatch, BatchResolutionCause, BatchResolutionFailure, DependencyError, DomainError,

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -60,7 +60,7 @@ pub use sprint_log::SprintLog;
 pub use tag::{Tag, TagId};
 pub use task_list_view::TaskListView;
 
-pub use command_store::CommandStore;
+pub use command_store::{CommandBatch, CommandStore};
 pub use data_store::{DataStore, GraphMutFn};
 pub use in_memory_store::InMemoryStore;
 pub use session_command_log::SessionCommandLog;

--- a/crates/kanban-domain/src/session_command_log.rs
+++ b/crates/kanban-domain/src/session_command_log.rs
@@ -5,13 +5,14 @@
 //! SQLite uses its own on-disk `command_log` table and does not
 //! depend on this type.
 
+use crate::command_store::CommandBatch;
 use crate::commands::Command;
 use crate::{KanbanError, KanbanResult};
 use std::sync::RwLock;
 
 #[derive(Debug, Default)]
 pub struct SessionCommandLog {
-    batches: RwLock<Vec<Vec<Command>>>,
+    batches: RwLock<Vec<CommandBatch>>,
 }
 
 impl SessionCommandLog {
@@ -19,13 +20,13 @@ impl SessionCommandLog {
         Self::default()
     }
 
-    fn read(&self) -> KanbanResult<std::sync::RwLockReadGuard<'_, Vec<Vec<Command>>>> {
+    fn read(&self) -> KanbanResult<std::sync::RwLockReadGuard<'_, Vec<CommandBatch>>> {
         self.batches.read().map_err(|e| {
             KanbanError::Internal(format!("SessionCommandLog RwLock poisoned (read): {e}"))
         })
     }
 
-    fn write(&self) -> KanbanResult<std::sync::RwLockWriteGuard<'_, Vec<Vec<Command>>>> {
+    fn write(&self) -> KanbanResult<std::sync::RwLockWriteGuard<'_, Vec<CommandBatch>>> {
         self.batches.write().map_err(|e| {
             KanbanError::Internal(format!("SessionCommandLog RwLock poisoned (write): {e}"))
         })
@@ -33,7 +34,7 @@ impl SessionCommandLog {
 
     pub fn append(&self, cmds: &[Command]) -> KanbanResult<u64> {
         let mut log = self.write()?;
-        log.push(cmds.to_vec());
+        log.push(CommandBatch::new(cmds.to_vec()));
         Ok(log.len() as u64)
     }
 
@@ -41,14 +42,14 @@ impl SessionCommandLog {
         Ok(self.read()?.len() as u64)
     }
 
-    pub fn load(&self, from: u64, to: u64) -> KanbanResult<Vec<Vec<Command>>> {
+    pub fn load(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
         let log = self.read()?;
         let from = (from as usize).min(log.len());
         let to = (to as usize).min(log.len());
         Ok(log[from..to].to_vec())
     }
 
-    pub fn load_all(&self) -> KanbanResult<(Vec<Vec<Command>>, u64)> {
+    pub fn load_all(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
         let log = self.read()?;
         Ok((log.clone(), log.len() as u64))
     }

--- a/crates/kanban-domain/src/session_command_log.rs
+++ b/crates/kanban-domain/src/session_command_log.rs
@@ -1,0 +1,112 @@
+//! In-memory, focused command-log storage.
+//!
+//! Used by `InMemoryStore` (and therefore the JSON backend) to satisfy
+//! the `CommandStore` trait without dragging in entity-store concerns.
+//! SQLite uses its own on-disk `command_log` table and does not
+//! depend on this type.
+
+use crate::commands::Command;
+use crate::{KanbanError, KanbanResult};
+use std::sync::RwLock;
+
+#[derive(Debug, Default)]
+pub struct SessionCommandLog {
+    batches: RwLock<Vec<Vec<Command>>>,
+}
+
+impl SessionCommandLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn read(&self) -> KanbanResult<std::sync::RwLockReadGuard<'_, Vec<Vec<Command>>>> {
+        self.batches.read().map_err(|e| {
+            KanbanError::Internal(format!("SessionCommandLog RwLock poisoned (read): {e}"))
+        })
+    }
+
+    fn write(&self) -> KanbanResult<std::sync::RwLockWriteGuard<'_, Vec<Vec<Command>>>> {
+        self.batches.write().map_err(|e| {
+            KanbanError::Internal(format!("SessionCommandLog RwLock poisoned (write): {e}"))
+        })
+    }
+
+    pub fn append(&self, cmds: &[Command]) -> KanbanResult<u64> {
+        let mut log = self.write()?;
+        log.push(cmds.to_vec());
+        Ok(log.len() as u64)
+    }
+
+    pub fn count(&self) -> KanbanResult<u64> {
+        Ok(self.read()?.len() as u64)
+    }
+
+    pub fn load(&self, from: u64, to: u64) -> KanbanResult<Vec<Vec<Command>>> {
+        let log = self.read()?;
+        let from = (from as usize).min(log.len());
+        let to = (to as usize).min(log.len());
+        Ok(log[from..to].to_vec())
+    }
+
+    pub fn load_all(&self) -> KanbanResult<(Vec<Vec<Command>>, u64)> {
+        let log = self.read()?;
+        Ok((log.clone(), log.len() as u64))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{BoardCommand, CreateBoard};
+    use uuid::Uuid;
+
+    fn make_create(name: &str) -> Command {
+        Command::Board(BoardCommand::Create(CreateBoard {
+            id: Uuid::new_v4(),
+            name: name.into(),
+            card_prefix: None,
+            position: 0,
+        }))
+    }
+
+    #[test]
+    fn test_new_log_is_empty() {
+        let log = SessionCommandLog::new();
+        assert_eq!(log.count().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_append_returns_new_count() {
+        let log = SessionCommandLog::new();
+        assert_eq!(log.append(&[make_create("A")]).unwrap(), 1);
+        assert_eq!(log.append(&[make_create("B")]).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_load_range_is_half_open() {
+        let log = SessionCommandLog::new();
+        log.append(&[make_create("A")]).unwrap();
+        log.append(&[make_create("B")]).unwrap();
+        log.append(&[make_create("C")]).unwrap();
+        assert_eq!(log.load(0, 1).unwrap().len(), 1);
+        assert_eq!(log.load(1, 3).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_load_clamps_to_log_length() {
+        let log = SessionCommandLog::new();
+        log.append(&[make_create("A")]).unwrap();
+        assert!(log.load(10, 20).unwrap().is_empty());
+        assert_eq!(log.load(0, 99).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_load_all_returns_count_and_data() {
+        let log = SessionCommandLog::new();
+        log.append(&[make_create("A")]).unwrap();
+        log.append(&[make_create("B")]).unwrap();
+        let (batches, count) = log.load_all().unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(batches.len(), 2);
+    }
+}

--- a/crates/kanban-domain/src/session_command_log.rs
+++ b/crates/kanban-domain/src/session_command_log.rs
@@ -48,11 +48,6 @@ impl SessionCommandLog {
         let to = (to as usize).min(log.len());
         Ok(log[from..to].to_vec())
     }
-
-    pub fn load_all(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
-        let log = self.read()?;
-        Ok((log.clone(), log.len() as u64))
-    }
 }
 
 #[cfg(test)]
@@ -99,15 +94,5 @@ mod tests {
         log.append(&[make_create("A")]).unwrap();
         assert!(log.load(10, 20).unwrap().is_empty());
         assert_eq!(log.load(0, 99).unwrap().len(), 1);
-    }
-
-    #[test]
-    fn test_load_all_returns_count_and_data() {
-        let log = SessionCommandLog::new();
-        log.append(&[make_create("A")]).unwrap();
-        log.append(&[make_create("B")]).unwrap();
-        let (batches, count) = log.load_all().unwrap();
-        assert_eq!(count, 2);
-        assert_eq!(batches.len(), 2);
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use kanban_core::graph::{Edge, Graph};
+use kanban_domain::command_store::{CommandBatch, CommandStore};
+use kanban_domain::commands::Command;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
     ArchivedCard, Board, Card, CardEdgeType, Column, DependencyGraph, KanbanError, KanbanResult,
@@ -401,70 +403,52 @@ impl SqliteStore {
         Ok(())
     }
 
-    // ── Command log (audit foundation; not yet wired through SqliteBackend) ──
+    // ── Command log (audit) ───────────────────────────────────────────────
+    //
+    // `batch_index` is `INTEGER PRIMARY KEY` so `INSERT ... VALUES (NULL, ...)`
+    // lets SQLite assign the next auto-incremented value atomically — no
+    // pre-read of `MAX(batch_index)`. The `CommandStore` impl below is the
+    // only writer; the log is never truncated or pruned through this API.
 
-    /// Append a single command batch at logical index `batch_index`.
-    /// `commands_json` is the serde-JSON encoding of the `Vec<Command>` batch.
-    pub async fn append_command_batch(
-        &self,
-        batch_index: u64,
-        commands_json: &str,
-    ) -> KanbanResult<()> {
-        sqlx::query(
-            "INSERT INTO command_log (batch_index, commands_json, created_at) VALUES (?, ?, ?)",
+    async fn insert_command_log_row(&self, commands_json: &str) -> KanbanResult<u64> {
+        let res = sqlx::query(
+            "INSERT INTO command_log (batch_index, commands_json, created_at)
+             VALUES (NULL, ?, ?)",
         )
-        .bind(batch_index as i64)
         .bind(commands_json)
         .bind(fmt_dt(&Utc::now()))
         .execute(&self.pool)
         .await
         .map_err(db_err)?;
-        Ok(())
+        Ok(res.last_insert_rowid() as u64)
     }
 
-    /// Load all persisted command batches in order. Returns the JSON strings
-    /// so callers can deserialise inside the domain layer.
-    pub async fn load_all_command_batches(&self) -> KanbanResult<Vec<String>> {
-        let rows = sqlx::query("SELECT commands_json FROM command_log ORDER BY batch_index ASC")
-            .fetch_all(&self.pool)
+    async fn command_log_row_count(&self) -> KanbanResult<u64> {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM command_log")
+            .fetch_one(&self.pool)
             .await
             .map_err(db_err)?;
+        Ok(count as u64)
+    }
+
+    async fn select_command_log_range(&self, from: u64, to: u64) -> KanbanResult<Vec<String>> {
+        if to <= from {
+            return Ok(vec![]);
+        }
+        let rows = sqlx::query(
+            "SELECT commands_json FROM command_log
+             ORDER BY batch_index ASC LIMIT ? OFFSET ?",
+        )
+        .bind((to - from) as i64)
+        .bind(from as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(db_err)?;
         let mut out = Vec::with_capacity(rows.len());
         for row in &rows {
             out.push(row.try_get::<String, _>("commands_json").map_err(db_err)?);
         }
         Ok(out)
-    }
-
-    /// Remove batches with logical index >= `after`. Retains [0, after).
-    pub async fn truncate_command_log_after(&self, after: u64) -> KanbanResult<()> {
-        sqlx::query("DELETE FROM command_log WHERE batch_index >= ?")
-            .bind(after as i64)
-            .execute(&self.pool)
-            .await
-            .map_err(db_err)?;
-        Ok(())
-    }
-
-    /// Remove the oldest `drop_count` batches and renumber the rest so the
-    /// surviving log starts at index 0.
-    pub async fn shift_command_log(&self, drop_count: u64) -> KanbanResult<()> {
-        if drop_count == 0 {
-            return Ok(());
-        }
-        let mut tx = self.pool.begin().await.map_err(db_err)?;
-        sqlx::query("DELETE FROM command_log WHERE batch_index < ?")
-            .bind(drop_count as i64)
-            .execute(&mut *tx)
-            .await
-            .map_err(db_err)?;
-        sqlx::query("UPDATE command_log SET batch_index = batch_index - ?")
-            .bind(drop_count as i64)
-            .execute(&mut *tx)
-            .await
-            .map_err(db_err)?;
-        tx.commit().await.map_err(db_err)?;
-        Ok(())
     }
 
     async fn fetch_board_aux(
@@ -1574,6 +1558,31 @@ impl DataStore for SqliteStore {
     fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
         run(self.apply_snapshot_async(snapshot))
     }
+}
+
+impl CommandStore for SqliteStore {
+    fn append_commands(&self, cmds: &[Command]) -> KanbanResult<u64> {
+        let json = serde_json::to_string(cmds).map_err(|e| {
+            KanbanError::Internal(format!("serialize command batch for audit log: {e}"))
+        })?;
+        run(self.insert_command_log_row(&json))?;
+        run(self.command_log_row_count())
+    }
+
+    fn command_count(&self) -> KanbanResult<u64> {
+        run(self.command_log_row_count())
+    }
+
+    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
+        let jsons = run(self.select_command_log_range(from, to))?;
+        jsons.into_iter().map(|j| parse_batch(&j)).collect()
+    }
+}
+
+fn parse_batch(json: &str) -> KanbanResult<CommandBatch> {
+    serde_json::from_str(json).map_err(|e| {
+        KanbanError::Internal(format!("deserialize command batch from audit log: {e}"))
+    })
 }
 
 #[async_trait::async_trait]

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use kanban_domain::commands::Command;
 use kanban_domain::data_store::GraphMutFn;
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, CommandStore, DataStore, DependencyGraph, InMemoryStore,
-    KanbanError, KanbanResult, Snapshot, Sprint,
+    ArchivedCard, Board, Card, Column, CommandBatch, CommandStore, DataStore, DependencyGraph,
+    InMemoryStore, KanbanError, KanbanResult, Snapshot, Sprint,
 };
 use kanban_persistence::{
     snapshot_from_json_bytes, snapshot_to_json_bytes, PersistenceMetadata, PersistenceStore,
@@ -289,10 +289,10 @@ impl CommandStore for JsonDataStore {
     fn command_count(&self) -> KanbanResult<u64> {
         self.with_read(|s| s.command_count())
     }
-    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<Vec<Command>>> {
+    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
         self.with_read(|s| s.load_commands(from, to))
     }
-    fn load_all_commands(&self) -> KanbanResult<(Vec<Vec<Command>>, u64)> {
+    fn load_all_commands(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
         self.with_read(|s| s.load_all_commands())
     }
 }

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -292,9 +292,6 @@ impl CommandStore for JsonDataStore {
     fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
         self.with_read(|s| s.load_commands(from, to))
     }
-    fn load_all_commands(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
-        self.with_read(|s| s.load_all_commands())
-    }
 }
 
 // ─── KanbanBackend ────────────────────────────────────────────────────────────

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -4,8 +4,7 @@ use kanban_domain::command_store::{CommandBatch, CommandStore};
 use kanban_domain::commands::Command;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, DependencyGraph, GraphMutFn, InMemoryStore, KanbanResult,
-    Snapshot, Sprint,
+    ArchivedCard, Board, Card, Column, DependencyGraph, GraphMutFn, KanbanResult, Snapshot, Sprint,
 };
 use kanban_persistence::PersistenceStore;
 use kanban_persistence_sqlite::SqliteStore;
@@ -13,16 +12,12 @@ use uuid::Uuid;
 
 pub struct SqliteBackend {
     db: SqliteStore,
-    /// In-session command log. The on-disk `command_log` table exists
-    /// in the schema but is not yet wired through this backend.
-    mem: InMemoryStore,
 }
 
 impl SqliteBackend {
     pub async fn open(locator: &str) -> KanbanResult<Self> {
         Ok(Self {
             db: SqliteStore::open(locator).await?,
-            mem: InMemoryStore::new(),
         })
     }
 }
@@ -168,19 +163,15 @@ impl DataStore for SqliteBackend {
     }
 }
 
-// ─── CommandStore ─────────────────────────────────────────────────────────────
-
-// Routes to the in-memory mirror; the on-disk command_log table stays
-// unwritten until a separate piece of work wires it up.
 impl CommandStore for SqliteBackend {
     fn append_commands(&self, cmds: &[Command]) -> KanbanResult<u64> {
-        self.mem.append_commands(cmds)
+        self.db.append_commands(cmds)
     }
     fn command_count(&self) -> KanbanResult<u64> {
-        self.mem.command_count()
+        self.db.command_count()
     }
     fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
-        self.mem.load_commands(from, to)
+        self.db.load_commands(from, to)
     }
 }
 

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use kanban_domain::command_store::CommandStore;
+use kanban_domain::command_store::{CommandBatch, CommandStore};
 use kanban_domain::commands::Command;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
@@ -179,7 +179,7 @@ impl CommandStore for SqliteBackend {
     fn command_count(&self) -> KanbanResult<u64> {
         self.mem.command_count()
     }
-    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<Vec<Command>>> {
+    fn load_commands(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
         self.mem.load_commands(from, to)
     }
 }

--- a/crates/kanban-service/tests/audit_log_append_only.rs
+++ b/crates/kanban-service/tests/audit_log_append_only.rs
@@ -49,7 +49,7 @@ async fn test_audit_log_records_all_forward_executes_in_order() -> KanbanResult<
     assert_eq!(batches.len(), 3);
     let names: Vec<String> = batches
         .iter()
-        .filter_map(|batch| match batch.first() {
+        .filter_map(|batch| match batch.commands.first() {
             Some(Command::Board(BoardCommand::Create(c))) => Some(c.name.clone()),
             _ => None,
         })
@@ -127,7 +127,7 @@ async fn test_audit_log_preserves_abandoned_redo_tail_on_branching_execute() -> 
     let batches = backend.load_commands(baseline, baseline + 3)?;
     let names: Vec<String> = batches
         .iter()
-        .filter_map(|batch| match batch.first() {
+        .filter_map(|batch| match batch.commands.first() {
             Some(Command::Board(BoardCommand::Create(c))) => Some(c.name.clone()),
             _ => None,
         })

--- a/crates/kanban-service/tests/command_replay.rs
+++ b/crates/kanban-service/tests/command_replay.rs
@@ -44,7 +44,7 @@ async fn test_replay_from_baseline_reproduces_state() -> KanbanResult<()> {
             store: replay_backend.as_ref() as &dyn DataStore,
         };
         for batch in &batches {
-            for cmd in batch {
+            for cmd in &batch.commands {
                 cmd.execute(&cmd_ctx)?;
             }
         }

--- a/crates/kanban-service/tests/command_replay.rs
+++ b/crates/kanban-service/tests/command_replay.rs
@@ -34,8 +34,9 @@ async fn test_replay_from_baseline_reproduces_state() -> KanbanResult<()> {
 
     let original = ctx.snapshot()?;
     let backend = ctx.backend();
-    let (batches, count) = backend.load_all_commands()?;
+    let count = backend.command_count()?;
     assert!(count > 0, "should have recorded at least one command batch");
+    let batches = backend.load_commands(0, count)?;
 
     let replay_backend = Arc::new(InMemoryStore::new());
     replay_backend.apply_snapshot(Snapshot::new())?;

--- a/crates/kanban-service/tests/sqlite_audit_log_persistence.rs
+++ b/crates/kanban-service/tests/sqlite_audit_log_persistence.rs
@@ -1,0 +1,89 @@
+#![cfg(feature = "sqlite")]
+
+//! SQLite audit log persists across sessions.
+
+use kanban_domain::command_store::CommandStore;
+use kanban_domain::commands::{BoardCommand, Command, CreateBoard};
+use kanban_service::sqlite_backend::SqliteBackend;
+use kanban_service::KanbanBackend;
+use uuid::Uuid;
+
+fn make_create(name: &str) -> Command {
+    Command::Board(BoardCommand::Create(CreateBoard {
+        id: Uuid::new_v4(),
+        name: name.into(),
+        card_prefix: None,
+        position: 0,
+    }))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_audit_log_persists_across_sessions() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("audit.sqlite3");
+    let locator = path.to_str().unwrap();
+
+    {
+        let backend = SqliteBackend::open(locator).await.unwrap();
+        backend.append_commands(&[make_create("first")]).unwrap();
+        backend.append_commands(&[make_create("second")]).unwrap();
+        assert_eq!(backend.command_count().unwrap(), 2);
+        backend.flush().await.unwrap();
+    }
+
+    let backend = SqliteBackend::open(locator).await.unwrap();
+    assert_eq!(
+        backend.command_count().unwrap(),
+        2,
+        "audit log entries from the previous session must persist"
+    );
+
+    let batches = backend.load_commands(0, 2).unwrap();
+    assert_eq!(batches.len(), 2);
+    match &batches[0].commands[0] {
+        Command::Board(BoardCommand::Create(cb)) => assert_eq!(cb.name, "first"),
+        other => panic!("expected Create('first'), got {other:?}"),
+    }
+    match &batches[1].commands[0] {
+        Command::Board(BoardCommand::Create(cb)) => assert_eq!(cb.name, "second"),
+        other => panic!("expected Create('second'), got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_audit_log_append_returns_new_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("count.sqlite3");
+    let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
+
+    assert_eq!(backend.append_commands(&[make_create("A")]).unwrap(), 1);
+    assert_eq!(backend.append_commands(&[make_create("B")]).unwrap(), 2);
+    assert_eq!(backend.append_commands(&[make_create("C")]).unwrap(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_audit_log_batch_preserves_multiple_commands() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("batch.sqlite3");
+    let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
+
+    backend
+        .append_commands(&[make_create("A"), make_create("B"), make_create("C")])
+        .unwrap();
+    let batches = backend.load_commands(0, 1).unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].len(), 3, "multi-command batch must stay grouped");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_audit_log_load_clamps_out_of_range() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("range.sqlite3");
+    let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
+    backend.append_commands(&[make_create("A")]).unwrap();
+
+    let batches = backend.load_commands(10, 20).unwrap();
+    assert!(batches.is_empty());
+    let batches = backend.load_commands(0, 99).unwrap();
+    assert_eq!(batches.len(), 1);
+}


### PR DESCRIPTION
Wires the SQLite backend's audit log through to disk and tightens the `CommandStore` return shape:

- New `SessionCommandLog` type in `kanban-domain` carries the in-RAM batch list with its own RwLock; `InMemoryStore` composes it instead of inlining a `RwLock<Vec<Vec<Command>>>`.
- New `CommandBatch` struct (`#[serde(transparent)]` over `Vec<Command>`) is the named row type for `CommandStore::load_commands`. Wire-format identical to the bare Vec, so existing rows deserialize unchanged.
- `load_all_commands` removed from the trait (YAGNI; only the replay test used it).
- `SqliteStore` implements `CommandStore` directly using the on-disk `command_log` table. Inserts use `INSERT ... VALUES (NULL, ...)` so SQLite auto-allocates `batch_index` atomically — no `MAX(batch_index)+1` pre-read.
- `SqliteBackend` drops its `mem: InMemoryStore` mirror field; every `CommandStore` call routes to `self.db`.

**What**: SQLite-backed kanban files now persist the audit log of executed command batches across sessions. JSON files and the no-persistence in-memory backend keep their existing session-scoped behaviour.

**Why**: The `command_log` table has existed in the schema since v0.6 but was unwritten — `SqliteBackend` mirrored commands into an in-RAM `InMemoryStore` that vanished on close. Close-and-reopen lost the history. KAN-191 reframed `CommandStore` as the audit-log foundation; this PR makes the SQLite story match by actually wiring the on-disk table.

**How**: `SqliteStore` gains a `CommandStore` impl with three private async helpers (`insert_command_log_row`, `command_log_row_count`, `select_command_log_range`) bridged through the existing `run()` sync wrapper. Auto-allocated `batch_index` via `NULL` insert avoids the pre-read race window. `SqliteBackend` becomes a pure delegate. The trait is also narrowed to a true CR-only surface by removing `load_all_commands` (one test re-expressed as `count()` + `load_commands(0, count)`).

**Testing**: `cargo test -p kanban-service --test sqlite_audit_log_persistence` (new — close-and-reopen, append-returns-count, batch-stays-grouped, load clamps out-of-range), `cargo test --workspace` (86 binaries, no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all -- --check` (clean).