### PR TITLE
KAN-539 ci(release): add build-windows job producing kanban + kanban-mcp archive

### DIFF
--- a/.changeset/kan-539-release-yml-build-and-upload-windows-release-archive-on-tag-push.md
+++ b/.changeset/kan-539-release-yml-build-and-upload-windows-release-archive-on-tag-push.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+GitHub releases now include a Windows release archive built directly
+by CI. Each release page surfaces
+`kanban-v$VERSION-x86_64-pc-windows-msvc.zip` containing prebuilt
+`kanban.exe` and `kanban-mcp.exe` binaries (alongside `LICENSE.md`
+and `README.md`), plus a `SHA256SUMS` file for integrity verification.
+
+Windows users can download and run the binaries directly from the
+GitHub release page without compiling from source. The same archive
+is the substrate for the upcoming Chocolatey publish workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       contents: write
     if: github.event.pull_request.merged == true
+    outputs:
+      new: ${{ steps.release.outputs.new }}
+      has_changesets: ${{ steps.check.outputs.has_changesets }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,3 +229,69 @@ jobs:
             exit 0
           fi
           git push origin develop
+
+  build-windows:
+    name: Build Windows release archive
+    needs: [release]
+    if: needs.release.outputs.has_changesets == 'true'
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.release.outputs.new }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build kanban + kanban-mcp (release)
+        shell: pwsh
+        run: |
+          cargo build --release `
+            --package kanban-cli `
+            --package kanban-mcp `
+            --target x86_64-pc-windows-msvc
+
+      - name: Stage archive contents
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.new }}
+        run: |
+          $stage = "stage/kanban-v$env:VERSION-x86_64-pc-windows-msvc"
+          New-Item -ItemType Directory -Path $stage -Force | Out-Null
+          Copy-Item target/x86_64-pc-windows-msvc/release/kanban.exe     $stage/
+          Copy-Item target/x86_64-pc-windows-msvc/release/kanban-mcp.exe $stage/
+          Copy-Item LICENSE.md $stage/
+          Copy-Item README.md  $stage/
+          & "$stage/kanban.exe" --version
+          & "$stage/kanban-mcp.exe" --version
+
+      - name: Compress archive
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.new }}
+        run: |
+          $name = "kanban-v$env:VERSION-x86_64-pc-windows-msvc"
+          Compress-Archive -Path "stage/$name/*" -DestinationPath "$name.zip" -Force
+
+      - name: Write SHA256SUMS
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.new }}
+        run: |
+          $name = "kanban-v$env:VERSION-x86_64-pc-windows-msvc.zip"
+          $sha  = (Get-FileHash -Algorithm SHA256 $name).Hash.ToLower()
+          "$sha  $name" | Out-File -Encoding ascii -FilePath SHA256SUMS
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.release.outputs.new }}
+          files: |
+            kanban-v${{ needs.release.outputs.new }}-x86_64-pc-windows-msvc.zip
+            SHA256SUMS
+          fail_on_unmatched_files: true


### PR DESCRIPTION
Add a Windows release archive to every GitHub Release, prerequisite for `choco install kanban` (KAN-541) and any future Windows-targeted registry:

- Expose `has_changesets` and `new` as job-level outputs on the existing `release` job, so downstream jobs can gate themselves and read the version.
- New top-level `build-windows` job on `windows-latest`. Checks out the tag the `release` job just pushed, builds `kanban-cli` + `kanban-mcp` for `x86_64-pc-windows-msvc`, stages both `.exe` files plus `LICENSE.md` and `README.md`, compresses into `kanban-v$VERSION-x86_64-pc-windows-msvc.zip`, writes a `SHA256SUMS` file, and attaches both to the GitHub Release via `softprops/action-gh-release@v2`.

**What**: Two related changes to `.github/workflows/release.yml`:
1. Three-line refactor exposing existing step outputs (`has_changesets`, `new`) at job level so downstream jobs can read them via `needs.release.outputs.*`.
2. New top-level `build-windows` job that consumes those outputs to produce and attach the Windows artifact.

**Why**: Windows users have had no first-class install path: building from source or downloading nothing have been the options. The `build-windows` job is the prerequisite for both:
- Direct downloads from the GitHub release page (immediate user-facing benefit).
- The upcoming Chocolatey publish workflow (KAN-541) which fetches this exact archive at pack time to embed the SHA into `chocolateyinstall.ps1`.

Future winget work will consume the same archive.

**How**:
- `needs: [release]` is sufficient gating. If any step in `release` fails (including the inline "Validate release build"), `build-windows` skips. No need to lift validate-release into a separate top-level job.
- `actions/checkout@v4` with `ref: v${{ needs.release.outputs.new }}` pins to the tag the release job just pushed — default `pull_request` checkout would pull the merge commit (pre-version-bump).
- `cargo build --release --package kanban-cli --package kanban-mcp` produces both binaries in one cargo invocation (~30-40% faster than two sequential `--package` calls because the workspace dep graph is walked once).
- Two `--version` smoke calls (`kanban.exe --version`, `kanban-mcp.exe --version`) in the staging step catch the worst-class bug: a binary that compiled but can't load at runtime. If either errors, the job fails before zipping.
- `fail_on_unmatched_files: true` on the upload step catches typo'd filenames — important because downstream consumers (KAN-541, future winget) will 404 silently otherwise.
- `Swatinem/rust-cache@v2` keeps subsequent runs fast; `dtolnay/rust-toolchain@stable` is the canonical Rust toolchain action.
- Note: `Compress-Archive` is not deterministic across runs, but `SHA256SUMS` is computed from the actual ZIP just produced, so the user-visible promise (download matches recorded SHA) holds.

**Testing**:
- YAML validation: `python yaml.safe_load` + `actionlint` — zero new findings (one pre-existing SC2016 on the unrelated AUR step in develop).
- Inline PowerShell parsed via `[System.Management.Automation.Language.Parser]::ParseInput` — clean for all 4 pwsh blocks introduced.
- URL cross-reference verified against KAN-538's `chocolateyinstall.ps1` (both use `kanban-v$VERSION-x86_64-pc-windows-msvc.zip` filename).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace` — all clean (no Rust code touched; baseline sanity).
- End-to-end validation runs on the next real release tag (first time the job fires).

**Follow-ups filed** (not blocking): pin Rust toolchain version for hermetic releases (KAN-546), SHA-pin third-party actions (KAN-548).