### PR TITLE
KAN-457 docs(mcp): align README schemas with name-accepting fields

### DIFF
--- a/.changeset/kan-457-mcp-readme-schema-labels-and-descriptions.md
+++ b/.changeset/kan-457-mcp-readme-schema-labels-and-descriptions.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+The MCP server's README now matches the actual tool schemas. Tool reference tables previously listed `board: UUID`, `column: UUID`, `sprint: UUID`, and a comma-separated `cards: String` for bulk operations, but the implementation has accepted entity names (and sprint numbers, and card identifiers like `KAN-5`) for some time. Param types are now shown as `String` / `Vec<String>`, the three `Get a specific X by ID` rows now read "by UUID or name" or "by UUID, name, or number", and the formerly card-specific "Card Identifiers" section has been generalized to cover boards, columns, sprints, and bulk-cards inputs.

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -80,44 +80,47 @@ kanban-mcp /path/to/boards.sqlite
 |------|-------------|-----------------|-----------------|
 | `tool_create_board` | Create a new kanban board | `name: String` | `card_prefix: String` |
 | `tool_list_boards` | List all boards | — | — |
-| `tool_get_board` | Get a specific board by ID | `board: UUID` | — |
-| `tool_update_board` | Update board properties | `board: UUID` | `name`, `description`, `sprint_prefix`, `card_prefix` |
-| `tool_delete_board` | Delete board and all its columns, cards, sprints | `board: UUID` | — |
+| `tool_get_board` | Get a specific board by UUID or name | `board: String` | — |
+| `tool_update_board` | Update board properties | `board: String` | `name`, `description`, `sprint_prefix`, `card_prefix` |
+| `tool_delete_board` | Delete board and all its columns, cards, sprints | `board: String` | — |
 
 ### Columns (6 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_column` | Create a new column in a board | `board: UUID`, `name: String` | `position: i32` |
-| `tool_list_columns` | List all columns in a board | `board: UUID` | — |
-| `tool_get_column` | Get a specific column by ID | `column: UUID` | — |
-| `tool_update_column` | Update column properties | `column: UUID` | `name`, `position`, `wip_limit: u32`, `clear_wip_limit: bool` |
-| `tool_delete_column` | Delete column and all its cards | `column: UUID` | — |
-| `tool_reorder_column` | Move column to a new position | `column: UUID`, `position: i32` | — |
+| `tool_create_column` | Create a new column in a board | `board: String`, `name: String` | `position: i32` |
+| `tool_list_columns` | List all columns in a board | `board: String` | — |
+| `tool_get_column` | Get a specific column by UUID or name | `column: String` | — |
+| `tool_update_column` | Update column properties | `column: String` | `name`, `position`, `wip_limit: u32`, `clear_wip_limit: bool` |
+| `tool_delete_column` | Delete column and all its cards | `column: String` | — |
+| `tool_reorder_column` | Move column to a new position | `column: String`, `position: i32` | — |
 
 ### Cards (10 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_card` | Create a new card in a column | `board: UUID`, `column: UUID`, `title: String` | `description`, `priority` (low/medium/high/critical), `points: u8`, `due_date` (YYYY-MM-DD or RFC 3339) |
+| `tool_create_card` | Create a new card in a column | `board: String`, `column: String`, `title: String` | `description`, `priority` (low/medium/high/critical), `points: u8`, `due_date` (YYYY-MM-DD or RFC 3339) |
 | `tool_list_cards` | List cards with filters. Returns `CardSummary` (title, status, priority, points — use tool_get_card for full detail). | — | `board`, `column`, `sprint`, `status`, `page: u32`, `page_size: u32` |
 | `tool_get_card` | Get card by UUID or identifier (e.g. `KAN-5`). Returns list if ambiguous. | `card: String` | — |
 | `tool_update_card` | Update card properties | `card: String` | `title`, `description`, `priority`, `status` (todo/in_progress/blocked/done), `points: u8`, `due_date`, `clear_due_date: bool` |
