### PR TITLE
Add documentation to serialization module

### DIFF
--- a/crates/kanban-persistence/src/serialization/mod.rs
+++ b/crates/kanban-persistence/src/serialization/mod.rs
@@ -1,3 +1,5 @@
+//! Provides serialization functionalities for the kanban application, including JSON serialization via the JsonSerializer type.
+
 pub mod json_serializer;
 
 pub use json_serializer::JsonSerializer;


### PR DESCRIPTION
### Problem Background
The public module declaration in `crates/kanban-persistence/src/serialization/mod.rs` lacked documentation comments, reducing code readability and maintainability, particularly in an open-source project.

### Changes Made
Added a module-level doc comment to the `serialization` module, describing its purpose and content, including JSON serialization via the `JsonSerializer` type. This enhances clarity for developers and users.

### Verification
This change only adds documentation and does not alter functionality. To verify, run `cargo doc` to ensure documentation generates correctly without errors. Also, review the code to confirm the comment aligns with the module's actual implementation.