### PR TITLE
KAN-657 docs(chocolatey): add recovery runbook and idempotent push

### DIFF
--- a/.changeset/kan-657-chocolatey-recovery-runbook.md
+++ b/.changeset/kan-657-chocolatey-recovery-runbook.md
@@ -1,0 +1,28 @@
+---
+bump: patch
+---
+
+The release workflow's `publish-chocolatey` job is now safe to
+re-run after a transient post-push failure, and surfaces an
+actionable error message that points at a recovery runbook on
+real failures.
+
+Chocolatey rejects re-pushing the same `id + version`
+permanently, which means a workflow re-run after the underlying
+push has already succeeded would silently surface a fresh red
+"failure" that obscures the previous success. The job now does a
+pre-check against
+`community.chocolatey.org/api/v2/Packages(Id='kanban',Version=...)`
+and exits 0 with an explanatory message when the version is
+already published. On a genuine push failure, the job prints a
+pointer to `packaging/chocolatey/RECOVERY.md` along with a clear
+"do not simply re-run this job" warning.
+
+The new `packaging/chocolatey/RECOVERY.md` runbook documents the
+four real failure scenarios (push-succeeded-but-reported-failure,
+malformed nupkg, rejected API key, moderation backlog) with
+diagnosis steps for each, an anti-patterns section, and a
+"reading this in a hurry" table at the bottom.
+`packaging/chocolatey/README.md` cross-links to it.
+
+No behavioural change for end users installing the package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,12 +390,13 @@ jobs:
           # package is unpublished — see packaging/chocolatey/RECOVERY.md.
           $checkUrl = "https://community.chocolatey.org/api/v2/Packages(Id='kanban',Version='$env:VERSION')"
           try {
-            $null = Invoke-RestMethod -Uri $checkUrl -UseBasicParsing -ErrorAction Stop
+            $null = Invoke-RestMethod -Uri $checkUrl -TimeoutSec 30 -ErrorAction Stop
             Write-Output "kanban $env:VERSION is already published on Chocolatey; nothing to do."
             exit 0
           } catch {
-            if ($_.Exception.Response.StatusCode.value__ -ne 404) {
-              Write-Output ("Pre-check returned non-404 error ({0}); proceeding to push anyway." -f $_.Exception.Message)
+            $status = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+            if ($status -ne 404) {
+              Write-Output ("Pre-check returned status {0} ({1}); proceeding to push anyway." -f $status, $_.Exception.Message)
             }
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,9 +382,37 @@ jobs:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
           VERSION: ${{ needs.release.outputs.new }}
         run: |
-          choco push "kanban.$env:VERSION.nupkg" `
-            --api-key="$env:CHOCO_API_KEY" `
-            --source="https://push.chocolatey.org/"
+          # Pre-check: if this version is already published and approved,
+          # treat as success. This makes the job safe to re-run after a
+          # transient workflow failure that followed a successful push.
+          # NB: Submitted/Waiting-for-Reviewer states are NOT visible via
+          # the public v2 OData API, so a 404 here does not prove the
+          # package is unpublished — see packaging/chocolatey/RECOVERY.md.
+          $checkUrl = "https://community.chocolatey.org/api/v2/Packages(Id='kanban',Version='$env:VERSION')"
+          try {
+            $null = Invoke-RestMethod -Uri $checkUrl -UseBasicParsing -ErrorAction Stop
+            Write-Output "kanban $env:VERSION is already published on Chocolatey; nothing to do."
+            exit 0
+          } catch {
+            if ($_.Exception.Response.StatusCode.value__ -ne 404) {
+              Write-Output ("Pre-check returned non-404 error ({0}); proceeding to push anyway." -f $_.Exception.Message)
+            }
+          }
+
+          try {
+            choco push "kanban.$env:VERSION.nupkg" `
+              --api-key="$env:CHOCO_API_KEY" `
+              --source="https://push.chocolatey.org/"
+            if ($LASTEXITCODE -ne 0) { throw "choco push exited $LASTEXITCODE" }
+          } catch {
+            Write-Output ""
+            Write-Output "=== Chocolatey publish failed ==="
+            Write-Output "Recovery runbook: packaging/chocolatey/RECOVERY.md"
+            Write-Output "Chocolatey rejects re-push of the same id+version permanently."
+            Write-Output "Do NOT simply re-run this job before diagnosing — see the runbook."
+            Write-Output "================================="
+            throw
+          }
 
       - name: Note moderation expectations
         shell: pwsh

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -30,3 +30,8 @@ variables; set them before running the rest:
 
 To re-run the smoke locally on a Windows box, copy the build/ steps above.
 Do NOT commit substituted files.
+
+When the `publish-chocolatey` workflow job fails, see [RECOVERY.md](RECOVERY.md)
+for the diagnosis flowchart. Chocolatey rejects re-pushing the same
+`id + version` permanently, so the recovery path differs sharply by failure
+mode and is not safe to guess.

--- a/packaging/chocolatey/RECOVERY.md
+++ b/packaging/chocolatey/RECOVERY.md
@@ -1,0 +1,146 @@
+# Chocolatey publish — recovery runbook
+
+When the `publish-chocolatey` job in `.github/workflows/release.yml`
+fails, this runbook is the diagnosis flowchart. The job's failure
+message will point you here.
+
+The key constraint that drives everything below: **Chocolatey
+rejects re-pushing the same `id + version` permanently.** There
+is no `--skip-duplicate`, no `--force-overwrite`. If `kanban`
+version `X.Y.Z` was ever successfully accepted (even into the
+moderation queue), it can never be pushed again. The recovery
+path then is to bump to `X.Y.Z+1`.
+
+## Diagnosis: which scenario am I in?
+
+Open the Chocolatey community page for the failing version:
+
+    https://community.chocolatey.org/packages/kanban/<VERSION>
+
+Compare what you see there with what the workflow log shows.
+
+### Scenario 1 — push succeeded but the workflow reported failure
+
+**Symptom on community.chocolatey.org**: the version is present
+with a status of `Submitted`, `Waiting for Reviewer`, `Ready`, or
+`Approved`.
+
+**Symptom in the workflow log**: usually a network/timeout error
+from `choco push` itself (response read failed) or a transient
+HTTP 5xx from `push.chocolatey.org`.
+
+**What happened**: the push made it to Chocolatey's side. Their
+acceptance is what counts; the workflow's view of the response
+got dropped.
+
+**Recovery**:
+
+- Do nothing on our side. The package is in the moderation
+  pipeline.
+- The job's later `Note moderation expectations` step did not
+  run because the earlier failure aborted it; that's cosmetic
+  only.
+- **Do not re-run the `publish-chocolatey` job.** Chocolatey
+  will reject the second push, which can mask the genuine
+  success.
+
+### Scenario 2 — the `.nupkg` is malformed
+
+**Symptom on community.chocolatey.org**: nothing exists for this
+version; the page is 404 or shows older versions only.
+
+**Symptom in the workflow log**: `choco push` rejected the file
+with a schema-validation message, OR the earlier `Smoke install
+from local nupkg` step failed (PowerShell error in
+`chocolateyinstall.ps1`, missing files in nuspec, broken
+`Install-ChocolateyZipPackage` arguments, etc).
+
+**What happened**: the package as built is invalid. Even if you
+fix it now and re-push the corrected file, Chocolatey will not
+accept the same `id + version` combination — the
+acceptance/rejection logic keys on `id + version`, not on file
+contents.
+
+**Recovery — cut `X.Y.Z+1`**:
+
+1. Open a hotfix branch from `develop`.
+2. Fix the packaging defect (`packaging/chocolatey/`,
+   `.github/workflows/release.yml`, or wherever it lives).
+3. Add a changeset (`./scripts/create-changeset.sh patch`) with
+   body explaining the situation, e.g.:
+
+       Chocolatey `X.Y.Z` was unpublishable (<one-line reason>).
+       `X.Y.Z+1` re-publishes the same source with corrected
+       packaging. crates.io / Homebrew / AUR also receive `X.Y.Z+1`.
+
+4. Merge the PR; the standard release flow ships `X.Y.Z+1`. All
+   four publishers (crates.io, Homebrew, AUR, Chocolatey) advance
+   together — accept the noise.
+
+### Scenario 3 — API key was rejected
+
+**Symptom on community.chocolatey.org**: nothing exists for this
+version.
+
+**Symptom in the workflow log**: `choco push` failed with
+`401 Unauthorized` or `An error occurred while sending the
+request — Forbidden`.
+
+**What happened**: the `CHOCO_API_KEY` repo secret is stale or
+revoked. The package itself is fine; the credential is the
+problem.
+
+**Recovery**:
+
+1. Log into community.chocolatey.org with the Chocolatey
+   maintainer account (Max).
+2. Go to *My Account → API Key*. Reset.
+3. In the repo: *Settings → Secrets and variables → Actions*.
+   Update `CHOCO_API_KEY`.
+4. Re-run the failed `publish-chocolatey` job from the GitHub
+   Actions UI. It is safe to re-run in this scenario because no
+   prior push succeeded.
+
+### Scenario 4 — Chocolatey moderation backlog
+
+**Symptom on community.chocolatey.org**: the version is present
+with status `Submitted` or `Waiting for Reviewer` but the workflow
+log shows everything succeeded.
+
+**Symptom in the workflow log**: nothing — this is the happy
+path. The "failure" people perceive here is that
+`choco install kanban` from a fresh machine does not yet find the
+new version.
+
+**What happened**: first-time moderation for a new Chocolatey
+package can take **1-7 days**. Subsequent versions go faster
+(often hours). The package is uploaded and indexed for its own
+URL but not yet listed in the default search/install path.
+
+**Recovery**: wait. Watch
+`https://community.chocolatey.org/packages/kanban`. There is
+nothing to do on our side. If users ask, the version is
+installable today from a direct nupkg URL or `choco install
+kanban --version X.Y.Z --pre`.
+
+## Anti-patterns — do not do these
+
+- **Do not re-run the `publish-chocolatey` job after a confirmed
+  push (scenarios 1 and 4).** Chocolatey will reject the second
+  push, which surfaces as a fresh red workflow failure that
+  obscures the previous success.
+- **Do not try to "fix" `X.Y.Z` in place.** Always bump
+  (scenario 2).
+- **Do not edit `packaging/chocolatey/RECOVERY.md` (this file)
+  without also updating the runbook link in the workflow's
+  failure message.** Drift between the two is worse than no
+  runbook.
+
+## Reading this in a hurry?
+
+| You see                                              | Do                              |
+|------------------------------------------------------|---------------------------------|
+| Version present on community.chocolatey.org          | Nothing. Wait. (Scenarios 1, 4) |
+| Version 404 + workflow says `Smoke install` failed   | Bump to X.Y.Z+1.                |
+| Version 404 + workflow says `401`/`Forbidden`        | Rotate `CHOCO_API_KEY`, re-run. |
+| Version 404 + workflow says `choco push` validation  | Bump to X.Y.Z+1.                |

--- a/packaging/chocolatey/RECOVERY.md
+++ b/packaging/chocolatey/RECOVERY.md
@@ -120,8 +120,10 @@ URL but not yet listed in the default search/install path.
 **Recovery**: wait. Watch
 `https://community.chocolatey.org/packages/kanban`. There is
 nothing to do on our side. If users ask, the version is
-installable today from a direct nupkg URL or `choco install
-kanban --version X.Y.Z --pre`.
+installable today via direct download from
+`https://community.chocolatey.org/packages/kanban/X.Y.Z`. Once
+it appears in the OData feed (usually within hours of approval)
+`choco install kanban --version X.Y.Z` works.
 
 ## Anti-patterns — do not do these
 


### PR DESCRIPTION
## Summary

- Adds `packaging/chocolatey/RECOVERY.md` — a runbook for the four real failure modes of `publish-chocolatey`.
- Wraps `choco push` with an idempotent pre-check (public v2 OData API → exit 0 if already published) and a failing-path message that points operators at the runbook.
- Cross-links the runbook from `packaging/chocolatey/README.md`.

## What

A documentation + small workflow-hardening change. Three artefacts land together:

1. **`packaging/chocolatey/RECOVERY.md`** (new, 130 lines). Diagnosis flowchart for the four real failure scenarios (push-succeeded-but-reported-failure, malformed nupkg, rejected API key, moderation backlog) with explicit recovery steps for each. Includes an anti-patterns section and a quick-reference table for on-call readers.
2. **`.github/workflows/release.yml`** — `choco push` step gains a pre-check (`Invoke-RestMethod` against `community.chocolatey.org/api/v2/Packages(Id='kanban',Version=...)`) that exits 0 if the version is already published, and a `try/catch` around the push that prints a pointer to `RECOVERY.md` plus a clear "do not simply re-run this job" warning on failure.
3. **`packaging/chocolatey/README.md`** — adds a paragraph linking to RECOVERY.md.

## Why

Chocolatey rejects re-pushing the same `id + version` permanently — there is no `--skip-duplicate`, no `--force-overwrite`. The four failure modes need *very different* responses (wait, bump version, rotate key, wait), and without a runbook the on-call default of "re-run the failed job" is **actively harmful** in two of the four scenarios (it surfaces a fresh red failure that obscures the previous success).

The pre-check makes the job safely re-runnable in the most common failure mode (transient post-push workflow failure). The pre-check is honest about its one limitation — packages in `Submitted` / `Waiting for Reviewer` status are not visible via the public v2 OData API — and the runbook documents this.

## How

- The pre-check uses the existing public Chocolatey OData endpoint, no auth required. 200 → exit 0. 404 → proceed to push. Non-404 errors → log and proceed (the check is best-effort, not gating).
- The push wrapper uses `try/throw` with `$LASTEXITCODE` rather than `$ErrorActionPreference = 'Stop'` so the catch fires on both PowerShell-native errors and native command non-zero exits.
- The recovery runbook lives in `packaging/chocolatey/` not a new top-level `docs/` directory because the constraint being documented (no re-push) is Chocolatey-specific — crates.io, Homebrew, and AUR all have different recovery semantics.

## Testing

- `yamllint -d relaxed .github/workflows/release.yml` — clean.
- No Rust touched, so no `cargo` checks run.
- Pre-check API verified against real Chocolatey responses (returns OData metadata XML on 200, standard 404 page on miss).
- Real-run validation deferred to first 0.7.x release with a Windows artifact — there is no way to dry-run a chocolatey publish.