### PR TITLE
KAN-580 refactor(domain): accept impl Into<String> for unconditional-store params

### DIFF
--- a/.changeset/kan-580-refactor-domain-apply-nuanced-string-str-impl-into-string-rule-to-domain-params.md
+++ b/.changeset/kan-580-refactor-domain-apply-nuanced-string-str-impl-into-string-rule-to-domain-params.md
@@ -11,7 +11,13 @@ rather than being forced at the domain boundary.
 There is no behaviour change for users. Saved files, the CLI surface,
 the MCP tool schemas, and the TUI all work exactly as before. The
 refactor is API-source-compatible for any external caller already
-passing `String`, and only loosens what those APIs accept.
+passing `String` or `Some("...".to_string())`, and only loosens what
+those APIs accept. One ergonomic note: parameters that became
+`Option<impl Into<String>>` can no longer infer the type of a bare
+`None`, so external callers that previously wrote `update_prefix(None)`
+must now write `update_prefix(None::<String>)` (or any concrete
+`Option::<T>::None`). This only affects the `None` case; `Some("...")`
+callers are unchanged.
 
 Call sites across the service, persistence-sqlite, and TUI test suites
 were updated to drop the now-redundant `.to_string()` allocations, which

--- a/.changeset/kan-580-refactor-domain-apply-nuanced-string-str-impl-into-string-rule-to-domain-params.md
+++ b/.changeset/kan-580-refactor-domain-apply-nuanced-string-str-impl-into-string-rule-to-domain-params.md
@@ -1,0 +1,20 @@
+---
+bump: patch
+---
+
+Internal: domain constructors and mutators that always store their string
+input now accept `impl Into<String>` instead of `String`. This means
+callers can pass `"foo"` or `String::from("foo")` interchangeably without
+a trailing `.to_string()`, and ownership decisions stay at the call site
+rather than being forced at the domain boundary.
+
+There is no behaviour change for users. Saved files, the CLI surface,
+the MCP tool schemas, and the TUI all work exactly as before. The
+refactor is API-source-compatible for any external caller already
+passing `String`, and only loosens what those APIs accept.
+
+Call sites across the service, persistence-sqlite, and TUI test suites
+were updated to drop the now-redundant `.to_string()` allocations, which
+removes a small amount of test setup noise. The contributor guide gains
+a short note describing the "unconditional store rule" so future domain
+APIs follow the same convention.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ cargo fmt --all
   - Read-only inspection / parsing: `&str`
   - Validate-then-maybe-store (rejection possible): `&str`
   - Always store (constructors, unconditional setters): `impl Into<String>` (or `Option<impl Into<String>>`)
-  - In-place mutation: `&mut String`
+  - In-place mutation of existing string: `&mut String`
   - Avoid `impl AsRef<str>` -- signature clutter without ergonomic gain
 - Use `impl Trait` for return types when appropriate
 - Keep functions focused and under 50 lines when possible

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,12 @@ cargo fmt --all
 - Follow standard Rust conventions and idioms
 - Use `rustfmt` for formatting (enforced in CI)
 - Address all `clippy` warnings before submitting PR
