### PR TITLE
KAN-541 ci(release): add publish-chocolatey job (pack + smoke install + push)

### DIFF
--- a/.changeset/kan-541-release-yml-add-chocolatey-publish-step.md
+++ b/.changeset/kan-541-release-yml-add-chocolatey-publish-step.md
@@ -1,0 +1,16 @@
+---
+bump: minor
+---
+
+`kanban` is now available on Chocolatey. After this release reaches
+moderation approval on community.chocolatey.org (typically 1-7 days
+for a first version), Windows users can install via:
+
+    choco install kanban
+
+The package installs both `kanban` (TUI/CLI) and `kanban-mcp` (MCP
+server) and adds shims for both onto PATH. Release CI handles
+packaging and publishing automatically on every release with
+changesets; the `CHOCO_API_KEY` repo secret authenticates the push.
+A smoke install on the Windows runner gates the push, so a broken
+package never reaches the registry.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,3 +295,109 @@ jobs:
             kanban-v${{ needs.release.outputs.new }}-x86_64-pc-windows-msvc.zip
             SHA256SUMS
           fail_on_unmatched_files: true
+
+  publish-chocolatey:
+    name: Publish to Chocolatey
+    needs: [release, build-windows]
+    if: needs.release.outputs.has_changesets == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.release.outputs.new }}
+
+      - name: Wait for release asset to be fetchable
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.new }}
+        run: |
+          $url = "https://github.com/fulsomenko/kanban/releases/download/v$env:VERSION/kanban-v$env:VERSION-x86_64-pc-windows-msvc.zip"
+          $ok = $false
+          for ($i = 0; $i -lt 30; $i++) {
+            try {
+              $r = Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -ErrorAction Stop
+              if ($r.StatusCode -eq 200) {
+                Write-Output "Asset live at $url"
+                $ok = $true
+                break
+              }
+            } catch {
+              Write-Output ("Attempt {0}: not yet ({1})" -f ($i + 1), $_.Exception.Message)
+            }
+            Start-Sleep -Seconds 5
+          }
+          if (-not $ok) {
+            Write-Error "Release asset never became fetchable after 30 attempts (~150s)"
+            exit 1
+          }
+
+      - name: Compute Windows ZIP SHA256
+        id: sha
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.new }}
+        run: |
+          $url = "https://github.com/fulsomenko/kanban/releases/download/v$env:VERSION/kanban-v$env:VERSION-x86_64-pc-windows-msvc.zip"
+          $tmp = New-TemporaryFile
+          Invoke-WebRequest -Uri $url -OutFile $tmp -UseBasicParsing
+          $sha = (Get-FileHash -Algorithm SHA256 $tmp).Hash.ToLower()
+          Remove-Item $tmp
+          Write-Output "Computed SHA256: $sha"
+          "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Stage Chocolatey package with substitutions
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.new }}
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          $build = "build/chocolatey"
+          New-Item -ItemType Directory -Path "$build/tools" -Force | Out-Null
+          Copy-Item packaging/chocolatey/kanban.nuspec $build/kanban.nuspec
+          Copy-Item packaging/chocolatey/tools/* $build/tools/ -Recurse
+          Copy-Item LICENSE.md $build/tools/LICENSE.txt -Force
+
+          (Get-Content "$build/kanban.nuspec") `
+            -replace '\$version\$', $env:VERSION `
+            | Set-Content "$build/kanban.nuspec"
+
+          (Get-Content "$build/tools/chocolateyinstall.ps1") `
+            -replace '\$version\$',   $env:VERSION `
+            -replace '\$checksum64\$', $env:SHA `
+            | Set-Content "$build/tools/chocolateyinstall.ps1"
+
+      - name: choco pack
+        shell: pwsh
+        working-directory: build/chocolatey
+        run: choco pack
+
+      - name: Smoke install from local nupkg
+        shell: pwsh
+        working-directory: build/chocolatey
+        run: |
+          choco install kanban -s . -y --force --no-progress
+          kanban --version
+          kanban-mcp --version
+
+      - name: choco push
+        shell: pwsh
+        working-directory: build/chocolatey
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          VERSION: ${{ needs.release.outputs.new }}
+        run: |
+          choco push "kanban.$env:VERSION.nupkg" `
+            --api-key="$env:CHOCO_API_KEY" `
+            --source="https://push.chocolatey.org/"
+
+      - name: Note moderation expectations
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.new }}
+        run: |
+          Write-Output "==="
+          Write-Output "Pushed kanban v$env:VERSION to community.chocolatey.org."
+          Write-Output "First-time moderation typically takes 1-7 days."
+          Write-Output "Status:"
+          Write-Output "  https://community.chocolatey.org/packages/kanban/$env:VERSION"
+          Write-Output "==="


### PR DESCRIPTION
Closes the Chocolatey publish loop — final piece of the KAN-537 chain after KAN-538 (packaging files) and KAN-539 (Windows release archive).

- New top-level `publish-chocolatey` job on `windows-latest`, `needs: [release, build-windows]`, gated on `has_changesets == 'true'`.
- Waits for the Windows ZIP at `releases/download/v$VERSION/...` to become CDN-live (Invoke-WebRequest HEAD loop, up to ~150s).
- Downloads the live ZIP and computes SHA256 (defensive — bytes Chocolatey embeds match bytes users actually download).
- Stages a `build/chocolatey/` copy with `$version$` and `$checksum64$` substituted via PowerShell `-replace`; overwrites `tools/LICENSE.txt` with project `LICENSE.md` at pack time.
- Runs `choco pack`, then a **smoke install** against the just-packed nupkg (`choco install kanban -s . -y --force`) — exercises the real chocolateyinstall.ps1 against the real GitHub release URL. Then `kanban --version` and `kanban-mcp --version`. **A broken package never reaches the registry.**
- Only after the smoke passes: `choco push` with `CHOCO_API_KEY`.

**What**: Single new job that packages and publishes the Chocolatey package on every release with changesets. Consumes KAN-538's packaging files and KAN-539's Windows release archive.

**Why**: Windows users get `choco install kanban` as an officially supported install path, parity with the existing AUR and Homebrew tap. SRP-clean: separate job for the registry push, rather than bolting it into the existing `release` job that already handles crates.io/AUR/brew.

**How**:
- Separate `windows-latest` job because `choco` is only preinstalled on Windows runners and the existing `release` job runs on `ubuntu-latest`.
- Smoke install before push is the entire reason a Linux-only maintainer can ship to Chocolatey safely without a Windows laptop. The local nupkg + `-s .` source flag exercises the install script end-to-end; failure aborts before any registry side effect.
- Defense-in-depth SHA computation: rather than reading `build-windows`'s emitted SHA, this job downloads the live release asset and rehashes. Same idiom as the AUR step (KAN-446).
- All `pwsh` shells for parity with the install scripts and to avoid sed quoting friction on `$` placeholders.

**Expected first-publish behavior**: on the next release-with-changesets merging to master, `choco push` exits 0 and the package lands in chocolatey.org moderation. First-version moderation typically takes 1-7 days; subsequent versions usually auto-pass. The job logs the moderation URL.

**Testing**:
- YAML parses, `actionlint` clean.
- All 7 inline PowerShell blocks parse via `[System.Management.Automation.Language.Parser]::ParseInput` — clean.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace` — all clean (no Rust touched; baseline sanity).
- End-to-end runtime validation happens on the first real release post-merge.

**Follow-ups already filed** (not blocking): defensive binary-presence check in install script (KAN-544), cosmetic polish (KAN-545), Rust toolchain pinning (KAN-546), `/master/` URL audit (KAN-547), SHA-pin third-party actions (KAN-548).