### PR TITLE
KAN-414 docs: welcome bug fixes in Areas for Contribution

### DIFF
--- a/.changeset/kan-414-welcome-bug-fixes-in-contributing.md
+++ b/.changeset/kan-414-welcome-bug-fixes-in-contributing.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-`CONTRIBUTING.md` now lists bug fixes as an explicit area for contribution. Small targeted fixes, crash and regression fixes, and cross-platform fixes for Windows, macOS, and Linux are called out as especially welcome. The change responds to feedback from a recent first-time contributor who hesitated to open a bug-fix PR because the "Areas for Contribution" section only mentioned feature-shaped work.
+`CONTRIBUTING.md` now lists bug fixes as an explicit area for contribution. Small targeted fixes, crash and regression fixes, and cross-platform fixes for Windows, macOS, and Linux are called out as especially welcome. The previous list only enumerated feature-shaped work, which implicitly framed bug fixes as out of scope.

--- a/.changeset/kan-414-welcome-bug-fixes-in-contributing.md
+++ b/.changeset/kan-414-welcome-bug-fixes-in-contributing.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+`CONTRIBUTING.md` now lists bug fixes as an explicit area for contribution. Small targeted fixes, crash and regression fixes, and cross-platform fixes for Windows, macOS, and Linux are called out as especially welcome. The change responds to feedback from a recent first-time contributor who hesitated to open a bug-fix PR because the "Areas for Contribution" section only mentioned feature-shaped work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -498,6 +498,7 @@ Description of changes
 
 ## Areas for Contribution
 
+- **Bug Fixes**: Crashes, regressions, and cross-platform fixes (Windows, macOS, Linux) are especially welcome. Small, targeted fixes are easy to review and ship quickly.
 - **UI Improvements**: Enhance TUI rendering, add color themes
 - **Features**: New metadata fields, filtering, searching
 - **Testing**: Increase test coverage, integration tests


### PR DESCRIPTION
Add a "Bug Fixes" entry at the top of the `Areas for Contribution` list in `CONTRIBUTING.md`, explicitly welcoming crash, regression, and cross-platform fixes.

- Adds one bullet at the top of the list calling out bug fixes, with Windows / macOS / Linux portability fixes named explicitly.
- Places "Bug Fixes" first so the highest-confidence contribution category is the first thing a reader sees.

**What**: One-bullet addition to `Areas for Contribution`.

**Why**: The existing list only enumerated feature-shaped work (UI improvements, new features, performance, refactoring), implicitly framing bug fixes as outside scope. Spelling out that fixes, particularly cross-platform fixes, are welcome closes that gap.

**How**: Pure docs change in `CONTRIBUTING.md`. No code or workflow changes.

**Testing**: `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo test --workspace` (no regressions, docs-only change).