### PR TITLE
KAN-551 fix(tui): retain card selection after toggle-completion in kanban view

### DIFF
--- a/.changeset/kan-174-toggle-completion-tests.md
+++ b/.changeset/kan-174-toggle-completion-tests.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+In the kanban (column) view, toggling a card's completion status now keeps the card
+selected after the toggle.  Previously, the card would be moved to the Done column
+by the service layer, but the selection would silently drop on the next render frame
+because the view was not refreshed before the selection was updated.
+
+`select_card_by_id` has also been made robust for any view: if the card is not found
+in the currently active column list it now searches all column lists, navigates to the
+column that holds the card, and selects it there.  This prevents silent selection drops
+whenever a card moves between columns as a side effect of an operation.

--- a/.changeset/kan-551-retain-card-selection-after-toggle-completion.md
+++ b/.changeset/kan-551-retain-card-selection-after-toggle-completion.md
@@ -3,11 +3,11 @@ bump: patch
 ---
 
 In the kanban (column) view, toggling a card's completion status now keeps the card
-selected after the toggle.  Previously, the card would be moved to the Done column
+selected after the toggle. Previously, the card would be moved to the Done column
 by the service layer, but the selection would silently drop on the next render frame
 because the view was not refreshed before the selection was updated.
 
 `select_card_by_id` has also been made robust for any view: if the card is not found
 in the currently active column list it now searches all column lists, navigates to the
