### PR TITLE
KAN-556 feat: optional sprint assignment at card creation

### DIFF
--- a/.changeset/kan-556-add-optional-sprint-assignment-to-card-creation.md
+++ b/.changeset/kan-556-add-optional-sprint-assignment-to-card-creation.md
@@ -1,0 +1,34 @@
+---
+bump: minor
+---
+
+Cards can now be assigned to a sprint at creation time, in a single
+action, across all three surfaces.
+
+In the TUI, the Create Task dialog gains a sprint picker below the
+title input. If the board has exactly one active (non-ended) sprint,
+that sprint is pre-selected, so pressing Enter creates the card already
+attached to the active sprint. With no active sprint or with multiple,
+the picker defaults to "None" and the user can pick deliberately. Tab
+toggles focus between the title input and the sprint picker; Down or
+Esc on the title focus drops focus into the picker (Esc on the picker
+focus closes the dialog); Up/Down or j/k navigate the picker; Enter
+confirms from either side. The focused side is signalled with a bright
+border on the title input or the picker block.
+
+From the CLI, `kanban card create` accepts a new `--assign` / `-a`
+flag. Pass a sprint UUID, name, or number to assign the new card to a
+specific sprint, or pass the flag with no value to use the board's
+sole active sprint. The flag fails with a clear message when there
+are zero or multiple active sprints on the board.
+
+The MCP `create_card` tool gains an optional `sprint_id` parameter
+that accepts a UUID, sprint name, or sprint number and resolves it via
+the same in-board sprint resolution used by `assign_card_to_sprint`.
+The schema description hints to LLM callers that when a board has a
+single active sprint, passing its id at create time avoids the extra
+assign round-trip.
+
+The on-disk format is unchanged. Existing scripts and integrations
+keep working with no migration required; omitting the new flag/field
+preserves the previous "create then assign separately" workflow.

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -372,6 +372,11 @@ pub struct CardCreateArgs {
     pub points: Option<u8>,
     #[arg(long)]
     pub due_date: Option<String>,
+    /// Assign the new card to a sprint. Pass a UUID, name, or number to pick a
+    /// specific sprint; pass without a value to use the board's sole active
+    /// sprint (errors if zero or more than one active sprint exists).
+    #[arg(long = "assign", short = 'a', num_args = 0..=1, default_missing_value = "")]
+    pub assign_sprint: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -306,6 +306,7 @@ fn build_create_options(args: &CardCreateArgs) -> Result<CreateCardOptions, Stri
         priority,
         points: args.points,
         due_date,
+        ..Default::default()
     })
 }
 

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -4,7 +4,7 @@ use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
     ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions,
-    FieldUpdate, KanbanOperations,
+    FieldUpdate, KanbanOperations, SprintStatus,
 };
 
 use uuid::Uuid;
@@ -20,10 +20,15 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let options = match build_create_options(&args) {
+            let sprint_uuid = match resolve_assign_sprint(ctx, board_uuid, &args.assign_sprint) {
+                Ok(s) => s,
+                Err(e) => return output::output_error(&e),
+            };
+            let mut options = match build_create_options(&args) {
                 Ok(o) => o,
                 Err(e) => return output::output_error(&e),
             };
+            options.sprint_id = sprint_uuid;
             let card = ctx.create_card(board_uuid, column_uuid, args.title, options)?;
             ctx.save().await?;
             output::output_success(&card);
@@ -290,6 +295,37 @@ fn build_filter(ctx: &CliContext, args: &CardListArgs) -> Result<CardListFilter,
         sprint_id,
         status,
     })
+}
+
+fn resolve_assign_sprint(
+    ctx: &CliContext,
+    board_id: Uuid,
+    flag: &Option<String>,
+) -> Result<Option<Uuid>, String> {
+    let raw = match flag {
+        None => return Ok(None),
+        Some(s) => s.as_str(),
+    };
+    if raw.is_empty() {
+        let now = chrono::Utc::now();
+        let sprints = ctx.list_sprints(board_id).map_err(|e| e.to_string())?;
+        let active: Vec<_> = sprints
+            .iter()
+            .filter(|s| s.status == SprintStatus::Active && !s.is_ended(now))
+            .collect();
+        match active.as_slice() {
+            [] => Err("--assign with no value requires exactly one active sprint on the board; found none".to_string()),
+            [s] => Ok(Some(s.id)),
+            many => Err(format!(
+                "--assign with no value requires exactly one active sprint; found {}",
+                many.len()
+            )),
+        }
+    } else {
+        ctx.resolve_sprint_id(raw, board_id)
+            .map(Some)
+            .map_err(|e| e.to_string())
+    }
 }
 
 fn build_create_options(args: &CardCreateArgs) -> Result<CreateCardOptions, String> {

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1562,7 +1562,13 @@ mod card_tests {
 
     fn create_sprint(file: &std::path::Path, board_id: &str) -> String {
         let output = kanban()
-            .args([file.to_str().unwrap(), "sprint", "create", "--board", board_id])
+            .args([
+                file.to_str().unwrap(),
+                "sprint",
+                "create",
+                "--board",
+                board_id,
+            ])
             .assert()
             .success()
             .get_output()

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1700,7 +1700,7 @@ mod card_tests {
             ])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("active sprint"));
+            .stderr(predicate::str::contains("found none"));
     }
 
     #[test]
@@ -1728,7 +1728,7 @@ mod card_tests {
             ])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("active sprint"));
+            .stderr(predicate::str::contains("found 2"));
     }
 
     #[test]

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1559,6 +1559,200 @@ mod card_tests {
             .stderr(predicate::str::contains(&card_a_id))
             .stderr(predicate::str::contains(&card_b_id));
     }
+
+    fn create_sprint(file: &std::path::Path, board_id: &str) -> String {
+        let output = kanban()
+            .args([file.to_str().unwrap(), "sprint", "create", "--board", board_id])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        extract_id(&parse_json_output(&String::from_utf8_lossy(&output)))
+    }
+
+    fn activate_sprint(file: &std::path::Path, sprint_id: &str) {
+        kanban()
+            .args([file.to_str().unwrap(), "sprint", "activate", sprint_id])
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn test_card_create_with_assign_id_assigns_new_card_to_sprint() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+        let sprint_id = create_sprint(&file, &board_id);
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "Sprinted",
+                "--assign",
+                &sprint_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert_eq!(json["data"]["sprint_id"], sprint_id);
+    }
+
+    #[test]
+    fn test_card_create_with_assign_short_flag_assigns_to_sprint() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+        let sprint_id = create_sprint(&file, &board_id);
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "Sprinted",
+                "-a",
+                &sprint_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert_eq!(json["data"]["sprint_id"], sprint_id);
+    }
+
+    #[test]
+    fn test_card_create_with_assign_no_value_uses_sole_active_sprint() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+        let sprint_id = create_sprint(&file, &board_id);
+        activate_sprint(&file, &sprint_id);
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "AutoSprinted",
+                "--assign",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert_eq!(json["data"]["sprint_id"], sprint_id);
+    }
+
+    #[test]
+    fn test_card_create_with_assign_no_value_errors_when_no_active_sprint() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+        let _ = create_sprint(&file, &board_id); // planning only
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "NoSprint",
+                "--assign",
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("active sprint"));
+    }
+
+    #[test]
+    fn test_card_create_with_assign_no_value_errors_when_multiple_active_sprints() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+        let s1 = create_sprint(&file, &board_id);
+        let s2 = create_sprint(&file, &board_id);
+        activate_sprint(&file, &s1);
+        activate_sprint(&file, &s2);
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "Ambig",
+                "--assign",
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("active sprint"));
+    }
+
+    #[test]
+    fn test_card_create_without_assign_leaves_card_unassigned() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+        let _ = create_sprint(&file, &board_id);
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "NoAssign",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["data"]["sprint_id"].is_null());
+    }
 }
 
 mod sprint_tests {

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -316,6 +316,8 @@ pub struct CreateCardOptions {
     pub priority: Option<CardPriority>,
     pub points: Option<u8>,
     pub due_date: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sprint_id: Option<Uuid>,
 }
 
 impl GraphNode for Card {

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -245,13 +245,14 @@ impl Card {
         sprint_number: u32,
         sprint_name: Option<String>,
         sprint_status: String,
+        now: DateTime<Utc>,
     ) {
         // Only create a sprint log entry if the sprint assignment actually changes
         if self.sprint_id != Some(sprint_id) {
             self.sprint_id = Some(sprint_id);
             let sprint_log = SprintLog::new(sprint_id, sprint_number, sprint_name, sprint_status);
             self.sprint_logs.push(sprint_log);
-            self.updated_at = Utc::now();
+            self.updated_at = now;
         }
     }
 
@@ -269,7 +270,7 @@ impl Card {
     }
 
     /// Update card with partial changes
-    pub fn update(&mut self, updates: CardUpdate) {
+    pub fn update(&mut self, updates: CardUpdate, now: DateTime<Utc>) {
         if let Some(title) = updates.title {
             self.title = title;
         }
@@ -289,7 +290,7 @@ impl Card {
         updates.due_date.apply_to(&mut self.due_date);
         updates.points.apply_to(&mut self.points);
         updates.sprint_id.apply_to(&mut self.sprint_id);
-        self.updated_at = Utc::now();
+        self.updated_at = now;
     }
 }
 
@@ -534,6 +535,7 @@ mod tests {
             1,
             Some("Sprint 1".to_string()),
             "Active".to_string(),
+            Utc::now(),
         );
 
         assert_eq!(card.get_sprint_history().len(), 1);
@@ -557,6 +559,7 @@ mod tests {
             1,
             Some("Sprint 1".to_string()),
             "Active".to_string(),
+            Utc::now(),
         );
 
         card.end_current_sprint_log();
@@ -579,6 +582,7 @@ mod tests {
             1,
             Some("Sprint 1".to_string()),
             "Active".to_string(),
+            Utc::now(),
         );
         assert_eq!(card.sprint_id, Some(sprint_id_1));
         assert_eq!(card.get_sprint_history().len(), 1);
@@ -589,6 +593,7 @@ mod tests {
             2,
             Some("Sprint 2".to_string()),
             "Active".to_string(),
+            Utc::now(),
         );
 
         assert_eq!(card.sprint_id, Some(sprint_id_2));
@@ -612,6 +617,7 @@ mod tests {
             1,
             Some("Sprint 1".to_string()),
             "Active".to_string(),
+            Utc::now(),
         );
         assert_eq!(card.sprint_id, Some(sprint_id));
         assert_eq!(card.get_sprint_history().len(), 1);
@@ -621,6 +627,7 @@ mod tests {
             1,
             Some("Sprint 1".to_string()),
             "Active".to_string(),
+            Utc::now(),
         );
 
         assert_eq!(card.sprint_id, Some(sprint_id));
@@ -628,5 +635,47 @@ mod tests {
         let log = &card.get_sprint_history()[0];
         assert_eq!(log.sprint_id, sprint_id);
         assert!(log.ended_at.is_none());
+    }
+
+    #[test]
+    fn test_assign_to_sprint_records_caller_provided_timestamp() {
+        use chrono::TimeZone;
+
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("Test Board".to_string(), None);
+        let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let sprint_id = uuid::Uuid::new_v4();
+
+        card.assign_to_sprint(
+            sprint_id,
+            1,
+            Some("Sprint 1".to_string()),
+            "Active".to_string(),
+            fixed_time,
+        );
+
+        assert_eq!(card.updated_at, fixed_time);
+    }
+
+    #[test]
+    fn test_update_records_caller_provided_timestamp() {
+        use chrono::TimeZone;
+
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("Test Board".to_string(), None);
+        let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+
+        card.update(
+            CardUpdate {
+                title: Some("Renamed".to_string()),
+                ..Default::default()
+            },
+            fixed_time,
+        );
+
+        assert_eq!(card.title, "Renamed");
+        assert_eq!(card.updated_at, fixed_time);
     }
 }

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -254,6 +254,15 @@ impl CreateCard {
             card.update(updates);
         }
 
+        if let Some(sprint_id) = self.options.sprint_id {
+            let sprint = context.get_sprint(sprint_id)?;
+            let sprint_number = sprint.sprint_number;
+            let sprint_name = sprint.get_name(&board).map(|s| s.to_string());
+            let sprint_status = format!("{:?}", sprint.status);
+            card.assign_to_sprint(sprint_id, sprint_number, sprint_name, sprint_status);
+            card.updated_at = now;
+        }
+
         context.store.upsert_board(board)?;
         context.store.upsert_card(card)?;
         Ok(())
@@ -1083,6 +1092,101 @@ mod tests {
         let cards = tc.store.list_cards_by_column(column_id).unwrap();
         assert_eq!(cards[0].position, 0);
         assert_eq!(cards[1].position, 1);
+    }
+
+    #[test]
+    fn test_create_card_with_sprint_id_assigns_card_to_sprint() {
+        let tc = TestContext::new();
+        let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, None);
+        let board_id = board.id;
+        let column_id = col.id;
+        let sprint_id = sprint.id;
+        // Bump card_counter so upsert_board doesn't reset it; mirrors real usage.
+        board.card_counter = 1;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+
+        let context = tc.as_command_context();
+        let card_id = Uuid::new_v4();
+        let cmd = CreateCard {
+            id: card_id,
+            card_number: 1,
+            board_id,
+            column_id,
+            title: "Test".to_string(),
+            position: 0,
+            options: CreateCardOptions {
+                sprint_id: Some(sprint_id),
+                ..Default::default()
+            },
+            timestamp: Utc::now(),
+        };
+        cmd.execute(&context).unwrap();
+
+        let card = tc.store.get_card(card_id).unwrap().unwrap();
+        assert_eq!(card.sprint_id, Some(sprint_id));
+        assert_eq!(card.sprint_logs.len(), 1);
+        assert_eq!(card.sprint_logs[0].sprint_id, sprint_id);
+    }
+
+    #[test]
+    fn test_create_card_without_sprint_id_leaves_card_unassigned() {
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board_id = board.id;
+        let column_id = col.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+
+        let context = tc.as_command_context();
+        let card_id = Uuid::new_v4();
+        let cmd = CreateCard {
+            id: card_id,
+            card_number: 1,
+            board_id,
+            column_id,
+            title: "Test".to_string(),
+            position: 0,
+            options: CreateCardOptions::default(),
+            timestamp: Utc::now(),
+        };
+        cmd.execute(&context).unwrap();
+
+        let card = tc.store.get_card(card_id).unwrap().unwrap();
+        assert_eq!(card.sprint_id, None);
+        assert!(card.sprint_logs.is_empty());
+    }
+
+    #[test]
+    fn test_create_card_with_invalid_sprint_id_returns_not_found_error() {
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board_id = board.id;
+        let column_id = col.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+
+        let context = tc.as_command_context();
+        let cmd = CreateCard {
+            id: Uuid::new_v4(),
+            card_number: 1,
+            board_id,
+            column_id,
+            title: "Test".to_string(),
+            position: 0,
+            options: CreateCardOptions {
+                sprint_id: Some(Uuid::new_v4()),
+                ..Default::default()
+            },
+            timestamp: Utc::now(),
+        };
+        let err = cmd.execute(&context).unwrap_err();
+        assert!(err.is_not_found(), "Expected not found, got: {:?}", err);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -1321,10 +1321,9 @@ mod tests {
             timestamp: Utc::now(),
         };
         let err = cmd.execute(&context).unwrap_err();
-        let msg = format!("{}", err);
         assert!(
-            msg.to_lowercase().contains("board"),
-            "cross-board sprint should error with a message mentioning the board mismatch, got: {msg}"
+            err.is_validation(),
+            "expected validation variant, got: {err:?}"
         );
     }
 

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -256,6 +256,12 @@ impl CreateCard {
 
         if let Some(sprint_id) = self.options.sprint_id {
             let sprint = context.get_sprint(sprint_id)?;
+            if sprint.board_id != self.board_id {
+                return Err(KanbanError::validation(format!(
+                    "sprint {} belongs to board {} but card is being created on board {}",
+                    sprint_id, sprint.board_id, self.board_id
+                )));
+            }
             let sprint_number = sprint.sprint_number;
             let sprint_name = sprint.get_name(&board).map(|s| s.to_string());
             let sprint_status = format!("{:?}", sprint.status);
@@ -1187,6 +1193,44 @@ mod tests {
         };
         let err = cmd.execute(&context).unwrap_err();
         assert!(err.is_not_found(), "Expected not found, got: {:?}", err);
+    }
+
+    #[test]
+    fn test_create_card_with_sprint_from_different_board_returns_validation_error() {
+        let tc = TestContext::new();
+        let board_a = crate::Board::new("A".to_string(), Some("AAA".to_string()));
+        let board_b = crate::Board::new("B".to_string(), Some("BBB".to_string()));
+        let col_a = crate::Column::new(board_a.id, "Col".to_string(), 0);
+        // Sprint belongs to board B.
+        let sprint_b = crate::Sprint::new(board_b.id, 1, None, None);
+        let board_a_id = board_a.id;
+        let column_id = col_a.id;
+        let sprint_b_id = sprint_b.id;
+        tc.store.upsert_board(board_a).unwrap();
+        tc.store.upsert_board(board_b).unwrap();
+        tc.store.upsert_column(col_a).unwrap();
+        tc.store.upsert_sprint(sprint_b).unwrap();
+
+        let context = tc.as_command_context();
+        let cmd = CreateCard {
+            id: Uuid::new_v4(),
+            card_number: 1,
+            board_id: board_a_id,
+            column_id,
+            title: "X".to_string(),
+            position: 0,
+            options: CreateCardOptions {
+                sprint_id: Some(sprint_b_id),
+                ..Default::default()
+            },
+            timestamp: Utc::now(),
+        };
+        let err = cmd.execute(&context).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.to_lowercase().contains("board"),
+            "cross-board sprint should error with a message mentioning the board mismatch, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -266,8 +266,15 @@ impl CreateCard {
             let sprint_name = sprint.get_name(&board).map(|s| s.to_string());
             let sprint_status = format!("{:?}", sprint.status);
             card.assign_to_sprint(sprint_id, sprint_number, sprint_name, sprint_status);
-            card.updated_at = now;
         }
+
+        // Card::update and Card::assign_to_sprint both bump updated_at to
+        // Utc::now() internally. Pin it back to the embedded timestamp so
+        // command replay and direct execute paths produce the same on-disk
+        // state — otherwise an undo + redo would shift updated_at to wall
+        // clock time and tests like create_card_uses_embedded_timestamp
+        // would fail whenever any options field is set.
+        card.updated_at = now;
 
         context.store.upsert_board(board)?;
         context.store.upsert_card(card)?;
@@ -1193,6 +1200,94 @@ mod tests {
         };
         let err = cmd.execute(&context).unwrap_err();
         assert!(err.is_not_found(), "Expected not found, got: {:?}", err);
+    }
+
+    #[test]
+    fn test_create_card_with_options_only_uses_embedded_timestamp() {
+        use chrono::TimeZone;
+
+        let tc = TestContext::new();
+        let board = crate::Board::new("B".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board_id = board.id;
+        let column_id = col.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+
+        let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let context = tc.as_command_context();
+        let card_id = Uuid::new_v4();
+        let cmd = CreateCard {
+            id: card_id,
+            card_number: 1,
+            board_id,
+            column_id,
+            title: "T".to_string(),
+            position: 0,
+            options: CreateCardOptions {
+                description: Some("d".to_string()),
+                priority: Some(crate::CardPriority::High),
+                points: Some(3),
+                due_date: None,
+                sprint_id: None,
+            },
+            timestamp: fixed_time,
+        };
+        cmd.execute(&context).unwrap();
+
+        let card = tc.store.get_card(card_id).unwrap().unwrap();
+        assert_eq!(card.created_at, fixed_time);
+        assert_eq!(
+            card.updated_at, fixed_time,
+            "updated_at must match the embedded command timestamp even when \
+             CardUpdate options reset it inside Card::update"
+        );
+    }
+
+    #[test]
+    fn test_create_card_with_options_and_sprint_uses_embedded_timestamp() {
+        use chrono::TimeZone;
+
+        let tc = TestContext::new();
+        let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
+        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, None);
+        let board_id = board.id;
+        let column_id = col.id;
+        let sprint_id = sprint.id;
+        board.card_counter = 1;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+        tc.store.upsert_sprint(sprint).unwrap();
+
+        let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let context = tc.as_command_context();
+        let card_id = Uuid::new_v4();
+        let cmd = CreateCard {
+            id: card_id,
+            card_number: 1,
+            board_id,
+            column_id,
+            title: "T".to_string(),
+            position: 0,
+            options: CreateCardOptions {
+                description: Some("d".to_string()),
+                priority: Some(crate::CardPriority::High),
+                points: Some(3),
+                due_date: None,
+                sprint_id: Some(sprint_id),
+            },
+            timestamp: fixed_time,
+        };
+        cmd.execute(&context).unwrap();
+
+        let card = tc.store.get_card(card_id).unwrap().unwrap();
+        assert_eq!(card.created_at, fixed_time);
+        assert_eq!(
+            card.updated_at, fixed_time,
+            "updated_at must match the embedded command timestamp even when both \
+             CardUpdate options and sprint assignment run inside execute"
+        );
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -120,7 +120,7 @@ pub struct UpdateCard {
 impl UpdateCard {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         let mut card = context.get_card(self.card_id)?;
-        card.update(self.updates.clone());
+        card.update(self.updates.clone(), Utc::now());
         context.store.upsert_card(card)?;
         Ok(())
     }
@@ -251,7 +251,7 @@ impl CreateCard {
                     .unwrap_or(crate::FieldUpdate::NoChange),
                 ..Default::default()
             };
-            card.update(updates);
+            card.update(updates, now);
         }
 
         if let Some(sprint_id) = self.options.sprint_id {
@@ -265,16 +265,8 @@ impl CreateCard {
             let sprint_number = sprint.sprint_number;
             let sprint_name = sprint.get_name(&board).map(|s| s.to_string());
             let sprint_status = format!("{:?}", sprint.status);
-            card.assign_to_sprint(sprint_id, sprint_number, sprint_name, sprint_status);
+            card.assign_to_sprint(sprint_id, sprint_number, sprint_name, sprint_status, now);
         }
-
-        // Card::update and Card::assign_to_sprint both bump updated_at to
-        // Utc::now() internally. Pin it back to the embedded timestamp so
-        // command replay and direct execute paths produce the same on-disk
-        // state — otherwise an undo + redo would shift updated_at to wall
-        // clock time and tests like create_card_uses_embedded_timestamp
-        // would fail whenever any options field is set.
-        card.updated_at = now;
 
         context.store.upsert_board(board)?;
         context.store.upsert_card(card)?;
@@ -539,6 +531,7 @@ impl AssignCardsToSprint {
         let sprint_status = format!("{:?}", sprint.status);
 
         let valid_ids = context.filter_valid_card_ids(&self.ids, "AssignCardsToSprint");
+        let now = Utc::now();
         for id in &valid_ids {
             let mut card = context.get_card(*id)?;
             if let Some(old_sprint_id) = card.sprint_id {
@@ -551,6 +544,7 @@ impl AssignCardsToSprint {
                 sprint_number,
                 sprint_name.clone(),
                 sprint_status.clone(),
+                now,
             );
             context.store.upsert_card(card)?;
         }

--- a/crates/kanban-domain/src/field_update.rs
+++ b/crates/kanban-domain/src/field_update.rs
@@ -148,6 +148,7 @@ mod tests {
             priority: Some(crate::CardPriority::Medium),
             points: Some(3),
             due_date: None,
+            sprint_id: None,
         };
         let json = serde_json::to_string(&opts).unwrap();
         let back: crate::CreateCardOptions = serde_json::from_str(&json).unwrap();

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -960,6 +960,7 @@ impl KanbanMcpServer {
             priority,
             points: req.points,
             due_date,
+            ..Default::default()
         };
         let card = locked_write(&self.ctx, |ctx| {
             let board_id = ctx.mcp_resolve_board(&req.board)?;

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -456,6 +456,12 @@ pub struct CreateCardRequest {
         description = "Due date in YYYY-MM-DD or RFC 3339 format (e.g. 2024-06-15 or 2024-06-15T10:30:00Z)"
     )]
     pub due_date: Option<String>,
+    #[schemars(
+        description = "UUID, name, or number of the sprint to assign the new card to (optional). \
+            If the board has exactly one Active (non-ended) sprint, prefer passing that \
+            sprint's id here so the card lands in the active sprint in a single call."
+    )]
+    pub sprint_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -955,16 +961,21 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let due_date = req.due_date.as_deref().map(parse_datetime).transpose()?;
-        let options = CreateCardOptions {
-            description: req.description,
-            priority,
-            points: req.points,
-            due_date,
-            ..Default::default()
-        };
         let card = locked_write(&self.ctx, |ctx| {
             let board_id = ctx.mcp_resolve_board(&req.board)?;
             let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
+            let sprint_id = req
+                .sprint_id
+                .as_deref()
+                .map(|raw| ctx.mcp_resolve_sprint_in_board(raw, board_id))
+                .transpose()?;
+            let options = CreateCardOptions {
+                description: req.description,
+                priority,
+                points: req.points,
+                due_date,
+                sprint_id,
+            };
             ctx.create_card(board_id, column_id, req.title, options)
                 .map_err(kanban_err_to_mcp)
         })

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -796,6 +796,7 @@ async fn tool_move_card_resolves_names_through_locked_session() {
             priority: None,
             points: None,
             due_date: None,
+        sprint_id: None,
         }))
         .await
         .unwrap();
@@ -848,6 +849,7 @@ async fn tool_move_cards_rejects_cross_board_batch() {
                 priority: None,
                 points: None,
                 due_date: None,
+                sprint_id: None,
             }))
             .await
             .unwrap();
@@ -972,6 +974,7 @@ async fn tool_assign_card_to_sprint_resolves_by_name_then_mutates() {
             priority: None,
             points: None,
             due_date: None,
+        sprint_id: None,
         }))
         .await
         .unwrap();
@@ -1030,6 +1033,7 @@ async fn setup_server_with_two_cards() -> (KanbanMcpServer, TempDir, String, Str
             priority: None,
             points: None,
             due_date: None,
+        sprint_id: None,
         }))
         .await
         .unwrap();
@@ -1042,6 +1046,7 @@ async fn setup_server_with_two_cards() -> (KanbanMcpServer, TempDir, String, Str
             priority: None,
             points: None,
             due_date: None,
+        sprint_id: None,
         }))
         .await
         .unwrap();
