### PR TITLE
KAN-480 chore: remove redundant git MCP server

### DIFF
--- a/.changeset/kan-480-remove-redundant-git-mcp-server.md
+++ b/.changeset/kan-480-remove-redundant-git-mcp-server.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Remove the `mcp-server-git` Nix package output and its `.mcp.json` entry. Claude Code already exposes git through its built-in `Bash` tool, so the wrapper added no capability and only contributed permission-prompt noise plus a `nix run` startup cost per session. The `fulsomenko/servers` flake input, which existed solely to provide this package, is dropped as well.

--- a/.changeset/kan-480-remove-redundant-git-mcp-server.md
+++ b/.changeset/kan-480-remove-redundant-git-mcp-server.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-Remove the `mcp-server-git` Nix package output and its `.mcp.json` entry. Claude Code already exposes git through its built-in `Bash` tool, so the wrapper added no capability and only contributed permission-prompt noise plus a `nix run` startup cost per session. The `fulsomenko/servers` flake input, which existed solely to provide this package, is dropped as well.
+Remove the `mcp-server-git` Nix package output and its `.mcp.json` entry. MCP-aware editors already provide git through their built-in shell tool, so the wrapper added no capability and only contributed permission-prompt noise plus a `nix run` startup cost per session. The `fulsomenko/servers` flake input, which existed solely to provide this package, is dropped as well.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,5 @@
 {
   "mcpServers": {
-    "git": {
-      "command": "nix",
-      "args": ["run", ".#mcp-server-git"]
-    },
     "kanban": {
       "command": "nix",
       "args": ["run", ".#kanban-mcp", "--", "kanban.json"]

--- a/flake.lock
+++ b/flake.lock
@@ -18,24 +18,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1771207753,
@@ -68,28 +50,11 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1765779637,
-        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "servers": "servers"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
@@ -110,41 +75,7 @@
         "type": "github"
       }
     },
-    "servers": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1765997225,
-        "narHash": "sha256-dnNlA8WHHQ7jphyZYg8sWKreC357OKrzt0PtdRxFhbI=",
-        "owner": "fulsomenko",
-        "repo": "servers",
-        "rev": "86986713721d7a701013b0e26a64c5ded211a722",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fulsomenko",
-        "repo": "servers",
-        "type": "github"
-      }
-    },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
-    servers.url = "github:fulsomenko/servers";
   };
 
   outputs = {
@@ -11,7 +10,6 @@
     nixpkgs,
     rust-overlay,
     flake-utils,
-    servers,
     ...
   }:
     flake-utils.lib.eachDefaultSystem (
@@ -83,7 +81,6 @@
           kanban-cli = kanban-cli;
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix { src = self; gitRev = self.rev or null; };
           kanban-web = pkgs.callPackage ./web/default.nix {};
-          mcp-server-git = servers.packages.${system}.mcp-server-git;
           aggregate-changelog = aggregateChangelog;
           bump-version = bumpVersion;
           publish-crates = publishCrates;


### PR DESCRIPTION
Drop the `git` MCP server from this repo. MCP-aware editors already provide git through their built-in shell tool, so the wrapper added no capability and only contributed permission-prompt noise plus a `nix run` startup cost per session.

- Removed the `git` server entry from `.mcp.json`; only `kanban` remains.
- Removed the `mcp-server-git` package output from `flake.nix`.
- Dropped the `fulsomenko/servers` flake input (it was used solely to provide that package) and regenerated `flake.lock`, pruning the `servers` node and its three transitive inputs.

**What**: The git MCP server is no longer exposed by this flake or wired into `.mcp.json`.

**Why**: It duplicated functionality already available through the host editor's built-in shell tool, while adding setup cost and prompt friction.

**How**: Straight removal. `grep -rn "mcp-server-git\|fulsomenko/servers" .` returns nothing across the repo. `nix flake show` still evaluates and lists the remaining packages (`default`, `kanban-cli`, `kanban-mcp`, `kanban-web`, and the script helpers).

**Testing**: `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo test --workspace` (no regressions), `nix flake show` (evaluates).