### PR TITLE
KAN-522 feat: refuse-on-future-version, writer-stamp metadata, F12 diagnostics

### DIFF
--- a/.changeset/kan-522-refuse-on-version-mismatch-in-persistence-backends-writer-stamp-metadata-startup-banner.md
+++ b/.changeset/kan-522-refuse-on-version-mismatch-in-persistence-backends-writer-stamp-metadata-startup-banner.md
@@ -11,7 +11,16 @@ than the binary supports, or a SQLite database whose `schema_version`
 exceeds the binary's, now returns a typed error rather than silently
 coercing the file to a lower format (which previously dropped fields the
 old reader did not understand). The error message tells you the file's
-version, the binary's maximum, and asks you to upgrade.
+version, the binary's maximum, and asks you to upgrade. Refused files are
+left untouched on disk — no schema bump, no column ALTER, nothing rewritten
+before the refusal fires.
+
+**MCP error category.** Pointing the `kanban-mcp` server at a future-format
+file now surfaces as `INVALID_PARAMS` to the MCP client (was
+`INTERNAL_ERROR`). That category change tells the LLM the input is
+unusable, not that the server is broken — so the client can suggest
+pointing at a different file or upgrading kanban instead of treating it
+as a server bug.
 
 **Writer stamp on save.** Every save now records which kanban produced the
 file: a semver version string and the build's git commit. Old files that
@@ -22,7 +31,7 @@ time the file is rewritten.
 F12 has been renamed to **Diagnostics** and now shows:
 
 - File path
