### PR TITLE
KAN-656 ci(release): read chocolatey digest from gh release API

### DIFF
--- a/.changeset/kan-656-chocolatey-asset-poll-via-gh-api.md
+++ b/.changeset/kan-656-chocolatey-asset-poll-via-gh-api.md
@@ -1,0 +1,21 @@
+---
+bump: patch
+---
+
+The release workflow's Chocolatey publish job now reads the Windows
+ZIP's SHA256 directly from the GitHub Release API's `digest` field
+(exposed since June 2025) and uses `state == "uploaded"` as the
+asset-readiness signal. Two release.yml steps collapse into one:
+the previous `HEAD`-based poll and the separate download-and-hash
+step both go away.
+
+The `HEAD` poll was latently broken. GitHub release-download URLs
+302-redirect to S3-style presigned URLs that are cryptographically
+signed for a specific HTTP method; `Invoke-WebRequest -Method Head`
+auto-follows the redirect and gets a 403 even when `GET` on the same
+URL would succeed. The bug would have surfaced on the first 0.7.x
+release attempt that produced Windows artifacts.
+
+No behavioural change for users. The chocolatey nupkg is templated
+with the same `$checksum64$` value as before; the change is only in
+how the workflow obtains that value.

--- a/.changeset/kan-656-chocolatey-asset-poll-via-gh-api.md
+++ b/.changeset/kan-656-chocolatey-asset-poll-via-gh-api.md
@@ -7,7 +7,12 @@ ZIP's SHA256 directly from the GitHub Release API's `digest` field
 (exposed since June 2025) and uses `state == "uploaded"` as the
 asset-readiness signal. Two release.yml steps collapse into one:
 the previous `HEAD`-based poll and the separate download-and-hash
-step both go away.
+step both go away. The `publish-chocolatey` job also gains an
+explicit `permissions: contents: read` scope so a future tightening
+of org-default token permissions cannot silently break the digest
+lookup, and per-iteration `gh release view` stderr is suppressed so
+the action log stays clean while the release tag is still being
+created upstream.
 
 The `HEAD` poll was latently broken. GitHub release-download URLs
 302-redirect to S3-style presigned URLs that are cryptographically

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,44 +306,38 @@ jobs:
         with:
           ref: v${{ needs.release.outputs.new }}
 