-| `tool_move_card` | Move card to a different column | `card: String`, `column: UUID` | `position: i32` |
+| `tool_move_card` | Move card to a different column | `card: String`, `column: String` | `position: i32` |
 | `tool_archive_card` | Archive a card (restorable) | `card: String` | — |
-| `tool_restore_card` | Restore an archived card | `card: String` | `column: UUID` |
+| `tool_restore_card` | Restore an archived card | `card: String` | `column: String` |
 | `tool_delete_card` | Delete a card permanently | `card: String` | — |
 | `tool_list_archived_cards` | Returns ArchivedCardSummary (title, archived_at, original column — use tool_get_card for full detail) | — | `page: u32`, `page_size: u32` |
 
-### Card Identifiers
+### Identifiers
 
-`card` accepts either a UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
+- `board`, `column` — UUID or the entity's name.
+- `sprint` — UUID, name, or sprint number.
+- `card` — UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
+- `cards` (bulk operations) — array of UUIDs or card identifiers (e.g. `["KAN-1", "KAN-2", "42"]`); all referenced cards must share a board.
 
 ### Card–Sprint (2 tools)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_assign_card_to_sprint` | Assign a card to a sprint | `card: String`, `sprint: UUID` |
+| `tool_assign_card_to_sprint` | Assign a card to a sprint | `card: String`, `sprint: String` |
 | `tool_unassign_card_from_sprint` | Remove card from its sprint | `card: String` |
 
 ### Card Utilities (2 tools)
@@ -131,34 +134,34 @@ kanban-mcp /path/to/boards.sqlite
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_archive_cards` | Archive multiple cards | `cards: String` (comma-separated UUIDs) |
-| `tool_move_cards` | Move multiple cards to a column | `cards: String`, `column: UUID` |
-| `tool_assign_cards_to_sprint` | Assign multiple cards to a sprint | `cards: String`, `sprint: UUID` |
+| `tool_archive_cards` | Archive multiple cards | `cards: Vec<String>` (UUIDs or identifiers, e.g. `["KAN-1", "KAN-2"]`) |
+| `tool_move_cards` | Move multiple cards to a column | `cards: Vec<String>`, `column: String` |
+| `tool_assign_cards_to_sprint` | Assign multiple cards to a sprint | `cards: Vec<String>`, `sprint: String` |
 
 ### Sprints (8 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_create_sprint` | Create a new sprint | `board: UUID` | `name: String`, `prefix: String` |
-| `tool_list_sprints` | List sprints for a board | `board: UUID` | — |
-| `tool_get_sprint` | Get a specific sprint by ID | `sprint: UUID` | — |
-| `tool_update_sprint` | Update sprint properties | `sprint: UUID` | `name`, `prefix`, `card_prefix`, `start_date`, `end_date`, `clear_start_date: bool`, `clear_end_date: bool` |
-| `tool_activate_sprint` | Activate a sprint | `sprint: UUID`, `duration_days: u32` | — |
-| `tool_complete_sprint` | Mark sprint as completed | `sprint: UUID` | — |
-| `tool_cancel_sprint` | Cancel a sprint | `sprint: UUID` | — |
-| `tool_delete_sprint` | Delete a sprint | `sprint: UUID` | — |
+| `tool_create_sprint` | Create a new sprint | `board: String` | `name: String`, `prefix: String` |
+| `tool_list_sprints` | List sprints for a board | `board: String` | — |
+| `tool_get_sprint` | Get a specific sprint by UUID, name, or number | `sprint: String` | — |
+| `tool_update_sprint` | Update sprint properties | `sprint: String` | `name`, `prefix`, `card_prefix`, `start_date`, `end_date`, `clear_start_date: bool`, `clear_end_date: bool` |
+| `tool_activate_sprint` | Activate a sprint | `sprint: String`, `duration_days: u32` | — |
+| `tool_complete_sprint` | Mark sprint as completed | `sprint: String` | — |
+| `tool_cancel_sprint` | Cancel a sprint | `sprint: String` | — |
+| `tool_delete_sprint` | Delete a sprint | `sprint: String` | — |
 
 ### Sprint Carry-over (1 tool)
 
 | Tool | Description | Required params |
 |------|-------------|-----------------|
