### PR TITLE
KAN-402 docs: add CI, AUR, nixpkgs, and Homebrew tap badges to README

### DIFF
--- a/.changeset/kan-402-add-package-version-badges-to-readme.md
+++ b/.changeset/kan-402-add-package-version-badges-to-readme.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+The README now shows live version badges for the AUR, nixpkgs, and Homebrew tap packages alongside the existing crates.io and license badges, plus a CI status badge linking to the GitHub Actions workflow. Each badge tracks its package source directly so the README always reflects what is currently available to install.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/fulsomenko/kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/fulsomenko/kanban/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/kanban-cli.svg)](https://crates.io/crates/kanban-cli)
 [![AUR](https://img.shields.io/aur/version/kanban?label=AUR)](https://aur.archlinux.org/packages/kanban)
-[![nixpkgs](https://repology.org/badge/version-for-repo/nix_unstable/kanban.svg)](https://search.nixos.org/packages?show=kanban&channel=unstable)
+[![nixpkgs](https://repology.org/badge/version-for-repo/nix_unstable/kanban.svg?header=nixpkgs%20unstable)](https://search.nixos.org/packages?show=kanban&channel=unstable)
 [![Homebrew](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffulsomenko%2Fhomebrew-tap%2Fmaster%2FFormula%2Fkanban.rb&search=refs%2Ftags%2Fv%28.%2A%29%5C.tar%5C.gz&replace=%241&label=homebrew)](https://github.com/fulsomenko/homebrew-tap)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.md)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Kanban
 
+[![CI](https://github.com/fulsomenko/kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/fulsomenko/kanban/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/kanban-cli.svg)](https://crates.io/crates/kanban-cli)
+[![AUR](https://img.shields.io/aur/version/kanban?label=AUR)](https://aur.archlinux.org/packages/kanban)
+[![nixpkgs](https://repology.org/badge/version-for-repo/nix_unstable/kanban.svg)](https://search.nixos.org/packages?show=kanban&channel=unstable)
+[![Homebrew](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffulsomenko%2Fhomebrew-tap%2Fmaster%2FFormula%2Fkanban.rb&search=refs%2Ftags%2Fv%28.%2A%29%5C.tar%5C.gz&replace=%241&label=homebrew)](https://github.com/fulsomenko/homebrew-tap)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.md)
 
 **Keyboard-first kanban for the terminal.**


### PR DESCRIPTION
Add live version badges and a CI status badge to the top of `README.md`, alongside the existing crates.io and license badges.

- CI badge linking to the GitHub Actions `ci.yml` workflow.
- AUR badge via `shields.io/aur/version/kanban`, linking to the AUR package page. (Direct AUR API rather than repology, because repology's `kanban` project key is ambiguous on the AUR namespace.)
- nixpkgs badge via `repology.org/badge/version-for-repo/nix_unstable/kanban.svg`, linking to `search.nixos.org`.
- Homebrew badge via shields.io dynamic regex over the raw formula at `fulsomenko/homebrew-tap`, extracting the version from the `refs/tags/vX.Y.Z.tar.gz` URL line (the formula uses Homebrew's URL-inferred version, no explicit `version "X"` line).

**What**: Five new badges at the top of the README giving live build and packaging-status visibility.

**Why**: The README previously only advertised crates.io. Users landing from search engines could not see at a glance which package managers carry the project or what version each ships, and there was no surfaced CI signal.

**How**: Pure additive change to lines 3-4 of `README.md`. No code or workflow changes.

**Testing**: Each badge URL was fetched with a GitHub-camo-style User-Agent and confirmed to return real content: CI 200 OK; AUR `v0.6.0-1`; nixpkgs `0.3.5` (matches `nix-instantiate --eval -E 'let pkgs = import <nixpkgs> {}; in pkgs.kanban.version'`); Homebrew `0.6.0` (matches `Formula/kanban.rb` HEAD). `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --workspace` are unaffected by docs-only changes.