@@ -1210,4 +1215,128 @@ async fn tool_remove_card_parent_returns_error_when_edge_missing() {
         msg.contains("not found") || msg.contains("missing") || msg.contains("does not exist"),
         "expected edge-not-found message, got: {msg}"
     );
+}
+
+#[tokio::test]
+async fn tool_create_card_with_sprint_id_assigns_to_sprint() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("KAN".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    let sprint_result = server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "B".into(),
+            prefix: None,
+            name: Some("alpha".into()),
+        }))
+        .await
+        .unwrap();
+    let sprint_body = text_payload(&sprint_result);
+    let sprint_id = sprint_body["id"].as_str().unwrap().to_string();
+
+    let result = server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "B".into(),
+            column: "TODO".into(),
+            title: "Sprinted".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+            sprint_id: Some(sprint_id.clone()),
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&result);
+    assert_eq!(body["sprint_id"].as_str().unwrap(), sprint_id);
+}
+
+#[tokio::test]
+async fn tool_create_card_with_sprint_name_resolves_and_assigns() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("KAN".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "B".into(),
+            prefix: None,
+            name: Some("alpha".into()),
+        }))
+        .await
+        .unwrap();
+    let result = server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "B".into(),
+            column: "TODO".into(),
+            title: "Sprinted".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+            sprint_id: Some("alpha".into()),
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&result);
+    assert!(body["sprint_id"].is_string());
+}
+
+#[tokio::test]
+async fn tool_create_card_without_sprint_id_leaves_card_unassigned() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("KAN".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    let result = server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "B".into(),
+            column: "TODO".into(),
+            title: "Plain".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+            sprint_id: None,
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&result);
+    assert!(body["sprint_id"].is_null());
 }

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -796,7 +796,7 @@ async fn tool_move_card_resolves_names_through_locked_session() {
             priority: None,
             points: None,
             due_date: None,
-        sprint_id: None,
+            sprint_id: None,
         }))
         .await
         .unwrap();
@@ -974,7 +974,7 @@ async fn tool_assign_card_to_sprint_resolves_by_name_then_mutates() {
             priority: None,
             points: None,
             due_date: None,
-        sprint_id: None,
+            sprint_id: None,
         }))
         .await
         .unwrap();
@@ -1033,7 +1033,7 @@ async fn setup_server_with_two_cards() -> (KanbanMcpServer, TempDir, String, Str
             priority: None,
             points: None,
             due_date: None,
-        sprint_id: None,
+            sprint_id: None,
         }))
         .await
         .unwrap();
@@ -1046,7 +1046,7 @@ async fn setup_server_with_two_cards() -> (KanbanMcpServer, TempDir, String, Str
             priority: None,
             points: None,
             due_date: None,
-        sprint_id: None,
+            sprint_id: None,
         }))
         .await
         .unwrap();

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -26,6 +26,7 @@ pub async fn test_card_all_fields_roundtrip(factory: &BackendFactory) {
                 priority: Some(CardPriority::Critical),
                 points: Some(8),
                 due_date: Some(chrono::Utc::now()),
+                ..Default::default()
             },
         )
         .unwrap();

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -223,6 +223,7 @@ pub async fn test_full_populated_context_roundtrip(factory: &BackendFactory) -> 
                 priority: Some(CardPriority::Critical),
                 points: Some(13),
                 due_date: Some(chrono::Utc::now()),
+                ..Default::default()
             },
         )
         .unwrap();