-- Prefer `&str` over `String` for function parameters
+- Choose string parameter types by what the function does with the value:
+  - Read-only inspection / parsing: `&str`
+  - Validate-then-maybe-store (rejection possible): `&str`
+  - Always store (constructors, unconditional setters): `impl Into<String>` (or `Option<impl Into<String>>`)
+  - In-place mutation: `&mut String`
+  - Avoid `impl AsRef<str>` -- signature clutter without ergonomic gain
 - Use `impl Trait` for return types when appropriate
 - Keep functions focused and under 50 lines when possible
 

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -452,6 +452,48 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_board_new_accepts_str_literal_without_to_string() {
+        let board = Board::new("my-board", Some("KAN"));
+        assert_eq!(board.name, "my-board");
+        assert_eq!(board.card_prefix, Some("KAN".to_string()));
+    }
+
+    #[test]
+    fn test_board_update_name_accepts_str_without_to_string() {
+        let mut board = Board::new("initial".to_string(), None);
+        board.update_name("updated");
+        assert_eq!(board.name, "updated");
+    }
+
+    #[test]
+    fn test_board_update_description_accepts_str_without_to_string() {
+        let mut board = Board::new("board".to_string(), None);
+        board.update_description(Some("desc"));
+        assert_eq!(board.description, Some("desc".to_string()));
+    }
+
+    #[test]
+    fn test_board_update_sprint_prefix_accepts_str_without_to_string() {
+        let mut board = Board::new("board".to_string(), None);
+        board.update_sprint_prefix(Some("sprint"));
+        assert_eq!(board.sprint_prefix, Some("sprint".to_string()));
+    }
+
+    #[test]
+    fn test_board_update_card_prefix_accepts_str_without_to_string() {
+        let mut board = Board::new("board".to_string(), None);
+        board.update_card_prefix(Some("KAN"));
+        assert_eq!(board.card_prefix, Some("KAN".to_string()));
+    }
+
+    #[test]
+    fn test_board_add_sprint_name_at_used_index_accepts_str_without_to_string() {
+        let mut board = Board::new("board".to_string(), None);
+        let idx = board.add_sprint_name_at_used_index("Alpha");
+        assert_eq!(board.sprint_names[idx], "Alpha");
+    }
+
+    #[test]
     fn test_board_new_card_counter_initialized_to_one() {
         let board = Board::new("Test".to_string(), None);
         assert_eq!(board.card_counter, 1);

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -175,14 +175,14 @@ fn default_sort_order() -> SortOrder {
 }
 
 impl Board {
-    pub fn new(name: String, card_prefix: Option<String>) -> Self {
+    pub fn new(name: impl Into<String>, card_prefix: Option<impl Into<String>>) -> Self {
         let now = Utc::now();
         Self {
             id: Uuid::new_v4(),
-            name,
+            name: name.into(),
             description: None,
             sprint_prefix: None,
-            card_prefix,
+            card_prefix: card_prefix.map(Into::into),
             task_sort_field: SortField::Default,
             task_sort_order: SortOrder::Ascending,
             sprint_duration_days: None,
@@ -200,23 +200,23 @@ impl Board {
         }
     }
 
-    pub fn update_name(&mut self, name: String) {
-        self.name = name;
+    pub fn update_name(&mut self, name: impl Into<String>) {
+        self.name = name.into();
         self.updated_at = Utc::now();
     }
 
-    pub fn update_description(&mut self, description: Option<String>) {
-        self.description = description;
+    pub fn update_description(&mut self, description: Option<impl Into<String>>) {
+        self.description = description.map(Into::into);
         self.updated_at = Utc::now();
     }
 
-    pub fn update_sprint_prefix(&mut self, prefix: Option<String>) {
-        self.sprint_prefix = prefix;
+    pub fn update_sprint_prefix(&mut self, prefix: Option<impl Into<String>>) {
+        self.sprint_prefix = prefix.map(Into::into);
         self.updated_at = Utc::now();
     }
 
-    pub fn update_card_prefix(&mut self, prefix: Option<String>) {
-        self.card_prefix = prefix;
+    pub fn update_card_prefix(&mut self, prefix: Option<impl Into<String>>) {
+        self.card_prefix = prefix.map(Into::into);
         self.updated_at = Utc::now();
     }
 
@@ -256,12 +256,12 @@ impl Board {
         }
     }
 
-    pub fn add_sprint_name_at_used_index(&mut self, name: String) -> usize {
+    pub fn add_sprint_name_at_used_index(&mut self, name: impl Into<String>) -> usize {
         if self.sprint_name_used_count > self.sprint_names.len() {
             self.sprint_name_used_count = self.sprint_names.len();
         }
         let index = self.sprint_name_used_count;
-        self.sprint_names.insert(index, name);
+        self.sprint_names.insert(index, name.into());
         self.sprint_name_used_count += 1;
         self.updated_at = Utc::now();
         index
@@ -460,48 +460,48 @@ mod tests {
 
     #[test]
     fn test_board_update_name_accepts_str_without_to_string() {
-        let mut board = Board::new("initial".to_string(), None);
+        let mut board = Board::new("initial".to_string(), None::<String>);
         board.update_name("updated");
         assert_eq!(board.name, "updated");
     }
 
     #[test]
     fn test_board_update_description_accepts_str_without_to_string() {
-        let mut board = Board::new("board".to_string(), None);
+        let mut board = Board::new("board".to_string(), None::<String>);
         board.update_description(Some("desc"));
         assert_eq!(board.description, Some("desc".to_string()));
     }
 
     #[test]
     fn test_board_update_sprint_prefix_accepts_str_without_to_string() {
-        let mut board = Board::new("board".to_string(), None);
+        let mut board = Board::new("board".to_string(), None::<String>);
         board.update_sprint_prefix(Some("sprint"));
         assert_eq!(board.sprint_prefix, Some("sprint".to_string()));
     }
 
     #[test]
     fn test_board_update_card_prefix_accepts_str_without_to_string() {
-        let mut board = Board::new("board".to_string(), None);
+        let mut board = Board::new("board".to_string(), None::<String>);
         board.update_card_prefix(Some("KAN"));
         assert_eq!(board.card_prefix, Some("KAN".to_string()));
     }
 
     #[test]
     fn test_board_add_sprint_name_at_used_index_accepts_str_without_to_string() {
-        let mut board = Board::new("board".to_string(), None);
+        let mut board = Board::new("board".to_string(), None::<String>);
         let idx = board.add_sprint_name_at_used_index("Alpha");
         assert_eq!(board.sprint_names[idx], "Alpha");
     }
 
     #[test]
     fn test_board_new_card_counter_initialized_to_one() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         assert_eq!(board.card_counter, 1);
     }
 
     #[test]
     fn test_board_get_next_card_number_increments_without_prefix() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         assert_eq!(board.get_next_card_number(), 1);
         assert_eq!(board.get_next_card_number(), 2);
         assert_eq!(board.get_next_card_number(), 3);
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_board_initialize_card_counter_sets_value_and_get_next_returns_it() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.initialize_card_counter(10);
         assert_eq!(board.get_card_counter(), 10);
         assert_eq!(board.get_next_card_number(), 10);
@@ -629,31 +629,31 @@ mod tests {
 
     #[test]
     fn test_update_sprint_prefix() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         assert_eq!(board.sprint_prefix, None);
 
         board.update_sprint_prefix(Some("feat".to_string()));
         assert_eq!(board.sprint_prefix, Some("feat".to_string()));
 
-        board.update_sprint_prefix(None);
+        board.update_sprint_prefix(None::<String>);
         assert_eq!(board.sprint_prefix, None);
     }
 
     #[test]
     fn test_update_card_prefix() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         assert_eq!(board.card_prefix, None);
 
         board.update_card_prefix(Some("task".to_string()));
         assert_eq!(board.card_prefix, Some("task".to_string()));
 
-        board.update_card_prefix(None);
+        board.update_card_prefix(None::<String>);
         assert_eq!(board.card_prefix, None);
     }
 
     #[test]
     fn test_effective_sprint_prefix() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         assert_eq!(board.effective_sprint_prefix("default"), "default");
 
         board.update_sprint_prefix(Some("custom".to_string()));
@@ -662,7 +662,7 @@ mod tests {
 
     #[test]
     fn test_effective_card_prefix() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         assert_eq!(board.effective_card_prefix("task"), "task");
 
         board.update_card_prefix(Some("feature".to_string()));
@@ -671,14 +671,14 @@ mod tests {
 
     #[test]
     fn test_effective_branch_prefix_backward_compat() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.update_sprint_prefix(Some("custom".to_string()));
         assert_eq!(board.effective_branch_prefix("default"), "custom");
     }
 
     #[test]
     fn test_resolve_completion_column_fallback() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let col1 = crate::Column::new(board.id, "Todo".to_string(), 0);
         let col2 = crate::Column::new(board.id, "In Progress".to_string(), 1);
         let col3 = crate::Column::new(board.id, "Done".to_string(), 2);
@@ -689,7 +689,7 @@ mod tests {
 
     #[test]
     fn test_resolve_completion_column_explicit() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         let col1 = crate::Column::new(board.id, "Todo".to_string(), 0);
         let col2 = crate::Column::new(board.id, "Done".to_string(), 1);
         let col3 = crate::Column::new(board.id, "Archive".to_string(), 2);
@@ -701,7 +701,7 @@ mod tests {
 
     #[test]
     fn test_resolve_completion_column_stale_id_falls_back() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         let col1 = crate::Column::new(board.id, "Todo".to_string(), 0);
         let col2 = crate::Column::new(board.id, "Done".to_string(), 1);
         let columns = vec![col1, col2.clone()];
@@ -712,13 +712,13 @@ mod tests {
 
     #[test]
     fn test_resolve_completion_column_empty_columns() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         assert_eq!(board.resolve_completion_column(&[]), None);
     }
 
     #[test]
     fn test_sprint_counter_initialization() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         assert_eq!(board.get_sprint_counter("sprint"), None);
 
         let num = board.get_next_sprint_number("sprint");
@@ -728,7 +728,7 @@ mod tests {
 
     #[test]
     fn test_shared_sprint_sequence() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
 
         let num1 = board.get_next_sprint_number("SPRINT");
         assert_eq!(num1, 1);
@@ -744,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_initialize_sprint_counter() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.initialize_sprint_counter("RELEASE", 5);
 
         let num = board.get_next_sprint_number("RELEASE");
@@ -756,11 +756,11 @@ mod tests {
     fn test_ensure_sprint_counter_initialized_with_existing_sprints() {
         use crate::Sprint;
 
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
 
-        let sprint1 = Sprint::new(board.id, 1, None, None);
-        let sprint2 = Sprint::new(board.id, 2, None, None);
-        let sprint3 = Sprint::new(board.id, 3, None, None);
+        let sprint1 = Sprint::new(board.id, 1, None, None::<String>);
+        let sprint2 = Sprint::new(board.id, 2, None, None::<String>);
+        let sprint3 = Sprint::new(board.id, 3, None, None::<String>);
 
         let sprints = vec![sprint1, sprint2, sprint3];
 
@@ -776,7 +776,7 @@ mod tests {
     fn test_ensure_sprint_counter_not_reinitialize() {
         use crate::Sprint;
 
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.initialize_sprint_counter("test", 10);
 
         let sprint1 = Sprint::new(board.id, 1, None, Some("test".to_string()));
@@ -808,7 +808,7 @@ mod sort_field_serialization_tests {
 
     #[test]
     fn test_board_with_position_sort_serializes() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.update_task_sort(SortField::Position, SortOrder::Descending);
 
         let json = serde_json::to_string(&board).unwrap();

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -460,48 +460,48 @@ mod tests {
 
     #[test]
     fn test_board_update_name_accepts_str_without_to_string() {
-        let mut board = Board::new("initial".to_string(), None::<String>);
+        let mut board = Board::new("initial", None::<String>);
         board.update_name("updated");
         assert_eq!(board.name, "updated");
     }
 
     #[test]
     fn test_board_update_description_accepts_str_without_to_string() {
-        let mut board = Board::new("board".to_string(), None::<String>);
+        let mut board = Board::new("board", None::<String>);
         board.update_description(Some("desc"));
         assert_eq!(board.description, Some("desc".to_string()));
     }
 
     #[test]
     fn test_board_update_sprint_prefix_accepts_str_without_to_string() {
-        let mut board = Board::new("board".to_string(), None::<String>);
+        let mut board = Board::new("board", None::<String>);
         board.update_sprint_prefix(Some("sprint"));
         assert_eq!(board.sprint_prefix, Some("sprint".to_string()));
     }
 
     #[test]
     fn test_board_update_card_prefix_accepts_str_without_to_string() {
-        let mut board = Board::new("board".to_string(), None::<String>);
+        let mut board = Board::new("board", None::<String>);
         board.update_card_prefix(Some("KAN"));
         assert_eq!(board.card_prefix, Some("KAN".to_string()));
     }
 
     #[test]
     fn test_board_add_sprint_name_at_used_index_accepts_str_without_to_string() {
-        let mut board = Board::new("board".to_string(), None::<String>);
+        let mut board = Board::new("board", None::<String>);
         let idx = board.add_sprint_name_at_used_index("Alpha");
         assert_eq!(board.sprint_names[idx], "Alpha");
     }
 
     #[test]
     fn test_board_new_card_counter_initialized_to_one() {
-        let board = Board::new("Test".to_string(), None::<String>);
+        let board = Board::new("Test", None::<String>);
         assert_eq!(board.card_counter, 1);
     }
 
     #[test]
     fn test_board_get_next_card_number_increments_without_prefix() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         assert_eq!(board.get_next_card_number(), 1);
         assert_eq!(board.get_next_card_number(), 2);
         assert_eq!(board.get_next_card_number(), 3);
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_board_initialize_card_counter_sets_value_and_get_next_returns_it() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         board.initialize_card_counter(10);
         assert_eq!(board.get_card_counter(), 10);
         assert_eq!(board.get_next_card_number(), 10);
@@ -629,10 +629,10 @@ mod tests {
 
     #[test]
     fn test_update_sprint_prefix() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         assert_eq!(board.sprint_prefix, None);
 
-        board.update_sprint_prefix(Some("feat".to_string()));
+        board.update_sprint_prefix(Some("feat"));
         assert_eq!(board.sprint_prefix, Some("feat".to_string()));
 
         board.update_sprint_prefix(None::<String>);
@@ -641,10 +641,10 @@ mod tests {
 
     #[test]
     fn test_update_card_prefix() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         assert_eq!(board.card_prefix, None);
 
-        board.update_card_prefix(Some("task".to_string()));
+        board.update_card_prefix(Some("task"));
         assert_eq!(board.card_prefix, Some("task".to_string()));
 
         board.update_card_prefix(None::<String>);
@@ -653,35 +653,35 @@ mod tests {
 
     #[test]
     fn test_effective_sprint_prefix() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         assert_eq!(board.effective_sprint_prefix("default"), "default");
 
-        board.update_sprint_prefix(Some("custom".to_string()));
+        board.update_sprint_prefix(Some("custom"));
         assert_eq!(board.effective_sprint_prefix("default"), "custom");
     }
 
     #[test]
     fn test_effective_card_prefix() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         assert_eq!(board.effective_card_prefix("task"), "task");
 
-        board.update_card_prefix(Some("feature".to_string()));
+        board.update_card_prefix(Some("feature"));
         assert_eq!(board.effective_card_prefix("task"), "feature");
     }
 
     #[test]
     fn test_effective_branch_prefix_backward_compat() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
-        board.update_sprint_prefix(Some("custom".to_string()));
+        let mut board = Board::new("Test", None::<String>);
+        board.update_sprint_prefix(Some("custom"));
         assert_eq!(board.effective_branch_prefix("default"), "custom");
     }
 
     #[test]
     fn test_resolve_completion_column_fallback() {
-        let board = Board::new("Test".to_string(), None::<String>);
-        let col1 = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let col2 = crate::Column::new(board.id, "In Progress".to_string(), 1);
-        let col3 = crate::Column::new(board.id, "Done".to_string(), 2);
+        let board = Board::new("Test", None::<String>);
+        let col1 = crate::Column::new(board.id, "Todo", 0);
+        let col2 = crate::Column::new(board.id, "In Progress", 1);
+        let col3 = crate::Column::new(board.id, "Done", 2);
         let columns = vec![col1, col2, col3.clone()];
 
         assert_eq!(board.resolve_completion_column(&columns), Some(col3.id));
@@ -689,10 +689,10 @@ mod tests {
 
     #[test]
     fn test_resolve_completion_column_explicit() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
-        let col1 = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let col2 = crate::Column::new(board.id, "Done".to_string(), 1);
-        let col3 = crate::Column::new(board.id, "Archive".to_string(), 2);
+        let mut board = Board::new("Test", None::<String>);
+        let col1 = crate::Column::new(board.id, "Todo", 0);
+        let col2 = crate::Column::new(board.id, "Done", 1);
+        let col3 = crate::Column::new(board.id, "Archive", 2);
         let columns = vec![col1, col2.clone(), col3];
 
         board.update_completion_column_id(Some(col2.id));
@@ -701,9 +701,9 @@ mod tests {
 
     #[test]
     fn test_resolve_completion_column_stale_id_falls_back() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
-        let col1 = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let col2 = crate::Column::new(board.id, "Done".to_string(), 1);
+        let mut board = Board::new("Test", None::<String>);
+        let col1 = crate::Column::new(board.id, "Todo", 0);
+        let col2 = crate::Column::new(board.id, "Done", 1);
         let columns = vec![col1, col2.clone()];
 
         board.update_completion_column_id(Some(Uuid::new_v4()));
@@ -712,13 +712,13 @@ mod tests {
 
     #[test]
     fn test_resolve_completion_column_empty_columns() {
-        let board = Board::new("Test".to_string(), None::<String>);
+        let board = Board::new("Test", None::<String>);
         assert_eq!(board.resolve_completion_column(&[]), None);
     }
 
     #[test]
     fn test_sprint_counter_initialization() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         assert_eq!(board.get_sprint_counter("sprint"), None);
 
         let num = board.get_next_sprint_number("sprint");
@@ -728,7 +728,7 @@ mod tests {
 
     #[test]
     fn test_shared_sprint_sequence() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
 
         let num1 = board.get_next_sprint_number("SPRINT");
         assert_eq!(num1, 1);
@@ -744,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_initialize_sprint_counter() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         board.initialize_sprint_counter("RELEASE", 5);
 
         let num = board.get_next_sprint_number("RELEASE");
@@ -756,7 +756,7 @@ mod tests {
     fn test_ensure_sprint_counter_initialized_with_existing_sprints() {
         use crate::Sprint;
 
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
 
         let sprint1 = Sprint::new(board.id, 1, None, None::<String>);
         let sprint2 = Sprint::new(board.id, 2, None, None::<String>);
@@ -776,11 +776,11 @@ mod tests {
     fn test_ensure_sprint_counter_not_reinitialize() {
         use crate::Sprint;
 
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         board.initialize_sprint_counter("test", 10);
 
-        let sprint1 = Sprint::new(board.id, 1, None, Some("test".to_string()));
-        let sprint2 = Sprint::new(board.id, 2, None, Some("test".to_string()));
+        let sprint1 = Sprint::new(board.id, 1, None, Some("test"));
+        let sprint2 = Sprint::new(board.id, 2, None, Some("test"));
         let sprints = vec![sprint1, sprint2];
 
         board.ensure_sprint_counter_initialized("test", &sprints);
@@ -808,7 +808,7 @@ mod sort_field_serialization_tests {
 
     #[test]
     fn test_board_with_position_sort_serializes() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         board.update_task_sort(SortField::Position, SortOrder::Descending);
 
         let json = serde_json::to_string(&board).unwrap();

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -119,7 +119,12 @@ impl From<&Card> for CardSummary {
 }
 
 impl Card {
-    pub fn new(board: &mut Board, column_id: ColumnId, title: impl Into<String>, position: i32) -> Self {
+    pub fn new(
+        board: &mut Board,
+        column_id: ColumnId,
+        title: impl Into<String>,
+        position: i32,
+    ) -> Self {
         let now = Utc::now();
         let card_number = board.get_next_card_number();
         Self {
@@ -569,13 +574,7 @@ mod tests {
         assert_eq!(card.get_sprint_history().len(), 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
-        card.assign_to_sprint(
-            sprint_id_1,
-            1,
-            Some("Sprint 1"),
-            "Active",
-            Utc::now(),
-        );
+        card.assign_to_sprint(sprint_id_1, 1, Some("Sprint 1"), "Active", Utc::now());
 
         assert_eq!(card.get_sprint_history().len(), 1);
         assert_eq!(card.sprint_id, Some(sprint_id_1));
@@ -593,13 +592,7 @@ mod tests {
         let mut card = Card::new(&mut board, column_id, "Test Card", 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
-        card.assign_to_sprint(
-            sprint_id_1,
-            1,
-            Some("Sprint 1"),
-            "Active",
-            Utc::now(),
-        );
+        card.assign_to_sprint(sprint_id_1, 1, Some("Sprint 1"), "Active", Utc::now());
 
         card.end_current_sprint_log();
 
@@ -616,24 +609,12 @@ mod tests {
         let sprint_id_1 = uuid::Uuid::new_v4();
         let sprint_id_2 = uuid::Uuid::new_v4();
 
-        card.assign_to_sprint(
-            sprint_id_1,
-            1,
-            Some("Sprint 1"),
-            "Active",
-            Utc::now(),
-        );
+        card.assign_to_sprint(sprint_id_1, 1, Some("Sprint 1"), "Active", Utc::now());
         assert_eq!(card.sprint_id, Some(sprint_id_1));
         assert_eq!(card.get_sprint_history().len(), 1);
 
         card.end_current_sprint_log();
-        card.assign_to_sprint(
-            sprint_id_2,
-            2,
-            Some("Sprint 2"),
-            "Active",
-            Utc::now(),
-        );
+        card.assign_to_sprint(sprint_id_2, 2, Some("Sprint 2"), "Active", Utc::now());
 
         assert_eq!(card.sprint_id, Some(sprint_id_2));
         assert_eq!(card.get_sprint_history().len(), 2);
@@ -651,23 +632,11 @@ mod tests {
 
         let sprint_id = uuid::Uuid::new_v4();
 
-        card.assign_to_sprint(
-            sprint_id,
-            1,
-            Some("Sprint 1"),
-            "Active",
-            Utc::now(),
-        );
+        card.assign_to_sprint(sprint_id, 1, Some("Sprint 1"), "Active", Utc::now());
         assert_eq!(card.sprint_id, Some(sprint_id));
         assert_eq!(card.get_sprint_history().len(), 1);
 
-        card.assign_to_sprint(
-            sprint_id,
-            1,
-            Some("Sprint 1"),
-            "Active",
-            Utc::now(),
-        );
+        card.assign_to_sprint(sprint_id, 1, Some("Sprint 1"), "Active", Utc::now());
 
         assert_eq!(card.sprint_id, Some(sprint_id));
         assert_eq!(card.get_sprint_history().len(), 1);
@@ -686,13 +655,7 @@ mod tests {
         let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
         let sprint_id = uuid::Uuid::new_v4();
 
-        card.assign_to_sprint(
-            sprint_id,
-            1,
-            Some("Sprint 1"),
-            "Active",
-            fixed_time,
-        );
+        card.assign_to_sprint(sprint_id, 1, Some("Sprint 1"), "Active", fixed_time);
 
         assert_eq!(card.updated_at, fixed_time);
     }

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -119,13 +119,13 @@ impl From<&Card> for CardSummary {
 }
 
 impl Card {
-    pub fn new(board: &mut Board, column_id: ColumnId, title: String, position: i32) -> Self {
+    pub fn new(board: &mut Board, column_id: ColumnId, title: impl Into<String>, position: i32) -> Self {
         let now = Utc::now();
         let card_number = board.get_next_card_number();
         Self {
             id: Uuid::new_v4(),
             column_id,
-            title,
+            title: title.into(),
             description: None,
             priority: CardPriority::Medium,
             status: CardStatus::Todo,
@@ -168,13 +168,13 @@ impl Card {
         self.updated_at = Utc::now();
     }
 
-    pub fn update_title(&mut self, title: String) {
-        self.title = title;
+    pub fn update_title(&mut self, title: impl Into<String>) {
+        self.title = title.into();
         self.updated_at = Utc::now();
     }
 
-    pub fn update_description(&mut self, description: Option<String>) {
-        self.description = description;
+    pub fn update_description(&mut self, description: Option<impl Into<String>>) {
+        self.description = description.map(Into::into);
         self.updated_at = Utc::now();
     }
 
@@ -243,8 +243,8 @@ impl Card {
         &mut self,
         sprint_id: Uuid,
         sprint_number: u32,
-        sprint_name: Option<String>,
-        sprint_status: String,
+        sprint_name: Option<impl Into<String>>,
+        sprint_status: impl Into<String>,
         now: DateTime<Utc>,
     ) {
         // Only create a sprint log entry if the sprint assignment actually changes
@@ -335,7 +335,7 @@ mod tests {
     #[test]
     fn test_card_new_accepts_str_title_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board".to_string(), None);
+        let mut board = Board::new("board".to_string(), None::<String>);
         let card = Card::new(&mut board, column_id, "my card", 0);
         assert_eq!(card.title, "my card");
     }
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn test_card_update_title_accepts_str_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board".to_string(), None);
+        let mut board = Board::new("board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "initial".to_string(), 0);
         card.update_title("updated");
         assert_eq!(card.title, "updated");
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn test_card_update_description_accepts_str_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board".to_string(), None);
+        let mut board = Board::new("board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "card".to_string(), 0);
         card.update_description(Some("desc"));
         assert_eq!(card.description, Some("desc".to_string()));
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn test_card_assign_to_sprint_accepts_str_args_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board".to_string(), None);
+        let mut board = Board::new("board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "card".to_string(), 0);
         let sprint_id = uuid::Uuid::new_v4();
         card.assign_to_sprint(sprint_id, 1, Some("Sprint 1"), "Active", Utc::now());
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn test_card_new_uses_board_card_counter_no_prefix_arg() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         assert_eq!(board.card_counter, 1);
 
         let card1 = Card::new(&mut board, column_id, "Test Card 1".to_string(), 0);
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn test_card_sequential_numbers_increment_board_counter() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
 
         let cards: Vec<Card> = (0..5)
             .map(|i| Card::new(&mut board, column_id, format!("Card {}", i), i))
@@ -406,7 +406,7 @@ mod tests {
         let column_id = uuid::Uuid::new_v4();
         let mut board = Board::new("Test Board".to_string(), Some("KAN".to_string()));
         let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
-        let sprint = crate::sprint::Sprint::new(board.id, 1, None, None);
+        let sprint = crate::sprint::Sprint::new(board.id, 1, None, None::<String>);
         let mut card_with_sprint = card.clone();
         card_with_sprint.sprint_id = Some(sprint.id);
         let sprints = vec![sprint];
@@ -453,7 +453,7 @@ mod tests {
     #[test]
     fn test_branch_name_falls_back_to_default_when_no_board_prefix() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
         let sprints = vec![];
 
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn test_branch_name() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
         let sprints = vec![];
 
@@ -497,7 +497,7 @@ mod tests {
     fn test_branch_name_truncation() {
         let column_id = uuid::Uuid::new_v4();
         let long_title = "a".repeat(300);
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let card = Card::new(&mut board, column_id, long_title, 0);
         let sprints = vec![];
 
@@ -509,7 +509,7 @@ mod tests {
     #[test]
     fn test_git_checkout_command() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
         let sprints = vec![];
 
@@ -524,11 +524,11 @@ mod tests {
         use crate::sprint::{Sprint, SprintStatus};
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
 
         let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
 
-        let sprint = Sprint::new(board.id, 1, Some(0), None);
+        let sprint = Sprint::new(board.id, 1, Some(0), None::<String>);
         let mut card_with_sprint = card.clone();
         card_with_sprint.sprint_id = Some(sprint.id);
 
@@ -563,7 +563,7 @@ mod tests {
     #[test]
     fn test_sprint_logging() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
 
         assert_eq!(card.get_sprint_history().len(), 0);
@@ -589,7 +589,7 @@ mod tests {
     #[test]
     fn test_sprint_log_ending() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
@@ -610,7 +610,7 @@ mod tests {
     #[test]
     fn test_multiple_sprint_logs() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
@@ -646,7 +646,7 @@ mod tests {
     #[test]
     fn test_assign_same_sprint_no_duplicate() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
 
         let sprint_id = uuid::Uuid::new_v4();
@@ -681,7 +681,7 @@ mod tests {
         use chrono::TimeZone;
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
         let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
         let sprint_id = uuid::Uuid::new_v4();
@@ -702,7 +702,7 @@ mod tests {
         use chrono::TimeZone;
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
         let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
 

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -335,7 +335,7 @@ mod tests {
     #[test]
     fn test_card_new_accepts_str_title_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board".to_string(), None::<String>);
+        let mut board = Board::new("board", None::<String>);
         let card = Card::new(&mut board, column_id, "my card", 0);
         assert_eq!(card.title, "my card");
     }
@@ -343,8 +343,8 @@ mod tests {
     #[test]
     fn test_card_update_title_accepts_str_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "initial".to_string(), 0);
+        let mut board = Board::new("board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "initial", 0);
         card.update_title("updated");
         assert_eq!(card.title, "updated");
     }
@@ -352,8 +352,8 @@ mod tests {
     #[test]
     fn test_card_update_description_accepts_str_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "card".to_string(), 0);
+        let mut board = Board::new("board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "card", 0);
         card.update_description(Some("desc"));
         assert_eq!(card.description, Some("desc".to_string()));
     }
@@ -361,8 +361,8 @@ mod tests {
     #[test]
     fn test_card_assign_to_sprint_accepts_str_args_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "card".to_string(), 0);
+        let mut board = Board::new("board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "card", 0);
         let sprint_id = uuid::Uuid::new_v4();
         card.assign_to_sprint(sprint_id, 1, Some("Sprint 1"), "Active", Utc::now());
         assert_eq!(card.sprint_id, Some(sprint_id));
@@ -374,14 +374,14 @@ mod tests {
     #[test]
     fn test_card_new_uses_board_card_counter_no_prefix_arg() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
+        let mut board = Board::new("Test Board", None::<String>);
         assert_eq!(board.card_counter, 1);
 
-        let card1 = Card::new(&mut board, column_id, "Test Card 1".to_string(), 0);
+        let card1 = Card::new(&mut board, column_id, "Test Card 1", 0);
         assert_eq!(card1.card_number, 1);
         assert_eq!(board.card_counter, 2);
 
-        let card2 = Card::new(&mut board, column_id, "Test Card 2".to_string(), 1);
+        let card2 = Card::new(&mut board, column_id, "Test Card 2", 1);
         assert_eq!(card2.card_number, 2);
         assert_eq!(board.card_counter, 3);
     }
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn test_card_sequential_numbers_increment_board_counter() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
+        let mut board = Board::new("Test Board", None::<String>);
 
         let cards: Vec<Card> = (0..5)
             .map(|i| Card::new(&mut board, column_id, format!("Card {}", i), i))
@@ -404,8 +404,8 @@ mod tests {
     #[test]
     fn test_branch_name_falls_back_to_board_when_no_sprint_prefix() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), Some("KAN".to_string()));
-        let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", Some("KAN"));
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
         let sprint = crate::sprint::Sprint::new(board.id, 1, None, None::<String>);
         let mut card_with_sprint = card.clone();
         card_with_sprint.sprint_id = Some(sprint.id);
@@ -423,8 +423,8 @@ mod tests {
         use crate::sprint::{Sprint, SprintStatus};
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), Some("KAN".to_string()));
-        let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", Some("KAN"));
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
 
         let sprint_with_prefix = Sprint {
             id: uuid::Uuid::new_v4(),
@@ -453,8 +453,8 @@ mod tests {
     #[test]
     fn test_branch_name_falls_back_to_default_when_no_board_prefix() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
         let sprints = vec![];
 
         assert_eq!(
@@ -466,8 +466,8 @@ mod tests {
     #[test]
     fn test_branch_name() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
         let sprints = vec![];
 
         assert_eq!(
@@ -497,7 +497,7 @@ mod tests {
     fn test_branch_name_truncation() {
         let column_id = uuid::Uuid::new_v4();
         let long_title = "a".repeat(300);
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
+        let mut board = Board::new("Test Board", None::<String>);
         let card = Card::new(&mut board, column_id, long_title, 0);
         let sprints = vec![];
 
@@ -509,8 +509,8 @@ mod tests {
     #[test]
     fn test_git_checkout_command() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
         let sprints = vec![];
 
         assert_eq!(
@@ -524,9 +524,9 @@ mod tests {
         use crate::sprint::{Sprint, SprintStatus};
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
+        let mut board = Board::new("Test Board", None::<String>);
 
-        let card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
 
         let sprint = Sprint::new(board.id, 1, Some(0), None::<String>);
         let mut card_with_sprint = card.clone();
@@ -563,8 +563,8 @@ mod tests {
     #[test]
     fn test_sprint_logging() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
 
         assert_eq!(card.get_sprint_history().len(), 0);
 
@@ -572,8 +572,8 @@ mod tests {
         card.assign_to_sprint(
             sprint_id_1,
             1,
-            Some("Sprint 1".to_string()),
-            "Active".to_string(),
+            Some("Sprint 1"),
+            "Active",
             Utc::now(),
         );
 
@@ -589,15 +589,15 @@ mod tests {
     #[test]
     fn test_sprint_log_ending() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
         card.assign_to_sprint(
             sprint_id_1,
             1,
-            Some("Sprint 1".to_string()),
-            "Active".to_string(),
+            Some("Sprint 1"),
+            "Active",
             Utc::now(),
         );
 
@@ -610,8 +610,8 @@ mod tests {
     #[test]
     fn test_multiple_sprint_logs() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
         let sprint_id_2 = uuid::Uuid::new_v4();
@@ -619,8 +619,8 @@ mod tests {
         card.assign_to_sprint(
             sprint_id_1,
             1,
-            Some("Sprint 1".to_string()),
-            "Active".to_string(),
+            Some("Sprint 1"),
+            "Active",
             Utc::now(),
         );
         assert_eq!(card.sprint_id, Some(sprint_id_1));
@@ -630,8 +630,8 @@ mod tests {
         card.assign_to_sprint(
             sprint_id_2,
             2,
-            Some("Sprint 2".to_string()),
-            "Active".to_string(),
+            Some("Sprint 2"),
+            "Active",
             Utc::now(),
         );
 
@@ -646,16 +646,16 @@ mod tests {
     #[test]
     fn test_assign_same_sprint_no_duplicate() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
 
         let sprint_id = uuid::Uuid::new_v4();
 
         card.assign_to_sprint(
             sprint_id,
             1,
-            Some("Sprint 1".to_string()),
-            "Active".to_string(),
+            Some("Sprint 1"),
+            "Active",
             Utc::now(),
         );
         assert_eq!(card.sprint_id, Some(sprint_id));
@@ -664,8 +664,8 @@ mod tests {
         card.assign_to_sprint(
             sprint_id,
             1,
-            Some("Sprint 1".to_string()),
-            "Active".to_string(),
+            Some("Sprint 1"),
+            "Active",
             Utc::now(),
         );
 
@@ -681,16 +681,16 @@ mod tests {
         use chrono::TimeZone;
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
         let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
         let sprint_id = uuid::Uuid::new_v4();
 
         card.assign_to_sprint(
             sprint_id,
             1,
-            Some("Sprint 1".to_string()),
-            "Active".to_string(),
+            Some("Sprint 1"),
+            "Active",
             fixed_time,
         );
 
@@ -702,8 +702,8 @@ mod tests {
         use chrono::TimeZone;
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card".to_string(), 0);
+        let mut board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
         let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
 
         card.update(

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -333,6 +333,45 @@ mod tests {
     use crate::board::Board;
 
     #[test]
+    fn test_card_new_accepts_str_title_without_to_string() {
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("board".to_string(), None);
+        let card = Card::new(&mut board, column_id, "my card", 0);
+        assert_eq!(card.title, "my card");
+    }
+
+    #[test]
+    fn test_card_update_title_accepts_str_without_to_string() {
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("board".to_string(), None);
+        let mut card = Card::new(&mut board, column_id, "initial".to_string(), 0);
+        card.update_title("updated");
+        assert_eq!(card.title, "updated");
+    }
+
+    #[test]
+    fn test_card_update_description_accepts_str_without_to_string() {
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("board".to_string(), None);
+        let mut card = Card::new(&mut board, column_id, "card".to_string(), 0);
+        card.update_description(Some("desc"));
+        assert_eq!(card.description, Some("desc".to_string()));
+    }
+
+    #[test]
+    fn test_card_assign_to_sprint_accepts_str_args_without_to_string() {
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("board".to_string(), None);
+        let mut card = Card::new(&mut board, column_id, "card".to_string(), 0);
+        let sprint_id = uuid::Uuid::new_v4();
+        card.assign_to_sprint(sprint_id, 1, Some("Sprint 1"), "Active", Utc::now());
+        assert_eq!(card.sprint_id, Some(sprint_id));
+        let log = &card.sprint_logs[0];
+        assert_eq!(log.sprint_name, Some("Sprint 1".to_string()));
+        assert_eq!(log.status, "Active");
+    }
+
+    #[test]
     fn test_card_new_uses_board_card_counter_no_prefix_arg() {
         let column_id = uuid::Uuid::new_v4();
         let mut board = Board::new("Test Board".to_string(), None);

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -708,7 +708,9 @@ mod tests {
         let mut card_already_logged = test_card(&mut board, &col, "Already Logged", 1);
         card_already_logged.sprint_id = Some(sprint.id);
         card_already_logged.sprint_logs.push(SprintLog::new(
-            sprint.id, 1, None::<String>,
+            sprint.id,
+            1,
+            None::<String>,
             "Active",
         ));
         let already_logged_before = card_already_logged.sprint_logs.clone();

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -345,7 +345,7 @@ mod tests {
     use crate::Board;
 
     fn test_board() -> Board {
-        Board::new("Test".to_string(), None::<String>)
+        Board::new("Test", None::<String>)
     }
 
     fn add_columns(board: &Board, names: &[&str]) -> Vec<Column> {
@@ -381,7 +381,7 @@ mod tests {
         let board = test_board();
         let other_board = test_board();
         let mut cols = add_columns(&board, &["Mine"]);
-        cols.push(Column::new(other_board.id, "Other".to_string(), 0));
+        cols.push(Column::new(other_board.id, "Other", 0));
 
         let sorted = sorted_board_columns(board.id, &cols);
         assert_eq!(sorted.len(), 1);
@@ -563,7 +563,7 @@ mod tests {
     #[test]
     fn compact_resequences_positions() {
         let mut board = test_board();
-        let col = Column::new(board.id, "Todo".to_string(), 0);
+        let col = Column::new(board.id, "Todo", 0);
         let mut cards = vec![
             test_card(&mut board, &col, "A", 0),
             test_card(&mut board, &col, "B", 5),
@@ -579,8 +579,8 @@ mod tests {
     #[test]
     fn compact_only_affects_target_column() {
         let mut board = test_board();
-        let col1 = Column::new(board.id, "Todo".to_string(), 0);
-        let col2 = Column::new(board.id, "Done".to_string(), 1);
+        let col1 = Column::new(board.id, "Todo", 0);
+        let col2 = Column::new(board.id, "Done", 1);
         let mut cards = vec![
             test_card(&mut board, &col1, "A", 5),
             test_card(&mut board, &col2, "B", 99),
@@ -654,7 +654,7 @@ mod tests {
     #[test]
     fn migrate_backfills_empty_sprint_logs() {
         let mut board = test_board();
-        let col = Column::new(board.id, "Todo".to_string(), 0);
+        let col = Column::new(board.id, "Todo", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let mut card = test_card(&mut board, &col, "Task", 0);
         card.sprint_id = Some(sprint.id);
@@ -670,12 +670,12 @@ mod tests {
     #[test]
     fn migrate_skips_cards_with_existing_logs() {
         let mut board = test_board();
-        let col = Column::new(board.id, "Todo".to_string(), 0);
+        let col = Column::new(board.id, "Todo", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let mut card = test_card(&mut board, &col, "Task", 0);
         card.sprint_id = Some(sprint.id);
         card.sprint_logs
-            .push(SprintLog::new(sprint.id, 1, None::<String>, "Active".to_string()));
+            .push(SprintLog::new(sprint.id, 1, None::<String>, "Active"));
 
         let mut cards = vec![card];
         let count = migrate_sprint_logs(&mut cards, &[sprint], &[board]);
@@ -687,7 +687,7 @@ mod tests {
     #[test]
     fn migrate_skips_cards_without_sprint() {
         let mut board = test_board();
-        let col = Column::new(board.id, "Todo".to_string(), 0);
+        let col = Column::new(board.id, "Todo", 0);
         let card = test_card(&mut board, &col, "Task", 0);
 
         let mut cards = vec![card];
@@ -699,7 +699,7 @@ mod tests {
     #[test]
     fn migrate_with_mixed_cards_only_backfills_eligible() {
         let mut board = test_board();
-        let col = Column::new(board.id, "Todo".to_string(), 0);
+        let col = Column::new(board.id, "Todo", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
         let mut card_needs_backfill = test_card(&mut board, &col, "Needs Backfill", 0);
@@ -709,7 +709,7 @@ mod tests {
         card_already_logged.sprint_id = Some(sprint.id);
         card_already_logged.sprint_logs.push(SprintLog::new(
             sprint.id, 1, None::<String>,
-            "Active".to_string(),
+            "Active",
         ));
         let already_logged_before = card_already_logged.sprint_logs.clone();
 

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -345,7 +345,7 @@ mod tests {
     use crate::Board;
 
     fn test_board() -> Board {
-        Board::new("Test".to_string(), None)
+        Board::new("Test".to_string(), None::<String>)
     }
 
     fn add_columns(board: &Board, names: &[&str]) -> Vec<Column> {
@@ -655,7 +655,7 @@ mod tests {
     fn migrate_backfills_empty_sprint_logs() {
         let mut board = test_board();
         let col = Column::new(board.id, "Todo".to_string(), 0);
-        let sprint = Sprint::new(board.id, 1, None, None);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let mut card = test_card(&mut board, &col, "Task", 0);
         card.sprint_id = Some(sprint.id);
 
@@ -671,11 +671,11 @@ mod tests {
     fn migrate_skips_cards_with_existing_logs() {
         let mut board = test_board();
         let col = Column::new(board.id, "Todo".to_string(), 0);
-        let sprint = Sprint::new(board.id, 1, None, None);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let mut card = test_card(&mut board, &col, "Task", 0);
         card.sprint_id = Some(sprint.id);
         card.sprint_logs
-            .push(SprintLog::new(sprint.id, 1, None, "Active".to_string()));
+            .push(SprintLog::new(sprint.id, 1, None::<String>, "Active".to_string()));
 
         let mut cards = vec![card];
         let count = migrate_sprint_logs(&mut cards, &[sprint], &[board]);
@@ -700,7 +700,7 @@ mod tests {
     fn migrate_with_mixed_cards_only_backfills_eligible() {
         let mut board = test_board();
         let col = Column::new(board.id, "Todo".to_string(), 0);
-        let sprint = Sprint::new(board.id, 1, None, None);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
         let mut card_needs_backfill = test_card(&mut board, &col, "Needs Backfill", 0);
         card_needs_backfill.sprint_id = Some(sprint.id);
@@ -708,9 +708,7 @@ mod tests {
         let mut card_already_logged = test_card(&mut board, &col, "Already Logged", 1);
         card_already_logged.sprint_id = Some(sprint.id);
         card_already_logged.sprint_logs.push(SprintLog::new(
-            sprint.id,
-            1,
-            None,
+            sprint.id, 1, None::<String>,
             "Active".to_string(),
         ));
         let already_logged_before = card_already_logged.sprint_logs.clone();

--- a/crates/kanban-domain/src/column.rs
+++ b/crates/kanban-domain/src/column.rs
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn test_column_update_name_accepts_str_without_to_string() {
         let board_id = uuid::Uuid::new_v4();
-        let mut column = Column::new(board_id, "To Do".to_string(), 0);
+        let mut column = Column::new(board_id, "To Do", 0);
         column.update_name("In Progress");
         assert_eq!(column.name, "In Progress");
     }

--- a/crates/kanban-domain/src/column.rs
+++ b/crates/kanban-domain/src/column.rs
@@ -60,6 +60,26 @@ impl Column {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_column_new_accepts_str_name_without_to_string() {
+        let board_id = uuid::Uuid::new_v4();
+        let column = Column::new(board_id, "To Do", 0);
+        assert_eq!(column.name, "To Do");
+    }
+
+    #[test]
+    fn test_column_update_name_accepts_str_without_to_string() {
+        let board_id = uuid::Uuid::new_v4();
+        let mut column = Column::new(board_id, "To Do".to_string(), 0);
+        column.update_name("In Progress");
+        assert_eq!(column.name, "In Progress");
+    }
+}
+
 /// Partial update struct for Column
 ///
 /// Uses `FieldUpdate<T>` for optional fields to provide clear three-state updates.

--- a/crates/kanban-domain/src/column.rs
+++ b/crates/kanban-domain/src/column.rs
@@ -19,12 +19,12 @@ pub struct Column {
 }
 
 impl Column {
-    pub fn new(board_id: BoardId, name: String, position: i32) -> Self {
+    pub fn new(board_id: BoardId, name: impl Into<String>, position: i32) -> Self {
         let now = Utc::now();
         Self {
             id: Uuid::new_v4(),
             board_id,
-            name,
+            name: name.into(),
             position,
             wip_limit: None,
             created_at: now,
@@ -42,8 +42,8 @@ impl Column {
         self.updated_at = Utc::now();
     }
 
-    pub fn update_name(&mut self, name: String) {
-        self.name = name;
+    pub fn update_name(&mut self, name: impl Into<String>) {
+        self.name = name.into();
         self.updated_at = Utc::now();
     }
 

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -574,11 +574,11 @@ mod tests {
     #[test]
     fn test_import_entities_with_duplicate_board_id_returns_error() {
         let tc = TestContext::new();
-        let b1 = Board::new("B1".to_string(), None);
+        let b1 = Board::new("B1".to_string(), None::<String>);
         let dup_id = b1.id;
         tc.store.upsert_board(b1).unwrap();
 
-        let mut dup = Board::new("Dup".to_string(), None);
+        let mut dup = Board::new("Dup".to_string(), None::<String>);
         dup.id = dup_id;
 
         let cmd = ImportEntities {
@@ -626,10 +626,10 @@ mod tests {
     #[test]
     fn test_import_entities_appends_without_replacing() {
         let tc = TestContext::new();
-        let b1 = Board::new("B1".to_string(), None);
+        let b1 = Board::new("B1".to_string(), None::<String>);
         tc.store.upsert_board(b1).unwrap();
 
-        let b2 = Board::new("B2".to_string(), None);
+        let b2 = Board::new("B2".to_string(), None::<String>);
         let col = crate::Column::new(b2.id, "Todo".to_string(), 0);
         let mut b2_clone = b2.clone();
         let card = crate::Card::new(&mut b2_clone, col.id, "Card".to_string(), 0);

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -574,11 +574,11 @@ mod tests {
     #[test]
     fn test_import_entities_with_duplicate_board_id_returns_error() {
         let tc = TestContext::new();
-        let b1 = Board::new("B1".to_string(), None::<String>);
+        let b1 = Board::new("B1", None::<String>);
         let dup_id = b1.id;
         tc.store.upsert_board(b1).unwrap();
 
-        let mut dup = Board::new("Dup".to_string(), None::<String>);
+        let mut dup = Board::new("Dup", None::<String>);
         dup.id = dup_id;
 
         let cmd = ImportEntities {
@@ -598,15 +598,15 @@ mod tests {
     #[test]
     fn test_import_entities_with_duplicate_card_id_returns_error() {
         let tc = TestContext::new();
-        let mut board = Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let card = crate::Card::new(&mut board, col.id, "Card".to_string(), 0);
+        let mut board = Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let card = crate::Card::new(&mut board, col.id, "Card", 0);
         let dup_card_id = card.id;
         tc.store.upsert_board(board.clone()).unwrap();
         tc.store.upsert_column(col).unwrap();
         tc.store.upsert_card(card).unwrap();
 
-        let mut dup_card = crate::Card::new(&mut board, Uuid::new_v4(), "Dup".to_string(), 0);
+        let mut dup_card = crate::Card::new(&mut board, Uuid::new_v4(), "Dup", 0);
         dup_card.id = dup_card_id;
 
         let cmd = ImportEntities {
@@ -626,13 +626,13 @@ mod tests {
     #[test]
     fn test_import_entities_appends_without_replacing() {
         let tc = TestContext::new();
-        let b1 = Board::new("B1".to_string(), None::<String>);
+        let b1 = Board::new("B1", None::<String>);
         tc.store.upsert_board(b1).unwrap();
 
-        let b2 = Board::new("B2".to_string(), None::<String>);
-        let col = crate::Column::new(b2.id, "Todo".to_string(), 0);
+        let b2 = Board::new("B2", None::<String>);
+        let col = crate::Column::new(b2.id, "Todo", 0);
         let mut b2_clone = b2.clone();
-        let card = crate::Card::new(&mut b2_clone, col.id, "Card".to_string(), 0);
+        let card = crate::Card::new(&mut b2_clone, col.id, "Card", 0);
 
         let cmd = ImportEntities {
             boards: vec![b2],
@@ -657,7 +657,7 @@ mod tests {
     #[test]
     fn test_update_board_card_prefix_allowed_before_first_card_succeeds() {
         let tc = TestContext::new();
-        let board = Board::new("B".to_string(), Some("OLD".to_string()));
+        let board = Board::new("B", Some("OLD"));
         let board_id = board.id;
         tc.store.upsert_board(board).unwrap();
         let context = tc.as_command_context();
@@ -677,10 +677,10 @@ mod tests {
     #[test]
     fn test_update_board_card_prefix_locked_after_first_card_returns_validation_error() {
         let tc = TestContext::new();
-        let mut board = Board::new("B".to_string(), Some("OLD".to_string()));
+        let mut board = Board::new("B", Some("OLD"));
         let board_id = board.id;
-        let col = Column::new(board_id, "Col".to_string(), 0);
-        let _card = Card::new(&mut board, col.id, "C".to_string(), 0);
+        let col = Column::new(board_id, "Col", 0);
+        let _card = Card::new(&mut board, col.id, "C", 0);
         // card_counter is now 2 (incremented past initial 1)
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
@@ -700,10 +700,10 @@ mod tests {
     #[test]
     fn test_update_board_clear_card_prefix_locked_after_first_card_returns_validation_error() {
         let tc = TestContext::new();
-        let mut board = Board::new("B".to_string(), Some("OLD".to_string()));
+        let mut board = Board::new("B", Some("OLD"));
         let board_id = board.id;
-        let col = Column::new(board_id, "Col".to_string(), 0);
-        let _card = Card::new(&mut board, col.id, "C".to_string(), 0);
+        let col = Column::new(board_id, "Col", 0);
+        let _card = Card::new(&mut board, col.id, "C", 0);
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
         let context = tc.as_command_context();
@@ -722,9 +722,9 @@ mod tests {
     #[test]
     fn test_delete_board_atomic_removes_only_board_record() {
         let tc = TestContext::new();
-        let board = Board::new("B".to_string(), Some("TST".to_string()));
+        let board = Board::new("B", Some("TST"));
         let board_id = board.id;
-        let col = Column::new(board_id, "Col".to_string(), 0);
+        let col = Column::new(board_id, "Col", 0);
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col.clone()).unwrap();
 

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -743,7 +743,7 @@ mod tests {
     #[test]
     fn test_move_card_not_found_returns_error() {
         let tc = TestContext::new();
-        let column = crate::Column::new(Uuid::new_v4(), "Col".to_string(), 0);
+        let column = crate::Column::new(Uuid::new_v4(), "Col", 0);
         let column_id = column.id;
         tc.store.upsert_column(column).unwrap();
         let context = tc.as_command_context();
@@ -759,8 +759,8 @@ mod tests {
     #[test]
     fn test_move_card_column_not_found_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
         let card_id = card.id;
         tc.store.upsert_card(card).unwrap();
         let context = tc.as_command_context();
@@ -787,8 +787,8 @@ mod tests {
     #[test]
     fn test_archive_cards_invalid_ids_skipped_valid_ids_archived() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
         let valid_id = card.id;
         tc.store.upsert_card(card).unwrap();
 
@@ -805,11 +805,11 @@ mod tests {
     #[test]
     fn test_create_card_exceeding_wip_limit_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let mut column = crate::Column::new(board.id, "Limited".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let mut column = crate::Column::new(board.id, "Limited", 0);
         column.wip_limit = Some(1);
         let column_id = column.id;
-        let existing = crate::Card::new(&mut board, column_id, "Existing".to_string(), 0);
+        let existing = crate::Card::new(&mut board, column_id, "Existing", 0);
         let board_id = board.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(column).unwrap();
@@ -833,12 +833,12 @@ mod tests {
     #[test]
     fn test_create_card_at_wip_limit_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let mut column = crate::Column::new(board.id, "Limited".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let mut column = crate::Column::new(board.id, "Limited", 0);
         column.wip_limit = Some(2);
         let column_id = column.id;
-        let card1 = crate::Card::new(&mut board, column_id, "C1".to_string(), 0);
-        let card2 = crate::Card::new(&mut board, column_id, "C2".to_string(), 1);
+        let card1 = crate::Card::new(&mut board, column_id, "C1", 0);
+        let card2 = crate::Card::new(&mut board, column_id, "C2", 1);
         let board_id = board.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(column).unwrap();
@@ -863,11 +863,11 @@ mod tests {
     #[test]
     fn test_create_card_below_wip_limit_succeeds() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let mut column = crate::Column::new(board.id, "Limited".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let mut column = crate::Column::new(board.id, "Limited", 0);
         column.wip_limit = Some(2);
         let column_id = column.id;
-        let card1 = crate::Card::new(&mut board, column_id, "C1".to_string(), 0);
+        let card1 = crate::Card::new(&mut board, column_id, "C1", 0);
         let board_id = board.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(column).unwrap();
@@ -890,13 +890,13 @@ mod tests {
     #[test]
     fn test_move_card_exceeding_wip_limit_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let src_col = crate::Column::new(board.id, "Source".to_string(), 0);
-        let mut dst_col = crate::Column::new(board.id, "Dest".to_string(), 1);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let src_col = crate::Column::new(board.id, "Source", 0);
+        let mut dst_col = crate::Column::new(board.id, "Dest", 1);
         dst_col.wip_limit = Some(1);
         let dst_id = dst_col.id;
-        let existing = crate::Card::new(&mut board, dst_id, "Existing".to_string(), 0);
-        let mover = crate::Card::new(&mut board, src_col.id, "Mover".to_string(), 0);
+        let existing = crate::Card::new(&mut board, dst_id, "Existing", 0);
+        let mover = crate::Card::new(&mut board, src_col.id, "Mover", 0);
         let mover_id = mover.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(src_col).unwrap();
@@ -917,10 +917,10 @@ mod tests {
     #[test]
     fn test_restore_card_to_deleted_column_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let col_id = col.id;
-        let card = crate::Card::new(&mut board, col_id, "Card".to_string(), 0);
+        let card = crate::Card::new(&mut board, col_id, "Card", 0);
         let card_id = card.id;
         let archived = crate::ArchivedCard::new(card, col_id, 0);
         tc.store.upsert_board(board).unwrap();
@@ -941,10 +941,10 @@ mod tests {
     #[test]
     fn test_restore_card_to_valid_column_succeeds() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let col_id = col.id;
-        let card = crate::Card::new(&mut board, col_id, "Card".to_string(), 0);
+        let card = crate::Card::new(&mut board, col_id, "Card", 0);
         let card_id = card.id;
         let archived = crate::ArchivedCard::new(card, col_id, 0);
         tc.store.upsert_board(board).unwrap();
@@ -966,12 +966,12 @@ mod tests {
     #[test]
     fn test_restore_card_exceeding_wip_limit_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let mut col = crate::Column::new(board.id, "Col", 0);
         col.wip_limit = Some(1);
         let col_id = col.id;
-        let existing = crate::Card::new(&mut board, col_id, "Existing".to_string(), 0);
-        let card = crate::Card::new(&mut board, col_id, "Card".to_string(), 1);
+        let existing = crate::Card::new(&mut board, col_id, "Existing", 0);
+        let card = crate::Card::new(&mut board, col_id, "Card", 1);
         let card_id = card.id;
         let archived = crate::ArchivedCard::new(card, col_id, 0);
         tc.store.upsert_board(board).unwrap();
@@ -1007,8 +1007,8 @@ mod tests {
     #[test]
     fn test_assign_cards_to_sprint_validates_sprint_exists() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
         let card_id = card.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_card(card).unwrap();
@@ -1025,10 +1025,10 @@ mod tests {
     #[test]
     fn test_assign_cards_to_sprint_invalid_ids_skipped_valid_ids_assigned() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
         let valid_id = card.id;
-        let sprint = crate::Sprint::new(board.id, 1, None, Some("Sprint".to_string()));
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("Sprint"));
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_card(card).unwrap();
@@ -1060,8 +1060,8 @@ mod tests {
     #[test]
     fn test_archive_cards_missing_card_after_filter_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), Some("TST".to_string()));
-        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card".to_string(), 0);
+        let mut board = crate::Board::new("Test", Some("TST"));
+        let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
         let card_id = card.id;
         tc.store.upsert_card(card).unwrap();
 
@@ -1080,12 +1080,12 @@ mod tests {
     #[test]
     fn test_compact_column_positions_makes_sequential() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let column_id = col.id;
-        let mut card1 = crate::Card::new(&mut board, column_id, "C1".to_string(), 0);
+        let mut card1 = crate::Card::new(&mut board, column_id, "C1", 0);
         card1.position = 0;
-        let mut card2 = crate::Card::new(&mut board, column_id, "C2".to_string(), 5);
+        let mut card2 = crate::Card::new(&mut board, column_id, "C2", 5);
         card2.position = 5;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
@@ -1104,8 +1104,8 @@ mod tests {
     #[test]
     fn test_create_card_with_sprint_id_assigns_card_to_sprint() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         let board_id = board.id;
         let column_id = col.id;
@@ -1142,8 +1142,8 @@ mod tests {
     #[test]
     fn test_create_card_without_sprint_id_leaves_card_unassigned() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let board_id = board.id;
         let column_id = col.id;
         tc.store.upsert_board(board).unwrap();
@@ -1171,8 +1171,8 @@ mod tests {
     #[test]
     fn test_create_card_with_invalid_sprint_id_returns_not_found_error() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let board_id = board.id;
         let column_id = col.id;
         tc.store.upsert_board(board).unwrap();
@@ -1201,8 +1201,8 @@ mod tests {
         use chrono::TimeZone;
 
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let board_id = board.id;
         let column_id = col.id;
         tc.store.upsert_board(board).unwrap();
@@ -1243,8 +1243,8 @@ mod tests {
         use chrono::TimeZone;
 
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         let board_id = board.id;
         let column_id = col.id;
@@ -1287,9 +1287,9 @@ mod tests {
     #[test]
     fn test_create_card_with_sprint_from_different_board_returns_validation_error() {
         let tc = TestContext::new();
-        let board_a = crate::Board::new("A".to_string(), Some("AAA".to_string()));
-        let board_b = crate::Board::new("B".to_string(), Some("BBB".to_string()));
-        let col_a = crate::Column::new(board_a.id, "Col".to_string(), 0);
+        let board_a = crate::Board::new("A", Some("AAA"));
+        let board_b = crate::Board::new("B", Some("BBB"));
+        let col_a = crate::Column::new(board_a.id, "Col", 0);
         // Sprint belongs to board B.
         let sprint_b = crate::Sprint::new(board_b.id, 1, None, None::<String>);
         let board_a_id = board_a.id;
@@ -1326,8 +1326,8 @@ mod tests {
         use chrono::{TimeZone, Utc};
 
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let board_id = board.id;
         let column_id = col.id;
         tc.store.upsert_board(board).unwrap();
@@ -1358,12 +1358,12 @@ mod tests {
         use chrono::{TimeZone, Utc};
 
         let tc = TestContext::new();
-        let col = crate::Column::new(Uuid::new_v4(), "Col".to_string(), 0);
+        let col = crate::Column::new(Uuid::new_v4(), "Col", 0);
         let column_id = col.id;
         tc.store.upsert_column(col).unwrap();
 
-        let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let card = crate::Card::new(&mut board, column_id, "Card".to_string(), 0);
+        let mut board = crate::Board::new("B", Some("TST"));
+        let card = crate::Card::new(&mut board, column_id, "Card", 0);
         let card_id = card.id;
         let archived = crate::ArchivedCard::new(card, column_id, 0);
         tc.store.insert_archived_card(archived).unwrap();
@@ -1387,9 +1387,9 @@ mod tests {
         use chrono::{TimeZone, Utc};
 
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let mut card = crate::Card::new(&mut board, col.id, "Card".to_string(), 0);
+        let mut board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let mut card = crate::Card::new(&mut board, col.id, "Card", 0);
         let card_id = card.id;
         card.sprint_id = Some(Uuid::new_v4());
         tc.store.upsert_card(card).unwrap();

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -1106,7 +1106,7 @@ mod tests {
         let tc = TestContext::new();
         let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
         let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board.id, 1, None, None);
+        let sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         let board_id = board.id;
         let column_id = col.id;
         let sprint_id = sprint.id;
@@ -1245,7 +1245,7 @@ mod tests {
         let tc = TestContext::new();
         let mut board = crate::Board::new("B".to_string(), Some("TST".to_string()));
         let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board.id, 1, None, None);
+        let sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         let board_id = board.id;
         let column_id = col.id;
         let sprint_id = sprint.id;
@@ -1291,7 +1291,7 @@ mod tests {
         let board_b = crate::Board::new("B".to_string(), Some("BBB".to_string()));
         let col_a = crate::Column::new(board_a.id, "Col".to_string(), 0);
         // Sprint belongs to board B.
-        let sprint_b = crate::Sprint::new(board_b.id, 1, None, None);
+        let sprint_b = crate::Sprint::new(board_b.id, 1, None, None::<String>);
         let board_a_id = board_a.id;
         let column_id = col_a.id;
         let sprint_b_id = sprint_b.id;

--- a/crates/kanban-domain/src/commands/cascade_commands.rs
+++ b/crates/kanban-domain/src/commands/cascade_commands.rs
@@ -412,9 +412,9 @@ mod tests {
     #[test]
     fn test_delete_sprints_by_board_removes_all_sprints_of_board() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), None::<String>);
+        let board = crate::Board::new("B", None::<String>);
         let board_id = board.id;
-        let other_board = crate::Board::new("Other".to_string(), None::<String>);
+        let other_board = crate::Board::new("Other", None::<String>);
         let other_board_id = other_board.id;
         let sprint1 = crate::Sprint::new(board_id, 1, None, None::<String>);
         let sprint2 = crate::Sprint::new(board_id, 2, None, None::<String>);

--- a/crates/kanban-domain/src/commands/cascade_commands.rs
+++ b/crates/kanban-domain/src/commands/cascade_commands.rs
@@ -325,13 +325,13 @@ mod tests {
     #[test]
     fn test_delete_cards_by_columns_removes_only_cards_in_given_columns() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".into(), Some("TST".into()));
-        let col1 = crate::Column::new(board.id, "C1".into(), 0);
-        let col2 = crate::Column::new(board.id, "C2".into(), 1);
-        let col3 = crate::Column::new(board.id, "C3".into(), 2);
-        let card1 = crate::Card::new(&mut board, col1.id, "1".into(), 0);
-        let card2 = crate::Card::new(&mut board, col2.id, "2".into(), 0);
-        let card3 = crate::Card::new(&mut board, col3.id, "3".into(), 0);
+        let mut board = crate::Board::new("B", Some("TST"));
+        let col1 = crate::Column::new(board.id, "C1", 0);
+        let col2 = crate::Column::new(board.id, "C2", 1);
+        let col3 = crate::Column::new(board.id, "C3", 2);
+        let card1 = crate::Card::new(&mut board, col1.id, "1", 0);
+        let card2 = crate::Card::new(&mut board, col2.id, "2", 0);
+        let card3 = crate::Card::new(&mut board, col3.id, "3", 0);
         let card3_id = card3.id;
         let col3_id = col3.id;
         tc.store.upsert_board(board).unwrap();
@@ -357,13 +357,13 @@ mod tests {
     #[test]
     fn test_delete_archived_cards_by_columns_removes_only_archived_in_given_columns() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".into(), Some("TST".into()));
-        let col1 = crate::Column::new(board.id, "C1".into(), 0);
-        let col2 = crate::Column::new(board.id, "C2".into(), 1);
+        let mut board = crate::Board::new("B", Some("TST"));
+        let col1 = crate::Column::new(board.id, "C1", 0);
+        let col2 = crate::Column::new(board.id, "C2", 1);
         let col1_id = col1.id;
         let col2_id = col2.id;
-        let card1 = crate::Card::new(&mut board, col1_id, "1".into(), 0);
-        let card2 = crate::Card::new(&mut board, col2_id, "2".into(), 0);
+        let card1 = crate::Card::new(&mut board, col1_id, "1", 0);
+        let card2 = crate::Card::new(&mut board, col2_id, "2", 0);
         let arch1 = crate::ArchivedCard::new(card1, col1_id, 0);
         let arch2 = crate::ArchivedCard::new(card2, col2_id, 0);
         let arch2_card_id = arch2.card.id;
@@ -387,13 +387,13 @@ mod tests {
     #[test]
     fn test_delete_columns_by_board_removes_all_columns_of_board() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".into(), None);
+        let board = crate::Board::new("B", None::<String>);
         let board_id = board.id;
-        let other_board = crate::Board::new("Other".into(), None);
+        let other_board = crate::Board::new("Other", None::<String>);
         let other_board_id = other_board.id;
-        let col1 = crate::Column::new(board_id, "C1".into(), 0);
-        let col2 = crate::Column::new(board_id, "C2".into(), 1);
-        let other_col = crate::Column::new(other_board_id, "OC".into(), 0);
+        let col1 = crate::Column::new(board_id, "C1", 0);
+        let col2 = crate::Column::new(board_id, "C2", 1);
+        let other_col = crate::Column::new(other_board_id, "OC", 0);
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_board(other_board).unwrap();
         tc.store.upsert_column(col1).unwrap();
@@ -412,13 +412,13 @@ mod tests {
     #[test]
     fn test_delete_sprints_by_board_removes_all_sprints_of_board() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), None);
+        let board = crate::Board::new("B".to_string(), None::<String>);
         let board_id = board.id;
-        let other_board = crate::Board::new("Other".to_string(), None);
+        let other_board = crate::Board::new("Other".to_string(), None::<String>);
         let other_board_id = other_board.id;
-        let sprint1 = crate::Sprint::new(board_id, 1, None, None);
-        let sprint2 = crate::Sprint::new(board_id, 2, None, None);
-        let other_sprint = crate::Sprint::new(other_board_id, 1, None, None);
+        let sprint1 = crate::Sprint::new(board_id, 1, None, None::<String>);
+        let sprint2 = crate::Sprint::new(board_id, 2, None, None::<String>);
+        let other_sprint = crate::Sprint::new(other_board_id, 1, None, None::<String>);
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_board(other_board).unwrap();
         tc.store.upsert_sprint(sprint1).unwrap();

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -1084,7 +1084,7 @@ mod tests {
         let tc = TestContext::new();
         let column_id = Uuid::new_v4();
 
-        let mut board = Board::new("Test Board".to_string(), None);
+        let mut board = Board::new("Test Board".to_string(), None::<String>);
         board.card_prefix = Some("TEST".to_string());
         let board_id = board.id;
         let parent = crate::Card::new(&mut board, column_id, "Parent".to_string(), 0);

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -1084,10 +1084,10 @@ mod tests {
         let tc = TestContext::new();
         let column_id = Uuid::new_v4();
 
-        let mut board = Board::new("Test Board".to_string(), None::<String>);
+        let mut board = Board::new("Test Board", None::<String>);
         board.card_prefix = Some("TEST".to_string());
         let board_id = board.id;
-        let parent = crate::Card::new(&mut board, column_id, "Parent".to_string(), 0);
+        let parent = crate::Card::new(&mut board, column_id, "Parent", 0);
         let parent_id = parent.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_card(parent).unwrap();
@@ -1119,8 +1119,8 @@ mod tests {
     #[test]
     fn test_create_subcard_with_nonexistent_parent_returns_not_found() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("TST".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let board_id = board.id;
         let column_id = col.id;
         tc.store.upsert_board(board).unwrap();

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -154,10 +154,10 @@ mod tests {
     #[test]
     fn test_check_wip_limit_no_limit_always_ok() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), None::<String>);
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("B", None::<String>);
+        let col = crate::Column::new(board.id, "Col", 0);
         let col_id = col.id;
-        let card = crate::Card::new(&mut board, col_id, "C".to_string(), 0);
+        let card = crate::Card::new(&mut board, col_id, "C", 0);
         tc.store.upsert_column(col).unwrap();
         tc.store.upsert_card(card).unwrap();
         let ctx = tc.as_command_context();
@@ -167,11 +167,11 @@ mod tests {
     #[test]
     fn test_check_wip_limit_below_limit_ok() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), None::<String>);
-        let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("B", None::<String>);
+        let mut col = crate::Column::new(board.id, "Col", 0);
         col.wip_limit = Some(2);
         let col_id = col.id;
-        let card = crate::Card::new(&mut board, col_id, "C".to_string(), 0);
+        let card = crate::Card::new(&mut board, col_id, "C", 0);
         tc.store.upsert_column(col).unwrap();
         tc.store.upsert_card(card).unwrap();
         let ctx = tc.as_command_context();
@@ -181,11 +181,11 @@ mod tests {
     #[test]
     fn test_check_wip_limit_at_limit_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), None::<String>);
-        let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("B", None::<String>);
+        let mut col = crate::Column::new(board.id, "Col", 0);
         col.wip_limit = Some(1);
         let col_id = col.id;
-        let card = crate::Card::new(&mut board, col_id, "C".to_string(), 0);
+        let card = crate::Card::new(&mut board, col_id, "C", 0);
         tc.store.upsert_column(col).unwrap();
         tc.store.upsert_card(card).unwrap();
         let ctx = tc.as_command_context();
@@ -196,11 +196,11 @@ mod tests {
     #[test]
     fn test_check_wip_limit_exclude_reduces_count() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), None::<String>);
-        let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let mut board = crate::Board::new("B", None::<String>);
+        let mut col = crate::Column::new(board.id, "Col", 0);
         col.wip_limit = Some(1);
         let col_id = col.id;
-        let card = crate::Card::new(&mut board, col_id, "C".to_string(), 0);
+        let card = crate::Card::new(&mut board, col_id, "C", 0);
         let card_id = card.id;
         tc.store.upsert_column(col).unwrap();
         tc.store.upsert_card(card).unwrap();
@@ -211,8 +211,8 @@ mod tests {
     #[test]
     fn test_check_wip_limit_batch_exceeds_limit_returns_error() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), None::<String>);
-        let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board = crate::Board::new("B", None::<String>);
+        let mut col = crate::Column::new(board.id, "Col", 0);
         col.wip_limit = Some(1);
         let col_id = col.id;
         tc.store.upsert_board(board).unwrap();
@@ -306,8 +306,8 @@ mod tests {
 
     #[test]
     fn test_command_serde_roundtrip_import_entities() {
-        let board = crate::Board::new("Imported".to_string(), Some("IMP".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
+        let board = crate::Board::new("Imported", Some("IMP"));
+        let col = crate::Column::new(board.id, "Col", 0);
         let cmd = Command::Board(BoardCommand::Import(ImportEntities {
             boards: vec![board],
             columns: vec![col],

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn test_check_wip_limit_no_limit_always_ok() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), None);
+        let mut board = crate::Board::new("B".to_string(), None::<String>);
         let col = crate::Column::new(board.id, "Col".to_string(), 0);
         let col_id = col.id;
         let card = crate::Card::new(&mut board, col_id, "C".to_string(), 0);
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_check_wip_limit_below_limit_ok() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), None);
+        let mut board = crate::Board::new("B".to_string(), None::<String>);
         let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
         col.wip_limit = Some(2);
         let col_id = col.id;
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn test_check_wip_limit_at_limit_returns_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), None);
+        let mut board = crate::Board::new("B".to_string(), None::<String>);
         let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
         col.wip_limit = Some(1);
         let col_id = col.id;
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn test_check_wip_limit_exclude_reduces_count() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), None);
+        let mut board = crate::Board::new("B".to_string(), None::<String>);
         let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
         col.wip_limit = Some(1);
         let col_id = col.id;
@@ -211,7 +211,7 @@ mod tests {
     #[test]
     fn test_check_wip_limit_batch_exceeds_limit_returns_error() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), None);
+        let board = crate::Board::new("B".to_string(), None::<String>);
         let mut col = crate::Column::new(board.id, "Col".to_string(), 0);
         col.wip_limit = Some(1);
         let col_id = col.id;

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -521,7 +521,7 @@ mod tests {
     fn test_update_sprint_name_with_nonexistent_board_returns_error() {
         let tc = TestContext::new();
         let nonexistent_board_id = Uuid::new_v4();
-        let sprint = crate::Sprint::new(nonexistent_board_id, 1, None, None);
+        let sprint = crate::Sprint::new(nonexistent_board_id, 1, None, None::<String>);
         let sprint_id = sprint.id;
         tc.store.upsert_sprint(sprint).unwrap();
 
@@ -574,7 +574,7 @@ mod tests {
     #[test]
     fn test_create_sprint_auto_consume_name_uses_name_pool() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), None);
+        let mut board = crate::Board::new("Test".to_string(), None::<String>);
         board.sprint_names = vec!["Alpha".to_string(), "Beta".to_string()];
         let board_id = board.id;
         tc.store.upsert_board(board).unwrap();
@@ -730,9 +730,9 @@ mod tests {
         let tc = TestContext::new();
         let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
         let board_id = board.id;
-        let mut sprint1 = crate::Sprint::new(board_id, 1, None, None);
+        let mut sprint1 = crate::Sprint::new(board_id, 1, None, None::<String>);
         sprint1.card_prefix = Some("SPR".to_string());
-        let sprint2 = crate::Sprint::new(board_id, 2, None, None);
+        let sprint2 = crate::Sprint::new(board_id, 2, None, None::<String>);
         let sprint2_id = sprint2.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint1).unwrap();
@@ -758,7 +758,7 @@ mod tests {
         let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
         let board_id = board.id;
         let col = crate::Column::new(board_id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board_id, 1, None, None);
+        let sprint = crate::Sprint::new(board_id, 1, None, None::<String>);
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col.clone()).unwrap();
@@ -798,7 +798,7 @@ mod tests {
         let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
         let board_id = board.id;
         let col = crate::Column::new(board_id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board_id, 1, None, None);
+        let sprint = crate::Sprint::new(board_id, 1, None, None::<String>);
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col.clone()).unwrap();
@@ -903,7 +903,7 @@ mod tests {
         let tc = TestContext::new();
         let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
         let board_id = board.id;
-        let sprint = crate::Sprint::new(board_id, 1, None, None);
+        let sprint = crate::Sprint::new(board_id, 1, None, None::<String>);
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
@@ -957,9 +957,9 @@ mod tests {
         let tc = TestContext::new();
         let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
         let board_id = board.id;
-        let mut sprint1 = crate::Sprint::new(board_id, 1, None, None);
+        let mut sprint1 = crate::Sprint::new(board_id, 1, None, None::<String>);
         sprint1.card_prefix = Some("SPR".to_string());
-        let sprint2 = crate::Sprint::new(board_id, 2, None, None);
+        let sprint2 = crate::Sprint::new(board_id, 2, None, None::<String>);
         let sprint2_id = sprint2.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint1).unwrap();

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -764,12 +764,7 @@ mod tests {
         tc.store.upsert_column(col.clone()).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
 
-        let mut card = crate::Card::new(
-            &mut crate::Board::new("B", Some("KAN")),
-            col.id,
-            "C".to_string(),
-            0,
-        );
+        let mut card = crate::Card::new(&mut crate::Board::new("B", Some("KAN")), col.id, "C", 0);
         card.sprint_id = Some(sprint_id);
         let card_id = card.id;
         tc.store.upsert_card(card).unwrap();

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -574,7 +574,7 @@ mod tests {
     #[test]
     fn test_create_sprint_auto_consume_name_uses_name_pool() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("Test".to_string(), None::<String>);
+        let mut board = crate::Board::new("Test", None::<String>);
         board.sprint_names = vec!["Alpha".to_string(), "Beta".to_string()];
         let board_id = board.id;
         tc.store.upsert_board(board).unwrap();
@@ -604,11 +604,11 @@ mod tests {
     #[test]
     fn test_update_sprint_card_prefix_locked_after_card_assigned_returns_validation_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let mut board = crate::Board::new("B", Some("KAN"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
-        let mut card = crate::Card::new(&mut board, col.id, "C".to_string(), 0);
+        let mut card = crate::Card::new(&mut board, col.id, "C", 0);
         card.sprint_id = Some(sprint_id);
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
@@ -631,11 +631,11 @@ mod tests {
     fn test_update_sprint_card_prefix_locked_after_archived_card_assigned_returns_validation_error()
     {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let mut board = crate::Board::new("B", Some("KAN"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
-        let mut card = crate::Card::new(&mut board, col.id, "C".to_string(), 0);
+        let mut card = crate::Card::new(&mut board, col.id, "C", 0);
         card.sprint_id = Some(sprint_id);
         let archived = crate::ArchivedCard::new(card, col.id, 0);
         tc.store.upsert_board(board).unwrap();
@@ -658,11 +658,11 @@ mod tests {
     #[test]
     fn test_update_sprint_clear_card_prefix_locked_after_card_assigned_returns_validation_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let mut board = crate::Board::new("B", Some("KAN"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
-        let mut card = crate::Card::new(&mut board, col.id, "C".to_string(), 0);
+        let mut card = crate::Card::new(&mut board, col.id, "C", 0);
         card.sprint_id = Some(sprint_id);
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
@@ -684,9 +684,9 @@ mod tests {
     #[test]
     fn test_update_sprint_card_prefix_collides_with_board_prefix_returns_validation_error() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
-        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
@@ -706,9 +706,9 @@ mod tests {
     #[test]
     fn test_update_sprint_card_prefix_case_insensitive_collision_returns_validation_error() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
-        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
@@ -728,7 +728,7 @@ mod tests {
     #[test]
     fn test_update_sprint_card_prefix_collides_with_sibling_sprint_returns_validation_error() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
         let mut sprint1 = crate::Sprint::new(board_id, 1, None, None::<String>);
         sprint1.card_prefix = Some("SPR".to_string());
@@ -755,9 +755,9 @@ mod tests {
         use chrono::{TimeZone, Utc};
 
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
-        let col = crate::Column::new(board_id, "Col".to_string(), 0);
+        let col = crate::Column::new(board_id, "Col", 0);
         let sprint = crate::Sprint::new(board_id, 1, None, None::<String>);
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
@@ -765,7 +765,7 @@ mod tests {
         tc.store.upsert_sprint(sprint).unwrap();
 
         let mut card = crate::Card::new(
-            &mut crate::Board::new("B".to_string(), Some("KAN".to_string())),
+            &mut crate::Board::new("B", Some("KAN")),
             col.id,
             "C".to_string(),
             0,
@@ -795,9 +795,9 @@ mod tests {
         use chrono::{TimeZone, Utc};
 
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
-        let col = crate::Column::new(board_id, "Col".to_string(), 0);
+        let col = crate::Column::new(board_id, "Col", 0);
         let sprint = crate::Sprint::new(board_id, 1, None, None::<String>);
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
@@ -841,8 +841,8 @@ mod tests {
     #[test]
     fn test_validate_card_prefix_not_locked_with_no_cards_returns_ok() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
-        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
@@ -854,11 +854,11 @@ mod tests {
     #[test]
     fn test_validate_card_prefix_not_locked_with_active_card_returns_validation_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let mut board = crate::Board::new("B", Some("KAN"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
-        let mut card = crate::Card::new(&mut board, col.id, "C".to_string(), 0);
+        let mut card = crate::Card::new(&mut board, col.id, "C", 0);
         card.sprint_id = Some(sprint_id);
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
@@ -873,9 +873,9 @@ mod tests {
     #[test]
     fn test_validate_card_prefix_unique_for_distinct_prefix_returns_ok() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
-        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
@@ -887,9 +887,9 @@ mod tests {
     #[test]
     fn test_validate_card_prefix_unique_self_does_not_collide() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
-        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
@@ -901,7 +901,7 @@ mod tests {
     #[test]
     fn test_allocate_sprint_name_sets_name_index_and_upserts_board() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
         let sprint = crate::Sprint::new(board_id, 1, None, None::<String>);
         let sprint_id = sprint.id;
@@ -920,11 +920,11 @@ mod tests {
     #[test]
     fn test_validate_card_prefix_not_locked_with_archived_card_returns_validation_error() {
         let tc = TestContext::new();
-        let mut board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
-        let col = crate::Column::new(board.id, "Col".to_string(), 0);
-        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR".to_string()));
+        let mut board = crate::Board::new("B", Some("KAN"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let sprint = crate::Sprint::new(board.id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
-        let mut card = crate::Card::new(&mut board, col.id, "C".to_string(), 0);
+        let mut card = crate::Card::new(&mut board, col.id, "C", 0);
         card.sprint_id = Some(sprint_id);
         let archived = crate::ArchivedCard::new(card, col.id, 0);
         tc.store.upsert_board(board).unwrap();
@@ -940,9 +940,9 @@ mod tests {
     #[test]
     fn test_validate_card_prefix_unique_collides_with_board_prefix_returns_validation_error() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
-        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
@@ -955,7 +955,7 @@ mod tests {
     #[test]
     fn test_validate_card_prefix_unique_collides_with_sibling_sprint_returns_validation_error() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
         let mut sprint1 = crate::Sprint::new(board_id, 1, None, None::<String>);
         sprint1.card_prefix = Some("SPR".to_string());
@@ -973,9 +973,9 @@ mod tests {
     #[test]
     fn test_update_sprint_card_prefix_unique_valid_succeeds() {
         let tc = TestContext::new();
-        let board = crate::Board::new("B".to_string(), Some("KAN".to_string()));
+        let board = crate::Board::new("B", Some("KAN"));
         let board_id = board.id;
-        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR".to_string()));
+        let sprint = crate::Sprint::new(board_id, 1, None, Some("SPR"));
         let sprint_id = sprint.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();

--- a/crates/kanban-domain/src/export/exporter.rs
+++ b/crates/kanban-domain/src/export/exporter.rs
@@ -90,12 +90,12 @@ mod tests {
 
     #[test]
     fn test_export_single_board() {
-        let board = Board::new("Test".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
         let columns = vec![column.clone()];
 
         let mut board_mut = board.clone();
-        let card = Card::new(&mut board_mut, column.id, "Task".to_string(), 0);
+        let card = Card::new(&mut board_mut, column.id, "Task", 0);
         let cards = vec![card];
 
         let archived_cards = vec![];
@@ -112,12 +112,12 @@ mod tests {
 
     #[test]
     fn test_export_all_boards() {
-        let board1 = Board::new("Board 1".to_string(), None::<String>);
-        let board2 = Board::new("Board 2".to_string(), None::<String>);
+        let board1 = Board::new("Board 1", None::<String>);
+        let board2 = Board::new("Board 2", None::<String>);
         let boards = vec![board1.clone(), board2.clone()];
 
-        let column1 = Column::new(board1.id, "Todo".to_string(), 0);
-        let column2 = Column::new(board2.id, "Todo".to_string(), 0);
+        let column1 = Column::new(board1.id, "Todo", 0);
+        let column2 = Column::new(board2.id, "Todo", 0);
         let columns = vec![column1.clone(), column2.clone()];
 
         let cards = vec![];
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_export_to_json() {
-        let board = Board::new("Test".to_string(), None::<String>);
+        let board = Board::new("Test", None::<String>);
         let export = AllBoardsExport {
             boards: vec![BoardExport {
                 board,

--- a/crates/kanban-domain/src/export/exporter.rs
+++ b/crates/kanban-domain/src/export/exporter.rs
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_export_single_board() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
         let columns = vec![column.clone()];
 
@@ -112,8 +112,8 @@ mod tests {
 
     #[test]
     fn test_export_all_boards() {
-        let board1 = Board::new("Board 1".to_string(), None);
-        let board2 = Board::new("Board 2".to_string(), None);
+        let board1 = Board::new("Board 1".to_string(), None::<String>);
+        let board2 = Board::new("Board 2".to_string(), None::<String>);
         let boards = vec![board1.clone(), board2.clone()];
 
         let column1 = Column::new(board1.id, "Todo".to_string(), 0);
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_export_to_json() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let export = AllBoardsExport {
             boards: vec![BoardExport {
                 board,

--- a/crates/kanban-domain/src/export/importer.rs
+++ b/crates/kanban-domain/src/export/importer.rs
@@ -208,11 +208,11 @@ mod tests {
 
     #[test]
     fn test_extract_entities() {
-        let board = Board::new("Test".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
 
         let mut board_mut = board.clone();
-        let card = Card::new(&mut board_mut, column.id, "Task".to_string(), 0);
+        let card = Card::new(&mut board_mut, column.id, "Task", 0);
 
         let export = AllBoardsExport {
             boards: vec![BoardExport {
@@ -241,8 +241,8 @@ mod tests {
 
     #[test]
     fn test_convert_snapshot_to_export() {
-        let board = Board::new("Test".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
 
         let snapshot = Snapshot {
             boards: vec![board.clone()],

--- a/crates/kanban-domain/src/export/importer.rs
+++ b/crates/kanban-domain/src/export/importer.rs
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_extract_entities() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
 
         let mut board_mut = board.clone();
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn test_convert_snapshot_to_export() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
 
         let snapshot = Snapshot {

--- a/crates/kanban-domain/src/filter/card_filter.rs
+++ b/crates/kanban-domain/src/filter/card_filter.rs
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn test_board_filter() {
-        let board = Board::new("Test Board".to_string(), None);
+        let board = Board::new("Test Board".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
         let other_column = Column::new(Uuid::new_v4(), "Other".to_string(), 0); // Different board
 
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn test_column_filter() {
-        let board = Board::new("Test Board".to_string(), None);
+        let board = Board::new("Test Board".to_string(), None::<String>);
         let column1 = Column::new(board.id, "Todo".to_string(), 0);
         let column2 = Column::new(board.id, "Done".to_string(), 1);
 
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_sprint_filter() {
-        let board = Board::new("Test Board".to_string(), None);
+        let board = Board::new("Test Board".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
 
         let mut board_mut = board.clone();
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_unassigned_only_filter() {
-        let board = Board::new("Test Board".to_string(), None);
+        let board = Board::new("Test Board".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
 
         let mut board_mut = board.clone();

--- a/crates/kanban-domain/src/filter/card_filter.rs
+++ b/crates/kanban-domain/src/filter/card_filter.rs
@@ -97,14 +97,14 @@ mod tests {
     use crate::Board;
 
     fn create_test_card(board: &mut Board, column_id: Uuid) -> Card {
-        Card::new(board, column_id, "Test Card".to_string(), 0)
+        Card::new(board, column_id, "Test Card", 0)
     }
 
     #[test]
     fn test_board_filter() {
-        let board = Board::new("Test Board".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
-        let other_column = Column::new(Uuid::new_v4(), "Other".to_string(), 0); // Different board
+        let board = Board::new("Test Board", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
+        let other_column = Column::new(Uuid::new_v4(), "Other", 0); // Different board
 
         let mut board_mut = board.clone();
         let card = create_test_card(&mut board_mut, column.id);
@@ -122,9 +122,9 @@ mod tests {
 
     #[test]
     fn test_column_filter() {
-        let board = Board::new("Test Board".to_string(), None::<String>);
-        let column1 = Column::new(board.id, "Todo".to_string(), 0);
-        let column2 = Column::new(board.id, "Done".to_string(), 1);
+        let board = Board::new("Test Board", None::<String>);
+        let column1 = Column::new(board.id, "Todo", 0);
+        let column2 = Column::new(board.id, "Done", 1);
 
         let mut board_mut = board.clone();
         let card1 = create_test_card(&mut board_mut, column1.id);
@@ -137,8 +137,8 @@ mod tests {
 
     #[test]
     fn test_sprint_filter() {
-        let board = Board::new("Test Board".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test Board", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
 
         let mut board_mut = board.clone();
         let mut card = create_test_card(&mut board_mut, column.id);
@@ -160,8 +160,8 @@ mod tests {
 
     #[test]
     fn test_unassigned_only_filter() {
-        let board = Board::new("Test Board".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test Board", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
 
         let mut board_mut = board.clone();
         let mut assigned_card = create_test_card(&mut board_mut, column.id);

--- a/crates/kanban-domain/src/in_memory_store.rs
+++ b/crates/kanban-domain/src/in_memory_store.rs
@@ -490,7 +490,7 @@ mod tests {
     use crate::{Board, Card, Column, Sprint};
 
     fn make_board(name: &str) -> Board {
-        Board::new(name.to_string(), None)
+        Board::new(name.to_string(), None::<String>)
     }
 
     fn make_column(board_id: Uuid, name: &str, pos: i32) -> Column {
@@ -976,7 +976,7 @@ mod tests {
     fn test_upsert_and_get_sprint() {
         let store = InMemoryStore::new();
         let board = make_board("B");
-        let sprint = Sprint::new(board.id, 1, None, None);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let sprint_id = sprint.id;
         store.upsert_sprint(sprint).unwrap();
 
@@ -990,9 +990,9 @@ mod tests {
         let store = InMemoryStore::new();
         let board1 = make_board("B1");
         let board2 = make_board("B2");
-        let s1 = Sprint::new(board1.id, 1, None, None);
-        let s2 = Sprint::new(board1.id, 2, None, None);
-        let s3 = Sprint::new(board2.id, 1, None, None);
+        let s1 = Sprint::new(board1.id, 1, None, None::<String>);
+        let s2 = Sprint::new(board1.id, 2, None, None::<String>);
+        let s3 = Sprint::new(board2.id, 1, None, None::<String>);
         store.upsert_sprint(s1).unwrap();
         store.upsert_sprint(s2).unwrap();
         store.upsert_sprint(s3).unwrap();
@@ -1007,8 +1007,8 @@ mod tests {
         let store = InMemoryStore::new();
         let board1 = make_board("B1");
         let board2 = make_board("B2");
-        let s1 = Sprint::new(board1.id, 1, None, None);
-        let s2 = Sprint::new(board2.id, 1, None, None);
+        let s1 = Sprint::new(board1.id, 1, None, None::<String>);
+        let s2 = Sprint::new(board2.id, 1, None, None::<String>);
         let s2_id = s2.id;
         store.upsert_sprint(s1).unwrap();
         store.upsert_sprint(s2).unwrap();
@@ -1167,7 +1167,7 @@ mod tests {
         let mut board = make_board("B");
         let col = make_column(board.id, "C", 0);
         let card = make_card(&mut board, col.id, "Card", 0);
-        let sprint = Sprint::new(board.id, 1, None, None);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
         store.upsert_board(board).unwrap();
         store.upsert_column(col).unwrap();
         store.upsert_card(card).unwrap();
@@ -1206,8 +1206,8 @@ mod tests {
         store.upsert_card(card3).unwrap();
         store.upsert_card(card1).unwrap();
 
-        let s2 = Sprint::new(board_a.id, 2, None, None);
-        let s1 = Sprint::new(board_a.id, 1, None, None);
+        let s2 = Sprint::new(board_a.id, 2, None, None::<String>);
+        let s1 = Sprint::new(board_a.id, 1, None, None::<String>);
         store.upsert_sprint(s2).unwrap();
         store.upsert_sprint(s1).unwrap();
 
@@ -1266,7 +1266,7 @@ mod tests {
         let mut board = make_board("B");
         let col = make_column(board.id, "C", 0);
         let card = make_card(&mut board, col.id, "Card", 0);
-        let sprint = Sprint::new(board.id, 1, None, None);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let ac = ArchivedCard::new(card.clone(), col.id, 0);
 
         assert!(store.upsert_board(board.clone()).is_ok());

--- a/crates/kanban-domain/src/query/mod.rs
+++ b/crates/kanban-domain/src/query/mod.rs
@@ -123,7 +123,7 @@ mod tests {
     use crate::{SortField, SortOrder};
 
     fn create_test_board() -> Board {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.update_task_sort(SortField::Default, SortOrder::Ascending);
         board
     }

--- a/crates/kanban-domain/src/query/mod.rs
+++ b/crates/kanban-domain/src/query/mod.rs
@@ -123,7 +123,7 @@ mod tests {
     use crate::{SortField, SortOrder};
 
     fn create_test_board() -> Board {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         board.update_task_sort(SortField::Default, SortOrder::Ascending);
         board
     }

--- a/crates/kanban-domain/src/query/sprint.rs
+++ b/crates/kanban-domain/src/query/sprint.rs
@@ -93,7 +93,7 @@ mod tests {
     use crate::{Board, CardStatus, Column};
 
     fn create_test_board() -> Board {
-        Board::new("Test".to_string(), None)
+        Board::new("Test".to_string(), None::<String>)
     }
 
     fn create_test_column(board: &Board) -> Column {

--- a/crates/kanban-domain/src/query/sprint.rs
+++ b/crates/kanban-domain/src/query/sprint.rs
@@ -93,11 +93,11 @@ mod tests {
     use crate::{Board, CardStatus, Column};
 
     fn create_test_board() -> Board {
-        Board::new("Test".to_string(), None::<String>)
+        Board::new("Test", None::<String>)
     }
 
     fn create_test_column(board: &Board) -> Column {
-        Column::new(board.id, "Todo".to_string(), 0)
+        Column::new(board.id, "Todo", 0)
     }
 
     fn create_test_card(board: &mut Board, column: &Column, title: &str) -> Card {

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_title_searcher_matches() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         let card = create_test_card(&mut board, "Fix authentication bug");
 
         let searcher = TitleSearcher::new("auth");
@@ -403,7 +403,7 @@ mod tests {
 
     #[test]
     fn test_title_searcher_empty_query() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         let card = create_test_card(&mut board, "Any card");
 
         let searcher = TitleSearcher::new("");
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_branch_name_searcher_matches() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         let card = create_test_card(&mut board, "Add new feature");
 
         let searcher = BranchNameSearcher::new("feature");
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_composite_searcher_any_match() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         let card = create_test_card(&mut board, "Fix bug");
 
         // Should match because title contains "bug"
@@ -435,7 +435,7 @@ mod tests {
 
     #[test]
     fn test_composite_searcher_empty() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         let card = create_test_card(&mut board, "Any card");
 
         let searcher = CompositeSearcher::new();
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn test_card_identifier_searcher_with_prefix() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_card_identifier_searcher_number_only() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let _card1 = Card::new(&mut board, column.id, "First".to_string(), 0);
         let card2 = Card::new(&mut board, column.id, "Second".to_string(), 1);
@@ -484,7 +484,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_unparseable_identifier_returns_empty() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_single_prefix_match_returns_one() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
@@ -512,12 +512,12 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_ambiguous_prefix_returns_both() {
-        let mut board1 = Board::new("Board One".to_string(), None);
+        let mut board1 = Board::new("Board One".to_string(), None::<String>);
         board1.card_prefix = Some("KAN".to_string());
         let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
         let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0);
 
-        let mut board2 = Board::new("Board Two".to_string(), None);
+        let mut board2 = Board::new("Board Two".to_string(), None::<String>);
         board2.card_prefix = Some("KAN".to_string());
         let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
         let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0);
@@ -532,7 +532,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_single_bare_number_returns_one() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
@@ -547,12 +547,12 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_ambiguous_bare_number_returns_both() {
-        let mut board1 = Board::new("Board One".to_string(), None);
+        let mut board1 = Board::new("Board One".to_string(), None::<String>);
         board1.card_prefix = Some("AAA".to_string());
         let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
         let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0);
 
-        let mut board2 = Board::new("Board Two".to_string(), None);
+        let mut board2 = Board::new("Board Two".to_string(), None::<String>);
         board2.card_prefix = Some("BBB".to_string());
         let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
         let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0);
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_no_match_returns_empty() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
@@ -580,14 +580,14 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_ambiguous_sprint_prefix_returns_both() {
-        let mut board_a = Board::new("Board A".to_string(), None);
+        let mut board_a = Board::new("Board A".to_string(), None::<String>);
         board_a.card_prefix = Some("PROJ".to_string());
         let col_a = crate::Column::new(board_a.id, "Todo".to_string(), 0);
         let card_a = Card::new(&mut board_a, col_a.id, "Card A".to_string(), 0);
 
-        let mut board_b = Board::new("Board B".to_string(), None);
+        let mut board_b = Board::new("Board B".to_string(), None::<String>);
         let col_b = crate::Column::new(board_b.id, "Todo".to_string(), 0);
-        let mut sprint = crate::Sprint::new(board_b.id, 1, None, None);
+        let mut sprint = crate::Sprint::new(board_b.id, 1, None, None::<String>);
         sprint.card_prefix = Some("PROJ".to_string());
         let mut card_b = Card::new(&mut board_b, col_b.id, "Card B".to_string(), 0);
         card_b.sprint_id = Some(sprint.id);
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_prefix_format() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
@@ -627,7 +627,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_number_only() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
@@ -645,7 +645,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_not_found() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
@@ -658,12 +658,12 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_second_board() {
-        let mut board1 = Board::new("Board One".to_string(), None);
+        let mut board1 = Board::new("Board One".to_string(), None::<String>);
         board1.card_prefix = Some("AAA".to_string());
         let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
         let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0);
 
-        let mut board2 = Board::new("Board Two".to_string(), None);
+        let mut board2 = Board::new("Board Two".to_string(), None::<String>);
         board2.card_prefix = Some("BBB".to_string());
         let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
         let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0);
@@ -682,7 +682,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_no_prefix_collision() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let mut card1 = Card::new(&mut board, column.id, "First".to_string(), 0);
@@ -700,7 +700,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_exact_number() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let mut card11 = Card::new(&mut board, column.id, "Eleven".to_string(), 0);
@@ -718,10 +718,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_sprint_prefix() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let mut sprint = crate::Sprint::new(board.id, 1, None, None);
+        let mut sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         sprint.card_prefix = Some("SP".to_string());
         let mut card = Card::new(&mut board, column.id, "Sprint task".to_string(), 0);
         card.sprint_id = Some(sprint.id);
@@ -738,10 +738,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_sprint_prefix_overrides_board() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let mut sprint = crate::Sprint::new(board.id, 1, None, None);
+        let mut sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         sprint.card_prefix = Some("SP".to_string());
         let mut card = Card::new(&mut board, column.id, "Override task".to_string(), 0);
         card.sprint_id = Some(sprint.id);
@@ -758,7 +758,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_no_prefix_no_match() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "No prefix task".to_string(), 0);
         let boards = vec![board];
@@ -773,7 +773,7 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_uses_task_fallback_for_no_prefix_board() {
-        let mut board = Board::new("Project".to_string(), None);
+        let mut board = Board::new("Project".to_string(), None::<String>);
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "task".to_string(), 0);
         let boards = vec![board];
@@ -790,7 +790,7 @@ mod tests {
 
     #[test]
     fn test_composite_searcher_matches_by_identifier() {
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo".to_string(), 0);
         let card = Card::new(&mut board, column.id, "Unrelated title".to_string(), 0);
@@ -817,8 +817,8 @@ mod tests {
     #[test]
     fn test_find_boards_by_name_case_insensitive_match() {
         let boards = vec![
-            Board::new("Kanban".to_string(), None),
-            Board::new("Personal".to_string(), None),
+            Board::new("Kanban".to_string(), None::<String>),
+            Board::new("Personal".to_string(), None::<String>),
         ];
         let result = find_boards_by_name("kanban", &boards);
         assert_eq!(result.len(), 1);
@@ -831,15 +831,15 @@ mod tests {
 
     #[test]
     fn test_find_boards_by_name_no_match_returns_empty() {
-        let boards = vec![Board::new("Kanban".to_string(), None)];
+        let boards = vec![Board::new("Kanban".to_string(), None::<String>)];
         assert!(find_boards_by_name("missing", &boards).is_empty());
     }
 
     #[test]
     fn test_find_boards_by_name_multiple_with_same_name_returns_all() {
         let boards = vec![
-            Board::new("Shared".to_string(), None),
-            Board::new("Shared".to_string(), None),
+            Board::new("Shared".to_string(), None::<String>),
+            Board::new("Shared".to_string(), None::<String>),
         ];
         let result = find_boards_by_name("shared", &boards);
         assert_eq!(result.len(), 2);
@@ -880,11 +880,11 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_matches_number() {
-        let mut board = Board::new("B".to_string(), None);
+        let mut board = Board::new("B".to_string(), None::<String>);
         board.sprint_names.push("alpha".to_string());
-        let mut sprint1 = crate::Sprint::new(board.id, 1, Some(0), None);
+        let mut sprint1 = crate::Sprint::new(board.id, 1, Some(0), None::<String>);
         sprint1.sprint_number = 1;
-        let mut sprint2 = crate::Sprint::new(board.id, 2, None, None);
+        let mut sprint2 = crate::Sprint::new(board.id, 2, None, None::<String>);
         sprint2.sprint_number = 2;
         let sprints = vec![sprint1, sprint2];
         let boards = vec![board];
@@ -896,11 +896,11 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_matches_name_case_insensitive() {
-        let mut board = Board::new("B".to_string(), None);
+        let mut board = Board::new("B".to_string(), None::<String>);
         board.sprint_names.push("yarara-release".to_string());
         board.sprint_names.push("moonshot".to_string());
-        let sprint1 = crate::Sprint::new(board.id, 1, Some(0), None);
-        let sprint2 = crate::Sprint::new(board.id, 2, Some(1), None);
+        let sprint1 = crate::Sprint::new(board.id, 1, Some(0), None::<String>);
+        let sprint2 = crate::Sprint::new(board.id, 2, Some(1), None::<String>);
         let sprints = vec![sprint1.clone(), sprint2];
         let boards = vec![board];
 
@@ -915,10 +915,10 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_number_takes_priority_over_name() {
-        let mut board = Board::new("B".to_string(), None);
+        let mut board = Board::new("B".to_string(), None::<String>);
         board.sprint_names.push("1".to_string());
-        let sprint_numbered = crate::Sprint::new(board.id, 1, None, None);
-        let sprint_named = crate::Sprint::new(board.id, 99, Some(0), None);
+        let sprint_numbered = crate::Sprint::new(board.id, 1, None, None::<String>);
+        let sprint_named = crate::Sprint::new(board.id, 99, Some(0), None::<String>);
         let sprints = vec![sprint_numbered.clone(), sprint_named];
         let boards = vec![board];
 
@@ -929,9 +929,9 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_no_match_returns_empty() {
-        let mut board = Board::new("B".to_string(), None);
+        let mut board = Board::new("B".to_string(), None::<String>);
         board.sprint_names.push("alpha".to_string());
-        let sprint = crate::Sprint::new(board.id, 1, Some(0), None);
+        let sprint = crate::Sprint::new(board.id, 1, Some(0), None::<String>);
         let sprints = vec![sprint];
         let boards = vec![board];
 
@@ -941,10 +941,10 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_ambiguous_number_across_boards_returns_all() {
-        let board_a = Board::new("A".to_string(), None);
-        let board_b = Board::new("B".to_string(), None);
-        let sprint_a = crate::Sprint::new(board_a.id, 13, None, None);
-        let sprint_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let board_a = Board::new("A".to_string(), None::<String>);
+        let board_b = Board::new("B".to_string(), None::<String>);
+        let sprint_a = crate::Sprint::new(board_a.id, 13, None, None::<String>);
+        let sprint_b = crate::Sprint::new(board_b.id, 13, None, None::<String>);
         let sprints = vec![sprint_a, sprint_b];
         let boards = vec![board_a, board_b];
 
@@ -956,10 +956,10 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_on_board_number_matches_only_on_that_board() {
-        let board_a = Board::new("A".to_string(), None);
-        let board_b = Board::new("B".to_string(), None);
-        let on_a = crate::Sprint::new(board_a.id, 13, None, None);
-        let on_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let board_a = Board::new("A".to_string(), None::<String>);
+        let board_b = Board::new("B".to_string(), None::<String>);
+        let on_a = crate::Sprint::new(board_a.id, 13, None, None::<String>);
+        let on_b = crate::Sprint::new(board_b.id, 13, None, None::<String>);
         let sprints = vec![on_a.clone(), on_b];
 
         let result = find_sprints_by_query_on_board("13", &sprints, &board_a);
@@ -969,12 +969,12 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_on_board_name_matches_only_on_that_board() {
-        let mut board_a = Board::new("A".to_string(), None);
+        let mut board_a = Board::new("A".to_string(), None::<String>);
         board_a.sprint_names.push("alpha".to_string());
-        let mut board_b = Board::new("B".to_string(), None);
+        let mut board_b = Board::new("B".to_string(), None::<String>);
         board_b.sprint_names.push("alpha".to_string());
-        let on_a = crate::Sprint::new(board_a.id, 1, Some(0), None);
-        let on_b = crate::Sprint::new(board_b.id, 1, Some(0), None);
+        let on_a = crate::Sprint::new(board_a.id, 1, Some(0), None::<String>);
+        let on_b = crate::Sprint::new(board_b.id, 1, Some(0), None::<String>);
         let sprints = vec![on_a.clone(), on_b];
 
         let result = find_sprints_by_query_on_board("alpha", &sprints, &board_a);
@@ -986,9 +986,9 @@ mod tests {
     fn test_find_sprints_by_query_on_board_ignores_other_board_sprints_in_slice() {
         // Footgun-regression: even if a caller passes sprints from a different
         // board, the on_board variant filters them out.
-        let board_a = Board::new("A".to_string(), None);
-        let board_b = Board::new("B".to_string(), None);
-        let only_on_b = crate::Sprint::new(board_b.id, 13, None, None);
+        let board_a = Board::new("A".to_string(), None::<String>);
+        let board_b = Board::new("B".to_string(), None::<String>);
+        let only_on_b = crate::Sprint::new(board_b.id, 13, None, None::<String>);
         let sprints = vec![only_on_b];
 
         let result = find_sprints_by_query_on_board("13", &sprints, &board_a);

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -382,13 +382,13 @@ mod tests {
     use uuid::Uuid;
 
     fn create_test_card(board: &mut Board, title: &str) -> Card {
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
         Card::new(board, column.id, title.to_string(), 0)
     }
 
     #[test]
     fn test_title_searcher_matches() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         let card = create_test_card(&mut board, "Fix authentication bug");
 
         let searcher = TitleSearcher::new("auth");
@@ -403,7 +403,7 @@ mod tests {
 
     #[test]
     fn test_title_searcher_empty_query() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         let card = create_test_card(&mut board, "Any card");
 
         let searcher = TitleSearcher::new("");
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_branch_name_searcher_matches() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         let card = create_test_card(&mut board, "Add new feature");
 
         let searcher = BranchNameSearcher::new("feature");
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_composite_searcher_any_match() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         let card = create_test_card(&mut board, "Fix bug");
 
         // Should match because title contains "bug"
@@ -435,7 +435,7 @@ mod tests {
 
     #[test]
     fn test_composite_searcher_empty() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         let card = create_test_card(&mut board, "Any card");
 
         let searcher = CompositeSearcher::new();
@@ -444,10 +444,10 @@ mod tests {
 
     #[test]
     fn test_card_identifier_searcher_with_prefix() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Some task", 0);
 
         let searcher = CardIdentifierSearcher::new("KAN-1");
         assert!(searcher.matches(&card, &board, &[]));
@@ -464,10 +464,10 @@ mod tests {
 
     #[test]
     fn test_card_identifier_searcher_number_only() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let _card1 = Card::new(&mut board, column.id, "First".to_string(), 0);
-        let card2 = Card::new(&mut board, column.id, "Second".to_string(), 1);
+        let mut board = Board::new("Test", None::<String>);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let _card1 = Card::new(&mut board, column.id, "First", 0);
+        let card2 = Card::new(&mut board, column.id, "Second", 1);
 
         // card2 has card_number=2
         let searcher = CardIdentifierSearcher::new("2");
@@ -484,10 +484,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_unparseable_identifier_returns_empty() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card];
@@ -497,10 +497,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_single_prefix_match_returns_one() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -512,15 +512,15 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_ambiguous_prefix_returns_both() {
-        let mut board1 = Board::new("Board One".to_string(), None::<String>);
+        let mut board1 = Board::new("Board One", None::<String>);
         board1.card_prefix = Some("KAN".to_string());
-        let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
-        let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0);
+        let col1 = crate::Column::new(board1.id, "Todo", 0);
+        let card1 = Card::new(&mut board1, col1.id, "First", 0);
 
-        let mut board2 = Board::new("Board Two".to_string(), None::<String>);
+        let mut board2 = Board::new("Board Two", None::<String>);
         board2.card_prefix = Some("KAN".to_string());
-        let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
-        let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0);
+        let col2 = crate::Column::new(board2.id, "Todo", 0);
+        let card2 = Card::new(&mut board2, col2.id, "Second", 0);
 
         let boards = vec![board1, board2];
         let columns = vec![col1, col2];
@@ -532,10 +532,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_single_bare_number_returns_one() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -547,15 +547,15 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_ambiguous_bare_number_returns_both() {
-        let mut board1 = Board::new("Board One".to_string(), None::<String>);
+        let mut board1 = Board::new("Board One", None::<String>);
         board1.card_prefix = Some("AAA".to_string());
-        let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
-        let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0);
+        let col1 = crate::Column::new(board1.id, "Todo", 0);
+        let card1 = Card::new(&mut board1, col1.id, "First", 0);
 
-        let mut board2 = Board::new("Board Two".to_string(), None::<String>);
+        let mut board2 = Board::new("Board Two", None::<String>);
         board2.card_prefix = Some("BBB".to_string());
-        let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
-        let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0);
+        let col2 = crate::Column::new(board2.id, "Todo", 0);
+        let card2 = Card::new(&mut board2, col2.id, "Second", 0);
 
         let boards = vec![board1, board2];
         let columns = vec![col1, col2];
@@ -567,10 +567,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_no_match_returns_empty() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card];
@@ -580,16 +580,16 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_ambiguous_sprint_prefix_returns_both() {
-        let mut board_a = Board::new("Board A".to_string(), None::<String>);
+        let mut board_a = Board::new("Board A", None::<String>);
         board_a.card_prefix = Some("PROJ".to_string());
-        let col_a = crate::Column::new(board_a.id, "Todo".to_string(), 0);
-        let card_a = Card::new(&mut board_a, col_a.id, "Card A".to_string(), 0);
+        let col_a = crate::Column::new(board_a.id, "Todo", 0);
+        let card_a = Card::new(&mut board_a, col_a.id, "Card A", 0);
 
-        let mut board_b = Board::new("Board B".to_string(), None::<String>);
-        let col_b = crate::Column::new(board_b.id, "Todo".to_string(), 0);
+        let mut board_b = Board::new("Board B", None::<String>);
+        let col_b = crate::Column::new(board_b.id, "Todo", 0);
         let mut sprint = crate::Sprint::new(board_b.id, 1, None, None::<String>);
         sprint.card_prefix = Some("PROJ".to_string());
-        let mut card_b = Card::new(&mut board_b, col_b.id, "Card B".to_string(), 0);
+        let mut card_b = Card::new(&mut board_b, col_b.id, "Card B", 0);
         card_b.sprint_id = Some(sprint.id);
 
         let boards = vec![board_a, board_b];
@@ -603,10 +603,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_prefix_format() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -627,10 +627,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_number_only() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -645,10 +645,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_not_found() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Some task".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card];
@@ -658,15 +658,15 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_second_board() {
-        let mut board1 = Board::new("Board One".to_string(), None::<String>);
+        let mut board1 = Board::new("Board One", None::<String>);
         board1.card_prefix = Some("AAA".to_string());
-        let col1 = crate::Column::new(board1.id, "Todo".to_string(), 0);
-        let card1 = Card::new(&mut board1, col1.id, "First".to_string(), 0);
+        let col1 = crate::Column::new(board1.id, "Todo", 0);
+        let card1 = Card::new(&mut board1, col1.id, "First", 0);
 
-        let mut board2 = Board::new("Board Two".to_string(), None::<String>);
+        let mut board2 = Board::new("Board Two", None::<String>);
         board2.card_prefix = Some("BBB".to_string());
-        let col2 = crate::Column::new(board2.id, "Todo".to_string(), 0);
-        let card2 = Card::new(&mut board2, col2.id, "Second".to_string(), 0);
+        let col2 = crate::Column::new(board2.id, "Todo", 0);
+        let card2 = Card::new(&mut board2, col2.id, "Second", 0);
 
         let boards = vec![board1, board2];
         let columns = vec![col1, col2];
@@ -682,12 +682,12 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_no_prefix_collision() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let mut card1 = Card::new(&mut board, column.id, "First".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let mut card1 = Card::new(&mut board, column.id, "First", 0);
         card1.card_number = 1;
-        let mut card11 = Card::new(&mut board, column.id, "Eleventh".to_string(), 0);
+        let mut card11 = Card::new(&mut board, column.id, "Eleventh", 0);
         card11.card_number = 11;
         let boards = vec![board];
         let columns = vec![column];
@@ -700,12 +700,12 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_exact_number() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let mut card11 = Card::new(&mut board, column.id, "Eleven".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let mut card11 = Card::new(&mut board, column.id, "Eleven", 0);
         card11.card_number = 11;
-        let mut card111 = Card::new(&mut board, column.id, "OneHundredEleven".to_string(), 0);
+        let mut card111 = Card::new(&mut board, column.id, "OneHundredEleven", 0);
         card111.card_number = 111;
         let boards = vec![board];
         let columns = vec![column];
@@ -718,12 +718,12 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_sprint_prefix() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
         let mut sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         sprint.card_prefix = Some("SP".to_string());
-        let mut card = Card::new(&mut board, column.id, "Sprint task".to_string(), 0);
+        let mut card = Card::new(&mut board, column.id, "Sprint task", 0);
         card.sprint_id = Some(sprint.id);
         let boards = vec![board];
         let columns = vec![column];
@@ -738,12 +738,12 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_sprint_prefix_overrides_board() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
+        let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
         let mut sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         sprint.card_prefix = Some("SP".to_string());
-        let mut card = Card::new(&mut board, column.id, "Override task".to_string(), 0);
+        let mut card = Card::new(&mut board, column.id, "Override task", 0);
         card.sprint_id = Some(sprint.id);
         let boards = vec![board];
         let columns = vec![column];
@@ -758,9 +758,9 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_no_prefix_no_match() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "No prefix task".to_string(), 0);
+        let mut board = Board::new("Project", None::<String>);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "No prefix task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -773,9 +773,9 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_uses_task_fallback_for_no_prefix_board() {
-        let mut board = Board::new("Project".to_string(), None::<String>);
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "task".to_string(), 0);
+        let mut board = Board::new("Project", None::<String>);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -790,10 +790,10 @@ mod tests {
 
     #[test]
     fn test_composite_searcher_matches_by_identifier() {
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         board.card_prefix = Some("KAN".to_string());
-        let column = crate::Column::new(board.id, "Todo".to_string(), 0);
-        let card = Card::new(&mut board, column.id, "Unrelated title".to_string(), 0);
+        let column = crate::Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Unrelated title", 0);
 
         // Title doesn't contain "KAN-1", but identifier does
         let searcher = CompositeSearcher::all("KAN-1");
@@ -817,8 +817,8 @@ mod tests {
     #[test]
     fn test_find_boards_by_name_case_insensitive_match() {
         let boards = vec![
-            Board::new("Kanban".to_string(), None::<String>),
-            Board::new("Personal".to_string(), None::<String>),
+            Board::new("Kanban", None::<String>),
+            Board::new("Personal", None::<String>),
         ];
         let result = find_boards_by_name("kanban", &boards);
         assert_eq!(result.len(), 1);
@@ -831,15 +831,15 @@ mod tests {
 
     #[test]
     fn test_find_boards_by_name_no_match_returns_empty() {
-        let boards = vec![Board::new("Kanban".to_string(), None::<String>)];
+        let boards = vec![Board::new("Kanban", None::<String>)];
         assert!(find_boards_by_name("missing", &boards).is_empty());
     }
 
     #[test]
     fn test_find_boards_by_name_multiple_with_same_name_returns_all() {
         let boards = vec![
-            Board::new("Shared".to_string(), None::<String>),
-            Board::new("Shared".to_string(), None::<String>),
+            Board::new("Shared", None::<String>),
+            Board::new("Shared", None::<String>),
         ];
         let result = find_boards_by_name("shared", &boards);
         assert_eq!(result.len(), 2);
@@ -849,9 +849,9 @@ mod tests {
     fn test_find_columns_by_name_case_insensitive_match() {
         let board_id = Uuid::new_v4();
         let columns = vec![
-            Column::new(board_id, "TODO".to_string(), 0),
-            Column::new(board_id, "Doing".to_string(), 1),
-            Column::new(board_id, "Done".to_string(), 2),
+            Column::new(board_id, "TODO", 0),
+            Column::new(board_id, "Doing", 1),
+            Column::new(board_id, "Done", 2),
         ];
         let result = find_columns_by_name("todo", &columns);
         assert_eq!(result.len(), 1);
@@ -865,8 +865,8 @@ mod tests {
     #[test]
     fn test_find_columns_by_name_returns_multiple_when_same_name_across_boards() {
         let columns = vec![
-            Column::new(Uuid::new_v4(), "TODO".to_string(), 0),
-            Column::new(Uuid::new_v4(), "TODO".to_string(), 0),
+            Column::new(Uuid::new_v4(), "TODO", 0),
+            Column::new(Uuid::new_v4(), "TODO", 0),
         ];
         let result = find_columns_by_name("todo", &columns);
         assert_eq!(result.len(), 2);
@@ -874,13 +874,13 @@ mod tests {
 
     #[test]
     fn test_find_columns_by_name_no_match_returns_empty() {
-        let columns = vec![Column::new(Uuid::new_v4(), "TODO".to_string(), 0)];
+        let columns = vec![Column::new(Uuid::new_v4(), "TODO", 0)];
         assert!(find_columns_by_name("missing", &columns).is_empty());
     }
 
     #[test]
     fn test_find_sprints_by_query_matches_number() {
-        let mut board = Board::new("B".to_string(), None::<String>);
+        let mut board = Board::new("B", None::<String>);
         board.sprint_names.push("alpha".to_string());
         let mut sprint1 = crate::Sprint::new(board.id, 1, Some(0), None::<String>);
         sprint1.sprint_number = 1;
@@ -896,7 +896,7 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_matches_name_case_insensitive() {
-        let mut board = Board::new("B".to_string(), None::<String>);
+        let mut board = Board::new("B", None::<String>);
         board.sprint_names.push("yarara-release".to_string());
         board.sprint_names.push("moonshot".to_string());
         let sprint1 = crate::Sprint::new(board.id, 1, Some(0), None::<String>);
@@ -915,7 +915,7 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_number_takes_priority_over_name() {
-        let mut board = Board::new("B".to_string(), None::<String>);
+        let mut board = Board::new("B", None::<String>);
         board.sprint_names.push("1".to_string());
         let sprint_numbered = crate::Sprint::new(board.id, 1, None, None::<String>);
         let sprint_named = crate::Sprint::new(board.id, 99, Some(0), None::<String>);
@@ -929,7 +929,7 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_no_match_returns_empty() {
-        let mut board = Board::new("B".to_string(), None::<String>);
+        let mut board = Board::new("B", None::<String>);
         board.sprint_names.push("alpha".to_string());
         let sprint = crate::Sprint::new(board.id, 1, Some(0), None::<String>);
         let sprints = vec![sprint];
@@ -941,8 +941,8 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_ambiguous_number_across_boards_returns_all() {
-        let board_a = Board::new("A".to_string(), None::<String>);
-        let board_b = Board::new("B".to_string(), None::<String>);
+        let board_a = Board::new("A", None::<String>);
+        let board_b = Board::new("B", None::<String>);
         let sprint_a = crate::Sprint::new(board_a.id, 13, None, None::<String>);
         let sprint_b = crate::Sprint::new(board_b.id, 13, None, None::<String>);
         let sprints = vec![sprint_a, sprint_b];
@@ -956,8 +956,8 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_on_board_number_matches_only_on_that_board() {
-        let board_a = Board::new("A".to_string(), None::<String>);
-        let board_b = Board::new("B".to_string(), None::<String>);
+        let board_a = Board::new("A", None::<String>);
+        let board_b = Board::new("B", None::<String>);
         let on_a = crate::Sprint::new(board_a.id, 13, None, None::<String>);
         let on_b = crate::Sprint::new(board_b.id, 13, None, None::<String>);
         let sprints = vec![on_a.clone(), on_b];
@@ -969,9 +969,9 @@ mod tests {
 
     #[test]
     fn test_find_sprints_by_query_on_board_name_matches_only_on_that_board() {
-        let mut board_a = Board::new("A".to_string(), None::<String>);
+        let mut board_a = Board::new("A", None::<String>);
         board_a.sprint_names.push("alpha".to_string());
-        let mut board_b = Board::new("B".to_string(), None::<String>);
+        let mut board_b = Board::new("B", None::<String>);
         board_b.sprint_names.push("alpha".to_string());
         let on_a = crate::Sprint::new(board_a.id, 1, Some(0), None::<String>);
         let on_b = crate::Sprint::new(board_b.id, 1, Some(0), None::<String>);
@@ -986,8 +986,8 @@ mod tests {
     fn test_find_sprints_by_query_on_board_ignores_other_board_sprints_in_slice() {
         // Footgun-regression: even if a caller passes sprints from a different
         // board, the on_board variant filters them out.
-        let board_a = Board::new("A".to_string(), None::<String>);
-        let board_b = Board::new("B".to_string(), None::<String>);
+        let board_a = Board::new("A", None::<String>);
+        let board_b = Board::new("B", None::<String>);
         let only_on_b = crate::Sprint::new(board_b.id, 13, None, None::<String>);
         let sprints = vec![only_on_b];
 

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_from_data() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let snapshot = Snapshot::from_data(
             vec![board.clone()],
             vec![],
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_serialization_roundtrip() {
-        let board = Board::new("Test Board".to_string(), None);
+        let board = Board::new("Test Board".to_string(), None::<String>);
         let snapshot = Snapshot::from_data(
             vec![board],
             vec![],

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_from_data() {
-        let board = Board::new("Test".to_string(), None::<String>);
+        let board = Board::new("Test", None::<String>);
         let snapshot = Snapshot::from_data(
             vec![board.clone()],
             vec![],
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_serialization_roundtrip() {
-        let board = Board::new("Test Board".to_string(), None::<String>);
+        let board = Board::new("Test Board", None::<String>);
         let snapshot = Snapshot::from_data(
             vec![board],
             vec![],

--- a/crates/kanban-domain/src/sort/mod.rs
+++ b/crates/kanban-domain/src/sort/mod.rs
@@ -117,12 +117,12 @@ mod tests {
     use crate::{Board, Column};
 
     fn create_test_cards() -> (Board, Column, Card, Card) {
-        let board = Board::new("Test".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
 
         let mut board_mut = board.clone();
-        let card1 = Card::new(&mut board_mut, column.id, "First".to_string(), 0);
-        let card2 = Card::new(&mut board_mut, column.id, "Second".to_string(), 1);
+        let card1 = Card::new(&mut board_mut, column.id, "First", 0);
+        let card2 = Card::new(&mut board_mut, column.id, "Second", 1);
 
         (board, column, card1, card2)
     }
@@ -170,13 +170,13 @@ mod tests {
 
     #[test]
     fn test_position_sorter() {
-        let board = Board::new("Test".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
 
         let mut board_mut = board.clone();
-        let card1 = Card::new(&mut board_mut, column.id, "Third".to_string(), 20);
-        let card2 = Card::new(&mut board_mut, column.id, "First".to_string(), 5);
-        let card3 = Card::new(&mut board_mut, column.id, "Second".to_string(), 10);
+        let card1 = Card::new(&mut board_mut, column.id, "Third", 20);
+        let card2 = Card::new(&mut board_mut, column.id, "First", 5);
+        let card3 = Card::new(&mut board_mut, column.id, "Second", 10);
 
         assert_eq!(SortBy::Position.compare(&card2, &card3), Ordering::Less); // 5 < 10
         assert_eq!(SortBy::Position.compare(&card3, &card1), Ordering::Less); // 10 < 20
@@ -186,12 +186,12 @@ mod tests {
     fn test_get_sorter_for_field() {
         let sorter = get_sorter_for_field(SortField::Position);
 
-        let board = Board::new("Test".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
         let mut board_mut = board.clone();
 
-        let card1 = Card::new(&mut board_mut, column.id, "A".to_string(), 10);
-        let card2 = Card::new(&mut board_mut, column.id, "B".to_string(), 5);
+        let card1 = Card::new(&mut board_mut, column.id, "A", 10);
+        let card2 = Card::new(&mut board_mut, column.id, "B", 5);
 
         assert_eq!(sorter.compare(&card2, &card1), Ordering::Less);
     }
@@ -218,14 +218,14 @@ mod tests {
     /// re-render.
     #[test]
     fn test_ordered_sorter_is_deterministic_when_primary_keys_tie() {
-        let board = Board::new("Test".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
         let mut board_mut = board.clone();
 
         // All three cards have points=None, so SortBy::Points reports them equal.
-        let card1 = Card::new(&mut board_mut, column.id, "A".to_string(), 0);
-        let card2 = Card::new(&mut board_mut, column.id, "B".to_string(), 1);
-        let card3 = Card::new(&mut board_mut, column.id, "C".to_string(), 2);
+        let card1 = Card::new(&mut board_mut, column.id, "A", 0);
+        let card2 = Card::new(&mut board_mut, column.id, "B", 1);
+        let card3 = Card::new(&mut board_mut, column.id, "C", 2);
         let card_numbers = (card1.card_number, card2.card_number, card3.card_number);
 
         let sorter = OrderedSorter::new(SortBy::Points, SortOrder::Ascending);
@@ -255,12 +255,12 @@ mod tests {
     /// the original instability.
     #[test]
     fn test_ordered_sorter_tiebreaker_is_ascending_under_descending_primary() {
-        let board = Board::new("Test".to_string(), None::<String>);
-        let column = Column::new(board.id, "Todo".to_string(), 0);
+        let board = Board::new("Test", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
         let mut board_mut = board.clone();
 
-        let card1 = Card::new(&mut board_mut, column.id, "A".to_string(), 0);
-        let card2 = Card::new(&mut board_mut, column.id, "B".to_string(), 1);
+        let card1 = Card::new(&mut board_mut, column.id, "A", 0);
+        let card2 = Card::new(&mut board_mut, column.id, "B", 1);
         let expected = (card1.card_number, card2.card_number);
 
         let sorter = OrderedSorter::new(SortBy::Points, SortOrder::Descending);
@@ -287,12 +287,12 @@ mod tests {
         ];
 
         for variant in variants {
-            let board = Board::new("Test".to_string(), None::<String>);
-            let column = Column::new(board.id, "Todo".to_string(), 0);
+            let board = Board::new("Test", None::<String>);
+            let column = Column::new(board.id, "Todo", 0);
             let mut board_mut = board.clone();
-            let card1 = Card::new(&mut board_mut, column.id, "A".to_string(), 0);
-            let card2 = Card::new(&mut board_mut, column.id, "B".to_string(), 1);
-            let card3 = Card::new(&mut board_mut, column.id, "C".to_string(), 2);
+            let card1 = Card::new(&mut board_mut, column.id, "A", 0);
+            let card2 = Card::new(&mut board_mut, column.id, "B", 1);
+            let card3 = Card::new(&mut board_mut, column.id, "C", 2);
             let expected = (card1.card_number, card2.card_number, card3.card_number);
 
             let sorter = OrderedSorter::new(variant, SortOrder::Ascending);

--- a/crates/kanban-domain/src/sort/mod.rs
+++ b/crates/kanban-domain/src/sort/mod.rs
@@ -117,7 +117,7 @@ mod tests {
     use crate::{Board, Column};
 
     fn create_test_cards() -> (Board, Column, Card, Card) {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
 
         let mut board_mut = board.clone();
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_position_sorter() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
 
         let mut board_mut = board.clone();
@@ -186,7 +186,7 @@ mod tests {
     fn test_get_sorter_for_field() {
         let sorter = get_sorter_for_field(SortField::Position);
 
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
         let mut board_mut = board.clone();
 
@@ -218,7 +218,7 @@ mod tests {
     /// re-render.
     #[test]
     fn test_ordered_sorter_is_deterministic_when_primary_keys_tie() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
         let mut board_mut = board.clone();
 
@@ -255,7 +255,7 @@ mod tests {
     /// the original instability.
     #[test]
     fn test_ordered_sorter_tiebreaker_is_ascending_under_descending_primary() {
-        let board = Board::new("Test".to_string(), None);
+        let board = Board::new("Test".to_string(), None::<String>);
         let column = Column::new(board.id, "Todo".to_string(), 0);
         let mut board_mut = board.clone();
 
@@ -287,7 +287,7 @@ mod tests {
         ];
 
         for variant in variants {
-            let board = Board::new("Test".to_string(), None);
+            let board = Board::new("Test".to_string(), None::<String>);
             let column = Column::new(board.id, "Todo".to_string(), 0);
             let mut board_mut = board.clone();
             let card1 = Card::new(&mut board_mut, column.id, "A".to_string(), 0);

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -37,7 +37,7 @@ impl Sprint {
         board_id: Uuid,
         sprint_number: u32,
         name_index: Option<usize>,
-        prefix: Option<String>,
+        prefix: Option<impl Into<String>>,
     ) -> Self {
         let now = Utc::now();
         Self {
@@ -45,7 +45,7 @@ impl Sprint {
             board_id,
             sprint_number,
             name_index,
-            prefix,
+            prefix: prefix.map(Into::into),
             card_prefix: None,
             status: SprintStatus::Planning,
             start_date: None,
@@ -118,13 +118,13 @@ impl Sprint {
         self.updated_at = Utc::now();
     }
 
-    pub fn update_prefix(&mut self, prefix: Option<String>) {
-        self.prefix = prefix;
+    pub fn update_prefix(&mut self, prefix: Option<impl Into<String>>) {
+        self.prefix = prefix.map(Into::into);
         self.updated_at = Utc::now();
     }
 
-    pub fn update_card_prefix(&mut self, card_prefix: Option<String>) {
-        self.card_prefix = card_prefix;
+    pub fn update_card_prefix(&mut self, card_prefix: Option<impl Into<String>>) {
+        self.card_prefix = card_prefix.map(Into::into);
         self.updated_at = Utc::now();
     }
 

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -240,6 +240,29 @@ mod tests {
     }
 
     #[test]
+    fn test_sprint_new_accepts_str_prefix_without_to_string() {
+        let board_id = uuid::Uuid::new_v4();
+        let sprint = Sprint::new(board_id, 1, None, Some("sprint"));
+        assert_eq!(sprint.prefix, Some("sprint".to_string()));
+    }
+
+    #[test]
+    fn test_sprint_update_prefix_accepts_str_without_to_string() {
+        let board_id = uuid::Uuid::new_v4();
+        let mut sprint = Sprint::new(board_id, 1, None, None::<String>);
+        sprint.update_prefix(Some("custom"));
+        assert_eq!(sprint.prefix, Some("custom".to_string()));
+    }
+
+    #[test]
+    fn test_sprint_update_card_prefix_accepts_str_without_to_string() {
+        let board_id = uuid::Uuid::new_v4();
+        let mut sprint = Sprint::new(board_id, 1, None, None::<String>);
+        sprint.update_card_prefix(Some("KAN"));
+        assert_eq!(sprint.card_prefix, Some("KAN".to_string()));
+    }
+
+    #[test]
     fn test_is_ended_returns_true_for_active_with_past_end_date() {
         let now = ts("2026-05-07T00:00:00Z");
         let s = make_sprint(

--- a/crates/kanban-domain/src/sprint_log.rs
+++ b/crates/kanban-domain/src/sprint_log.rs
@@ -33,3 +33,16 @@ impl SprintLog {
         self.ended_at = Some(Utc::now());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sprint_log_new_accepts_str_args_without_to_string() {
+        let sprint_id = uuid::Uuid::new_v4();
+        let log = SprintLog::new(sprint_id, 1, Some("Sprint 1"), "Active");
+        assert_eq!(log.sprint_name, Some("Sprint 1".to_string()));
+        assert_eq!(log.status, "Active");
+    }
+}

--- a/crates/kanban-domain/src/sprint_log.rs
+++ b/crates/kanban-domain/src/sprint_log.rs
@@ -16,16 +16,16 @@ impl SprintLog {
     pub fn new(
         sprint_id: Uuid,
         sprint_number: u32,
-        sprint_name: Option<String>,
-        status: String,
+        sprint_name: Option<impl Into<String>>,
+        status: impl Into<String>,
     ) -> Self {
         Self {
             sprint_id,
             sprint_number,
-            sprint_name,
+            sprint_name: sprint_name.map(Into::into),
             started_at: Utc::now(),
             ended_at: None,
-            status,
+            status: status.into(),
         }
     }
 

--- a/crates/kanban-domain/src/tag.rs
+++ b/crates/kanban-domain/src/tag.rs
@@ -19,3 +19,15 @@ impl Tag {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tag_new_accepts_str_args_without_to_string() {
+        let tag = Tag::new("feature", "blue");
+        assert_eq!(tag.name, "feature");
+        assert_eq!(tag.color, "blue");
+    }
+}

--- a/crates/kanban-domain/src/tag.rs
+++ b/crates/kanban-domain/src/tag.rs
@@ -11,11 +11,11 @@ pub struct Tag {
 }
 
 impl Tag {
-    pub fn new(name: String, color: String) -> Self {
+    pub fn new(name: impl Into<String>, color: impl Into<String>) -> Self {
         Self {
             id: Uuid::new_v4(),
-            name,
-            color,
+            name: name.into(),
+            color: color.into(),
         }
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1950,7 +1950,7 @@ mod tests {
 
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let board = Board::new("Test Board".to_string(), None::<String>);
+            let board = Board::new("Test Board", None::<String>);
             let snapshot = Snapshot::from_data(
                 vec![board],
                 vec![],
@@ -2137,9 +2137,9 @@ mod tests {
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
 
-            let mut board = kanban_domain::Board::new("B".to_string(), None::<String>);
-            let column = kanban_domain::Column::new(board.id, "Col".to_string(), 0);
-            let card = kanban_domain::Card::new(&mut board, column.id, "Task".to_string(), 0);
+            let mut board = kanban_domain::Board::new("B", None::<String>);
+            let column = kanban_domain::Column::new(board.id, "Col", 0);
+            let card = kanban_domain::Card::new(&mut board, column.id, "Task", 0);
             let card_id = card.id;
             let column_id = column.id;
             store.upsert_board(board).unwrap();
@@ -2173,9 +2173,9 @@ mod tests {
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
 
-            let mut board = kanban_domain::Board::new("B".to_string(), None::<String>);
-            let column = kanban_domain::Column::new(board.id, "Col".to_string(), 0);
-            let card = kanban_domain::Card::new(&mut board, column.id, "Task".to_string(), 0);
+            let mut board = kanban_domain::Board::new("B", None::<String>);
+            let column = kanban_domain::Column::new(board.id, "Col", 0);
+            let card = kanban_domain::Card::new(&mut board, column.id, "Task", 0);
             let card_id = card.id;
             let column_id = column.id;
             store.upsert_board(board).unwrap();
@@ -2618,13 +2618,13 @@ mod tests {
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
 
-            let mut board = Board::new("B".to_string(), None::<String>);
-            let column = Column::new(board.id, "Col".to_string(), 0);
-            let mut card = Card::new(&mut board, column.id, "Task".to_string(), 0);
+            let mut board = Board::new("B", None::<String>);
+            let column = Column::new(board.id, "Col", 0);
+            let mut card = Card::new(&mut board, column.id, "Task", 0);
             store.upsert_board(board).unwrap();
             store.upsert_column(column).unwrap();
 
-            let log = SprintLog::new(uuid::Uuid::new_v4(), 1, None::<String>, "".to_string());
+            let log = SprintLog::new(uuid::Uuid::new_v4(), 1, None::<String>, "");
             card.sprint_logs.push(log);
 
             let result = store.upsert_card(card);
@@ -2644,7 +2644,7 @@ mod tests {
         let rt = make_rt();
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let board = Board::new("".to_string(), None::<String>);
+            let board = Board::new("", None::<String>);
             let result = store.upsert_board(board);
             assert!(
                 result.is_err(),
@@ -2662,10 +2662,10 @@ mod tests {
         let rt = make_rt();
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let board = Board::new("B".to_string(), None::<String>);
+            let board = Board::new("B", None::<String>);
             let board_id = board.id;
             store.upsert_board(board).unwrap();
-            let col = Column::new(board_id, "".to_string(), 0);
+            let col = Column::new(board_id, "", 0);
             let result = store.upsert_column(col);
             assert!(
                 result.is_err(),
@@ -2683,11 +2683,11 @@ mod tests {
         let rt = make_rt();
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let mut board = Board::new("B".to_string(), None::<String>);
-            let col = Column::new(board.id, "Col".to_string(), 0);
+            let mut board = Board::new("B", None::<String>);
+            let col = Column::new(board.id, "Col", 0);
             let col_id = col.id;
             // Card::new borrows &mut board -- call it before upsert_board moves board
-            let card = Card::new(&mut board, col_id, "".to_string(), 0);
+            let card = Card::new(&mut board, col_id, "", 0);
             store.upsert_board(board).unwrap();
             store.upsert_column(col).unwrap();
             let result = store.upsert_card(card);

--- a/crates/kanban-persistence-sqlite/src/sqlite_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store.rs
@@ -1950,7 +1950,7 @@ mod tests {
 
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let board = Board::new("Test Board".to_string(), None);
+            let board = Board::new("Test Board".to_string(), None::<String>);
             let snapshot = Snapshot::from_data(
                 vec![board],
                 vec![],
@@ -2137,7 +2137,7 @@ mod tests {
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
 
-            let mut board = kanban_domain::Board::new("B".to_string(), None);
+            let mut board = kanban_domain::Board::new("B".to_string(), None::<String>);
             let column = kanban_domain::Column::new(board.id, "Col".to_string(), 0);
             let card = kanban_domain::Card::new(&mut board, column.id, "Task".to_string(), 0);
             let card_id = card.id;
@@ -2173,7 +2173,7 @@ mod tests {
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
 
-            let mut board = kanban_domain::Board::new("B".to_string(), None);
+            let mut board = kanban_domain::Board::new("B".to_string(), None::<String>);
             let column = kanban_domain::Column::new(board.id, "Col".to_string(), 0);
             let card = kanban_domain::Card::new(&mut board, column.id, "Task".to_string(), 0);
             let card_id = card.id;
@@ -2618,13 +2618,13 @@ mod tests {
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
 
-            let mut board = Board::new("B".to_string(), None);
+            let mut board = Board::new("B".to_string(), None::<String>);
             let column = Column::new(board.id, "Col".to_string(), 0);
             let mut card = Card::new(&mut board, column.id, "Task".to_string(), 0);
             store.upsert_board(board).unwrap();
             store.upsert_column(column).unwrap();
 
-            let log = SprintLog::new(uuid::Uuid::new_v4(), 1, None, "".to_string());
+            let log = SprintLog::new(uuid::Uuid::new_v4(), 1, None::<String>, "".to_string());
             card.sprint_logs.push(log);
 
             let result = store.upsert_card(card);
@@ -2644,7 +2644,7 @@ mod tests {
         let rt = make_rt();
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let board = Board::new("".to_string(), None);
+            let board = Board::new("".to_string(), None::<String>);
             let result = store.upsert_board(board);
             assert!(
                 result.is_err(),
@@ -2662,7 +2662,7 @@ mod tests {
         let rt = make_rt();
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let board = Board::new("B".to_string(), None);
+            let board = Board::new("B".to_string(), None::<String>);
             let board_id = board.id;
             store.upsert_board(board).unwrap();
             let col = Column::new(board_id, "".to_string(), 0);
@@ -2683,7 +2683,7 @@ mod tests {
         let rt = make_rt();
         rt.block_on(async {
             let store = SqliteStore::open(&path).await.unwrap();
-            let mut board = Board::new("B".to_string(), None);
+            let mut board = Board::new("B".to_string(), None::<String>);
             let col = Column::new(board.id, "Col".to_string(), 0);
             let col_id = col.id;
             // Card::new borrows &mut board -- call it before upsert_board moves board

--- a/crates/kanban-persistence-sqlite/tests/data_store.rs
+++ b/crates/kanban-persistence-sqlite/tests/data_store.rs
@@ -12,7 +12,7 @@ async fn make_store() -> (SqliteStore, TempDir) {
 }
 
 fn make_board(name: &str) -> Board {
-    Board::new(name.to_string(), None)
+    Board::new(name.to_string(), None::<String>)
 }
 
 fn make_column(board_id: Uuid, name: &str, pos: i32) -> Column {
@@ -150,7 +150,7 @@ async fn test_sqlite_list_cards_by_sprint() {
     let (store, _dir) = make_store().await;
     let mut board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let sprint = Sprint::new(board.id, 1, None, None);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
     store.upsert_sprint(sprint.clone()).unwrap();
@@ -213,7 +213,7 @@ async fn test_sqlite_clear_sprint_from_cards() {
     let (store, _dir) = make_store().await;
     let mut board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let sprint = Sprint::new(board.id, 1, None, None);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
     store.upsert_sprint(sprint.clone()).unwrap();
@@ -242,7 +242,7 @@ async fn test_sqlite_upsert_and_get_sprint() {
     let (store, _dir) = make_store().await;
     let board = make_board("B");
     store.upsert_board(board.clone()).unwrap();
-    let sprint = Sprint::new(board.id, 1, None, None);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
     let sprint_id = sprint.id;
     store.upsert_sprint(sprint).unwrap();
 
@@ -260,13 +260,13 @@ async fn test_sqlite_list_sprints_by_board() {
     store.upsert_board(board2.clone()).unwrap();
 
     store
-        .upsert_sprint(Sprint::new(board1.id, 1, None, None))
+        .upsert_sprint(Sprint::new(board1.id, 1, None, None::<String>))
         .unwrap();
     store
-        .upsert_sprint(Sprint::new(board1.id, 2, None, None))
+        .upsert_sprint(Sprint::new(board1.id, 2, None, None::<String>))
         .unwrap();
     store
-        .upsert_sprint(Sprint::new(board2.id, 1, None, None))
+        .upsert_sprint(Sprint::new(board2.id, 1, None, None::<String>))
         .unwrap();
 
     let sprints = store.list_sprints_by_board(board1.id).unwrap();
@@ -318,7 +318,7 @@ async fn test_sqlite_snapshot_roundtrip() {
     let (store, _dir) = make_store().await;
     let mut board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let sprint = Sprint::new(board.id, 1, None, None);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
     store.upsert_sprint(sprint.clone()).unwrap();
@@ -468,7 +468,7 @@ async fn test_sqlite_concurrent_reads_and_writes_no_panic() {
     for i in 0..10 {
         let s = Arc::clone(&store);
         handles.push(tokio::spawn(async move {
-            let board = Board::new(format!("Board-{i}"), None);
+            let board = Board::new(format!("Board-{i}"), None::<String>);
             s.upsert_board(board.clone()).unwrap();
             let col = Column::new(board.id, format!("Col-{i}"), i);
             s.upsert_column(col).unwrap();

--- a/crates/kanban-persistence/src/snapshot_serde.rs
+++ b/crates/kanban-persistence/src/snapshot_serde.rs
@@ -16,7 +16,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_roundtrip() {
-        let board = Board::new("Test Board".to_string(), None::<String>);
+        let board = Board::new("Test Board", None::<String>);
         let snapshot = Snapshot::from_data(
             vec![board],
             vec![],

--- a/crates/kanban-persistence/src/snapshot_serde.rs
+++ b/crates/kanban-persistence/src/snapshot_serde.rs
@@ -16,7 +16,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_roundtrip() {
-        let board = Board::new("Test Board".to_string(), None);
+        let board = Board::new("Test Board".to_string(), None::<String>);
         let snapshot = Snapshot::from_data(
             vec![board],
             vec![],

--- a/crates/kanban-service/src/backend.rs
+++ b/crates/kanban-service/src/backend.rs
@@ -161,7 +161,9 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("t.sqlite3");
             let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
-            backend.upsert_board(Board::new("B", None::<String>)).unwrap();
+            backend
+                .upsert_board(Board::new("B", None::<String>))
+                .unwrap();
             backend
                 .flush()
                 .await
@@ -196,7 +198,9 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("t.sqlite3");
             let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
-            backend.upsert_board(Board::new("A", None::<String>)).unwrap();
+            backend
+                .upsert_board(Board::new("A", None::<String>))
+                .unwrap();
             backend.reload().await.unwrap();
             let boards = backend.list_boards().unwrap();
             assert_eq!(boards.len(), 1);

--- a/crates/kanban-service/src/backend.rs
+++ b/crates/kanban-service/src/backend.rs
@@ -161,7 +161,7 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("t.sqlite3");
             let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
-            backend.upsert_board(Board::new("B".into(), None)).unwrap();
+            backend.upsert_board(Board::new("B", None::<String>)).unwrap();
             backend
                 .flush()
                 .await
@@ -196,7 +196,7 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("t.sqlite3");
             let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
-            backend.upsert_board(Board::new("A".into(), None)).unwrap();
+            backend.upsert_board(Board::new("A", None::<String>)).unwrap();
             backend.reload().await.unwrap();
             let boards = backend.list_boards().unwrap();
             assert_eq!(boards.len(), 1);

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -383,8 +383,7 @@ mod tests {
         let path = dir.path().join("md.json");
         let jds = make_store(&path);
         // Trigger a write so flush has something to persist.
-        jds.upsert_board(Board::new("B".to_string(), None::<String>))
-            .unwrap();
+        jds.upsert_board(Board::new("B", None::<String>)).unwrap();
         jds.flush().await.unwrap();
         let meta = jds
             .persistence_metadata()

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -383,7 +383,7 @@ mod tests {
         let path = dir.path().join("md.json");
         let jds = make_store(&path);
         // Trigger a write so flush has something to persist.
-        jds.upsert_board(Board::new("B".to_string(), None)).unwrap();
+        jds.upsert_board(Board::new("B".to_string(), None::<String>)).unwrap();
         jds.flush().await.unwrap();
         let meta = jds
             .persistence_metadata()
@@ -454,7 +454,7 @@ mod tests {
         }
 
         let jds = JsonDataStore::new(Arc::new(FailingStore));
-        jds.upsert_board(Board::new("B".into(), None)).unwrap();
+        jds.upsert_board(Board::new("B", None::<String>)).unwrap();
         assert!(jds.needs_flush(), "must be dirty before flush attempt");
 
         let result = jds.flush().await;
@@ -482,7 +482,7 @@ mod tests {
         // Pre-create a file with one board.
         let (boards_json, _) = {
             let store = JsonFileStore::new(&path);
-            let board = Board::new("Alpha".into(), None);
+            let board = Board::new("Alpha", None::<String>);
             let snap = Snapshot {
                 boards: vec![board],
                 ..Snapshot::new()
@@ -528,7 +528,7 @@ mod tests {
     async fn test_needs_flush_true_after_upsert() {
         let dir = tempdir().unwrap();
         let jds = make_store(&dir.path().join("t.json"));
-        jds.upsert_board(Board::new("B".into(), None)).unwrap();
+        jds.upsert_board(Board::new("B", None::<String>)).unwrap();
         assert!(jds.needs_flush());
     }
 
@@ -537,7 +537,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("flush.json");
         let jds = make_store(&path);
-        jds.upsert_board(Board::new("Flushed".into(), None))
+        jds.upsert_board(Board::new("Flushed", None::<String>))
             .unwrap();
         jds.flush().await.unwrap();
         assert!(!jds.needs_flush(), "dirty flag cleared after flush");
@@ -556,7 +556,7 @@ mod tests {
         // Write initial data via a separate store.
         let writer = make_store(&path);
         writer
-            .upsert_board(Board::new("Initial".into(), None))
+            .upsert_board(Board::new("Initial", None::<String>))
             .unwrap();
         writer.flush().await.unwrap();
 
@@ -567,7 +567,7 @@ mod tests {
 
         // Externally update the file by flushing a new board through the writer.
         writer
-            .upsert_board(Board::new("Updated".into(), None))
+            .upsert_board(Board::new("Updated", None::<String>))
             .unwrap();
         writer.flush().await.unwrap();
 
@@ -605,7 +605,7 @@ mod tests {
         // Pre-populate the file with one board.
         {
             let store = Arc::new(JsonFileStore::new(&path));
-            let board = Board::new("ConcurrentBoard".into(), None);
+            let board = Board::new("ConcurrentBoard", None::<String>);
             let snap = kanban_domain::Snapshot {
                 boards: vec![board],
                 ..kanban_domain::Snapshot::new()

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -383,7 +383,8 @@ mod tests {
         let path = dir.path().join("md.json");
         let jds = make_store(&path);
         // Trigger a write so flush has something to persist.
-        jds.upsert_board(Board::new("B".to_string(), None::<String>)).unwrap();
+        jds.upsert_board(Board::new("B".to_string(), None::<String>))
+            .unwrap();
         jds.flush().await.unwrap();
         let meta = jds
             .persistence_metadata()

--- a/crates/kanban-service/tests/card_graph.rs
+++ b/crates/kanban-service/tests/card_graph.rs
@@ -41,12 +41,12 @@ async fn open_sqlite_ctx() -> (KanbanContext, tempfile::TempDir) {
 /// Seed a board with a single column and three cards. Returns the card ids
 /// for use as graph nodes in tests.
 fn seed_three_cards(backend: &Arc<dyn KanbanBackend>) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid) {
-    let mut board = Board::new("Test".to_string(), Some("TST".to_string()));
-    let col = Column::new(board.id, "TODO".to_string(), 0);
+    let mut board = Board::new("Test", Some("TST"));
+    let col = Column::new(board.id, "TODO", 0);
     let col_id = col.id;
-    let a = Card::new(&mut board, col_id, "A".to_string(), 0);
-    let b = Card::new(&mut board, col_id, "B".to_string(), 1);
-    let c = Card::new(&mut board, col_id, "C".to_string(), 2);
+    let a = Card::new(&mut board, col_id, "A", 0);
+    let b = Card::new(&mut board, col_id, "B", 1);
+    let c = Card::new(&mut board, col_id, "C", 2);
     let (a_id, b_id, c_id) = (a.id, b.id, c.id);
     backend.upsert_board(board).unwrap();
     backend.upsert_column(col).unwrap();
@@ -203,14 +203,14 @@ fn assert_add_is_undoable(
 /// parent/child as permitted; this helper backs the tests that exercise
 /// it.
 fn seed_two_boards_one_card_each(backend: &Arc<dyn KanbanBackend>) -> (uuid::Uuid, uuid::Uuid) {
-    let mut board_a = Board::new("Board A".to_string(), Some("AAA".to_string()));
-    let col_a = Column::new(board_a.id, "TODO".to_string(), 0);
-    let card_a = Card::new(&mut board_a, col_a.id, "Card A".to_string(), 0);
+    let mut board_a = Board::new("Board A", Some("AAA"));
+    let col_a = Column::new(board_a.id, "TODO", 0);
+    let card_a = Card::new(&mut board_a, col_a.id, "Card A", 0);
     let card_a_id = card_a.id;
 
-    let mut board_b = Board::new("Board B".to_string(), Some("BBB".to_string()));
-    let col_b = Column::new(board_b.id, "TODO".to_string(), 0);
-    let card_b = Card::new(&mut board_b, col_b.id, "Card B".to_string(), 0);
+    let mut board_b = Board::new("Board B", Some("BBB"));
+    let col_b = Column::new(board_b.id, "TODO", 0);
+    let card_b = Card::new(&mut board_b, col_b.id, "Card B", 0);
     let card_b_id = card_b.id;
 
     backend.upsert_board(board_a).unwrap();

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -159,7 +159,7 @@ async fn test_open_context_first_list_boards_triggers_load() -> KanbanResult<()>
         use kanban_persistence::{snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot};
 
         let snap = Snapshot {
-            boards: vec![Board::new("Alpha".into(), None)],
+            boards: vec![Board::new("Alpha", None::<String>)],
             ..Snapshot::new()
         };
         let data = snapshot_to_json_bytes(&snap).unwrap();
@@ -246,7 +246,7 @@ async fn test_open_context_reload_delegates_to_backend() -> KanbanResult<()> {
 
     // External writer adds a board.
     let external = make_json_data_store(&path);
-    external.upsert_board(kanban_domain::Board::new("External".into(), None))?;
+    external.upsert_board(kanban_domain::Board::new("External", None::<String>))?;
     external.flush().await?;
 
     // Before reload the context cache is stale.
@@ -311,7 +311,7 @@ async fn test_reload_after_external_json_change_returns_updated_data() -> Kanban
 
     // External writer adds a board, bypassing ctx.
     let external = make_json_data_store(&path);
-    external.upsert_board(kanban_domain::Board::new("External".into(), None))?;
+    external.upsert_board(kanban_domain::Board::new("External", None::<String>))?;
     external.flush().await?;
 
     // reload() clears the lazy cache; next read loads the updated file.
@@ -365,7 +365,7 @@ mod sqlite_tests {
 
         // Second instance writes a board directly to the DB.
         let backend2 = SqliteBackend::open(path.to_str().unwrap()).await?;
-        backend2.upsert_board(kanban_domain::Board::new("Via2nd".into(), None))?;
+        backend2.upsert_board(kanban_domain::Board::new("Via2nd", None::<String>))?;
 
         // First context sees the write immediately — SQLite reads are live.
         let boards = ctx.boards()?;
@@ -420,7 +420,7 @@ async fn test_replace_backend_reads_go_to_new_backend() -> KanbanResult<()> {
 
     // Pre-populate backend B with one board.
     let writer = make_json_data_store(&path_b);
-    writer.upsert_board(kanban_domain::Board::new("B".into(), None))?;
+    writer.upsert_board(kanban_domain::Board::new("B", None::<String>))?;
     writer.flush().await?;
 
     let mut ctx = KanbanContext::open(
@@ -467,7 +467,7 @@ async fn test_open_session_undo_preserves_preexisting_boards() -> KanbanResult<(
     // Session 0: pre-populate the file with B0.
     {
         let jds = make_json_data_store(&path);
-        jds.upsert_board(kanban_domain::Board::new("B0".into(), None))?;
+        jds.upsert_board(kanban_domain::Board::new("B0", None::<String>))?;
         jds.flush().await?;
     }
 

--- a/crates/kanban-service/tests/data_integrity_tests.rs
+++ b/crates/kanban-service/tests/data_integrity_tests.rs
@@ -31,8 +31,18 @@ async fn test_delete_card_cleans_dependencies() -> KanbanResult<()> {
 
     let board = ctx.create_board("B".to_string(), None)?;
     let col = ctx.create_column(board.id, "Col".to_string(), None)?;
-    let card_a = ctx.create_card(board.id, col.id, "A".to_string(), CreateCardOptions::default())?;
-    let card_b = ctx.create_card(board.id, col.id, "B".to_string(), CreateCardOptions::default())?;
+    let card_a = ctx.create_card(
+        board.id,
+        col.id,
+        "A".to_string(),
+        CreateCardOptions::default(),
+    )?;
+    let card_b = ctx.create_card(
+        board.id,
+        col.id,
+        "B".to_string(),
+        CreateCardOptions::default(),
+    )?;
 
     ctx.block(card_a.id, card_b.id, Severity::default())?;
     assert_eq!(
@@ -61,7 +71,12 @@ async fn test_delete_column_with_cards_returns_error() -> KanbanResult<()> {
     let board = ctx.create_board("B".to_string(), None)?;
     let col = ctx.create_column(board.id, "Col".to_string(), None)?;
     let col_id = col.id;
-    ctx.create_card(board.id, col_id, "C".to_string(), CreateCardOptions::default())?;
+    ctx.create_card(
+        board.id,
+        col_id,
+        "C".to_string(),
+        CreateCardOptions::default(),
+    )?;
 
     let result = ctx.delete_column(col_id);
     assert!(
@@ -90,8 +105,18 @@ async fn test_delete_sprint_unassigns_cards() -> KanbanResult<()> {
     let sprint = ctx.create_sprint(board.id, None, None)?;
     let sprint_id = sprint.id;
 
-    let card_a = ctx.create_card(board.id, col.id, "A".to_string(), CreateCardOptions::default())?;
-    let card_b = ctx.create_card(board.id, col.id, "B".to_string(), CreateCardOptions::default())?;
+    let card_a = ctx.create_card(
+        board.id,
+        col.id,
+        "A".to_string(),
+        CreateCardOptions::default(),
+    )?;
+    let card_b = ctx.create_card(
+        board.id,
+        col.id,
+        "B".to_string(),
+        CreateCardOptions::default(),
+    )?;
     ctx.assign_card_to_sprint(card_a.id, sprint_id)?;
     ctx.assign_card_to_sprint(card_b.id, sprint_id)?;
 

--- a/crates/kanban-service/tests/data_integrity_tests.rs
+++ b/crates/kanban-service/tests/data_integrity_tests.rs
@@ -29,10 +29,10 @@ async fn open_json_ctx() -> (KanbanContext, tempfile::TempDir) {
 async fn test_delete_card_cleans_dependencies() -> KanbanResult<()> {
     let (mut ctx, _dir) = open_json_ctx().await;
 
-    let board = ctx.create_board("B".into(), None)?;
-    let col = ctx.create_column(board.id, "Col".into(), None)?;
-    let card_a = ctx.create_card(board.id, col.id, "A".into(), CreateCardOptions::default())?;
-    let card_b = ctx.create_card(board.id, col.id, "B".into(), CreateCardOptions::default())?;
+    let board = ctx.create_board("B".to_string(), None)?;
+    let col = ctx.create_column(board.id, "Col".to_string(), None)?;
+    let card_a = ctx.create_card(board.id, col.id, "A".to_string(), CreateCardOptions::default())?;
+    let card_b = ctx.create_card(board.id, col.id, "B".to_string(), CreateCardOptions::default())?;
 
     ctx.block(card_a.id, card_b.id, Severity::default())?;
     assert_eq!(
@@ -58,10 +58,10 @@ async fn test_delete_card_cleans_dependencies() -> KanbanResult<()> {
 async fn test_delete_column_with_cards_returns_error() -> KanbanResult<()> {
     let (mut ctx, _dir) = open_json_ctx().await;
 
-    let board = ctx.create_board("B".into(), None)?;
-    let col = ctx.create_column(board.id, "Col".into(), None)?;
+    let board = ctx.create_board("B".to_string(), None)?;
+    let col = ctx.create_column(board.id, "Col".to_string(), None)?;
     let col_id = col.id;
-    ctx.create_card(board.id, col_id, "C".into(), CreateCardOptions::default())?;
+    ctx.create_card(board.id, col_id, "C".to_string(), CreateCardOptions::default())?;
 
     let result = ctx.delete_column(col_id);
     assert!(
@@ -85,13 +85,13 @@ async fn test_delete_column_with_cards_returns_error() -> KanbanResult<()> {
 async fn test_delete_sprint_unassigns_cards() -> KanbanResult<()> {
     let (mut ctx, _dir) = open_json_ctx().await;
 
-    let board = ctx.create_board("B".into(), None)?;
-    let col = ctx.create_column(board.id, "Col".into(), None)?;
+    let board = ctx.create_board("B".to_string(), None)?;
+    let col = ctx.create_column(board.id, "Col".to_string(), None)?;
     let sprint = ctx.create_sprint(board.id, None, None)?;
     let sprint_id = sprint.id;
 
-    let card_a = ctx.create_card(board.id, col.id, "A".into(), CreateCardOptions::default())?;
-    let card_b = ctx.create_card(board.id, col.id, "B".into(), CreateCardOptions::default())?;
+    let card_a = ctx.create_card(board.id, col.id, "A".to_string(), CreateCardOptions::default())?;
+    let card_b = ctx.create_card(board.id, col.id, "B".to_string(), CreateCardOptions::default())?;
     ctx.assign_card_to_sprint(card_a.id, sprint_id)?;
     ctx.assign_card_to_sprint(card_b.id, sprint_id)?;
 
@@ -139,13 +139,13 @@ async fn test_update_nonexistent_card_returns_not_found() -> KanbanResult<()> {
 async fn test_import_with_invalid_column_reference_fails() -> KanbanResult<()> {
     let (mut ctx, _dir) = open_json_ctx().await;
 
-    let board = kanban_domain::Board::new("Imported".into(), None);
+    let board = kanban_domain::Board::new("Imported", None::<String>);
     let board_id = board.id;
     let nonexistent_column_id = Uuid::new_v4();
 
     let mut orphan_board = board.clone();
     let orphan_card =
-        kanban_domain::Card::new(&mut orphan_board, nonexistent_column_id, "Orphan".into(), 0);
+        kanban_domain::Card::new(&mut orphan_board, nonexistent_column_id, "Orphan", 0);
 
     let snapshot = kanban_domain::Snapshot {
         boards: vec![board],
@@ -183,8 +183,8 @@ async fn test_import_with_invalid_column_reference_fails() -> KanbanResult<()> {
 async fn test_rapid_save_queue_completes_all() -> KanbanResult<()> {
     let (mut ctx, _dir) = open_json_ctx().await;
 
-    let board = ctx.create_board("Board".into(), None)?;
-    let col = ctx.create_column(board.id, "Col".into(), None)?;
+    let board = ctx.create_board("Board".to_string(), None)?;
+    let col = ctx.create_column(board.id, "Col".to_string(), None)?;
 
     let mut card_ids = Vec::new();
     for i in 0..220 {

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -48,12 +48,12 @@ macro_rules! cascade_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
+                let mut board = Board::new("B", Some("TST"));
                 let board_id = board.id;
-                let col1 = Column::new(board_id, "Col1".to_string(), 0);
-                let col2 = Column::new(board_id, "Col2".to_string(), 1);
-                let card1 = Card::new(&mut board, col1.id, "C1".to_string(), 0);
-                let card2 = Card::new(&mut board, col2.id, "C2".to_string(), 0);
+                let col1 = Column::new(board_id, "Col1", 0);
+                let col2 = Column::new(board_id, "Col2", 1);
+                let card1 = Card::new(&mut board, col1.id, "C1", 0);
+                let card2 = Card::new(&mut board, col2.id, "C2", 0);
                 let sprint = Sprint::new(board_id, 1, None, None::<String>);
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col1).unwrap();
@@ -75,11 +75,11 @@ macro_rules! cascade_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
+                let mut board = Board::new("B", Some("TST"));
                 let board_id = board.id;
-                let col = Column::new(board_id, "Col".to_string(), 0);
-                let card_a = Card::new(&mut board, col.id, "A".to_string(), 0);
-                let card_b = Card::new(&mut board, col.id, "B".to_string(), 1);
+                let col = Column::new(board_id, "Col", 0);
+                let card_a = Card::new(&mut board, col.id, "A", 0);
+                let card_b = Card::new(&mut board, col.id, "B", 1);
                 let card_a_id = card_a.id;
                 let card_b_id = card_b.id;
                 backend.upsert_board(board).unwrap();
@@ -106,11 +106,11 @@ macro_rules! cascade_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
+                let mut board = Board::new("B", Some("TST"));
                 let board_id = board.id;
-                let col = Column::new(board_id, "Col".to_string(), 0);
+                let col = Column::new(board_id, "Col", 0);
                 let col_id = col.id;
-                let card = Card::new(&mut board, col_id, "C".to_string(), 0);
+                let card = Card::new(&mut board, col_id, "C", 0);
                 let archived = ArchivedCard::new(card, col_id, 0);
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col).unwrap();

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -54,7 +54,7 @@ macro_rules! cascade_tests {
                 let col2 = Column::new(board_id, "Col2".to_string(), 1);
                 let card1 = Card::new(&mut board, col1.id, "C1".to_string(), 0);
                 let card2 = Card::new(&mut board, col2.id, "C2".to_string(), 0);
-                let sprint = Sprint::new(board_id, 1, None, None);
+                let sprint = Sprint::new(board_id, 1, None, None::<String>);
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col1).unwrap();
                 backend.upsert_column(col2).unwrap();

--- a/crates/kanban-service/tests/migrate_sprint_logs.rs
+++ b/crates/kanban-service/tests/migrate_sprint_logs.rs
@@ -45,11 +45,11 @@ macro_rules! migrate_sprint_logs_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
-                let col = Column::new(board.id, "Col".to_string(), 0);
-                let sprint = Sprint::new(board.id, 1, None, Some("Alpha".to_string()));
+                let mut board = Board::new("B", Some("TST"));
+                let col = Column::new(board.id, "Col", 0);
+                let sprint = Sprint::new(board.id, 1, None, Some("Alpha"));
                 let sprint_id = sprint.id;
-                let mut card = Card::new(&mut board, col.id, "Card".to_string(), 0);
+                let mut card = Card::new(&mut board, col.id, "Card", 0);
                 let card_id = card.id;
                 card.sprint_id = Some(sprint_id);
                 assert!(card.sprint_logs.is_empty());
@@ -75,9 +75,9 @@ macro_rules! migrate_sprint_logs_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
-                let col = Column::new(board.id, "Col".to_string(), 0);
-                let card = Card::new(&mut board, col.id, "Card".to_string(), 0);
+                let mut board = Board::new("B", Some("TST"));
+                let col = Column::new(board.id, "Col", 0);
+                let card = Card::new(&mut board, col.id, "Card", 0);
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col).unwrap();
                 backend.upsert_card(card).unwrap();
@@ -100,18 +100,16 @@ macro_rules! migrate_sprint_logs_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
-                let col = Column::new(board.id, "Col".to_string(), 0);
-                let sprint = Sprint::new(board.id, 1, None, Some("Alpha".to_string()));
+                let mut board = Board::new("B", Some("TST"));
+                let col = Column::new(board.id, "Col", 0);
+                let sprint = Sprint::new(board.id, 1, None, Some("Alpha"));
                 let sprint_id = sprint.id;
 
-                let mut card_needs_backfill =
-                    Card::new(&mut board, col.id, "Needs Backfill".to_string(), 0);
+                let mut card_needs_backfill = Card::new(&mut board, col.id, "Needs Backfill", 0);
                 card_needs_backfill.sprint_id = Some(sprint_id);
                 let needs_backfill_id = card_needs_backfill.id;
 
-                let mut card_already_logged =
-                    Card::new(&mut board, col.id, "Already Logged".to_string(), 1);
+                let mut card_already_logged = Card::new(&mut board, col.id, "Already Logged", 1);
                 card_already_logged.sprint_id = Some(sprint_id);
                 card_already_logged
                     .sprint_logs
@@ -119,12 +117,12 @@ macro_rules! migrate_sprint_logs_tests {
                         sprint_id,
                         1,
                         None::<String>,
-                        "Active".to_string(),
+                        "Active",
                     ));
                 let already_logged_id = card_already_logged.id;
                 let already_logged_before = card_already_logged.sprint_logs.clone();
 
-                let card_no_sprint = Card::new(&mut board, col.id, "No Sprint".to_string(), 2);
+                let card_no_sprint = Card::new(&mut board, col.id, "No Sprint", 2);
                 let no_sprint_id = card_no_sprint.id;
 
                 backend.upsert_board(board).unwrap();

--- a/crates/kanban-service/tests/migrate_sprint_logs.rs
+++ b/crates/kanban-service/tests/migrate_sprint_logs.rs
@@ -116,9 +116,7 @@ macro_rules! migrate_sprint_logs_tests {
                 card_already_logged
                     .sprint_logs
                     .push(kanban_domain::SprintLog::new(
-                        sprint_id,
-                        1,
-                        None,
+                        sprint_id, 1, None::<String>,
                         "Active".to_string(),
                     ));
                 let already_logged_id = card_already_logged.id;

--- a/crates/kanban-service/tests/migrate_sprint_logs.rs
+++ b/crates/kanban-service/tests/migrate_sprint_logs.rs
@@ -116,7 +116,9 @@ macro_rules! migrate_sprint_logs_tests {
                 card_already_logged
                     .sprint_logs
                     .push(kanban_domain::SprintLog::new(
-                        sprint_id, 1, None::<String>,
+                        sprint_id,
+                        1,
+                        None::<String>,
                         "Active".to_string(),
                     ));
                 let already_logged_id = card_already_logged.id;

--- a/crates/kanban-service/tests/move_cards.rs
+++ b/crates/kanban-service/tests/move_cards.rs
@@ -45,15 +45,15 @@ macro_rules! move_cards_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
-                let col_from = Column::new(board.id, "From".to_string(), 0);
-                let col_to = Column::new(board.id, "To".to_string(), 1);
+                let mut board = Board::new("B", Some("TST"));
+                let col_from = Column::new(board.id, "From", 0);
+                let col_to = Column::new(board.id, "To", 1);
                 let col_to_id = col_to.id;
 
-                let existing1 = Card::new(&mut board, col_to_id, "E1".to_string(), 0);
-                let existing2 = Card::new(&mut board, col_to_id, "E2".to_string(), 1);
-                let move1 = Card::new(&mut board, col_from.id, "M1".to_string(), 0);
-                let move2 = Card::new(&mut board, col_from.id, "M2".to_string(), 1);
+                let existing1 = Card::new(&mut board, col_to_id, "E1", 0);
+                let existing2 = Card::new(&mut board, col_to_id, "E2", 1);
+                let move1 = Card::new(&mut board, col_from.id, "M1", 0);
+                let move2 = Card::new(&mut board, col_from.id, "M2", 1);
                 let move1_id = move1.id;
                 let move2_id = move2.id;
                 backend.upsert_board(board).unwrap();
@@ -79,12 +79,12 @@ macro_rules! move_cards_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
-                let col = Column::new(board.id, "Col".to_string(), 0);
+                let mut board = Board::new("B", Some("TST"));
+                let col = Column::new(board.id, "Col", 0);
                 let col_id = col.id;
-                let card1 = Card::new(&mut board, col_id, "C1".to_string(), 0);
-                let card2 = Card::new(&mut board, col_id, "C2".to_string(), 1);
-                let card3 = Card::new(&mut board, col_id, "C3".to_string(), 2);
+                let card1 = Card::new(&mut board, col_id, "C1", 0);
+                let card2 = Card::new(&mut board, col_id, "C2", 1);
+                let card3 = Card::new(&mut board, col_id, "C3", 2);
                 let c1_id = card1.id;
                 let c3_id = card3.id;
                 backend.upsert_board(board).unwrap();
@@ -148,11 +148,11 @@ macro_rules! move_cards_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B".to_string(), Some("TST".to_string()));
-                let col_from = Column::new(board.id, "From".to_string(), 0);
-                let col_to = Column::new(board.id, "To".to_string(), 1);
+                let mut board = Board::new("B", Some("TST"));
+                let col_from = Column::new(board.id, "From", 0);
+                let col_to = Column::new(board.id, "To", 1);
                 let col_to_id = col_to.id;
-                let card = Card::new(&mut board, col_from.id, "C".to_string(), 0);
+                let card = Card::new(&mut board, col_from.id, "C", 0);
                 let valid_id = card.id;
                 let invalid_id = uuid::Uuid::new_v4();
                 backend.upsert_board(board).unwrap();

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -21,7 +21,7 @@ async fn test_import_board_checkpoints_wal_on_sqlite_path() {
         .await
         .unwrap();
     let snapshot = Snapshot {
-        boards: vec![Board::new("Imported".to_string(), None::<String>)],
+        boards: vec![Board::new("Imported", None::<String>)],
         columns: vec![],
         cards: vec![],
         archived_cards: vec![],

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -21,7 +21,7 @@ async fn test_import_board_checkpoints_wal_on_sqlite_path() {
         .await
         .unwrap();
     let snapshot = Snapshot {
-        boards: vec![Board::new("Imported".to_string(), None)],
+        boards: vec![Board::new("Imported".to_string(), None::<String>)],
         columns: vec![],
         cards: vec![],
         archived_cards: vec![],

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -530,8 +530,8 @@ async fn test_import_entities_is_undoable() -> KanbanResult<()> {
     ctx.create_board("B1".into(), None)?;
     ctx.clear_history()?;
 
-    let b2 = kanban_domain::Board::new("B2".to_string(), None::<String>);
-    let col = kanban_domain::Column::new(b2.id, "Todo".to_string(), 0);
+    let b2 = kanban_domain::Board::new("B2", None::<String>);
+    let col = kanban_domain::Column::new(b2.id, "Todo", 0);
     let cmd = Command::Board(BoardCommand::Import(ImportEntities {
         boards: vec![b2],
         columns: vec![col],

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -530,7 +530,7 @@ async fn test_import_entities_is_undoable() -> KanbanResult<()> {
     ctx.create_board("B1".into(), None)?;
     ctx.clear_history()?;
 
-    let b2 = kanban_domain::Board::new("B2".to_string(), None);
+    let b2 = kanban_domain::Board::new("B2".to_string(), None::<String>);
     let col = kanban_domain::Column::new(b2.id, "Todo".to_string(), 0);
     let cmd = Command::Board(BoardCommand::Import(ImportEntities {
         boards: vec![b2],

--- a/crates/kanban-service/tests/validate_and_load.rs
+++ b/crates/kanban-service/tests/validate_and_load.rs
@@ -163,7 +163,7 @@ async fn create_test_sqlite(dir: &std::path::Path, name: &str, boards: &[&str]) 
 
     let domain_boards: Vec<kanban_domain::Board> = boards
         .iter()
-        .map(|name| kanban_domain::Board::new(name.to_string(), None))
+        .map(|name| kanban_domain::Board::new(name.to_string(), None::<String>))
         .collect();
     let snapshot = kanban_domain::Snapshot {
         boards: domain_boards,

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 #[test]
 fn test_with_transaction_commits_on_success() -> KanbanResult<()> {
     let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
-    let board = Board::new("Committed".into(), None);
+    let board = Board::new("Committed", None::<String>);
     let board_id = board.id;
 
     let backend_for_closure = Arc::clone(&backend);
@@ -29,13 +29,13 @@ fn test_with_transaction_rolls_back_on_failure() -> KanbanResult<()> {
     let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
     // Pre-state: one board already exists; the transaction below tries to add
     // a second but fails. After rollback only the pre-state survives.
-    backend.upsert_board(Board::new("Original".into(), None))?;
+    backend.upsert_board(Board::new("Original", None::<String>))?;
     let pre_count = backend.list_boards()?.len();
 
     let backend_for_closure = Arc::clone(&backend);
     let result = backend.with_transaction(&mut || {
         let store: &dyn DataStore = backend_for_closure.as_data_store();
-        store.upsert_board(Board::new("Will be rolled back".into(), None))?;
+        store.upsert_board(Board::new("Will be rolled back", None::<String>))?;
         Err(KanbanError::Internal("simulated failure".into()))
     });
 

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -2762,7 +2762,9 @@ mod tests {
         // Seed in-memory state with a board so we can detect whether adopt
         // transferred it to the new on-disk backend.
         let mut snapshot = app.ctx.snapshot().unwrap();
-        snapshot.boards.push(Board::new("BeforeAdopt", None::<String>));
+        snapshot
+            .boards
+            .push(Board::new("BeforeAdopt", None::<String>));
         app.ctx.apply_snapshot(snapshot).unwrap();
 
         app.maybe_push_startup_file_dialog();

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -2575,7 +2575,7 @@ mod tests {
 
         let backend = Arc::new(JsonDataStore::new(Arc::new(ConflictingStore)));
         backend
-            .upsert_board(kanban_domain::Board::new("B".into(), None))
+            .upsert_board(kanban_domain::Board::new("B", None::<String>))
             .unwrap();
 
         let inner = kanban_service::KanbanContext::open_deferred(
@@ -2762,7 +2762,7 @@ mod tests {
         // Seed in-memory state with a board so we can detect whether adopt
         // transferred it to the new on-disk backend.
         let mut snapshot = app.ctx.snapshot().unwrap();
-        snapshot.boards.push(Board::new("BeforeAdopt".into(), None));
+        snapshot.boards.push(Board::new("BeforeAdopt", None::<String>));
         app.ctx.apply_snapshot(snapshot).unwrap();
 
         app.maybe_push_startup_file_dialog();

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -81,7 +81,7 @@ mod tests {
     use kanban_domain::{ArchivedCard, Board, Card, Column, Snapshot};
 
     fn make_card(board: &mut Board, column_id: Uuid) -> Card {
-        Card::new(board, column_id, "task".to_string(), 0)
+        Card::new(board, column_id, "task", 0)
     }
 
     #[test]
@@ -98,8 +98,8 @@ mod tests {
     #[test]
     fn test_load_from_snapshot_populates_boards_and_columns() {
         let mut m = Model::default();
-        let board = Board::new("B".to_string(), None::<String>);
-        let col = Column::new(board.id, "Col".to_string(), 0);
+        let board = Board::new("B", None::<String>);
+        let col = Column::new(board.id, "Col", 0);
         m.load_from_snapshot(Snapshot {
             boards: vec![board.clone()],
             columns: vec![col.clone()],
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn test_card_lookup_by_id_returns_correct_card() {
         let mut m = Model::default();
-        let mut board = Board::new("B".to_string(), None::<String>);
+        let mut board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
         let card_a = make_card(&mut board, col_id);
         let card_b = make_card(&mut board, col_id);
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn test_archived_card_lookup_by_id() {
         let mut m = Model::default();
-        let mut board = Board::new("B".to_string(), None::<String>);
+        let mut board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
         let card = make_card(&mut board, col_id);
         let card_id = card.id;
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_archived_cards_flat_matches_archived_cards() {
         let mut m = Model::default();
-        let mut board = Board::new("B".to_string(), None::<String>);
+        let mut board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
         let card = make_card(&mut board, col_id);
         let card_id = card.id;
@@ -173,15 +173,15 @@ mod tests {
     #[test]
     fn test_load_from_snapshot_overwrites_previous_state() {
         let mut m = Model::default();
-        let board_a = Board::new("A".to_string(), None::<String>);
+        let board_a = Board::new("A", None::<String>);
         m.load_from_snapshot(Snapshot {
             boards: vec![board_a],
             ..Default::default()
         });
         assert_eq!(m.boards().len(), 1);
 
-        let board_b = Board::new("B".to_string(), None::<String>);
-        let board_c = Board::new("C".to_string(), None::<String>);
+        let board_b = Board::new("B", None::<String>);
+        let board_c = Board::new("C", None::<String>);
         m.load_from_snapshot(Snapshot {
             boards: vec![board_b, board_c],
             ..Default::default()
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn test_load_from_snapshot_clears_stale_card_index() {
         let mut m = Model::default();
-        let mut board = Board::new("B".to_string(), None::<String>);
+        let mut board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
         let card = make_card(&mut board, col_id);
         let old_id = card.id;

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn test_load_from_snapshot_populates_boards_and_columns() {
         let mut m = Model::default();
-        let board = Board::new("B".to_string(), None);
+        let board = Board::new("B".to_string(), None::<String>);
         let col = Column::new(board.id, "Col".to_string(), 0);
         m.load_from_snapshot(Snapshot {
             boards: vec![board.clone()],
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn test_card_lookup_by_id_returns_correct_card() {
         let mut m = Model::default();
-        let mut board = Board::new("B".to_string(), None);
+        let mut board = Board::new("B".to_string(), None::<String>);
         let col_id = Uuid::new_v4();
         let card_a = make_card(&mut board, col_id);
         let card_b = make_card(&mut board, col_id);
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn test_archived_card_lookup_by_id() {
         let mut m = Model::default();
-        let mut board = Board::new("B".to_string(), None);
+        let mut board = Board::new("B".to_string(), None::<String>);
         let col_id = Uuid::new_v4();
         let card = make_card(&mut board, col_id);
         let card_id = card.id;
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_archived_cards_flat_matches_archived_cards() {
         let mut m = Model::default();
-        let mut board = Board::new("B".to_string(), None);
+        let mut board = Board::new("B".to_string(), None::<String>);
         let col_id = Uuid::new_v4();
         let card = make_card(&mut board, col_id);
         let card_id = card.id;
@@ -173,15 +173,15 @@ mod tests {
     #[test]
     fn test_load_from_snapshot_overwrites_previous_state() {
         let mut m = Model::default();
-        let board_a = Board::new("A".to_string(), None);
+        let board_a = Board::new("A".to_string(), None::<String>);
         m.load_from_snapshot(Snapshot {
             boards: vec![board_a],
             ..Default::default()
         });
         assert_eq!(m.boards().len(), 1);
 
-        let board_b = Board::new("B".to_string(), None);
-        let board_c = Board::new("C".to_string(), None);
+        let board_b = Board::new("B".to_string(), None::<String>);
+        let board_c = Board::new("C".to_string(), None::<String>);
         m.load_from_snapshot(Snapshot {
             boards: vec![board_b, board_c],
             ..Default::default()
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn test_load_from_snapshot_clears_stale_card_index() {
         let mut m = Model::default();
-        let mut board = Board::new("B".to_string(), None);
+        let mut board = Board::new("B".to_string(), None::<String>);
         let col_id = Uuid::new_v4();
         let card = make_card(&mut board, col_id);
         let old_id = card.id;

--- a/crates/kanban-tui/src/components/sprint_assign_list.rs
+++ b/crates/kanban-tui/src/components/sprint_assign_list.rs
@@ -502,7 +502,7 @@ mod tests {
     }
 
     fn make_board_for_render() -> Board {
-        Board::new("B".to_string(), Some("TST".to_string()))
+        Board::new("B", Some("TST"))
     }
 
     #[test]

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -368,7 +368,7 @@ mod tests {
     use kanban_domain::SprintStatus;
 
     fn make_board() -> Board {
-        Board::new("B".to_string(), Some("TST".to_string()))
+        Board::new("B", Some("TST"))
     }
 
     fn active_sprint(board_id: Uuid, n: u32, now: DateTime<Utc>) -> Sprint {

--- a/crates/kanban-tui/src/components/sprint_picker.rs
+++ b/crates/kanban-tui/src/components/sprint_picker.rs
@@ -448,8 +448,8 @@ mod tests {
     fn test_arrow_moves_cursor_without_changing_selection() {
         let now = Utc::now();
         let board = make_board();
-        let planning_a = Sprint::new(board.id, 1, None, None);
-        let planning_b = Sprint::new(board.id, 2, None, None);
+        let planning_a = Sprint::new(board.id, 1, None, None::<String>);
+        let planning_b = Sprint::new(board.id, 2, None, None::<String>);
         let sprints = vec![planning_a, planning_b];
 
         let mut picker = SprintPicker::new();
@@ -472,8 +472,8 @@ mod tests {
         // Two planning sprints — no active, so the picker opens with
         // selection Unset and cursor on (None). Down walks the cursor
         // onto a sprint; Space then checks it.
-        let p_a = Sprint::new(board.id, 1, None, None);
-        let p_b = Sprint::new(board.id, 2, None, None);
+        let p_a = Sprint::new(board.id, 1, None, None::<String>);
+        let p_b = Sprint::new(board.id, 2, None, None::<String>);
         let sprints = vec![p_a, p_b];
 
         let mut picker = SprintPicker::new();
@@ -492,8 +492,8 @@ mod tests {
     fn test_space_after_arrow_switches_check_to_new_cursor_sprint() {
         let now = Utc::now();
         let board = make_board();
-        let planning_a = Sprint::new(board.id, 1, None, None);
-        let planning_b = Sprint::new(board.id, 2, None, None);
+        let planning_a = Sprint::new(board.id, 1, None, None::<String>);
+        let planning_b = Sprint::new(board.id, 2, None, None::<String>);
         let sprints = vec![planning_a.clone(), planning_b.clone()];
 
         let mut picker = SprintPicker::new();
@@ -572,8 +572,8 @@ mod tests {
     fn test_handle_key_down_moves_cursor_returns_true() {
         let now = Utc::now();
         let board = make_board();
-        let planning_a = Sprint::new(board.id, 1, None, None);
-        let planning_b = Sprint::new(board.id, 2, None, None);
+        let planning_a = Sprint::new(board.id, 1, None, None::<String>);
+        let planning_b = Sprint::new(board.id, 2, None, None::<String>);
         let sprints = vec![planning_a, planning_b];
 
         let mut picker = SprintPicker::new();
@@ -627,7 +627,7 @@ mod tests {
             created_at: now_open,
             updated_at: now_open,
         };
-        let sprint_b = Sprint::new(board.id, 2, None, None);
+        let sprint_b = Sprint::new(board.id, 2, None, None::<String>);
         let sprints = vec![sprint_a.clone(), sprint_b];
 
         let mut picker = SprintPicker::new();
@@ -677,7 +677,7 @@ mod tests {
 
         // Sprint that ended in the past — would normally appear in the
         // Completed/Ended section of build_entries.
-        let mut completed = Sprint::new(board.id, 2, None, None);
+        let mut completed = Sprint::new(board.id, 2, None, None::<String>);
         completed.status = SprintStatus::Completed;
         completed.start_date = Some(now - Duration::days(30));
         completed.end_date = Some(now - Duration::days(15));
@@ -792,7 +792,7 @@ mod tests {
         // ambiguity about what Enter should do.
         let now = Utc::now();
         let board = make_board();
-        let mut completed = Sprint::new(board.id, 1, None, None);
+        let mut completed = Sprint::new(board.id, 1, None, None::<String>);
         completed.status = SprintStatus::Completed;
         completed.start_date = Some(now - Duration::days(30));
         completed.end_date = Some(now - Duration::days(15));

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn test_apply_to_app_syncs_sort_field_from_board() {
         // Create a board with Position sort field
-        let mut board = Board::new("Test".to_string(), None);
+        let mut board = Board::new("Test".to_string(), None::<String>);
         board.update_task_sort(SortField::Position, kanban_domain::SortOrder::Ascending);
 
         let snapshot = Snapshot {

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn test_apply_to_app_syncs_sort_field_from_board() {
         // Create a board with Position sort field
-        let mut board = Board::new("Test".to_string(), None::<String>);
+        let mut board = Board::new("Test", None::<String>);
         board.update_task_sort(SortField::Position, kanban_domain::SortOrder::Ascending);
 
         let snapshot = Snapshot {

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -118,11 +118,11 @@ fn test_markdown_rendering_of_description() {
     use kanban_domain::{Board, Card};
     use kanban_tui::components::*;
 
-    let mut board = Board::new("Test Board".to_string(), None::<String>);
+    let mut board = Board::new("Test Board", None::<String>);
     let column_id = uuid::Uuid::new_v4();
 
     // Test rendering of non-empty description
-    let mut card = Card::new(&mut board, column_id, "Test".to_string(), 0);
+    let mut card = Card::new(&mut board, column_id, "Test", 0);
     card.description = Some("# Heading\n\nSome **bold** text".to_string());
 
     let lines = build_description_lines(&card);

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -118,7 +118,7 @@ fn test_markdown_rendering_of_description() {
     use kanban_domain::{Board, Card};
     use kanban_tui::components::*;
 
-    let mut board = Board::new("Test Board".to_string(), None);
+    let mut board = Board::new("Test Board".to_string(), None::<String>);
     let column_id = uuid::Uuid::new_v4();
 
     // Test rendering of non-empty description

--- a/crates/kanban-tui/tests/card_detail_tests.rs
+++ b/crates/kanban-tui/tests/card_detail_tests.rs
@@ -6,7 +6,7 @@ use kanban_domain::{Board, Card, Column, Snapshot};
 fn test_active_card_detail_shows_selected_card() {
     let mut app = kanban_tui::App::test_default();
 
-    let mut board = Board::new("TestBoard".to_string(), None);
+    let mut board = Board::new("TestBoard".to_string(), None::<String>);
     let col = Column::new(board.id, "Backlog".to_string(), 0);
     let card_a = Card::new(&mut board, col.id, "Card Alpha".to_string(), 0);
     let card_b = Card::new(&mut board, col.id, "Card Beta".to_string(), 1);

--- a/crates/kanban-tui/tests/card_detail_tests.rs
+++ b/crates/kanban-tui/tests/card_detail_tests.rs
@@ -6,10 +6,10 @@ use kanban_domain::{Board, Card, Column, Snapshot};
 fn test_active_card_detail_shows_selected_card() {
     let mut app = kanban_tui::App::test_default();
 
-    let mut board = Board::new("TestBoard".to_string(), None::<String>);
-    let col = Column::new(board.id, "Backlog".to_string(), 0);
-    let card_a = Card::new(&mut board, col.id, "Card Alpha".to_string(), 0);
-    let card_b = Card::new(&mut board, col.id, "Card Beta".to_string(), 1);
+    let mut board = Board::new("TestBoard", None::<String>);
+    let col = Column::new(board.id, "Backlog", 0);
+    let card_a = Card::new(&mut board, col.id, "Card Alpha", 0);
+    let card_b = Card::new(&mut board, col.id, "Card Beta", 1);
 
     let card_b_id = card_b.id;
 

--- a/crates/kanban-tui/tests/conflict_detection_tests.rs
+++ b/crates/kanban-tui/tests/conflict_detection_tests.rs
@@ -12,9 +12,9 @@ async fn test_conflict_detection_on_concurrent_modification() {
     let file_path = dir.path().join("kanban.json");
 
     // Create initial data and save via first instance
-    let mut board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
+    let mut board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot1 = Snapshot {
         boards: vec![board.clone()],
@@ -80,9 +80,9 @@ async fn test_no_conflict_when_file_unchanged() {
     let file_path = dir.path().join("kanban.json");
 
     // Create and save initial data
-    let mut board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
+    let mut board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
         boards: vec![board.clone()],
@@ -115,9 +115,9 @@ async fn test_conflict_detection_tracks_file_metadata() {
     let file_path = dir.path().join("kanban.json");
 
     // Create and save initial data
-    let mut board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    let _card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
+    let mut board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let _card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
         boards: vec![board.clone()],
@@ -173,9 +173,9 @@ async fn test_multiple_instances_with_different_ids() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
-    let mut board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
+    let mut board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
         boards: vec![board.clone()],
@@ -217,9 +217,9 @@ async fn test_conflict_resolution_with_force_overwrite() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
-    let mut board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
+    let mut board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
         boards: vec![board.clone()],
@@ -271,12 +271,12 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let instance1_id = uuid::Uuid::new_v4();
     let store1 = JsonFileStore::with_instance_id(&file_path, instance1_id);
 
-    let mut board1 = Board::new("Shared Project".to_string(), None::<String>);
-    let column1 = Column::new(board1.id, "Todo".to_string(), 0);
-    let column2 = Column::new(board1.id, "In Progress".to_string(), 1);
+    let mut board1 = Board::new("Shared Project", None::<String>);
+    let column1 = Column::new(board1.id, "Todo", 0);
+    let column2 = Column::new(board1.id, "In Progress", 1);
 
-    let card1 = Card::new(&mut board1, column1.id, "Task A".to_string(), 0);
-    let card2 = Card::new(&mut board1, column2.id, "Task B".to_string(), 0);
+    let card1 = Card::new(&mut board1, column1.id, "Task A", 0);
+    let card2 = Card::new(&mut board1, column2.id, "Task B", 0);
 
     let snapshot1 = Snapshot {
         boards: vec![board1.clone()],
@@ -304,7 +304,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let new_card = Card::new(
         &mut snapshot2.boards[0],
         snapshot2.columns[0].id,
-        "Task C (from Instance 2)".to_string(),
+        "Task C (from Instance 2)",
         0,
     );
     snapshot2.cards.push(new_card);

--- a/crates/kanban-tui/tests/conflict_detection_tests.rs
+++ b/crates/kanban-tui/tests/conflict_detection_tests.rs
@@ -12,7 +12,7 @@ async fn test_conflict_detection_on_concurrent_modification() {
     let file_path = dir.path().join("kanban.json");
 
     // Create initial data and save via first instance
-    let mut board = Board::new("Test Board".to_string(), None);
+    let mut board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
 
@@ -80,7 +80,7 @@ async fn test_no_conflict_when_file_unchanged() {
     let file_path = dir.path().join("kanban.json");
 
     // Create and save initial data
-    let mut board = Board::new("Test Board".to_string(), None);
+    let mut board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
 
@@ -115,7 +115,7 @@ async fn test_conflict_detection_tracks_file_metadata() {
     let file_path = dir.path().join("kanban.json");
 
     // Create and save initial data
-    let mut board = Board::new("Test Board".to_string(), None);
+    let mut board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let _card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
 
@@ -173,7 +173,7 @@ async fn test_multiple_instances_with_different_ids() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
-    let mut board = Board::new("Test Board".to_string(), None);
+    let mut board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
 
@@ -217,7 +217,7 @@ async fn test_conflict_resolution_with_force_overwrite() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
-    let mut board = Board::new("Test Board".to_string(), None);
+    let mut board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let card = Card::new(&mut board, column.id, "Test Task".to_string(), 0);
 
@@ -271,7 +271,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let instance1_id = uuid::Uuid::new_v4();
     let store1 = JsonFileStore::with_instance_id(&file_path, instance1_id);
 
-    let mut board1 = Board::new("Shared Project".to_string(), None);
+    let mut board1 = Board::new("Shared Project".to_string(), None::<String>);
     let column1 = Column::new(board1.id, "Todo".to_string(), 0);
     let column2 = Column::new(board1.id, "In Progress".to_string(), 1);
 

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -4,8 +4,8 @@ use kanban_domain::*;
 #[test]
 fn test_delete_card_cleans_dependencies() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let board_id = board.id;
     let column_id = column.id;
     store.upsert_board(board).unwrap();
@@ -55,8 +55,8 @@ fn test_delete_card_cleans_dependencies() {
 #[test]
 fn test_delete_column_with_cards_fails() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let board_id = board.id;
     let column_id = column.id;
     store.upsert_board(board).unwrap();
@@ -86,8 +86,8 @@ fn test_delete_column_with_cards_fails() {
 #[test]
 fn test_delete_column_with_archived_cards_fails() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let board_id = board.id;
     let column_id = column.id;
     store.upsert_board(board).unwrap();
@@ -121,8 +121,8 @@ fn test_delete_column_with_archived_cards_fails() {
 #[test]
 fn test_delete_sprint_unassigns_cards() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
     let board_id = board.id;
     let column_id = column.id;
@@ -195,8 +195,8 @@ fn test_delete_sprint_unassigns_cards() {
 #[test]
 fn test_archive_card_preserves_edges() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let board_id = board.id;
     let column_id = column.id;
     store.upsert_board(board).unwrap();
@@ -256,8 +256,8 @@ fn test_archive_card_preserves_edges() {
 #[test]
 fn test_delete_column_succeeds_when_empty() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let column_id = column.id;
     store.upsert_board(board).unwrap();
     store.upsert_column(column).unwrap();
@@ -274,8 +274,8 @@ fn test_delete_column_succeeds_when_empty() {
 #[test]
 fn test_cycle_detection_parent_child() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let board_id = board.id;
     let column_id = column.id;
     store.upsert_board(board).unwrap();
@@ -339,8 +339,8 @@ fn test_cycle_detection_parent_child() {
 #[test]
 fn test_cycle_detection_blocks() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let board_id = board.id;
     let column_id = column.id;
     store.upsert_board(board).unwrap();

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -4,7 +4,7 @@ use kanban_domain::*;
 #[test]
 fn test_delete_card_cleans_dependencies() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let board_id = board.id;
     let column_id = column.id;
@@ -55,7 +55,7 @@ fn test_delete_card_cleans_dependencies() {
 #[test]
 fn test_delete_column_with_cards_fails() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let board_id = board.id;
     let column_id = column.id;
@@ -86,7 +86,7 @@ fn test_delete_column_with_cards_fails() {
 #[test]
 fn test_delete_column_with_archived_cards_fails() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let board_id = board.id;
     let column_id = column.id;
@@ -121,9 +121,9 @@ fn test_delete_column_with_archived_cards_fails() {
 #[test]
 fn test_delete_sprint_unassigns_cards() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
-    let sprint = Sprint::new(board.id, 1, None, None);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
     let board_id = board.id;
     let column_id = column.id;
     let sprint_id = sprint.id;
@@ -195,7 +195,7 @@ fn test_delete_sprint_unassigns_cards() {
 #[test]
 fn test_archive_card_preserves_edges() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let board_id = board.id;
     let column_id = column.id;
@@ -256,7 +256,7 @@ fn test_archive_card_preserves_edges() {
 #[test]
 fn test_delete_column_succeeds_when_empty() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let column_id = column.id;
     store.upsert_board(board).unwrap();
@@ -274,7 +274,7 @@ fn test_delete_column_succeeds_when_empty() {
 #[test]
 fn test_cycle_detection_parent_child() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let board_id = board.id;
     let column_id = column.id;
@@ -339,7 +339,7 @@ fn test_cycle_detection_parent_child() {
 #[test]
 fn test_cycle_detection_blocks() {
     let store = InMemoryStore::new();
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let board_id = board.id;
     let column_id = column.id;

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -239,7 +239,7 @@ async fn test_async_load_initial_state_sqlite() {
         .await
         .unwrap();
 
-    let board = Board::new("SQLite Board".to_string(), None);
+    let board = Board::new("SQLite Board", None::<String>);
     let column = Column::new(board.id, "Backlog".to_string(), 0);
 
     let snapshot = kanban_domain::Snapshot {

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -240,7 +240,7 @@ async fn test_async_load_initial_state_sqlite() {
         .unwrap();
 
     let board = Board::new("SQLite Board", None::<String>);
-    let column = Column::new(board.id, "Backlog".to_string(), 0);
+    let column = Column::new(board.id, "Backlog", 0);
 
     let snapshot = kanban_domain::Snapshot {
         boards: vec![board.clone()],

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -99,7 +99,7 @@ pub async fn create_test_json_file(dir: &std::path::Path, name: &str, boards: &[
 
     let domain_boards: Vec<kanban_domain::Board> = boards
         .iter()
-        .map(|n| kanban_domain::Board::new(n.to_string(), None))
+        .map(|n| kanban_domain::Board::new(n.to_string(), None::<String>))
         .collect();
     let snapshot = kanban_domain::Snapshot {
         boards: domain_boards,
@@ -130,7 +130,7 @@ pub async fn create_test_sqlite_file(dir: &std::path::Path, name: &str, boards: 
 
     let domain_boards: Vec<kanban_domain::Board> = boards
         .iter()
-        .map(|n| kanban_domain::Board::new(n.to_string(), None))
+        .map(|n| kanban_domain::Board::new(n.to_string(), None::<String>))
         .collect();
     let snapshot = kanban_domain::Snapshot {
         boards: domain_boards,

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -9,7 +9,7 @@ async fn test_import_failure_prevents_empty_state_save() {
     let file_path = dir.path().join("kanban.json");
 
     // Create a real board and then save it in V2 format
-    let board = Board::new("Test Board".to_string(), None);
+    let board = Board::new("Test Board".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
 
     // Create snapshot with one board
@@ -82,7 +82,7 @@ async fn test_v2_format_is_imported_correctly() {
     let file_path = dir.path().join("kanban.json");
 
     // Create a real board
-    let board = Board::new("My Project".to_string(), None);
+    let board = Board::new("My Project".to_string(), None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let mut board_mut = board.clone();
     let card = Card::new(&mut board_mut, column.id, "Important Task".to_string(), 0);

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -9,8 +9,8 @@ async fn test_import_failure_prevents_empty_state_save() {
     let file_path = dir.path().join("kanban.json");
 
     // Create a real board and then save it in V2 format
-    let board = Board::new("Test Board".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("Test Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
 
     // Create snapshot with one board
     let snapshot = Snapshot {
@@ -82,10 +82,10 @@ async fn test_v2_format_is_imported_correctly() {
     let file_path = dir.path().join("kanban.json");
 
     // Create a real board
-    let board = Board::new("My Project".to_string(), None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let board = Board::new("My Project", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     let mut board_mut = board.clone();
-    let card = Card::new(&mut board_mut, column.id, "Important Task".to_string(), 0);
+    let card = Card::new(&mut board_mut, column.id, "Important Task", 0);
 
     // Create snapshot with board, column, and card
     let snapshot = Snapshot {

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -24,7 +24,7 @@ async fn test_load_initial_state_with_boards_refreshes_card_view() -> KanbanResu
     let path = dir.path().join("with_cards.json");
     let path_str = path.to_str().unwrap().to_string();
 
-    let mut board = Board::new("Alpha".to_string(), None);
+    let mut board = Board::new("Alpha", None::<String>);
     let column = Column::new(board.id, "Todo".to_string(), 0);
     let card = Card::new(&mut board, column.id, "Task One".to_string(), 0);
     let snapshot = Snapshot {

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -25,8 +25,8 @@ async fn test_load_initial_state_with_boards_refreshes_card_view() -> KanbanResu
     let path_str = path.to_str().unwrap().to_string();
 
     let mut board = Board::new("Alpha", None::<String>);
-    let column = Column::new(board.id, "Todo".to_string(), 0);
-    let card = Card::new(&mut board, column.id, "Task One".to_string(), 0);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(&mut board, column.id, "Task One", 0);
     let snapshot = Snapshot {
         boards: vec![board],
         columns: vec![column],

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -21,8 +21,8 @@ fn test_empty_model_returns_empty_slices() {
 fn test_load_from_snapshot_populates_all_fields() {
     let mut model = Model::default();
 
-    let mut board = Board::new("Board1".to_string(), None::<String>);
-    let column = Column::new(board.id, "Col1".to_string(), 0);
+    let mut board = Board::new("Board1", None::<String>);
+    let column = Column::new(board.id, "Col1", 0);
     let card = make_card(&mut board, column.id, "Card1", 0);
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
@@ -51,7 +51,7 @@ fn test_load_from_snapshot_populates_all_fields() {
 fn test_card_lookup_by_id() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None::<String>);
+    let mut board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
     let card1 = make_card(&mut board, column_id, "First", 0);
     let card2 = make_card(&mut board, column_id, "Second", 1);
@@ -71,7 +71,7 @@ fn test_card_lookup_by_id() {
 fn test_card_lookup_missing_id_returns_none() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None::<String>);
+    let mut board = Board::new("B", None::<String>);
     let card = make_card(&mut board, Uuid::new_v4(), "Exists", 0);
     model.load_from_snapshot(Snapshot {
         cards: vec![card],
@@ -85,7 +85,7 @@ fn test_card_lookup_missing_id_returns_none() {
 fn test_load_from_snapshot_rebuilds_card_index() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None::<String>);
+    let mut board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
     let card_a = make_card(&mut board, column_id, "A", 0);
     let id_a = card_a.id;
@@ -111,7 +111,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
 fn test_archived_cards_flat_returns_card_data() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None::<String>);
+    let mut board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
     let card1 = make_card(&mut board, column_id, "Archived1", 0);
     let card2 = make_card(&mut board, column_id, "Archived2", 1);
@@ -133,7 +133,7 @@ fn test_archived_cards_flat_returns_card_data() {
 fn test_archived_cards_flat_rebuilds_on_reload() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None::<String>);
+    let mut board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
 
     let card1 = make_card(&mut board, column_id, "First", 0);
@@ -164,7 +164,7 @@ fn test_archived_cards_flat_rebuilds_on_reload() {
 fn test_archived_card_lookup_by_id() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None::<String>);
+    let mut board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
     let card1 = make_card(&mut board, column_id, "Archived1", 0);
     let card2 = make_card(&mut board, column_id, "Archived2", 1);
@@ -186,7 +186,7 @@ fn test_archived_card_lookup_by_id() {
 fn test_archived_card_lookup_missing_returns_none() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None::<String>);
+    let mut board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
     let card = make_card(&mut board, column_id, "Archived", 0);
     let ac = ArchivedCard::new(card, column_id, 0);

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -21,10 +21,10 @@ fn test_empty_model_returns_empty_slices() {
 fn test_load_from_snapshot_populates_all_fields() {
     let mut model = Model::default();
 
-    let mut board = Board::new("Board1".to_string(), None);
+    let mut board = Board::new("Board1".to_string(), None::<String>);
     let column = Column::new(board.id, "Col1".to_string(), 0);
     let card = make_card(&mut board, column.id, "Card1", 0);
-    let sprint = Sprint::new(board.id, 1, None, None);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
     let snapshot = Snapshot {
         boards: vec![board],
@@ -51,7 +51,7 @@ fn test_load_from_snapshot_populates_all_fields() {
 fn test_card_lookup_by_id() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None);
+    let mut board = Board::new("B".to_string(), None::<String>);
     let column_id = Uuid::new_v4();
     let card1 = make_card(&mut board, column_id, "First", 0);
     let card2 = make_card(&mut board, column_id, "Second", 1);
@@ -71,7 +71,7 @@ fn test_card_lookup_by_id() {
 fn test_card_lookup_missing_id_returns_none() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None);
+    let mut board = Board::new("B".to_string(), None::<String>);
     let card = make_card(&mut board, Uuid::new_v4(), "Exists", 0);
     model.load_from_snapshot(Snapshot {
         cards: vec![card],
@@ -85,7 +85,7 @@ fn test_card_lookup_missing_id_returns_none() {
 fn test_load_from_snapshot_rebuilds_card_index() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None);
+    let mut board = Board::new("B".to_string(), None::<String>);
     let column_id = Uuid::new_v4();
     let card_a = make_card(&mut board, column_id, "A", 0);
     let id_a = card_a.id;
@@ -111,7 +111,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
 fn test_archived_cards_flat_returns_card_data() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None);
+    let mut board = Board::new("B".to_string(), None::<String>);
     let column_id = Uuid::new_v4();
     let card1 = make_card(&mut board, column_id, "Archived1", 0);
     let card2 = make_card(&mut board, column_id, "Archived2", 1);
@@ -133,7 +133,7 @@ fn test_archived_cards_flat_returns_card_data() {
 fn test_archived_cards_flat_rebuilds_on_reload() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None);
+    let mut board = Board::new("B".to_string(), None::<String>);
     let column_id = Uuid::new_v4();
 
     let card1 = make_card(&mut board, column_id, "First", 0);
@@ -164,7 +164,7 @@ fn test_archived_cards_flat_rebuilds_on_reload() {
 fn test_archived_card_lookup_by_id() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None);
+    let mut board = Board::new("B".to_string(), None::<String>);
     let column_id = Uuid::new_v4();
     let card1 = make_card(&mut board, column_id, "Archived1", 0);
     let card2 = make_card(&mut board, column_id, "Archived2", 1);
@@ -186,7 +186,7 @@ fn test_archived_card_lookup_by_id() {
 fn test_archived_card_lookup_missing_returns_none() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B".to_string(), None);
+    let mut board = Board::new("B".to_string(), None::<String>);
     let column_id = Uuid::new_v4();
     let card = make_card(&mut board, column_id, "Archived", 0);
     let ac = ArchivedCard::new(card, column_id, 0);


### PR DESCRIPTION
Loosens domain constructors and mutators that always store their string input to accept `impl Into<String>` instead of `String`, removing redundant `.to_string()` calls at call sites:

- Convert unconditional-store params on `Board`, `Card`, `Column`, `Sprint`, `Tag`, and `SprintLog` from `String` to `impl Into<String>` (or `Option<impl Into<String>>`). Command-struct DTOs in `kanban-domain/src/commands/` are left as `String` (they are serde-deserialized) so only the test call sites inside those files were updated.
- Sweep redundant `.to_string()` from call sites across the workspace: `kanban-domain`, `kanban-persistence`, `kanban-persistence-sqlite`, `kanban-service` (including its integration tests in `tests/`), and `kanban-tui` (including its integration tests). String literals are now passed directly to the widened APIs.
- Document the "unconditional store implies `impl Into<String>`" convention in `CONTRIBUTING.md` so future domain APIs follow the same rule.

**What**: Domain APIs that unconditionally store a string now take `impl Into<String>`. Source-compatible for any caller already passing `String` or `Some("...".to_string())`; new callers can pass `&str` directly. The one ergonomic gotcha is bare `None` on `Option<impl Into<String>>` params, which now needs `None::<String>` so the type can be inferred. This is documented in the changeset.

**Why**: Every call site holding a string literal had to write `"foo".to_string()` to satisfy the domain. The allocation decision belongs at the call site, not as a forced boundary requirement, and the noise was especially visible in test setup. Beyond the ergonomics, the project's contributor guide previously said "prefer `&str` over `String` for function parameters", which was misleading for unconditional-store signatures; this PR replaces that line with a nuanced rule and brings the code in line with it.

**How**: Follows Red Green Refactor across the affected types. Commits, in order:

1. `test(domain): add failing tests for str-literal ergonomics on unconditional-store params` (Red)
2. `refactor(domain): change unconditional-store params from String to impl Into<String>` (Green, with bodies using `name.into()` / `prefix.map(Into::into)`)
3. `refactor: remove redundant .to_string() from domain test call sites and update docs` (Refactor + docs)
4. `style: cargo fmt after domain string refactor`
5. `chore: add changeset`
6. `refactor: sweep redundant .to_string() across persistence, service, and tui call sites of widened domain APIs` (workspace-wide sweep to fully satisfy KAN-580's acceptance criteria)
7. `chore: note None::<String> turbofish requirement in KAN-580 changeset`

No `AsRef<str>` introduced anywhere. Validate-then-maybe-store domain methods continue to take `&str`. DTO struct fields remain `String` for serde compatibility.

**Testing**: `cargo test --workspace` (no regressions across all crate test binaries), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean), and the new `test_*_accepts_str_*_without_to_string` tests in `kanban-domain` cover each widened signature.