-      - name: Wait for release asset to be fetchable
-        shell: pwsh
-        env:
-          VERSION: ${{ needs.release.outputs.new }}
-        run: |
-          $url = "https://github.com/fulsomenko/kanban/releases/download/v$env:VERSION/kanban-v$env:VERSION-x86_64-pc-windows-msvc.zip"
-          $ok = $false
-          for ($i = 0; $i -lt 30; $i++) {
-            try {
-              $r = Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -ErrorAction Stop
-              if ($r.StatusCode -eq 200) {
-                Write-Output "Asset live at $url"
-                $ok = $true
-                break
-              }
-            } catch {
-              Write-Output ("Attempt {0}: not yet ({1})" -f ($i + 1), $_.Exception.Message)
-            }
-            Start-Sleep -Seconds 5
-          }
-          if (-not $ok) {
-            Write-Error "Release asset never became fetchable after 30 attempts (~150s)"
-            exit 1
-          }
-
-      - name: Compute Windows ZIP SHA256
+      - name: Read Windows ZIP digest from GitHub Release
         id: sha
         shell: pwsh
         env:
           VERSION: ${{ needs.release.outputs.new }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          $url = "https://github.com/fulsomenko/kanban/releases/download/v$env:VERSION/kanban-v$env:VERSION-x86_64-pc-windows-msvc.zip"
-          $tmp = New-TemporaryFile
-          Invoke-WebRequest -Uri $url -OutFile $tmp -UseBasicParsing
-          $sha = (Get-FileHash -Algorithm SHA256 $tmp).Hash.ToLower()
-          Remove-Item $tmp
-          Write-Output "Computed SHA256: $sha"
-          "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $asset = "kanban-v$env:VERSION-x86_64-pc-windows-msvc.zip"
+          $ok = $false
+          for ($i = 1; $i -le 30; $i++) {
+            $json = gh release view "v$env:VERSION" --repo $env:REPO `
+              --json assets --jq ".assets[] | select(.name == `"$asset`")"
+            if ($json) {
+              $obj = $json | ConvertFrom-Json
+              if ($obj.state -eq 'uploaded' -and $obj.digest) {
+                $sha = $obj.digest -replace '^sha256:', ''
+                Write-Output "Found $asset: sha=$sha"
+                "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                $ok = $true
+                break
+              }
+              Write-Output ("Attempt {0}: state='{1}' digest='{2}'" -f $i, $obj.state, $obj.digest)
+            } else {
+              Write-Output ("Attempt {0}: asset not yet listed" -f $i)
+            }
+            Start-Sleep -Seconds 5
+          }
+          if (-not $ok) {
+            Write-Error "Release asset never became ready after 30 attempts (~150s)"
+            exit 1
+          }
 
       - name: Stage Chocolatey package with substitutions
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,8 @@ jobs:
     needs: [release, build-windows]
     if: needs.release.outputs.has_changesets == 'true'
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -318,7 +320,7 @@ jobs:
           $ok = $false
           for ($i = 1; $i -le 30; $i++) {
             $json = gh release view "v$env:VERSION" --repo $env:REPO `
-              --json assets --jq ".assets[] | select(.name == `"$asset`")"
+              --json assets --jq ".assets[] | select(.name == `"$asset`")" 2>$null
             if ($json) {
               $obj = $json | ConvertFrom-Json
               if ($obj.state -eq 'uploaded' -and $obj.digest) {


### PR DESCRIPTION
## Summary

- Replaces the `publish-chocolatey` job's broken HEAD-on-presigned-URL poll and the redundant local download-and-hash step with a single `gh release view --json assets` call.
- SHA256 comes from the `digest` field GitHub exposes since [June 2025](https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/); asset readiness is checked via the official `state == "uploaded"` contract.
- Adds explicit `permissions: contents: read` on the job and silences early-iteration `gh` stderr noise.
- Net diff in `.github/workflows/release.yml`: +18 / −25.

## Root cause of the original bug (latent)

GitHub release-download URLs 302-redirect to S3-style presigned URLs on `release-assets.githubusercontent.com`. Those signed URLs are cryptographically signed for a specific HTTP method, so `HEAD` returns 403 even when `GET` on the same URL would succeed. PowerShell's `Invoke-WebRequest -Method Head` auto-follows the redirect and trips this. The poll would have exhausted its 150s budget and failed the job on the first 0.7.x release that produces Windows artifacts.

Documented elsewhere: [Gitea #35086](https://github.com/go-gitea/gitea/issues/35086), [grab #43](https://github.com/cavaliergopher/grab/issues/43), [AWS re:Post on signed-URL method scoping](https://repost.aws/questions/QUXlm00GaUSd2GAWQfkVf47w/403-when-accessing-s3-signed-https-url-with-postman-or-python).

## Why this is the proper 2026 approach

- Authoritative source: GitHub generates and stores the digest server-side at upload time.
- Method-agnostic: uses the GitHub REST API via `gh`, not S3 signed URLs.
- Pre-existing auth: `secrets.GITHUB_TOKEN` already in scope on the runner.
- `state == "uploaded"` is the readiness contract GitHub publishes, not a guess from HTTP semantics.
- Single source of truth: the digest the chocolatey package verifies against is the same digest GitHub serves to other clients.

## Commits

1. **`90e9644c`** — primary fix. Collapse the HEAD poll and the download-and-hash step into one `gh release view` call that requires both `state == "uploaded"` and a non-empty `digest`. Output contract (`steps.sha.outputs.sha`) unchanged, so downstream `Stage Chocolatey package` step is untouched.
2. **`c12b2fab`** — review follow-ups. Add explicit `permissions: contents: read` to the `publish-chocolatey` job (defense against future org-default token-permission tightening); suppress `gh` stderr (`2>$null`) on the per-iteration call so the action log is not red on early iterations before the release tag exists.

## Test plan

- [x] `yamllint` clean (verified locally with relaxed rules).
- [x] No downstream step changes: `Stage Chocolatey package with substitutions` still reads `${{ steps.sha.outputs.sha }}`.
- [x] Asset filename matches `build-windows` output (`kanban-v$VERSION-x86_64-pc-windows-msvc.zip`).
- [ ] Real-run validation deferred to the first 0.7.x release with Windows artifacts (no way to dry-run without a real Release object; v0.6.0 has no assets).