### PR TITLE
KAN-520 fix(tui): restore card-detail enter and backspace navigation across parent/child boxes

### DIFF
--- a/.changeset/kan-520-card-detail-enter-on-parent-child-does-not-navigate-to-that-card-active-card-id-stale.md
+++ b/.changeset/kan-520-card-detail-enter-on-parent-child-does-not-navigate-to-that-card-active-card-id-stale.md
@@ -2,4 +2,6 @@
 bump: patch
 ---
 
-Pressing Enter on a card in the Parents or Children box of the card detail view now reloads the detail view against that card, as it always should have. The same fix applies at the other entry points into the detail view (Enter and 'e' on a sprint-detail card row) and to Backspace returning through the navigation history. Previously the detail view appeared to stay on the original card while the parents box silently emptied out, because those handlers updated the active-card index but not the active-card UUID that the detail view actually reads from.
+Pressing Enter on a card in the Parents or Children box of the card detail view now reloads the detail view against that card, as it always should have. The same fix applies at the other entry points into the detail view (Enter and 'e' on a sprint-detail card row) and to Backspace returning through the navigation history. Previously the detail view appeared to stay on the original card while the parents box silently emptied out.
+
+The underlying drift between the active-card index and the active-card UUID is now prevented at the type level: the two fields have been collapsed into a single struct whose constructor requires both values, so future handlers cannot reintroduce this bug class.

--- a/.changeset/kan-520-card-detail-enter-on-parent-child-does-not-navigate-to-that-card-active-card-id-stale.md
+++ b/.changeset/kan-520-card-detail-enter-on-parent-child-does-not-navigate-to-that-card-active-card-id-stale.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Pressing Enter on a card in the Parents or Children box of the card detail view now reloads the detail view against that card, as it always should have. Previously the detail view appeared to stay on the original card while the parents box silently emptied out, because the in-detail navigation updated the active-card index but not the active-card UUID that the detail view actually reads from. Backspace, which returns to the card you came from via the navigation history, was affected by the same gap and is fixed as part of the same change.

--- a/.changeset/kan-520-card-detail-enter-on-parent-child-does-not-navigate-to-that-card-active-card-id-stale.md
+++ b/.changeset/kan-520-card-detail-enter-on-parent-child-does-not-navigate-to-that-card-active-card-id-stale.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-Pressing Enter on a card in the Parents or Children box of the card detail view now reloads the detail view against that card, as it always should have. Previously the detail view appeared to stay on the original card while the parents box silently emptied out, because the in-detail navigation updated the active-card index but not the active-card UUID that the detail view actually reads from. Backspace, which returns to the card you came from via the navigation history, was affected by the same gap and is fixed as part of the same change.
+Pressing Enter on a card in the Parents or Children box of the card detail view now reloads the detail view against that card, as it always should have. The same fix applies at the other entry points into the detail view (Enter and 'e' on a sprint-detail card row) and to Backspace returning through the navigation history. Previously the detail view appeared to stay on the original card while the parents box silently emptied out, because those handlers updated the active-card index but not the active-card UUID that the detail view actually reads from.

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -11,7 +11,7 @@ pub mod animation;
 pub use animation::{AnimationState, CardAnimation};
 
 pub mod selection;
-pub use selection::SelectionHub;
+pub use selection::{ActiveCard, SelectionHub};
 
 pub mod filter;
 pub use filter::FilterState;
