### PR TITLE
KAN-249 refactor(domain): remove unused DomainError not_found helpers

### DIFF
--- a/.changeset/kan-249-audit-domainerror-helpers.md
+++ b/.changeset/kan-249-audit-domainerror-helpers.md
@@ -1,0 +1,15 @@
+---
+bump: patch
+---
+
+Internal cleanup with no user-visible change. Six unused convenience
+constructors on `DomainError` (`board_not_found`, `card_not_found`,
+`column_not_found`, `sprint_not_found`, `archived_card_not_found`,
+`tag_not_found`) were removed. They had no remaining callers since the
+command layer standardised on `KanbanError::not_found(entity, id)`, so
+they were pure dead code and a stale duplicate API for producing the
+same error value. The still-used `DomainError::wip_limit_exceeded`
+helper is retained.
+
+Error messages, error variants, and matching behaviour
+(`is_not_found`) are unchanged.

--- a/.changeset/kan-249-audit-domainerror-helpers.md
+++ b/.changeset/kan-249-audit-domainerror-helpers.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 Internal cleanup with no user-visible change. Six unused convenience

--- a/.changeset/kan-249-audit-domainerror-helpers.md
+++ b/.changeset/kan-249-audit-domainerror-helpers.md
@@ -2,14 +2,13 @@
 bump: minor
 ---
 
-Internal cleanup with no user-visible change. Six unused convenience
-constructors on `DomainError` (`board_not_found`, `card_not_found`,
+Removes six public convenience constructors from
+`kanban-domain::DomainError`: `board_not_found`, `card_not_found`,
 `column_not_found`, `sprint_not_found`, `archived_card_not_found`,
-`tag_not_found`) were removed. They had no remaining callers since the
-command layer standardised on `KanbanError::not_found(entity, id)`, so
-they were pure dead code and a stale duplicate API for producing the
-same error value. The still-used `DomainError::wip_limit_exceeded`
-helper is retained.
+and `tag_not_found`. End-user behaviour, error messages, error
+variants, and matching behaviour (`is_not_found`) are unchanged, but
+direct library consumers of the `kanban-domain` crate must switch to
+`KanbanError::not_found(entity, id)`, which has been the standard
+construction path in the rest of the workspace for some time.
 
-Error messages, error variants, and matching behaviour
-(`is_not_found`) are unchanged.
+The still-used `DomainError::wip_limit_exceeded` helper is retained.

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -167,36 +167,6 @@ impl DomainError {
         )
     }
 
-    pub fn board_not_found(id: Uuid) -> Self {
-        Self::NotFound {
-            entity: "board",
-            id,
-        }
-    }
-    pub fn card_not_found(id: Uuid) -> Self {
-        Self::NotFound { entity: "card", id }
-    }
-    pub fn column_not_found(id: Uuid) -> Self {
-        Self::NotFound {
-            entity: "column",
-            id,
-        }
-    }
-    pub fn sprint_not_found(id: Uuid) -> Self {
-        Self::NotFound {
-            entity: "sprint",
-            id,
-        }
-    }
-    pub fn archived_card_not_found(id: Uuid) -> Self {
-        Self::NotFound {
-            entity: "archived card",
-            id,
-        }
-    }
-    pub fn tag_not_found(id: Uuid) -> Self {
-        Self::NotFound { entity: "tag", id }
-    }
     pub fn wip_limit_exceeded(column_id: Uuid, limit: u32) -> Self {
         Self::WipLimitExceeded { column_id, limit }
     }


### PR DESCRIPTION
Removes six dead convenience constructors on `DomainError` that were superseded by `KanbanError::not_found(entity, id)`:

- Remove `DomainError::board_not_found`, `card_not_found`, `column_not_found`, `sprint_not_found`, `archived_card_not_found`, and `tag_not_found` from `crates/kanban-domain/src/error.rs`
- Keep `DomainError::wip_limit_exceeded`, which is still called from `KanbanContext::move_card` (`kanban-service/src/context.rs`) and the WIP-limit check in `kanban-domain/src/commands/mod.rs`
- No internal call sites changed; no error variants, error messages, or matching behaviour (`is_not_found`) affected

**What**: Delete six unused `*_not_found` constructors on `DomainError`.

**Why**: After PR #200 the entire command layer switched to `KanbanError::not_found(entity, id)` (70 call sites across the workspace). The `DomainError` helpers became aliases that produced byte-identical values, with zero non-test callers. They were stale API surface that suggested two valid ways to spell the same error.

**How**: A grep audit confirmed all apparent matches in the codebase were test function names like `test_update_card_not_found_returns_error`, not actual calls. The helpers were removed in one focused commit; `wip_limit_exceeded` is retained because real callers exist.

**Bump level**: `minor`. End-user behaviour is unchanged, but the removed symbols are `pub` on a published crate (`kanban-domain`), so any external library consumer of `DomainError::*_not_found` is a SemVer-breaking removal and must switch to `KanbanError::not_found(entity, id)`.

**Testing**: `cargo test --workspace` (all tests pass; no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all` (clean).