-column that holds the card, and selects it there.  This prevents silent selection drops
+column that holds the card, and selects it there. This prevents silent selection drops
 whenever a card moves between columns as a side effect of an operation.

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1457,7 +1457,6 @@ impl App {
         // Kanban (column) view: if the card moved to a different column the
         // active list no longer contains it.  Find the column that now holds
         // the card, switch the active column to it, then select.
-        use crate::view_strategy::UnifiedViewStrategy;
         let col_index = self
             .view
             .strategy
@@ -1466,14 +1465,7 @@ impl App {
             .enumerate()
             .find_map(|(i, list)| list.cards.iter().position(|&id| id == card_id).map(|_| i));
         if let Some(idx) = col_index {
-            if let Some(unified) = self
-                .view
-                .strategy
-                .as_any_mut()
-                .downcast_mut::<UnifiedViewStrategy>()
-            {
-                unified.try_set_active_column_index(idx);
-            }
+            self.view.strategy.try_navigate_to_column(idx);
             if let Some(task_list) = self.view.strategy.get_active_task_list_mut() {
                 task_list.select_card(card_id);
             }

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -1447,8 +1447,36 @@ impl App {
     }
 
     pub fn select_card_by_id(&mut self, card_id: uuid::Uuid) {
+        // Try the active task list first (covers flat and grouped views, and
+        // kanban view when the card stays in the same column).
         if let Some(task_list) = self.view.strategy.get_active_task_list_mut() {
-            task_list.select_card(card_id);
+            if task_list.select_card(card_id) {
+                return;
+            }
+        }
+        // Kanban (column) view: if the card moved to a different column the
+        // active list no longer contains it.  Find the column that now holds
+        // the card, switch the active column to it, then select.
+        use crate::view_strategy::UnifiedViewStrategy;
+        let col_index = self
+            .view
+            .strategy
+            .get_all_task_lists()
+            .iter()
+            .enumerate()
+            .find_map(|(i, list)| list.cards.iter().position(|&id| id == card_id).map(|_| i));
+        if let Some(idx) = col_index {
+            if let Some(unified) = self
+                .view
+                .strategy
+                .as_any_mut()
+                .downcast_mut::<UnifiedViewStrategy>()
+            {
+                unified.try_set_active_column_index(idx);
+            }
+            if let Some(task_list) = self.view.strategy.get_active_task_list_mut() {
+                task_list.select_card(card_id);
+            }
         }
     }
 

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -246,8 +246,7 @@ impl App {
                 return;
             }
 
-            // Refresh the view-layer task list so the card new column is
-            // reflected before we re-select it (same stale-model fix as KAN-403).
+            // Refresh the view-layer task list before selecting so column lists are current.
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -294,8 +293,7 @@ impl App {
         self.multi_select.selected_cards.clear();
         self.multi_select.selection_mode_active = false;
         if let Some(card_id) = first_card_id {
-            // Refresh the view-layer task list so cards new columns are
-            // reflected before we re-select (same stale-model fix as KAN-403).
+            // Refresh the view-layer task list before selecting so column lists are current.
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -386,8 +384,7 @@ impl App {
                 }
 
                 // Refresh the view-layer task list so the new card's ID is
-                // present before we try to select it. Without this the
-                // selection silently stays on the prior card (KAN-403).
+                // present before we try to select it.
                 self.prepare_frame();
                 self.select_card_by_id(card_id);
             }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -246,6 +246,9 @@ impl App {
                 return;
             }
 
+            // Refresh the view-layer task list so the card new column is
+            // reflected before we re-select it (same stale-model fix as KAN-403).
+            self.prepare_frame();
             self.select_card_by_id(card_id);
         }
     }
@@ -291,6 +294,9 @@ impl App {
         self.multi_select.selected_cards.clear();
         self.multi_select.selection_mode_active = false;
         if let Some(card_id) = first_card_id {
+            // Refresh the view-layer task list so cards new columns are
+            // reflected before we re-select (same stale-model fix as KAN-403).
+            self.prepare_frame();
             self.select_card_by_id(card_id);
         }
     }

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -563,11 +563,7 @@ impl App {
             let column_count = self.view.strategy.get_all_task_lists().len();
 
             if index < column_count {
-                self.view
-                    .strategy
-                    .as_any_mut()
-                    .downcast_mut::<UnifiedViewStrategy>()
-                    .map(|unified| unified.try_set_active_column_index(index));
+                self.view.strategy.try_navigate_to_column(index);
 
                 if let Some(list) = self.view.strategy.get_active_task_list_mut() {
                     if list.is_empty() {

--- a/crates/kanban-tui/src/view_strategy.rs
+++ b/crates/kanban-tui/src/view_strategy.rs
@@ -23,6 +23,9 @@ pub trait ViewStrategy {
     fn refresh_task_lists(&mut self, ctx: &ViewRefreshContext);
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
     fn as_any(&self) -> &dyn std::any::Any;
+    fn try_navigate_to_column(&mut self, _index: usize) -> bool {
+        false
+    }
 }
 
 pub struct UnifiedViewStrategy {
@@ -120,5 +123,9 @@ impl ViewStrategy for UnifiedViewStrategy {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn try_navigate_to_column(&mut self, index: usize) -> bool {
+        self.try_set_active_column_index(index)
     }
 }

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -356,3 +356,113 @@ fn test_delete_column_adjusts_selection() {
         "selection should adjust to last remaining column"
     );
 }
+
+#[test]
+fn test_toggle_card_completion_retains_selection() {
+    // Stale-model regression: `toggle_card_completion` must call `prepare_frame()`
+    // before `select_card_by_id` so the view task list reflects the post-toggle
+    // card layout.  In the kanban (column) view the card moves to a different
+    // column list, so without the refresh the selection silently drops.
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let _todo = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let _done = app
+        .ctx
+        .create_column(board.id, "Done".to_string(), Some(1))
+        .unwrap();
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+
+    // Switch to the kanban (column) view so each column has its own CardList.
+    // This is the view where stale-model causes select_card_by_id to silently fail.
+    app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.input.set("Task".to_string());
+    app.create_card();
+    app.prepare_frame();
+
+    let card_id = app
+        .get_selected_card_id()
+        .expect("card should be selected after creation");
+
+    // Toggle completion -- service will auto-move the card to the Done column.
+    // Without prepare_frame() inside toggle_card_completion (before select_card_by_id)
+    // the next prepare_frame() call (simulating the next render frame) will move the
+    // card to the Done column list while the selector still points to the Todo column,
+    // silently dropping the selection.
+    app.handle_toggle_card_completion();
+    // Simulate the next render frame -- this is where the stale-model bug manifests.
+    app.prepare_frame();
+
+    let selected_after = app.get_selected_card_id();
+    assert_eq!(
+        selected_after,
+        Some(card_id),
+        "selection must remain on the toggled card even after it moves to the Done column"
+    );
+}
+
+#[test]
+fn test_toggle_multi_card_completion_retains_selection() {
+    // Same stale-model regression for the multi-select toggle path in kanban view.
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let _todo = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let _done = app
+        .ctx
+        .create_column(board.id, "Done".to_string(), Some(1))
+        .unwrap();
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+
+    app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.input.set("Alpha".to_string());
+    app.create_card();
+    app.prepare_frame();
+    let alpha_id = app
+        .get_selected_card_id()
+        .expect("alpha should be selected after creation");
+
+    app.input.set("Beta".to_string());
+    app.create_card();
+    app.prepare_frame();
+    let beta_id = app
+        .get_selected_card_id()
+        .expect("beta should be selected after creation");
+
+    // Enter multi-select mode and select both cards.
+    app.multi_select.selection_mode_active = true;
+    app.multi_select.selected_cards.insert(alpha_id);
+    app.multi_select.selected_cards.insert(beta_id);
+
+    // Toggle completion for both -- both cards move to the Done column.
+    app.handle_toggle_card_completion();
+    // Simulate the next render frame -- this is where the stale-model bug manifests.
+    app.prepare_frame();
+
+    // After the toggle the first selected card (alpha or beta) must still be
+    // reachable via get_selected_card_id; losing the selection is the bug.
+    let selected_after = app.get_selected_card_id();
+    assert!(
+        selected_after.is_some(),
+        "a card must remain selected after multi-select toggle completion"
+    );
+    assert!(
+        selected_after == Some(alpha_id) || selected_after == Some(beta_id),
+        "selection must be one of the toggled cards, got {:?}",
+        selected_after
+    );
+}


### PR DESCRIPTION
Toggling a card's completion status in the kanban (column) view now keeps the card selected after the operation:

- Add `prepare_frame()` before `select_card_by_id` in `toggle_card_completion` and `toggle_selected_cards_completion` — matching the KAN-403 fix already applied in `create_card`
- Extend `select_card_by_id` to search all column lists when the card is not in the active one, navigate to the containing column, then select — making the method robust for any future cross-column operation
- Add two regression tests in `stale_model_regression_tests.rs` covering single-card and multi-select toggle paths in kanban (column) view

**What**: When toggling a card's completion status, the service layer auto-moves the card to the Done column. Without a view refresh before the selection update, the next render frame clears the old column list and the selector drops silently.

**Why**: `toggle_card_completion` and `toggle_selected_cards_completion` called `select_card_by_id` on a stale view (same root cause as KAN-403 in `create_card`). The kanban column view keeps a separate `CardList` per column; after the card moves, the active column list no longer contains it so `select_card` returns false and the selection is lost on the next `prepare_frame()` call.

**How**: Two-part fix. First, `prepare_frame()` is called before `select_card_by_id` in both toggle paths so the column lists are current when the selection runs. Second, `select_card_by_id` itself is made defensive: if `select_card` fails on the active list it searches all task lists via `get_all_task_lists()`, resolves the column index containing the card, calls `try_set_active_column_index()` to navigate there, and then selects.

**Testing**: `cargo test -p kanban-tui --test stale_model_regression_tests` (12 pass including 2 new), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean).

## Test plan

- [x] test_toggle_card_completion_retains_selection passes
- [x] test_toggle_multi_card_completion_retains_selection passes
- [x] Existing stale_model_regression_tests stay green
- [x] cargo test --workspace passes
- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo fmt --check passes