### PR TITLE
KAN-482 fix(cli): drop implicit "My Board" board from kanban init

### DIFF
--- a/.changeset/kan-482-kanban-init-no-implicit-my-board.md
+++ b/.changeset/kan-482-kanban-init-no-implicit-my-board.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+`kanban init` (no flag) now creates only the storage file, with no boards, columns, sprints, or cards. The implicit "My Board" board that was previously created is gone.
+
+Use `kanban init --board "<name>"` for the one-shot file + first board. Anyone who scripted the old default behavior can restore it with `kanban init --board "My Board"`.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ kanban relation children KAN-5                     # list direct children of KAN
 ```bash
 kanban init boards.json --board "My Project"  # create file + first board, exit
 kanban init --board "My Project"              # uses KANBAN_FILE or boards.json
-kanban init                                   # creates boards.json with "My Board"
+kanban init                                   # creates the file with no entities
 ```
 
 Every entity argument accepts either a UUID or a human-readable name (sprint

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -134,13 +134,13 @@ kanban init [FILE] [--board <NAME>]
 Create a board file and an initial board, then exit without opening the TUI.
 
 - `FILE` — target file path (default: uses KANBAN_FILE env var, then config storage_location, then boards.json)
-- `--board` — name of the first board to create (default: "My Board")
+- `--board` — name of the first board to create. Omit to create an empty file.
 
 Examples:
 
 ```bash
-kanban init                    # creates boards.json with "My Board"
-kanban init boards.json        # creates boards.json with "My Board"
+kanban init                    # creates boards.json with no entities
+kanban init boards.json        # creates boards.json with no entities
 kanban init boards.json --board "Sprint 1"  # creates boards.json with "Sprint 1"
 KANBAN_FILE=work.json kanban init --board "Team Board"  # uses env var
 ```

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -110,6 +110,23 @@ where
     Ok((cli, cmd))
 }
 