@@ -1461,8 +1461,8 @@ impl App {
 
     pub fn get_card_for_detail_view(&self) -> Option<Card> {
         self.selection
-            .active_card_id
-            .and_then(|id| self.model.card(id).cloned())
+            .active_card
+            .and_then(|ac| self.model.card(ac.id()).cloned())
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
@@ -1786,9 +1786,9 @@ impl App {
         event_handler: &EventHandler,
         field: CardField,
     ) -> io::Result<()> {
-        if let Some(card_idx) = self.selection.active_card_index {
+        if let Some(active) = self.selection.active_card {
             let cards = self.model.cards();
-            if let Some(card) = cards.get(card_idx) {
+            if let Some(card) = cards.get(active.index()) {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {
                     CardField::Title => {
@@ -2294,12 +2294,12 @@ impl App {
     where
         F: Fn(&Card, &Board, &[Sprint], &str) -> String,
     {
-        if let Some(card_idx) = self.selection.active_card_index {
+        if let Some(active) = self.selection.active_card {
             if let Some(board_idx) = self.selection.active_board_index {
                 let boards = self.model.boards();
                 if let Some(board) = boards.get(board_idx) {
                     let cards = self.model.cards();
-                    if let Some(card) = cards.get(card_idx) {
+                    if let Some(card) = cards.get(active.index()) {
                         let sprints = self.model.sprints();
                         let output = get_output(
                             card,
@@ -2331,9 +2331,9 @@ impl App {
     }
 
     pub fn get_current_priority_selection_index(&self) -> usize {
-        if let Some(card_idx) = self.selection.active_card_index {
+        if let Some(active) = self.selection.active_card {
             let cards = self.model.cards();
-            if let Some(card) = cards.get(card_idx) {
+            if let Some(card) = cards.get(active.index()) {
                 use kanban_domain::CardPriority;
                 return match card.priority {
                     CardPriority::Low => 0,
@@ -2349,9 +2349,9 @@ impl App {
     pub fn get_current_sprint_selection_index(&self) -> usize {
         use crate::components::sprint_assign_list::{build_entries, sprint_id_of};
 
-        if let Some(card_idx) = self.selection.active_card_index {
+        if let Some(active) = self.selection.active_card {
             let cards = self.model.cards();
-            if let Some(card) = cards.get(card_idx) {
+            if let Some(card) = cards.get(active.index()) {
                 if let Some(card_sprint_id) = card.sprint_id {
                     if let Some(board_idx) = self.selection.active_board_index {
                         let boards = self.model.boards();

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -17,11 +17,13 @@ pub struct SelectionHub {
 }
 
 impl SelectionHub {
-    /// The detail view resolves its card off `active_card_id` (since KAN-364)
-    /// while many handlers still address cards by index. Use this when both
-    /// are known so the two stay consistent.
     pub fn set_active_card(&mut self, idx: usize, id: uuid::Uuid) {
         self.active_card_index = Some(idx);
         self.active_card_id = Some(id);
+    }
+
+    pub fn clear_active_card(&mut self) {
+        self.active_card_index = None;
+        self.active_card_id = None;
     }
 }

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -1,12 +1,31 @@
 use kanban_core::SelectionState;
 use std::cell::Cell;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ActiveCard {
+    index: usize,
+    id: uuid::Uuid,
+}
+
+impl ActiveCard {
+    pub fn new(index: usize, id: uuid::Uuid) -> Self {
+        Self { index, id }
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    pub fn id(&self) -> uuid::Uuid {
+        self.id
+    }
+}
+
 #[derive(Default)]
 pub struct SelectionHub {
     pub board: SelectionState,
     pub active_board_index: Option<usize>,
-    pub active_card_index: Option<usize>,
-    pub active_card_id: Option<uuid::Uuid>,
+    pub active_card: Option<ActiveCard>,
     pub sprint: SelectionState,
     pub sprint_scroll: Cell<usize>,
     pub active_sprint_index: Option<usize>,
@@ -14,16 +33,4 @@ pub struct SelectionHub {
     pub settings_config: SelectionState,
     pub settings_config_file: SelectionState,
     pub settings_storage: SelectionState,
-}
-
-impl SelectionHub {
-    pub fn set_active_card(&mut self, idx: usize, id: uuid::Uuid) {
-        self.active_card_index = Some(idx);
-        self.active_card_id = Some(id);
-    }
-
-    pub fn clear_active_card(&mut self) {
-        self.active_card_index = None;
-        self.active_card_id = None;
-    }
 }

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -15,3 +15,13 @@ pub struct SelectionHub {
     pub settings_config_file: SelectionState,
     pub settings_storage: SelectionState,
 }
+
+impl SelectionHub {
+    /// The detail view resolves its card off `active_card_id` (since KAN-364)
+    /// while many handlers still address cards by index. Use this when both
+    /// are known so the two stay consistent.
+    pub fn set_active_card(&mut self, idx: usize, id: uuid::Uuid) {
+        self.active_card_index = Some(idx);
+        self.active_card_id = Some(id);
+    }
+}

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -337,8 +337,8 @@ impl SelectionDialog for SprintAssignDialog {
                 let entries = build_entries(sprints, board.id, chrono::Utc::now());
 
                 let cards = app.model.cards();
-                let current_sprint_id = if let Some(card_idx) = app.selection.active_card_index {
-                    cards.get(card_idx).and_then(|c| c.sprint_id)
+                let current_sprint_id = if let Some(active) = app.selection.active_card {
+                    cards.get(active.index()).and_then(|c| c.sprint_id)
                 } else {
                     None
                 };

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, AppMode, CardField, DialogMode, Focus};
+use crate::app::{ActiveCard, App, AppMode, CardField, DialogMode, Focus};
 use crate::card_list::CardListId;
 use crate::events::EventHandler;
 use kanban_domain::commands::{
@@ -109,9 +109,12 @@ impl App {
                     if has_assignable {
                         if let Some(selected_card) = self.get_selected_card_in_context() {
                             let card_id = selected_card.id;
-                            let actual_idx =
-                                self.model.cards().iter().position(|c| c.id == card_id);
-                            self.selection.active_card_index = actual_idx;
+                            self.selection.active_card = self
+                                .model
+                                .cards()
+                                .iter()
+                                .position(|c| c.id == card_id)
+                                .map(|idx| ActiveCard::new(idx, card_id));
                         }
                         let selection_idx = self.get_current_sprint_selection_index();
                         self.dialog_input
@@ -214,8 +217,12 @@ impl App {
         if self.focus.active == Focus::Cards {
             if let Some(selected_card) = self.get_selected_card_in_context() {
                 let card_id = selected_card.id;
-                let actual_idx = self.model.cards().iter().position(|c| c.id == card_id);
-                self.selection.active_card_index = actual_idx;
+                self.selection.active_card = self
+                    .model
+                    .cards()
+                    .iter()
+                    .position(|c| c.id == card_id)
+                    .map(|idx| ActiveCard::new(idx, card_id));
 
                 if let Err(e) =
                     self.edit_card_field(terminal, event_handler, CardField::Description)
@@ -815,9 +822,12 @@ impl App {
         let current_children: std::collections::HashSet<_> =
             graph.children(card_id).into_iter().collect();
 
-        // Store the card index so the popup knows which card we're managing
+        // Store the active card so the popup knows which card we're managing
         let cards = self.model.cards();
-        self.selection.active_card_index = cards.iter().position(|c| c.id == card_id);
+        self.selection.active_card = cards
+            .iter()
+            .position(|c| c.id == card_id)
+            .map(|idx| ActiveCard::new(idx, card_id));
 
         // Set up dialog state
         self.relationship.card_ids = eligible_cards;

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1249,9 +1249,23 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    use crate::app::sprint_view::SprintTaskPanel;
     use crate::app::CardFocus;
     use crate::App;
+    use crossterm::event::KeyCode;
     use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, Snapshot};
+
+    fn reload_snapshot(app: &mut App) {
+        let snap = Snapshot {
+            boards: app.ctx.data_store().list_boards().unwrap(),
+            columns: app.ctx.data_store().list_all_columns().unwrap(),
+            cards: app.ctx.data_store().list_all_cards().unwrap(),
+            archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+            sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+            graph: app.ctx.data_store().get_graph().unwrap(),
+        };
+        app.model.load_from_snapshot(snap);
+    }
 
     fn seed_chain(app: &mut App, titles: &[&str]) -> Vec<uuid::Uuid> {
         let board = app.ctx.create_board("Board".into(), None).unwrap();
@@ -1275,16 +1289,37 @@ mod tests {
         for w in ids.windows(2) {
             app.ctx.attach_child(w[0], w[1]).unwrap();
         }
-        let snap = Snapshot {
-            boards: app.ctx.data_store().list_boards().unwrap(),
-            columns: app.ctx.data_store().list_all_columns().unwrap(),
-            cards: app.ctx.data_store().list_all_cards().unwrap(),
-            archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
-            sprints: app.ctx.data_store().list_all_sprints().unwrap(),
-            graph: app.ctx.data_store().get_graph().unwrap(),
-        };
-        app.model.load_from_snapshot(snap);
+        reload_snapshot(app);
         ids
+    }
+
+    fn seed_sprint_with_card(app: &mut App, title: &str) -> uuid::Uuid {
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "TODO".into(), None)
+            .unwrap();
+        let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                title.into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        app.ctx.assign_card_to_sprint(card.id, sprint.id).unwrap();
+        reload_snapshot(app);
+        app.populate_sprint_task_lists(sprint.id);
+        app.sprint_view.panel = SprintTaskPanel::Uncompleted;
+        app.sprint_view
+            .uncompleted_component
+            .update_cards(vec![card.id]);
+        app.sprint_view
+            .uncompleted_component
+            .set_selected_index(Some(0));
+        card.id
     }
 
     #[test]
@@ -1378,6 +1413,74 @@ mod tests {
                 .expect("detail must resolve")
                 .id,
             b_id
+        );
+    }
+
+    #[test]
+    fn test_sprint_detail_enter_on_card_sets_active_card_id_so_detail_view_resolves() {
+        let mut app = App::test_default();
+        let card_id = seed_sprint_with_card(&mut app, "task");
+
+        app.handle_sprint_detail_key(KeyCode::Enter);
+
+        assert_eq!(
+            app.selection.active_card_id,
+            Some(card_id),
+            "Enter on a sprint-detail card row must set active_card_id so the detail view can resolve the card"
+        );
+        assert_eq!(
+            app.get_card_for_detail_view()
+                .expect("detail must resolve")
+                .id,
+            card_id
+        );
+    }
+
+    #[test]
+    fn test_sprint_detail_e_on_card_sets_active_card_id_so_detail_view_resolves() {
+        let mut app = App::test_default();
+        let card_id = seed_sprint_with_card(&mut app, "task");
+
+        app.handle_sprint_detail_key(KeyCode::Char('e'));
+
+        assert_eq!(
+            app.selection.active_card_id,
+            Some(card_id),
+            "'e' on a sprint-detail card row must set active_card_id so the detail view can resolve the card"
+        );
+        assert_eq!(
+            app.get_card_for_detail_view()
+                .expect("detail must resolve")
+                .id,
+            card_id
+        );
+    }
+
+    #[test]
+    fn test_backspace_return_with_stale_previous_idx_clears_active_card_entirely() {
+        let mut app = App::test_default();
+        let ids = seed_chain(&mut app, &["A", "B"]);
+        let b_id = ids[1];
+        let b_idx = app.model.cards().iter().position(|c| c.id == b_id).unwrap();
+        let stale_idx = app.model.cards().len() + 99;
+
+        app.selection.active_card_index = Some(b_idx);
+        app.selection.active_card_id = Some(b_id);
+        app.selection.card_navigation_history.push(stale_idx);
+
+        app.return_to_previous_card_from_detail_history();
+
+        assert_eq!(
+            app.selection.active_card_id, None,
+            "when previous_idx no longer resolves, active_card_id must be cleared"
+        );
+        assert_eq!(
+            app.selection.active_card_index, None,
+            "when previous_idx no longer resolves, active_card_index must be cleared too — the two fields cannot drift apart"
+        );
+        assert!(
+            app.get_card_for_detail_view().is_none(),
+            "detail view must resolve to None when active_card was cleared by stale-index recovery"
         );
     }
 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -13,6 +13,12 @@ use std::io;
 // Viewport constants (must match ui.rs values)
 const RELATIONSHIP_VIEWPORT_RAW: usize = 5;
 
+#[derive(Clone, Copy)]
+pub(crate) enum RelationSide {
+    Parents,
+    Children,
+}
+
 impl App {
     pub fn handle_card_detail_key(
         &mut self,
@@ -1101,6 +1107,31 @@ impl App {
         Vec::new()
     }
 
+    fn refresh_relationship_counts(&mut self) {
+        let parents = self.get_current_card_parents();
+        let children = self.get_current_card_children();
+        self.relationship
+            .parents_list
+            .update_item_count(parents.len());
+        self.relationship
+            .children_list
+            .update_item_count(children.len());
+    }
+
+    fn related_card_ids(&self, side: RelationSide) -> Vec<uuid::Uuid> {
+        match side {
+            RelationSide::Parents => self.get_current_card_parents(),
+            RelationSide::Children => self.get_current_card_children(),
+        }
+    }
+
+    fn list_selection(&self, side: RelationSide) -> Option<usize> {
+        match side {
+            RelationSide::Parents => self.relationship.parents_list.selection.get(),
+            RelationSide::Children => self.relationship.children_list.selection.get(),
+        }
+    }
+
     pub(crate) fn return_to_previous_card_from_detail_history(&mut self) {
         if let Some(previous_idx) = self.selection.card_navigation_history.pop() {
             self.selection.active_card = self
@@ -1109,106 +1140,35 @@ impl App {
                 .get(previous_idx)
                 .map(|c| ActiveCard::new(previous_idx, c.id));
             self.focus.card_focus = CardFocus::Title;
-            let parents = self.get_current_card_parents();
-            let children = self.get_current_card_children();
-            self.relationship
-                .parents_list
-                .update_item_count(parents.len());
-            self.relationship
-                .children_list
-                .update_item_count(children.len());
+            self.refresh_relationship_counts();
         }
     }
 
     pub(crate) fn navigate_to_selected_parent(&mut self, current_card_idx: usize) {
-        let parents = self.get_current_card_parents();
-        if let Some(selected_idx) = self.relationship.parents_list.selection.get() {
-            if let Some(&parent_id) = parents.get(selected_idx) {
-                if let Some(parent_idx) = self.model.cards().iter().position(|c| c.id == parent_id)
-                {
-                    // Push current card to history
-                    self.selection
-                        .card_navigation_history
-                        .push(current_card_idx);
-                    // Navigate to parent
-                    self.selection.active_card = Some(ActiveCard::new(parent_idx, parent_id));
-                    self.focus.card_focus = CardFocus::Title;
-                    // Update item counts for new card
-                    let new_parents = self.get_current_card_parents();
-                    let new_children = self.get_current_card_children();
-                    self.relationship
-                        .parents_list
-                        .update_item_count(new_parents.len());
-                    self.relationship
-                        .children_list
-                        .update_item_count(new_children.len());
-                    return;
-                }
-            }
-        }
-        // If no valid selection, navigate to first parent if available
-        if !parents.is_empty() {
-            if let Some(parent_idx) = self.model.cards().iter().position(|c| c.id == parents[0]) {
-                self.selection
-                    .card_navigation_history
-                    .push(current_card_idx);
-                self.selection.active_card = Some(ActiveCard::new(parent_idx, parents[0]));
-                self.focus.card_focus = CardFocus::Title;
-                // Update item counts for new card
-                let new_parents = self.get_current_card_parents();
-                let new_children = self.get_current_card_children();
-                self.relationship
-                    .parents_list
-                    .update_item_count(new_parents.len());
-                self.relationship
-                    .children_list
-                    .update_item_count(new_children.len());
-            }
-        }
+        self.navigate_to_related_card(current_card_idx, RelationSide::Parents);
     }
 
     pub(crate) fn navigate_to_selected_child(&mut self, current_card_idx: usize) {
-        let children = self.get_current_card_children();
-        if let Some(selected_idx) = self.relationship.children_list.selection.get() {
-            if let Some(&child_id) = children.get(selected_idx) {
-                if let Some(child_idx) = self.model.cards().iter().position(|c| c.id == child_id) {
-                    // Push current card to history
-                    self.selection
-                        .card_navigation_history
-                        .push(current_card_idx);
-                    // Navigate to child
-                    self.selection.active_card = Some(ActiveCard::new(child_idx, child_id));
-                    self.focus.card_focus = CardFocus::Title;
-                    // Update item counts for new card
-                    let new_parents = self.get_current_card_parents();
-                    let new_children = self.get_current_card_children();
-                    self.relationship
-                        .parents_list
-                        .update_item_count(new_parents.len());
-                    self.relationship
-                        .children_list
-                        .update_item_count(new_children.len());
-                    return;
-                }
-            }
-        }
-        // If no valid selection, navigate to first child if available
-        if !children.is_empty() {
-            if let Some(child_idx) = self.model.cards().iter().position(|c| c.id == children[0]) {
+        self.navigate_to_related_card(current_card_idx, RelationSide::Children);
+    }
+
+    fn navigate_to_related_card(&mut self, current_card_idx: usize, side: RelationSide) {
+        let related = self.related_card_ids(side);
+        let selected_id = self
+            .list_selection(side)
+            .and_then(|i| related.get(i).copied());
+        // Prefer the list selection; fall back to the first related card.
+        let candidates = selected_id.into_iter().chain(related.first().copied());
+
+        for target_id in candidates {
+            if let Some(target_idx) = self.model.cards().iter().position(|c| c.id == target_id) {
                 self.selection
                     .card_navigation_history
                     .push(current_card_idx);
-                self.selection.active_card = Some(ActiveCard::new(child_idx, children[0]));
+                self.selection.active_card = Some(ActiveCard::new(target_idx, target_id));
                 self.focus.card_focus = CardFocus::Title;
-                // Update item counts for new card
-                let new_parents = self.get_current_card_parents();
-                let new_children = self.get_current_card_children();
-                self.relationship
-                    .parents_list
-                    .update_item_count(new_parents.len());
-                self.relationship
-                    .children_list
-                    .update_item_count(new_children.len());
+                self.refresh_relationship_counts();
+                return;
             }
         }
     }
@@ -1458,6 +1418,60 @@ mod tests {
                 .expect("detail must resolve")
                 .id,
             card_id
+        );
+    }
+
+    #[test]
+    fn test_navigate_to_selected_parent_falls_back_to_first_parent_when_no_list_selection() {
+        let mut app = App::test_default();
+        let ids = seed_chain(&mut app, &["Parent", "Child"]);
+        let parent_id = ids[0];
+        let child_id = ids[1];
+        let child_idx = app
+            .model
+            .cards()
+            .iter()
+            .position(|c| c.id == child_id)
+            .unwrap();
+
+        app.selection.active_card = Some(ActiveCard::new(child_idx, child_id));
+        app.focus.card_focus = CardFocus::Parents;
+        app.relationship.parents_list.update_item_count(1);
+        // Deliberately no parents_list.selection.set(...) — exercise the fallback path.
+
+        app.navigate_to_selected_parent(child_idx);
+
+        assert_eq!(
+            app.selection.active_card.map(|a| a.id()),
+            Some(parent_id),
+            "with no list selection, Enter on Parents must fall back to navigating to the first parent"
+        );
+    }
+
+    #[test]
+    fn test_navigate_to_selected_child_falls_back_to_first_child_when_no_list_selection() {
+        let mut app = App::test_default();
+        let ids = seed_chain(&mut app, &["Parent", "Child"]);
+        let parent_id = ids[0];
+        let child_id = ids[1];
+        let parent_idx = app
+            .model
+            .cards()
+            .iter()
+            .position(|c| c.id == parent_id)
+            .unwrap();
+
+        app.selection.active_card = Some(ActiveCard::new(parent_idx, parent_id));
+        app.focus.card_focus = CardFocus::Children;
+        app.relationship.children_list.update_item_count(1);
+        // Deliberately no children_list.selection.set(...).
+
+        app.navigate_to_selected_child(parent_idx);
+
+        assert_eq!(
+            app.selection.active_card.map(|a| a.id()),
+            Some(child_id),
+            "with no list selection, Enter on Children must fall back to navigating to the first child"
         );
     }
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1244,3 +1244,150 @@ impl App {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::app::CardFocus;
+    use crate::App;
+    use kanban_domain::{
+        CreateCardOptions, GraphOperations, KanbanOperations, Snapshot,
+    };
+
+    fn seed_chain(app: &mut App, titles: &[&str]) -> Vec<uuid::Uuid> {
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "TODO".into(), None)
+            .unwrap();
+        let mut ids = Vec::new();
+        for t in titles {
+            let card = app
+                .ctx
+                .create_card(
+                    board.id,
+                    column.id,
+                    (*t).into(),
+                    CreateCardOptions::default(),
+                )
+                .unwrap();
+            ids.push(card.id);
+        }
+        for w in ids.windows(2) {
+            app.ctx.attach_child(w[0], w[1]).unwrap();
+        }
+        let snap = Snapshot {
+            boards: app.ctx.data_store().list_boards().unwrap(),
+            columns: app.ctx.data_store().list_all_columns().unwrap(),
+            cards: app.ctx.data_store().list_all_cards().unwrap(),
+            archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+            sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+            graph: app.ctx.data_store().get_graph().unwrap(),
+        };
+        app.model.load_from_snapshot(snap);
+        ids
+    }
+
+    #[test]
+    fn test_navigate_to_selected_parent_updates_active_card_id_so_detail_view_reloads() {
+        let mut app = App::test_default();
+        let ids = seed_chain(&mut app, &["Parent", "Child"]);
+        let parent_id = ids[0];
+        let child_id = ids[1];
+        let child_idx = app
+            .model
+            .cards()
+            .iter()
+            .position(|c| c.id == child_id)
+            .unwrap();
+
+        app.selection.active_card_index = Some(child_idx);
+        app.selection.active_card_id = Some(child_id);
+        app.focus.card_focus = CardFocus::Parents;
+        app.relationship.parents_list.update_item_count(1);
+        app.relationship.parents_list.selection.set(Some(0));
+
+        app.navigate_to_selected_parent(child_idx);
+
+        assert_eq!(
+            app.selection.active_card_id,
+            Some(parent_id),
+            "active_card_id must be updated to the parent so the detail view rerenders against the parent card"
+        );
+        assert_eq!(
+            app.get_card_for_detail_view()
+                .expect("detail must resolve")
+                .id,
+            parent_id,
+            "get_card_for_detail_view() must return the parent after Enter on a parent entry"
+        );
+    }
+
+    #[test]
+    fn test_navigate_to_selected_child_updates_active_card_id_so_detail_view_reloads() {
+        let mut app = App::test_default();
+        let ids = seed_chain(&mut app, &["Parent", "Child"]);
+        let parent_id = ids[0];
+        let child_id = ids[1];
+        let parent_idx = app
+            .model
+            .cards()
+            .iter()
+            .position(|c| c.id == parent_id)
+            .unwrap();
+
+        app.selection.active_card_index = Some(parent_idx);
+        app.selection.active_card_id = Some(parent_id);
+        app.focus.card_focus = CardFocus::Children;
+        app.relationship.children_list.update_item_count(1);
+        app.relationship.children_list.selection.set(Some(0));
+
+        app.navigate_to_selected_child(parent_idx);
+
+        assert_eq!(app.selection.active_card_id, Some(child_id));
+        assert_eq!(
+            app.get_card_for_detail_view()
+                .expect("detail must resolve")
+                .id,
+            child_id
+        );
+    }
+
+    #[test]
+    fn test_backspace_return_from_detail_history_updates_active_card_id() {
+        let mut app = App::test_default();
+        let ids = seed_chain(&mut app, &["A", "B", "C"]);
+        let b_id = ids[1];
+        let c_id = ids[2];
+        let b_idx = app
+            .model
+            .cards()
+            .iter()
+            .position(|c| c.id == b_id)
+            .unwrap();
+        let c_idx = app
+            .model
+            .cards()
+            .iter()
+            .position(|c| c.id == c_id)
+            .unwrap();
+
+        app.selection.active_card_index = Some(c_idx);
+        app.selection.active_card_id = Some(c_id);
+        app.selection.card_navigation_history.push(b_idx);
+        app.focus.card_focus = CardFocus::Parents;
+
+        app.return_to_previous_card_from_detail_history();
+
+        assert_eq!(
+            app.selection.active_card_id,
+            Some(b_id),
+            "Backspace return must update active_card_id along with the index"
+        );
+        assert_eq!(
+            app.get_card_for_detail_view()
+                .expect("detail must resolve")
+                .id,
+            b_id
+        );
+    }
+}

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1,5 +1,6 @@
 use crate::app::{
-    App, AppMode, BoardField, BoardFocus, CardField, CardFocus, DialogMode, SprintTaskPanel,
+    ActiveCard, App, AppMode, BoardField, BoardFocus, CardField, CardFocus, DialogMode,
+    SprintTaskPanel,
 };
 use crate::editor::edit_in_external_editor;
 use crate::events::EventHandler;
@@ -23,7 +24,7 @@ impl App {
         match key_code {
             KeyCode::Esc => {
                 self.pop_mode();
-                self.selection.active_card_index = None;
+                self.selection.active_card = None;
                 self.focus.card_focus = CardFocus::Title;
                 self.relationship.parents_list.selection.clear();
                 self.relationship.children_list.selection.clear();
@@ -227,8 +228,8 @@ impl App {
                     should_restart = true;
                 }
                 CardFocus::Metadata => {
-                    if let Some(card_idx) = self.selection.active_card_index {
-                        if let Some(card) = self.model.cards().get(card_idx) {
+                    if let Some(active) = self.selection.active_card {
+                        if let Some(card) = self.model.cards().get(active.index()) {
                             let card_id = card.id;
                             let dto = CardMetadataDto::from_entity(card);
                             let json = serde_json::to_string_pretty(&dto)
@@ -285,7 +286,7 @@ impl App {
             KeyCode::Char('d') => {
                 self.handle_archive_card();
                 self.pop_mode();
-                self.selection.active_card_index = None;
+                self.selection.active_card = None;
                 self.focus.card_focus = CardFocus::Title;
             }
             KeyCode::Char('a') => {
@@ -323,13 +324,13 @@ impl App {
             }
             KeyCode::Enter => match self.focus.card_focus {
                 CardFocus::Parents => {
-                    if let Some(current_idx) = self.selection.active_card_index {
-                        self.navigate_to_selected_parent(current_idx);
+                    if let Some(active) = self.selection.active_card {
+                        self.navigate_to_selected_parent(active.index());
                     }
                 }
                 CardFocus::Children => {
-                    if let Some(current_idx) = self.selection.active_card_index {
-                        self.navigate_to_selected_child(current_idx);
+                    if let Some(active) = self.selection.active_card {
+                        self.navigate_to_selected_child(active.index());
                     }
                 }
                 _ => {}
@@ -739,7 +740,8 @@ impl App {
                             if let Some(card_idx) =
                                 self.model.cards().iter().position(|c| c.id == card_id)
                             {
-                                self.selection.set_active_card(card_idx, card_id);
+                                self.selection.active_card =
+                                    Some(ActiveCard::new(card_idx, card_id));
                                 // Initialize list components with item counts
                                 let parents = self.get_current_card_parents();
                                 let children = self.get_current_card_children();
@@ -757,7 +759,8 @@ impl App {
                             if let Some(card_idx) =
                                 self.model.cards().iter().position(|c| c.id == card_id)
                             {
-                                self.selection.set_active_card(card_idx, card_id);
+                                self.selection.active_card =
+                                    Some(ActiveCard::new(card_idx, card_id));
                                 // Initialize list components with item counts
                                 let parents = self.get_current_card_parents();
                                 let children = self.get_current_card_children();
@@ -801,7 +804,8 @@ impl App {
                             if let Some(card_idx) =
                                 self.model.cards().iter().position(|c| c.id == card_id)
                             {
-                                self.selection.active_card_index = Some(card_idx);
+                                self.selection.active_card =
+                                    Some(ActiveCard::new(card_idx, card_id));
                                 let priority_idx = self.get_current_priority_selection_index();
                                 self.dialog_input.priority_selection.set(Some(priority_idx));
                                 self.open_dialog(DialogMode::SetCardPriority);
@@ -811,7 +815,8 @@ impl App {
                             if let Some(card_idx) =
                                 self.model.cards().iter().position(|c| c.id == card_id)
                             {
-                                self.selection.active_card_index = Some(card_idx);
+                                self.selection.active_card =
+                                    Some(ActiveCard::new(card_idx, card_id));
                                 if let Some(board_idx) = self.selection.active_board_index {
                                     if let Some(board) = self.model.boards().get(board_idx) {
                                         let sprint_count = self
@@ -836,7 +841,8 @@ impl App {
                             if let Some(card_idx) =
                                 self.model.cards().iter().position(|c| c.id == card_id)
                             {
-                                self.selection.active_card_index = Some(card_idx);
+                                self.selection.active_card =
+                                    Some(ActiveCard::new(card_idx, card_id));
                                 if let Some(board_idx) = self.selection.active_board_index {
                                     if let Some(board) = self.model.boards().get(board_idx) {
                                         let sprint_count = self
@@ -972,8 +978,8 @@ impl App {
     }
 
     pub(crate) fn handle_manage_parents(&mut self) {
-        if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.model.cards().get(card_idx) {
+        if let Some(active) = self.selection.active_card {
+            if let Some(card) = self.model.cards().get(active.index()) {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
@@ -1025,8 +1031,8 @@ impl App {
     }
 
     pub(crate) fn handle_manage_children(&mut self) {
-        if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.model.cards().get(card_idx) {
+        if let Some(active) = self.selection.active_card {
+            if let Some(card) = self.model.cards().get(active.index()) {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
@@ -1078,8 +1084,8 @@ impl App {
     }
 
     pub fn get_current_card_parents(&self) -> Vec<uuid::Uuid> {
-        if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.model.cards().get(card_idx) {
+        if let Some(active) = self.selection.active_card {
+            if let Some(card) = self.model.cards().get(active.index()) {
                 return self.model.graph().parents(card.id);
             }
         }
@@ -1087,8 +1093,8 @@ impl App {
     }
 
     pub fn get_current_card_children(&self) -> Vec<uuid::Uuid> {
-        if let Some(card_idx) = self.selection.active_card_index {
-            if let Some(card) = self.model.cards().get(card_idx) {
+        if let Some(active) = self.selection.active_card {
+            if let Some(card) = self.model.cards().get(active.index()) {
                 return self.model.graph().children(card.id);
             }
         }
@@ -1097,11 +1103,11 @@ impl App {
 
     pub(crate) fn return_to_previous_card_from_detail_history(&mut self) {
         if let Some(previous_idx) = self.selection.card_navigation_history.pop() {
-            if let Some(previous_id) = self.model.cards().get(previous_idx).map(|c| c.id) {
-                self.selection.set_active_card(previous_idx, previous_id);
-            } else {
-                self.selection.clear_active_card();
-            }
+            self.selection.active_card = self
+                .model
+                .cards()
+                .get(previous_idx)
+                .map(|c| ActiveCard::new(previous_idx, c.id));
             self.focus.card_focus = CardFocus::Title;
             let parents = self.get_current_card_parents();
             let children = self.get_current_card_children();
@@ -1125,7 +1131,7 @@ impl App {
                         .card_navigation_history
                         .push(current_card_idx);
                     // Navigate to parent
-                    self.selection.set_active_card(parent_idx, parent_id);
+                    self.selection.active_card = Some(ActiveCard::new(parent_idx, parent_id));
                     self.focus.card_focus = CardFocus::Title;
                     // Update item counts for new card
                     let new_parents = self.get_current_card_parents();
@@ -1146,7 +1152,7 @@ impl App {
                 self.selection
                     .card_navigation_history
                     .push(current_card_idx);
-                self.selection.set_active_card(parent_idx, parents[0]);
+                self.selection.active_card = Some(ActiveCard::new(parent_idx, parents[0]));
                 self.focus.card_focus = CardFocus::Title;
                 // Update item counts for new card
                 let new_parents = self.get_current_card_parents();
@@ -1171,7 +1177,7 @@ impl App {
                         .card_navigation_history
                         .push(current_card_idx);
                     // Navigate to child
-                    self.selection.set_active_card(child_idx, child_id);
+                    self.selection.active_card = Some(ActiveCard::new(child_idx, child_id));
                     self.focus.card_focus = CardFocus::Title;
                     // Update item counts for new card
                     let new_parents = self.get_current_card_parents();
@@ -1192,7 +1198,7 @@ impl App {
                 self.selection
                     .card_navigation_history
                     .push(current_card_idx);
-                self.selection.set_active_card(child_idx, children[0]);
+                self.selection.active_card = Some(ActiveCard::new(child_idx, children[0]));
                 self.focus.card_focus = CardFocus::Title;
                 // Update item counts for new card
                 let new_parents = self.get_current_card_parents();
@@ -1252,7 +1258,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use crate::app::sprint_view::SprintTaskPanel;
-    use crate::app::CardFocus;
+    use crate::app::{ActiveCard, CardFocus};
     use crate::App;
     use crossterm::event::KeyCode;
     use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, Snapshot};
@@ -1337,8 +1343,7 @@ mod tests {
             .position(|c| c.id == child_id)
             .unwrap();
 
-        app.selection.active_card_index = Some(child_idx);
-        app.selection.active_card_id = Some(child_id);
+        app.selection.active_card = Some(ActiveCard::new(child_idx, child_id));
         app.focus.card_focus = CardFocus::Parents;
         app.relationship.parents_list.update_item_count(1);
         app.relationship.parents_list.selection.set(Some(0));
@@ -1346,9 +1351,9 @@ mod tests {
         app.navigate_to_selected_parent(child_idx);
 
         assert_eq!(
-            app.selection.active_card_id,
+            app.selection.active_card.map(|a| a.id()),
             Some(parent_id),
-            "active_card_id must be updated to the parent so the detail view rerenders against the parent card"
+            "active_card.id() must be updated to the parent so the detail view rerenders against the parent card"
         );
         assert_eq!(
             app.get_card_for_detail_view()
@@ -1372,15 +1377,14 @@ mod tests {
             .position(|c| c.id == parent_id)
             .unwrap();
 
-        app.selection.active_card_index = Some(parent_idx);
-        app.selection.active_card_id = Some(parent_id);
+        app.selection.active_card = Some(ActiveCard::new(parent_idx, parent_id));
         app.focus.card_focus = CardFocus::Children;
         app.relationship.children_list.update_item_count(1);
         app.relationship.children_list.selection.set(Some(0));
 
         app.navigate_to_selected_child(parent_idx);
 
-        assert_eq!(app.selection.active_card_id, Some(child_id));
+        assert_eq!(app.selection.active_card.map(|a| a.id()), Some(child_id));
         assert_eq!(
             app.get_card_for_detail_view()
                 .expect("detail must resolve")
@@ -1398,17 +1402,16 @@ mod tests {
         let b_idx = app.model.cards().iter().position(|c| c.id == b_id).unwrap();
         let c_idx = app.model.cards().iter().position(|c| c.id == c_id).unwrap();
 
-        app.selection.active_card_index = Some(c_idx);
-        app.selection.active_card_id = Some(c_id);
+        app.selection.active_card = Some(ActiveCard::new(c_idx, c_id));
         app.selection.card_navigation_history.push(b_idx);
         app.focus.card_focus = CardFocus::Parents;
 
         app.return_to_previous_card_from_detail_history();
 
         assert_eq!(
-            app.selection.active_card_id,
+            app.selection.active_card.map(|a| a.id()),
             Some(b_id),
-            "Backspace return must update active_card_id along with the index"
+            "Backspace return must update active_card to the previous card"
         );
         assert_eq!(
             app.get_card_for_detail_view()
@@ -1426,9 +1429,9 @@ mod tests {
         app.handle_sprint_detail_key(KeyCode::Enter);
 
         assert_eq!(
-            app.selection.active_card_id,
+            app.selection.active_card.map(|a| a.id()),
             Some(card_id),
-            "Enter on a sprint-detail card row must set active_card_id so the detail view can resolve the card"
+            "Enter on a sprint-detail card row must set active_card so the detail view can resolve the card"
         );
         assert_eq!(
             app.get_card_for_detail_view()
@@ -1446,9 +1449,9 @@ mod tests {
         app.handle_sprint_detail_key(KeyCode::Char('e'));
 
         assert_eq!(
-            app.selection.active_card_id,
+            app.selection.active_card.map(|a| a.id()),
             Some(card_id),
-            "'e' on a sprint-detail card row must set active_card_id so the detail view can resolve the card"
+            "'e' on a sprint-detail card row must set active_card so the detail view can resolve the card"
         );
         assert_eq!(
             app.get_card_for_detail_view()
@@ -1466,19 +1469,14 @@ mod tests {
         let b_idx = app.model.cards().iter().position(|c| c.id == b_id).unwrap();
         let stale_idx = app.model.cards().len() + 99;
 
-        app.selection.active_card_index = Some(b_idx);
-        app.selection.active_card_id = Some(b_id);
+        app.selection.active_card = Some(ActiveCard::new(b_idx, b_id));
         app.selection.card_navigation_history.push(stale_idx);
 
         app.return_to_previous_card_from_detail_history();
 
-        assert_eq!(
-            app.selection.active_card_id, None,
-            "when previous_idx no longer resolves, active_card_id must be cleared"
-        );
-        assert_eq!(
-            app.selection.active_card_index, None,
-            "when previous_idx no longer resolves, active_card_index must be cleared too — the two fields cannot drift apart"
+        assert!(
+            app.selection.active_card.is_none(),
+            "when previous_idx no longer resolves, active_card must be cleared — the wrapper enforces that index and id move together"
         );
         assert!(
             app.get_card_for_detail_view().is_none(),

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1123,8 +1123,7 @@ impl App {
                         .card_navigation_history
                         .push(current_card_idx);
                     // Navigate to parent
-                    self.selection.active_card_index = Some(parent_idx);
-                    self.selection.active_card_id = Some(parent_id);
+                    self.selection.set_active_card(parent_idx, parent_id);
                     self.focus.card_focus = CardFocus::Title;
                     // Update item counts for new card
                     let new_parents = self.get_current_card_parents();
@@ -1145,8 +1144,7 @@ impl App {
                 self.selection
                     .card_navigation_history
                     .push(current_card_idx);
-                self.selection.active_card_index = Some(parent_idx);
-                self.selection.active_card_id = Some(parents[0]);
+                self.selection.set_active_card(parent_idx, parents[0]);
                 self.focus.card_focus = CardFocus::Title;
                 // Update item counts for new card
                 let new_parents = self.get_current_card_parents();
@@ -1171,8 +1169,7 @@ impl App {
                         .card_navigation_history
                         .push(current_card_idx);
                     // Navigate to child
-                    self.selection.active_card_index = Some(child_idx);
-                    self.selection.active_card_id = Some(child_id);
+                    self.selection.set_active_card(child_idx, child_id);
                     self.focus.card_focus = CardFocus::Title;
                     // Update item counts for new card
                     let new_parents = self.get_current_card_parents();
@@ -1193,8 +1190,7 @@ impl App {
                 self.selection
                     .card_navigation_history
                     .push(current_card_idx);
-                self.selection.active_card_index = Some(child_idx);
-                self.selection.active_card_id = Some(children[0]);
+                self.selection.set_active_card(child_idx, children[0]);
                 self.focus.card_focus = CardFocus::Title;
                 // Update item counts for new card
                 let new_parents = self.get_current_card_parents();
@@ -1255,9 +1251,7 @@ impl App {
 mod tests {
     use crate::app::CardFocus;
     use crate::App;
-    use kanban_domain::{
-        CreateCardOptions, GraphOperations, KanbanOperations, Snapshot,
-    };
+    use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, Snapshot};
 
     fn seed_chain(app: &mut App, titles: &[&str]) -> Vec<uuid::Uuid> {
         let board = app.ctx.create_board("Board".into(), None).unwrap();
@@ -1364,18 +1358,8 @@ mod tests {
         let ids = seed_chain(&mut app, &["A", "B", "C"]);
         let b_id = ids[1];
         let c_id = ids[2];
-        let b_idx = app
-            .model
-            .cards()
-            .iter()
-            .position(|c| c.id == b_id)
-            .unwrap();
-        let c_idx = app
-            .model
-            .cards()
-            .iter()
-            .position(|c| c.id == c_id)
-            .unwrap();
+        let b_idx = app.model.cards().iter().position(|c| c.id == b_id).unwrap();
+        let c_idx = app.model.cards().iter().position(|c| c.id == c_id).unwrap();
 
         app.selection.active_card_index = Some(c_idx);
         app.selection.active_card_id = Some(c_id);

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -329,16 +329,8 @@ impl App {
                 self.handle_manage_children();
             }
             KeyCode::Enter => match self.focus.card_focus {
-                CardFocus::Parents => {
-                    if let Some(active) = self.selection.active_card {
-                        self.navigate_to_selected_parent(active.index());
-                    }
-                }
-                CardFocus::Children => {
-                    if let Some(active) = self.selection.active_card {
-                        self.navigate_to_selected_child(active.index());
-                    }
-                }
+                CardFocus::Parents => self.navigate_to_selected_parent(),
+                CardFocus::Children => self.navigate_to_selected_child(),
                 _ => {}
             },
             KeyCode::Backspace | KeyCode::Char('h')
@@ -1144,15 +1136,18 @@ impl App {
         }
     }
 
-    pub(crate) fn navigate_to_selected_parent(&mut self, current_card_idx: usize) {
-        self.navigate_to_related_card(current_card_idx, RelationSide::Parents);
+    pub(crate) fn navigate_to_selected_parent(&mut self) {
+        self.navigate_to_related_card(RelationSide::Parents);
     }
 
-    pub(crate) fn navigate_to_selected_child(&mut self, current_card_idx: usize) {
-        self.navigate_to_related_card(current_card_idx, RelationSide::Children);
+    pub(crate) fn navigate_to_selected_child(&mut self) {
+        self.navigate_to_related_card(RelationSide::Children);
     }
 
-    fn navigate_to_related_card(&mut self, current_card_idx: usize, side: RelationSide) {
+    fn navigate_to_related_card(&mut self, side: RelationSide) {
+        let Some(current_card_idx) = self.selection.active_card.map(|a| a.index()) else {
+            return;
+        };
         let related = self.related_card_ids(side);
         let selected_id = self
             .list_selection(side)
@@ -1308,7 +1303,7 @@ mod tests {
         app.relationship.parents_list.update_item_count(1);
         app.relationship.parents_list.selection.set(Some(0));
 
-        app.navigate_to_selected_parent(child_idx);
+        app.navigate_to_selected_parent();
 
         assert_eq!(
             app.selection.active_card.map(|a| a.id()),
@@ -1342,7 +1337,7 @@ mod tests {
         app.relationship.children_list.update_item_count(1);
         app.relationship.children_list.selection.set(Some(0));
 
-        app.navigate_to_selected_child(parent_idx);
+        app.navigate_to_selected_child();
 
         assert_eq!(app.selection.active_card.map(|a| a.id()), Some(child_id));
         assert_eq!(
@@ -1439,7 +1434,7 @@ mod tests {
         app.relationship.parents_list.update_item_count(1);
         // Deliberately no parents_list.selection.set(...) — exercise the fallback path.
 
-        app.navigate_to_selected_parent(child_idx);
+        app.navigate_to_selected_parent();
 
         assert_eq!(
             app.selection.active_card.map(|a| a.id()),
@@ -1466,7 +1461,7 @@ mod tests {
         app.relationship.children_list.update_item_count(1);
         // Deliberately no children_list.selection.set(...).
 
-        app.navigate_to_selected_child(parent_idx);
+        app.navigate_to_selected_child();
 
         assert_eq!(
             app.selection.active_card.map(|a| a.id()),

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -739,7 +739,7 @@ impl App {
                             if let Some(card_idx) =
                                 self.model.cards().iter().position(|c| c.id == card_id)
                             {
-                                self.selection.active_card_index = Some(card_idx);
+                                self.selection.set_active_card(card_idx, card_id);
                                 // Initialize list components with item counts
                                 let parents = self.get_current_card_parents();
                                 let children = self.get_current_card_children();
@@ -757,7 +757,7 @@ impl App {
                             if let Some(card_idx) =
                                 self.model.cards().iter().position(|c| c.id == card_id)
                             {
-                                self.selection.active_card_index = Some(card_idx);
+                                self.selection.set_active_card(card_idx, card_id);
                                 // Initialize list components with item counts
                                 let parents = self.get_current_card_parents();
                                 let children = self.get_current_card_children();
@@ -1097,9 +1097,11 @@ impl App {
 
     pub(crate) fn return_to_previous_card_from_detail_history(&mut self) {
         if let Some(previous_idx) = self.selection.card_navigation_history.pop() {
-            let previous_id = self.model.cards().get(previous_idx).map(|c| c.id);
-            self.selection.active_card_index = Some(previous_idx);
-            self.selection.active_card_id = previous_id;
+            if let Some(previous_id) = self.model.cards().get(previous_idx).map(|c| c.id) {
+                self.selection.set_active_card(previous_idx, previous_id);
+            } else {
+                self.selection.clear_active_card();
+            }
             self.focus.card_focus = CardFocus::Title;
             let parents = self.get_current_card_parents();
             let children = self.get_current_card_children();

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1097,7 +1097,9 @@ impl App {
 
     pub(crate) fn return_to_previous_card_from_detail_history(&mut self) {
         if let Some(previous_idx) = self.selection.card_navigation_history.pop() {
+            let previous_id = self.model.cards().get(previous_idx).map(|c| c.id);
             self.selection.active_card_index = Some(previous_idx);
+            self.selection.active_card_id = previous_id;
             self.focus.card_focus = CardFocus::Title;
             let parents = self.get_current_card_parents();
             let children = self.get_current_card_children();
@@ -1122,6 +1124,7 @@ impl App {
                         .push(current_card_idx);
                     // Navigate to parent
                     self.selection.active_card_index = Some(parent_idx);
+                    self.selection.active_card_id = Some(parent_id);
                     self.focus.card_focus = CardFocus::Title;
                     // Update item counts for new card
                     let new_parents = self.get_current_card_parents();
@@ -1143,6 +1146,7 @@ impl App {
                     .card_navigation_history
                     .push(current_card_idx);
                 self.selection.active_card_index = Some(parent_idx);
+                self.selection.active_card_id = Some(parents[0]);
                 self.focus.card_focus = CardFocus::Title;
                 // Update item counts for new card
                 let new_parents = self.get_current_card_parents();
@@ -1168,6 +1172,7 @@ impl App {
                         .push(current_card_idx);
                     // Navigate to child
                     self.selection.active_card_index = Some(child_idx);
+                    self.selection.active_card_id = Some(child_id);
                     self.focus.card_focus = CardFocus::Title;
                     // Update item counts for new card
                     let new_parents = self.get_current_card_parents();
@@ -1189,6 +1194,7 @@ impl App {
                     .card_navigation_history
                     .push(current_card_idx);
                 self.selection.active_card_index = Some(child_idx);
+                self.selection.active_card_id = Some(children[0]);
                 self.focus.card_focus = CardFocus::Title;
                 // Update item counts for new card
                 let new_parents = self.get_current_card_parents();

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -339,20 +339,7 @@ impl App {
                     && self.focus.card_focus != CardFocus::Metadata
                     && self.focus.card_focus != CardFocus::Description =>
             {
-                // Allow backspace for back navigation in parents/children, but not in text editing sections
-                if let Some(previous_idx) = self.selection.card_navigation_history.pop() {
-                    self.selection.active_card_index = Some(previous_idx);
-                    self.focus.card_focus = CardFocus::Title;
-                    // Update item counts for the card we're returning to
-                    let parents = self.get_current_card_parents();
-                    let children = self.get_current_card_children();
-                    self.relationship
-                        .parents_list
-                        .update_item_count(parents.len());
-                    self.relationship
-                        .children_list
-                        .update_item_count(children.len());
-                }
+                self.return_to_previous_card_from_detail_history();
             }
             _ => {}
         }
@@ -1108,7 +1095,22 @@ impl App {
         Vec::new()
     }
 
-    fn navigate_to_selected_parent(&mut self, current_card_idx: usize) {
+    pub(crate) fn return_to_previous_card_from_detail_history(&mut self) {
+        if let Some(previous_idx) = self.selection.card_navigation_history.pop() {
+            self.selection.active_card_index = Some(previous_idx);
+            self.focus.card_focus = CardFocus::Title;
+            let parents = self.get_current_card_parents();
+            let children = self.get_current_card_children();
+            self.relationship
+                .parents_list
+                .update_item_count(parents.len());
+            self.relationship
+                .children_list
+                .update_item_count(children.len());
+        }
+    }
+
+    pub(crate) fn navigate_to_selected_parent(&mut self, current_card_idx: usize) {
         let parents = self.get_current_card_parents();
         if let Some(selected_idx) = self.relationship.parents_list.selection.get() {
             if let Some(&parent_id) = parents.get(selected_idx) {
@@ -1155,7 +1157,7 @@ impl App {
         }
     }
 
-    fn navigate_to_selected_child(&mut self, current_card_idx: usize) {
+    pub(crate) fn navigate_to_selected_child(&mut self, current_card_idx: usize) {
         let children = self.get_current_card_children();
         if let Some(selected_idx) = self.relationship.children_list.selection.get() {
             if let Some(&child_id) = children.get(selected_idx) {

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -137,8 +137,8 @@ impl App {
                 let cards = self.model.cards();
                 let card_id = self
                     .selection
-                    .active_card_index
-                    .and_then(|idx| cards.get(idx))
+                    .active_card
+                    .and_then(|active| cards.get(active.index()))
                     .map(|c| c.id)
                     .or_else(|| self.get_selected_card_in_context().map(|c| c.id));
 

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, AppMode, Focus};
+use crate::app::{ActiveCard, App, AppMode, Focus};
 use crate::view_strategy::UnifiedViewStrategy;
 use kanban_domain::TaskListView;
 
@@ -488,9 +488,12 @@ impl App {
             Focus::Cards => {
                 if let Some(selected_card) = self.get_selected_card_in_context() {
                     let card_id = selected_card.id;
-                    let actual_idx = self.model.cards().iter().position(|c| c.id == card_id);
-                    self.selection.active_card_index = actual_idx;
-                    self.selection.active_card_id = Some(card_id);
+                    self.selection.active_card = self
+                        .model
+                        .cards()
+                        .iter()
+                        .position(|c| c.id == card_id)
+                        .map(|idx| ActiveCard::new(idx, card_id));
                     // Initialize list components with item counts
                     let parents = self.get_current_card_parents();
                     let children = self.get_current_card_children();

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -51,8 +51,8 @@ impl App {
             }
             KeyCode::Enter => {
                 if let Some(priority_idx) = self.dialog_input.priority_selection.get() {
-                    if let Some(card_idx) = self.selection.active_card_index {
-                        if let Some(card) = self.model.cards().get(card_idx) {
+                    if let Some(active) = self.selection.active_card {
+                        if let Some(card) = self.model.cards().get(active.index()) {
                             use kanban_domain::{CardPriority, CardUpdate};
                             let priority = match priority_idx {
                                 0 => CardPriority::Low,
@@ -254,8 +254,8 @@ impl App {
             }
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if let Some(selection_idx) = self.dialog_input.sprint_assign_selection.get() {
-                    if let Some(card_idx) = self.selection.active_card_index {
-                        let card_id = match self.model.cards().get(card_idx) {
+                    if let Some(active) = self.selection.active_card {
+                        let card_id = match self.model.cards().get(active.index()) {
                             Some(card) => card.id,
                             None => return,
                         };
@@ -590,8 +590,8 @@ impl App {
                 // Toggle relationship
                 if let Some(idx) = self.relationship.selection.get() {
                     if let Some(selected_card_id) = filtered_cards.get(idx).copied() {
-                        if let Some(card_idx) = self.selection.active_card_index {
-                            if let Some(current_card) = self.model.cards().get(card_idx) {
+                        if let Some(active) = self.selection.active_card {
+                            if let Some(current_card) = self.model.cards().get(active.index()) {
                                 let current_card_id = current_card.id;
 
                                 let (child_id, parent_id) = if is_parent_mode {

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -277,7 +277,7 @@ impl App {
         } else {
             Some(0)
         });
-        self.selection.active_card_index = None;
+        self.selection.active_card = None;
         self.selection.card_navigation_history.clear();
 
         self.persistence.save_file = Some(new_storage_location.clone());

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -1,4 +1,5 @@
 use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_tui::app::ActiveCard;
 use kanban_tui::components::build_description_lines;
 use kanban_tui::App;
 
@@ -32,7 +33,7 @@ fn test_card_description_appears_in_detail_view() {
 
     // Setup app state to show the card detail view
     app.selection.active_board_index = Some(0);
-    app.selection.active_card_index = Some(0);
+    app.selection.active_card = Some(ActiveCard::new(0, card.id));
 
     // Verify the card has the description
     app.prepare_frame();
@@ -168,7 +169,7 @@ fn test_card_with_empty_string_description_displays_placeholder() {
         .unwrap();
 
     // Create card with empty string description (simulating user clearing a description)
-    let _card = app
+    let card = app
         .ctx
         .create_card(
             board.id,
@@ -183,7 +184,7 @@ fn test_card_with_empty_string_description_displays_placeholder() {
 
     // Setup app state
     app.selection.active_board_index = Some(0);
-    app.selection.active_card_index = Some(0);
+    app.selection.active_card = Some(ActiveCard::new(0, card.id));
 
     // Verify the card has an empty string description (not None)
     app.prepare_frame();

--- a/crates/kanban-tui/tests/card_detail_tests.rs
+++ b/crates/kanban-tui/tests/card_detail_tests.rs
@@ -1,7 +1,8 @@
 use kanban_domain::{Board, Card, Column, Snapshot};
+use kanban_tui::app::ActiveCard;
 
 /// Verify that `get_card_for_detail_view` resolves to the card whose UUID is
-/// stored in `active_card_id`, regardless of iteration order.
+/// held in `active_card`, regardless of iteration order.
 #[test]
 fn test_active_card_detail_shows_selected_card() {
     let mut app = kanban_tui::App::test_default();
@@ -18,23 +19,23 @@ fn test_active_card_detail_shows_selected_card() {
         ..Default::default()
     });
 
-    // Select the second card by ID.
-    app.selection.active_card_id = Some(card_b_id);
+    // Select the second card by id (and matching index 1).
+    app.selection.active_card = Some(ActiveCard::new(1, card_b_id));
 
     let detail_card = app
         .get_card_for_detail_view()
-        .expect("should return a card when active_card_id is set");
+        .expect("should return a card when active_card is set");
 
     assert_eq!(
         detail_card.id, card_b_id,
-        "detail view must show the card whose UUID matches active_card_id"
+        "detail view must show the card whose UUID matches active_card.id()"
     );
 }
 
-/// When `active_card_id` is None, `get_card_for_detail_view` returns None.
+/// When `active_card` is None, `get_card_for_detail_view` returns None.
 #[test]
 fn test_active_card_detail_returns_none_when_no_card_selected() {
     let app = kanban_tui::App::test_default();
-    assert!(app.selection.active_card_id.is_none());
+    assert!(app.selection.active_card.is_none());
     assert!(app.get_card_for_detail_view().is_none());
 }

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -1,5 +1,6 @@
 mod helpers;
 
+use kanban_tui::app::ActiveCard;
 use kanban_tui::App;
 
 #[test]
@@ -93,7 +94,7 @@ fn test_manage_parents_popup_enter_creates_parent_edge() {
         .unwrap();
 
     // Wire the model so popup_handlers' `self.model.cards()` reflects
-    // the data store. `selection.active_card_index` points at child.
+    // the data store. `selection.active_card` points at child.
     let snapshot = Snapshot {
         boards: app.ctx.data_store().list_boards().unwrap(),
         columns: app.ctx.data_store().list_all_columns().unwrap(),
@@ -109,7 +110,7 @@ fn test_manage_parents_popup_enter_creates_parent_edge() {
         .iter()
         .position(|c| c.id == child.id)
         .expect("child must be in model");
-    app.selection.active_card_index = Some(card_idx);
+    app.selection.active_card = Some(ActiveCard::new(card_idx, child.id));
 
     // Enter ManageParents mode with the parent as the only candidate
     // and select it.
@@ -204,7 +205,7 @@ fn test_manage_parents_popup_cycle_surfaces_error_banner_to_user() {
         .iter()
         .position(|card| card.id == a.id)
         .expect("a must be in model");
-    app.selection.active_card_index = Some(card_idx);
+    app.selection.active_card = Some(ActiveCard::new(card_idx, a.id));
 
     app.push_mode(AppMode::Dialog(DialogMode::ManageParents));
     app.relationship.card_ids = vec![c.id];

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -8,6 +8,7 @@ use kanban_domain::{
 use kanban_tui::components::{build_entries, sprint_id_of};
 use kanban_tui::{
     app::mode::{AppMode, DialogMode},
+    app::ActiveCard,
     components::{SelectionDialog, SprintAssignDialog},
     App,
 };
@@ -63,7 +64,7 @@ fn setup_app_with_sprints() -> DialogFixture {
     app.ctx.complete_sprint(to_complete.id).unwrap();
 
     app.selection.active_board_index = Some(0);
-    app.selection.active_card_index = Some(0);
+    app.selection.active_card = Some(ActiveCard::new(0, card.id));
     app.prepare_frame();
 
     DialogFixture {
@@ -400,7 +401,8 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
         .ctx
         .create_column(board.id, "Todo".into(), None)
         .unwrap();
-    app.ctx
+    let card = app
+        .ctx
         .create_card(
             board.id,
             column.id,
@@ -412,7 +414,7 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
         app.ctx.create_sprint(board.id, None, None).unwrap();
     }
     app.selection.active_board_index = Some(0);
-    app.selection.active_card_index = Some(0);
+    app.selection.active_card = Some(ActiveCard::new(0, card.id));
     app.prepare_frame();
 
     open_assign_dialog(&mut app);
@@ -471,7 +473,8 @@ fn test_sticky_header_appears_at_top_when_scrolled_past_active_planned_header() 
         .ctx
         .create_column(board.id, "Todo".into(), None)
         .unwrap();
-    app.ctx
+    let card = app
+        .ctx
         .create_card(
             board.id,
             column.id,
@@ -483,7 +486,7 @@ fn test_sticky_header_appears_at_top_when_scrolled_past_active_planned_header() 
         app.ctx.create_sprint(board.id, None, None).unwrap();
     }
     app.selection.active_board_index = Some(0);
-    app.selection.active_card_index = Some(0);
+    app.selection.active_card = Some(ActiveCard::new(0, card.id));
     app.prepare_frame();
 
     open_assign_dialog(&mut app);
@@ -529,7 +532,8 @@ fn test_sticky_header_switches_to_completed_ended_when_selecting_in_lower_sectio
         .ctx
         .create_column(board.id, "Todo".into(), None)
         .unwrap();
-    app.ctx
+    let card = app
+        .ctx
         .create_card(
             board.id,
             column.id,
@@ -546,7 +550,7 @@ fn test_sticky_header_switches_to_completed_ended_when_selecting_in_lower_sectio
         app.ctx.complete_sprint(s.id).unwrap();
     }
     app.selection.active_board_index = Some(0);
-    app.selection.active_card_index = Some(0);
+    app.selection.active_card = Some(ActiveCard::new(0, card.id));
     app.prepare_frame();
 
     open_assign_dialog(&mut app);


### PR DESCRIPTION
Restores in-detail navigation across the card-detail view and turns the underlying field-drift class into a compile-time-impossible state going forward.

## What

In the card detail view, pressing Enter on a parent or child entry now navigates the detail view to that card; Backspace returns. The same fix applies to the other entry points into the detail view (Enter and `e` on a sprint-detail card row) and to the dialog-opening arms (TogglePriority / AssignSprint / ReassignSprint on a sprint-detail row). Before this PR all of these paths appeared broken: the detail view stayed on the original card while the relationship boxes silently emptied out.

## Why

Since KAN-364 (`9c79172 fix(tui): resolve card detail card by UUID instead of HashMap index`), `get_card_for_detail_view()` resolves the rendered card off `selection.active_card_id`, not the index. Eight handler sites mutated `active_card_index` without writing `active_card_id`, leaving the two fields drifted. The bug went unnoticed until KAN-504 populated parent/child edges across the personal kanban board and the navigation path was exercised heavily.

## How

The PR lands in four logical layers, each commit-bisectable.

### Layer 1 — narrow bugfix (commits 1-5)
Red → Green → Refactor for the parent/child Enter and Backspace paths. A `SelectionHub::set_active_card(idx, id)` helper routed the four `navigate_to_selected_*` sites through a single atomic write so the two fields could not drift apart again.

### Layer 2 — fold in the remaining entry points (commits 6-7, post-review)
Code review surfaced the same drift at three more handler arms:
- `CardListAction::Select` (sprint-detail Enter into detail view)
- `CardListAction::Edit` (sprint-detail `e` into detail view)
- The Backspace stale-index defensive branch (left `active_card_index` populated while `active_card_id` was `None`)

RED tests added for all three; GREEN routed Select/Edit through the helper and added a `clear_active_card` helper for the stale-index branch.

### Layer 3 — design-enforced consistency (commits 8-9, post-review)
Replaced the two parallel `Option<usize>` and `Option<Uuid>` fields on `SelectionHub` with a single `Option<ActiveCard>` whose private fields and `new(idx, id)` constructor make drift **structurally impossible**:

```rust
pub struct ActiveCard {
    index: usize,        // private
    id: uuid::Uuid,      // private
}
impl ActiveCard {
    pub fn new(index: usize, id: uuid::Uuid) -> Self { ... }
    pub fn index(&self) -> usize { ... }
    pub fn id(&self) -> uuid::Uuid { ... }
}
// SelectionHub:
pub active_card: Option<ActiveCard>,
```

The constructor requires both values; accessors return by value; mutation goes through whole-Option assignment. The old `set_active_card` and `clear_active_card` helpers are dropped because the struct constructor *is* the helper, enforced by the type system. Mechanically updated ~43 read/write sites across `kanban-tui` (handlers, components, integration tests). The compiler verifies every site.

### Layer 4 — DRY and symmetry (commits 10-11, post-review)
- Extracted `refresh_relationship_counts` to remove a six-line duplication that appeared in five places.
- Introduced `RelationSide` enum and `navigate_to_related_card` so the parent/child symmetry is expressed in the type system. `navigate_to_selected_parent` / `navigate_to_selected_child` become zero-arg delegators that pass `RelationSide::Parents` / `RelationSide::Children`.
- Dropped the redundant `current_card_idx` parameter; it is derived internally from `self.selection.active_card.map(|a| a.index())` with an early return when no card is active.

## Testing

8 inline tests in `handlers::detail_view_handlers::tests`:
- 3 from the original cycle (parent / child navigation with selection; Backspace return with valid history).
- 3 added for the un-fixed entry points (sprint-detail Enter, sprint-detail `e`, stale-index backspace clears `active_card` entirely).
- 2 added for the previously-untested no-list-selection fallback path in `navigate_to_selected_*`.

Plus existing `card_detail_tests.rs` and the four other integration tests updated to construct via the new `ActiveCard` wrapper.

Verification: `cargo test --workspace` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean.

## Out of scope (filed separately)

The UX gaps surfaced during this work (discoverability of back-nav, breadcrumb of drill-down path, focus-restriction lift, forward stack) are tracked as KAN-532. They live above the data layer this PR fixes.