### PR TITLE
KAN-538 chore(choco): add packaging/chocolatey/ source files

### DIFF
--- a/.changeset/kan-538-author-packaging-chocolatey-skeleton-nuspec-install-scripts-license-verification.md
+++ b/.changeset/kan-538-author-packaging-chocolatey-skeleton-nuspec-install-scripts-license-verification.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+Internal: added the Chocolatey package source files under
+`packaging/chocolatey/` (nuspec, install/uninstall scripts, LICENSE
+placeholder, VERIFICATION). No user-visible change in this release —
+the files sit unused until the Chocolatey publish workflow lands in
+a follow-up commit, at which point `choco install kanban` becomes
+available on Windows.

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -1,0 +1,25 @@
+# Chocolatey package source
+
+This directory holds the source files for the `kanban` Chocolatey
+package. Pack and publish are automated in
+`.github/workflows/release.yml` — local Windows isn't required.
+
+The CI flow (publish-chocolatey job) does the equivalent of:
+
+    # Substitute placeholders into a temp build directory.
+    Copy-Item kanban.nuspec build/kanban.nuspec
+    Copy-Item tools/* build/tools/ -Recurse
+    Copy-Item ../../LICENSE.md build/tools/LICENSE.txt -Force
+    (Get-Content build/kanban.nuspec) -replace '\$version\$', $VERSION | Set-Content build/kanban.nuspec
+    (Get-Content build/tools/chocolateyinstall.ps1) `
+      -replace '\$version\$',   $VERSION `
+      -replace '\$checksum64\$', $SHA `
+      | Set-Content build/tools/chocolateyinstall.ps1
+    choco pack                                  # in build/
+    choco install kanban -s . -y --force        # smoke test
+    kanban --version
+    kanban-mcp --version
+    choco push kanban.$VERSION.nupkg ...
+
+To re-run the smoke locally on a Windows box, copy the build/ steps above.
+Do NOT commit substituted files.

--- a/packaging/chocolatey/kanban.nuspec
+++ b/packaging/chocolatey/kanban.nuspec
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>kanban</id>
+    <version>$version$</version>
+    <title>kanban</title>
+    <authors>Max Blomstervall</authors>
+    <owners>fulsomenko</owners>
+    <projectUrl>https://github.com/fulsomenko/kanban</projectUrl>
+    <licenseUrl>https://github.com/fulsomenko/kanban/blob/master/LICENSE.md</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/fulsomenko/kanban</projectSourceUrl>
+    <packageSourceUrl>https://github.com/fulsomenko/kanban/tree/master/packaging/chocolatey</packageSourceUrl>
+    <docsUrl>https://github.com/fulsomenko/kanban#readme</docsUrl>
+    <bugTrackerUrl>https://github.com/fulsomenko/kanban/issues</bugTrackerUrl>
+    <tags>kanban tui terminal productivity rust mcp</tags>
+    <summary>Fast, keyboard-driven terminal kanban board (with MCP server)</summary>
+    <description><![CDATA[
+A terminal-based kanban / project management tool written in Rust,
+inspired by lazygit's interface design. Provides a fast,
+keyboard-driven UI for tracking tasks across boards, columns, and
+sprints. Stores data in a portable JSON or SQLite file.
+
+This package installs two binaries:
+
+  - `kanban`     — the TUI / CLI; run `kanban` for the interactive
+                    interface or `kanban --help` for one-shot commands.
+  - `kanban-mcp` — Model Context Protocol server for LLM integrations
+                    (Claude Desktop, VS Code, etc.). Point your MCP
+                    client at this binary.
+
+Run `kanban --help` to get started.
+    ]]></description>
+    <releaseNotes>https://github.com/fulsomenko/kanban/releases/tag/v$version$</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/tools/LICENSE.txt
+++ b/packaging/chocolatey/tools/LICENSE.txt
@@ -1,0 +1,5 @@
+This file is populated from the project root's LICENSE.md at package
+pack time. See packaging/chocolatey/README.md for the local validation
+workflow if you need to populate it manually.
+
+(Pack-time substitution lives in .github/workflows/release.yml.)

--- a/packaging/chocolatey/tools/VERIFICATION.txt
+++ b/packaging/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,30 @@
+VERIFICATION
+
+This package wraps the official kanban Windows release binaries
+(`kanban.exe` and `kanban-mcp.exe`), which are downloaded at install
+time from the project's GitHub release page as a single ZIP archive:
+
+  https://github.com/fulsomenko/kanban/releases
+
+The SHA256 checksum of the downloaded archive is embedded in
+chocolateyinstall.ps1 via the `$checksum64` substitution variable,
+populated at pack time from the corresponding release artifact's
+SHA256SUMS line.
+
+To verify the binaries manually:
+
+  1. Download the release ZIP from:
+       https://github.com/fulsomenko/kanban/releases/download/v<VERSION>/kanban-v<VERSION>-x86_64-pc-windows-msvc.zip
+  2. Compute its SHA256:
+       Get-FileHash -Algorithm SHA256 <file>.zip
+  3. Confirm it matches the `checksum64` value in
+     chocolateyinstall.ps1 of the published Chocolatey package
+     (visible at https://community.chocolatey.org/packages/kanban).
+  4. Unzip and confirm the archive contains `kanban.exe`,
+     `kanban-mcp.exe`, `LICENSE.md`, and `README.md`.
+
+The source for the binaries is at:
+  https://github.com/fulsomenko/kanban
+
+The build that produced the binaries is reproducible from the
+corresponding tagged commit using the project's release.yml workflow.

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$version  = '$version$'
+$url64    = "https://github.com/fulsomenko/kanban/releases/download/v$version/kanban-v$version-x86_64-pc-windows-msvc.zip"
+
+$packageArgs = @{
+  packageName    = 'kanban'
+  unzipLocation  = $toolsDir
+  url64bit       = $url64
+  checksum64     = '$checksum64$'
+  checksumType64 = 'sha256'
+}
+
+Install-ChocolateyZipPackage @packageArgs

--- a/packaging/chocolatey/tools/chocolateyuninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,0 +1,2 @@
+$ErrorActionPreference = 'Stop'
+Uninstall-ChocolateyZipPackage -PackageName 'kanban' -ZipFileName "kanban-*-x86_64-pc-windows-msvc.zip"


### PR DESCRIPTION
Add the static source files for the upcoming Chocolatey package; foundation of the `choco install kanban` install path:

- `packaging/chocolatey/kanban.nuspec` — package metadata (templated; `$version$` and `$checksum64$` substituted at pack time)
- `packaging/chocolatey/tools/chocolateyinstall.ps1` — downloads and verifies the Windows release ZIP at install time via `Install-ChocolateyZipPackage`
- `packaging/chocolatey/tools/chocolateyuninstall.ps1` — reverses the install
- `packaging/chocolatey/tools/LICENSE.txt` — placeholder body; release.yml overwrites with project LICENSE at pack time
- `packaging/chocolatey/tools/VERIFICATION.txt` — required by Chocolatey moderation; explains the binary verification chain
- `packaging/chocolatey/README.md` — developer notes on the local validation workflow

**What**: Static package source files that the upcoming `publish-chocolatey` workflow (KAN-541) will substitute and push to community.chocolatey.org. No behavioural change in this PR — the files sit unused until the publish workflow lands.

**Why**: Windows users currently have no first-class install path; `cargo install kanban-cli` from source is the only option. Chocolatey is the broadest Windows package manager. Splitting the source files into their own PR keeps the publish-workflow PR smaller and lets the package source go through review independently of the CI plumbing.

**How**: Mirrors the existing `aur/` directory pattern — packaging assets live in this repo; CI consumes them at release time. The nuspec wraps both `kanban.exe` and `kanban-mcp.exe` into a single package (matching AUR + Homebrew tap conventions, where users get both binaries on PATH). `chocolateyinstall.ps1` uses `Install-ChocolateyZipPackage` for the canonical download-verify-unzip flow; Chocolatey auto-shims both `.exe` files after unzip. LICENSE.txt and VERIFICATION.txt presence are required by Chocolatey moderation policy.

**Testing**: Static validation only (no Rust code touched).
- `xmllint --noout packaging/chocolatey/kanban.nuspec` — clean
- PowerShell parser on both `.ps1` files (`[System.Management.Automation.Language.Parser]::ParseFile`) — clean
- URL cross-reference: install script's download URL matches the archive name produced by KAN-539's `build-windows` job
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace` — all clean (baseline sanity)
- End-to-end runtime validation happens in KAN-541's smoke install step (`choco install kanban -s . -y --force`); these files are the substrate for that step