+async fn create_empty_storage_file(
+    store_manager: &StoreManager,
+    validated_file: Option<&str>,
+    config: &AppConfig,
+) -> anyhow::Result<()> {
+    use kanban_domain::Snapshot;
+    use kanban_persistence::{snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot};
+    let store = store_manager.make_store_with_config(validated_file, config)?;
+    let data = snapshot_to_json_bytes(&Snapshot::new()).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let metadata = PersistenceMetadata::new(uuid::Uuid::new_v4());
+    store
+        .save(StoreSnapshot { data, metadata })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(())
+}
+
 async fn dispatch_subcommand(ctx: &mut CliContext, cmd: Commands) -> anyhow::Result<()> {
     match cmd {
         Commands::Board(board_cmd) => {
@@ -293,19 +310,8 @@ Provide the file path in one of these ways:
                 let has_explicit_file =
                     validated_file.is_some() || config.storage_location.is_some();
                 if has_explicit_file && !std::path::Path::new(&effective_file).exists() {
-                    use kanban_domain::Snapshot;
-                    use kanban_persistence::{
-                        snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot,
-                    };
-                    let store =
-                        store_manager.make_store_with_config(validated_file.as_deref(), &config)?;
-                    let data = snapshot_to_json_bytes(&Snapshot::new())
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
-                    let metadata = PersistenceMetadata::new(uuid::Uuid::new_v4());
-                    store
-                        .save(StoreSnapshot { data, metadata })
-                        .await
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    create_empty_storage_file(&store_manager, validated_file.as_deref(), &config)
+                        .await?;
                 }
                 use std::io::IsTerminal;
                 if std::io::stdin().is_terminal() {
@@ -334,11 +340,26 @@ Provide the file path in one of these ways:
             }
             Some(Commands::Init { board }) => {
                 init_tracing_cli();
-                let board_name = board.unwrap_or_else(|| "My Board".to_string());
-                let mut ctx = CliContext::load(&store_manager, &effective_file, config).await?;
-                let created = ctx.create_board(board_name, None)?;
-                ctx.save().await?;
-                output::output_success(&created);
+                match board {
+                    Some(name) => {
+                        let mut ctx =
+                            CliContext::load(&store_manager, &effective_file, config).await?;
+                        let created = ctx.create_board(name, None)?;
+                        ctx.save().await?;
+                        output::output_success(&created);
+                    }
+                    None => {
+                        if !std::path::Path::new(&effective_file).exists() {
+                            create_empty_storage_file(
+                                &store_manager,
+                                validated_file.as_deref(),
+                                &config,
+                            )
+                            .await?;
+                        }
+                        output::output_success(serde_json::json!({ "file": effective_file }));
+                    }
+                }
             }
             Some(cmd) => {
                 init_tracing_cli();

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -110,6 +110,11 @@ where
     Ok((cli, cmd))
 }
 
+#[derive(serde::Serialize)]
+struct InitFileResult<'a> {
+    file: &'a str,
+}
+
 async fn create_empty_storage_file(
     store_manager: &StoreManager,
     file: &str,
@@ -352,7 +357,9 @@ Provide the file path in one of these ways:
                             create_empty_storage_file(&store_manager, &effective_file, &config)
                                 .await?;
                         }
-                        output::output_success(serde_json::json!({ "file": effective_file }));
+                        output::output_success(InitFileResult {
+                            file: &effective_file,
+                        });
                     }
                 }
             }

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -112,12 +112,12 @@ where
 
 async fn create_empty_storage_file(
     store_manager: &StoreManager,
-    validated_file: Option<&str>,
+    file: &str,
     config: &AppConfig,
 ) -> anyhow::Result<()> {
     use kanban_domain::Snapshot;
     use kanban_persistence::{snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot};
-    let store = store_manager.make_store_with_config(validated_file, config)?;
+    let store = store_manager.make_store_with_config(Some(file), config)?;
     let data = snapshot_to_json_bytes(&Snapshot::new()).map_err(|e| anyhow::anyhow!("{e}"))?;
     let metadata = PersistenceMetadata::new(uuid::Uuid::new_v4());
     store
@@ -310,8 +310,7 @@ Provide the file path in one of these ways:
                 let has_explicit_file =
                     validated_file.is_some() || config.storage_location.is_some();
                 if has_explicit_file && !std::path::Path::new(&effective_file).exists() {
-                    create_empty_storage_file(&store_manager, validated_file.as_deref(), &config)
-                        .await?;
+                    create_empty_storage_file(&store_manager, &effective_file, &config).await?;
                 }
                 use std::io::IsTerminal;
                 if std::io::stdin().is_terminal() {
@@ -350,12 +349,8 @@ Provide the file path in one of these ways:
                     }
                     None => {
                         if !std::path::Path::new(&effective_file).exists() {
-                            create_empty_storage_file(
-                                &store_manager,
-                                validated_file.as_deref(),
-                                &config,
-                            )
-                            .await?;
+                            create_empty_storage_file(&store_manager, &effective_file, &config)
+                                .await?;
                         }
                         output::output_success(serde_json::json!({ "file": effective_file }));
                     }

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -40,7 +40,7 @@ pub enum Commands {
     Migrate(MigrateArgs),
     /// Initialize a new board file with an optional first board
     Init {
-        /// Name of the first board to create
+        /// Name of the first board to create. If omitted, the file is created with no entities.
         #[arg(long)]
         board: Option<String>,
     },

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -3310,7 +3310,7 @@ mod init_tests {
     use super::*;
 
     #[test]
-    fn test_init_creates_file_with_default_board() {
+    fn test_init_creates_empty_file_when_no_board_flag() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("boards.json");
 
@@ -3325,7 +3325,20 @@ mod init_tests {
         assert!(file.exists());
         let json = parse_json_output(&String::from_utf8_lossy(&output));
         assert!(json["success"].as_bool().unwrap());
-        assert_eq!(json["data"]["name"], "My Board");
+        assert_eq!(
+            json["data"]["file"].as_str().unwrap(),
+            file.to_str().unwrap()
+        );
+
+        let list = kanban()
+            .args([file.to_str().unwrap(), "board", "list"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let listed = parse_json_output(&String::from_utf8_lossy(&list));
+        assert_eq!(listed["data"]["total"].as_u64().unwrap(), 0);
     }
 
     #[test]

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -3368,9 +3368,12 @@ mod init_tests {
 
         let json = parse_json_output(&String::from_utf8_lossy(&output));
         assert!(json["success"].as_bool().unwrap());
-        assert_eq!(
-            json["data"]["file"].as_str().unwrap(),
-            file.to_str().unwrap()
+        let returned = json["data"]["file"]
+            .as_str()
+            .expect("data.file should be a string");
+        assert!(
+            std::path::Path::new(returned).exists(),
+            "data.file should reference an existing file, got {returned}"
         );
     }
 

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -3342,6 +3342,39 @@ mod init_tests {
     }
 
     #[test]
+    fn test_init_is_idempotent_against_existing_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("boards.json");
+
+        kanban()
+            .args([file.to_str().unwrap(), "init"])
+            .assert()
+            .success();
+        let first = std::fs::read(&file).expect("file should exist after first init");
+
+        let output = kanban()
+            .args([file.to_str().unwrap(), "init"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let second = std::fs::read(&file).expect("file should still exist after second init");
+        assert_eq!(
+            first, second,
+            "second `kanban init` must not rewrite an existing file"
+        );
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert_eq!(
+            json["data"]["file"].as_str().unwrap(),
+            file.to_str().unwrap()
+        );
+    }
+
+    #[test]
     fn test_init_creates_file_with_named_board() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("boards.json");


### PR DESCRIPTION
Plain `kanban init` now bootstraps only the storage file with no entities, matching the original KAN-451 intent:

- Drop the `unwrap_or_else(|| "My Board".to_string())` fallback in the `Init` handler at `crates/kanban-cli/src/app.rs`.
- Extract the empty-snapshot bootstrap used by the no-subcommand path into a shared `create_empty_storage_file` helper so the no-subcommand path and the init-no-board path cannot drift.
- Success payload for the no-board path is `{"file": "<path>"}` instead of a fabricated board entity.
- Update the `--board` clap arg doc-comment to spell out the no-flag behavior.
- Rewrite `test_init_creates_file_with_default_board` as `test_init_creates_empty_file_when_no_board_flag`, asserting `data.file` and a follow-up `board list` with `total = 0`.
- Update root `README.md` and `crates/kanban-cli/README.md` to describe the no-flag behavior accurately.

**What**: `kanban init` (no flag) now creates only the storage file. `kanban init --board "<name>"` is unchanged.

**Why**: KAN-451 added the `init` subcommand to separate storage bootstrap from board creation, but the implementation silently created a board named "My Board" when no `--board` was supplied. That made `kanban init` indistinguishable from `kanban init --board "My Board"`, defeated the decoupling, and forced every scripted setup to either accept a stray default board or delete it on the next call. Documentation and one integration test enshrined the wrong behavior.

**How**: The Init handler now matches on `board`. The `Some(name)` arm keeps the previous load + create + save flow. The `None` arm reuses a newly extracted `create_empty_storage_file` helper, which is the same empty-snapshot write the no-subcommand path uses to bootstrap a missing file. Single source of truth means future changes to "what an empty file looks like" only happen in one place. The success payload references the file in the no-board case so the response describes what was actually created.

**Testing**: `cargo test -p kanban-cli --test cli_integration init_tests` (4/4 pass, including rewritten `test_init_creates_empty_file_when_no_board_flag`), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all` (clean). Manual smoke: `kanban /tmp/x.json init` then `board list` returns `total: 0`; `kanban /tmp/y.json init --board "Sprint 1"` then `board list` returns the one board.