-| `tool_carry_over_sprint_cards` | Move uncompleted cards from a completed/cancelled sprint to a planning sprint | `from_sprint: UUID`, `to_sprint: UUID` |
+| `tool_carry_over_sprint_cards` | Move uncompleted cards from a completed/cancelled sprint to a planning sprint | `from_sprint: String`, `to_sprint: String` |
 
 ### Import / Export (2 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
-| `tool_export_board` | Export board data as JSON string | — | `board: UUID` (omit for all boards) |
+| `tool_export_board` | Export board data as JSON string | — | `board: String` (omit for all boards) |
 | `tool_import_board` | Import board from JSON string | `data: String` | — |
 
 ### Undo / Redo (2 tools)

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -74,6 +74,15 @@ kanban-mcp /path/to/boards.sqlite
 
 ## Tools Reference
 
+### Identifiers
+
+Most tool inputs accept either an opaque UUID or a friendlier reference, resolved server-side:
+
+- `board`, `column`: UUID or the entity's name.
+- `sprint`: UUID, name, or sprint number.
+- `card`: UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
+- `cards` (bulk operations): array of UUIDs or card identifiers (for example `["KAN-1", "KAN-2", "42"]`); all referenced cards must share a board.
+
 ### Boards (5 tools)
 
 | Tool | Description | Required params | Optional params |
@@ -108,13 +117,6 @@ kanban-mcp /path/to/boards.sqlite
 | `tool_restore_card` | Restore an archived card | `card: String` | `column: String` |
 | `tool_delete_card` | Delete a card permanently | `card: String` | — |
 | `tool_list_archived_cards` | Returns ArchivedCardSummary (title, archived_at, original column — use tool_get_card for full detail) | — | `page: u32`, `page_size: u32` |
-
-### Identifiers
-
-- `board`, `column` — UUID or the entity's name.
-- `sprint` — UUID, name, or sprint number.
-- `card` — UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
-- `cards` (bulk operations) — array of UUIDs or card identifiers (e.g. `["KAN-1", "KAN-2", "42"]`); all referenced cards must share a board.
 
 ### Card–Sprint (2 tools)
 


### PR DESCRIPTION
After KAN-400, the MCP server's tool inputs accept entity names (and sprint numbers, and card identifiers like `KAN-5`) wherever they previously required a UUID. The MCP README's tool reference tables were never updated to reflect that, so callers reading the README still saw `board: UUID`, `column: UUID`, `sprint: UUID`, and "by ID" descriptions. This brings the README in line with the actual `schemars` descriptions in `crates/kanban-mcp/src/lib.rs`.

- Replaced `board: UUID`, `column: UUID`, `sprint: UUID`, `from_sprint: UUID`, `to_sprint: UUID` across all tool tables with `String`.
- Updated three "Get a specific X by ID" rows to "Get a specific X by UUID or name" (board, column) and "by UUID, name, or number" (sprint), matching the lib.rs `#[tool(description = ...)]` strings.
- Bulk-card-operations rows: `cards: String` (comma-separated UUIDs) replaced with `cards: Vec<String>` (UUIDs or identifiers, for example `["KAN-1", "KAN-2"]`). These tools now take a JSON array, not a CSV.
- Renamed the "Card Identifiers" section to "Identifiers", expanded it to cover boards, columns, sprints, cards, and bulk-cards inputs, and hoisted it to the top of "Tools Reference" so callers see the resolution rules before any of the per-entity tables.

**What**: The MCP README now accurately describes what each tool accepts.

**Why**: Schema labels and descriptions had drifted behind the implementation since KAN-400. Anyone consulting the README to construct an MCP call would either send UUIDs unnecessarily or hit avoidable validation errors trying to pass names that the README claimed were unsupported.

**How**: Pure docs change in `crates/kanban-mcp/README.md`. Cross-checked every changed row against the `#[schemars(description = ...)]` and `#[tool(description = ...)]` attributes in `crates/kanban-mcp/src/lib.rs`. No code changes.

**Testing**: `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo test --workspace` (no regressions, docs-only change).