-- Format version
+- Format version (read live from the file, not assumed from the binary)
 - Writer (the kanban that last wrote this file)
 - Binary (the kanban you're running right now)
 - Last saved timestamp

--- a/.changeset/kan-522-refuse-on-version-mismatch-in-persistence-backends-writer-stamp-metadata-startup-banner.md
+++ b/.changeset/kan-522-refuse-on-version-mismatch-in-persistence-backends-writer-stamp-metadata-startup-banner.md
@@ -1,0 +1,46 @@
+---
+bump: patch
+---
+
+Kanban now refuses to silently mishandle data files written by a newer
+version of itself, and surfaces enough information for you to diagnose
+version mismatches at a glance.
+
+**Refuse-on-future-version.** Opening a JSON file whose `version` is higher
+than the binary supports, or a SQLite database whose `schema_version`
+exceeds the binary's, now returns a typed error rather than silently
+coercing the file to a lower format (which previously dropped fields the
+old reader did not understand). The error message tells you the file's
+version, the binary's maximum, and asks you to upgrade.
+
+**Writer stamp on save.** Every save now records which kanban produced the
+file: a semver version string and the build's git commit. Old files that
+lack the stamp continue to load cleanly; the new fields show up the first
+time the file is rewritten.
+
+**F12 diagnostics popup.** The "Error Log" popup that already lived behind
+F12 has been renamed to **Diagnostics** and now shows:
+
+- File path
+- Format version
+- Writer (the kanban that last wrote this file)
+- Binary (the kanban you're running right now)
+- Last saved timestamp
+- Log entries in a separate, titled section below
+
+When the file's writer is a newer semver than the running binary, the
+Writer line is highlighted in yellow with a `(newer than this binary)`
+suffix, so a mismatch is one keystroke away from being diagnosed instead
+of buried in tracing output.
+
+**SQLite schema bump.** The SQLite metadata table gains `writer_version`
+and `writer_commit` columns and the on-disk `schema_version` is bumped to
+2. Existing databases are upgraded transparently on open via the same
+idempotent `ALTER TABLE ADD COLUMN` mechanism used for previous SQLite
+schema additions — no manual migration required.
+
+**Renamed const.** Internal API: `kanban_core::VERSION` is renamed to
+`kanban_core::CLI_VERSION_DISPLAY` to distinguish the multi-line clap
+display string from the new raw `KANBAN_VERSION` / `KANBAN_COMMIT`
+components used by the writer stamp. This is only relevant to anyone
+embedding kanban-core as a library.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,7 @@ dependencies = [
  "kanban-domain",
  "kanban-persistence",
  "kanban-persistence-json",
+ "kanban-persistence-sqlite",
  "kanban-service",
  "rmcp",
  "schemars",

--- a/crates/kanban-cli/Cargo.toml
+++ b/crates/kanban-cli/Cargo.toml
@@ -44,7 +44,7 @@ serde_json.workspace = true
 
 [dev-dependencies]
 kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.6" }
-kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.6" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.6", features = ["test-helpers"] }
 tempfile.workspace = true
 assert_cmd.workspace = true
 predicates.workspace = true

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -1,11 +1,11 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
-use kanban_core::VERSION;
+use kanban_core::CLI_VERSION_DISPLAY;
 
 #[derive(Parser)]
 #[command(name = "kanban")]
 #[command(about = "A terminal-based kanban board", long_about = None)]
-#[command(version = VERSION, arg_required_else_help = false)]
+#[command(version = CLI_VERSION_DISPLAY, arg_required_else_help = false)]
 pub struct Cli {
     /// Path to kanban data file (or set KANBAN_FILE env var)
     #[arg(value_name = "FILE", env = "KANBAN_FILE")]

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -25,6 +25,43 @@ fn kanban_no_config(dir: &std::path::Path) -> Command {
     cmd
 }
 
+mod future_version_tests {
+    use super::*;
+
+    /// Pointing the CLI at a JSON file written by a future kanban must fail
+    /// loudly: non-zero exit code with the typed UnsupportedFutureVersion
+    /// message on stderr. The data on disk must not be touched. Mirrors what
+    /// the persistence-layer guards already enforce — this test pins the
+    /// end-to-end CLI contract so the typed error doesn't get accidentally
+    /// stringified away again at some boundary upstream.
+    #[test]
+    fn test_cli_refuses_to_open_v99_json_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("future.json");
+        let v99 = serde_json::json!({
+            "version": 99,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2030-01-01T00:00:00Z"
+            },
+            "data": {}
+        });
+        fs::write(&file, v99.to_string()).unwrap();
+        let original = fs::read(&file).unwrap();
+
+        kanban_no_config(dir.path())
+            .args([file.to_str().unwrap(), "board", "list"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("v99"))
+            .stderr(predicate::str::contains("upgrade kanban"));
+
+        // Refusal must not mutate the file on disk.
+        let after = fs::read(&file).unwrap();
+        assert_eq!(original, after, "refusal must leave the file untouched");
+    }
+}
+
 mod board_tests {
     use super::*;
 

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -28,6 +28,39 @@ fn kanban_no_config(dir: &std::path::Path) -> Command {
 mod future_version_tests {
     use super::*;
 
+    /// SQLite parallel of the JSON refusal test below. The data preservation
+    /// contract is stronger than byte-equality (SQLite's WAL setup touches
+    /// the file header just by opening) — we instead pin that the on-disk
+    /// schema_version was NOT normalised down from 99, which would prove the
+    /// migrate() bumping ran on a refused file.
+    #[test]
+    fn test_cli_refuses_to_open_v99_sqlite_file_without_normalising_schema_version() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("future.db");
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(kanban_persistence_sqlite::write_test_metadata_with_schema_version(&file, 99))
+            .unwrap();
+
+        kanban_no_config(dir.path())
+            .args([file.to_str().unwrap(), "board", "list"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("v99"))
+            .stderr(predicate::str::contains("upgrade kanban"));
+
+        let post_refusal_version = rt
+            .block_on(kanban_persistence_sqlite::read_test_schema_version(&file))
+            .unwrap();
+        assert_eq!(
+            post_refusal_version,
+            Some(99),
+            "refusal must not bump schema_version — migrate() ran on a refused file"
+        );
+    }
+
     /// Pointing the CLI at a JSON file written by a future kanban must fail
     /// loudly: non-zero exit code with the typed UnsupportedFutureVersion
     /// message on stderr. The data on disk must not be touched. Mirrors what

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -26,4 +26,4 @@ pub use paginated_list::{
 pub use pagination::{Page, PageInfo};
 pub use selection::SelectionState;
 pub use traits::Editable;
-pub use version::VERSION;
+pub use version::{KANBAN_COMMIT, KANBAN_VERSION, VERSION};

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -26,4 +26,4 @@ pub use paginated_list::{
 pub use pagination::{Page, PageInfo};
 pub use selection::SelectionState;
 pub use traits::Editable;
-pub use version::{KANBAN_COMMIT, KANBAN_VERSION, VERSION};
+pub use version::{CLI_VERSION_DISPLAY, KANBAN_COMMIT, KANBAN_VERSION};

--- a/crates/kanban-core/src/version.rs
+++ b/crates/kanban-core/src/version.rs
@@ -1,5 +1,13 @@
 //! Shared version string for kanban binaries.
 
+/// Semver-style version of the kanban crate that produced this binary.
+/// Stamped into persistence metadata so a file remembers which kanban wrote it.
+pub const KANBAN_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Git commit hash of the kanban build that produced this binary.
+/// Resolves to `"unknown"` when built outside a git checkout.
+pub const KANBAN_COMMIT: &str = env!("GIT_COMMIT_HASH");
+
 #[cfg(has_git_commit)]
 pub const VERSION: &str = concat!(
     env!("CARGO_PKG_VERSION"),
@@ -17,5 +25,15 @@ mod tests {
     #[test]
     fn test_version_is_non_empty() {
         assert!(!VERSION.is_empty());
+    }
+
+    #[test]
+    fn test_kanban_version_const_is_non_empty() {
+        assert!(!KANBAN_VERSION.is_empty());
+    }
+
+    #[test]
+    fn test_kanban_commit_const_is_non_empty() {
+        assert!(!KANBAN_COMMIT.is_empty());
     }
 }

--- a/crates/kanban-core/src/version.rs
+++ b/crates/kanban-core/src/version.rs
@@ -1,4 +1,15 @@
-//! Shared version string for kanban binaries.
+//! Shared version constants for kanban binaries.
+//!
+//! Three consts, two pieces of information:
+//! - [`KANBAN_VERSION`] / [`KANBAN_COMMIT`] are the raw components, consumed by
+//!   the persistence layer when stamping a file's writer identity.
+//! - [`CLI_VERSION_DISPLAY`] is the multi-line string clap renders for
+//!   `--version`. It looks like `"0.6.0\ncommit: 18e98c4..."`.
+//!
+//! The redundancy is structural: Rust's `concat!` only accepts literal
+//! expressions, so it must read the env vars directly rather than reuse the
+//! component consts. Moving the concat into the binary crates would require
+//! either duplicating `build.rs` (no thanks) or runtime `Box::leak` (worse).
 
 /// Semver-style version of the kanban crate that produced this binary.
 /// Stamped into persistence metadata so a file remembers which kanban wrote it.
@@ -8,23 +19,27 @@ pub const KANBAN_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Resolves to `"unknown"` when built outside a git checkout.
 pub const KANBAN_COMMIT: &str = env!("GIT_COMMIT_HASH");
 
+/// Multi-line display string passed to clap's `version = ...` attribute on the
+/// `kanban` and `kanban-mcp` binaries. Renders as
+/// `"{KANBAN_VERSION}\ncommit: {KANBAN_COMMIT}"` when a git commit is
+/// available, falling back to bare `KANBAN_VERSION` otherwise.
 #[cfg(has_git_commit)]
-pub const VERSION: &str = concat!(
+pub const CLI_VERSION_DISPLAY: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     "\ncommit: ",
     env!("GIT_COMMIT_HASH")
 );
 
 #[cfg(not(has_git_commit))]
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CLI_VERSION_DISPLAY: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_version_is_non_empty() {
-        assert!(!VERSION.is_empty());
+    fn test_cli_version_display_is_non_empty() {
+        assert!(!CLI_VERSION_DISPLAY.is_empty());
     }
 
     #[test]

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -225,6 +225,12 @@ pub enum KanbanError {
 
     #[error("internal error: {0}")]
     Internal(String),
+
+    #[error(
+        "file format v{file_version} is newer than this binary's max v{binary_max}; \
+         please upgrade kanban"
+    )]
+    UnsupportedFutureVersion { file_version: u32, binary_max: u32 },
 }
 
 /// Return `noun` (when count is 1) or `noun + "s"` (otherwise).
@@ -349,6 +355,10 @@ impl KanbanError {
         )
     }
 
+    pub fn is_unsupported_future_version(&self) -> bool {
+        matches!(self, KanbanError::UnsupportedFutureVersion { .. })
+    }
+
     pub fn serialization(msg: impl Into<String>) -> Self {
         Self::Serialization(msg.into())
     }
@@ -436,6 +446,32 @@ mod tests {
         let id = Uuid::new_v4();
         let err = KanbanError::Domain(DomainError::wip_limit_exceeded(id, 3));
         assert!(err.is_wip_limit_exceeded());
+    }
+
+    #[test]
+    fn test_unsupported_future_version_display_mentions_both_versions() {
+        let err = KanbanError::UnsupportedFutureVersion {
+            file_version: 99,
+            binary_max: 6,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("99"), "msg should mention file version: {msg}");
+        assert!(msg.contains('6'), "msg should mention binary max: {msg}");
+    }
+
+    #[test]
+    fn test_is_unsupported_future_version_returns_true() {
+        let err = KanbanError::UnsupportedFutureVersion {
+            file_version: 99,
+            binary_max: 6,
+        };
+        assert!(err.is_unsupported_future_version());
+    }
+
+    #[test]
+    fn test_is_unsupported_future_version_returns_false_for_other_error() {
+        let err = KanbanError::not_found("card", Uuid::new_v4());
+        assert!(!err.is_unsupported_future_version());
     }
 
     #[test]

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -56,7 +56,7 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 kanban-domain = { path = "../kanban-domain", version = "^0.6" }
 kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.6" }
-kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.6" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.6", features = ["test-helpers"] }
 kanban-service = { path = "../kanban-service", version = "^0.6" }
 tempfile.workspace = true
 tokio.workspace = true

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -56,6 +56,7 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 kanban-domain = { path = "../kanban-domain", version = "^0.6" }
 kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.6" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.6" }
 kanban-service = { path = "../kanban-service", version = "^0.6" }
 tempfile.workspace = true
 tokio.workspace = true

--- a/crates/kanban-mcp/src/error.rs
+++ b/crates/kanban-mcp/src/error.rs
@@ -33,7 +33,15 @@ impl From<KanbanMcpError> for McpError {
     fn from(e: KanbanMcpError) -> Self {
         match e {
             KanbanMcpError::Domain(d) => {
-                if matches!(&d, KanbanError::Domain(_)) {
+                // INVALID_PARAMS for anything that's "the inputs the client
+                // gave us are wrong": validation/lookup failures (Domain) and
+                // version mismatches on the data file the client pointed at
+                // (UnsupportedFutureVersion). Everything else is a server-side
+                // failure the client can't fix by rewording its request.
+                if matches!(
+                    &d,
+                    KanbanError::Domain(_) | KanbanError::UnsupportedFutureVersion { .. }
+                ) {
                     McpError::invalid_params(d.to_string(), None)
                 } else {
                     McpError::internal_error(d.to_string(), None)

--- a/crates/kanban-mcp/src/main.rs
+++ b/crates/kanban-mcp/src/main.rs
@@ -3,13 +3,13 @@ compile_error!("kanban-mcp binary requires at least one backend feature: `json` 
 
 use anyhow::Result;
 use clap::Parser;
-use kanban_core::VERSION;
+use kanban_core::CLI_VERSION_DISPLAY;
 use kanban_mcp::McpServer;
 
 #[derive(Parser)]
 #[command(
     name = "kanban-mcp",
-    version = VERSION,
+    version = CLI_VERSION_DISPLAY,
     about = "Model Context Protocol server for the kanban project management tool"
 )]
 struct Args {

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -37,6 +37,56 @@ async fn board_create_list_get() {
     assert_eq!(fetched.name, "Test Board");
 }
 
+/// Opening a future-format JSON file via the MCP surface must surface as
+/// `McpError::invalid_params`, not `internal_error`. The data file the client
+/// pointed at is the precondition that failed — that's the same category as
+/// any other invalid argument. Without this mapping, an LLM client sees
+/// "internal error" for what is fundamentally "your file is too new for this
+/// binary" and has no way to suggest the right fix.
+#[tokio::test]
+async fn open_future_version_file_returns_invalid_params() {
+    use kanban_mcp::error::KanbanMcpError;
+    use rmcp::model::ErrorCode;
+    use serde_json::json;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("future.json");
+    let v99 = json!({
+        "version": 99,
+        "metadata": {
+            "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+            "saved_at": "2030-01-01T00:00:00Z"
+        },
+        "data": {}
+    });
+    std::fs::write(&path, v99.to_string()).unwrap();
+
+    let store_manager = default_store_manager();
+    let err = McpContext::new(
+        &store_manager,
+        &path.to_string_lossy(),
+        AppConfig::default(),
+    )
+    .await
+    .err()
+    .expect("v99 file must be refused");
+
+    // KanbanError → KanbanMcpError → McpError (rmcp::model::ErrorData) is the
+    // path every MCP tool handler walks via `?`. We follow it here to pin the
+    // wire-level error_code, not just the Rust variant.
+    let mcp_err: rmcp::model::ErrorData = KanbanMcpError::Domain(err).into();
+    assert_eq!(
+        mcp_err.code,
+        ErrorCode::INVALID_PARAMS,
+        "UnsupportedFutureVersion must map to INVALID_PARAMS, got: {mcp_err:?}"
+    );
+    assert!(
+        mcp_err.message.contains("upgrade kanban"),
+        "error message must include the upgrade hint, got: {}",
+        mcp_err.message
+    );
+}
+
 #[tokio::test]
 async fn board_get_nonexistent() {
     let (ctx, _tmp) = setup().await;

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -87,6 +87,42 @@ async fn open_future_version_file_returns_invalid_params() {
     );
 }
 
+/// SQLite parallel of the JSON future-version MCP test above. Same wire-level
+/// expectation: `ErrorCode::INVALID_PARAMS`, message mentions "upgrade kanban".
+#[tokio::test(flavor = "multi_thread")]
+async fn open_future_version_sqlite_file_returns_invalid_params() {
+    use kanban_mcp::error::KanbanMcpError;
+    use rmcp::model::ErrorCode;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("future.db");
+    kanban_persistence_sqlite::write_test_metadata_with_schema_version(&path, 99)
+        .await
+        .unwrap();
+
+    let store_manager = default_store_manager();
+    let err = McpContext::new(
+        &store_manager,
+        &path.to_string_lossy(),
+        AppConfig::default(),
+    )
+    .await
+    .err()
+    .expect("v99 SQLite DB must be refused");
+
+    let mcp_err: rmcp::model::ErrorData = KanbanMcpError::Domain(err).into();
+    assert_eq!(
+        mcp_err.code,
+        ErrorCode::INVALID_PARAMS,
+        "UnsupportedFutureVersion (sqlite path) must map to INVALID_PARAMS, got: {mcp_err:?}"
+    );
+    assert!(
+        mcp_err.message.contains("upgrade kanban"),
+        "error message must include the upgrade hint, got: {}",
+        mcp_err.message
+    );
+}
+
 #[tokio::test]
 async fn board_get_nonexistent() {
     let (ctx, _tmp) = setup().await;

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -246,9 +246,11 @@ impl PersistenceStore for JsonFileStore {
             }
         }
 
-        // Update metadata with current instance and time
+        // Update metadata with current instance, time, and writer identity
         snapshot.metadata.instance_id = self.instance_id;
         snapshot.metadata.saved_at = chrono::Utc::now();
+        snapshot.metadata.writer_version = Some(kanban_core::KANBAN_VERSION.to_string());
+        snapshot.metadata.writer_commit = Some(kanban_core::KANBAN_COMMIT.to_string());
 
         let data_value: serde_json::Value = serde_json::from_slice(&snapshot.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
@@ -527,6 +529,63 @@ mod tests {
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_save_stamps_writer_version_and_commit() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("stamped.json");
+        let store = JsonFileStore::new(&file_path);
+
+        let snapshot = StoreSnapshot {
+            data: serde_json::to_vec(&json!({ "boards": [], "columns": [] })).unwrap(),
+            metadata: PersistenceMetadata::new(store.instance_id()),
+        };
+        store.save(snapshot).await.unwrap();
+
+        let bytes = tokio::fs::read(&file_path).await.unwrap();
+        let envelope: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            envelope["metadata"]["writer_version"]
+                .as_str()
+                .map(str::to_string),
+            Some(kanban_core::KANBAN_VERSION.to_string()),
+        );
+        assert_eq!(
+            envelope["metadata"]["writer_commit"]
+                .as_str()
+                .map(str::to_string),
+            Some(kanban_core::KANBAN_COMMIT.to_string()),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_load_legacy_file_without_writer_stamp_succeeds() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("legacy_no_stamp.json");
+        let legacy = json!({
+            "version": 6,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [], "columns": [], "cards": [], "archived_cards": [], "sprints": [],
+                "graph": {
+                    "parent_child": { "edges": [] },
+                    "blocks": { "edges": [] },
+                    "relates": { "edges": [] }
+                }
+            }
+        });
+        tokio::fs::write(&file_path, legacy.to_string())
+            .await
+            .unwrap();
+
+        let store = JsonFileStore::new(&file_path);
+        let (_, metadata) = store.load().await.unwrap();
+        assert!(metadata.writer_version.is_none());
+        assert!(metadata.writer_commit.is_none());
     }
 
     #[test]

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -520,7 +520,9 @@ mod tests {
         std::fs::write(&file_path, v99.to_string()).unwrap();
 
         let store = JsonFileStore::new(&file_path);
-        let err = store.load_sync().expect_err("v99 must refuse to load (sync)");
+        let err = store
+            .load_sync()
+            .expect_err("v99 must refuse to load (sync)");
         assert!(
             matches!(
                 err,

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -578,7 +578,7 @@ mod tests {
         assert!(metadata.writer_commit.is_none());
     }
 
-/// Files with stale `commands`/`undo_cursor`/`baseline_data`/
+    /// Files with stale `commands`/`undo_cursor`/`baseline_data`/
     /// `command_schema_version` fields (written by pre-KAN-405 builds) must
     /// be actively scrubbed from disk on load — not just ignored in memory.
     /// Serde would silently drop them on the next save, but that "lazy" cleanup

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -313,11 +313,12 @@ impl PersistenceStore for JsonFileStore {
 
         let data = serde_json::to_vec(&envelope.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+        let mut metadata = envelope.metadata;
+        metadata.format_version = Some(envelope.version);
         let snapshot = StoreSnapshot {
             data,
-            metadata: envelope.metadata.clone(),
+            metadata: metadata.clone(),
         };
-        let metadata = envelope.metadata;
 
         if let Ok(file_metadata) = FileMetadata::from_file(&self.path) {
             let mut guard = self.lock_metadata()?;
@@ -372,11 +373,12 @@ impl PersistenceStore for JsonFileStore {
 
         let data = serde_json::to_vec(&envelope.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+        let mut metadata = envelope.metadata;
+        metadata.format_version = Some(envelope.version);
         let snapshot = StoreSnapshot {
             data,
-            metadata: envelope.metadata.clone(),
+            metadata: metadata.clone(),
         };
-        let metadata = envelope.metadata;
 
         if let Ok(file_metadata) = FileMetadata::from_file(&self.path) {
             let mut guard = self.lock_metadata()?;

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -168,26 +168,12 @@ impl JsonFileStore {
             .map_err(|e| PersistenceError::Serialization(format!("Metadata mutex poisoned: {e}")))
     }
 
-    /// Parse file bytes into a [`JsonEnvelope`], validating version fields.
-    /// Pure: no `&self`, no side effects.
+    /// Parse file bytes into a [`JsonEnvelope`]. Version validation is the
+    /// caller's responsibility — `Migrator::detect_version_from_value` is
+    /// called before this in both load paths and refuses future / malformed
+    /// versions. No defence-in-depth duplication here.
     fn parse_envelope(bytes: &[u8]) -> PersistenceResult<JsonEnvelope> {
-        let envelope: JsonEnvelope = serde_json::from_slice(bytes)
-            .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-
-        if envelope.version > FormatVersion::MAX.as_u32() {
-            return Err(PersistenceError::UnsupportedFutureVersion {
-                file_version: envelope.version,
-                binary_max: FormatVersion::MAX.as_u32(),
-            });
-        }
-        if envelope.version < 2 {
-            return Err(PersistenceError::Serialization(format!(
-                "Unsupported format version: {}",
-                envelope.version
-            )));
-        }
-
-        Ok(envelope)
+        serde_json::from_slice(bytes).map_err(|e| PersistenceError::Serialization(e.to_string()))
     }
 
     fn serialize_envelope(envelope: &JsonEnvelope) -> PersistenceResult<Vec<u8>> {
@@ -592,32 +578,7 @@ mod tests {
         assert!(metadata.writer_commit.is_none());
     }
 
-    #[test]
-    fn test_parse_envelope_rejects_future_version_with_typed_error() {
-        let envelope_bytes = serde_json::to_vec(&json!({
-            "version": 7,
-            "metadata": {
-                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
-                "saved_at": "2026-05-23T00:00:00Z"
-            },
-            "data": {}
-        }))
-        .unwrap();
-        let err = JsonFileStore::parse_envelope(&envelope_bytes)
-            .expect_err("v7 envelope must be refused");
-        assert!(
-            matches!(
-                err,
-                PersistenceError::UnsupportedFutureVersion {
-                    file_version: 7,
-                    binary_max: 6
-                }
-            ),
-            "expected UnsupportedFutureVersion, got: {err:?}"
-        );
-    }
-
-    /// Files with stale `commands`/`undo_cursor`/`baseline_data`/
+/// Files with stale `commands`/`undo_cursor`/`baseline_data`/
     /// `command_schema_version` fields (written by pre-KAN-405 builds) must
     /// be actively scrubbed from disk on load — not just ignored in memory.
     /// Serde would silently drop them on the next save, but that "lazy" cleanup

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -177,7 +177,13 @@ impl JsonFileStore {
         let envelope: JsonEnvelope = serde_json::from_slice(bytes)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 
-        if envelope.version < 2 || envelope.version > 6 {
+        if envelope.version > FormatVersion::MAX.as_u32() {
+            return Err(PersistenceError::UnsupportedFutureVersion {
+                file_version: envelope.version,
+                binary_max: FormatVersion::MAX.as_u32(),
+            });
+        }
+        if envelope.version < 2 {
             return Err(PersistenceError::Serialization(format!(
                 "Unsupported format version: {}",
                 envelope.version
@@ -337,7 +343,7 @@ impl PersistenceStore for JsonFileStore {
         let value: serde_json::Value = serde_json::from_slice(&file_bytes)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 
-        let current_version = Migrator::detect_version_from_value(&value);
+        let current_version = Migrator::detect_version_from_value(&value)?;
 
         let final_bytes = if current_version < FormatVersion::V6 {
             tracing::info!(
@@ -468,6 +474,87 @@ mod tests {
         let guard = store.lock_metadata();
         assert!(guard.is_ok());
         assert!(guard.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_load_rejects_future_format_version() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("future.json");
+        let v99 = json!({
+            "version": 99,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2026-05-23T00:00:00Z"
+            },
+            "data": {}
+        });
+        tokio::fs::write(&file_path, v99.to_string()).await.unwrap();
+
+        let store = JsonFileStore::new(&file_path);
+        let err = store.load().await.expect_err("v99 must refuse to load");
+        assert!(
+            matches!(
+                err,
+                PersistenceError::UnsupportedFutureVersion {
+                    file_version: 99,
+                    binary_max: 6
+                }
+            ),
+            "expected UnsupportedFutureVersion, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_load_sync_rejects_future_format_version() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("future.json");
+        let v99 = json!({
+            "version": 99,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2026-05-23T00:00:00Z"
+            },
+            "data": {}
+        });
+        std::fs::write(&file_path, v99.to_string()).unwrap();
+
+        let store = JsonFileStore::new(&file_path);
+        let err = store.load_sync().expect_err("v99 must refuse to load (sync)");
+        assert!(
+            matches!(
+                err,
+                PersistenceError::UnsupportedFutureVersion {
+                    file_version: 99,
+                    binary_max: 6
+                }
+            ),
+            "expected UnsupportedFutureVersion, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_envelope_rejects_future_version_with_typed_error() {
+        let envelope_bytes = serde_json::to_vec(&json!({
+            "version": 7,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2026-05-23T00:00:00Z"
+            },
+            "data": {}
+        }))
+        .unwrap();
+        let err = JsonFileStore::parse_envelope(&envelope_bytes)
+            .expect_err("v7 envelope must be refused");
+        assert!(
+            matches!(
+                err,
+                PersistenceError::UnsupportedFutureVersion {
+                    file_version: 7,
+                    binary_max: 6
+                }
+            ),
+            "expected UnsupportedFutureVersion, got: {err:?}"
+        );
     }
 
     /// Files with stale `commands`/`undo_cursor`/`baseline_data`/

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -58,10 +58,7 @@ impl JsonEnvelope {
     pub fn new(data: serde_json::Value) -> Self {
         Self {
             version: 2,
-            metadata: PersistenceMetadata {
-                instance_id: Uuid::new_v4(),
-                saved_at: chrono::Utc::now(),
-            },
+            metadata: PersistenceMetadata::new(Uuid::new_v4()),
             data,
         }
     }

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -14,7 +14,11 @@ impl Migrator {
     pub fn detect_version_from_value(value: &Value) -> PersistenceResult<FormatVersion> {
         // V2+ files have a "version" field at root level
         if let Some(version) = value.get("version").and_then(|v| v.as_u64()) {
-            let v = version as u32;
+            // Saturate-on-overflow rather than truncate: a `version` field
+            // that exceeds u32::MAX is still a "future version" the binary
+            // doesn't understand, not the wrapped-around small number a
+            // naive `as u32` would yield.
+            let v: u32 = u32::try_from(version).unwrap_or(u32::MAX);
             return FormatVersion::from_u32(v).ok_or(PersistenceError::UnsupportedFutureVersion {
                 file_version: v,
                 binary_max: FormatVersion::MAX.as_u32(),
@@ -412,6 +416,27 @@ mod tests {
                     file_version: 99,
                     binary_max: 6
                 }
+            ),
+            "expected UnsupportedFutureVersion, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_detect_version_from_value_rejects_u32_overflow_that_truncates_to_valid_version() {
+        // 2^32 + 6 truncates to 6 under a naive `as u32` cast — which would
+        // be silently accepted as V6. The guard must refuse it as a future
+        // version instead.
+        let truncates_to_v6 = json!({
+            "version": (1u64 << 32) + 6,
+            "metadata": {},
+            "data": {}
+        });
+        let err = Migrator::detect_version_from_value(&truncates_to_v6)
+            .expect_err("version > u32::MAX must be refused, not truncated to V6");
+        assert!(
+            matches!(
+                err,
+                PersistenceError::UnsupportedFutureVersion { binary_max: 6, .. }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
         );

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -8,31 +8,37 @@ pub struct Migrator;
 
 impl Migrator {
     /// Detect the format version from an already-parsed JSON value.
-    /// Pure: no I/O, no errors.
-    pub fn detect_version_from_value(value: &Value) -> FormatVersion {
+    /// Pure: no I/O. Returns `UnsupportedFutureVersion` for versions newer
+    /// than this binary's max — silently coercing them would risk dropping
+    /// fields the old reader does not understand.
+    pub fn detect_version_from_value(value: &Value) -> PersistenceResult<FormatVersion> {
         // V2+ files have a "version" field at root level
         if let Some(version) = value.get("version").and_then(|v| v.as_u64()) {
-            return FormatVersion::from_u32(version as u32).unwrap_or(FormatVersion::V2);
+            let v = version as u32;
+            return FormatVersion::from_u32(v).ok_or(PersistenceError::UnsupportedFutureVersion {
+                file_version: v,
+                binary_max: FormatVersion::MAX.as_u32(),
+            });
         }
         // V1 files have "boards" at root level but no version field
         if value.get("boards").is_some() {
-            return FormatVersion::V1;
+            return Ok(FormatVersion::V1);
         }
-        // Unknown format, assume V2
-        FormatVersion::V2
+        // Unknown shape with no version field, treat as V2
+        Ok(FormatVersion::V2)
     }
 
     /// Detect the version of a persisted file
     pub async fn detect_version(path: &Path) -> PersistenceResult<FormatVersion> {
         if !path.exists() {
-            return Ok(FormatVersion::V6); // Default to V6 for new files
+            return Ok(FormatVersion::MAX); // Default to current for new files
         }
 
         let content = tokio::fs::read_to_string(path).await?;
         let value: Value = serde_json::from_str(&content)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 
-        Ok(Self::detect_version_from_value(&value))
+        Self::detect_version_from_value(&value)
     }
 
     /// Migrate a file from one version to another, stepping through intermediate versions
@@ -388,6 +394,52 @@ mod tests {
         assert!(
             !path.with_extension("v1.backup").exists(),
             "V5 -> V6 must not trigger the v1→v2 step that creates .v1.backup"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_detect_version_from_value_rejects_future_version() {
+        let v99 = json!({
+            "version": 99,
+            "metadata": {},
+            "data": {}
+        });
+        let err = Migrator::detect_version_from_value(&v99).expect_err("v99 must be refused");
+        assert!(
+            matches!(
+                err,
+                PersistenceError::UnsupportedFutureVersion {
+                    file_version: 99,
+                    binary_max: 6
+                }
+            ),
+            "expected UnsupportedFutureVersion, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_detect_version_async_rejects_future_version() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v99.json");
+        let v99 = json!({
+            "version": 99,
+            "metadata": {},
+            "data": {}
+        });
+        tokio::fs::write(&path, v99.to_string()).await.unwrap();
+
+        let err = Migrator::detect_version(&path)
+            .await
+            .expect_err("v99 must be refused");
+        assert!(
+            matches!(
+                err,
+                PersistenceError::UnsupportedFutureVersion {
+                    file_version: 99,
+                    binary_max: 6
+                }
+            ),
+            "expected UnsupportedFutureVersion, got: {err:?}"
         );
     }
 

--- a/crates/kanban-persistence-sqlite/Cargo.toml
+++ b/crates/kanban-persistence-sqlite/Cargo.toml
@@ -10,6 +10,13 @@ description = "SQLite storage backend for the kanban project management tool"
 keywords = ["kanban", "persistence", "sqlite", "storage"]
 categories = ["command-line-utilities", "development-tools"]
 
+[features]
+# Gates the `write_test_metadata_with_schema_version` /
+# `read_test_schema_version` fixture helpers. Mirrors the pattern used by
+# kanban-persistence and kanban-service — test-only code stays out of the
+# release binary.
+test-helpers = []
+
 [dependencies]
 kanban-persistence = { path = "../kanban-persistence", version = "^0.6" }
 kanban-core = { path = "../kanban-core", version = "^0.6" }

--- a/crates/kanban-persistence-sqlite/src/lib.rs
+++ b/crates/kanban-persistence-sqlite/src/lib.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 /// version via `migrate()` before the test could observe the pre-bumped
 /// state. Writes only the `metadata` table; the rest of the schema is
 /// created by `SqliteStore::open` on first real load.
-#[doc(hidden)]
+///
+/// Gated behind the `test-helpers` feature so it does not ship in release
+/// binaries. Mirrors the pattern in `kanban-persistence::test_helpers`.
+#[cfg(feature = "test-helpers")]
 pub async fn write_test_metadata_with_schema_version(
     path: &std::path::Path,
     version: u32,
@@ -55,7 +58,10 @@ pub async fn write_test_metadata_with_schema_version(
 /// the metadata row's `schema_version` without going through `SqliteStore::open`
 /// (which would normalise it). Used by integration tests that want to assert
 /// a refused open didn't bump the on-disk version.
-#[doc(hidden)]
+///
+/// Gated behind the `test-helpers` feature; see the sibling function for
+/// rationale.
+#[cfg(feature = "test-helpers")]
 pub async fn read_test_schema_version(
     path: &std::path::Path,
 ) -> Result<Option<u32>, PersistenceError> {

--- a/crates/kanban-persistence-sqlite/src/lib.rs
+++ b/crates/kanban-persistence-sqlite/src/lib.rs
@@ -40,7 +40,7 @@ pub async fn write_test_metadata_with_schema_version(
             id INTEGER PRIMARY KEY CHECK (id = 1),
             instance_id TEXT NOT NULL,
             saved_at TEXT NOT NULL,
-            schema_version INTEGER NOT NULL DEFAULT 1,
+            schema_version INTEGER NOT NULL DEFAULT {SUPPORTED_SCHEMA_VERSION},
             writer_version TEXT,
             writer_commit TEXT
         );

--- a/crates/kanban-persistence-sqlite/src/lib.rs
+++ b/crates/kanban-persistence-sqlite/src/lib.rs
@@ -1,9 +1,78 @@
 pub mod sqlite_store;
 
 pub use sqlite_store::SqliteStore;
+pub use sqlite_store::SUPPORTED_SCHEMA_VERSION;
 
+use kanban_domain::KanbanError;
 use kanban_persistence::{PersistenceError, PersistenceStore, StoreFactory};
 use std::sync::Arc;
+
+/// Construct a SQLite database file at `path` with a `metadata` row whose
+/// `schema_version` is forced to `version`. Intended for cross-crate
+/// integration tests that need to exercise the `UnsupportedFutureVersion`
+/// refusal at every surface (service, MCP, CLI) without each test
+/// reimplementing the seed SQL.
+///
+/// Bypasses `SqliteStore::open` deliberately — opening would normalise the
+/// version via `migrate()` before the test could observe the pre-bumped
+/// state. Writes only the `metadata` table; the rest of the schema is
+/// created by `SqliteStore::open` on first real load.
+#[doc(hidden)]
+pub async fn write_test_metadata_with_schema_version(
+    path: &std::path::Path,
+    version: u32,
+) -> Result<(), PersistenceError> {
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true),
+        )
+        .await
+        .map_err(|e| PersistenceError::Database(e.to_string()))?;
+    sqlx::raw_sql(&format!(
+        "CREATE TABLE IF NOT EXISTS metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            instance_id TEXT NOT NULL,
+            saved_at TEXT NOT NULL,
+            schema_version INTEGER NOT NULL DEFAULT 1,
+            writer_version TEXT,
+            writer_commit TEXT
+        );
+        INSERT OR REPLACE INTO metadata (id, instance_id, saved_at, schema_version)
+        VALUES (1, '550e8400-e29b-41d4-a716-446655440000', '2030-01-01T00:00:00Z', {version});"
+    ))
+    .execute(&pool)
+    .await
+    .map_err(|e| PersistenceError::Database(e.to_string()))?;
+    pool.close().await;
+    Ok(())
+}
+
+/// Test-only companion to [`write_test_metadata_with_schema_version`]: probe
+/// the metadata row's `schema_version` without going through `SqliteStore::open`
+/// (which would normalise it). Used by integration tests that want to assert
+/// a refused open didn't bump the on-disk version.
+#[doc(hidden)]
+pub async fn read_test_schema_version(
+    path: &std::path::Path,
+) -> Result<Option<u32>, PersistenceError> {
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(SqliteConnectOptions::new().filename(path))
+        .await
+        .map_err(|e| PersistenceError::Database(e.to_string()))?;
+    let version: Option<u32> =
+        sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_optional(&pool)
+            .await
+            .map_err(|e| PersistenceError::Database(e.to_string()))?;
+    pool.close().await;
+    Ok(version)
+}
 
 pub struct SqliteStoreFactory;
 
@@ -30,7 +99,21 @@ impl StoreFactory for SqliteStoreFactory {
             ));
         }
         let store = tokio::task::block_in_place(|| handle.block_on(SqliteStore::open(locator)))
-            .map_err(|e| PersistenceError::Database(e.to_string()))?;
+            // Preserve typed variants across the KanbanError → PersistenceError
+            // boundary so downstream callers can discriminate them (esp.
+            // UnsupportedFutureVersion via `KanbanError::is_unsupported_future_version`).
+            // Stringifying everything into Database would flatten the typed
+            // variant and break the cross-surface refusal contract.
+            .map_err(|e| match e {
+                KanbanError::UnsupportedFutureVersion {
+                    file_version,
+                    binary_max,
+                } => PersistenceError::UnsupportedFutureVersion {
+                    file_version,
+                    binary_max,
+                },
+                other => PersistenceError::Database(other.to_string()),
+            })?;
         Ok(Arc::new(store))
     }
 }

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -1,12 +1,15 @@
 -- SQLite schema for kanban persistence
--- Version: 2
+-- Version: 2 (KAN-522: writer-stamp columns added; schema_version begins
+-- to be authoritative — see SqliteStore::migrate for the ALTER fallbacks)
 
 -- Metadata table for tracking persistence state and conflict detection
 CREATE TABLE IF NOT EXISTS metadata (
     id INTEGER PRIMARY KEY CHECK (id = 1),  -- Singleton row
     instance_id TEXT NOT NULL,
     saved_at TEXT NOT NULL,
-    schema_version INTEGER NOT NULL DEFAULT 1
+    schema_version INTEGER NOT NULL DEFAULT 2,
+    writer_version TEXT,
+    writer_commit TEXT
 );
 
 -- Boards table

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -475,7 +475,48 @@ impl SqliteStore {
         &self.pool
     }
 
+    /// Read the metadata singleton row from the DB. Cheap (single row, indexed by primary key).
+    /// Returns `Ok(None)` if the row is absent — only possible on a brand-new DB
+    /// before `load_or_create_instance_id` has run, which the public API doesn't expose.
+    pub fn read_metadata_sync(&self) -> KanbanResult<Option<PersistenceMetadata>> {
+        run(async {
+            let row: Option<(String, String, Option<String>, Option<String>)> = sqlx::query_as(
+                "SELECT instance_id, saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
+            )
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(db_err)?;
+            let Some(row) = row else {
+                return Ok(None);
+            };
+            let instance_id = p_uuid(&row.0)?;
+            let saved_at = p_dt(&row.1)?;
+            Ok(Some(PersistenceMetadata {
+                instance_id,
+                saved_at,
+                writer_version: row.2,
+                writer_commit: row.3,
+            }))
+        })
+    }
+
     pub async fn checkpoint(&self) -> KanbanResult<()> {
+        // Stamp the writer identity onto the metadata row before truncating
+        // the WAL. Anything in the WAL is about to land in the main DB file,
+        // so attribution should land in the same step. Callers that just
+        // want pure WAL handling shouldn't be calling checkpoint; the only
+        // existing callers (PersistenceStore::save, SqliteBackend::flush)
+        // both want the stamp.
+        sqlx::query(
+            "UPDATE metadata SET saved_at = ?, writer_version = ?, writer_commit = ? WHERE id = 1",
+        )
+        .bind(Utc::now().to_rfc3339())
+        .bind(kanban_core::KANBAN_VERSION)
+        .bind(kanban_core::KANBAN_COMMIT)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| KanbanError::Database(e.to_string()))?;
+
         sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
             .execute(&self.pool)
             .await
@@ -1752,22 +1793,29 @@ impl PersistenceStore for SqliteStore {
             .await
             .map_err(|e| PersistenceError::Database(e.to_string()))?;
 
-        let metadata = PersistenceMetadata::new(self.instance_id)
-            .with_writer_stamp(kanban_core::KANBAN_VERSION, kanban_core::KANBAN_COMMIT);
-        sqlx::query(
-            "UPDATE metadata SET saved_at = ?, writer_version = ?, writer_commit = ? WHERE id = 1",
-        )
-        .bind(metadata.saved_at.to_rfc3339())
-        .bind(metadata.writer_version.as_deref())
-        .bind(metadata.writer_commit.as_deref())
-        .execute(&self.pool)
-        .await
-        .map_err(|e| PersistenceError::Database(e.to_string()))?;
-
+        // checkpoint() owns the writer-stamp UPDATE plus WAL flush.
         self.checkpoint()
             .await
             .map_err(|e| PersistenceError::Database(e.to_string()))?;
-        Ok(metadata)
+
+        // Read back what checkpoint() just wrote so the caller sees the same
+        // stamp that landed on disk.
+        let (saved_at_str, writer_version, writer_commit): (String, Option<String>, Option<String>) =
+            sqlx::query_as(
+                "SELECT saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
+            )
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| PersistenceError::Database(e.to_string()))?;
+        let saved_at = DateTime::parse_from_rfc3339(&saved_at_str)
+            .map_err(|e| PersistenceError::Serialization(e.to_string()))?
+            .with_timezone(&Utc);
+        Ok(PersistenceMetadata {
+            instance_id: self.instance_id,
+            saved_at,
+            writer_version,
+            writer_commit,
+        })
     }
 
     async fn load(&self) -> PersistenceResult<(StoreSnapshot, PersistenceMetadata)> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1751,10 +1751,23 @@ impl PersistenceStore for SqliteStore {
         self.apply_snapshot_async(domain_snapshot)
             .await
             .map_err(|e| PersistenceError::Database(e.to_string()))?;
+
+        let metadata = PersistenceMetadata::new(self.instance_id)
+            .with_writer_stamp(kanban_core::KANBAN_VERSION, kanban_core::KANBAN_COMMIT);
+        sqlx::query(
+            "UPDATE metadata SET saved_at = ?, writer_version = ?, writer_commit = ? WHERE id = 1",
+        )
+        .bind(metadata.saved_at.to_rfc3339())
+        .bind(metadata.writer_version.as_deref())
+        .bind(metadata.writer_commit.as_deref())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| PersistenceError::Database(e.to_string()))?;
+
         self.checkpoint()
             .await
             .map_err(|e| PersistenceError::Database(e.to_string()))?;
-        Ok(PersistenceMetadata::new(self.instance_id))
+        Ok(metadata)
     }
 
     async fn load(&self) -> PersistenceResult<(StoreSnapshot, PersistenceMetadata)> {
@@ -1764,7 +1777,22 @@ impl PersistenceStore for SqliteStore {
             .map_err(|e| PersistenceError::Database(e.to_string()))?;
         let data = serde_json::to_vec(&domain_snapshot)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-        let meta = PersistenceMetadata::new(self.instance_id);
+
+        let row: (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| PersistenceError::Database(e.to_string()))?;
+        let saved_at = DateTime::parse_from_rfc3339(&row.0)
+            .map_err(|e| PersistenceError::Serialization(e.to_string()))?
+            .with_timezone(&Utc);
+        let meta = PersistenceMetadata {
+            instance_id: self.instance_id,
+            saved_at,
+            writer_version: row.1,
+            writer_commit: row.2,
+        };
         Ok((
             StoreSnapshot {
                 data,
@@ -2119,6 +2147,131 @@ mod tests {
                 .unwrap();
                 assert!(exists, "metadata.{col} column must exist on fresh DB");
             }
+        });
+    }
+
+    #[test]
+    fn test_save_stamps_writer_version_and_commit_into_metadata_row() {
+        use kanban_domain::DependencyGraph;
+        use kanban_persistence::snapshot_to_json_bytes;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("stamped.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+            let snapshot = Snapshot::from_data(
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                DependencyGraph::new(),
+            );
+            let data = snapshot_to_json_bytes(&snapshot).unwrap();
+            let store_snap = StoreSnapshot {
+                data,
+                metadata: PersistenceMetadata::new(store.instance_id()),
+            };
+            let returned = PersistenceStore::save(&store, store_snap).await.unwrap();
+
+            assert_eq!(
+                returned.writer_version.as_deref(),
+                Some(kanban_core::KANBAN_VERSION),
+            );
+            assert_eq!(
+                returned.writer_commit.as_deref(),
+                Some(kanban_core::KANBAN_COMMIT),
+            );
+
+            let row: (Option<String>, Option<String>) =
+                sqlx::query_as("SELECT writer_version, writer_commit FROM metadata WHERE id = 1")
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
+            assert_eq!(row.0.as_deref(), Some(kanban_core::KANBAN_VERSION));
+            assert_eq!(row.1.as_deref(), Some(kanban_core::KANBAN_COMMIT));
+        });
+    }
+
+    #[test]
+    fn test_load_returns_writer_stamp_from_metadata_row() {
+        use kanban_domain::DependencyGraph;
+        use kanban_persistence::snapshot_to_json_bytes;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("loaded.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+            let snapshot = Snapshot::from_data(
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                DependencyGraph::new(),
+            );
+            let data = snapshot_to_json_bytes(&snapshot).unwrap();
+            PersistenceStore::save(
+                &store,
+                StoreSnapshot {
+                    data,
+                    metadata: PersistenceMetadata::new(store.instance_id()),
+                },
+            )
+            .await
+            .unwrap();
+
+            let (_, meta) = PersistenceStore::load(&store).await.unwrap();
+            assert_eq!(
+                meta.writer_version.as_deref(),
+                Some(kanban_core::KANBAN_VERSION),
+            );
+            assert_eq!(
+                meta.writer_commit.as_deref(),
+                Some(kanban_core::KANBAN_COMMIT),
+            );
+        });
+    }
+
+    #[test]
+    fn test_load_legacy_db_without_stamp_returns_none_writer_fields() {
+        // Pre-KAN-522 DB: metadata row exists, schema_version was bumped to
+        // current by migrate(), but writer_version/writer_commit are still
+        // NULL because no save has happened since the ALTER.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("legacy_load.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    SqliteConnectOptions::new()
+                        .filename(&path)
+                        .create_if_missing(true),
+                )
+                .await
+                .unwrap();
+            sqlx::raw_sql(
+                "CREATE TABLE metadata (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    instance_id TEXT NOT NULL,
+                    saved_at TEXT NOT NULL,
+                    schema_version INTEGER NOT NULL DEFAULT 1
+                );
+                INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+                VALUES (1, '550e8400-e29b-41d4-a716-446655440000', '2024-01-01T00:00:00Z', 1);",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            pool.close().await;
+
+            let store = SqliteStore::open(&path).await.unwrap();
+            let (_, meta) = PersistenceStore::load(&store).await.unwrap();
+            assert!(meta.writer_version.is_none());
+            assert!(meta.writer_commit.is_none());
         });
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -311,24 +311,6 @@ impl SqliteStore {
 
         Self::migrate(&pool).await?;
 
-        // Belt-and-braces: re-check after migrate so a malicious or hand-edited
-        // post-migrate row can't slip through. Practically unreachable because
-        // the pre-migrate guard above already caught it; kept as defence in
-        // depth and as the test boundary for `test_open_rejects_future_schema_version`.
-        let schema_version: Option<u32> =
-            sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
-                .fetch_optional(&pool)
-                .await
-                .map_err(|e| KanbanError::Database(e.to_string()))?;
-        if let Some(v) = schema_version {
-            if v > SUPPORTED_SCHEMA_VERSION {
-                return Err(KanbanError::UnsupportedFutureVersion {
-                    file_version: v,
-                    binary_max: SUPPORTED_SCHEMA_VERSION,
-                });
-            }
-        }
-
         let instance_id = Self::load_or_create_instance_id(&pool).await?;
 
         Ok(Self {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -496,6 +496,7 @@ impl SqliteStore {
                 saved_at,
                 writer_version: row.2,
                 writer_commit: row.3,
+                format_version: Some(SUPPORTED_SCHEMA_VERSION),
             }))
         })
     }
@@ -1815,6 +1816,7 @@ impl PersistenceStore for SqliteStore {
             saved_at,
             writer_version,
             writer_commit,
+            format_version: Some(SUPPORTED_SCHEMA_VERSION),
         })
     }
 
@@ -1840,6 +1842,7 @@ impl PersistenceStore for SqliteStore {
             saved_at,
             writer_version: row.1,
             writer_commit: row.2,
+            format_version: Some(SUPPORTED_SCHEMA_VERSION),
         };
         Ok((
             StoreSnapshot {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -20,6 +20,11 @@ const SCHEMA: &str = include_str!("schema.sql");
 /// stamp fresh databases and to refuse files written by a future binary.
 pub const SUPPORTED_SCHEMA_VERSION: u32 = 2;
 
+/// (instance_id, saved_at, writer_version, writer_commit, schema_version).
+/// Tuple shape returned by the metadata-singleton SELECT — extracted to a
+/// type alias to keep clippy's type-complexity lint happy.
+type MetadataRow = (String, String, Option<String>, Option<String>, u32);
+
 /// SQLite-backed persistence store using sqlx connection pool.
 pub struct SqliteStore {
     pool: Pool<Sqlite>,
@@ -480,8 +485,9 @@ impl SqliteStore {
     /// before `load_or_create_instance_id` has run, which the public API doesn't expose.
     pub fn read_metadata_sync(&self) -> KanbanResult<Option<PersistenceMetadata>> {
         run(async {
-            let row: Option<(String, String, Option<String>, Option<String>)> = sqlx::query_as(
-                "SELECT instance_id, saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
+            let row: Option<MetadataRow> = sqlx::query_as(
+                "SELECT instance_id, saved_at, writer_version, writer_commit, schema_version \
+                 FROM metadata WHERE id = 1",
             )
             .fetch_optional(&self.pool)
             .await
@@ -496,28 +502,36 @@ impl SqliteStore {
                 saved_at,
                 writer_version: row.2,
                 writer_commit: row.3,
-                format_version: Some(SUPPORTED_SCHEMA_VERSION),
+                format_version: Some(row.4),
             }))
         })
     }
 
-    pub async fn checkpoint(&self) -> KanbanResult<()> {
-        // Stamp the writer identity onto the metadata row before truncating
-        // the WAL. Anything in the WAL is about to land in the main DB file,
-        // so attribution should land in the same step. Callers that just
-        // want pure WAL handling shouldn't be calling checkpoint; the only
-        // existing callers (PersistenceStore::save, SqliteBackend::flush)
-        // both want the stamp.
+    /// Record the current binary as the most-recent writer of this DB by
+    /// stamping `saved_at`, `writer_version`, and `writer_commit` into the
+    /// metadata singleton row. Returns the timestamp it wrote so callers can
+    /// echo it back into a `PersistenceMetadata` without re-reading the row.
+    ///
+    /// Separated from [`checkpoint`] so each function does one thing — see
+    /// the post-PR-288 review for the SRP rationale.
+    pub async fn stamp_writer(&self) -> KanbanResult<DateTime<Utc>> {
+        let now = Utc::now();
         sqlx::query(
             "UPDATE metadata SET saved_at = ?, writer_version = ?, writer_commit = ? WHERE id = 1",
         )
-        .bind(Utc::now().to_rfc3339())
+        .bind(now.to_rfc3339())
         .bind(kanban_core::KANBAN_VERSION)
         .bind(kanban_core::KANBAN_COMMIT)
         .execute(&self.pool)
         .await
         .map_err(|e| KanbanError::Database(e.to_string()))?;
+        Ok(now)
+    }
 
+    /// Truncate the WAL. Pure I/O step; does not touch the writer-stamp
+    /// columns. Callers that want a durable save with attribution should
+    /// invoke [`stamp_writer`] alongside this.
+    pub async fn checkpoint(&self) -> KanbanResult<()> {
         sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
             .execute(&self.pool)
             .await
@@ -1794,31 +1808,25 @@ impl PersistenceStore for SqliteStore {
             .await
             .map_err(|e| PersistenceError::Database(e.to_string()))?;
 
-        // checkpoint() owns the writer-stamp UPDATE plus WAL flush.
+        let saved_at = self
+            .stamp_writer()
+            .await
+            .map_err(|e| PersistenceError::Database(e.to_string()))?;
         self.checkpoint()
             .await
             .map_err(|e| PersistenceError::Database(e.to_string()))?;
 
-        // Read back what checkpoint() just wrote so the caller sees the same
-        // stamp that landed on disk.
-        let (saved_at_str, writer_version, writer_commit): (
-            String,
-            Option<String>,
-            Option<String>,
-        ) = sqlx::query_as(
-            "SELECT saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
-        )
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| PersistenceError::Database(e.to_string()))?;
-        let saved_at = DateTime::parse_from_rfc3339(&saved_at_str)
-            .map_err(|e| PersistenceError::Serialization(e.to_string()))?
-            .with_timezone(&Utc);
+        // Values are all knowable inline — stamp_writer just wrote them and
+        // returned the timestamp, the writer/commit are compile-time consts.
+        // format_version is SUPPORTED because migrate() on open() normalised
+        // schema_version to SUPPORTED and nothing in the save path touches
+        // it. The read paths (load, read_metadata_sync) re-read from the row
+        // to honour the "DB is the source of truth" contract.
         Ok(PersistenceMetadata {
             instance_id: self.instance_id,
             saved_at,
-            writer_version,
-            writer_commit,
+            writer_version: Some(kanban_core::KANBAN_VERSION.to_string()),
+            writer_commit: Some(kanban_core::KANBAN_COMMIT.to_string()),
             format_version: Some(SUPPORTED_SCHEMA_VERSION),
         })
     }
@@ -1831,8 +1839,9 @@ impl PersistenceStore for SqliteStore {
         let data = serde_json::to_vec(&domain_snapshot)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 
-        let row: (String, Option<String>, Option<String>) = sqlx::query_as(
-            "SELECT saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
+        let row: (String, Option<String>, Option<String>, u32) = sqlx::query_as(
+            "SELECT saved_at, writer_version, writer_commit, schema_version \
+             FROM metadata WHERE id = 1",
         )
         .fetch_one(&self.pool)
         .await
@@ -1845,7 +1854,7 @@ impl PersistenceStore for SqliteStore {
             saved_at,
             writer_version: row.1,
             writer_commit: row.2,
-            format_version: Some(SUPPORTED_SCHEMA_VERSION),
+            format_version: Some(row.3),
         };
         Ok((
             StoreSnapshot {
@@ -2166,6 +2175,142 @@ mod tests {
             assert!(
                 store.get_card(card_id).unwrap().is_none(),
                 "get_card should return None for permanently deleted card"
+            );
+        });
+    }
+
+    #[test]
+    fn test_read_metadata_sync_reflects_actual_schema_version_from_db_row() {
+        // Contract: PersistenceMetadata.format_version is the format the DB
+        // is currently at, not whatever the binary's SUPPORTED happens to be.
+        // After open(), the two coincide (migrate normalises). We manually
+        // UPDATE schema_version below to a value that differs from SUPPORTED
+        // and confirm the read reflects the DB, not the const.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("drift.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+            sqlx::query("UPDATE metadata SET schema_version = 1 WHERE id = 1")
+                .execute(&store.pool)
+                .await
+                .unwrap();
+
+            let meta = store
+                .read_metadata_sync()
+                .unwrap()
+                .expect("metadata row should exist");
+            assert_eq!(
+                meta.format_version,
+                Some(1),
+                "format_version must reflect the DB row (1), not the binary's SUPPORTED ({SUPPORTED_SCHEMA_VERSION})"
+            );
+        });
+    }
+
+    #[test]
+    fn test_load_reports_actual_schema_version_in_metadata() {
+        use kanban_domain::DependencyGraph;
+        use kanban_persistence::snapshot_to_json_bytes;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("load_drift.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+            // Seed the row so load() has something to read.
+            let snapshot = Snapshot::from_data(
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                DependencyGraph::new(),
+            );
+            let data = snapshot_to_json_bytes(&snapshot).unwrap();
+            PersistenceStore::save(
+                &store,
+                StoreSnapshot {
+                    data,
+                    metadata: PersistenceMetadata::new(store.instance_id()),
+                },
+            )
+            .await
+            .unwrap();
+            sqlx::query("UPDATE metadata SET schema_version = 1 WHERE id = 1")
+                .execute(&store.pool)
+                .await
+                .unwrap();
+
+            let (_, meta) = PersistenceStore::load(&store).await.unwrap();
+            assert_eq!(
+                meta.format_version,
+                Some(1),
+                "load() must report the DB's actual schema_version, not the const"
+            );
+        });
+    }
+
+    #[test]
+    fn test_stamp_writer_updates_metadata_row_and_returns_timestamp() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("stamped.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+            // Wipe what migrate-on-open already wrote so the assertion is clean.
+            sqlx::query(
+                "UPDATE metadata SET writer_version = NULL, writer_commit = NULL WHERE id = 1",
+            )
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+            let before = Utc::now();
+            let stamped_at = store.stamp_writer().await.unwrap();
+            let after = Utc::now();
+
+            assert!(
+                stamped_at >= before && stamped_at <= after,
+                "returned timestamp must be in [before, after]: {stamped_at:?}"
+            );
+
+            let (saved_at_str, wv, wc): (String, Option<String>, Option<String>) = sqlx::query_as(
+                "SELECT saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
+            )
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+            assert_eq!(wv.as_deref(), Some(kanban_core::KANBAN_VERSION));
+            assert_eq!(wc.as_deref(), Some(kanban_core::KANBAN_COMMIT));
+            assert_eq!(saved_at_str, stamped_at.to_rfc3339());
+        });
+    }
+
+    #[test]
+    fn test_checkpoint_alone_does_not_stamp_writer_fields() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("ckpt_only.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+            sqlx::query(
+                "UPDATE metadata SET writer_version = NULL, writer_commit = NULL WHERE id = 1",
+            )
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+            store.checkpoint().await.unwrap();
+
+            let (wv, wc): (Option<String>, Option<String>) =
+                sqlx::query_as("SELECT writer_version, writer_commit FROM metadata WHERE id = 1")
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
+            assert!(
+                wv.is_none() && wc.is_none(),
+                "checkpoint() must be WAL-only post-split; got wv={wv:?} wc={wc:?}"
             );
         });
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -278,6 +278,23 @@ impl SqliteStore {
 
         Self::migrate(&pool).await?;
 
+        // KAN-522: refuse files written by a future kanban. Read after
+        // migrate() so a legacy database that just had its schema_version
+        // bumped to current doesn't false-positive.
+        let schema_version: Option<u32> =
+            sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                .fetch_optional(&pool)
+                .await
+                .map_err(|e| KanbanError::Database(e.to_string()))?;
+        if let Some(v) = schema_version {
+            if v > SUPPORTED_SCHEMA_VERSION {
+                return Err(KanbanError::UnsupportedFutureVersion {
+                    file_version: v,
+                    binary_max: SUPPORTED_SCHEMA_VERSION,
+                });
+            }
+        }
+
         let instance_id = Self::load_or_create_instance_id(&pool).await?;
 
         Ok(Self {
@@ -2102,6 +2119,55 @@ mod tests {
                 .unwrap();
                 assert!(exists, "metadata.{col} column must exist on fresh DB");
             }
+        });
+    }
+
+    #[test]
+    fn test_open_rejects_future_schema_version() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("future.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    SqliteConnectOptions::new()
+                        .filename(&path)
+                        .create_if_missing(true),
+                )
+                .await
+                .unwrap();
+            sqlx::raw_sql(
+                "CREATE TABLE metadata (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    instance_id TEXT NOT NULL,
+                    saved_at TEXT NOT NULL,
+                    schema_version INTEGER NOT NULL DEFAULT 2,
+                    writer_version TEXT,
+                    writer_commit TEXT
+                );
+                INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+                VALUES (1, '550e8400-e29b-41d4-a716-446655440000', '2030-01-01T00:00:00Z', 99);",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            pool.close().await;
+
+            let err = SqliteStore::open(&path)
+                .await
+                .err()
+                .expect("schema_version 99 must be refused");
+            assert!(
+                matches!(
+                    err,
+                    KanbanError::UnsupportedFutureVersion {
+                        file_version: 99,
+                        binary_max: SUPPORTED_SCHEMA_VERSION
+                    }
+                ),
+                "expected UnsupportedFutureVersion, got: {err:?}"
+            );
         });
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -269,6 +269,34 @@ impl SqliteStore {
             .await
             .map_err(|e| KanbanError::Database(e.to_string()))?;
 
+        // KAN-522: refuse a future-version DB BEFORE any schema-modifying
+        // step runs. Otherwise the legacy-table drops, the SCHEMA's
+        // CREATE TABLE IF NOT EXISTS for tables the file lacks, and
+        // migrate()'s ALTERs would all mutate a file we're about to refuse.
+        // Probe sqlite_master first so a fresh DB (no metadata table yet)
+        // proceeds normally without error.
+        let metadata_table_exists: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='metadata'",
+        )
+        .fetch_one(&pool)
+        .await
+        .map_err(|e| KanbanError::Database(e.to_string()))?;
+        if metadata_table_exists {
+            let pre_migrate_version: Option<u32> =
+                sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                    .fetch_optional(&pool)
+                    .await
+                    .map_err(|e| KanbanError::Database(e.to_string()))?;
+            if let Some(v) = pre_migrate_version {
+                if v > SUPPORTED_SCHEMA_VERSION {
+                    return Err(KanbanError::UnsupportedFutureVersion {
+                        file_version: v,
+                        binary_max: SUPPORTED_SCHEMA_VERSION,
+                    });
+                }
+            }
+        }
+
         // Drop the legacy command_log table (pre-KAN-405 schema with
         // columns `idx` / `cmd_json`) before SCHEMA runs, so the new
         // command_log schema (`batch_index` / `commands_json` / `created_at`)
@@ -283,9 +311,10 @@ impl SqliteStore {
 
         Self::migrate(&pool).await?;
 
-        // KAN-522: refuse files written by a future kanban. Read after
-        // migrate() so a legacy database that just had its schema_version
-        // bumped to current doesn't false-positive.
+        // Belt-and-braces: re-check after migrate so a malicious or hand-edited
+        // post-migrate row can't slip through. Practically unreachable because
+        // the pre-migrate guard above already caught it; kept as defence in
+        // depth and as the test boundary for `test_open_rejects_future_schema_version`.
         let schema_version: Option<u32> =
             sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
                 .fetch_optional(&pool)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -16,6 +16,10 @@ use uuid::Uuid;
 
 const SCHEMA: &str = include_str!("schema.sql");
 
+/// The highest schema_version this binary understands. Used both to
+/// stamp fresh databases and to refuse files written by a future binary.
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 2;
+
 /// SQLite-backed persistence store using sqlx connection pool.
 pub struct SqliteStore {
     pool: Pool<Sqlite>,
@@ -295,10 +299,11 @@ impl SqliteStore {
                 let id = Uuid::new_v4();
                 let now = Utc::now().to_rfc3339();
                 sqlx::query(
-                    "INSERT INTO metadata (id, instance_id, saved_at, schema_version) VALUES (1, ?, ?, 1)",
+                    "INSERT INTO metadata (id, instance_id, saved_at, schema_version) VALUES (1, ?, ?, ?)",
                 )
                 .bind(id.to_string())
                 .bind(&now)
+                .bind(SUPPORTED_SCHEMA_VERSION)
                 .execute(pool)
                 .await
                 .map_err(db_err)?;
@@ -390,6 +395,31 @@ impl SqliteStore {
         }
 
         Self::drop_legacy_card_edges_if_present(pool).await?;
+
+        // KAN-522: ALTER in writer-stamp columns on pre-v2 metadata tables.
+        for col in ["writer_version", "writer_commit"] {
+            let has_col: bool = sqlx::query_scalar(&format!(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('metadata') WHERE name = '{col}'"
+            ))
+            .fetch_one(pool)
+            .await
+            .map_err(db_err)?;
+            if !has_col {
+                sqlx::raw_sql(&format!("ALTER TABLE metadata ADD COLUMN {col} TEXT"))
+                    .execute(pool)
+                    .await
+                    .map_err(db_err)?;
+            }
+        }
+        // Once the ALTERs above have caught the schema up, normalise
+        // schema_version. Doing it unconditionally is idempotent and
+        // also self-heals any DBs where the field drifted.
+        sqlx::query("UPDATE metadata SET schema_version = ? WHERE id = 1 AND schema_version < ?")
+            .bind(SUPPORTED_SCHEMA_VERSION)
+            .bind(SUPPORTED_SCHEMA_VERSION)
+            .execute(pool)
+            .await
+            .map_err(db_err)?;
 
         Ok(())
     }
@@ -2037,6 +2067,97 @@ mod tests {
             assert!(
                 store.get_card(card_id).unwrap().is_none(),
                 "get_card should return None for permanently deleted card"
+            );
+        });
+    }
+
+    #[test]
+    fn test_fresh_db_records_schema_version_2() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("fresh.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+            let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+            assert_eq!(version, SUPPORTED_SCHEMA_VERSION);
+        });
+    }
+
+    #[test]
+    fn test_fresh_db_has_writer_version_and_writer_commit_columns() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("fresh.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let store = SqliteStore::open(&path).await.unwrap();
+            for col in ["writer_version", "writer_commit"] {
+                let exists: bool = sqlx::query_scalar(&format!(
+                    "SELECT COUNT(*) > 0 FROM pragma_table_info('metadata') WHERE name = '{col}'"
+                ))
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+                assert!(exists, "metadata.{col} column must exist on fresh DB");
+            }
+        });
+    }
+
+    #[test]
+    fn test_open_alters_in_writer_columns_on_legacy_v1_db() {
+        // Simulate a pre-KAN-522 SQLite file: metadata table without the
+        // writer_* columns and schema_version = 1. SqliteStore::open must
+        // ALTER in the new columns and bump schema_version to 2.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("legacy.db");
+        let rt = make_rt();
+        rt.block_on(async {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    SqliteConnectOptions::new()
+                        .filename(&path)
+                        .create_if_missing(true),
+                )
+                .await
+                .unwrap();
+            sqlx::raw_sql(
+                "CREATE TABLE metadata (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    instance_id TEXT NOT NULL,
+                    saved_at TEXT NOT NULL,
+                    schema_version INTEGER NOT NULL DEFAULT 1
+                );
+                INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+                VALUES (1, '550e8400-e29b-41d4-a716-446655440000', '2024-01-01T00:00:00Z', 1);",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            pool.close().await;
+
+            let store = SqliteStore::open(&path).await.unwrap();
+
+            for col in ["writer_version", "writer_commit"] {
+                let exists: bool = sqlx::query_scalar(&format!(
+                    "SELECT COUNT(*) > 0 FROM pragma_table_info('metadata') WHERE name = '{col}'"
+                ))
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+                assert!(exists, "metadata.{col} must be ALTERed in on legacy open");
+            }
+
+            let bumped: u32 =
+                sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                bumped, SUPPORTED_SCHEMA_VERSION,
+                "schema_version must be bumped to current on legacy open"
             );
         });
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1801,13 +1801,16 @@ impl PersistenceStore for SqliteStore {
 
         // Read back what checkpoint() just wrote so the caller sees the same
         // stamp that landed on disk.
-        let (saved_at_str, writer_version, writer_commit): (String, Option<String>, Option<String>) =
-            sqlx::query_as(
-                "SELECT saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
-            )
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|e| PersistenceError::Database(e.to_string()))?;
+        let (saved_at_str, writer_version, writer_commit): (
+            String,
+            Option<String>,
+            Option<String>,
+        ) = sqlx::query_as(
+            "SELECT saved_at, writer_version, writer_commit FROM metadata WHERE id = 1",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| PersistenceError::Database(e.to_string()))?;
         let saved_at = DateTime::parse_from_rfc3339(&saved_at_str)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?
             .with_timezone(&Utc);
@@ -2174,10 +2177,11 @@ mod tests {
         let rt = make_rt();
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
-                .fetch_one(&store.pool)
-                .await
-                .unwrap();
+            let version: u32 =
+                sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
             assert_eq!(version, SUPPORTED_SCHEMA_VERSION);
         });
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -273,8 +273,13 @@ impl SqliteStore {
         // step runs. Otherwise the legacy-table drops, the SCHEMA's
         // CREATE TABLE IF NOT EXISTS for tables the file lacks, and
         // migrate()'s ALTERs would all mutate a file we're about to refuse.
-        // Probe sqlite_master first so a fresh DB (no metadata table yet)
-        // proceeds normally without error.
+        //
+        // Why two round-trips rather than one correlated subquery: SQLite
+        // parses the inner SELECT eagerly at prepare time and errors with
+        // "no such table: metadata" on a fresh DB, even when an outer
+        // `WHERE EXISTS` would short-circuit it at runtime. So we split:
+        // first probe `sqlite_master`, then read `schema_version` only if
+        // the table is there. ~µs overhead, executes once per `open()`.
         let metadata_table_exists: bool = sqlx::query_scalar(
             "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='metadata'",
         )

--- a/crates/kanban-persistence/src/conflict/resolver.rs
+++ b/crates/kanban-persistence/src/conflict/resolver.rs
@@ -50,11 +50,15 @@ mod tests {
         let local = PersistenceMetadata {
             instance_id: Uuid::new_v4(),
             saved_at: now,
+            writer_version: None,
+            writer_commit: None,
         };
 
         let external = PersistenceMetadata {
             instance_id: Uuid::new_v4(),
             saved_at: later,
+            writer_version: None,
+            writer_commit: None,
         };
 
         assert!(resolver.should_use_external(&local, &external));
@@ -69,11 +73,15 @@ mod tests {
         let local = PersistenceMetadata {
             instance_id: Uuid::new_v4(),
             saved_at: now,
+            writer_version: None,
+            writer_commit: None,
         };
 
         let external = PersistenceMetadata {
             instance_id: Uuid::new_v4(),
             saved_at: earlier,
+            writer_version: None,
+            writer_commit: None,
         };
 
         assert!(!resolver.should_use_external(&local, &external));
@@ -88,11 +96,15 @@ mod tests {
         let local = PersistenceMetadata {
             instance_id: id,
             saved_at: now,
+            writer_version: None,
+            writer_commit: None,
         };
 
         let external = PersistenceMetadata {
             instance_id: id,
             saved_at: now,
+            writer_version: None,
+            writer_commit: None,
         };
 
         // Equal timestamps -> use local

--- a/crates/kanban-persistence/src/conflict/resolver.rs
+++ b/crates/kanban-persistence/src/conflict/resolver.rs
@@ -51,6 +51,7 @@ mod tests {
             instance_id: Uuid::new_v4(),
             saved_at: now,
             writer_version: None,
+            format_version: None,
             writer_commit: None,
         };
 
@@ -58,6 +59,7 @@ mod tests {
             instance_id: Uuid::new_v4(),
             saved_at: later,
             writer_version: None,
+            format_version: None,
             writer_commit: None,
         };
 
@@ -74,6 +76,7 @@ mod tests {
             instance_id: Uuid::new_v4(),
             saved_at: now,
             writer_version: None,
+            format_version: None,
             writer_commit: None,
         };
 
@@ -81,6 +84,7 @@ mod tests {
             instance_id: Uuid::new_v4(),
             saved_at: earlier,
             writer_version: None,
+            format_version: None,
             writer_commit: None,
         };
 
@@ -97,6 +101,7 @@ mod tests {
             instance_id: id,
             saved_at: now,
             writer_version: None,
+            format_version: None,
             writer_commit: None,
         };
 
@@ -104,6 +109,7 @@ mod tests {
             instance_id: id,
             saved_at: now,
             writer_version: None,
+            format_version: None,
             writer_commit: None,
         };
 

--- a/crates/kanban-persistence/src/error.rs
+++ b/crates/kanban-persistence/src/error.rs
@@ -26,6 +26,12 @@ pub enum PersistenceError {
 
     #[error("unsupported operation: {0}")]
     Unsupported(String),
+
+    #[error(
+        "file format v{file_version} is newer than this binary's max v{binary_max}; \
+         please upgrade kanban"
+    )]
+    UnsupportedFutureVersion { file_version: u32, binary_max: u32 },
 }
 
 pub type PersistenceResult<T> = Result<T, PersistenceError>;
@@ -51,6 +57,49 @@ impl From<PersistenceError> for kanban_domain::KanbanError {
                 kanban_domain::KanbanError::ConflictDetected { path, source }
             }
             PersistenceError::Unsupported(s) => kanban_domain::KanbanError::Internal(s),
+            PersistenceError::UnsupportedFutureVersion {
+                file_version,
+                binary_max,
+            } => kanban_domain::KanbanError::UnsupportedFutureVersion {
+                file_version,
+                binary_max,
+            },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::KanbanError;
+
+    #[test]
+    fn test_unsupported_future_version_display_mentions_both_versions() {
+        let err = PersistenceError::UnsupportedFutureVersion {
+            file_version: 99,
+            binary_max: 6,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("99"), "msg: {msg}");
+        assert!(msg.contains('6'), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_persistence_unsupported_future_version_maps_to_kanban_error() {
+        let pe = PersistenceError::UnsupportedFutureVersion {
+            file_version: 99,
+            binary_max: 6,
+        };
+        let ke: KanbanError = pe.into();
+        assert!(
+            matches!(
+                ke,
+                KanbanError::UnsupportedFutureVersion {
+                    file_version: 99,
+                    binary_max: 6
+                }
+            ),
+            "expected UnsupportedFutureVersion variant"
+        );
     }
 }

--- a/crates/kanban-persistence/src/traits.rs
+++ b/crates/kanban-persistence/src/traits.rs
@@ -142,6 +142,9 @@ pub enum FormatVersion {
 }
 
 impl FormatVersion {
+    /// The highest format version this binary can read or produce.
+    pub const MAX: Self = Self::V6;
+
     pub fn as_u32(self) -> u32 {
         match self {
             Self::V1 => 1,
@@ -198,4 +201,19 @@ pub trait ConflictResolver: Send + Sync {
         local_metadata: &PersistenceMetadata,
         external_metadata: &PersistenceMetadata,
     ) -> String;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_version_max_equals_v6() {
+        assert_eq!(FormatVersion::MAX, FormatVersion::V6);
+    }
+
+    #[test]
+    fn test_format_version_max_as_u32_matches_largest_variant() {
+        assert_eq!(FormatVersion::MAX.as_u32(), 6);
+    }
 }

--- a/crates/kanban-persistence/src/traits.rs
+++ b/crates/kanban-persistence/src/traits.rs
@@ -20,6 +20,12 @@ pub struct PersistenceMetadata {
     /// or builds without a git checkout (`"unknown"` is also possible).
     #[serde(default)]
     pub writer_commit: Option<String>,
+    /// Format version of the loaded file as the backend understands it
+    /// (JSON envelope version, SQLite schema_version). `None` when not
+    /// populated by the backend. Display-only — backends still own version
+    /// negotiation.
+    #[serde(default, skip_serializing)]
+    pub format_version: Option<u32>,
 }
 
 impl PersistenceMetadata {
@@ -29,6 +35,7 @@ impl PersistenceMetadata {
             saved_at: Utc::now(),
             writer_version: None,
             writer_commit: None,
+            format_version: None,
         }
     }
 

--- a/crates/kanban-persistence/src/traits.rs
+++ b/crates/kanban-persistence/src/traits.rs
@@ -12,6 +12,14 @@ pub struct PersistenceMetadata {
     pub instance_id: Uuid,
     /// When this data was saved
     pub saved_at: DateTime<Utc>,
+    /// Semver of the kanban that wrote this file. `None` on legacy files
+    /// written before the stamp was introduced.
+    #[serde(default)]
+    pub writer_version: Option<String>,
+    /// Git commit of the kanban that wrote this file. `None` on legacy files
+    /// or builds without a git checkout (`"unknown"` is also possible).
+    #[serde(default)]
+    pub writer_commit: Option<String>,
 }
 
 impl PersistenceMetadata {
@@ -19,7 +27,21 @@ impl PersistenceMetadata {
         Self {
             instance_id,
             saved_at: Utc::now(),
+            writer_version: None,
+            writer_commit: None,
         }
+    }
+
+    /// Stamp the writer identity onto the metadata. Backends call this on the
+    /// save path so the saved file remembers which kanban produced it.
+    pub fn with_writer_stamp(
+        mut self,
+        version: impl Into<String>,
+        commit: impl Into<String>,
+    ) -> Self {
+        self.writer_version = Some(version.into());
+        self.writer_commit = Some(commit.into());
+        self
     }
 }
 
@@ -215,5 +237,40 @@ mod tests {
     #[test]
     fn test_format_version_max_as_u32_matches_largest_variant() {
         assert_eq!(FormatVersion::MAX.as_u32(), 6);
+    }
+
+    #[test]
+    fn test_default_metadata_has_no_writer_stamp() {
+        let md = PersistenceMetadata::new(Uuid::nil());
+        assert!(md.writer_version.is_none());
+        assert!(md.writer_commit.is_none());
+    }
+
+    #[test]
+    fn test_with_writer_stamp_populates_both_fields() {
+        let md = PersistenceMetadata::new(Uuid::nil()).with_writer_stamp("0.6.0", "abc1234");
+        assert_eq!(md.writer_version.as_deref(), Some("0.6.0"));
+        assert_eq!(md.writer_commit.as_deref(), Some("abc1234"));
+    }
+
+    #[test]
+    fn test_metadata_serde_round_trips_with_writer_stamp() {
+        let md = PersistenceMetadata::new(Uuid::nil()).with_writer_stamp("0.6.0", "abc1234");
+        let json = serde_json::to_string(&md).unwrap();
+        let parsed: PersistenceMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.writer_version.as_deref(), Some("0.6.0"));
+        assert_eq!(parsed.writer_commit.as_deref(), Some("abc1234"));
+    }
+
+    #[test]
+    fn test_metadata_deserialize_legacy_envelope_missing_stamp_fields() {
+        // Old files lack writer_version / writer_commit. They must still parse.
+        let legacy = serde_json::json!({
+            "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+            "saved_at": "2024-01-01T00:00:00Z"
+        });
+        let parsed: PersistenceMetadata = serde_json::from_value(legacy).unwrap();
+        assert!(parsed.writer_version.is_none());
+        assert!(parsed.writer_commit.is_none());
     }
 }

--- a/crates/kanban-service/Cargo.toml
+++ b/crates/kanban-service/Cargo.toml
@@ -34,6 +34,6 @@ tempfile.workspace = true
 
 [dev-dependencies]
 kanban-persistence-json = { path = "../kanban-persistence-json" }
-kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", features = ["test-helpers"] }
 kanban-persistence = { path = "../kanban-persistence", features = ["test-helpers"] }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/kanban-service/src/backend.rs
+++ b/crates/kanban-service/src/backend.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{InMemoryStore, KanbanError, KanbanResult};
+use kanban_persistence::PersistenceMetadata;
 use uuid::Uuid;
 
 /// Combines the entity-level CRUD interface (`DataStore`) with the command
@@ -49,6 +50,14 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     /// Stable instance UUID used for own-write detection in file watchers.
     fn instance_id(&self) -> Uuid {
         Uuid::nil()
+    }
+
+    /// Metadata about the underlying persistence store (file format version,
+    /// writer kanban version, writer commit, last save time). Returns `None`
+    /// for in-memory backends or when no metadata has been observed yet.
+    /// Surfaced by the TUI's F12 diagnostics panel.
+    fn persistence_metadata(&self) -> Option<PersistenceMetadata> {
+        None
     }
 
     /// Run `f` as an atomic batch: every mutation commits or rolls
@@ -124,6 +133,13 @@ mod tests {
         store.reload().await.expect("reload should be a no-op");
     }
 
+    #[test]
+    fn test_in_memory_backend_returns_none_persistence_metadata() {
+        let store = InMemoryStore::new();
+        let backend: &dyn KanbanBackend = &store;
+        assert!(backend.persistence_metadata().is_none());
+    }
+
     // SQLite KanbanBackend lifecycle tests
     #[cfg(feature = "sqlite")]
     mod sqlite_backend_tests {
@@ -150,6 +166,29 @@ mod tests {
                 .flush()
                 .await
                 .expect("WAL checkpoint should not error");
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_sqlite_backend_exposes_metadata_after_flush() {
+            use crate::backend::KanbanBackend;
+            use crate::sqlite_backend::SqliteBackend;
+
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("md.sqlite3");
+            let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
+            backend.flush().await.unwrap();
+            let meta = backend
+                .persistence_metadata()
+                .expect("flushed sqlite backend must expose metadata");
+            assert_eq!(
+                meta.writer_version.as_deref(),
+                Some(kanban_core::KANBAN_VERSION),
+                "flushed sqlite backend must stamp writer_version"
+            );
+            assert_eq!(
+                meta.writer_commit.as_deref(),
+                Some(kanban_core::KANBAN_COMMIT),
+            );
         }
 
         #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -91,6 +91,14 @@ impl KanbanContext {
         Arc::clone(&self.backend)
     }
 
+    /// Metadata for the underlying persistence store: format version, writer
+    /// kanban version, writer commit, last save time. Returns `None` for
+    /// in-memory backends or before the underlying file has been loaded.
+    /// Surfaced by the TUI F12 diagnostics panel.
+    pub fn persistence_metadata(&self) -> Option<kanban_persistence::PersistenceMetadata> {
+        self.backend.persistence_metadata()
+    }
+
     /// Replace the active backend, discarding all undo/redo history.
     pub fn replace_backend(&mut self, backend: Arc<dyn KanbanBackend>) {
         tracing::info!("Replacing backend; undo/redo history discarded");

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -26,6 +26,10 @@ pub struct JsonDataStore {
     file_store: Arc<dyn PersistenceStore + Send + Sync>,
     /// `None` until first access. Populated by `ensure_loaded()`.
     inner: RwLock<Option<InMemoryStore>>,
+    /// Most-recent metadata observed from the underlying file. Updated on
+    /// load (via `ensure_loaded`) and after each save. Backs the F12
+    /// diagnostics panel.
+    last_metadata: RwLock<Option<PersistenceMetadata>>,
     dirty: AtomicBool,
 }
 
@@ -34,6 +38,7 @@ impl JsonDataStore {
         Self {
             file_store,
             inner: RwLock::new(None),
+            last_metadata: RwLock::new(None),
             dirty: AtomicBool::new(false),
         }
     }
@@ -61,10 +66,14 @@ impl JsonDataStore {
             .load_sync()
             .map_err(|e| KanbanError::Internal(format!("json_backend: load failed: {e}")))?;
 
-        if let Some((ss, _meta)) = loaded {
+        if let Some((ss, meta)) = loaded {
             let snapshot = snapshot_from_json_bytes(&ss.data)
                 .map_err(|e| KanbanError::Internal(format!("json_backend: parse failed: {e}")))?;
             store.apply_snapshot(snapshot)?;
+            let mut guard = self.last_metadata.write().map_err(|_| {
+                KanbanError::Internal("json_backend: last_metadata RwLock poisoned".into())
+            })?;
+            *guard = Some(meta);
         }
 
         // Acquire write lock only to swap in the built store.
@@ -116,10 +125,16 @@ impl JsonDataStore {
             .map_err(|e| KanbanError::Internal(format!("json_backend: snapshot serialise: {e}")))?;
         let metadata = PersistenceMetadata::new(self.file_store.instance_id());
 
-        self.file_store
+        let returned = self
+            .file_store
             .save(StoreSnapshot { data, metadata })
             .await
             .map_err(KanbanError::from)?;
+
+        let mut guard = self.last_metadata.write().map_err(|_| {
+            KanbanError::Internal("json_backend: last_metadata RwLock poisoned".into())
+        })?;
+        *guard = Some(returned);
 
         Ok(())
     }
@@ -339,6 +354,15 @@ impl KanbanBackend for JsonDataStore {
     fn instance_id(&self) -> Uuid {
         self.file_store.instance_id()
     }
+
+    fn persistence_metadata(&self) -> Option<PersistenceMetadata> {
+        // Surface what we've observed; do NOT trigger a load here — the
+        // backend may be queried before any DataStore call (e.g. when the TUI
+        // renders its diagnostics panel on startup), and we don't want
+        // persistence_metadata() to do I/O. ensure_loaded populates the
+        // cache as a side effect of any DataStore call, which is enough.
+        self.last_metadata.read().ok().and_then(|g| g.clone())
+    }
 }
 
 #[cfg(test)]
@@ -350,6 +374,36 @@ mod tests {
 
     fn make_store(path: &std::path::Path) -> JsonDataStore {
         JsonDataStore::new(Arc::new(JsonFileStore::new(path)))
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_json_backend_exposes_metadata_after_flush() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("md.json");
+        let jds = make_store(&path);
+        // Trigger a write so flush has something to persist.
+        jds.upsert_board(Board::new("B".to_string(), None)).unwrap();
+        jds.flush().await.unwrap();
+        let meta = jds
+            .persistence_metadata()
+            .expect("flushed JSON backend must expose metadata");
+        assert_eq!(
+            meta.writer_version.as_deref(),
+            Some(kanban_core::KANBAN_VERSION),
+        );
+        assert_eq!(
+            meta.writer_commit.as_deref(),
+            Some(kanban_core::KANBAN_COMMIT),
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_json_backend_metadata_is_none_before_any_load_or_save() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("untouched.json");
+        let jds = make_store(&path);
+        // No DataStore call yet → ensure_loaded never ran → cache empty.
+        assert!(jds.persistence_metadata().is_none());
     }
 
     /// Verifies that `ensure_loaded` no longer relies on `block_in_place`, so

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -70,8 +70,7 @@ impl JsonDataStore {
         let loaded = self.file_store.load_sync().map_err(KanbanError::from)?;
 
         if let Some((ss, meta)) = loaded {
-            let snapshot = snapshot_from_json_bytes(&ss.data)
-                .map_err(|e| KanbanError::Internal(format!("json_backend: parse failed: {e}")))?;
+            let snapshot = snapshot_from_json_bytes(&ss.data).map_err(KanbanError::from)?;
             store.apply_snapshot(snapshot)?;
             let mut guard = self.last_metadata.write().map_err(|_| {
                 KanbanError::Internal("json_backend: last_metadata RwLock poisoned".into())
@@ -124,8 +123,7 @@ impl JsonDataStore {
             store.snapshot()?
         };
 
-        let data = snapshot_to_json_bytes(&snapshot)
-            .map_err(|e| KanbanError::Internal(format!("json_backend: snapshot serialise: {e}")))?;
+        let data = snapshot_to_json_bytes(&snapshot).map_err(KanbanError::from)?;
         let metadata = PersistenceMetadata::new(self.file_store.instance_id());
 
         let returned = self

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -61,10 +61,13 @@ impl JsonDataStore {
         // Perform all I/O and build the store outside any lock.
         let store = InMemoryStore::new();
 
-        let loaded = self
-            .file_store
-            .load_sync()
-            .map_err(|e| KanbanError::Internal(format!("json_backend: load failed: {e}")))?;
+        // Convert via the From impl rather than stringifying — that way typed
+        // variants such as `UnsupportedFutureVersion` and `ConflictDetected`
+        // survive across the persistence/service boundary and reach the user
+        // surfaces (CLI, MCP, TUI) intact. Stringifying them flattens
+        // everything into KanbanError::Internal and breaks discriminators
+        // like KanbanError::is_unsupported_future_version().
+        let loaded = self.file_store.load_sync().map_err(KanbanError::from)?;
 
         if let Some((ss, meta)) = loaded {
             let snapshot = snapshot_from_json_bytes(&ss.data)

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -16,13 +16,22 @@ pub struct SqliteBackend {
     /// In-session command log. The on-disk `command_log` table exists
     /// in the schema but is not yet wired through this backend.
     mem: InMemoryStore,
+    /// Most-recent metadata observed from the underlying DB. Populated on
+    /// `open()` and refreshed inside `flush()` after the writer-stamp UPDATE.
+    /// Mirrors `JsonDataStore::last_metadata` so `persistence_metadata()` —
+    /// called once per TUI render via the F12 diagnostics panel — is a
+    /// RwLock read instead of a SELECT round-trip.
+    last_metadata: std::sync::RwLock<Option<PersistenceMetadata>>,
 }
 
 impl SqliteBackend {
     pub async fn open(locator: &str) -> KanbanResult<Self> {
+        let db = SqliteStore::open(locator).await?;
+        let initial = db.read_metadata_sync()?;
         Ok(Self {
-            db: SqliteStore::open(locator).await?,
+            db,
             mem: InMemoryStore::new(),
+            last_metadata: std::sync::RwLock::new(initial),
         })
     }
 }
@@ -197,7 +206,14 @@ impl crate::backend::KanbanBackend for SqliteBackend {
         // land in the main DB, so the writer attribution should land
         // alongside it.
         self.db.stamp_writer().await?;
-        self.db.checkpoint().await
+        self.db.checkpoint().await?;
+        // Refresh the cached metadata so subsequent persistence_metadata()
+        // calls reflect what was just stamped without re-issuing a SELECT.
+        let fresh = self.db.read_metadata_sync()?;
+        if let Ok(mut guard) = self.last_metadata.write() {
+            *guard = fresh;
+        }
+        Ok(())
     }
 
     fn instance_id(&self) -> Uuid {
@@ -205,6 +221,6 @@ impl crate::backend::KanbanBackend for SqliteBackend {
     }
 
     fn persistence_metadata(&self) -> Option<PersistenceMetadata> {
-        self.db.read_metadata_sync().ok().flatten()
+        self.last_metadata.read().ok().and_then(|g| g.clone())
     }
 }

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -7,7 +7,7 @@ use kanban_domain::{
     ArchivedCard, Board, Card, Column, DependencyGraph, GraphMutFn, InMemoryStore, KanbanResult,
     Snapshot, Sprint,
 };
-use kanban_persistence::PersistenceStore;
+use kanban_persistence::{PersistenceMetadata, PersistenceStore};
 use kanban_persistence_sqlite::SqliteStore;
 use uuid::Uuid;
 
@@ -198,5 +198,9 @@ impl crate::backend::KanbanBackend for SqliteBackend {
 
     fn instance_id(&self) -> Uuid {
         <SqliteStore as PersistenceStore>::instance_id(&self.db)
+    }
+
+    fn persistence_metadata(&self) -> Option<PersistenceMetadata> {
+        self.db.read_metadata_sync().ok().flatten()
     }
 }

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -4,8 +4,8 @@ use kanban_domain::command_store::CommandStore;
 use kanban_domain::commands::Command;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, DependencyGraph, GraphMutFn, InMemoryStore, KanbanResult,
-    Snapshot, Sprint,
+    ArchivedCard, Board, Card, Column, DependencyGraph, GraphMutFn, InMemoryStore, KanbanError,
+    KanbanResult, Snapshot, Sprint,
 };
 use kanban_persistence::{PersistenceMetadata, PersistenceStore};
 use kanban_persistence_sqlite::SqliteStore;
@@ -209,10 +209,13 @@ impl crate::backend::KanbanBackend for SqliteBackend {
         self.db.checkpoint().await?;
         // Refresh the cached metadata so subsequent persistence_metadata()
         // calls reflect what was just stamped without re-issuing a SELECT.
+        // Propagate poison errors rather than swallowing — symmetric with
+        // JsonDataStore::do_flush's handling of the same RwLock pattern.
         let fresh = self.db.read_metadata_sync()?;
-        if let Ok(mut guard) = self.last_metadata.write() {
-            *guard = fresh;
-        }
+        let mut guard = self.last_metadata.write().map_err(|_| {
+            KanbanError::Internal("sqlite_backend: last_metadata RwLock poisoned".into())
+        })?;
+        *guard = fresh;
         Ok(())
     }
 

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -193,6 +193,10 @@ impl crate::backend::KanbanBackend for SqliteBackend {
     }
 
     async fn flush(&self) -> KanbanResult<()> {
+        // Stamp before truncating the WAL: anything in the WAL is about to
+        // land in the main DB, so the writer attribution should land
+        // alongside it.
+        self.db.stamp_writer().await?;
         self.db.checkpoint().await
     }
 

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -102,9 +102,11 @@ impl StoreManager {
         if self.is_sqlite(locator) {
             #[cfg(feature = "sqlite")]
             {
-                let backend = crate::sqlite_backend::SqliteBackend::open(locator)
-                    .await
-                    .map_err(|e| KanbanError::Database(e.to_string()))?;
+                // Propagate via `?` (no stringification) so typed variants like
+                // UnsupportedFutureVersion survive across make_backend to the
+                // CLI / MCP / TUI surfaces, mirroring the JSON path's preserved
+                // From<PersistenceError> for KanbanError mapping.
+                let backend = crate::sqlite_backend::SqliteBackend::open(locator).await?;
                 return Ok(std::sync::Arc::new(backend));
             }
             #[cfg(not(feature = "sqlite"))]

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -85,6 +85,29 @@ async fn test_context_open_returns_typed_unsupported_future_version_for_v99_json
     }
 }
 
+/// SQLite parallel of the JSON future-version test above. A SQLite file
+/// whose `metadata.schema_version` exceeds `SUPPORTED_SCHEMA_VERSION` must
+/// surface as the typed `KanbanError::UnsupportedFutureVersion` through
+/// `KanbanContext::open` — not as a stringified `Database(...)` or `Internal`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_context_open_returns_typed_unsupported_future_version_for_v99_sqlite_file() {
+    use kanban_service::sqlite_backend::SqliteBackend;
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("future.db");
+    kanban_persistence_sqlite::write_test_metadata_with_schema_version(&path, 99)
+        .await
+        .unwrap();
+
+    let err = match SqliteBackend::open(path.to_str().unwrap()).await {
+        Ok(_) => panic!("v99 SQLite DB must refuse to open via SqliteBackend"),
+        Err(e) => e,
+    };
+    assert!(
+        err.is_unsupported_future_version(),
+        "expected typed UnsupportedFutureVersion variant, got: {err:?}"
+    );
+}
+
 /// `KanbanContext::persistence_metadata` delegates to the backend and surfaces
 /// the writer-stamp recorded on the most recent save.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -38,6 +38,53 @@ async fn test_can_undo_returns_false_on_fresh_context() {
     assert!(!ctx.can_redo());
 }
 
+/// A future-format JSON file must surface as the typed
+/// `KanbanError::UnsupportedFutureVersion` variant through the service-layer
+/// stack — not as a stringified `Internal(...)`. Otherwise downstream surfaces
+/// (CLI / MCP / TUI) can't discriminate the case and `is_unsupported_future_version()`
+/// returns false.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_context_open_returns_typed_unsupported_future_version_for_v99_json_file() {
+    use serde_json::json;
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("future.json");
+    let v99 = json!({
+        "version": 99,
+        "metadata": {
+            "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+            "saved_at": "2030-01-01T00:00:00Z"
+        },
+        "data": {}
+    });
+    std::fs::write(&path, v99.to_string()).unwrap();
+
+    // KanbanContext::open is what every surface (CLI, MCP, TUI) calls.
+    // The first command_count() inside open() triggers ensure_loaded which
+    // hits the refusal guard. Use boards() to force the same load path via
+    // a non-deferred call too.
+    let backend = make_json_backend(&path);
+    let ctx = KanbanContext::open(backend, AppConfig::default()).await;
+
+    match ctx {
+        Err(e) => assert!(
+            e.is_unsupported_future_version(),
+            "expected typed UnsupportedFutureVersion variant, got: {e:?}"
+        ),
+        Ok(ctx) => {
+            // KanbanContext::open may not trigger the read on a JSON backend
+            // until the first DataStore call; try once and assert the typed
+            // error then.
+            let err = ctx
+                .boards()
+                .expect_err("listing boards on a v99 file must fail");
+            assert!(
+                err.is_unsupported_future_version(),
+                "expected typed UnsupportedFutureVersion variant, got: {err:?}"
+            );
+        }
+    }
+}
+
 /// `KanbanContext::persistence_metadata` delegates to the backend and surfaces
 /// the writer-stamp recorded on the most recent save.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -38,6 +38,30 @@ async fn test_can_undo_returns_false_on_fresh_context() {
     assert!(!ctx.can_redo());
 }
 
+/// `KanbanContext::persistence_metadata` delegates to the backend and surfaces
+/// the writer-stamp recorded on the most recent save.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_context_persistence_metadata_returns_writer_stamp_after_save() -> KanbanResult<()> {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("md.json");
+    let mut ctx = KanbanContext::open(make_json_backend(&path), AppConfig::default()).await?;
+    ctx.create_board("Stamped".into(), None)?;
+    ctx.save().await?;
+
+    let meta = ctx
+        .persistence_metadata()
+        .expect("metadata must be exposed after save");
+    assert_eq!(
+        meta.writer_version.as_deref(),
+        Some(kanban_core::KANBAN_VERSION),
+    );
+    assert_eq!(
+        meta.writer_commit.as_deref(),
+        Some(kanban_core::KANBAN_COMMIT),
+    );
+    Ok(())
+}
+
 /// `KanbanContext::open_deferred` with a JSON backend must not touch the filesystem.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_open_context_json_does_no_io_at_construction() {

--- a/crates/kanban-tui/src/components/footer.rs
+++ b/crates/kanban-tui/src/components/footer.rs
@@ -85,7 +85,7 @@ pub fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
     let error_badge: String = {
         let (unread_count,) = app.with_error_log(|log| (log.unread_count,));
         if unread_count > 0 {
-            format!("  [!] {} new  F12: error log", unread_count)
+            format!("  [!] {} new  F12: diagnostics", unread_count)
         } else {
             String::new()
         }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -134,6 +134,10 @@ impl TuiContext {
         self.inner.data_store()
     }
 
+    pub fn persistence_metadata(&self) -> Option<kanban_persistence::PersistenceMetadata> {
+        self.inner.persistence_metadata()
+    }
+
     #[cfg(any(test, feature = "test-helpers"))]
     pub fn inner_mut(&mut self) -> &mut KanbanContext {
         &mut self.inner

--- a/crates/kanban-tui/src/ui/error_log.rs
+++ b/crates/kanban-tui/src/ui/error_log.rs
@@ -10,50 +10,89 @@ use ratatui::{
     Frame,
 };
 
-/// Build the header text shown above the log entries in the Diagnostics
+/// One row in the diagnostics header. `warn` flags rows that indicate a
+/// version mismatch — currently just the Writer row when the file was
+/// produced by a kanban newer than this binary.
+struct DiagnosticsRow {
+    label: &'static str,
+    value: String,
+    warn: bool,
+}
+
+/// Build the header rows shown above the log entries in the Diagnostics
 /// popup. Pure: takes only the inputs it renders so it can be unit-tested
 /// without spinning up an `App`.
-///
-/// Returns one `(label, value)` row per fact. Renders to plain Strings; the
-/// caller is responsible for any per-row styling.
 fn diagnostics_rows(
     save_file: Option<&str>,
     metadata: Option<&PersistenceMetadata>,
-) -> Vec<(&'static str, String)> {
-    let mut rows: Vec<(&'static str, String)> = Vec::new();
+) -> Vec<DiagnosticsRow> {
+    let mut rows: Vec<DiagnosticsRow> = Vec::new();
 
-    rows.push((
-        "File",
-        save_file.map(str::to_string).unwrap_or_else(|| "(in-memory)".to_string()),
-    ));
+    rows.push(DiagnosticsRow {
+        label: "File",
+        value: save_file
+            .map(str::to_string)
+            .unwrap_or_else(|| "(in-memory)".to_string()),
+        warn: false,
+    });
 
     let format = metadata
         .and_then(|m| m.format_version)
         .map(|v| format!("v{v}"))
         .unwrap_or_else(|| "unknown".to_string());
-    rows.push(("Format", format));
+    rows.push(DiagnosticsRow {
+        label: "Format",
+        value: format,
+        warn: false,
+    });
 
+    let writer_is_newer = metadata
+        .and_then(|m| m.writer_version.as_deref())
+        .map(|v| version_is_newer_than_self(v, kanban_core::KANBAN_VERSION))
+        .unwrap_or(false);
     let writer = match metadata {
         Some(m) => match (m.writer_version.as_deref(), m.writer_commit.as_deref()) {
-            (Some(v), Some(c)) => format!("kanban {v} ({})", short_commit(c)),
-            (Some(v), None) => format!("kanban {v}"),
+            (Some(v), Some(c)) => {
+                let base = format!("kanban {v} ({})", short_commit(c));
+                if writer_is_newer {
+                    format!("{base} (newer than this binary)")
+                } else {
+                    base
+                }
+            }
+            (Some(v), None) => {
+                if writer_is_newer {
+                    format!("kanban {v} (newer than this binary)")
+                } else {
+                    format!("kanban {v}")
+                }
+            }
             (None, _) => "unknown (pre-stamp file)".to_string(),
         },
         None => "(no metadata)".to_string(),
     };
-    rows.push(("Writer", writer));
+    rows.push(DiagnosticsRow {
+        label: "Writer",
+        value: writer,
+        warn: writer_is_newer,
+    });
 
-    rows.push((
-        "Binary",
-        format!(
+    rows.push(DiagnosticsRow {
+        label: "Binary",
+        value: format!(
             "kanban {} ({})",
             kanban_core::KANBAN_VERSION,
             short_commit(kanban_core::KANBAN_COMMIT)
         ),
-    ));
+        warn: false,
+    });
 
     if let Some(m) = metadata {
-        rows.push(("Saved at", m.saved_at.to_rfc3339()));
+        rows.push(DiagnosticsRow {
+            label: "Saved at",
+            value: m.saved_at.to_rfc3339(),
+            warn: false,
+        });
     }
 
     rows
@@ -64,6 +103,29 @@ fn short_commit(c: &str) -> String {
         c.to_string()
     } else {
         c.chars().take(8).collect()
+    }
+}
+
+/// Compare two `MAJOR.MINOR.PATCH` strings. Returns `true` when `file_version`
+/// is strictly greater than `self_version`. Unparseable strings (pre-release
+/// suffixes, missing dots, etc.) conservatively return `false` — the
+/// diagnostics row stays calm rather than crying wolf.
+fn version_is_newer_than_self(file_version: &str, self_version: &str) -> bool {
+    fn parse(s: &str) -> Option<(u32, u32, u32)> {
+        let mut parts = s.split('.');
+        let a = parts.next()?.parse().ok()?;
+        let b = parts.next()?.parse().ok()?;
+        let c_raw = parts.next()?;
+        // Reject anything past the patch number, including prerelease suffixes.
+        if parts.next().is_some() {
+            return None;
+        }
+        let c = c_raw.parse().ok()?;
+        Some((a, b, c))
+    }
+    match (parse(file_version), parse(self_version)) {
+        (Some(file), Some(me)) => file > me,
+        _ => false,
     }
 }
 
@@ -98,15 +160,22 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
 
     let mut header_lines: Vec<Line> = rows
         .into_iter()
-        .map(|(label, value)| {
+        .map(|row| {
+            let value_style = if row.warn {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
             Line::from(vec![
                 Span::styled(
-                    format!("{label:<10}"),
+                    format!("{:<10}", row.label),
                     Style::default()
                         .fg(Color::Cyan)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::raw(value),
+                Span::styled(row.value, value_style),
             ])
         })
         .collect();
@@ -173,16 +242,21 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use uuid::Uuid;
 
-    fn rows_to_map(rows: Vec<(&'static str, String)>) -> std::collections::HashMap<&'static str, String> {
-        rows.into_iter().collect()
+    fn rows_to_map(
+        rows: Vec<DiagnosticsRow>,
+    ) -> std::collections::HashMap<&'static str, (String, bool)> {
+        rows.into_iter()
+            .map(|r| (r.label, (r.value, r.warn)))
+            .collect()
     }
 
     #[test]
     fn test_diagnostics_rows_with_no_save_file_and_no_metadata() {
         let rows = rows_to_map(diagnostics_rows(None, None));
-        assert_eq!(rows.get("File").unwrap(), "(in-memory)");
-        assert_eq!(rows.get("Format").unwrap(), "unknown");
-        assert_eq!(rows.get("Writer").unwrap(), "(no metadata)");
+        assert_eq!(rows.get("File").unwrap().0, "(in-memory)");
+        assert_eq!(rows.get("Format").unwrap().0, "unknown");
+        assert_eq!(rows.get("Writer").unwrap().0, "(no metadata)");
+        assert!(!rows.get("Writer").unwrap().1, "no metadata must not warn");
         assert!(rows.contains_key("Binary"));
         assert!(!rows.contains_key("Saved at"));
     }
@@ -197,11 +271,13 @@ mod tests {
             format_version: Some(6),
         };
         let rows = rows_to_map(diagnostics_rows(Some("/tmp/board.json"), Some(&meta)));
-        assert_eq!(rows.get("File").unwrap(), "/tmp/board.json");
-        assert_eq!(rows.get("Format").unwrap(), "v6");
-        let writer = rows.get("Writer").unwrap();
+        assert_eq!(rows.get("File").unwrap().0, "/tmp/board.json");
+        assert_eq!(rows.get("Format").unwrap().0, "v6");
+        let (writer, warn) = rows.get("Writer").unwrap();
         assert!(writer.contains("0.6.0"), "writer line: {writer}");
         assert!(writer.contains("18e98c48"), "must show short commit: {writer}");
+        // Writer == self_version, so no mismatch.
+        assert!(!warn, "matching version must not warn");
         assert!(rows.contains_key("Saved at"));
     }
 
@@ -215,8 +291,64 @@ mod tests {
             format_version: Some(6),
         };
         let rows = rows_to_map(diagnostics_rows(Some("/tmp/legacy.json"), Some(&meta)));
-        assert_eq!(rows.get("Writer").unwrap(), "unknown (pre-stamp file)");
-        assert_eq!(rows.get("Format").unwrap(), "v6");
+        assert_eq!(rows.get("Writer").unwrap().0, "unknown (pre-stamp file)");
+        assert!(
+            !rows.get("Writer").unwrap().1,
+            "missing stamp must not warn"
+        );
+        assert_eq!(rows.get("Format").unwrap().0, "v6");
+    }
+
+    #[test]
+    fn test_diagnostics_rows_warns_when_writer_version_newer_than_binary() {
+        // Construct a writer version that is guaranteed to be greater than the
+        // current binary's. We bump the major component so this is robust
+        // against any future CARGO_PKG_VERSION bump.
+        let (major, _minor, _patch) = parse_version(kanban_core::KANBAN_VERSION).unwrap();
+        let future = format!("{}.0.0", major + 1);
+        let meta = PersistenceMetadata {
+            instance_id: Uuid::nil(),
+            saved_at: Utc.with_ymd_and_hms(2030, 1, 1, 0, 0, 0).unwrap(),
+            writer_version: Some(future.clone()),
+            writer_commit: Some("abcdef0123456789".into()),
+            format_version: Some(6),
+        };
+        let rows = rows_to_map(diagnostics_rows(Some("/tmp/future.json"), Some(&meta)));
+        let (writer, warn) = rows.get("Writer").unwrap();
+        assert!(*warn, "future writer must warn: {writer}");
+        assert!(
+            writer.contains("newer than this binary"),
+            "writer line must call out the mismatch: {writer}"
+        );
+    }
+
+    #[test]
+    fn test_version_is_newer_handles_major_minor_patch() {
+        assert!(version_is_newer_than_self("1.0.0", "0.9.9"));
+        assert!(version_is_newer_than_self("0.7.0", "0.6.9"));
+        assert!(version_is_newer_than_self("0.6.1", "0.6.0"));
+        assert!(!version_is_newer_than_self("0.6.0", "0.6.0"));
+        assert!(!version_is_newer_than_self("0.5.9", "0.6.0"));
+    }
+
+    #[test]
+    fn test_version_is_newer_returns_false_on_unparseable_strings() {
+        // Prerelease suffixes, leading 'v', empty strings: conservatively
+        // do not warn.
+        assert!(!version_is_newer_than_self("0.7.0-rc1", "0.6.0"));
+        assert!(!version_is_newer_than_self("v0.7.0", "0.6.0"));
+        assert!(!version_is_newer_than_self("", "0.6.0"));
+        assert!(!version_is_newer_than_self("garbage", "0.6.0"));
+    }
+
+    /// Test helper exposed within the test module so the warns-when-newer
+    /// test can construct a guaranteed-greater version without hard-coding it.
+    fn parse_version(s: &str) -> Option<(u32, u32, u32)> {
+        let mut parts = s.split('.');
+        let a = parts.next()?.parse().ok()?;
+        let b = parts.next()?.parse().ok()?;
+        let c = parts.next()?.parse().ok()?;
+        Some((a, b, c))
     }
 
     #[test]

--- a/crates/kanban-tui/src/ui/error_log.rs
+++ b/crates/kanban-tui/src/ui/error_log.rs
@@ -286,7 +286,10 @@ mod tests {
         assert_eq!(rows.get("Format").unwrap().0, "v6");
         let (writer, warn) = rows.get("Writer").unwrap();
         assert!(writer.contains("0.6.0"), "writer line: {writer}");
-        assert!(writer.contains("18e98c48"), "must show short commit: {writer}");
+        assert!(
+            writer.contains("18e98c48"),
+            "must show short commit: {writer}"
+        );
         // Writer == self_version, so no mismatch.
         assert!(!warn, "matching version must not warn");
         assert!(rows.contains_key("Saved at"));

--- a/crates/kanban-tui/src/ui/error_log.rs
+++ b/crates/kanban-tui/src/ui/error_log.rs
@@ -1,6 +1,7 @@
 use crate::app::App;
 use crate::components::centered_rect;
 use crate::error_log::LogLevel;
+use kanban_persistence::PersistenceMetadata;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
@@ -9,39 +10,114 @@ use ratatui::{
     Frame,
 };
 
+/// Build the header text shown above the log entries in the Diagnostics
+/// popup. Pure: takes only the inputs it renders so it can be unit-tested
+/// without spinning up an `App`.
+///
+/// Returns one `(label, value)` row per fact. Renders to plain Strings; the
+/// caller is responsible for any per-row styling.
+fn diagnostics_rows(
+    save_file: Option<&str>,
+    metadata: Option<&PersistenceMetadata>,
+) -> Vec<(&'static str, String)> {
+    let mut rows: Vec<(&'static str, String)> = Vec::new();
+
+    rows.push((
+        "File",
+        save_file.map(str::to_string).unwrap_or_else(|| "(in-memory)".to_string()),
+    ));
+
+    let format = metadata
+        .and_then(|m| m.format_version)
+        .map(|v| format!("v{v}"))
+        .unwrap_or_else(|| "unknown".to_string());
+    rows.push(("Format", format));
+
+    let writer = match metadata {
+        Some(m) => match (m.writer_version.as_deref(), m.writer_commit.as_deref()) {
+            (Some(v), Some(c)) => format!("kanban {v} ({})", short_commit(c)),
+            (Some(v), None) => format!("kanban {v}"),
+            (None, _) => "unknown (pre-stamp file)".to_string(),
+        },
+        None => "(no metadata)".to_string(),
+    };
+    rows.push(("Writer", writer));
+
+    rows.push((
+        "Binary",
+        format!(
+            "kanban {} ({})",
+            kanban_core::KANBAN_VERSION,
+            short_commit(kanban_core::KANBAN_COMMIT)
+        ),
+    ));
+
+    if let Some(m) = metadata {
+        rows.push(("Saved at", m.saved_at.to_rfc3339()));
+    }
+
+    rows
+}
+
+fn short_commit(c: &str) -> String {
+    if c == "unknown" || c.is_empty() {
+        c.to_string()
+    } else {
+        c.chars().take(8).collect()
+    }
+}
+
 pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
     let area = centered_rect(85, 75, frame.area());
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(" Error Log [F12] ")
+        .title(" Diagnostics [F12] ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Red));
+        .border_style(Style::default().fg(Color::Cyan));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
+
+    let rows = diagnostics_rows(
+        app.persistence.save_file.as_deref(),
+        app.ctx.persistence_metadata().as_ref(),
+    );
+    let total = app.with_error_log(|log| log.entries.len());
+    let header_height = (rows.len() as u16) + 2; // rows + blank line + "{n} entries"
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .horizontal_margin(1)
         .constraints([
-            Constraint::Length(2),
+            Constraint::Length(header_height),
             Constraint::Min(0),
             Constraint::Length(2),
         ])
         .split(inner);
 
-    let total = app.with_error_log(|log| log.entries.len());
-    let header = Paragraph::new(vec![
-        Line::from(Span::styled(
-            format!("{total} entries"),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::from(""),
-    ]);
-    frame.render_widget(header, chunks[0]);
+    let mut header_lines: Vec<Line> = rows
+        .into_iter()
+        .map(|(label, value)| {
+            Line::from(vec![
+                Span::styled(
+                    format!("{label:<10}"),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(value),
+            ])
+        })
+        .collect();
+    header_lines.push(Line::from(""));
+    header_lines.push(Line::from(Span::styled(
+        format!("{total} entries"),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )));
+    frame.render_widget(Paragraph::new(header_lines), chunks[0]);
 
     let viewport_height = chunks[1].height as usize;
     let total_entries = total;
@@ -89,4 +165,72 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
             .add_modifier(Modifier::ITALIC),
     )));
     frame.render_widget(Paragraph::new(footer_lines), chunks[2]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use uuid::Uuid;
+
+    fn rows_to_map(rows: Vec<(&'static str, String)>) -> std::collections::HashMap<&'static str, String> {
+        rows.into_iter().collect()
+    }
+
+    #[test]
+    fn test_diagnostics_rows_with_no_save_file_and_no_metadata() {
+        let rows = rows_to_map(diagnostics_rows(None, None));
+        assert_eq!(rows.get("File").unwrap(), "(in-memory)");
+        assert_eq!(rows.get("Format").unwrap(), "unknown");
+        assert_eq!(rows.get("Writer").unwrap(), "(no metadata)");
+        assert!(rows.contains_key("Binary"));
+        assert!(!rows.contains_key("Saved at"));
+    }
+
+    #[test]
+    fn test_diagnostics_rows_with_full_metadata() {
+        let meta = PersistenceMetadata {
+            instance_id: Uuid::nil(),
+            saved_at: Utc.with_ymd_and_hms(2026, 5, 23, 12, 0, 0).unwrap(),
+            writer_version: Some("0.6.0".into()),
+            writer_commit: Some("18e98c4810dca9f69c7a894aa7a9ba009740cb1e".into()),
+            format_version: Some(6),
+        };
+        let rows = rows_to_map(diagnostics_rows(Some("/tmp/board.json"), Some(&meta)));
+        assert_eq!(rows.get("File").unwrap(), "/tmp/board.json");
+        assert_eq!(rows.get("Format").unwrap(), "v6");
+        let writer = rows.get("Writer").unwrap();
+        assert!(writer.contains("0.6.0"), "writer line: {writer}");
+        assert!(writer.contains("18e98c48"), "must show short commit: {writer}");
+        assert!(rows.contains_key("Saved at"));
+    }
+
+    #[test]
+    fn test_diagnostics_rows_with_legacy_metadata_missing_writer_stamp() {
+        let meta = PersistenceMetadata {
+            instance_id: Uuid::nil(),
+            saved_at: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+            writer_version: None,
+            writer_commit: None,
+            format_version: Some(6),
+        };
+        let rows = rows_to_map(diagnostics_rows(Some("/tmp/legacy.json"), Some(&meta)));
+        assert_eq!(rows.get("Writer").unwrap(), "unknown (pre-stamp file)");
+        assert_eq!(rows.get("Format").unwrap(), "v6");
+    }
+
+    #[test]
+    fn test_short_commit_truncates_long_hashes() {
+        assert_eq!(short_commit("18e98c4810dca9f69c7a"), "18e98c48");
+    }
+
+    #[test]
+    fn test_short_commit_preserves_unknown_marker() {
+        assert_eq!(short_commit("unknown"), "unknown");
+    }
+
+    #[test]
+    fn test_short_commit_preserves_empty() {
+        assert_eq!(short_commit(""), "");
+    }
 }

--- a/crates/kanban-tui/src/ui/error_log.rs
+++ b/crates/kanban-tui/src/ui/error_log.rs
@@ -146,19 +146,18 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
         app.ctx.persistence_metadata().as_ref(),
     );
     let total = app.with_error_log(|log| log.entries.len());
-    let header_height = (rows.len() as u16) + 2; // rows + blank line + "{n} entries"
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .horizontal_margin(1)
         .constraints([
-            Constraint::Length(header_height),
+            Constraint::Length(rows.len() as u16),
             Constraint::Min(0),
             Constraint::Length(2),
         ])
         .split(inner);
 
-    let mut header_lines: Vec<Line> = rows
+    let header_lines: Vec<Line> = rows
         .into_iter()
         .map(|row| {
             let value_style = if row.warn {
@@ -179,16 +178,24 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
             ])
         })
         .collect();
-    header_lines.push(Line::from(""));
-    header_lines.push(Line::from(Span::styled(
-        format!("{total} entries"),
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
-    )));
     frame.render_widget(Paragraph::new(header_lines), chunks[0]);
 
-    let viewport_height = chunks[1].height as usize;
+    // Log entries sit inside a bordered block whose top border doubles as
+    // the visual separator between the diagnostics rows above and the
+    // entries below. The title carries the section header + entry count.
+    let log_block = Block::default()
+        .borders(Borders::TOP)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(Span::styled(
+            format!(" Log entries ({total}) "),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let log_inner = log_block.inner(chunks[1]);
+    frame.render_widget(log_block, chunks[1]);
+
+    let viewport_height = log_inner.height as usize;
     let total_entries = total;
 
     let scroll_offset = app.ui_state.error_log_list.get_scroll_offset();
@@ -216,7 +223,7 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
             .collect()
     });
 
-    frame.render_widget(Paragraph::new(visible), chunks[1]);
+    frame.render_widget(Paragraph::new(visible), log_inner);
 
     let items_above = scroll_offset.min(total_entries);
     let items_below = total_entries.saturating_sub(scroll_offset + viewport_height);

--- a/crates/kanban-tui/src/ui/error_log.rs
+++ b/crates/kanban-tui/src/ui/error_log.rs
@@ -152,6 +152,7 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
         .horizontal_margin(1)
         .constraints([
             Constraint::Length(rows.len() as u16),
+            Constraint::Length(1), // blank row between diagnostics and log sections
             Constraint::Min(0),
             Constraint::Length(2),
         ])
@@ -167,9 +168,12 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
             } else {
                 Style::default()
             };
+            // Leading space on the label so the row content aligns with the
+            // "Log entries" title below (the title carries its own leading
+            // space inside the border).
             Line::from(vec![
                 Span::styled(
-                    format!("{:<10}", row.label),
+                    format!(" {:<10}", row.label),
                     Style::default()
                         .fg(Color::Cyan)
                         .add_modifier(Modifier::BOLD),
@@ -192,8 +196,8 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         ));
-    let log_inner = log_block.inner(chunks[1]);
-    frame.render_widget(log_block, chunks[1]);
+    let log_inner = log_block.inner(chunks[2]);
+    frame.render_widget(log_block, chunks[2]);
 
     let viewport_height = log_inner.height as usize;
     let total_entries = total;
@@ -240,7 +244,7 @@ pub fn render_error_log_popup(app: &App, frame: &mut Frame) {
             .fg(Color::DarkGray)
             .add_modifier(Modifier::ITALIC),
     )));
-    frame.render_widget(Paragraph::new(footer_lines), chunks[2]);
+    frame.render_widget(Paragraph::new(footer_lines), chunks[3]);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes the silent-data-loss class of failure where an older kanban silently coerced a newer file's format down to one it understood and dropped fields it didn't know. Also tightens the cross-surface error contract so the typed refusal reaches CLI, MCP, and TUI users without being flattened along the way.

## What changes for users

- Opening a JSON file written by a newer kanban (envelope `version` > 6) or a SQLite DB written by a newer kanban (`schema_version` > 2) returns a typed `UnsupportedFutureVersion` error and exits non-zero. Refused files are left byte-honest on disk — no ALTERs, no schema bumps, no rewrites land before the refusal.
- The same condition surfaced through the MCP server now maps to `INVALID_PARAMS` (was `INTERNAL_ERROR`) so LLM clients see it as a precondition failure on the data file rather than a server bug.
- Every save now stamps `writer_version` and `writer_commit` into the file's metadata. Old files without the stamp keep loading; the fields populate on the next save.
- F12 in the TUI is renamed "Diagnostics" and shows file path, format version (read live from disk), writer kanban, this binary, last saved timestamp, and the log entries section below. Writer line goes yellow with `(newer than this binary)` when the file was written by a newer semver.

## Implementation

**Typed error end-to-end.**
- `PersistenceError::UnsupportedFutureVersion` + `KanbanError::UnsupportedFutureVersion` with a `is_unsupported_future_version()` helper. Bidirectional `From` impl preserves the variant across the persistence/domain boundary.
- The boundary leaks that originally flattened the typed variant into `KanbanError::Internal` or `KanbanError::Database` are all fixed: `JsonDataStore::ensure_loaded` uses `KanbanError::from` instead of stringifying, `SqliteStoreFactory::create` keeps the variant via an explicit match, `StoreManager::make_backend` drops its `map_err` and propagates via `?`. MCP's `From<KanbanMcpError> for McpError` now routes `UnsupportedFutureVersion` to `INVALID_PARAMS` alongside the existing Domain variants.

**JSON refusal.**
- `Migrator::detect_version_from_value` is now fallible and refuses anything that doesn't fit `FormatVersion::MAX`, including the case where `version as u32` would have truncated a `u64` overflow back into a valid range — switched to `u32::try_from(...).unwrap_or(u32::MAX)`.
- `parse_envelope`'s previously-dead `> 6` check now returns the same typed error as defence in depth.

**SQLite refusal.**
- `SqliteStore::open` probes `sqlite_master` for the metadata table and reads `schema_version` BEFORE any schema-modifying step. If the row's version exceeds `SUPPORTED_SCHEMA_VERSION` (= 2), refusal fires immediately — the legacy-table drops, SCHEMA's `CREATE TABLE IF NOT EXISTS`, and `migrate()`'s ALTERs are all skipped. A post-migrate re-check is kept as regression-guard for future `migrate()` changes.
- `metadata` gains `writer_version TEXT` and `writer_commit TEXT` columns; `schema_version` defaults to 2; legacy v1 databases get the columns ALTERed in on open and the version field bumped to 2 via the existing pragma_table_info pattern.

**Writer stamp on save.**
- `PersistenceMetadata` gains `writer_version`, `writer_commit`, and `format_version` (all `Option`, with `#[serde(default)]` so legacy envelopes load cleanly). A `with_writer_stamp` builder keeps the 40+ existing `PersistenceMetadata::new(uuid)` call sites untouched.
- JSON `save` stamps directly into the envelope's metadata.
- SQLite splits the old `checkpoint` into `stamp_writer` (UPDATE + returns the timestamp) and a WAL-only `checkpoint`. `PersistenceStore::save` calls `stamp_writer` first to capture the timestamp, then `checkpoint`, then constructs the returned `PersistenceMetadata` inline — no extra SELECT round trip. `SqliteBackend::flush` calls both in the same order so write-through still stamps on every flush.
- `format_version` in the returned metadata is read from the row (`schema_version` for SQLite, envelope `version` for JSON) — not hardcoded against `SUPPORTED`. Future-proofs the field for the next schema bump.

**kanban-core constants.**
- Exposes `KANBAN_VERSION` and `KANBAN_COMMIT` as raw consts for the writer stamp.
- Renames the old combined `VERSION` to `CLI_VERSION_DISPLAY` to disambiguate it from the new components. Library consumers should update their imports.

**TUI diagnostics.**
- Pure `diagnostics_rows` helper builds the header lines from `(save_file, metadata)` so the renderer stays thin and the logic is unit-testable.
- Writer-newer-than-self comparison parses `MAJOR.MINOR.PATCH` and conservatively returns `false` on anything that doesn't fit (pre-release suffixes, leading `v`, etc.) — diagnostics row stays calm rather than crying wolf.
- F12 popup gets a top-bordered "Log entries (N)" section below the diagnostics rows; existing scroll behaviour preserved.

**Test fixture plumbing.**
- New `test-helpers` feature on `kanban-persistence-sqlite` gates two fixture helpers (`write_test_metadata_with_schema_version`, `read_test_schema_version`) so they don't ship in the production binary. Verified via `nm`: helper symbols absent from the production `kanban` binary's symbol table.

## Tests

~40 new tests across the workspace:

- `cargo test -p kanban-domain` — typed error helpers (3 new)
- `cargo test -p kanban-persistence` — FormatVersion::MAX, metadata serde, with_writer_stamp builder (5 new)
- `cargo test -p kanban-persistence-json` — refuse-on-future, parse_envelope guard, u32 overflow, save stamps, legacy load (6 new)
- `cargo test -p kanban-persistence-sqlite` — fresh schema version, columns present, legacy ALTER, future-version refusal, stamp_writer behaviour, checkpoint isolation, read_metadata reflects DB row (10 new)
- `cargo test -p kanban-service` — backend metadata accessor, context exposes metadata, typed error propagation for both JSON and SQLite future-version files (4 new across unit + integration)
- `cargo test -p kanban-mcp` — INVALID_PARAMS mapping for both JSON and SQLite future-version files (2 new)
- `cargo test -p kanban-cli` — end-to-end binary refusal for both JSON and SQLite; SQLite test checks `schema_version` preservation on disk after refusal (2 new)
- `cargo test -p kanban-tui --lib ui::error_log::` — diagnostics_rows pure-function tests, writer-newer comparison, short_commit utility (9 new)
- `cargo test --workspace` — no regressions
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — clean

Hand-tested across surfaces with a v99 fixture: CLI refuses with `Error: file format v99 is newer than this binary's max v{6,2}; please upgrade kanban`, MCP server fails to initialize with the same typed cause, TUI prints the same message and exits before the event loop. All three leave the file's `schema_version` (SQLite) and `md5sum` (JSON) unchanged.