--- a/crates/kanban-service/tests/create_card_with_sprint.rs
+++ b/crates/kanban-service/tests/create_card_with_sprint.rs
@@ -41,7 +41,12 @@ async fn create_card_without_sprint_id_leaves_card_unassigned() {
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
     let card = ctx
-        .create_card(board.id, col.id, "Card".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
 
     assert_eq!(card.sprint_id, None);

--- a/crates/kanban-service/tests/create_card_with_sprint.rs
+++ b/crates/kanban-service/tests/create_card_with_sprint.rs
@@ -1,0 +1,80 @@
+use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_service::{open_context, AppConfig};
+use tempfile::TempDir;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_card_with_sprint_id_in_options_assigns_card_to_sprint() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = open_context(&path, AppConfig::default()).await.unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    let card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card".into(),
+            CreateCardOptions {
+                sprint_id: Some(sprint.id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(card.sprint_id, Some(sprint.id));
+    assert_eq!(card.sprint_logs.len(), 1);
+    assert_eq!(card.sprint_logs[0].sprint_id, sprint.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_card_without_sprint_id_leaves_card_unassigned() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = open_context(&path, AppConfig::default()).await.unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+
+    let card = ctx
+        .create_card(board.id, col.id, "Card".into(), CreateCardOptions::default())
+        .unwrap();
+
+    assert_eq!(card.sprint_id, None);
+    assert!(card.sprint_logs.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_card_with_sprint_and_undo_removes_card_and_assignment() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = open_context(&path, AppConfig::default()).await.unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    let card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card".into(),
+            CreateCardOptions {
+                sprint_id: Some(sprint.id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    ctx.undo().unwrap();
+
+    assert!(
+        ctx.get_card(card.id).unwrap().is_none(),
+        "Card should be gone after undo of single create-with-sprint command"
+    );
+}

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -1,3 +1,4 @@
+use crate::components::sprint_picker::SprintPicker;
 use kanban_core::SelectionState;
 use std::cell::Cell;
 use uuid::Uuid;
@@ -13,4 +14,5 @@ pub struct DialogInputState {
     pub task_list_view_selection: SelectionState,
     pub carry_over_sprint_selection: SelectionState,
     pub carry_over_source_sprint_id: Option<Uuid>,
+    pub create_card_sprint_picker: SprintPicker,
 }

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -3,6 +3,13 @@ use kanban_core::SelectionState;
 use std::cell::Cell;
 use uuid::Uuid;
 
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CreateCardFocus {
+    #[default]
+    Title,
+    Sprint,
+}
+
 #[derive(Default)]
 pub struct DialogInputState {
     pub import_files: Vec<String>,
@@ -15,4 +22,22 @@ pub struct DialogInputState {
     pub carry_over_sprint_selection: SelectionState,
     pub carry_over_source_sprint_id: Option<Uuid>,
     pub create_card_sprint_picker: SprintPicker,
+    pub create_card_focus: CreateCardFocus,
+}
+
+impl DialogInputState {
+    pub fn create_card_focus_is_title(&self) -> bool {
+        self.create_card_focus == CreateCardFocus::Title
+    }
+
+    pub fn toggle_create_card_focus(&mut self) {
+        self.create_card_focus = match self.create_card_focus {
+            CreateCardFocus::Title => CreateCardFocus::Sprint,
+            CreateCardFocus::Sprint => CreateCardFocus::Title,
+        };
+    }
+
+    pub fn reset_create_card_focus(&mut self) {
+        self.create_card_focus = CreateCardFocus::Title;
+    }
 }

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -1,4 +1,4 @@
-use crate::components::sprint_picker::SprintPicker;
+use crate::components::sprint_picker::{SprintFilter, SprintPicker};
 use kanban_core::SelectionState;
 use std::cell::Cell;
 use uuid::Uuid;
@@ -10,7 +10,6 @@ pub enum CreateCardFocus {
     Sprint,
 }
 
-#[derive(Default)]
 pub struct DialogInputState {
     pub import_files: Vec<String>,
     pub import_selection: SelectionState,
@@ -23,6 +22,30 @@ pub struct DialogInputState {
     pub carry_over_source_sprint_id: Option<Uuid>,
     pub create_card_sprint_picker: SprintPicker,
     pub create_card_focus: CreateCardFocus,
+    /// Picker for the assign-to-existing-card dialogs (single and
+    /// bulk). Configured with SprintFilter::All so the user can pick
+    /// from completed/ended sprints as well, which the create-card
+    /// picker intentionally hides.
+    pub assign_sprint_picker: SprintPicker,
+}
+
+impl Default for DialogInputState {
+    fn default() -> Self {
+        Self {
+            import_files: Vec::new(),
+            import_selection: SelectionState::default(),
+            priority_selection: SelectionState::default(),
+            column_selection: SelectionState::default(),
+            column_scroll: Cell::new(0),
+            sprint_assign_selection: SelectionState::default(),
+            task_list_view_selection: SelectionState::default(),
+            carry_over_sprint_selection: SelectionState::default(),
+            carry_over_source_sprint_id: None,
+            create_card_sprint_picker: SprintPicker::with_filter(SprintFilter::ActiveOnly),
+            create_card_focus: CreateCardFocus::default(),
+            assign_sprint_picker: SprintPicker::with_filter(SprintFilter::All),
+        }
+    }
 }
 
 impl DialogInputState {

--- a/crates/kanban-tui/src/components/mod.rs
+++ b/crates/kanban-tui/src/components/mod.rs
@@ -18,6 +18,7 @@ pub mod selection_dialog;
 pub mod selection_list;
 pub mod sprint_assign_list;
 pub mod sprint_picker;
+pub mod sprint_picker_view;
 
 pub use banner::*;
 pub use card_detail_sections::*;
@@ -39,3 +40,4 @@ pub use selection_dialog::*;
 pub use selection_list::*;
 pub use sprint_assign_list::*;
 pub use sprint_picker::*;
+pub use sprint_picker_view::*;

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,6 +1,5 @@
 use crate::app::App;
 use crate::components::sprint_assign_list::build_entries;
-use crate::components::sprint_picker_view::SprintPickerView;
 use kanban_domain::SprintStatus;
 use ratatui::Frame;
 
@@ -335,21 +334,12 @@ impl SelectionDialog for SprintAssignDialog {
         let Some(board) = app.model.boards().get(board_idx) else {
             return;
         };
-        let current_sprint_id = app
-            .selection
-            .active_card_id
-            .and_then(|id| app.model.card(id))
-            .and_then(|c| c.sprint_id);
-        let picker = SprintPickerView::for_card_assignment(
-            app.model.sprints(),
-            board,
-            current_sprint_id,
-            chrono::Utc::now(),
-        );
-        picker.render(
+        app.dialog_input.assign_sprint_picker.render(
             frame,
             chunks[1],
-            app.dialog_input.sprint_assign_selection.get(),
+            app.model.sprints(),
+            board,
+            chrono::Utc::now(),
         );
     }
 }

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::components::sprint_assign_list::build_entries;
-use crate::components::sprint_picker::SprintPicker;
+use crate::components::sprint_picker_view::SprintPickerView;
 use kanban_domain::SprintStatus;
 use ratatui::Frame;
 
@@ -340,7 +340,7 @@ impl SelectionDialog for SprintAssignDialog {
             .active_card_id
             .and_then(|id| app.model.card(id))
             .and_then(|c| c.sprint_id);
-        let picker = SprintPicker::for_card_assignment(
+        let picker = SprintPickerView::for_card_assignment(
             app.model.sprints(),
             board,
             current_sprint_id,

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -29,6 +29,28 @@ impl SprintAssignEntry<'_> {
 pub const ACTIVE_PLANNED_HEADER: &str = "Active / Planned";
 pub const COMPLETED_ENDED_HEADER: &str = "Completed / Ended";
 
+/// Build the entry list for the new-card picker: same as
+/// [`build_entries`], minus the Completed/Ended section. Completed and
+/// Ended sprints aren't valid targets when creating a brand-new card,
+/// so they don't appear at all (no row, no section header).
+pub fn build_entries_active_only<'a>(
+    sprints: &'a [Sprint],
+    board_id: Uuid,
+    now: DateTime<Utc>,
+) -> Vec<SprintAssignEntry<'a>> {
+    build_entries(sprints, board_id, now)
+        .into_iter()
+        .filter(|entry| {
+            !matches!(
+                entry,
+                SprintAssignEntry::Header(COMPLETED_ENDED_HEADER)
+                    | SprintAssignEntry::Completed(_)
+                    | SprintAssignEntry::Ended(_)
+            )
+        })
+        .collect()
+}
+
 /// Build the entry list for the dialog. Headers are emitted only when their
 /// section is non-empty. The `(None)` entry is always at index 0.
 pub fn build_entries<'a>(

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -129,7 +129,7 @@ pub fn render_entry_line(
         )),
         SprintAssignEntry::None => {
             let is_current = current_sprint_id.is_none();
-            let prefix = if is_selected { "> " } else { "  " };
+            let prefix = if is_selected { "[x] " } else { "[ ] " };
             let suffix = if is_current { " (current)" } else { "" };
             let style = if is_selected {
                 Style::default().fg(Color::White).bg(Color::Blue)
@@ -144,7 +144,7 @@ pub fn render_entry_line(
         }
         SprintAssignEntry::ActiveOrPlanned(s) => {
             let is_current = current_sprint_id == Some(s.id);
-            let prefix = if is_selected { "> " } else { "  " };
+            let prefix = if is_selected { "[x] " } else { "[ ] " };
             let suffix = if is_current { " (current)" } else { "" };
             let style = if is_selected {
                 Style::default().fg(Color::White).bg(Color::Blue)
@@ -162,7 +162,7 @@ pub fn render_entry_line(
         }
         SprintAssignEntry::Completed(s) | SprintAssignEntry::Ended(s) => {
             let is_current = current_sprint_id == Some(s.id);
-            let prefix = if is_selected { "> " } else { "  " };
+            let prefix = if is_selected { "[x] " } else { "[ ] " };
             let suffix = if is_current { " (current)" } else { "" };
             let status_color = if matches!(entry, SprintAssignEntry::Completed(_)) {
                 Color::Green

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -116,7 +116,8 @@ pub fn sprint_id_of(entry: &SprintAssignEntry) -> Option<Uuid> {
 /// sprint (e.g. the multi-card variant).
 pub fn render_entry_line(
     entry: &SprintAssignEntry<'_>,
-    is_selected: bool,
+    is_checked: bool,
+    is_focused: bool,
     current_sprint_id: Option<Uuid>,
     board: &Board,
 ) -> Line<'static> {
@@ -129,9 +130,9 @@ pub fn render_entry_line(
         )),
         SprintAssignEntry::None => {
             let is_current = current_sprint_id.is_none();
-            let prefix = if is_selected { "[x] " } else { "[ ] " };
+            let prefix = if is_checked { "[x] " } else { "[ ] " };
             let suffix = if is_current { " (current)" } else { "" };
-            let style = if is_selected {
+            let style = if is_focused {
                 Style::default().fg(Color::White).bg(Color::Blue)
             } else if is_current {
                 Style::default()
@@ -144,9 +145,9 @@ pub fn render_entry_line(
         }
         SprintAssignEntry::ActiveOrPlanned(s) => {
             let is_current = current_sprint_id == Some(s.id);
-            let prefix = if is_selected { "[x] " } else { "[ ] " };
+            let prefix = if is_checked { "[x] " } else { "[ ] " };
             let suffix = if is_current { " (current)" } else { "" };
-            let style = if is_selected {
+            let style = if is_focused {
                 Style::default().fg(Color::White).bg(Color::Blue)
             } else if is_current {
                 Style::default()
@@ -162,14 +163,14 @@ pub fn render_entry_line(
         }
         SprintAssignEntry::Completed(s) | SprintAssignEntry::Ended(s) => {
             let is_current = current_sprint_id == Some(s.id);
-            let prefix = if is_selected { "[x] " } else { "[ ] " };
+            let prefix = if is_checked { "[x] " } else { "[ ] " };
             let suffix = if is_current { " (current)" } else { "" };
             let status_color = if matches!(entry, SprintAssignEntry::Completed(_)) {
                 Color::Green
             } else {
                 Color::Red
             };
-            let style = if is_selected {
+            let style = if is_focused {
                 Style::default().fg(Color::White).bg(Color::Blue)
             } else {
                 Style::default().fg(status_color)
@@ -483,25 +484,25 @@ mod tests {
     }
 
     #[test]
-    fn test_render_entry_line_marks_selected_with_filled_checkbox() {
+    fn test_render_entry_line_marks_checked_with_filled_checkbox() {
         let board = make_board_for_render();
         let entry = SprintAssignEntry::None;
-        let line = render_entry_line(&entry, /*is_selected=*/ true, None, &board);
+        let line = render_entry_line(&entry, /*is_checked=*/ true, false, None, &board);
         assert!(
             line_to_string(&line).starts_with("[x]"),
-            "selected row should start with [x], got: {:?}",
+            "checked row should start with [x], got: {:?}",
             line_to_string(&line)
         );
     }
 
     #[test]
-    fn test_render_entry_line_marks_unselected_with_empty_checkbox() {
+    fn test_render_entry_line_marks_unchecked_with_empty_checkbox() {
         let board = make_board_for_render();
         let entry = SprintAssignEntry::None;
-        let line = render_entry_line(&entry, /*is_selected=*/ false, None, &board);
+        let line = render_entry_line(&entry, /*is_checked=*/ false, false, None, &board);
         assert!(
             line_to_string(&line).starts_with("[ ]"),
-            "unselected row should start with [ ], got: {:?}",
+            "unchecked row should start with [ ], got: {:?}",
             line_to_string(&line)
         );
     }
@@ -512,22 +513,37 @@ mod tests {
         let sprint = make_sprint(1, board.id, SprintStatus::Planning, None);
         let entry = SprintAssignEntry::ActiveOrPlanned(&sprint);
 
-        let selected = render_entry_line(&entry, true, None, &board);
-        let unselected = render_entry_line(&entry, false, None, &board);
+        let checked = render_entry_line(&entry, true, false, None, &board);
+        let unchecked = render_entry_line(&entry, false, false, None, &board);
 
-        assert!(line_to_string(&selected).starts_with("[x]"));
-        assert!(line_to_string(&unselected).starts_with("[ ]"));
+        assert!(line_to_string(&checked).starts_with("[x]"));
+        assert!(line_to_string(&unchecked).starts_with("[ ]"));
     }
 
     #[test]
     fn test_render_entry_line_header_has_no_checkbox() {
         let board = make_board_for_render();
         let entry = SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER);
-        let line = render_entry_line(&entry, false, None, &board);
+        let line = render_entry_line(&entry, false, false, None, &board);
         let text = line_to_string(&line);
         assert!(
             !text.contains("[x]") && !text.contains("[ ]"),
             "section headers should not render a checkbox, got: {text:?}"
         );
+    }
+
+    #[test]
+    fn test_render_entry_line_checked_and_focused_are_independent() {
+        let board = make_board_for_render();
+        let sprint = make_sprint(1, board.id, SprintStatus::Planning, None);
+        let entry = SprintAssignEntry::ActiveOrPlanned(&sprint);
+
+        // Checked but cursor is elsewhere: [x] without blue background.
+        let checked_only = render_entry_line(&entry, true, false, None, &board);
+        // Focused but not checked: [ ] with blue background.
+        let focused_only = render_entry_line(&entry, false, true, None, &board);
+
+        assert!(line_to_string(&checked_only).starts_with("[x]"));
+        assert!(line_to_string(&focused_only).starts_with("[ ]"));
     }
 }

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -473,4 +473,61 @@ mod tests {
             Some((3, COMPLETED_ENDED_HEADER))
         );
     }
+
+    fn line_to_string(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn make_board_for_render() -> Board {
+        Board::new("B".to_string(), Some("TST".to_string()))
+    }
+
+    #[test]
+    fn test_render_entry_line_marks_selected_with_filled_checkbox() {
+        let board = make_board_for_render();
+        let entry = SprintAssignEntry::None;
+        let line = render_entry_line(&entry, /*is_selected=*/ true, None, &board);
+        assert!(
+            line_to_string(&line).starts_with("[x]"),
+            "selected row should start with [x], got: {:?}",
+            line_to_string(&line)
+        );
+    }
+
+    #[test]
+    fn test_render_entry_line_marks_unselected_with_empty_checkbox() {
+        let board = make_board_for_render();
+        let entry = SprintAssignEntry::None;
+        let line = render_entry_line(&entry, /*is_selected=*/ false, None, &board);
+        assert!(
+            line_to_string(&line).starts_with("[ ]"),
+            "unselected row should start with [ ], got: {:?}",
+            line_to_string(&line)
+        );
+    }
+
+    #[test]
+    fn test_render_entry_line_checkbox_applies_to_sprint_rows() {
+        let board = make_board_for_render();
+        let sprint = make_sprint(1, board.id, SprintStatus::Planning, None);
+        let entry = SprintAssignEntry::ActiveOrPlanned(&sprint);
+
+        let selected = render_entry_line(&entry, true, None, &board);
+        let unselected = render_entry_line(&entry, false, None, &board);
+
+        assert!(line_to_string(&selected).starts_with("[x]"));
+        assert!(line_to_string(&unselected).starts_with("[ ]"));
+    }
+
+    #[test]
+    fn test_render_entry_line_header_has_no_checkbox() {
+        let board = make_board_for_render();
+        let entry = SprintAssignEntry::Header(ACTIVE_PLANNED_HEADER);
+        let line = render_entry_line(&entry, false, None, &board);
+        let text = line_to_string(&line);
+        assert!(
+            !text.contains("[x]") && !text.contains("[ ]"),
+            "section headers should not render a checkbox, got: {text:?}"
+        );
+    }
 }

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -1,5 +1,6 @@
 use crate::components::sprint_assign_list::{
-    build_entries_active_only, next_selectable, prev_selectable, sprint_id_of, SprintAssignEntry,
+    build_entries, build_entries_active_only, next_selectable, prev_selectable, sprint_id_of,
+    SprintAssignEntry,
 };
 use crate::components::sprint_picker_view::SprintPickerView;
 use chrono::{DateTime, Utc};
@@ -34,19 +35,31 @@ enum Cursor {
     Sprint(Uuid),
 }
 
-/// Stateful sprint picker for dialogs that embed a sprint selector
-/// alongside other inputs (e.g. the Create Card dialog). The picker
-/// keeps two independent identities:
+/// Which subset of sprints the picker shows. Create-card flows hide
+/// finished sprints (you can't bind a brand-new card to one), while
+/// assign-to-existing-card flows let the user pick from everything so
+/// they can look back at the card's history.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SprintFilter {
+    /// Only the Active/Planned section; no Completed/Ended entries.
+    #[default]
+    ActiveOnly,
+    /// Active/Planned and Completed/Ended sections both shown.
+    All,
+}
+
+/// Stateful sprint picker shared by every sprint-selection dialog. The
+/// picker keeps two independent identities:
 ///
 /// - `cursor` is where Up/Down/j/k arrow keys move; it is what the
 ///   user is currently *pointing at*.
 /// - `selection` is what gets the `[x]` checkbox and is what the host
 ///   reads back via `selected_sprint_id`. Only Space writes to it.
 ///
-/// On open, the cursor is positioned on the sole Active non-ended
-/// sprint when there is exactly one (so Space is one keystroke away
-/// from assigning it), but selection starts `Unset` — the user must
-/// deliberately press Space to commit a choice.
+/// The same struct drives both the create-card picker (built with
+/// `SprintFilter::ActiveOnly`) and the assign-to-card picker (built
+/// with `SprintFilter::All`); the filter only changes which entries
+/// the picker considers, the navigation and toggle model is identical.
 ///
 /// Composition: `SprintPicker` -> `SprintPickerView` (stateless adapter
 /// that turns sprints into ListItem rows) -> `RadioList<Option<Uuid>>`
@@ -55,33 +68,73 @@ enum Cursor {
 pub struct SprintPicker {
     selection: Selection,
     cursor: Cursor,
+    filter: SprintFilter,
 }
 
 impl SprintPicker {
+    /// Convenience: a picker for the create-card dialog
+    /// (`SprintFilter::ActiveOnly`).
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            filter: SprintFilter::ActiveOnly,
+            ..Default::default()
+        }
     }
 
-    /// Reset for a fresh dialog opening. The selection is cleared to
-    /// `Unset` (no `[x]` shown yet — the user has to press Space to
-    /// commit). The cursor lands on the sole Active non-ended sprint
-    /// when there is exactly one; otherwise on the "(None)" row.
+    /// Construct a picker with an explicit filter. Use
+    /// `SprintFilter::All` for the assign-to-existing-card dialogs so
+    /// the user can also pick Completed/Ended sprints; use
+    /// `SprintFilter::ActiveOnly` for create-card flows.
+    pub fn with_filter(filter: SprintFilter) -> Self {
+        Self {
+            filter,
+            ..Default::default()
+        }
+    }
+
+    /// Reset for a fresh create-card dialog. The cursor lands on the
+    /// sole Active non-ended sprint when there is exactly one — and in
+    /// that case the sprint is also pre-checked. Otherwise the cursor
+    /// parks on (None) and selection starts `Unset`.
     pub fn reset_for_board(&mut self, sprints: &[Sprint], board: &Board, now: DateTime<Utc>) {
         let view = SprintPickerView::for_new_card(sprints, board, now);
-        let entries = build_entries_active_only(sprints, board.id, now);
+        let entries = self.build_entries(sprints, board, now);
         self.cursor = view
             .initial_selection()
             .and_then(|idx| entries.get(idx).map(Self::entry_to_cursor))
             .unwrap_or(Cursor::NoSprint);
-        // The view's initial-selection rule only lands on a sprint row
-        // when there is exactly one Active non-ended sprint. In that
-        // case pre-check it so the dialog opens with [x] already on
-        // the sprint and Enter confirms in one keystroke. Otherwise no
-        // [x] is shown — the user must press Space to commit a choice.
         self.selection = match self.cursor {
             Cursor::Sprint(id) => Selection::Sprint(id),
             Cursor::NoSprint => Selection::Unset,
         };
+    }
+
+    /// Reset for an assign-to-card dialog where the card already has a
+    /// `current_sprint_id` (or `None` if it's unassigned). Cursor +
+    /// selection both follow that current id, so the dialog opens with
+    /// `[x]` already on whatever the card is bound to.
+    pub fn reset_for_card_assignment(
+        &mut self,
+        current_sprint_id: Option<Uuid>,
+        sprints: &[Sprint],
+        board: &Board,
+        now: DateTime<Utc>,
+    ) {
+        let entries = self.build_entries(sprints, board, now);
+        let (cursor, selection) = match current_sprint_id {
+            Some(id) => {
+                // Only consider it pre-checked if the sprint is in the
+                // current entry list (the filter might exclude it).
+                if entries.iter().any(|e| sprint_id_of(e) == Some(id)) {
+                    (Cursor::Sprint(id), Selection::Sprint(id))
+                } else {
+                    (Cursor::NoSprint, Selection::Unset)
+                }
+            }
+            None => (Cursor::NoSprint, Selection::NoSprint),
+        };
+        self.cursor = cursor;
+        self.selection = selection;
     }
 
     pub fn clear(&mut self) {
@@ -90,9 +143,9 @@ impl SprintPicker {
     }
 
     /// Try to consume a key. Returns true when the picker handled it:
-    /// Up/Down/j/k move the cursor; Space commits the cursor's row as
-    /// the new selection (placing or moving `[x]`). Other keys fall
-    /// through to the host (text input, etc.).
+    /// Up/Down/j/k move the cursor; Space toggles `[x]` at the cursor
+    /// (places or moves it, or removes it from a row that already has
+    /// it). Other keys fall through to the host (text input, etc.).
     pub fn handle_key(
         &mut self,
         key_code: KeyCode,
@@ -105,8 +158,6 @@ impl SprintPicker {
                 Cursor::NoSprint => Selection::NoSprint,
                 Cursor::Sprint(id) => Selection::Sprint(id),
             };
-            // Toggle: Space on the row that already has [x] removes the
-            // checkbox; on any other row it places or moves [x] there.
             self.selection = if self.selection == cursor_as_selection {
                 Selection::Unset
             } else {
@@ -114,7 +165,7 @@ impl SprintPicker {
             };
             return true;
         }
-        let entries = build_entries_active_only(sprints, board.id, now);
+        let entries = self.build_entries(sprints, board, now);
         let cur = self.cursor_index(&entries);
         let next_idx = match key_code {
             KeyCode::Down | KeyCode::Char('j') => next_selectable(&entries, cur),
@@ -138,6 +189,14 @@ impl SprintPicker {
         }
     }
 
+    /// True when the user has explicitly committed a "(None)" choice
+    /// via Space. Used by the assign-to-existing-card flow to
+    /// distinguish "unassign the card" from "user didn't touch the
+    /// picker so leave the card alone".
+    pub fn explicitly_unassigned(&self) -> bool {
+        matches!(self.selection, Selection::NoSprint)
+    }
+
     pub fn render(
         &self,
         frame: &mut Frame,
@@ -146,7 +205,7 @@ impl SprintPicker {
         board: &Board,
         now: DateTime<Utc>,
     ) {
-        let view = SprintPickerView::for_new_card(sprints, board, now);
+        let view = self.build_view(sprints, board, now);
         let checked = match self.selection {
             Selection::Unset => None,
             Selection::NoSprint => view.index_of_sprint(None),
@@ -157,6 +216,30 @@ impl SprintPicker {
             Cursor::Sprint(id) => view.index_of_sprint(Some(id)),
         };
         view.render_with_cursor(frame, area, checked, cursor);
+    }
+
+    fn build_entries<'a>(
+        &self,
+        sprints: &'a [Sprint],
+        board: &Board,
+        now: DateTime<Utc>,
+    ) -> Vec<SprintAssignEntry<'a>> {
+        match self.filter {
+            SprintFilter::ActiveOnly => build_entries_active_only(sprints, board.id, now),
+            SprintFilter::All => build_entries(sprints, board.id, now),
+        }
+    }
+
+    fn build_view<'a>(
+        &self,
+        sprints: &'a [Sprint],
+        board: &'a Board,
+        now: DateTime<Utc>,
+    ) -> SprintPickerView<'a> {
+        match self.filter {
+            SprintFilter::ActiveOnly => SprintPickerView::for_new_card(sprints, board, now),
+            SprintFilter::All => SprintPickerView::for_card_assignment(sprints, board, None, now),
+        }
     }
 
     fn cursor_index(&self, entries: &[SprintAssignEntry]) -> Option<usize> {

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -141,7 +141,10 @@ mod tests {
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
 
-        assert_eq!(picker.selected_sprint_id(&sprints, &board, now), Some(sprint.id));
+        assert_eq!(
+            picker.selected_sprint_id(&sprints, &board, now),
+            Some(sprint.id)
+        );
     }
 
     #[test]
@@ -192,7 +195,10 @@ mod tests {
         let after = picker.selection_index();
 
         assert!(consumed, "Down should be consumed by the picker");
-        assert_ne!(before, after, "Down should move selection when more entries exist");
+        assert_ne!(
+            before, after,
+            "Down should move selection when more entries exist"
+        );
     }
 
     #[test]

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -253,13 +253,14 @@ mod tests {
 
     #[test]
     fn test_selection_survives_clock_advance_that_ends_the_selected_sprint() {
-        // Open time: sprint A is Active non-ended (end_date in the future).
-        // The "sole active" rule pre-selects it. Then time advances past
-        // A's end_date so A moves from the active-or-planned section into
-        // the completed-or-ended section in build_entries. An index-based
-        // store would now point at whatever entry occupies A's old slot
-        // (a header, or sprint B); the identity-based store still
-        // resolves to A.
+        // Open time: sprint A is Active non-ended. The "sole active" rule
+        // pre-selects A at row index `idx_open`. Confirm time: A has
+        // crossed its end_date and moves into the completed/ended
+        // section, shifting to a different row `idx_confirm`. An index-
+        // based store would still report row `idx_open`, which at
+        // confirm time points at a *different* entry (a section header,
+        // or sprint B). The identity-based store reports A regardless of
+        // the layout change.
         let board = make_board();
         let now_open = Utc::now();
         let now_confirm = now_open + Duration::days(30);
@@ -282,13 +283,32 @@ mod tests {
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now_open);
         assert_eq!(picker.selected_sprint_id(), Some(sprint_a.id));
+        assert_eq!(picker.raw_selection(), Selection::Sprint(sprint_a.id));
 
-        // At now_confirm A has crossed its end_date — entries layout
-        // shifts, but the picker still reports A.
-        assert!(
-            sprint_a.is_ended(now_confirm),
-            "test precondition: sprint A is ended at now_confirm"
+        // Precondition: A's row index actually shifts between the two
+        // times — otherwise the test wouldn't be exercising the race.
+        let entries_open =
+            crate::components::sprint_assign_list::build_entries(&sprints, board.id, now_open);
+        let entries_confirm =
+            crate::components::sprint_assign_list::build_entries(&sprints, board.id, now_confirm);
+        let idx_open = entries_open
+            .iter()
+            .position(|e| sprint_id_of(e) == Some(sprint_a.id));
+        let idx_confirm = entries_confirm
+            .iter()
+            .position(|e| sprint_id_of(e) == Some(sprint_a.id));
+        assert!(idx_open.is_some());
+        assert!(idx_confirm.is_some());
+        assert_ne!(
+            idx_open, idx_confirm,
+            "precondition: A's row position must differ between open and confirm"
         );
+
+        // The picker's internal row resolution at confirm time tracks A
+        // by identity — it lands on A's *new* row, not on whatever entry
+        // sits at the old row. Same property as selected_sprint_id, but
+        // demonstrated via the navigation path that handle_key follows.
+        assert_eq!(picker.current_index(&entries_confirm), idx_confirm);
         assert_eq!(picker.selected_sprint_id(), Some(sprint_a.id));
     }
 

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 /// changes to the underlying sprint list between frames (clock crossing
 /// a sprint's `end_date`, a background reload, an undo elsewhere, ...).
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Selection {
+pub(crate) enum Selection {
     /// Picker has not been initialised yet (default before `reset_for_board`).
     #[default]
     Unset,
@@ -103,8 +103,12 @@ impl SprintPicker {
         now: DateTime<Utc>,
     ) {
         let view = SprintPickerView::for_card_assignment(sprints, board, None, now);
-        let entries = build_entries(sprints, board.id, now);
-        view.render(frame, area, self.current_index(&entries));
+        let row = match self.selection {
+            Selection::Unset => None,
+            Selection::NoSprint => view.index_of_sprint(None),
+            Selection::Sprint(id) => view.index_of_sprint(Some(id)),
+        };
+        view.render(frame, area, row);
     }
 
     /// Map the stored identity back to the row index in the current entry

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -54,13 +54,13 @@ impl SprintPicker {
         let entries = build_entries(sprints, board.id, now);
         let cur = self.selection.get();
         match key_code {
-            KeyCode::Down => {
+            KeyCode::Down | KeyCode::Char('j') => {
                 if let Some(next) = next_selectable(&entries, cur) {
                     self.selection.set(Some(next));
                 }
                 true
             }
-            KeyCode::Up => {
+            KeyCode::Up | KeyCode::Char('k') => {
                 if let Some(prev) = prev_selectable(&entries, cur) {
                     self.selection.set(Some(prev));
                 }

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -1,5 +1,5 @@
 use crate::components::sprint_assign_list::{
-    build_entries, next_selectable, prev_selectable, sprint_id_of, SprintAssignEntry,
+    build_entries_active_only, next_selectable, prev_selectable, sprint_id_of, SprintAssignEntry,
 };
 use crate::components::sprint_picker_view::SprintPickerView;
 use chrono::{DateTime, Utc};
@@ -68,8 +68,8 @@ impl SprintPicker {
     /// when there is exactly one; otherwise on the "(None)" row.
     pub fn reset_for_board(&mut self, sprints: &[Sprint], board: &Board, now: DateTime<Utc>) {
         self.selection = Selection::Unset;
-        let view = SprintPickerView::for_board(sprints, board, now);
-        let entries = build_entries(sprints, board.id, now);
+        let view = SprintPickerView::for_new_card(sprints, board, now);
+        let entries = build_entries_active_only(sprints, board.id, now);
         self.cursor = view
             .initial_selection()
             .and_then(|idx| entries.get(idx).map(Self::entry_to_cursor))
@@ -99,7 +99,7 @@ impl SprintPicker {
             };
             return true;
         }
-        let entries = build_entries(sprints, board.id, now);
+        let entries = build_entries_active_only(sprints, board.id, now);
         let cur = self.cursor_index(&entries);
         let next_idx = match key_code {
             KeyCode::Down | KeyCode::Char('j') => next_selectable(&entries, cur),
@@ -131,7 +131,7 @@ impl SprintPicker {
         board: &Board,
         now: DateTime<Utc>,
     ) {
-        let view = SprintPickerView::for_card_assignment(sprints, board, None, now);
+        let view = SprintPickerView::for_new_card(sprints, board, now);
         let checked = match self.selection {
             Selection::Unset => None,
             Selection::NoSprint => view.index_of_sprint(None),
@@ -448,6 +448,42 @@ mod tests {
         // demonstrated via the navigation path that handle_key follows.
         assert_eq!(picker.current_index(&entries_confirm), idx_confirm);
         assert_eq!(picker.selected_sprint_id(), Some(sprint_a.id));
+    }
+
+    #[test]
+    fn test_picker_skips_completed_and_ended_sprints_during_navigation() {
+        // Active and Planning sprints are valid targets in the create-card
+        // picker; Completed and Ended ones are intentionally hidden so the
+        // user can't accidentally bind a brand-new card to a sprint that's
+        // already wrapped up. Arrowing past the active section should
+        // clamp instead of walking into a Completed row.
+        let now = Utc::now();
+        let board = make_board();
+        let active = active_sprint(board.id, 1, now);
+
+        // Sprint that ended in the past — would normally appear in the
+        // Completed/Ended section of build_entries.
+        let mut completed = Sprint::new(board.id, 2, None, None);
+        completed.status = SprintStatus::Completed;
+        completed.start_date = Some(now - Duration::days(30));
+        completed.end_date = Some(now - Duration::days(15));
+
+        let sprints = vec![active.clone(), completed.clone()];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        // Cursor parks on the sole active sprint (the only candidate).
+        assert_eq!(picker.cursor_sprint_id(), Some(active.id));
+
+        // Walk down — completed sprint must not be reachable.
+        for _ in 0..3 {
+            picker.handle_key(KeyCode::Down, &sprints, &board, now);
+        }
+        assert_ne!(
+            picker.cursor_sprint_id(),
+            Some(completed.id),
+            "Down must not reach a completed sprint in the new-card picker"
+        );
     }
 
     #[test]

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -23,20 +23,38 @@ pub(crate) enum Selection {
     Sprint(Uuid),
 }
 
+/// What the picker's keyboard cursor is pointing at. Stored as an
+/// identity so it survives reflows of the underlying entries list.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+enum Cursor {
+    /// Cursor parked on the "(None)" row at index 0.
+    #[default]
+    NoSprint,
+    /// Cursor on a specific sprint row.
+    Sprint(Uuid),
+}
+
 /// Stateful sprint picker for dialogs that embed a sprint selector
-/// alongside other inputs (e.g. the Create Card dialog). Owns the
-/// selection, applies the "pre-select sole active sprint" rule on open,
-/// translates navigation keys into selection moves, and exposes the
-/// resolved sprint id for the host to apply.
+/// alongside other inputs (e.g. the Create Card dialog). The picker
+/// keeps two independent identities:
+///
+/// - `cursor` is where Up/Down/j/k arrow keys move; it is what the
+///   user is currently *pointing at*.
+/// - `selection` is what gets the `[x]` checkbox and is what the host
+///   reads back via `selected_sprint_id`. Only Space writes to it.
+///
+/// On open, the cursor is positioned on the sole Active non-ended
+/// sprint when there is exactly one (so Space is one keystroke away
+/// from assigning it), but selection starts `Unset` — the user must
+/// deliberately press Space to commit a choice.
 ///
 /// Composition: `SprintPicker` -> `SprintPickerView` (stateless adapter
 /// that turns sprints into ListItem rows) -> `RadioList<Option<Uuid>>`
-/// (generic radio-list primitive). The stateful layer adds identity-
-/// based selection state and key handling on top of the existing
-/// stateless presenter.
+/// (generic radio-list primitive).
 #[derive(Default)]
 pub struct SprintPicker {
     selection: Selection,
+    cursor: Cursor,
 }
 
 impl SprintPicker {
@@ -44,26 +62,29 @@ impl SprintPicker {
         Self::default()
     }
 
-    /// Reset selection for a fresh dialog opening. If the board has exactly
-    /// one Active (non-ended) sprint at `now`, that sprint becomes the
-    /// initial selection; otherwise the "(None)" entry.
+    /// Reset for a fresh dialog opening. The selection is cleared to
+    /// `Unset` (no `[x]` shown yet — the user has to press Space to
+    /// commit). The cursor lands on the sole Active non-ended sprint
+    /// when there is exactly one; otherwise on the "(None)" row.
     pub fn reset_for_board(&mut self, sprints: &[Sprint], board: &Board, now: DateTime<Utc>) {
+        self.selection = Selection::Unset;
         let view = SprintPickerView::for_board(sprints, board, now);
         let entries = build_entries(sprints, board.id, now);
-        self.selection = view
+        self.cursor = view
             .initial_selection()
-            .and_then(|idx| entries.get(idx).map(Self::entry_to_selection))
-            .unwrap_or(Selection::NoSprint);
+            .and_then(|idx| entries.get(idx).map(Self::entry_to_cursor))
+            .unwrap_or(Cursor::NoSprint);
     }
 
     pub fn clear(&mut self) {
         self.selection = Selection::Unset;
+        self.cursor = Cursor::NoSprint;
     }
 
-    /// Try to consume a navigation key. Returns true when the key moved the
-    /// selection (Up/Down/j/k) or cleared it (Space); false when the key
-    /// should fall through to other handlers (typing into a text input,
-    /// etc.).
+    /// Try to consume a key. Returns true when the picker handled it:
+    /// Up/Down/j/k move the cursor; Space commits the cursor's row as
+    /// the new selection (placing or moving `[x]`). Other keys fall
+    /// through to the host (text input, etc.).
     pub fn handle_key(
         &mut self,
         key_code: KeyCode,
@@ -72,11 +93,14 @@ impl SprintPicker {
         now: DateTime<Utc>,
     ) -> bool {
         if matches!(key_code, KeyCode::Char(' ')) {
-            self.selection = Selection::NoSprint;
+            self.selection = match self.cursor {
+                Cursor::NoSprint => Selection::NoSprint,
+                Cursor::Sprint(id) => Selection::Sprint(id),
+            };
             return true;
         }
         let entries = build_entries(sprints, board.id, now);
-        let cur = self.current_index(&entries);
+        let cur = self.cursor_index(&entries);
         let next_idx = match key_code {
             KeyCode::Down | KeyCode::Char('j') => next_selectable(&entries, cur),
             KeyCode::Up | KeyCode::Char('k') => prev_selectable(&entries, cur),
@@ -84,14 +108,14 @@ impl SprintPicker {
         };
         if let Some(idx) = next_idx {
             if let Some(entry) = entries.get(idx) {
-                self.selection = Self::entry_to_selection(entry);
+                self.cursor = Self::entry_to_cursor(entry);
             }
         }
         true
     }
 
-    /// Resolve the currently-selected sprint id. Returns None when the
-    /// "(None)" entry is selected or the picker is uninitialised.
+    /// Resolve the currently-checked sprint id. Returns None when
+    /// nothing is checked yet or the user explicitly checked "(None)".
     pub fn selected_sprint_id(&self) -> Option<Uuid> {
         match self.selection {
             Selection::Sprint(id) => Some(id),
@@ -108,19 +132,54 @@ impl SprintPicker {
         now: DateTime<Utc>,
     ) {
         let view = SprintPickerView::for_card_assignment(sprints, board, None, now);
-        let row = match self.selection {
+        let checked = match self.selection {
             Selection::Unset => None,
             Selection::NoSprint => view.index_of_sprint(None),
             Selection::Sprint(id) => view.index_of_sprint(Some(id)),
         };
-        view.render(frame, area, row);
+        let cursor = match self.cursor {
+            Cursor::NoSprint => view.index_of_sprint(None),
+            Cursor::Sprint(id) => view.index_of_sprint(Some(id)),
+        };
+        view.render_with_cursor(frame, area, checked, cursor);
     }
 
-    /// Map the stored identity back to the row index in the current entry
-    /// list. Returns `None` when the selection is `Unset` or when the
-    /// selected sprint no longer appears in the list (e.g. it was deleted
-    /// between frames — the caller should treat that as a lost selection).
-    fn current_index(&self, entries: &[SprintAssignEntry]) -> Option<usize> {
+    fn cursor_index(&self, entries: &[SprintAssignEntry]) -> Option<usize> {
+        match self.cursor {
+            Cursor::NoSprint => entries
+                .iter()
+                .position(|e| matches!(e, SprintAssignEntry::None)),
+            Cursor::Sprint(id) => entries.iter().position(|e| sprint_id_of(e) == Some(id)),
+        }
+    }
+
+    fn entry_to_cursor(entry: &SprintAssignEntry) -> Cursor {
+        match entry {
+            SprintAssignEntry::None => Cursor::NoSprint,
+            SprintAssignEntry::Header(_) => Cursor::NoSprint,
+            SprintAssignEntry::ActiveOrPlanned(s)
+            | SprintAssignEntry::Completed(s)
+            | SprintAssignEntry::Ended(s) => Cursor::Sprint(s.id),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw_selection(&self) -> Selection {
+        self.selection
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cursor_sprint_id(&self) -> Option<Uuid> {
+        match self.cursor {
+            Cursor::NoSprint => None,
+            Cursor::Sprint(id) => Some(id),
+        }
+    }
+
+    /// Used by the same-module race-resistance test that asserts the
+    /// internal lookup still finds the checked sprint after reflow.
+    #[cfg(test)]
+    pub(crate) fn current_index(&self, entries: &[SprintAssignEntry]) -> Option<usize> {
         match self.selection {
             Selection::Unset => None,
             Selection::NoSprint => entries
@@ -128,21 +187,6 @@ impl SprintPicker {
                 .position(|e| matches!(e, SprintAssignEntry::None)),
             Selection::Sprint(id) => entries.iter().position(|e| sprint_id_of(e) == Some(id)),
         }
-    }
-
-    fn entry_to_selection(entry: &SprintAssignEntry) -> Selection {
-        match entry {
-            SprintAssignEntry::None => Selection::NoSprint,
-            SprintAssignEntry::Header(_) => Selection::Unset,
-            SprintAssignEntry::ActiveOrPlanned(s)
-            | SprintAssignEntry::Completed(s)
-            | SprintAssignEntry::Ended(s) => Selection::Sprint(s.id),
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn raw_selection(&self) -> Selection {
-        self.selection
     }
 }
 
@@ -173,7 +217,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reset_with_sole_active_sprint_pre_selects_that_sprint() {
+    fn test_reset_with_sole_active_sprint_positions_cursor_but_does_not_check() {
         let now = Utc::now();
         let board = make_board();
         let sprint = active_sprint(board.id, 1, now);
@@ -182,11 +226,101 @@ mod tests {
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
 
+        // Nothing is checked yet — the user has to press Space to place [x].
+        assert_eq!(picker.selected_sprint_id(), None);
+        assert_eq!(picker.raw_selection(), Selection::Unset);
+        // But the cursor is parked on the sole active sprint so Space is
+        // one keystroke away from assigning it.
+        assert_eq!(picker.cursor_sprint_id(), Some(sprint.id));
+    }
+
+    #[test]
+    fn test_arrow_moves_cursor_without_changing_selection() {
+        let now = Utc::now();
+        let board = make_board();
+        let planning_a = Sprint::new(board.id, 1, None, None);
+        let planning_b = Sprint::new(board.id, 2, None, None);
+        let sprints = vec![planning_a, planning_b];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        let before_selection = picker.raw_selection();
+
+        picker.handle_key(KeyCode::Down, &sprints, &board, now);
+
+        assert_eq!(
+            picker.raw_selection(),
+            before_selection,
+            "Down must not flip a [x] on; only Space places one"
+        );
+    }
+
+    #[test]
+    fn test_space_at_cursor_places_check_on_cursor_sprint() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprint = active_sprint(board.id, 1, now);
+        let sprints = vec![sprint.clone()];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        assert_eq!(picker.selected_sprint_id(), None);
+
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+
         assert_eq!(picker.selected_sprint_id(), Some(sprint.id));
     }
 
     #[test]
-    fn test_reset_with_no_active_sprint_selects_none_entry() {
+    fn test_space_after_arrow_switches_check_to_new_cursor_sprint() {
+        let now = Utc::now();
+        let board = make_board();
+        let planning_a = Sprint::new(board.id, 1, None, None);
+        let planning_b = Sprint::new(board.id, 2, None, None);
+        let sprints = vec![planning_a.clone(), planning_b.clone()];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+
+        // Cursor starts on (None) since neither sprint is active. Down
+        // walks to the first sprint row (planning_b: higher sprint_number
+        // is rendered first in the section); Space checks it.
+        picker.handle_key(KeyCode::Down, &sprints, &board, now);
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        let first_checked = picker.selected_sprint_id();
+        assert!(first_checked.is_some());
+
+        // Move cursor to the other sprint and press Space — the check
+        // switches over instead of staying with the previous row.
+        picker.handle_key(KeyCode::Down, &sprints, &board, now);
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        let second_checked = picker.selected_sprint_id();
+        assert!(second_checked.is_some());
+        assert_ne!(
+            first_checked, second_checked,
+            "Space at a new cursor position must move [x] there"
+        );
+    }
+
+    #[test]
+    fn test_space_on_none_row_marks_none_as_explicitly_chosen() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprint = active_sprint(board.id, 1, now);
+        let sprints = vec![sprint];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        // Cursor starts on the sole active sprint, walk it up onto (None).
+        picker.handle_key(KeyCode::Up, &sprints, &board, now);
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+
+        assert_eq!(picker.raw_selection(), Selection::NoSprint);
+        assert_eq!(picker.selected_sprint_id(), None);
+    }
+
+    #[test]
+    fn test_reset_with_no_active_sprint_parks_cursor_on_none_row() {
         let now = Utc::now();
         let board = make_board();
         let sprints: Vec<Sprint> = vec![];
@@ -195,11 +329,12 @@ mod tests {
         picker.reset_for_board(&sprints, &board, now);
 
         assert_eq!(picker.selected_sprint_id(), None);
-        assert_eq!(picker.raw_selection(), Selection::NoSprint);
+        assert_eq!(picker.raw_selection(), Selection::Unset);
+        assert_eq!(picker.cursor_sprint_id(), None);
     }
 
     #[test]
-    fn test_reset_with_multiple_active_sprints_falls_back_to_none() {
+    fn test_reset_with_multiple_active_sprints_parks_cursor_on_none_row() {
         let now = Utc::now();
         let board = make_board();
         let s1 = active_sprint(board.id, 1, now);
@@ -209,54 +344,30 @@ mod tests {
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
 
-        assert_eq!(
-            picker.selected_sprint_id(),
-            None,
-            "ambiguous active sprints should fall back to the None entry"
-        );
-        assert_eq!(picker.raw_selection(), Selection::NoSprint);
+        assert_eq!(picker.selected_sprint_id(), None);
+        assert_eq!(picker.raw_selection(), Selection::Unset);
+        // Multiple active sprints — the picker can't guess which one, so
+        // cursor parks on (None) and the user picks deliberately.
+        assert_eq!(picker.cursor_sprint_id(), None);
     }
 
     #[test]
-    fn test_handle_key_down_advances_selection_and_returns_true() {
+    fn test_handle_key_down_moves_cursor_returns_true() {
         let now = Utc::now();
         let board = make_board();
-        // No active sprint, just two planning sprints, so the picker opens on
-        // the "(None)" entry and Down can advance to a sprint row.
         let planning_a = Sprint::new(board.id, 1, None, None);
         let planning_b = Sprint::new(board.id, 2, None, None);
         let sprints = vec![planning_a, planning_b];
 
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
-        let before = picker.raw_selection();
+        let before = picker.cursor_sprint_id();
 
         let consumed = picker.handle_key(KeyCode::Down, &sprints, &board, now);
-        let after = picker.raw_selection();
+        let after = picker.cursor_sprint_id();
 
         assert!(consumed, "Down should be consumed by the picker");
-        assert_ne!(
-            before, after,
-            "Down should move selection when more entries exist"
-        );
-        assert!(matches!(after, Selection::Sprint(_)));
-    }
-
-    #[test]
-    fn test_handle_key_space_clears_selection_to_nosprint() {
-        let now = Utc::now();
-        let board = make_board();
-        let sprint = active_sprint(board.id, 1, now);
-        let sprints = vec![sprint.clone()];
-
-        let mut picker = SprintPicker::new();
-        picker.reset_for_board(&sprints, &board, now);
-        assert_eq!(picker.raw_selection(), Selection::Sprint(sprint.id));
-
-        let consumed = picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
-        assert!(consumed, "Space should be consumed by the picker");
-        assert_eq!(picker.raw_selection(), Selection::NoSprint);
-        assert_eq!(picker.selected_sprint_id(), None);
+        assert_ne!(before, after, "Down should advance the cursor");
     }
 
     #[test]
@@ -304,6 +415,11 @@ mod tests {
 
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now_open);
+        // Cursor parks on A; user presses Space to commit it as the
+        // selection. (After decoupling, reset alone does not check
+        // anything — see test_reset_with_sole_active_sprint_positions_
+        // cursor_but_does_not_check.)
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now_open);
         assert_eq!(picker.selected_sprint_id(), Some(sprint_a.id));
         assert_eq!(picker.raw_selection(), Selection::Sprint(sprint_a.id));
 
@@ -335,15 +451,17 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_resets_selection_to_unset() {
+    fn test_clear_resets_selection_to_unset_after_space_commit() {
         let now = Utc::now();
         let board = make_board();
         let sprint = active_sprint(board.id, 1, now);
-        let sprints = vec![sprint];
+        let sprints = vec![sprint.clone()];
 
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
-        assert_ne!(picker.raw_selection(), Selection::Unset);
+        // Commit a selection via Space so there's something for clear() to reset.
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        assert_eq!(picker.raw_selection(), Selection::Sprint(sprint.id));
 
         picker.clear();
         assert_eq!(picker.raw_selection(), Selection::Unset);

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -287,7 +287,14 @@ impl SprintPicker {
     fn entry_to_cursor(entry: &SprintAssignEntry) -> Cursor {
         match entry {
             SprintAssignEntry::None => Cursor::NoSprint,
-            SprintAssignEntry::Header(_) => Cursor::NoSprint,
+            SprintAssignEntry::Header(_) => {
+                // next_selectable / prev_selectable are supposed to skip
+                // headers, so reaching this arm signals a navigation
+                // bug. Fall back to NoSprint in release, but trip the
+                // assertion in debug/test builds.
+                debug_assert!(false, "navigation landed on a section header entry");
+                Cursor::NoSprint
+            }
             SprintAssignEntry::ActiveOrPlanned(s)
             | SprintAssignEntry::Completed(s)
             | SprintAssignEntry::Ended(s) => Cursor::Sprint(s.id),

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -1,117 +1,226 @@
-use crate::components::radio_list::{ListItem, RadioList};
 use crate::components::sprint_assign_list::{
-    build_entries, render_entry_line, sprint_id_of, SprintAssignEntry,
+    build_entries, next_selectable, prev_selectable, sprint_id_of, SprintAssignEntry,
 };
+use crate::components::sprint_picker_view::SprintPickerView;
 use chrono::{DateTime, Utc};
-use kanban_domain::{Board, Sprint, SprintStatus};
+use crossterm::event::KeyCode;
+use kanban_core::SelectionState;
+use kanban_domain::{Board, Sprint};
 use ratatui::{layout::Rect, Frame};
 use uuid::Uuid;
 
-pub struct SprintPicker<'a> {
-    entries: Vec<SprintAssignEntry<'a>>,
-    board: &'a Board,
-    current_sprint_id: Option<Uuid>,
-    initial: Option<usize>,
+/// Stateful sprint picker for dialogs that embed a sprint selector
+/// alongside other inputs (e.g. the Create Card dialog). Owns the
+/// selection, applies the "pre-select sole active sprint" rule on open,
+/// translates navigation keys into selection moves, and exposes the
+/// resolved sprint id for the host to apply.
+///
+/// Composition: `SprintPicker` -> `SprintPickerView` (stateless adapter
+/// that turns sprints into ListItem rows) -> `RadioList<Option<Uuid>>`
+/// (generic radio-list primitive). The stateful layer adds selection
+/// state and key handling on top of the existing stateless presenter.
+#[derive(Default)]
+pub struct SprintPicker {
+    selection: SelectionState,
 }
 
-impl<'a> SprintPicker<'a> {
-    pub fn for_card_assignment(
-        sprints: &'a [Sprint],
-        board: &'a Board,
-        current_sprint_id: Option<Uuid>,
+impl SprintPicker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reset selection for a fresh dialog opening. If the board has exactly
+    /// one Active (non-ended) sprint at `now`, that sprint becomes the
+    /// initial selection; otherwise the "None" entry at index 0.
+    pub fn reset_for_board(&mut self, sprints: &[Sprint], board: &Board, now: DateTime<Utc>) {
+        let picker = SprintPickerView::for_board(sprints, board, now);
+        self.selection.set(picker.initial_selection());
+    }
+
+    pub fn clear(&mut self) {
+        self.selection.clear();
+    }
+
+    /// Try to consume a navigation key. Returns true when the key moved the
+    /// selection (Up/Down/j/k); false when the key should fall through to
+    /// other handlers (typing into a text input, etc.).
+    pub fn handle_key(
+        &mut self,
+        key_code: KeyCode,
+        sprints: &[Sprint],
+        board: &Board,
         now: DateTime<Utc>,
-    ) -> Self {
+    ) -> bool {
         let entries = build_entries(sprints, board.id, now);
-        let initial = match current_sprint_id {
-            Some(id) => entries
-                .iter()
-                .position(|e| sprint_id_of(e) == Some(id))
-                .or(Some(0)),
-            None => Some(0),
-        };
-        Self {
-            entries,
-            board,
-            current_sprint_id,
-            initial,
-        }
-    }
-
-    pub fn for_board(sprints: &'a [Sprint], board: &'a Board, now: DateTime<Utc>) -> Self {
-        let entries = build_entries(sprints, board.id, now);
-        let active_non_ended: Vec<usize> = entries
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, entry)| match entry {
-                SprintAssignEntry::ActiveOrPlanned(s)
-                    if s.status == SprintStatus::Active && !s.is_ended(now) =>
-                {
-                    Some(idx)
+        let cur = self.selection.get();
+        match key_code {
+            KeyCode::Down => {
+                if let Some(next) = next_selectable(&entries, cur) {
+                    self.selection.set(Some(next));
                 }
-                _ => None,
-            })
-            .collect();
-        let initial = if active_non_ended.len() == 1 {
-            Some(active_non_ended[0])
-        } else {
-            Some(0)
-        };
-        Self {
-            entries,
-            board,
-            current_sprint_id: None,
-            initial,
-        }
-    }
-
-    pub fn initial_selection(&self) -> Option<usize> {
-        self.initial
-    }
-
-    pub fn value_at(&self, idx: usize) -> Option<Option<Uuid>> {
-        match self.entries.get(idx)? {
-            SprintAssignEntry::Header(_) => None,
-            SprintAssignEntry::None => Some(None),
-            SprintAssignEntry::ActiveOrPlanned(s)
-            | SprintAssignEntry::Completed(s)
-            | SprintAssignEntry::Ended(s) => Some(Some(s.id)),
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
-    pub fn render(&self, frame: &mut Frame, area: Rect, selected: Option<usize>) {
-        let items: Vec<ListItem<Option<Uuid>>> = self
-            .entries
-            .iter()
-            .enumerate()
-            .map(|(idx, entry)| {
-                let is_selected = selected == Some(idx);
-                let label =
-                    render_entry_line(entry, is_selected, self.current_sprint_id, self.board);
-                ListItem {
-                    value: sprint_id_of(entry),
-                    label,
-                    selectable: entry.is_selectable(),
-                }
-            })
-            .collect();
-
-        let list = RadioList::new(&items).with_sticky_header(|items, sel_idx| {
-            let upper = sel_idx.min(items.len());
-            for i in (0..upper).rev() {
-                if !items[i].selectable {
-                    return Some((i, items[i].label.clone()));
-                }
+                true
             }
-            None
-        });
-        list.render(frame, area, selected);
+            KeyCode::Up => {
+                if let Some(prev) = prev_selectable(&entries, cur) {
+                    self.selection.set(Some(prev));
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Resolve the currently-selected sprint id, or None if the "None"
+    /// entry is selected or the picker is empty.
+    pub fn selected_sprint_id(
+        &self,
+        sprints: &[Sprint],
+        board: &Board,
+        now: DateTime<Utc>,
+    ) -> Option<Uuid> {
+        let entries = build_entries(sprints, board.id, now);
+        let idx = self.selection.get()?;
+        let entry = entries.get(idx)?;
+        match entry {
+            SprintAssignEntry::None | SprintAssignEntry::Header(_) => None,
+            _ => sprint_id_of(entry),
+        }
+    }
+
+    pub fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        sprints: &[Sprint],
+        board: &Board,
+        now: DateTime<Utc>,
+    ) {
+        let picker = SprintPickerView::for_card_assignment(sprints, board, None, now);
+        picker.render(frame, area, self.selection.get());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn selection_index(&self) -> Option<usize> {
+        self.selection.get()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use kanban_domain::SprintStatus;
+
+    fn make_board() -> Board {
+        Board::new("B".to_string(), Some("TST".to_string()))
+    }
+
+    fn active_sprint(board_id: Uuid, n: u32, now: DateTime<Utc>) -> Sprint {
+        Sprint {
+            id: Uuid::new_v4(),
+            board_id,
+            sprint_number: n,
+            name_index: None,
+            prefix: None,
+            card_prefix: None,
+            status: SprintStatus::Active,
+            start_date: Some(now - Duration::days(1)),
+            end_date: Some(now + Duration::days(7)),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn test_reset_with_sole_active_sprint_pre_selects_that_sprint() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprint = active_sprint(board.id, 1, now);
+        let sprints = vec![sprint.clone()];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+
+        assert_eq!(picker.selected_sprint_id(&sprints, &board, now), Some(sprint.id));
+    }
+
+    #[test]
+    fn test_reset_with_no_active_sprint_selects_none_entry() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprints: Vec<Sprint> = vec![];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+
+        assert_eq!(picker.selected_sprint_id(&sprints, &board, now), None);
+    }
+
+    #[test]
+    fn test_reset_with_multiple_active_sprints_falls_back_to_none() {
+        let now = Utc::now();
+        let board = make_board();
+        let s1 = active_sprint(board.id, 1, now);
+        let s2 = active_sprint(board.id, 2, now);
+        let sprints = vec![s1, s2];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+
+        assert_eq!(
+            picker.selected_sprint_id(&sprints, &board, now),
+            None,
+            "ambiguous active sprints should fall back to the None entry"
+        );
+    }
+
+    #[test]
+    fn test_handle_key_down_advances_selection_and_returns_true() {
+        let now = Utc::now();
+        let board = make_board();
+        // No active sprint, just two planning sprints, so the picker opens on
+        // the "None" entry at index 0 and Down can advance to a sprint row.
+        let planning_a = Sprint::new(board.id, 1, None, None);
+        let planning_b = Sprint::new(board.id, 2, None, None);
+        let sprints = vec![planning_a, planning_b];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        let before = picker.selection_index();
+
+        let consumed = picker.handle_key(KeyCode::Down, &sprints, &board, now);
+        let after = picker.selection_index();
+
+        assert!(consumed, "Down should be consumed by the picker");
+        assert_ne!(before, after, "Down should move selection when more entries exist");
+    }
+
+    #[test]
+    fn test_handle_key_other_returns_false_so_host_can_handle_it() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprints: Vec<Sprint> = vec![];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+
+        assert!(!picker.handle_key(KeyCode::Char('a'), &sprints, &board, now));
+        assert!(!picker.handle_key(KeyCode::Enter, &sprints, &board, now));
+        assert!(!picker.handle_key(KeyCode::Backspace, &sprints, &board, now));
+    }
+
+    #[test]
+    fn test_clear_resets_selection_to_none() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprint = active_sprint(board.id, 1, now);
+        let sprints = vec![sprint];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        assert!(picker.selection_index().is_some());
+
+        picker.clear();
+        assert_eq!(picker.selection_index(), None);
     }
 }

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -61,8 +61,9 @@ impl SprintPicker {
     }
 
     /// Try to consume a navigation key. Returns true when the key moved the
-    /// selection (Up/Down/j/k); false when the key should fall through to
-    /// other handlers (typing into a text input, etc.).
+    /// selection (Up/Down/j/k) or cleared it (Space); false when the key
+    /// should fall through to other handlers (typing into a text input,
+    /// etc.).
     pub fn handle_key(
         &mut self,
         key_code: KeyCode,
@@ -70,6 +71,10 @@ impl SprintPicker {
         board: &Board,
         now: DateTime<Utc>,
     ) -> bool {
+        if matches!(key_code, KeyCode::Char(' ')) {
+            self.selection = Selection::NoSprint;
+            return true;
+        }
         let entries = build_entries(sprints, board.id, now);
         let cur = self.current_index(&entries);
         let next_idx = match key_code {
@@ -235,6 +240,23 @@ mod tests {
             "Down should move selection when more entries exist"
         );
         assert!(matches!(after, Selection::Sprint(_)));
+    }
+
+    #[test]
+    fn test_handle_key_space_clears_selection_to_nosprint() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprint = active_sprint(board.id, 1, now);
+        let sprints = vec![sprint.clone()];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        assert_eq!(picker.raw_selection(), Selection::Sprint(sprint.id));
+
+        let consumed = picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        assert!(consumed, "Space should be consumed by the picker");
+        assert_eq!(picker.raw_selection(), Selection::NoSprint);
+        assert_eq!(picker.selected_sprint_id(), None);
     }
 
     #[test]

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -130,13 +130,18 @@ impl SprintPicker {
         let entries = self.build_entries(sprints, board, now);
         let (cursor, selection) = match current_sprint_id {
             Some(id) => {
-                // Only consider it pre-checked if the sprint is in the
-                // current entry list (the filter might exclude it).
-                if entries.iter().any(|e| sprint_id_of(e) == Some(id)) {
-                    (Cursor::Sprint(id), Selection::Sprint(id))
+                // The sprint might be hidden by the filter (e.g. an
+                // ActiveOnly picker pointed at a card on a Completed
+                // sprint). Carry the id in Selection regardless so a
+                // bare Enter re-assigns to the same sprint (no-op)
+                // rather than silently falling through to "do nothing"
+                // — the cursor can only park on a visible row.
+                let cursor = if entries.iter().any(|e| sprint_id_of(e) == Some(id)) {
+                    Cursor::Sprint(id)
                 } else {
-                    (Cursor::NoSprint, Selection::Unset)
-                }
+                    Cursor::NoSprint
+                };
+                (cursor, Selection::Sprint(id))
             }
             None => (Cursor::NoSprint, Selection::NoSprint),
         };
@@ -654,5 +659,28 @@ mod tests {
 
         picker.clear();
         assert_eq!(picker.raw_selection(), Selection::Unset);
+    }
+
+    #[test]
+    fn test_reset_for_assignment_preserves_current_sprint_even_when_filter_hides_it() {
+        // Build an ActiveOnly picker (filter excludes Completed) and reset
+        // it for a card whose current sprint is Completed. The picker
+        // must still carry the sprint id in Selection::Sprint so a bare
+        // Enter is a safe no-op re-assignment to the existing sprint —
+        // not Selection::Unset (silent fall-through) which would leave
+        // ambiguity about what Enter should do.
+        let now = Utc::now();
+        let board = make_board();
+        let mut completed = Sprint::new(board.id, 1, None, None);
+        completed.status = SprintStatus::Completed;
+        completed.start_date = Some(now - Duration::days(30));
+        completed.end_date = Some(now - Duration::days(15));
+        let sprints = vec![completed.clone()];
+
+        let mut picker = SprintPicker::with_filter(SprintFilter::ActiveOnly);
+        picker.reset_for_card_assignment(Some(completed.id), &sprints, &board, now);
+
+        assert_eq!(picker.selected_sprint_id(), Some(completed.id));
+        assert_eq!(picker.raw_selection(), Selection::Sprint(completed.id));
     }
 }

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -83,7 +83,9 @@ impl SprintPicker {
         let entry = entries.get(idx)?;
         match entry {
             SprintAssignEntry::None | SprintAssignEntry::Header(_) => None,
-            _ => sprint_id_of(entry),
+            SprintAssignEntry::ActiveOrPlanned(_)
+            | SprintAssignEntry::Completed(_)
+            | SprintAssignEntry::Ended(_) => sprint_id_of(entry),
         }
     }
 

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -69,6 +69,12 @@ pub struct SprintPicker {
     selection: Selection,
     cursor: Cursor,
     filter: SprintFilter,
+    /// Sprint id the host's card is currently bound to. Drives the
+    /// "(current)" suffix in the rendered rows so the user can see at
+    /// a glance which sprint the card is on. Independent of `selection`
+    /// — the user might toggle [x] elsewhere while (current) still
+    /// points at the unchanged on-disk value.
+    current_sprint_id: Option<Uuid>,
 }
 
 impl SprintPicker {
@@ -120,6 +126,7 @@ impl SprintPicker {
         board: &Board,
         now: DateTime<Utc>,
     ) {
+        self.current_sprint_id = current_sprint_id;
         let entries = self.build_entries(sprints, board, now);
         let (cursor, selection) = match current_sprint_id {
             Some(id) => {
@@ -140,6 +147,7 @@ impl SprintPicker {
     pub fn clear(&mut self) {
         self.selection = Selection::Unset;
         self.cursor = Cursor::NoSprint;
+        self.current_sprint_id = None;
     }
 
     /// Try to consume a key. Returns true when the picker handled it:
@@ -238,7 +246,9 @@ impl SprintPicker {
     ) -> SprintPickerView<'a> {
         match self.filter {
             SprintFilter::ActiveOnly => SprintPickerView::for_new_card(sprints, board, now),
-            SprintFilter::All => SprintPickerView::for_card_assignment(sprints, board, None, now),
+            SprintFilter::All => {
+                SprintPickerView::for_card_assignment(sprints, board, self.current_sprint_id, now)
+            }
         }
     }
 
@@ -266,8 +276,11 @@ impl SprintPicker {
         self.selection
     }
 
-    #[cfg(test)]
-    pub(crate) fn cursor_sprint_id(&self) -> Option<Uuid> {
+    /// The sprint id under the keyboard cursor, or None when the cursor
+    /// is parked on the "(None)" row. Useful for callers that want to
+    /// drive navigation programmatically (e.g. tests walking the cursor
+    /// to a specific sprint before pressing Space).
+    pub fn cursor_sprint_id(&self) -> Option<Uuid> {
         match self.cursor {
             Cursor::NoSprint => None,
             Cursor::Sprint(id) => Some(id),

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -67,13 +67,21 @@ impl SprintPicker {
     /// commit). The cursor lands on the sole Active non-ended sprint
     /// when there is exactly one; otherwise on the "(None)" row.
     pub fn reset_for_board(&mut self, sprints: &[Sprint], board: &Board, now: DateTime<Utc>) {
-        self.selection = Selection::Unset;
         let view = SprintPickerView::for_new_card(sprints, board, now);
         let entries = build_entries_active_only(sprints, board.id, now);
         self.cursor = view
             .initial_selection()
             .and_then(|idx| entries.get(idx).map(Self::entry_to_cursor))
             .unwrap_or(Cursor::NoSprint);
+        // The view's initial-selection rule only lands on a sprint row
+        // when there is exactly one Active non-ended sprint. In that
+        // case pre-check it so the dialog opens with [x] already on
+        // the sprint and Enter confirms in one keystroke. Otherwise no
+        // [x] is shown — the user must press Space to commit a choice.
+        self.selection = match self.cursor {
+            Cursor::Sprint(id) => Selection::Sprint(id),
+            Cursor::NoSprint => Selection::Unset,
+        };
     }
 
     pub fn clear(&mut self) {
@@ -93,9 +101,16 @@ impl SprintPicker {
         now: DateTime<Utc>,
     ) -> bool {
         if matches!(key_code, KeyCode::Char(' ')) {
-            self.selection = match self.cursor {
+            let cursor_as_selection = match self.cursor {
                 Cursor::NoSprint => Selection::NoSprint,
                 Cursor::Sprint(id) => Selection::Sprint(id),
+            };
+            // Toggle: Space on the row that already has [x] removes the
+            // checkbox; on any other row it places or moves [x] there.
+            self.selection = if self.selection == cursor_as_selection {
+                Selection::Unset
+            } else {
+                cursor_as_selection
             };
             return true;
         }
@@ -217,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reset_with_sole_active_sprint_positions_cursor_but_does_not_check() {
+    fn test_reset_with_sole_active_sprint_pre_checks_it() {
         let now = Utc::now();
         let board = make_board();
         let sprint = active_sprint(board.id, 1, now);
@@ -226,12 +241,51 @@ mod tests {
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
 
-        // Nothing is checked yet — the user has to press Space to place [x].
-        assert_eq!(picker.selected_sprint_id(), None);
-        assert_eq!(picker.raw_selection(), Selection::Unset);
-        // But the cursor is parked on the sole active sprint so Space is
-        // one keystroke away from assigning it.
+        // Exactly one active non-ended sprint → both cursor and selection
+        // land on it, so the dialog opens with [x] already there and the
+        // user can Enter immediately to confirm.
+        assert_eq!(picker.selected_sprint_id(), Some(sprint.id));
+        assert_eq!(picker.raw_selection(), Selection::Sprint(sprint.id));
         assert_eq!(picker.cursor_sprint_id(), Some(sprint.id));
+    }
+
+    #[test]
+    fn test_space_on_already_checked_row_unchecks_it() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprint = active_sprint(board.id, 1, now);
+        let sprints = vec![sprint.clone()];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        assert_eq!(picker.raw_selection(), Selection::Sprint(sprint.id));
+
+        // Cursor already on the checked sprint — Space toggles off.
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        assert_eq!(picker.raw_selection(), Selection::Unset);
+        assert_eq!(picker.selected_sprint_id(), None);
+
+        // And toggles back on.
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        assert_eq!(picker.raw_selection(), Selection::Sprint(sprint.id));
+    }
+
+    #[test]
+    fn test_space_on_none_row_toggles_between_nosprint_and_unset() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprints: Vec<Sprint> = vec![];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        // No active sprint → cursor parks on (None), selection starts Unset.
+        assert_eq!(picker.raw_selection(), Selection::Unset);
+
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        assert_eq!(picker.raw_selection(), Selection::NoSprint);
+
+        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        assert_eq!(picker.raw_selection(), Selection::Unset);
     }
 
     #[test]
@@ -256,19 +310,26 @@ mod tests {
     }
 
     #[test]
-    fn test_space_at_cursor_places_check_on_cursor_sprint() {
+    fn test_space_at_uncrossed_sprint_cursor_places_check_there() {
         let now = Utc::now();
         let board = make_board();
-        let sprint = active_sprint(board.id, 1, now);
-        let sprints = vec![sprint.clone()];
+        // Two planning sprints — no active, so the picker opens with
+        // selection Unset and cursor on (None). Down walks the cursor
+        // onto a sprint; Space then checks it.
+        let p_a = Sprint::new(board.id, 1, None, None);
+        let p_b = Sprint::new(board.id, 2, None, None);
+        let sprints = vec![p_a, p_b];
 
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
         assert_eq!(picker.selected_sprint_id(), None);
+        assert_eq!(picker.raw_selection(), Selection::Unset);
 
+        picker.handle_key(KeyCode::Down, &sprints, &board, now);
+        let cursor_id = picker.cursor_sprint_id().expect("cursor on sprint");
         picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
 
-        assert_eq!(picker.selected_sprint_id(), Some(sprint.id));
+        assert_eq!(picker.selected_sprint_id(), Some(cursor_id));
     }
 
     #[test]
@@ -415,11 +476,8 @@ mod tests {
 
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now_open);
-        // Cursor parks on A; user presses Space to commit it as the
-        // selection. (After decoupling, reset alone does not check
-        // anything — see test_reset_with_sole_active_sprint_positions_
-        // cursor_but_does_not_check.)
-        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now_open);
+        // Sole active sprint at open time → A is pre-checked, no Space
+        // needed.
         assert_eq!(picker.selected_sprint_id(), Some(sprint_a.id));
         assert_eq!(picker.raw_selection(), Selection::Sprint(sprint_a.id));
 
@@ -487,7 +545,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_resets_selection_to_unset_after_space_commit() {
+    fn test_clear_resets_selection_to_unset() {
         let now = Utc::now();
         let board = make_board();
         let sprint = active_sprint(board.id, 1, now);
@@ -495,8 +553,7 @@ mod tests {
 
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
-        // Commit a selection via Space so there's something for clear() to reset.
-        picker.handle_key(KeyCode::Char(' '), &sprints, &board, now);
+        // Sole active sprint → pre-checked.
         assert_eq!(picker.raw_selection(), Selection::Sprint(sprint.id));
 
         picker.clear();

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -75,6 +75,11 @@ pub struct SprintPicker {
     /// — the user might toggle [x] elsewhere while (current) still
     /// points at the unchanged on-disk value.
     current_sprint_id: Option<Uuid>,
+    /// Board the picker was last reset for. Callers that read
+    /// `selected_sprint_id` after a possible board switch should use
+    /// `selected_sprint_id_for(board_id)` so a stale sprint UUID from
+    /// the previous board can't leak into a write command.
+    bound_board_id: Option<Uuid>,
 }
 
 impl SprintPicker {
@@ -113,6 +118,7 @@ impl SprintPicker {
             Cursor::Sprint(id) => Selection::Sprint(id),
             Cursor::NoSprint => Selection::Unset,
         };
+        self.bound_board_id = Some(board.id);
     }
 
     /// Reset for an assign-to-card dialog where the card already has a
@@ -147,6 +153,7 @@ impl SprintPicker {
         };
         self.cursor = cursor;
         self.selection = selection;
+        self.bound_board_id = Some(board.id);
     }
 
     /// Reset for the bulk-assign-many-cards-to-sprint dialog. Unlike
@@ -159,18 +166,41 @@ impl SprintPicker {
     pub fn reset_for_bulk_card_assignment(
         &mut self,
         _sprints: &[Sprint],
-        _board: &Board,
+        board: &Board,
         _now: DateTime<Utc>,
     ) {
         self.current_sprint_id = None;
         self.cursor = Cursor::NoSprint;
         self.selection = Selection::Unset;
+        self.bound_board_id = Some(board.id);
     }
 
     pub fn clear(&mut self) {
         self.selection = Selection::Unset;
         self.cursor = Cursor::NoSprint;
         self.current_sprint_id = None;
+        self.bound_board_id = None;
+    }
+
+    /// Board the picker was last reset for, or `None` if it has been
+    /// cleared. Callers about to act on `selected_sprint_id` should
+    /// either check this matches the board they think they're on, or
+    /// use [`selected_sprint_id_for`] which does the check internally.
+    pub fn bound_board_id(&self) -> Option<Uuid> {
+        self.bound_board_id
+    }
+
+    /// Like [`selected_sprint_id`], but returns `None` when the picker
+    /// was last reset for a different board than `board_id`. Use this
+    /// at write-command boundaries to defend against a board switch
+    /// between dialog open and submit (which would otherwise leak a
+    /// sprint UUID from the previous board into the command).
+    pub fn selected_sprint_id_for(&self, board_id: Uuid) -> Option<Uuid> {
+        if self.bound_board_id == Some(board_id) {
+            self.selected_sprint_id()
+        } else {
+            None
+        }
     }
 
     /// Try to consume a key. Returns true when the picker handled it:
@@ -684,6 +714,53 @@ mod tests {
 
         picker.clear();
         assert_eq!(picker.raw_selection(), Selection::Unset);
+    }
+
+    #[test]
+    fn test_bound_board_id_returns_id_passed_to_reset() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprint = active_sprint(board.id, 1, now);
+        let sprints = vec![sprint];
+
+        let mut picker = SprintPicker::new();
+        assert_eq!(picker.bound_board_id(), None);
+        picker.reset_for_board(&sprints, &board, now);
+        assert_eq!(picker.bound_board_id(), Some(board.id));
+    }
+
+    #[test]
+    fn test_selected_sprint_id_for_returns_none_on_board_mismatch() {
+        // The picker was reset for board A; a caller that thinks it's
+        // on board B must NOT receive board A's sprint id, otherwise a
+        // stale UUID could leak into CreateCard::execute and only
+        // surface as a cross-board validation error.
+        let now = Utc::now();
+        let board_a = make_board();
+        let sprint_a = active_sprint(board_a.id, 1, now);
+        let board_b = make_board();
+        let sprints = vec![sprint_a.clone()];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board_a, now);
+        assert_eq!(picker.selected_sprint_id(), Some(sprint_a.id));
+
+        assert_eq!(picker.selected_sprint_id_for(board_a.id), Some(sprint_a.id));
+        assert_eq!(picker.selected_sprint_id_for(board_b.id), None);
+    }
+
+    #[test]
+    fn test_clear_drops_bound_board_id() {
+        let now = Utc::now();
+        let board = make_board();
+        let sprints: Vec<Sprint> = vec![];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now);
+        assert_eq!(picker.bound_board_id(), Some(board.id));
+
+        picker.clear();
+        assert_eq!(picker.bound_board_id(), None);
     }
 
     #[test]

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -4,10 +4,24 @@ use crate::components::sprint_assign_list::{
 use crate::components::sprint_picker_view::SprintPickerView;
 use chrono::{DateTime, Utc};
 use crossterm::event::KeyCode;
-use kanban_core::SelectionState;
 use kanban_domain::{Board, Sprint};
 use ratatui::{layout::Rect, Frame};
 use uuid::Uuid;
+
+/// What the picker currently has selected. Stored as an identity, not as
+/// an index into the rendered list, so that the selection survives
+/// changes to the underlying sprint list between frames (clock crossing
+/// a sprint's `end_date`, a background reload, an undo elsewhere, ...).
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Selection {
+    /// Picker has not been initialised yet (default before `reset_for_board`).
+    #[default]
+    Unset,
+    /// The "(None)" entry is selected — user explicitly picked no sprint.
+    NoSprint,
+    /// A specific sprint is selected.
+    Sprint(Uuid),
+}
 
 /// Stateful sprint picker for dialogs that embed a sprint selector
 /// alongside other inputs (e.g. the Create Card dialog). Owns the
@@ -17,11 +31,12 @@ use uuid::Uuid;
 ///
 /// Composition: `SprintPicker` -> `SprintPickerView` (stateless adapter
 /// that turns sprints into ListItem rows) -> `RadioList<Option<Uuid>>`
-/// (generic radio-list primitive). The stateful layer adds selection
-/// state and key handling on top of the existing stateless presenter.
+/// (generic radio-list primitive). The stateful layer adds identity-
+/// based selection state and key handling on top of the existing
+/// stateless presenter.
 #[derive(Default)]
 pub struct SprintPicker {
-    selection: SelectionState,
+    selection: Selection,
 }
 
 impl SprintPicker {
@@ -31,14 +46,18 @@ impl SprintPicker {
 
     /// Reset selection for a fresh dialog opening. If the board has exactly
     /// one Active (non-ended) sprint at `now`, that sprint becomes the
-    /// initial selection; otherwise the "None" entry at index 0.
+    /// initial selection; otherwise the "(None)" entry.
     pub fn reset_for_board(&mut self, sprints: &[Sprint], board: &Board, now: DateTime<Utc>) {
-        let picker = SprintPickerView::for_board(sprints, board, now);
-        self.selection.set(picker.initial_selection());
+        let view = SprintPickerView::for_board(sprints, board, now);
+        let entries = build_entries(sprints, board.id, now);
+        self.selection = view
+            .initial_selection()
+            .and_then(|idx| entries.get(idx).map(Self::entry_to_selection))
+            .unwrap_or(Selection::NoSprint);
     }
 
     pub fn clear(&mut self) {
-        self.selection.clear();
+        self.selection = Selection::Unset;
     }
 
     /// Try to consume a navigation key. Returns true when the key moved the
@@ -52,40 +71,26 @@ impl SprintPicker {
         now: DateTime<Utc>,
     ) -> bool {
         let entries = build_entries(sprints, board.id, now);
-        let cur = self.selection.get();
-        match key_code {
-            KeyCode::Down | KeyCode::Char('j') => {
-                if let Some(next) = next_selectable(&entries, cur) {
-                    self.selection.set(Some(next));
-                }
-                true
+        let cur = self.current_index(&entries);
+        let next_idx = match key_code {
+            KeyCode::Down | KeyCode::Char('j') => next_selectable(&entries, cur),
+            KeyCode::Up | KeyCode::Char('k') => prev_selectable(&entries, cur),
+            _ => return false,
+        };
+        if let Some(idx) = next_idx {
+            if let Some(entry) = entries.get(idx) {
+                self.selection = Self::entry_to_selection(entry);
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if let Some(prev) = prev_selectable(&entries, cur) {
-                    self.selection.set(Some(prev));
-                }
-                true
-            }
-            _ => false,
         }
+        true
     }
 
-    /// Resolve the currently-selected sprint id, or None if the "None"
-    /// entry is selected or the picker is empty.
-    pub fn selected_sprint_id(
-        &self,
-        sprints: &[Sprint],
-        board: &Board,
-        now: DateTime<Utc>,
-    ) -> Option<Uuid> {
-        let entries = build_entries(sprints, board.id, now);
-        let idx = self.selection.get()?;
-        let entry = entries.get(idx)?;
-        match entry {
-            SprintAssignEntry::None | SprintAssignEntry::Header(_) => None,
-            SprintAssignEntry::ActiveOrPlanned(_)
-            | SprintAssignEntry::Completed(_)
-            | SprintAssignEntry::Ended(_) => sprint_id_of(entry),
+    /// Resolve the currently-selected sprint id. Returns None when the
+    /// "(None)" entry is selected or the picker is uninitialised.
+    pub fn selected_sprint_id(&self) -> Option<Uuid> {
+        match self.selection {
+            Selection::Sprint(id) => Some(id),
+            Selection::NoSprint | Selection::Unset => None,
         }
     }
 
@@ -97,13 +102,38 @@ impl SprintPicker {
         board: &Board,
         now: DateTime<Utc>,
     ) {
-        let picker = SprintPickerView::for_card_assignment(sprints, board, None, now);
-        picker.render(frame, area, self.selection.get());
+        let view = SprintPickerView::for_card_assignment(sprints, board, None, now);
+        let entries = build_entries(sprints, board.id, now);
+        view.render(frame, area, self.current_index(&entries));
+    }
+
+    /// Map the stored identity back to the row index in the current entry
+    /// list. Returns `None` when the selection is `Unset` or when the
+    /// selected sprint no longer appears in the list (e.g. it was deleted
+    /// between frames — the caller should treat that as a lost selection).
+    fn current_index(&self, entries: &[SprintAssignEntry]) -> Option<usize> {
+        match self.selection {
+            Selection::Unset => None,
+            Selection::NoSprint => entries
+                .iter()
+                .position(|e| matches!(e, SprintAssignEntry::None)),
+            Selection::Sprint(id) => entries.iter().position(|e| sprint_id_of(e) == Some(id)),
+        }
+    }
+
+    fn entry_to_selection(entry: &SprintAssignEntry) -> Selection {
+        match entry {
+            SprintAssignEntry::None => Selection::NoSprint,
+            SprintAssignEntry::Header(_) => Selection::Unset,
+            SprintAssignEntry::ActiveOrPlanned(s)
+            | SprintAssignEntry::Completed(s)
+            | SprintAssignEntry::Ended(s) => Selection::Sprint(s.id),
+        }
     }
 
     #[cfg(test)]
-    pub(crate) fn selection_index(&self) -> Option<usize> {
-        self.selection.get()
+    pub(crate) fn raw_selection(&self) -> Selection {
+        self.selection
     }
 }
 
@@ -143,10 +173,7 @@ mod tests {
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
 
-        assert_eq!(
-            picker.selected_sprint_id(&sprints, &board, now),
-            Some(sprint.id)
-        );
+        assert_eq!(picker.selected_sprint_id(), Some(sprint.id));
     }
 
     #[test]
@@ -158,7 +185,8 @@ mod tests {
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
 
-        assert_eq!(picker.selected_sprint_id(&sprints, &board, now), None);
+        assert_eq!(picker.selected_sprint_id(), None);
+        assert_eq!(picker.raw_selection(), Selection::NoSprint);
     }
 
     #[test]
@@ -173,10 +201,11 @@ mod tests {
         picker.reset_for_board(&sprints, &board, now);
 
         assert_eq!(
-            picker.selected_sprint_id(&sprints, &board, now),
+            picker.selected_sprint_id(),
             None,
             "ambiguous active sprints should fall back to the None entry"
         );
+        assert_eq!(picker.raw_selection(), Selection::NoSprint);
     }
 
     #[test]
@@ -184,23 +213,24 @@ mod tests {
         let now = Utc::now();
         let board = make_board();
         // No active sprint, just two planning sprints, so the picker opens on
-        // the "None" entry at index 0 and Down can advance to a sprint row.
+        // the "(None)" entry and Down can advance to a sprint row.
         let planning_a = Sprint::new(board.id, 1, None, None);
         let planning_b = Sprint::new(board.id, 2, None, None);
         let sprints = vec![planning_a, planning_b];
 
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
-        let before = picker.selection_index();
+        let before = picker.raw_selection();
 
         let consumed = picker.handle_key(KeyCode::Down, &sprints, &board, now);
-        let after = picker.selection_index();
+        let after = picker.raw_selection();
 
         assert!(consumed, "Down should be consumed by the picker");
         assert_ne!(
             before, after,
             "Down should move selection when more entries exist"
         );
+        assert!(matches!(after, Selection::Sprint(_)));
     }
 
     #[test]
@@ -218,7 +248,48 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_resets_selection_to_none() {
+    fn test_selection_survives_clock_advance_that_ends_the_selected_sprint() {
+        // Open time: sprint A is Active non-ended (end_date in the future).
+        // The "sole active" rule pre-selects it. Then time advances past
+        // A's end_date so A moves from the active-or-planned section into
+        // the completed-or-ended section in build_entries. An index-based
+        // store would now point at whatever entry occupies A's old slot
+        // (a header, or sprint B); the identity-based store still
+        // resolves to A.
+        let board = make_board();
+        let now_open = Utc::now();
+        let now_confirm = now_open + Duration::days(30);
+        let sprint_a = Sprint {
+            id: Uuid::new_v4(),
+            board_id: board.id,
+            sprint_number: 1,
+            name_index: None,
+            prefix: None,
+            card_prefix: None,
+            status: SprintStatus::Active,
+            start_date: Some(now_open - Duration::days(1)),
+            end_date: Some(now_open + Duration::days(1)),
+            created_at: now_open,
+            updated_at: now_open,
+        };
+        let sprint_b = Sprint::new(board.id, 2, None, None);
+        let sprints = vec![sprint_a.clone(), sprint_b];
+
+        let mut picker = SprintPicker::new();
+        picker.reset_for_board(&sprints, &board, now_open);
+        assert_eq!(picker.selected_sprint_id(), Some(sprint_a.id));
+
+        // At now_confirm A has crossed its end_date — entries layout
+        // shifts, but the picker still reports A.
+        assert!(
+            sprint_a.is_ended(now_confirm),
+            "test precondition: sprint A is ended at now_confirm"
+        );
+        assert_eq!(picker.selected_sprint_id(), Some(sprint_a.id));
+    }
+
+    #[test]
+    fn test_clear_resets_selection_to_unset() {
         let now = Utc::now();
         let board = make_board();
         let sprint = active_sprint(board.id, 1, now);
@@ -226,9 +297,9 @@ mod tests {
 
         let mut picker = SprintPicker::new();
         picker.reset_for_board(&sprints, &board, now);
-        assert!(picker.selection_index().is_some());
+        assert_ne!(picker.raw_selection(), Selection::Unset);
 
         picker.clear();
-        assert_eq!(picker.selection_index(), None);
+        assert_eq!(picker.raw_selection(), Selection::Unset);
     }
 }

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -149,6 +149,24 @@ impl SprintPicker {
         self.selection = selection;
     }
 
+    /// Reset for the bulk-assign-many-cards-to-sprint dialog. Unlike
+    /// the single-card flow there is no shared "current" sprint to
+    /// pre-check, so selection starts `Unset`: a bare Enter is a no-op
+    /// and the user must commit a row with Space before the dialog
+    /// mutates any card. This prevents the prior footgun where opening
+    /// the dialog and immediately pressing Enter mass-unassigned every
+    /// selected card.
+    pub fn reset_for_bulk_card_assignment(
+        &mut self,
+        _sprints: &[Sprint],
+        _board: &Board,
+        _now: DateTime<Utc>,
+    ) {
+        self.current_sprint_id = None;
+        self.cursor = Cursor::NoSprint;
+        self.selection = Selection::Unset;
+    }
+
     pub fn clear(&mut self) {
         self.selection = Selection::Unset;
         self.cursor = Cursor::NoSprint;
@@ -659,6 +677,25 @@ mod tests {
 
         picker.clear();
         assert_eq!(picker.raw_selection(), Selection::Unset);
+    }
+
+    #[test]
+    fn test_reset_for_bulk_assignment_opens_with_selection_unset() {
+        // In bulk mode there is no shared "current" sprint to pre-check.
+        // A bare Enter should be a no-op until the user commits a row
+        // with Space — otherwise opening the dialog and pressing Enter
+        // would mass-unassign every selected card.
+        let now = Utc::now();
+        let board = make_board();
+        let sprint = active_sprint(board.id, 1, now);
+        let sprints = vec![sprint];
+
+        let mut picker = SprintPicker::with_filter(SprintFilter::All);
+        picker.reset_for_bulk_card_assignment(&sprints, &board, now);
+
+        assert_eq!(picker.raw_selection(), Selection::Unset);
+        assert!(!picker.explicitly_unassigned());
+        assert_eq!(picker.selected_sprint_id(), None);
     }
 
     #[test]

--- a/crates/kanban-tui/src/components/sprint_picker_view.rs
+++ b/crates/kanban-tui/src/components/sprint_picker_view.rs
@@ -1,6 +1,6 @@
 use crate::components::radio_list::{ListItem, RadioList};
 use crate::components::sprint_assign_list::{
-    build_entries, render_entry_line, sprint_id_of, SprintAssignEntry,
+    build_entries, build_entries_active_only, render_entry_line, sprint_id_of, SprintAssignEntry,
 };
 use chrono::{DateTime, Utc};
 use kanban_domain::{Board, Sprint, SprintStatus};
@@ -33,6 +33,37 @@ impl<'a> SprintPickerView<'a> {
             entries,
             board,
             current_sprint_id,
+            initial,
+        }
+    }
+
+    /// Variant of [`for_board`] that excludes the Completed/Ended
+    /// section entirely. Used by the create-card picker, where a card
+    /// being created right now should never be bound to a sprint that
+    /// has already finished.
+    pub fn for_new_card(sprints: &'a [Sprint], board: &'a Board, now: DateTime<Utc>) -> Self {
+        let entries = build_entries_active_only(sprints, board.id, now);
+        let active_non_ended: Vec<usize> = entries
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, entry)| match entry {
+                SprintAssignEntry::ActiveOrPlanned(s)
+                    if s.status == SprintStatus::Active && !s.is_ended(now) =>
+                {
+                    Some(idx)
+                }
+                _ => None,
+            })
+            .collect();
+        let initial = if active_non_ended.len() == 1 {
+            Some(active_non_ended[0])
+        } else {
+            Some(0)
+        };
+        Self {
+            entries,
+            board,
+            current_sprint_id: None,
             initial,
         }
     }

--- a/crates/kanban-tui/src/components/sprint_picker_view.rs
+++ b/crates/kanban-tui/src/components/sprint_picker_view.rs
@@ -105,14 +105,36 @@ impl<'a> SprintPickerView<'a> {
     }
 
     pub fn render(&self, frame: &mut Frame, area: Rect, selected: Option<usize>) {
+        // Coupled mode: cursor and `[x]` are on the same row.
+        self.render_with_cursor(frame, area, selected, selected);
+    }
+
+    /// Decoupled render: `checked` is the row that shows `[x]`; `cursor`
+    /// is the row that gets the keyboard highlight (and drives scroll +
+    /// sticky-header). Callers that want the coupled "cursor IS the
+    /// selected row" behaviour pass the same value for both — that is
+    /// what `render` does.
+    pub fn render_with_cursor(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        checked: Option<usize>,
+        cursor: Option<usize>,
+    ) {
         let items: Vec<ListItem<Option<Uuid>>> = self
             .entries
             .iter()
             .enumerate()
             .map(|(idx, entry)| {
-                let is_selected = selected == Some(idx);
-                let label =
-                    render_entry_line(entry, is_selected, self.current_sprint_id, self.board);
+                let is_checked = checked == Some(idx);
+                let is_focused = cursor == Some(idx);
+                let label = render_entry_line(
+                    entry,
+                    is_checked,
+                    is_focused,
+                    self.current_sprint_id,
+                    self.board,
+                );
                 ListItem {
                     value: sprint_id_of(entry),
                     label,
@@ -130,6 +152,6 @@ impl<'a> SprintPickerView<'a> {
             }
             None
         });
-        list.render(frame, area, selected);
+        list.render(frame, area, cursor);
     }
 }

--- a/crates/kanban-tui/src/components/sprint_picker_view.rs
+++ b/crates/kanban-tui/src/components/sprint_picker_view.rs
@@ -37,39 +37,12 @@ impl<'a> SprintPickerView<'a> {
         }
     }
 
-    /// Variant of [`for_board`] that excludes the Completed/Ended
-    /// section entirely. Used by the create-card picker, where a card
-    /// being created right now should never be bound to a sprint that
-    /// has already finished.
+    /// Variant for the create-card picker: hides the Completed/Ended
+    /// section entirely (a card being created right now should never
+    /// be bound to a sprint that has already finished) and pre-selects
+    /// the sole Active non-ended sprint if there is exactly one.
     pub fn for_new_card(sprints: &'a [Sprint], board: &'a Board, now: DateTime<Utc>) -> Self {
         let entries = build_entries_active_only(sprints, board.id, now);
-        let active_non_ended: Vec<usize> = entries
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, entry)| match entry {
-                SprintAssignEntry::ActiveOrPlanned(s)
-                    if s.status == SprintStatus::Active && !s.is_ended(now) =>
-                {
-                    Some(idx)
-                }
-                _ => None,
-            })
-            .collect();
-        let initial = if active_non_ended.len() == 1 {
-            Some(active_non_ended[0])
-        } else {
-            Some(0)
-        };
-        Self {
-            entries,
-            board,
-            current_sprint_id: None,
-            initial,
-        }
-    }
-
-    pub fn for_board(sprints: &'a [Sprint], board: &'a Board, now: DateTime<Utc>) -> Self {
-        let entries = build_entries(sprints, board.id, now);
         let active_non_ended: Vec<usize> = entries
             .iter()
             .enumerate()

--- a/crates/kanban-tui/src/components/sprint_picker_view.rs
+++ b/crates/kanban-tui/src/components/sprint_picker_view.rs
@@ -1,0 +1,117 @@
+use crate::components::radio_list::{ListItem, RadioList};
+use crate::components::sprint_assign_list::{
+    build_entries, render_entry_line, sprint_id_of, SprintAssignEntry,
+};
+use chrono::{DateTime, Utc};
+use kanban_domain::{Board, Sprint, SprintStatus};
+use ratatui::{layout::Rect, Frame};
+use uuid::Uuid;
+
+pub struct SprintPickerView<'a> {
+    entries: Vec<SprintAssignEntry<'a>>,
+    board: &'a Board,
+    current_sprint_id: Option<Uuid>,
+    initial: Option<usize>,
+}
+
+impl<'a> SprintPickerView<'a> {
+    pub fn for_card_assignment(
+        sprints: &'a [Sprint],
+        board: &'a Board,
+        current_sprint_id: Option<Uuid>,
+        now: DateTime<Utc>,
+    ) -> Self {
+        let entries = build_entries(sprints, board.id, now);
+        let initial = match current_sprint_id {
+            Some(id) => entries
+                .iter()
+                .position(|e| sprint_id_of(e) == Some(id))
+                .or(Some(0)),
+            None => Some(0),
+        };
+        Self {
+            entries,
+            board,
+            current_sprint_id,
+            initial,
+        }
+    }
+
+    pub fn for_board(sprints: &'a [Sprint], board: &'a Board, now: DateTime<Utc>) -> Self {
+        let entries = build_entries(sprints, board.id, now);
+        let active_non_ended: Vec<usize> = entries
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, entry)| match entry {
+                SprintAssignEntry::ActiveOrPlanned(s)
+                    if s.status == SprintStatus::Active && !s.is_ended(now) =>
+                {
+                    Some(idx)
+                }
+                _ => None,
+            })
+            .collect();
+        let initial = if active_non_ended.len() == 1 {
+            Some(active_non_ended[0])
+        } else {
+            Some(0)
+        };
+        Self {
+            entries,
+            board,
+            current_sprint_id: None,
+            initial,
+        }
+    }
+
+    pub fn initial_selection(&self) -> Option<usize> {
+        self.initial
+    }
+
+    pub fn value_at(&self, idx: usize) -> Option<Option<Uuid>> {
+        match self.entries.get(idx)? {
+            SprintAssignEntry::Header(_) => None,
+            SprintAssignEntry::None => Some(None),
+            SprintAssignEntry::ActiveOrPlanned(s)
+            | SprintAssignEntry::Completed(s)
+            | SprintAssignEntry::Ended(s) => Some(Some(s.id)),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn render(&self, frame: &mut Frame, area: Rect, selected: Option<usize>) {
+        let items: Vec<ListItem<Option<Uuid>>> = self
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| {
+                let is_selected = selected == Some(idx);
+                let label =
+                    render_entry_line(entry, is_selected, self.current_sprint_id, self.board);
+                ListItem {
+                    value: sprint_id_of(entry),
+                    label,
+                    selectable: entry.is_selectable(),
+                }
+            })
+            .collect();
+
+        let list = RadioList::new(&items).with_sticky_header(|items, sel_idx| {
+            let upper = sel_idx.min(items.len());
+            for i in (0..upper).rev() {
+                if !items[i].selectable {
+                    return Some((i, items[i].label.clone()));
+                }
+            }
+            None
+        });
+        list.render(frame, area, selected);
+    }
+}

--- a/crates/kanban-tui/src/components/sprint_picker_view.rs
+++ b/crates/kanban-tui/src/components/sprint_picker_view.rs
@@ -68,6 +68,24 @@ impl<'a> SprintPickerView<'a> {
         self.initial
     }
 
+    /// Find the row index of a sprint id (or the "(None)" entry if `id`
+    /// is `None`). Returns `None` only when a sprint id is supplied that
+    /// does not appear in the current entries — e.g. it was deleted
+    /// between frames. Avoids a redundant `build_entries` call for
+    /// callers that already have a `SprintPickerView` constructed.
+    pub fn index_of_sprint(&self, id: Option<Uuid>) -> Option<usize> {
+        match id {
+            None => self
+                .entries
+                .iter()
+                .position(|e| matches!(e, SprintAssignEntry::None)),
+            Some(target) => self
+                .entries
+                .iter()
+                .position(|e| sprint_id_of(e) == Some(target)),
+        }
+    }
+
     pub fn value_at(&self, idx: usize) -> Option<Option<Uuid>> {
         match self.entries.get(idx)? {
             SprintAssignEntry::Header(_) => None,

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -99,8 +99,7 @@ impl App {
                 if let Some(board) = self.model.boards().get(board_idx) {
                     self.dialog_input
                         .assign_sprint_picker
-                        .reset_for_card_assignment(
-                            None, // bulk: no single "current" sprint to pre-check
+                        .reset_for_bulk_card_assignment(
                             self.model.sprints(),
                             board,
                             chrono::Utc::now(),

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -363,15 +363,9 @@ impl App {
 
                 let now = chrono::Utc::now();
                 let sprint_id = self
-                    .model
-                    .boards()
-                    .get(idx)
-                    .map(|board| {
-                        self.dialog_input
-                            .create_card_sprint_picker
-                            .selected_sprint_id(self.model.sprints(), board, now)
-                    })
-                    .unwrap_or(None);
+                    .dialog_input
+                    .create_card_sprint_picker
+                    .selected_sprint_id();
                 let card_id = uuid::Uuid::new_v4();
                 let mut commands: Vec<Command> =
                     vec![Command::Card(CardCommand::Create(CreateCard {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -11,6 +11,15 @@ use std::io;
 impl App {
     pub fn handle_create_card_key(&mut self) {
         if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
+            if let Some(idx) = self.selection.active_board_index {
+                if let Some(board) = self.model.boards().get(idx) {
+                    self.dialog_input.create_card_sprint_picker.reset_for_board(
+                        self.model.sprints(),
+                        board,
+                        chrono::Utc::now(),
+                    );
+                }
+            }
             self.open_dialog(DialogMode::CreateCard);
             self.input.clear();
         }
@@ -352,6 +361,17 @@ impl App {
                     })
                     .unwrap_or(false);
 
+                let now = chrono::Utc::now();
+                let sprint_id = self
+                    .model
+                    .boards()
+                    .get(idx)
+                    .map(|board| {
+                        self.dialog_input
+                            .create_card_sprint_picker
+                            .selected_sprint_id(self.model.sprints(), board, now)
+                    })
+                    .unwrap_or(None);
                 let card_id = uuid::Uuid::new_v4();
                 let mut commands: Vec<Command> =
                     vec![Command::Card(CardCommand::Create(CreateCard {
@@ -361,8 +381,11 @@ impl App {
                         column_id: column.id,
                         title: self.input.as_str().to_string(),
                         position,
-                        options: kanban_domain::CreateCardOptions::default(),
-                        timestamp: chrono::Utc::now(),
+                        options: kanban_domain::CreateCardOptions {
+                            sprint_id,
+                            ..Default::default()
+                        },
+                        timestamp: now,
                     }))];
 
                 if mark_as_complete {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -386,7 +386,7 @@ impl App {
                 let sprint_id = self
                     .dialog_input
                     .create_card_sprint_picker
-                    .selected_sprint_id();
+                    .selected_sprint_id_for(bid);
                 let card_id = uuid::Uuid::new_v4();
                 let mut commands: Vec<Command> =
                     vec![Command::Card(CardCommand::Create(CreateCard {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -95,38 +95,60 @@ impl App {
         }
 
         if !self.multi_select.selected_cards.is_empty() {
-            self.dialog_input.sprint_assign_selection.clear();
-            self.open_dialog(DialogMode::AssignMultipleCardsToSprint);
-        } else if self.get_selected_card_id().is_some() {
             if let Some(board_idx) = self.selection.active_board_index {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
-                    let sprints = self.model.sprints();
-                    let entries = crate::components::sprint_assign_list::build_entries(
-                        sprints,
-                        board.id,
-                        chrono::Utc::now(),
-                    );
-                    let has_assignable = entries.iter().any(|e| {
-                        matches!(
-                            e,
-                            crate::components::sprint_assign_list::SprintAssignEntry::ActiveOrPlanned(_)
-                                | crate::components::sprint_assign_list::SprintAssignEntry::Completed(_)
-                                | crate::components::sprint_assign_list::SprintAssignEntry::Ended(_)
-                        )
-                    });
-                    if has_assignable {
-                        if let Some(selected_card) = self.get_selected_card_in_context() {
-                            self.set_active_card_or_clear(selected_card.id);
-                        }
-                        let selection_idx = self.get_current_sprint_selection_index();
-                        self.dialog_input
-                            .sprint_assign_selection
-                            .set(Some(selection_idx));
-                        self.open_dialog(DialogMode::AssignCardToSprint);
-                    }
+                if let Some(board) = self.model.boards().get(board_idx) {
+                    self.dialog_input
+                        .assign_sprint_picker
+                        .reset_for_card_assignment(
+                            None, // bulk: no single "current" sprint to pre-check
+                            self.model.sprints(),
+                            board,
+                            chrono::Utc::now(),
+                        );
                 }
             }
+            self.open_dialog(DialogMode::AssignMultipleCardsToSprint);
+        } else if self.get_selected_card_id().is_some() {
+            let Some(board_idx) = self.selection.active_board_index else {
+                return;
+            };
+            let board_id = match self.model.boards().get(board_idx) {
+                Some(b) => b.id,
+                None => return,
+            };
+            let now = chrono::Utc::now();
+            let has_assignable = {
+                let sprints = self.model.sprints();
+                let entries =
+                    crate::components::sprint_assign_list::build_entries(sprints, board_id, now);
+                entries.iter().any(|e| {
+                    matches!(
+                        e,
+                        crate::components::sprint_assign_list::SprintAssignEntry::ActiveOrPlanned(
+                            _
+                        ) | crate::components::sprint_assign_list::SprintAssignEntry::Completed(_)
+                            | crate::components::sprint_assign_list::SprintAssignEntry::Ended(_)
+                    )
+                })
+            };
+            if !has_assignable {
+                return;
+            }
+            if let Some(selected_card) = self.get_selected_card_in_context() {
+                self.set_active_card_or_clear(selected_card.id);
+            }
+            let current_sprint_id = self
+                .selection
+                .active_card_id
+                .and_then(|id| self.model.card(id))
+                .and_then(|c| c.sprint_id);
+            // Re-borrow board after the &mut self call above.
+            if let Some(board) = self.model.boards().get(board_idx) {
+                self.dialog_input
+                    .assign_sprint_picker
+                    .reset_for_card_assignment(current_sprint_id, self.model.sprints(), board, now);
+            }
+            self.open_dialog(DialogMode::AssignCardToSprint);
         }
     }
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -301,10 +301,19 @@ impl App {
                             .filter(|s| s.board_id == board.id)
                             .count();
                         if sprint_count > 0 {
-                            let selection_idx = self.get_current_sprint_selection_index();
+                            let current_sprint_id = self
+                                .selection
+                                .active_card_id
+                                .and_then(|id| self.model.card(id))
+                                .and_then(|c| c.sprint_id);
                             self.dialog_input
-                                .sprint_assign_selection
-                                .set(Some(selection_idx));
+                                .assign_sprint_picker
+                                .reset_for_card_assignment(
+                                    current_sprint_id,
+                                    self.model.sprints(),
+                                    board,
+                                    chrono::Utc::now(),
+                                );
                             self.open_dialog(DialogMode::AssignCardToSprint);
                         }
                     }
@@ -793,7 +802,8 @@ impl App {
                                 self.open_dialog(DialogMode::SetCardPriority);
                             }
                         }
-                        CardListAction::AssignSprint(card_id) => {
+                        CardListAction::AssignSprint(card_id)
+                        | CardListAction::ReassignSprint(card_id) => {
                             if self.activate_card(card_id) {
                                 if let Some(board_idx) = self.selection.active_board_index {
                                     if let Some(board) = self.model.boards().get(board_idx) {
@@ -804,33 +814,16 @@ impl App {
                                             .filter(|s| s.board_id == board.id)
                                             .count();
                                         if sprint_count > 0 {
-                                            let selection_idx =
-                                                self.get_current_sprint_selection_index();
+                                            let current_sprint_id =
+                                                self.model.card(card_id).and_then(|c| c.sprint_id);
                                             self.dialog_input
-                                                .sprint_assign_selection
-                                                .set(Some(selection_idx));
-                                            self.open_dialog(DialogMode::AssignCardToSprint);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        CardListAction::ReassignSprint(card_id) => {
-                            if self.activate_card(card_id) {
-                                if let Some(board_idx) = self.selection.active_board_index {
-                                    if let Some(board) = self.model.boards().get(board_idx) {
-                                        let sprint_count = self
-                                            .model
-                                            .sprints()
-                                            .iter()
-                                            .filter(|s| s.board_id == board.id)
-                                            .count();
-                                        if sprint_count > 0 {
-                                            let selection_idx =
-                                                self.get_current_sprint_selection_index();
-                                            self.dialog_input
-                                                .sprint_assign_selection
-                                                .set(Some(selection_idx));
+                                                .assign_sprint_picker
+                                                .reset_for_card_assignment(
+                                                    current_sprint_id,
+                                                    self.model.sprints(),
+                                                    board,
+                                                    chrono::Utc::now(),
+                                                );
                                             self.open_dialog(DialogMode::AssignCardToSprint);
                                         }
                                     }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -30,15 +30,31 @@ impl App {
     }
 
     pub fn handle_create_card_dialog(&mut self, key_code: KeyCode) {
+        if let Some(idx) = self.selection.active_board_index {
+            if let Some(board) = self.model.boards().get(idx).cloned() {
+                let now = chrono::Utc::now();
+                let consumed = self.dialog_input.create_card_sprint_picker.handle_key(
+                    key_code,
+                    self.model.sprints(),
+                    &board,
+                    now,
+                );
+                if consumed {
+                    return;
+                }
+            }
+        }
         match handle_dialog_input(&mut self.input, key_code, false) {
             DialogAction::Confirm => {
                 self.create_card();
                 self.pop_mode();
                 self.input.clear();
+                self.dialog_input.create_card_sprint_picker.clear();
             }
             DialogAction::Cancel => {
                 self.pop_mode();
                 self.input.clear();
+                self.dialog_input.create_card_sprint_picker.clear();
             }
             DialogAction::None => {}
         }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -74,12 +74,12 @@ impl App {
             return;
         }
         if let Some(idx) = self.selection.active_board_index {
-            if let Some(board) = self.model.boards().get(idx).cloned() {
+            if let Some(board) = self.model.boards().get(idx) {
                 let now = chrono::Utc::now();
                 self.dialog_input.create_card_sprint_picker.handle_key(
                     key_code,
                     self.model.sprints(),
-                    &board,
+                    board,
                     now,
                 );
             }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -30,33 +30,69 @@ impl App {
     }
 
     pub fn handle_create_card_dialog(&mut self, key_code: KeyCode) {
+        // Enter always submits and Tab always toggles focus, regardless of
+        // which sub-field currently has focus.
+        match key_code {
+            KeyCode::Enter => {
+                self.create_card();
+                self.pop_mode();
+                self.input.clear();
+                self.dialog_input.create_card_sprint_picker.clear();
+                self.dialog_input.reset_create_card_focus();
+                return;
+            }
+            KeyCode::Tab => {
+                self.dialog_input.toggle_create_card_focus();
+                return;
+            }
+            _ => {}
+        }
+
+        if self.dialog_input.create_card_focus_is_title() {
+            // Title focus: Down/Esc drop focus into the sprint picker so the
+            // visual cursor moves out of the text input; all other keys edit
+            // the title.
+            match key_code {
+                KeyCode::Down | KeyCode::Esc => {
+                    self.dialog_input.toggle_create_card_focus();
+                }
+                _ => match handle_dialog_input(&mut self.input, key_code, false) {
+                    DialogAction::Cancel => {
+                        // Esc was already special-cased; this branch only
+                        // fires when handle_dialog_input emits Cancel for
+                        // some other key (currently none, but kept for
+                        // forward-compatibility).
+                        self.pop_mode();
+                        self.input.clear();
+                        self.dialog_input.create_card_sprint_picker.clear();
+                        self.dialog_input.reset_create_card_focus();
+                    }
+                    DialogAction::None | DialogAction::Confirm => {}
+                },
+            }
+            return;
+        }
+
+        // Sprint focus: Esc closes the dialog, Up/Down navigate the picker,
+        // everything else is ignored so a stray keystroke does not modify
+        // the title behind the user's back.
+        if matches!(key_code, KeyCode::Esc) {
+            self.pop_mode();
+            self.input.clear();
+            self.dialog_input.create_card_sprint_picker.clear();
+            self.dialog_input.reset_create_card_focus();
+            return;
+        }
         if let Some(idx) = self.selection.active_board_index {
             if let Some(board) = self.model.boards().get(idx).cloned() {
                 let now = chrono::Utc::now();
-                let consumed = self.dialog_input.create_card_sprint_picker.handle_key(
+                self.dialog_input.create_card_sprint_picker.handle_key(
                     key_code,
                     self.model.sprints(),
                     &board,
                     now,
                 );
-                if consumed {
-                    return;
-                }
             }
-        }
-        match handle_dialog_input(&mut self.input, key_code, false) {
-            DialogAction::Confirm => {
-                self.create_card();
-                self.pop_mode();
-                self.input.clear();
-                self.dialog_input.create_card_sprint_picker.clear();
-            }
-            DialogAction::Cancel => {
-                self.pop_mode();
-                self.input.clear();
-                self.dialog_input.create_card_sprint_picker.clear();
-            }
-            DialogAction::None => {}
         }
     }
 

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -56,19 +56,9 @@ impl App {
                 KeyCode::Down | KeyCode::Esc => {
                     self.dialog_input.toggle_create_card_focus();
                 }
-                _ => match handle_dialog_input(&mut self.input, key_code, false) {
-                    DialogAction::Cancel => {
-                        // Esc was already special-cased; this branch only
-                        // fires when handle_dialog_input emits Cancel for
-                        // some other key (currently none, but kept for
-                        // forward-compatibility).
-                        self.pop_mode();
-                        self.input.clear();
-                        self.dialog_input.create_card_sprint_picker.clear();
-                        self.dialog_input.reset_create_card_focus();
-                    }
-                    DialogAction::None | DialogAction::Confirm => {}
-                },
+                _ => {
+                    handle_dialog_input(&mut self.input, key_code, false);
+                }
             }
             return;
         }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -248,8 +248,18 @@ impl App {
                     Some(card) => card.id,
                     None => return,
                 };
+                let active_board_id = self
+                    .selection
+                    .active_board_index
+                    .and_then(|idx| self.model.boards().get(idx))
+                    .map(|b| b.id);
                 let picker = &self.dialog_input.assign_sprint_picker;
-                let cmd = if let Some(sprint_id) = picker.selected_sprint_id() {
+                let board_matches = active_board_id
+                    .map(|bid| picker.bound_board_id() == Some(bid))
+                    .unwrap_or(false);
+                let cmd = if !board_matches {
+                    None
+                } else if let Some(sprint_id) = picker.selected_sprint_id() {
                     Some(kanban_domain::commands::Command::Card(
                         kanban_domain::commands::CardCommand::AssignToSprint(
                             kanban_domain::commands::AssignCardsToSprint {
@@ -306,34 +316,43 @@ impl App {
             KeyCode::Enter => {
                 let card_ids: Vec<uuid::Uuid> =
                     self.multi_select.selected_cards.iter().copied().collect();
+                let active_board_id = self
+                    .selection
+                    .active_board_index
+                    .and_then(|idx| self.model.boards().get(idx))
+                    .map(|b| b.id);
                 let picker = &self.dialog_input.assign_sprint_picker;
-                let cmds: Vec<kanban_domain::commands::Command> =
-                    if let Some(sprint_id) = picker.selected_sprint_id() {
-                        vec![kanban_domain::commands::Command::Card(
-                            kanban_domain::commands::CardCommand::AssignToSprint(
-                                kanban_domain::commands::AssignCardsToSprint {
-                                    ids: card_ids.clone(),
-                                    sprint_id,
-                                },
-                            ),
-                        )]
-                    } else if picker.explicitly_unassigned() {
-                        card_ids
-                            .iter()
-                            .map(|card_id| {
-                                kanban_domain::commands::Command::Card(
-                                    kanban_domain::commands::CardCommand::UnassignFromSprint(
-                                        kanban_domain::commands::UnassignCardFromSprint {
-                                            card_id: *card_id,
-                                            timestamp: chrono::Utc::now(),
-                                        },
-                                    ),
-                                )
-                            })
-                            .collect()
-                    } else {
-                        Vec::new()
-                    };
+                let board_matches = active_board_id
+                    .map(|bid| picker.bound_board_id() == Some(bid))
+                    .unwrap_or(false);
+                let cmds: Vec<kanban_domain::commands::Command> = if !board_matches {
+                    Vec::new()
+                } else if let Some(sprint_id) = picker.selected_sprint_id() {
+                    vec![kanban_domain::commands::Command::Card(
+                        kanban_domain::commands::CardCommand::AssignToSprint(
+                            kanban_domain::commands::AssignCardsToSprint {
+                                ids: card_ids.clone(),
+                                sprint_id,
+                            },
+                        ),
+                    )]
+                } else if picker.explicitly_unassigned() {
+                    card_ids
+                        .iter()
+                        .map(|card_id| {
+                            kanban_domain::commands::Command::Card(
+                                kanban_domain::commands::CardCommand::UnassignFromSprint(
+                                    kanban_domain::commands::UnassignCardFromSprint {
+                                        card_id: *card_id,
+                                        timestamp: chrono::Utc::now(),
+                                    },
+                                ),
+                            )
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
                 if !cmds.is_empty() {
                     if let Err(e) = self.execute_commands_batch(cmds) {
                         tracing::error!("Failed to update cards' sprint: {}", e);

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,7 +1,4 @@
 use crate::app::App;
-use crate::components::sprint_assign_list::{
-    build_entries, next_selectable, prev_selectable, sprint_id_of, SprintAssignEntry,
-};
 use crossterm::event::KeyCode;
 use kanban_domain::{GraphOperations, KanbanOperations, SortField, SortOrder};
 
@@ -236,189 +233,131 @@ impl App {
         match key_code {
             KeyCode::Esc => {
                 self.pop_mode();
-                self.dialog_input.sprint_assign_selection.clear();
+                self.dialog_input.assign_sprint_picker.clear();
             }
-            KeyCode::Char('j') | KeyCode::Down => {
-                let entries = self.sprint_assign_entries();
-                let cur = self.dialog_input.sprint_assign_selection.get();
-                if let Some(next) = next_selectable(&entries, cur) {
-                    self.dialog_input.sprint_assign_selection.set(Some(next));
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                let entries = self.sprint_assign_entries();
-                let cur = self.dialog_input.sprint_assign_selection.get();
-                if let Some(prev) = prev_selectable(&entries, cur) {
-                    self.dialog_input.sprint_assign_selection.set(Some(prev));
-                }
-            }
-            KeyCode::Enter | KeyCode::Char(' ') => {
-                if let Some(selection_idx) = self.dialog_input.sprint_assign_selection.get() {
-                    if let Some(active_id) = self.selection.active_card_id {
-                        let card_id = match self.model.card(active_id) {
-                            Some(card) => card.id,
-                            None => return,
-                        };
-
-                        let entries = self.sprint_assign_entries();
-                        match entries.get(selection_idx) {
-                            Some(SprintAssignEntry::None) => {
-                                let unassign_cmd = kanban_domain::commands::Command::Card(
-                                    kanban_domain::commands::CardCommand::UnassignFromSprint(
-                                        kanban_domain::commands::UnassignCardFromSprint {
-                                            card_id,
-                                            timestamp: chrono::Utc::now(),
-                                        },
-                                    ),
-                                );
-                                if let Err(e) = self.execute_commands_batch(vec![unassign_cmd]) {
-                                    tracing::error!("Failed to unassign card from sprint: {}", e);
-                                    self.set_error(format!(
-                                        "Failed to unassign card from sprint: {}",
-                                        e
-                                    ));
-                                } else {
-                                    tracing::info!("Unassigned card from sprint");
-                                }
-                            }
-                            Some(entry) => {
-                                if let Some(sprint_id) = sprint_id_of(entry) {
-                                    let assign_cmd = kanban_domain::commands::Command::Card(
-                                        kanban_domain::commands::CardCommand::AssignToSprint(
-                                            kanban_domain::commands::AssignCardsToSprint {
-                                                ids: vec![card_id],
-                                                sprint_id,
-                                            },
-                                        ),
-                                    );
-                                    if let Err(e) = self.execute_commands_batch(vec![assign_cmd]) {
-                                        tracing::error!("Failed to assign card to sprint: {}", e);
-                                        self.set_error(format!(
-                                            "Failed to assign card to sprint: {}",
-                                            e
-                                        ));
-                                    } else {
-                                        tracing::info!(
-                                            "Assigned card to sprint with id: {}",
-                                            sprint_id
-                                        );
-                                    }
-                                }
-                            }
-                            None => {}
-                        }
+            KeyCode::Enter => {
+                let active_card_id = match self.selection.active_card_id {
+                    Some(id) => id,
+                    None => {
+                        self.pop_mode();
+                        self.dialog_input.assign_sprint_picker.clear();
+                        return;
+                    }
+                };
+                let card_id = match self.model.card(active_card_id) {
+                    Some(card) => card.id,
+                    None => return,
+                };
+                let picker = &self.dialog_input.assign_sprint_picker;
+                let cmd = if let Some(sprint_id) = picker.selected_sprint_id() {
+                    Some(kanban_domain::commands::Command::Card(
+                        kanban_domain::commands::CardCommand::AssignToSprint(
+                            kanban_domain::commands::AssignCardsToSprint {
+                                ids: vec![card_id],
+                                sprint_id,
+                            },
+                        ),
+                    ))
+                } else if picker.explicitly_unassigned() {
+                    Some(kanban_domain::commands::Command::Card(
+                        kanban_domain::commands::CardCommand::UnassignFromSprint(
+                            kanban_domain::commands::UnassignCardFromSprint {
+                                card_id,
+                                timestamp: chrono::Utc::now(),
+                            },
+                        ),
+                    ))
+                } else {
+                    None
+                };
+                if let Some(cmd) = cmd {
+                    if let Err(e) = self.execute_commands_batch(vec![cmd]) {
+                        tracing::error!("Failed to update card sprint: {}", e);
+                        self.set_error(format!("Failed to update card sprint: {}", e));
                     }
                 }
                 self.pop_mode();
-                self.dialog_input.sprint_assign_selection.clear();
+                self.dialog_input.assign_sprint_picker.clear();
             }
-            _ => {}
-        }
-    }
-
-    fn sprint_assign_entries(&self) -> Vec<SprintAssignEntry<'_>> {
-        if let Some(board_idx) = self.selection.active_board_index {
-            let boards = self.model.boards();
-            if let Some(board) = boards.get(board_idx) {
-                let sprints = self.model.sprints();
-                return build_entries(sprints, board.id, chrono::Utc::now());
+            _ => {
+                if let Some(board_idx) = self.selection.active_board_index {
+                    if let Some(board) = self.model.boards().get(board_idx) {
+                        let now = chrono::Utc::now();
+                        self.dialog_input.assign_sprint_picker.handle_key(
+                            key_code,
+                            self.model.sprints(),
+                            board,
+                            now,
+                        );
+                    }
+                }
             }
         }
-        Vec::new()
     }
 
     pub fn handle_assign_multiple_cards_to_sprint_popup(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {
                 self.pop_mode();
-                self.dialog_input.sprint_assign_selection.clear();
+                self.dialog_input.assign_sprint_picker.clear();
                 self.multi_select.selected_cards.clear();
                 self.multi_select.selection_mode_active = false;
             }
-            KeyCode::Char('j') | KeyCode::Down => {
-                let entries = self.sprint_assign_entries();
-                let cur = self.dialog_input.sprint_assign_selection.get();
-                if let Some(next) = next_selectable(&entries, cur) {
-                    self.dialog_input.sprint_assign_selection.set(Some(next));
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                let entries = self.sprint_assign_entries();
-                let cur = self.dialog_input.sprint_assign_selection.get();
-                if let Some(prev) = prev_selectable(&entries, cur) {
-                    self.dialog_input.sprint_assign_selection.set(Some(prev));
-                }
-            }
-            KeyCode::Enter | KeyCode::Char(' ') => {
-                if let Some(selection_idx) = self.dialog_input.sprint_assign_selection.get() {
-                    let card_ids: Vec<uuid::Uuid> =
-                        self.multi_select.selected_cards.iter().copied().collect();
-
-                    let entries = self.sprint_assign_entries();
-                    match entries.get(selection_idx) {
-                        Some(SprintAssignEntry::None) => {
-                            let mut unassign_commands: Vec<kanban_domain::commands::Command> =
-                                Vec::new();
-                            for card_id in &card_ids {
-                                let cmd = kanban_domain::commands::Command::Card(
+            KeyCode::Enter => {
+                let card_ids: Vec<uuid::Uuid> =
+                    self.multi_select.selected_cards.iter().copied().collect();
+                let picker = &self.dialog_input.assign_sprint_picker;
+                let cmds: Vec<kanban_domain::commands::Command> =
+                    if let Some(sprint_id) = picker.selected_sprint_id() {
+                        vec![kanban_domain::commands::Command::Card(
+                            kanban_domain::commands::CardCommand::AssignToSprint(
+                                kanban_domain::commands::AssignCardsToSprint {
+                                    ids: card_ids.clone(),
+                                    sprint_id,
+                                },
+                            ),
+                        )]
+                    } else if picker.explicitly_unassigned() {
+                        card_ids
+                            .iter()
+                            .map(|card_id| {
+                                kanban_domain::commands::Command::Card(
                                     kanban_domain::commands::CardCommand::UnassignFromSprint(
                                         kanban_domain::commands::UnassignCardFromSprint {
                                             card_id: *card_id,
                                             timestamp: chrono::Utc::now(),
                                         },
                                     ),
-                                );
-                                unassign_commands.push(cmd);
-                            }
-                            if let Err(e) = self.execute_commands_batch(unassign_commands) {
-                                tracing::error!("Failed to unassign cards from sprint: {}", e);
-                                self.set_error(format!(
-                                    "Failed to unassign cards from sprint: {}",
-                                    e
-                                ));
-                            } else {
-                                tracing::info!(
-                                    "Unassigned {} cards from sprint",
-                                    self.multi_select.selected_cards.len()
-                                );
-                            }
-                        }
-                        Some(entry) => {
-                            if let Some(sprint_id) = sprint_id_of(entry) {
-                                let assigned_count = self.multi_select.selected_cards.len();
-                                let commands: Vec<kanban_domain::commands::Command> =
-                                    vec![kanban_domain::commands::Command::Card(
-                                        kanban_domain::commands::CardCommand::AssignToSprint(
-                                            kanban_domain::commands::AssignCardsToSprint {
-                                                ids: card_ids.clone(),
-                                                sprint_id,
-                                            },
-                                        ),
-                                    )];
-                                if let Err(e) = self.execute_commands_batch(commands) {
-                                    tracing::error!("Failed to assign cards to sprint: {}", e);
-                                    self.set_error(format!(
-                                        "Failed to assign cards to sprint: {}",
-                                        e
-                                    ));
-                                } else {
-                                    tracing::info!(
-                                        "Assigned {} cards to sprint with id: {}",
-                                        assigned_count,
-                                        sprint_id
-                                    );
-                                }
-                            }
-                        }
-                        None => {}
+                                )
+                            })
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+                if !cmds.is_empty() {
+                    if let Err(e) = self.execute_commands_batch(cmds) {
+                        tracing::error!("Failed to update cards' sprint: {}", e);
+                        self.set_error(format!("Failed to update cards' sprint: {}", e));
                     }
                 }
                 self.pop_mode();
-                self.dialog_input.sprint_assign_selection.clear();
+                self.dialog_input.assign_sprint_picker.clear();
                 self.multi_select.selected_cards.clear();
                 self.multi_select.selection_mode_active = false;
             }
-            _ => {}
+            _ => {
+                if let Some(board_idx) = self.selection.active_board_index {
+                    if let Some(board) = self.model.boards().get(board_idx) {
+                        let now = chrono::Utc::now();
+                        self.dialog_input.assign_sprint_picker.handle_key(
+                            key_code,
+                            self.model.sprints(),
+                            board,
+                            now,
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -695,23 +634,24 @@ mod tests {
     #[test]
     fn test_handle_assign_card_to_sprint_popup_after_reload_resort_acts_on_originally_selected_card(
     ) {
-        use crate::components::sprint_assign_list::{build_entries, sprint_id_of};
-
         let mut app = App::test_default();
         let fx = setup_reload_resort_fixture(&mut app);
 
         let sprint = app.ctx.create_sprint(fx.board_id, None, None).unwrap();
         load_with_card_order(&mut app, &[fx.a_id, fx.p_id, fx.b_id, fx.c_id, fx.d_id]);
 
+        // Prime the picker with the target sprint pre-checked.
         let sprints = app.model.sprints().to_vec();
-        let entries = build_entries(&sprints, fx.board_id, chrono::Utc::now());
-        let target_idx = entries
+        let board = app
+            .model
+            .boards()
             .iter()
-            .position(|e| sprint_id_of(e) == Some(sprint.id))
-            .expect("created sprint must appear in entries");
+            .find(|b| b.id == fx.board_id)
+            .cloned()
+            .expect("board exists");
         app.dialog_input
-            .sprint_assign_selection
-            .set(Some(target_idx));
+            .assign_sprint_picker
+            .reset_for_card_assignment(Some(sprint.id), &sprints, &board, chrono::Utc::now());
 
         app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
 

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -73,7 +73,7 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
     }
 
     frame.render_widget(
-        Paragraph::new("Sprint (optional):").style(Style::default().fg(Color::Yellow)),
+        Paragraph::new("Sprint:").style(Style::default().fg(Color::Yellow)),
         chunks[2],
     );
 

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -8,12 +8,67 @@ use ratatui::{
 };
 
 pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
-    render_input_popup(
+    use crate::components::centered_rect;
+
+    let Some(board_idx) = app.selection.active_board_index else {
+        render_input_popup(
+            frame,
+            "Create New Task",
+            "Task Title:",
+            app.input.as_str(),
+            app.input.cursor_byte_offset(),
+        );
+        return;
+    };
+    let Some(board) = app.model.boards().get(board_idx) else {
+        return;
+    };
+
+    let area = centered_rect(60, 60, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title("Create New Task")
+        .borders(Borders::ALL)
+        .style(Style::default().bg(Color::Black));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    let label_widget =
+        Paragraph::new("Task Title:").style(Style::default().fg(Color::Yellow));
+    frame.render_widget(label_widget, chunks[0]);
+
+    let input = Paragraph::new(app.input.as_str())
+        .style(crate::theme::normal_text())
+        .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(input, chunks[1]);
+    let cursor_x = chunks[1].x + app.input.cursor_byte_offset() as u16 + 1;
+    let cursor_y = chunks[1].y + 1;
+    frame.set_cursor_position((cursor_x, cursor_y));
+
+    frame.render_widget(
+        Paragraph::new("Sprint (optional):").style(Style::default().fg(Color::Yellow)),
+        chunks[2],
+    );
+
+    app.dialog_input.create_card_sprint_picker.render(
         frame,
-        "Create New Task",
-        "Task Title:",
-        app.input.as_str(),
-        app.input.cursor_byte_offset(),
+        chunks[3],
+        app.model.sprints(),
+        board,
+        chrono::Utc::now(),
     );
 }
 
@@ -54,7 +109,7 @@ pub(crate) fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
 }
 
 pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
-    use crate::components::sprint_picker::SprintPicker;
+    use crate::components::sprint_picker_view::SprintPickerView;
 
     let area = centered_rect(60, 50, frame.area());
     frame.render_widget(Clear, area);
@@ -87,8 +142,12 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     let Some(board) = app.model.boards().get(board_idx) else {
         return;
     };
-    let picker =
-        SprintPicker::for_card_assignment(app.model.sprints(), board, None, chrono::Utc::now());
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints(),
+        board,
+        None,
+        chrono::Utc::now(),
+    );
     picker.render(
         frame,
         chunks[1],

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -46,18 +46,21 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         ])
         .split(inner);
 
-    let label_widget =
-        Paragraph::new("Task Title:").style(Style::default().fg(Color::Yellow));
-    frame.render_widget(label_widget, chunks[0]);
-
     let title_focused = app.dialog_input.create_card_focus_is_title();
+    let unfocused_border = Style::default().fg(Color::DarkGray);
+
+    frame.render_widget(
+        Paragraph::new("Task Title:").style(Style::default().fg(Color::Yellow)),
+        chunks[0],
+    );
+
     let input = Paragraph::new(app.input.as_str())
         .style(crate::theme::normal_text())
         .block(Block::default().borders(Borders::ALL).border_style(
             if title_focused {
                 crate::theme::focused_border()
             } else {
-                Style::default()
+                unfocused_border
             },
         ));
     frame.render_widget(input, chunks[1]);
@@ -67,24 +70,23 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         frame.set_cursor_position((cursor_x, cursor_y));
     }
 
-    let sprint_label_color = if title_focused {
-        Color::Yellow
-    } else {
-        Color::LightYellow
-    };
     frame.render_widget(
-        Paragraph::new(if title_focused {
-            "Sprint (optional):"
-        } else {
-            "Sprint (optional):  [focused — Tab/Enter to confirm]"
-        })
-        .style(Style::default().fg(sprint_label_color)),
+        Paragraph::new("Sprint (optional):").style(Style::default().fg(Color::Yellow)),
         chunks[2],
     );
 
+    let picker_block = Block::default().borders(Borders::ALL).border_style(
+        if title_focused {
+            unfocused_border
+        } else {
+            crate::theme::focused_border()
+        },
+    );
+    let picker_inner = picker_block.inner(chunks[3]);
+    frame.render_widget(picker_block, chunks[3]);
     app.dialog_input.create_card_sprint_picker.render(
         frame,
-        chunks[3],
+        picker_inner,
         app.model.sprints(),
         board,
         chrono::Utc::now(),

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -50,16 +50,35 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         Paragraph::new("Task Title:").style(Style::default().fg(Color::Yellow));
     frame.render_widget(label_widget, chunks[0]);
 
+    let title_focused = app.dialog_input.create_card_focus_is_title();
     let input = Paragraph::new(app.input.as_str())
         .style(crate::theme::normal_text())
-        .block(Block::default().borders(Borders::ALL));
+        .block(Block::default().borders(Borders::ALL).border_style(
+            if title_focused {
+                crate::theme::focused_border()
+            } else {
+                Style::default()
+            },
+        ));
     frame.render_widget(input, chunks[1]);
-    let cursor_x = chunks[1].x + app.input.cursor_byte_offset() as u16 + 1;
-    let cursor_y = chunks[1].y + 1;
-    frame.set_cursor_position((cursor_x, cursor_y));
+    if title_focused {
+        let cursor_x = chunks[1].x + app.input.cursor_byte_offset() as u16 + 1;
+        let cursor_y = chunks[1].y + 1;
+        frame.set_cursor_position((cursor_x, cursor_y));
+    }
 
+    let sprint_label_color = if title_focused {
+        Color::Yellow
+    } else {
+        Color::LightYellow
+    };
     frame.render_widget(
-        Paragraph::new("Sprint (optional):").style(Style::default().fg(Color::Yellow)),
+        Paragraph::new(if title_focused {
+            "Sprint (optional):"
+        } else {
+            "Sprint (optional):  [focused — Tab/Enter to confirm]"
+        })
+        .style(Style::default().fg(sprint_label_color)),
         chunks[2],
     );
 

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -132,8 +132,6 @@ pub(crate) fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
 }
 
 pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
-    use crate::components::sprint_picker_view::SprintPickerView;
-
     let area = centered_rect(60, 50, frame.area());
     frame.render_widget(Clear, area);
 
@@ -165,11 +163,11 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     let Some(board) = app.model.boards().get(board_idx) else {
         return;
     };
-    let picker =
-        SprintPickerView::for_card_assignment(app.model.sprints(), board, None, chrono::Utc::now());
-    picker.render(
+    app.dialog_input.assign_sprint_picker.render(
         frame,
         chunks[1],
-        app.dialog_input.sprint_assign_selection.get(),
+        app.model.sprints(),
+        board,
+        chrono::Utc::now(),
     );
 }

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -56,13 +56,15 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
 
     let input = Paragraph::new(app.input.as_str())
         .style(crate::theme::normal_text())
-        .block(Block::default().borders(Borders::ALL).border_style(
-            if title_focused {
-                crate::theme::focused_border()
-            } else {
-                unfocused_border
-            },
-        ));
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(if title_focused {
+                    crate::theme::focused_border()
+                } else {
+                    unfocused_border
+                }),
+        );
     frame.render_widget(input, chunks[1]);
     if title_focused {
         let cursor_x = chunks[1].x + app.input.cursor_byte_offset() as u16 + 1;
@@ -75,13 +77,13 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         chunks[2],
     );
 
-    let picker_block = Block::default().borders(Borders::ALL).border_style(
-        if title_focused {
+    let picker_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(if title_focused {
             unfocused_border
         } else {
             crate::theme::focused_border()
-        },
-    );
+        });
     let picker_inner = picker_block.inner(chunks[3]);
     frame.render_widget(picker_block, chunks[3]);
     app.dialog_input.create_card_sprint_picker.render(
@@ -163,12 +165,8 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     let Some(board) = app.model.boards().get(board_idx) else {
         return;
     };
-    let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints(),
-        board,
-        None,
-        chrono::Utc::now(),
-    );
+    let picker =
+        SprintPickerView::for_card_assignment(app.model.sprints(), board, None, chrono::Utc::now());
     picker.render(
         frame,
         chunks[1],

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -199,6 +199,50 @@ fn test_j_on_title_focus_inserts_character_into_title() {
 }
 
 #[test]
+fn test_space_on_sprint_focus_clears_selection_to_none() {
+    let mut app = setup_app_with_board();
+    let bid = board_id(&app);
+    let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.ctx.activate_sprint(sprint.id, Some(7)).unwrap();
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    // Sole active sprint pre-selected.
+    for ch in "Unset".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Tab);
+    app.handle_create_card_dialog(KeyCode::Char(' '));
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.prepare_frame();
+
+    let cards = app.model.cards();
+    let created = cards
+        .iter()
+        .find(|c| c.title == "Unset")
+        .expect("card created");
+    assert_eq!(
+        created.sprint_id, None,
+        "Space on the picker should clear the assignment back to None"
+    );
+}
+
+#[test]
+fn test_space_on_title_focus_inserts_space_into_title() {
+    let mut app = setup_app_with_board();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    assert!(app.dialog_input.create_card_focus_is_title());
+
+    app.handle_create_card_dialog(KeyCode::Char('h'));
+    app.handle_create_card_dialog(KeyCode::Char(' '));
+    app.handle_create_card_dialog(KeyCode::Char('i'));
+
+    assert_eq!(app.input.as_str(), "h i");
+}
+
+#[test]
 fn test_arrow_down_after_tab_navigates_picker_and_enter_assigns_sprint() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -90,11 +90,78 @@ fn test_create_card_dialog_leaves_card_unassigned_when_multiple_active_sprints()
 }
 
 #[test]
-fn test_create_card_dialog_arrow_down_selects_planning_sprint_then_confirm_assigns_it() {
+fn test_tab_toggles_focus_between_title_and_sprint_picker() {
+    let mut app = setup_app_with_board();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    assert!(app.dialog_input.create_card_focus_is_title());
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert!(!app.dialog_input.create_card_focus_is_title());
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert!(app.dialog_input.create_card_focus_is_title());
+}
+
+#[test]
+fn test_esc_on_title_focus_moves_focus_to_sprint_picker_without_closing() {
+    let mut app = setup_app_with_board();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    assert!(app.dialog_input.create_card_focus_is_title());
+
+    app.handle_create_card_dialog(KeyCode::Esc);
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::CreateCard)
+    ));
+    assert!(!app.dialog_input.create_card_focus_is_title());
+}
+
+#[test]
+fn test_esc_on_sprint_focus_closes_the_dialog() {
+    let mut app = setup_app_with_board();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert!(!app.dialog_input.create_card_focus_is_title());
+
+    app.handle_create_card_dialog(KeyCode::Esc);
+
+    assert!(
+        !matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)),
+        "Esc while sprint-focused should close the dialog"
+    );
+}
+
+#[test]
+fn test_down_on_title_focus_moves_focus_to_sprint_picker() {
+    let mut app = setup_app_with_board();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    assert!(app.dialog_input.create_card_focus_is_title());
+
+    app.handle_create_card_dialog(KeyCode::Down);
+
+    assert!(!app.dialog_input.create_card_focus_is_title());
+}
+
+#[test]
+fn test_typing_on_sprint_focus_does_not_modify_title_input() {
+    let mut app = setup_app_with_board();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert!(!app.dialog_input.create_card_focus_is_title());
+
+    app.handle_create_card_dialog(KeyCode::Char('x'));
+    assert_eq!(app.input.as_str(), "");
+}
+
+#[test]
+fn test_arrow_down_after_tab_navigates_picker_and_enter_assigns_sprint() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
-    // No active sprint -> dialog opens with "None" highlighted. Down should
-    // walk past any header to reach an assignable planning sprint.
     let planning = app.ctx.create_sprint(bid, None, None).unwrap();
     app.prepare_frame();
 
@@ -103,6 +170,7 @@ fn test_create_card_dialog_arrow_down_selects_planning_sprint_then_confirm_assig
     for ch in "Picked".chars() {
         app.handle_create_card_dialog(KeyCode::Char(ch));
     }
+    app.handle_create_card_dialog(KeyCode::Tab);
     app.handle_create_card_dialog(KeyCode::Down);
     app.handle_create_card_dialog(KeyCode::Enter);
     app.prepare_frame();

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -298,3 +298,55 @@ fn test_arrow_down_then_space_assigns_navigated_sprint() {
         .expect("card created");
     assert_eq!(created.sprint_id, Some(planning.id));
 }
+
+#[test]
+fn test_create_card_does_not_carry_sprint_id_from_a_different_board() {
+    // Defense: the picker was reset for board A but by submit time the
+    // active board is B. The selected sprint id belongs to A and would
+    // otherwise leak into B's CreateCard command, surfacing only as a
+    // cross-board validation error from the domain. The board-aware
+    // accessor should drop the stale id before the command is built.
+    let mut app = setup_app_with_board();
+    let board_a = board_id(&app);
+    let sprint_on_a = app.ctx.create_sprint(board_a, None, None).unwrap();
+    app.ctx.activate_sprint(sprint_on_a.id, Some(7)).unwrap();
+
+    let board_b = app.ctx.create_board("Board B".to_string(), None).unwrap();
+    let col_b = app
+        .ctx
+        .create_column(board_b.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    app.prepare_frame();
+
+    // Reset picker for board A.
+    let sprints = app.model.sprints().to_vec();
+    let board_a_ref = app
+        .model
+        .boards()
+        .iter()
+        .find(|b| b.id == board_a)
+        .cloned()
+        .unwrap();
+    app.dialog_input.create_card_sprint_picker.reset_for_board(
+        &sprints,
+        &board_a_ref,
+        chrono::Utc::now(),
+    );
+
+    // Sanity: the picker holds board A's sprint id.
+    assert_eq!(
+        app.dialog_input
+            .create_card_sprint_picker
+            .selected_sprint_id(),
+        Some(sprint_on_a.id)
+    );
+    // Board-aware accessor refuses to return it for board B.
+    assert_eq!(
+        app.dialog_input
+            .create_card_sprint_picker
+            .selected_sprint_id_for(board_b.id),
+        None
+    );
+    // Ditto column on B exists for completeness of the scenario.
+    let _ = col_b;
+}

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -24,10 +24,7 @@ fn board_id(app: &App) -> uuid::Uuid {
 fn confirm_create_card_dialog(app: &mut App, title: &str) {
     app.focus.active = Focus::Cards;
     app.handle_create_card_key();
-    assert!(matches!(
-        app.mode,
-        AppMode::Dialog(DialogMode::CreateCard)
-    ));
+    assert!(matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)));
     for ch in title.chars() {
         app.handle_create_card_dialog(KeyCode::Char(ch));
     }
@@ -46,7 +43,10 @@ fn test_create_card_dialog_assigns_sole_active_sprint_on_open() {
     confirm_create_card_dialog(&mut app, "Task");
 
     let cards = app.model.cards();
-    let created = cards.iter().find(|c| c.title == "Task").expect("card created");
+    let created = cards
+        .iter()
+        .find(|c| c.title == "Task")
+        .expect("card created");
     assert_eq!(
         created.sprint_id,
         Some(sprint.id),
@@ -65,7 +65,10 @@ fn test_create_card_dialog_leaves_card_unassigned_when_no_active_sprint() {
     confirm_create_card_dialog(&mut app, "Plain");
 
     let cards = app.model.cards();
-    let created = cards.iter().find(|c| c.title == "Plain").expect("card created");
+    let created = cards
+        .iter()
+        .find(|c| c.title == "Plain")
+        .expect("card created");
     assert_eq!(created.sprint_id, None);
 }
 
@@ -82,7 +85,10 @@ fn test_create_card_dialog_leaves_card_unassigned_when_multiple_active_sprints()
     confirm_create_card_dialog(&mut app, "Ambig");
 
     let cards = app.model.cards();
-    let created = cards.iter().find(|c| c.title == "Ambig").expect("card created");
+    let created = cards
+        .iter()
+        .find(|c| c.title == "Ambig")
+        .expect("card created");
     assert_eq!(
         created.sprint_id, None,
         "with multiple active sprints, no pre-selection so card stays unassigned"
@@ -111,10 +117,7 @@ fn test_esc_on_title_focus_moves_focus_to_sprint_picker_without_closing() {
 
     app.handle_create_card_dialog(KeyCode::Esc);
 
-    assert!(matches!(
-        app.mode,
-        AppMode::Dialog(DialogMode::CreateCard)
-    ));
+    assert!(matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)));
     assert!(!app.dialog_input.create_card_focus_is_title());
 }
 
@@ -176,7 +179,10 @@ fn test_j_on_sprint_focus_navigates_picker_like_down() {
     app.prepare_frame();
 
     let cards = app.model.cards();
-    let created = cards.iter().find(|c| c.title == "Vim").expect("card created");
+    let created = cards
+        .iter()
+        .find(|c| c.title == "Vim")
+        .expect("card created");
     assert_eq!(created.sprint_id, Some(planning.id));
 }
 
@@ -210,6 +216,9 @@ fn test_arrow_down_after_tab_navigates_picker_and_enter_assigns_sprint() {
     app.prepare_frame();
 
     let cards = app.model.cards();
-    let created = cards.iter().find(|c| c.title == "Picked").expect("card created");
+    let created = cards
+        .iter()
+        .find(|c| c.title == "Picked")
+        .expect("card created");
     assert_eq!(created.sprint_id, Some(planning.id));
 }

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -33,7 +33,7 @@ fn confirm_create_card_dialog(app: &mut App, title: &str) {
 }
 
 #[test]
-fn test_create_card_dialog_assigns_sole_active_sprint_on_open() {
+fn test_create_card_dialog_does_not_auto_assign_active_sprint_without_space() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
     let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
@@ -48,10 +48,39 @@ fn test_create_card_dialog_assigns_sole_active_sprint_on_open() {
         .find(|c| c.title == "Task")
         .expect("card created");
     assert_eq!(
-        created.sprint_id,
-        Some(sprint.id),
-        "card should be assigned to sole active sprint when dialog opens"
+        created.sprint_id, None,
+        "the sole active sprint is the cursor target on open, but the user \
+         must press Space to commit it; pressing Enter without Space leaves \
+         the card unassigned"
     );
+    // Sanity: the sprint exists, just wasn't selected.
+    let _ = sprint;
+}
+
+#[test]
+fn test_create_card_dialog_space_at_sole_active_sprint_assigns_it() {
+    let mut app = setup_app_with_board();
+    let bid = board_id(&app);
+    let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.ctx.activate_sprint(sprint.id, Some(7)).unwrap();
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    for ch in "Task".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Tab);
+    app.handle_create_card_dialog(KeyCode::Char(' '));
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.prepare_frame();
+
+    let cards = app.model.cards();
+    let created = cards
+        .iter()
+        .find(|c| c.title == "Task")
+        .expect("card created");
+    assert_eq!(created.sprint_id, Some(sprint.id));
 }
 
 #[test]
@@ -175,6 +204,7 @@ fn test_j_on_sprint_focus_navigates_picker_like_down() {
     }
     app.handle_create_card_dialog(KeyCode::Tab);
     app.handle_create_card_dialog(KeyCode::Char('j'));
+    app.handle_create_card_dialog(KeyCode::Char(' '));
     app.handle_create_card_dialog(KeyCode::Enter);
     app.prepare_frame();
 
@@ -199,7 +229,10 @@ fn test_j_on_title_focus_inserts_character_into_title() {
 }
 
 #[test]
-fn test_space_on_sprint_focus_clears_selection_to_none() {
+fn test_arrow_to_none_row_then_space_explicitly_leaves_card_unassigned() {
+    // From a sole-active board, walk the cursor up onto the (None) row
+    // and press Space. The card lands unassigned even though there was
+    // a candidate active sprint sitting under the initial cursor.
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
     let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
@@ -208,11 +241,12 @@ fn test_space_on_sprint_focus_clears_selection_to_none() {
 
     app.focus.active = Focus::Cards;
     app.handle_create_card_key();
-    // Sole active sprint pre-selected.
-    for ch in "Unset".chars() {
+    for ch in "NoSprint".chars() {
         app.handle_create_card_dialog(KeyCode::Char(ch));
     }
     app.handle_create_card_dialog(KeyCode::Tab);
+    // Cursor starts on the active sprint; Up walks it to the (None) row.
+    app.handle_create_card_dialog(KeyCode::Up);
     app.handle_create_card_dialog(KeyCode::Char(' '));
     app.handle_create_card_dialog(KeyCode::Enter);
     app.prepare_frame();
@@ -220,12 +254,9 @@ fn test_space_on_sprint_focus_clears_selection_to_none() {
     let cards = app.model.cards();
     let created = cards
         .iter()
-        .find(|c| c.title == "Unset")
+        .find(|c| c.title == "NoSprint")
         .expect("card created");
-    assert_eq!(
-        created.sprint_id, None,
-        "Space on the picker should clear the assignment back to None"
-    );
+    assert_eq!(created.sprint_id, None);
 }
 
 #[test]
@@ -243,7 +274,7 @@ fn test_space_on_title_focus_inserts_space_into_title() {
 }
 
 #[test]
-fn test_arrow_down_after_tab_navigates_picker_and_enter_assigns_sprint() {
+fn test_arrow_down_then_space_assigns_navigated_sprint() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
     let planning = app.ctx.create_sprint(bid, None, None).unwrap();
@@ -256,6 +287,7 @@ fn test_arrow_down_after_tab_navigates_picker_and_enter_assigns_sprint() {
     }
     app.handle_create_card_dialog(KeyCode::Tab);
     app.handle_create_card_dialog(KeyCode::Down);
+    app.handle_create_card_dialog(KeyCode::Char(' '));
     app.handle_create_card_dialog(KeyCode::Enter);
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -33,7 +33,7 @@ fn confirm_create_card_dialog(app: &mut App, title: &str) {
 }
 
 #[test]
-fn test_create_card_dialog_does_not_auto_assign_active_sprint_without_space() {
+fn test_create_card_dialog_auto_assigns_sole_active_sprint_on_open() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
     let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
@@ -48,17 +48,15 @@ fn test_create_card_dialog_does_not_auto_assign_active_sprint_without_space() {
         .find(|c| c.title == "Task")
         .expect("card created");
     assert_eq!(
-        created.sprint_id, None,
-        "the sole active sprint is the cursor target on open, but the user \
-         must press Space to commit it; pressing Enter without Space leaves \
-         the card unassigned"
+        created.sprint_id,
+        Some(sprint.id),
+        "exactly one active sprint pre-checks it, so Enter without Space \
+         confirms the assignment in one keystroke"
     );
-    // Sanity: the sprint exists, just wasn't selected.
-    let _ = sprint;
 }
 
 #[test]
-fn test_create_card_dialog_space_at_sole_active_sprint_assigns_it() {
+fn test_create_card_dialog_space_on_pre_checked_sprint_unchecks_it() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
     let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
@@ -70,6 +68,8 @@ fn test_create_card_dialog_space_at_sole_active_sprint_assigns_it() {
     for ch in "Task".chars() {
         app.handle_create_card_dialog(KeyCode::Char(ch));
     }
+    // Sole active sprint was pre-checked on open. Tab into the picker
+    // (cursor already on that sprint), Space toggles the check off.
     app.handle_create_card_dialog(KeyCode::Tab);
     app.handle_create_card_dialog(KeyCode::Char(' '));
     app.handle_create_card_dialog(KeyCode::Enter);
@@ -80,7 +80,7 @@ fn test_create_card_dialog_space_at_sole_active_sprint_assigns_it() {
         .iter()
         .find(|c| c.title == "Task")
         .expect("card created");
-    assert_eq!(created.sprint_id, Some(sprint.id));
+    assert_eq!(created.sprint_id, None);
 }
 
 #[test]

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -1,0 +1,113 @@
+use crossterm::event::KeyCode;
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+
+fn setup_app_with_board() -> App {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let _col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_index = Some(0);
+    app
+}
+
+fn board_id(app: &App) -> uuid::Uuid {
+    app.model.boards()[0].id
+}
+
+fn confirm_create_card_dialog(app: &mut App, title: &str) {
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::CreateCard)
+    ));
+    for ch in title.chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.prepare_frame();
+}
+
+#[test]
+fn test_create_card_dialog_assigns_sole_active_sprint_on_open() {
+    let mut app = setup_app_with_board();
+    let bid = board_id(&app);
+    let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.ctx.activate_sprint(sprint.id, Some(7)).unwrap();
+    app.prepare_frame();
+
+    confirm_create_card_dialog(&mut app, "Task");
+
+    let cards = app.model.cards();
+    let created = cards.iter().find(|c| c.title == "Task").expect("card created");
+    assert_eq!(
+        created.sprint_id,
+        Some(sprint.id),
+        "card should be assigned to sole active sprint when dialog opens"
+    );
+}
+
+#[test]
+fn test_create_card_dialog_leaves_card_unassigned_when_no_active_sprint() {
+    let mut app = setup_app_with_board();
+    let bid = board_id(&app);
+    // planning sprint exists but is not active
+    let _planning = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.prepare_frame();
+
+    confirm_create_card_dialog(&mut app, "Plain");
+
+    let cards = app.model.cards();
+    let created = cards.iter().find(|c| c.title == "Plain").expect("card created");
+    assert_eq!(created.sprint_id, None);
+}
+
+#[test]
+fn test_create_card_dialog_leaves_card_unassigned_when_multiple_active_sprints() {
+    let mut app = setup_app_with_board();
+    let bid = board_id(&app);
+    let s1 = app.ctx.create_sprint(bid, None, None).unwrap();
+    let s2 = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.ctx.activate_sprint(s1.id, Some(7)).unwrap();
+    app.ctx.activate_sprint(s2.id, Some(7)).unwrap();
+    app.prepare_frame();
+
+    confirm_create_card_dialog(&mut app, "Ambig");
+
+    let cards = app.model.cards();
+    let created = cards.iter().find(|c| c.title == "Ambig").expect("card created");
+    assert_eq!(
+        created.sprint_id, None,
+        "with multiple active sprints, no pre-selection so card stays unassigned"
+    );
+}
+
+#[test]
+fn test_create_card_dialog_arrow_down_selects_planning_sprint_then_confirm_assigns_it() {
+    let mut app = setup_app_with_board();
+    let bid = board_id(&app);
+    // No active sprint -> dialog opens with "None" highlighted. Down should
+    // walk past any header to reach an assignable planning sprint.
+    let planning = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    for ch in "Picked".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Down);
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.prepare_frame();
+
+    let cards = app.model.cards();
+    let created = cards.iter().find(|c| c.title == "Picked").expect("card created");
+    assert_eq!(created.sprint_id, Some(planning.id));
+}

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -159,6 +159,40 @@ fn test_typing_on_sprint_focus_does_not_modify_title_input() {
 }
 
 #[test]
+fn test_j_on_sprint_focus_navigates_picker_like_down() {
+    let mut app = setup_app_with_board();
+    let bid = board_id(&app);
+    let planning = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    for ch in "Vim".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Tab);
+    app.handle_create_card_dialog(KeyCode::Char('j'));
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.prepare_frame();
+
+    let cards = app.model.cards();
+    let created = cards.iter().find(|c| c.title == "Vim").expect("card created");
+    assert_eq!(created.sprint_id, Some(planning.id));
+}
+
+#[test]
+fn test_j_on_title_focus_inserts_character_into_title() {
+    let mut app = setup_app_with_board();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    assert!(app.dialog_input.create_card_focus_is_title());
+
+    app.handle_create_card_dialog(KeyCode::Char('j'));
+
+    assert_eq!(app.input.as_str(), "j");
+}
+
+#[test]
 fn test_arrow_down_after_tab_navigates_picker_and_enter_assigns_sprint() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -2,10 +2,7 @@ mod helpers;
 
 use chrono::{Duration, Utc};
 use crossterm::event::KeyCode;
-use kanban_domain::{
-    field_update::FieldUpdate, CreateCardOptions, KanbanOperations, Sprint, SprintUpdate,
-};
-use kanban_tui::components::{build_entries, sprint_id_of};
+use kanban_domain::{field_update::FieldUpdate, CreateCardOptions, KanbanOperations, SprintUpdate};
 use kanban_tui::{
     app::mode::{AppMode, DialogMode},
     components::{SelectionDialog, SprintAssignDialog},
@@ -75,7 +72,21 @@ fn setup_app_with_sprints() -> DialogFixture {
 }
 
 fn open_assign_dialog(app: &mut App) {
-    app.dialog_input.sprint_assign_selection.set(Some(0));
+    let current_sprint_id = app
+        .selection
+        .active_card_id
+        .and_then(|id| app.model.card(id))
+        .and_then(|c| c.sprint_id);
+    let sprints = app.model.sprints().to_vec();
+    let board = app
+        .model
+        .boards()
+        .first()
+        .cloned()
+        .expect("test app has at least one board");
+    app.dialog_input
+        .assign_sprint_picker
+        .reset_for_card_assignment(current_sprint_id, &sprints, &board, Utc::now());
     app.push_mode(AppMode::Dialog(DialogMode::AssignCardToSprint));
 }
 
@@ -211,18 +222,33 @@ fn test_down_arrow_skips_headers() {
     let fx = setup_app_with_sprints();
     let mut app = fx.app;
     open_assign_dialog(&mut app);
-    // Selection starts at 0 (None entry).
-    assert_eq!(app.dialog_input.sprint_assign_selection.get(), Some(0));
-
-    // Pressing j once should land on the first selectable entry past the
-    // (None) entry — the "Active / Planned" header is at index 1, so
-    // selection should jump to index 2 (the first sprint).
-    app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+    // The fixture's card has no current sprint, so the picker opens
+    // with the cursor on the (None) row.
     assert_eq!(
-        app.dialog_input.sprint_assign_selection.get(),
-        Some(2),
-        "down should skip the Active / Planned header"
+        app.dialog_input.assign_sprint_picker.cursor_sprint_id(),
+        None
     );
+
+    // One Down lands on a real sprint row — the Active/Planned section
+    // header gets skipped by next_selectable.
+    app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+    assert!(
+        app.dialog_input
+            .assign_sprint_picker
+            .cursor_sprint_id()
+            .is_some(),
+        "Down should land the cursor on a sprint row, not a header"
+    );
+}
+
+fn walk_cursor_to_sprint(app: &mut App, target: Uuid, max_steps: usize) {
+    for _ in 0..max_steps {
+        if app.dialog_input.assign_sprint_picker.cursor_sprint_id() == Some(target) {
+            return;
+        }
+        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
+    }
+    panic!("could not navigate cursor to target sprint within {max_steps} steps");
 }
 
 #[test]
@@ -233,26 +259,11 @@ fn test_assigning_to_completed_sprint_succeeds() {
     let target_sprint = fx.completed_id;
 
     open_assign_dialog(&mut app);
-
-    // Walk down with j until selection_idx points at the completed sprint.
-    let max_steps = 20;
-    let mut steps = 0;
-    loop {
-        let idx = app
-            .dialog_input
-            .sprint_assign_selection
-            .get()
-            .expect("selection set");
-        if let Some(s) = sprint_at(&app, idx) {
-            if s == target_sprint {
-                break;
-            }
-        }
-        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
-        steps += 1;
-        assert!(steps < max_steps, "could not navigate to completed sprint");
-    }
+    walk_cursor_to_sprint(&mut app, target_sprint, 20);
+    // Space commits the cursor's row as the [x] selection, Enter applies.
+    app.handle_assign_card_to_sprint_popup(KeyCode::Char(' '));
     app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
+
     let card = app.ctx.get_card(card_id).unwrap().unwrap();
     assert_eq!(
         card.sprint_id,
@@ -269,25 +280,10 @@ fn test_assigning_to_ended_sprint_succeeds() {
     let target_sprint = fx.ended_id;
 
     open_assign_dialog(&mut app);
-
-    let max_steps = 20;
-    let mut steps = 0;
-    loop {
-        let idx = app
-            .dialog_input
-            .sprint_assign_selection
-            .get()
-            .expect("selection set");
-        if let Some(s) = sprint_at(&app, idx) {
-            if s == target_sprint {
-                break;
-            }
-        }
-        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
-        steps += 1;
-        assert!(steps < max_steps, "could not navigate to ended sprint");
-    }
+    walk_cursor_to_sprint(&mut app, target_sprint, 20);
+    app.handle_assign_card_to_sprint_popup(KeyCode::Char(' '));
     app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
+
     let card = app.ctx.get_card(card_id).unwrap().unwrap();
     assert_eq!(
         card.sprint_id,
@@ -303,29 +299,26 @@ fn test_bulk_assign_handler_supports_completed_sprint() {
     let card_id = fx.card_id;
     let target_sprint = fx.completed_id;
 
-    // Switch to bulk-assign flow with one selected card.
+    // Switch to bulk-assign flow with one selected card, with picker
+    // primed (no single "current" sprint in bulk mode).
     app.multi_select.selected_cards.insert(card_id);
-    app.dialog_input.sprint_assign_selection.set(Some(0));
+    let sprints = app.model.sprints().to_vec();
+    let board = app.model.boards().first().cloned().unwrap();
+    app.dialog_input
+        .assign_sprint_picker
+        .reset_for_card_assignment(None, &sprints, &board, Utc::now());
     app.push_mode(AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint));
 
     let max_steps = 20;
-    let mut steps = 0;
-    loop {
-        let idx = app
-            .dialog_input
-            .sprint_assign_selection
-            .get()
-            .expect("selection set");
-        if let Some(s) = sprint_at(&app, idx) {
-            if s == target_sprint {
-                break;
-            }
+    for _ in 0..max_steps {
+        if app.dialog_input.assign_sprint_picker.cursor_sprint_id() == Some(target_sprint) {
+            break;
         }
         app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Char('j'));
-        steps += 1;
-        assert!(steps < max_steps, "could not navigate to completed sprint");
     }
+    app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Char(' '));
     app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Enter);
+
     let card = app.ctx.get_card(card_id).unwrap().unwrap();
     assert_eq!(
         card.sprint_id,
@@ -349,6 +342,19 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
     app.prepare_frame();
 
     open_assign_dialog(&mut app);
+    // The dialog opens with cursor + checkbox on the current sprint —
+    // which is the completed one here. Move the cursor off that row
+    // (onto the (None) row at the top) so the focus-blue does not
+    // dominate the row's color, leaving the status colour test
+    // meaningful.
+    while app
+        .dialog_input
+        .assign_sprint_picker
+        .cursor_sprint_id()
+        .is_some()
+    {
+        app.handle_assign_card_to_sprint_popup(KeyCode::Char('k'));
+    }
 
     let board = app.model.boards()[0].clone();
     let completed = app
@@ -362,8 +368,8 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
 
     let grid = render_dialog_with_colors(&app);
 
-    // The completed entry should still render in green (status colour wins),
-    // not in any "current sprint" highlight that would override it.
+    // Cursor is off the completed row, so its row keeps the Completed
+    // status colour (green) instead of the cursor-focus blue.
     let color = line_color(&grid, &completed_name);
     assert_eq!(
         color,
@@ -379,15 +385,6 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
         "expected ' (current)' suffix on the completed-current entry; output:\n{}",
         output
     );
-}
-
-// Helper: returns the sprint id selected by the dialog at index `idx`,
-// using the same entry layout the renderer/handler uses.
-fn sprint_at(app: &App, idx: usize) -> Option<Uuid> {
-    let board = app.model.boards().first().cloned()?;
-    let sprints: Vec<Sprint> = app.model.sprints().to_vec();
-    let entries = build_entries(&sprints, board.id, Utc::now());
-    sprint_id_of(entries.get(idx)?)
 }
 
 #[test]
@@ -428,21 +425,7 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
         .map(|s| s.id)
         .unwrap();
 
-    let max_steps = 50;
-    let mut steps = 0;
-    loop {
-        let idx = app
-            .dialog_input
-            .sprint_assign_selection
-            .get()
-            .expect("selection set");
-        if sprint_at(&app, idx) == Some(oldest_id) {
-            break;
-        }
-        app.handle_assign_card_to_sprint_popup(KeyCode::Char('j'));
-        steps += 1;
-        assert!(steps < max_steps, "could not navigate to oldest sprint");
-    }
+    walk_cursor_to_sprint(&mut app, oldest_id, 50);
 
     let board_after = app.model.boards()[0].clone();
     let oldest = app

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -312,9 +312,7 @@ fn test_bulk_assign_bare_enter_is_a_no_op_and_does_not_mass_unassign() {
         .find(|s| s.board_id == board.id)
         .map(|s| s.id)
         .unwrap();
-    app.ctx
-        .assign_card_to_sprint(card_id, some_sprint)
-        .unwrap();
+    app.ctx.assign_card_to_sprint(card_id, some_sprint).unwrap();
     app.prepare_frame();
 
     // Open bulk dialog with no interaction, then press Enter immediately.

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -293,6 +293,47 @@ fn test_assigning_to_ended_sprint_succeeds() {
 }
 
 #[test]
+fn test_bulk_assign_bare_enter_is_a_no_op_and_does_not_mass_unassign() {
+    // Regression guard for KAN-556 review: opening the bulk-assign
+    // dialog and pressing Enter without first touching the picker must
+    // leave every selected card's sprint_id untouched. Previously the
+    // dialog opened with Selection::NoSprint, so a bare Enter
+    // unassigned the entire selection.
+    let fx = setup_app_with_sprints();
+    let mut app = fx.app;
+    let card_id = fx.card_id;
+
+    // Pre-assign the card to a sprint so we can detect the regression
+    // (unassign-on-open would clear sprint_id).
+    let sprints = app.model.sprints().to_vec();
+    let board = app.model.boards().first().cloned().unwrap();
+    let some_sprint = sprints
+        .iter()
+        .find(|s| s.board_id == board.id)
+        .map(|s| s.id)
+        .unwrap();
+    app.ctx
+        .assign_card_to_sprint(card_id, some_sprint)
+        .unwrap();
+    app.prepare_frame();
+
+    // Open bulk dialog with no interaction, then press Enter immediately.
+    app.multi_select.selected_cards.insert(card_id);
+    app.dialog_input
+        .assign_sprint_picker
+        .reset_for_bulk_card_assignment(&sprints, &board, Utc::now());
+    app.push_mode(AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint));
+    app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Enter);
+
+    let card = app.ctx.get_card(card_id).unwrap().unwrap();
+    assert_eq!(
+        card.sprint_id,
+        Some(some_sprint),
+        "bare Enter on bulk-assign must not clobber the pre-existing assignment"
+    );
+}
+
+#[test]
 fn test_bulk_assign_handler_supports_completed_sprint() {
     let fx = setup_app_with_sprints();
     let mut app = fx.app;
@@ -306,7 +347,7 @@ fn test_bulk_assign_handler_supports_completed_sprint() {
     let board = app.model.boards().first().cloned().unwrap();
     app.dialog_input
         .assign_sprint_picker
-        .reset_for_card_assignment(None, &sprints, &board, Utc::now());
+        .reset_for_bulk_card_assignment(&sprints, &board, Utc::now());
     app.push_mode(AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint));
 
     let max_steps = 20;

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -317,6 +317,62 @@ fn test_value_at_returns_sprint_id_for_sprint_row() {
 }
 
 #[test]
+fn test_index_of_sprint_returns_row_index_for_known_sprint() {
+    let (mut app, board_id, _col) = make_app_with_board();
+    let active = add_active_sprint(&mut app, board_id);
+    let _planning = add_planning_sprint(&mut app, board_id);
+    let now = Utc::now();
+    let board = app
+        .model
+        .boards()
+        .iter()
+        .find(|b| b.id == board_id)
+        .cloned()
+        .unwrap();
+    let entries = build_entries(app.model.sprints(), board_id, now);
+    let expected = entries.iter().position(|e| sprint_id_of(e) == Some(active));
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    assert_eq!(picker.index_of_sprint(Some(active)), expected);
+}
+
+#[test]
+fn test_index_of_sprint_returns_none_entry_index_when_no_sprint_selected() {
+    let (mut app, board_id, _col) = make_app_with_board();
+    add_active_sprint(&mut app, board_id);
+    let now = Utc::now();
+    let board = app
+        .model
+        .boards()
+        .iter()
+        .find(|b| b.id == board_id)
+        .cloned()
+        .unwrap();
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    assert_eq!(
+        picker.index_of_sprint(None),
+        Some(0),
+        "the (None) entry is always at index 0"
+    );
+}
+
+#[test]
+fn test_index_of_sprint_returns_none_when_sprint_is_not_in_list() {
+    let (mut app, board_id, _col) = make_app_with_board();
+    add_active_sprint(&mut app, board_id);
+    let now = Utc::now();
+    let board = app
+        .model
+        .boards()
+        .iter()
+        .find(|b| b.id == board_id)
+        .cloned()
+        .unwrap();
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let unknown = uuid::Uuid::new_v4();
+    assert_eq!(picker.index_of_sprint(Some(unknown)), None);
+}
+
+#[test]
 fn test_value_at_indices_match_build_entries_order() {
     let (mut app, board_id, _col) = make_app_with_board();
     add_active_sprint(&mut app, board_id);

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -208,16 +208,11 @@ fn test_for_card_assignment_render_shows_current_suffix_for_card_sprint() {
 }
 
 #[test]
-fn test_for_board_preselects_sole_active_non_ended_sprint() {
+fn test_for_new_card_preselects_sole_active_non_ended_sprint() {
     let (mut app, board_id, _col) = make_app_with_board();
     let active = add_active_sprint(&mut app, board_id);
     add_planning_sprint(&mut app, board_id);
     let now = Utc::now();
-    let entries = build_entries(app.model.sprints(), board_id, now);
-    let expected_idx = entries
-        .iter()
-        .position(|e| sprint_id_of(e) == Some(active))
-        .expect("active sprint must appear");
     let board = app
         .model
         .boards()
@@ -225,7 +220,10 @@ fn test_for_board_preselects_sole_active_non_ended_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_board(app.model.sprints(), &board, now);
+    let picker = SprintPickerView::for_new_card(app.model.sprints(), &board, now);
+    let expected_idx = picker
+        .index_of_sprint(Some(active))
+        .expect("active sprint must appear in the new-card picker");
     assert_eq!(
         picker.initial_selection(),
         Some(expected_idx),
@@ -234,7 +232,7 @@ fn test_for_board_preselects_sole_active_non_ended_sprint() {
 }
 
 #[test]
-fn test_for_board_preselects_none_when_no_active_sprints() {
+fn test_for_new_card_preselects_none_when_no_active_sprints() {
     let (mut app, board_id, _col) = make_app_with_board();
     add_planning_sprint(&mut app, board_id);
     add_completed_sprint(&mut app, board_id);
@@ -246,7 +244,7 @@ fn test_for_board_preselects_none_when_no_active_sprints() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_board(app.model.sprints(), &board, now);
+    let picker = SprintPickerView::for_new_card(app.model.sprints(), &board, now);
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -255,7 +253,7 @@ fn test_for_board_preselects_none_when_no_active_sprints() {
 }
 
 #[test]
-fn test_for_board_preselects_none_when_multiple_active_sprints() {
+fn test_for_new_card_preselects_none_when_multiple_active_sprints() {
     let (mut app, board_id, _col) = make_app_with_board();
     add_active_sprint(&mut app, board_id);
     add_active_sprint(&mut app, board_id);
@@ -267,7 +265,7 @@ fn test_for_board_preselects_none_when_multiple_active_sprints() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_board(app.model.sprints(), &board, now);
+    let picker = SprintPickerView::for_new_card(app.model.sprints(), &board, now);
     assert_eq!(
         picker.initial_selection(),
         Some(0),

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -178,7 +178,8 @@ fn test_for_card_assignment_initial_selection_is_index_of_current_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, Some(active), now);
+    let picker =
+        SprintPickerView::for_card_assignment(app.model.sprints(), &board, Some(active), now);
     assert_eq!(picker.initial_selection(), Some(expected_idx));
 }
 
@@ -196,7 +197,8 @@ fn test_for_card_assignment_render_shows_current_suffix_for_card_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, Some(active), now);
+    let picker =
+        SprintPickerView::for_card_assignment(app.model.sprints(), &board, Some(active), now);
     let out = render_picker_to_string(&picker, picker.initial_selection());
     assert!(
         out.contains("(current)"),

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{Duration, Utc};
 use kanban_domain::{field_update::FieldUpdate, CreateCardOptions, KanbanOperations, SprintUpdate};
-use kanban_tui::components::{build_entries, sprint_id_of, SprintPicker};
+use kanban_tui::components::{build_entries, sprint_id_of, SprintPickerView};
 use kanban_tui::App;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
@@ -81,7 +81,7 @@ fn assign_card_sprint(app: &mut App, card_id: Uuid, sprint_id: Uuid) {
     app.prepare_frame();
 }
 
-fn render_picker_to_string(picker: &SprintPicker<'_>, selected: Option<usize>) -> String {
+fn render_picker_to_string(picker: &SprintPickerView<'_>, selected: Option<usize>) -> String {
     let backend = TestBackend::new(TEST_W, TEST_H);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
@@ -102,7 +102,7 @@ fn render_picker_to_string(picker: &SprintPicker<'_>, selected: Option<usize>) -
 }
 
 fn render_picker_with_colors(
-    picker: &SprintPicker<'_>,
+    picker: &SprintPickerView<'_>,
     selected: Option<usize>,
 ) -> Vec<(String, Option<Color>)> {
     let backend = TestBackend::new(TEST_W, TEST_H);
@@ -152,7 +152,7 @@ fn test_for_card_assignment_initial_selection_is_zero_when_card_has_no_sprint() 
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -178,7 +178,7 @@ fn test_for_card_assignment_initial_selection_is_index_of_current_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, Some(active), now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, Some(active), now);
     assert_eq!(picker.initial_selection(), Some(expected_idx));
 }
 
@@ -196,7 +196,7 @@ fn test_for_card_assignment_render_shows_current_suffix_for_card_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, Some(active), now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, Some(active), now);
     let out = render_picker_to_string(&picker, picker.initial_selection());
     assert!(
         out.contains("(current)"),
@@ -223,7 +223,7 @@ fn test_for_board_preselects_sole_active_non_ended_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_board(app.model.sprints(), &board, now);
+    let picker = SprintPickerView::for_board(app.model.sprints(), &board, now);
     assert_eq!(
         picker.initial_selection(),
         Some(expected_idx),
@@ -244,7 +244,7 @@ fn test_for_board_preselects_none_when_no_active_sprints() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_board(app.model.sprints(), &board, now);
+    let picker = SprintPickerView::for_board(app.model.sprints(), &board, now);
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -265,7 +265,7 @@ fn test_for_board_preselects_none_when_multiple_active_sprints() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_board(app.model.sprints(), &board, now);
+    let picker = SprintPickerView::for_board(app.model.sprints(), &board, now);
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -285,7 +285,7 @@ fn test_value_at_returns_none_uuid_for_none_row() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
     assert_eq!(
         picker.value_at(0),
         Some(None),
@@ -310,7 +310,7 @@ fn test_value_at_returns_sprint_id_for_sprint_row() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
     assert_eq!(picker.value_at(idx), Some(Some(active)));
 }
 
@@ -330,7 +330,7 @@ fn test_value_at_indices_match_build_entries_order() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
     assert_eq!(
         picker.len(),
         entries.len(),
@@ -364,7 +364,7 @@ fn test_render_emits_active_planned_header_with_yellow_color() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
     let grid = render_picker_with_colors(&picker, Some(0));
     let color = line_color(&grid, "Active / Planned");
     assert_eq!(
@@ -390,7 +390,7 @@ fn test_render_with_none_selection_leaves_all_rows_unselected() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
     let out = render_picker_to_string(&picker, None);
     assert!(
         !out.contains("> (None)"),
@@ -414,7 +414,7 @@ fn test_render_with_out_of_bounds_selected_does_not_panic() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPicker::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
     let out_of_bounds = picker.len() + 100;
     // Test passes if this render call returns instead of panicking.
     let _ = render_picker_to_string(&picker, Some(out_of_bounds));


### PR DESCRIPTION
Add optional sprint assignment to card creation across domain, service, CLI, MCP, and TUI:

- `CreateCardOptions` gains `sprint_id: Option<Uuid>`; `CreateCard::execute` calls `Card::assign_to_sprint` so creation and assignment land in one undoable command.
- `kanban card create --assign / -a` accepts a UUID, name, number, or no value (uses sole active sprint, errors on zero or multiple).
- MCP `tool_create_card` accepts an optional `sprint_id` resolved via `mcp_resolve_sprint_in_board`.
- TUI Create Task dialog embeds a stateful `SprintPicker` below the title input that pre-selects the sole active non-ended sprint.
- KAN-557's stateless presenter is renamed to `SprintPickerView`; the bare `SprintPicker` name now belongs to a stateful component composing `SprintPickerView` → `RadioList`.
- Tab and Esc/Down toggle focus between title and picker; Esc on picker closes; Up/Down/j/k navigate the picker; focused element shows a bright border so the user can tell which side gets keystrokes.

**What**: A single user action ("create card") can now also assign the new card to a sprint, from the TUI dialog, the CLI, or the MCP tool.

**Why**: The common "create card in the active sprint" workflow required two separate interactions, create then assign, adding friction without any safety benefit. The new behaviour collapses that into one action while keeping the old "create unassigned" path as the default when no sprint is requested.

**How**: `CreateCardOptions` carries the optional `sprint_id` and `CreateCard::execute` calls `Card::assign_to_sprint` (sprint log entry included) inline after card construction; capture_inverse already deletes the card so undo cleans up both the card and the assignment in one step. The CLI uses clap's `num_args = 0..=1` with `default_missing_value = ""` so `--assign` works both with and without a value. The TUI picker is a new stateful `SprintPicker` that wraps the existing `SprintPickerView` presenter, owns its `SelectionState`, applies the pre-selection rule, and routes Up/Down/j/k. A `CreateCardFocus { Title, Sprint }` enum on `DialogInputState` gates which side receives keystrokes.

**Testing**: `cargo test -p kanban-domain` (3 new command tests), `cargo test -p kanban-service --test create_card_with_sprint` (3 service integration tests), `cargo test -p kanban-cli --test cli_integration` (6 CLI assign tests), `cargo test -p kanban-mcp --test integration` (3 MCP tests), `cargo test -p kanban-tui --test create_card_dialog_tests` (11 dialog tests) plus 6 unit tests on the new `SprintPicker`. `cargo test --workspace` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --all --check` clean.

---

## Post-review polish

In-review hardening landed in six follow-up commits before merge:

| Commit | Type | Effect |
|---|---|---|
| `5e8dc8b8` | refactor(domain) | `Card::update` and `Card::assign_to_sprint` now require an explicit `now`; removes the brittle `card.updated_at = now` reset in `CreateCard::execute`. Makes undo + redo deterministic at the type level. |
| `07177ad7` | fix(tui) | `reset_for_card_assignment` keeps a filter-hidden current sprint in `Selection::Sprint(id)` so bare Enter is a safe no-op re-assignment instead of silently doing nothing. |
| `55f44b28` | fix(tui) | New `reset_for_bulk_card_assignment` opens with `Selection::Unset`. Bare Enter on the bulk-assign dialog no longer mass-unassigns every selected card; user must commit a row with Space first. |
| `9304653e` | chore(tui) | `debug_assert!` when `entry_to_cursor` reaches a header. Surfaces a navigation regression in tests instead of silently snapping the cursor to (None). |
| `2a3969d0` | refactor(tui) | Dropped unused `SprintPickerView::for_board`; tests migrated to `for_new_card`. |
| `b2b7d0c2` | fix(tui) | `SprintPicker` tracks `bound_board_id`; new `selected_sprint_id_for(board_id)` returns `None` on mismatch. Create-card and both assign handlers now refuse stale-board state so a board switch between dialog open and submit can't leak a UUID into a write command. |

Additional test coverage from this round: 8 new SprintPicker unit tests (race-resistance, board mismatch, hidden-sprint, bulk-vs-single), 2 `Card` timestamp invariant tests, 1 bulk-assign regression guard, 1 picker-level board-switch defense test. Final tally: 1999 passing.

## Follow-ups filed

- KAN-565 — Add redo determinism test for create-card-with-sprint
- KAN-566 — Make `UpdateCard` and `AssignCardsToSprint` replay-deterministic
- KAN-567 — Symmetrize SprintPicker stale-board guard with `explicitly_unassigned_for`
- KAN-568 — Drop unused params from `reset_for_bulk_card_assignment`
- KAN-569 — Rename board-switch defense test to reflect what it actually checks