### PR TITLE
KAN-550 chore: ignore .claude/ (Claude Code CLI scratch + per-machine settings)

### DIFF
--- a/.changeset/kan-550-add-claude-to-gitignore-cli-tool-scratch-per-machine-settings.md
+++ b/.changeset/kan-550-add-claude-to-gitignore-cli-tool-scratch-per-machine-settings.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+Internal: `.claude/` is now gitignored. Contributors using the
+Claude Code CLI will no longer risk accidentally committing
+per-machine settings (`.claude/settings.local.json`) or
+agent scratch worktrees (`.claude/worktrees/`, which can grow
+to tens of MB during parallel agent runs). No user-visible
+change.

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 *~
 .direnv
 
+# Claude Code CLI (per-machine settings + scratch worktrees for agent runs)
+.claude/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Add `.claude/` to `.gitignore`. The directory is created and populated by the Claude Code CLI when it operates against this project; nothing under it belongs in the repo.

Contents the CLI puts there:

- `.claude/settings.local.json` — per-machine CLI preferences (paths, options specific to one developer's environment).
- `.claude/worktrees/` — agent-spawned scratch git worktrees, can grow to tens of MB per active session.

**What**: One-line addition to `.gitignore` under a new `# Claude Code CLI` section, between the existing `# IDE` and `# OS` groupings. Plus a changeset.

**Why**: Today nothing is *tracked* under `.claude/` (verified `git ls-files .claude` returns empty), but a careless `git add -A` from a future contributor would stage the entire tree — both the per-machine settings (privacy/leak risk) and the agent worktrees (repo-bloat risk). Preventive hygiene.

**How**: Standard `.claude/` glob in `.gitignore`. The pattern also covers any nested files under `.claude/`. Verified with `git check-ignore -v .claude/worktrees` → matched at `.gitignore:24`.

**Testing**:
- `git check-ignore .claude/worktrees` → matches new pattern ✅
- `git check-ignore .claude/settings.local.json` → matches new pattern ✅
- `git ls-files .claude` → empty (nothing currently tracked, sanity baseline) ✅
- `cargo fmt --check` → clean (`.gitignore` change has no Rust impact) ✅

**Out of scope** (not blocking; could file separately if desired):
- Cleaning up the existing dangling agent worktrees that currently live under `.claude/worktrees/`. Orthogonal cleanup.
- Selective un-ignore for any future project-shared Claude config (e.g. `.claude/agents/*.md`) if/when the project ever introduces them. Cross that bridge then.