### PR TITLE
KAN-655 refactor(domain): typed SprintBoardMismatch + negative-path tests for card create --assign

### DIFF
--- a/.changeset/kan-522-refuse-on-version-mismatch-in-persistence-backends-writer-stamp-metadata-startup-banner.md
+++ b/.changeset/kan-522-refuse-on-version-mismatch-in-persistence-backends-writer-stamp-metadata-startup-banner.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 Kanban now refuses to silently mishandle data files written by a newer
@@ -53,3 +53,6 @@ schema additions — no manual migration required.
 display string from the new raw `KANBAN_VERSION` / `KANBAN_COMMIT`
 components used by the writer stamp. This is only relevant to anyone
 embedding kanban-core as a library.
+
+Library consumers exhaustively matching on `kanban_domain::KanbanError`
+will need to add an arm for the new `UnsupportedFutureVersion` variant.

--- a/.changeset/kan-644-add-due-date-sort-field-for-cards.md
+++ b/.changeset/kan-644-add-due-date-sort-field-for-cards.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 Cards can now be sorted by their due date in every view across all three
@@ -58,3 +58,7 @@ frontends.
 - MCP descriptions for `task_sort_field`, `sort` and the archived-card
   `sort` now explain that `default` orders by card number and that date
   fields and points place None values last in ascending order.
+
+Library consumers exhaustively matching on `kanban_domain::SortField` or
+`kanban_domain::SortBy` will need to add an arm for the new `DueDate`
+variant.

--- a/.changeset/kan-655-card-create-assign-negative-tests.md
+++ b/.changeset/kan-655-card-create-assign-negative-tests.md
@@ -1,0 +1,31 @@
+---
+bump: patch
+---
+
+The cross-board sprint check on `card create --assign` now returns a
+typed `DomainError::SprintBoardMismatch { sprint_id, sprint_board,
+card_board }` error variant instead of an untyped `Validation`
+message. End-user error text is unchanged across the CLI, MCP, and
+TUI (the message format is preserved verbatim by the new variant's
+`Display` impl), but library consumers can now match on the variant
+structurally and get the three relevant UUIDs without parsing a
+string.
+
+A new `KanbanError::is_sprint_board_mismatch()` predicate follows
+the same shape as the other `is_*` helpers.
+
+Negative-path test coverage has been added for `card create
+--assign` across all three surfaces:
+
+- `kanban-service` integration tests cover the unknown-sprint-UUID
+  case (returns `NotFound { entity: "sprint" }`) and the
+  cross-board-sprint case (returns the new typed variant).
+- `kanban-cli` integration tests invoke the real binary and assert
+  that stderr surfaces "Sprint" and the offending name or UUID when
+  `--assign` is given an identifier the resolver cannot find.
+- `kanban-mcp` integration tests exercise the same negative paths
+  through the actual `tool_create_card` handler so the wire-level
+  error message is pinned for LLM clients.
+
+No behavioural change for end users; this fills a coverage gap and
+strengthens the error contract for library and MCP consumers.

--- a/.changeset/kan-655-card-create-assign-negative-tests.md
+++ b/.changeset/kan-655-card-create-assign-negative-tests.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 The cross-board sprint check on `card create --assign` now returns a
@@ -29,3 +29,5 @@ Negative-path test coverage has been added for `card create
 
 No behavioural change for end users; this fills a coverage gap and
 strengthens the error contract for library and MCP consumers.
+Library consumers exhaustively matching on `kanban_domain::DomainError`
+will need to add an arm for `SprintBoardMismatch`.

--- a/.changeset/kan-655-card-create-assign-negative-tests.md
+++ b/.changeset/kan-655-card-create-assign-negative-tests.md
@@ -29,5 +29,6 @@ Negative-path test coverage has been added for `card create
 
 No behavioural change for end users; this fills a coverage gap and
 strengthens the error contract for library and MCP consumers.
+
 Library consumers exhaustively matching on `kanban_domain::DomainError`
 will need to add an arm for `SprintBoardMismatch`.

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1855,6 +1855,68 @@ mod card_tests {
         let json = parse_json_output(&String::from_utf8_lossy(&output));
         assert!(json["data"]["sprint_id"].is_null());
     }
+
+    /// Negative path: `--assign` with a name that doesn't match any sprint
+    /// produces an error mentioning both "sprint" and the offending name,
+    /// not a panic or a generic message. Pins the surface contract that
+    /// MCP/CLI/TUI agents rely on when learning the schema by trial.
+    #[test]
+    fn test_card_create_with_assign_unknown_name_fails_with_useful_error() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+        // No sprint created on purpose.
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "X",
+                "--assign",
+                "nonexistent",
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Sprint"))
+            .stderr(predicate::str::contains("nonexistent"));
+    }
+
+    /// Negative path: `--assign <random-uuid>` produces an error mentioning
+    /// both "sprint" and the offending UUID. Same surface contract as the
+    /// name case above; the resolver accepts UUIDs first, so this exercises
+    /// a different code path inside `resolve_sprint_id`.
+    #[test]
+    fn test_card_create_with_assign_unknown_uuid_fails_with_useful_error() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+
+        let bogus = "11111111-2222-3333-4444-555555555555";
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "X",
+                "--assign",
+                bogus,
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("sprint"))
+            .stderr(predicate::str::contains(bogus));
+    }
 }
 
 mod sprint_tests {

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -1,6 +1,6 @@
 use super::{Command, CommandContext};
 use crate::data_store::DataStore;
-use crate::{CardUpdate, CreateCardOptions, KanbanError, KanbanResult, SprintLog};
+use crate::{CardUpdate, CreateCardOptions, DomainError, KanbanError, KanbanResult, SprintLog};
 use chrono::{DateTime, Utc};
 use kanban_core::Editable;
 use serde::{Deserialize, Serialize};
@@ -257,10 +257,11 @@ impl CreateCard {
         if let Some(sprint_id) = self.options.sprint_id {
             let sprint = context.get_sprint(sprint_id)?;
             if sprint.board_id != self.board_id {
-                return Err(KanbanError::validation(format!(
-                    "sprint {} belongs to board {} but card is being created on board {}",
-                    sprint_id, sprint.board_id, self.board_id
-                )));
+                return Err(KanbanError::Domain(DomainError::SprintBoardMismatch {
+                    sprint_id,
+                    sprint_board: sprint.board_id,
+                    card_board: self.board_id,
+                }));
             }
             let sprint_number = sprint.sprint_number;
             let sprint_name = sprint.get_name(&board).map(|s| s.to_string());
@@ -1285,7 +1286,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_card_with_sprint_from_different_board_returns_validation_error() {
+    fn test_create_card_with_sprint_from_different_board_returns_typed_mismatch() {
         let tc = TestContext::new();
         let board_a = crate::Board::new("A", Some("AAA"));
         let board_b = crate::Board::new("B", Some("BBB"));
@@ -1293,6 +1294,7 @@ mod tests {
         // Sprint belongs to board B.
         let sprint_b = crate::Sprint::new(board_b.id, 1, None, None::<String>);
         let board_a_id = board_a.id;
+        let board_b_id = board_b.id;
         let column_id = col_a.id;
         let sprint_b_id = sprint_b.id;
         tc.store.upsert_board(board_a).unwrap();
@@ -1316,9 +1318,21 @@ mod tests {
         };
         let err = cmd.execute(&context).unwrap_err();
         assert!(
-            err.is_validation(),
-            "expected validation variant, got: {err:?}"
+            err.is_sprint_board_mismatch(),
+            "expected SprintBoardMismatch, got: {err:?}"
         );
+        match err {
+            KanbanError::Domain(DomainError::SprintBoardMismatch {
+                sprint_id,
+                sprint_board,
+                card_board,
+            }) => {
+                assert_eq!(sprint_id, sprint_b_id);
+                assert_eq!(sprint_board, board_b_id);
+                assert_eq!(card_board, board_a_id);
+            }
+            other => panic!("expected SprintBoardMismatch fields, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -122,6 +122,15 @@ pub enum DomainError {
 
     #[error("column {column_id} has reached its WIP limit of {limit}")]
     WipLimitExceeded { column_id: Uuid, limit: u32 },
+
+    #[error(
+        "sprint {sprint_id} belongs to board {sprint_board} but card is being created on board {card_board}"
+    )]
+    SprintBoardMismatch {
+        sprint_id: Uuid,
+        sprint_board: Uuid,
+        card_board: Uuid,
+    },
 }
 
 impl DomainError {
@@ -325,6 +334,13 @@ impl KanbanError {
         )
     }
 
+    pub fn is_sprint_board_mismatch(&self) -> bool {
+        matches!(
+            self,
+            KanbanError::Domain(DomainError::SprintBoardMismatch { .. })
+        )
+    }
+
     pub fn is_unsupported_future_version(&self) -> bool {
         matches!(self, KanbanError::UnsupportedFutureVersion { .. })
     }
@@ -416,6 +432,35 @@ mod tests {
         let id = Uuid::new_v4();
         let err = KanbanError::Domain(DomainError::wip_limit_exceeded(id, 3));
         assert!(err.is_wip_limit_exceeded());
+    }
+
+    #[test]
+    fn test_sprint_board_mismatch_display_includes_all_three_ids() {
+        let sprint_id = Uuid::new_v4();
+        let sprint_board = Uuid::new_v4();
+        let card_board = Uuid::new_v4();
+        let err = KanbanError::Domain(DomainError::SprintBoardMismatch {
+            sprint_id,
+            sprint_board,
+            card_board,
+        });
+        let msg = err.to_string();
+        assert!(msg.contains(&sprint_id.to_string()), "msg: {msg}");
+        assert!(msg.contains(&sprint_board.to_string()), "msg: {msg}");
+        assert!(msg.contains(&card_board.to_string()), "msg: {msg}");
+        assert!(msg.contains("belongs to board"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_is_sprint_board_mismatch_predicate() {
+        let err = KanbanError::Domain(DomainError::SprintBoardMismatch {
+            sprint_id: Uuid::new_v4(),
+            sprint_board: Uuid::new_v4(),
+            card_board: Uuid::new_v4(),
+        });
+        assert!(err.is_sprint_board_mismatch());
+        assert!(!err.is_validation());
+        assert!(!err.is_not_found());
     }
 
     #[test]

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1340,3 +1340,107 @@ async fn tool_create_card_without_sprint_id_leaves_card_unassigned() {
     let body = text_payload(&result);
     assert!(body["sprint_id"].is_null());
 }
+
+/// Negative path: passing a sprint identifier the resolver can't find
+/// surfaces a useful error mentioning both "Sprint" and the offending
+/// name, not a panic or a generic message. Pins the contract that LLM
+/// clients rely on when learning the tool schema by trial.
+#[tokio::test]
+async fn tool_create_card_with_unknown_sprint_name_returns_useful_error() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("KAN".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "B".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+
+    let err = server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "B".into(),
+            column: "TODO".into(),
+            title: "Sprinted".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+            sprint_id: Some("nonexistent".into()),
+        }))
+        .await
+        .unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("Sprint"), "err: {msg}");
+    assert!(msg.contains("nonexistent"), "err: {msg}");
+}
+
+/// Negative path: a sprint UUID from another board cannot be used when
+/// creating a card on the current board. The error returned by the tool
+/// path comes from the typed `SprintBoardMismatch` variant via
+/// `kanban_err_to_mcp`, so the message mentions "belongs to board".
+#[tokio::test]
+async fn tool_create_card_with_cross_board_sprint_returns_useful_error() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "A".into(),
+            card_prefix: Some("A".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_board(Parameters(CreateBoardRequest {
+            name: "B".into(),
+            card_prefix: Some("B".into()),
+        }))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(CreateColumnRequest {
+            board: "A".into(),
+            name: "TODO".into(),
+            position: None,
+        }))
+        .await
+        .unwrap();
+    let sprint_b_result = server
+        .tool_create_sprint(Parameters(CreateSprintRequest {
+            board: "B".into(),
+            prefix: None,
+            name: Some("beta".into()),
+        }))
+        .await
+        .unwrap();
+    let sprint_b_id = text_payload(&sprint_b_result)["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Pass sprint B's UUID while creating a card on board A. The
+    // sprint resolver scoped to board A would reject this as a name
+    // miss, so we pass the UUID directly to ensure we exercise the
+    // domain-level cross-board check rather than the resolver miss.
+    let err = server
+        .tool_create_card(Parameters(CreateCardRequest {
+            board: "A".into(),
+            column: "TODO".into(),
+            title: "Sprinted".into(),
+            description: None,
+            priority: None,
+            points: None,
+            due_date: None,
+            sprint_id: Some(sprint_b_id.clone()),
+        }))
+        .await
+        .unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("belongs to board"), "err: {msg}");
+}

--- a/crates/kanban-service/tests/create_card_with_sprint.rs
+++ b/crates/kanban-service/tests/create_card_with_sprint.rs
@@ -1,6 +1,7 @@
-use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_domain::{CreateCardOptions, DomainError, KanbanError, KanbanOperations};
 use kanban_service::{open_context, AppConfig};
 use tempfile::TempDir;
+use uuid::Uuid;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_card_with_sprint_id_in_options_assigns_card_to_sprint() {
@@ -82,4 +83,87 @@ async fn create_card_with_sprint_and_undo_removes_card_and_assignment() {
         ctx.get_card(card.id).unwrap().is_none(),
         "Card should be gone after undo of single create-with-sprint command"
     );
+}
+
+/// Negative path: passing a sprint UUID that does not exist surfaces a
+/// typed `NotFound { entity: "sprint" }` error through the full service
+/// stack, not a panic or a generic validation message. Pins the
+/// `get_sprint(sprint_id)?` line in `CreateCard::execute`.
+#[tokio::test(flavor = "multi_thread")]
+async fn create_card_with_unknown_sprint_uuid_returns_not_found() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = open_context(&path, AppConfig::default()).await.unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+
+    let bogus = Uuid::new_v4();
+    let err = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card".into(),
+            CreateCardOptions {
+                sprint_id: Some(bogus),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(err.is_not_found(), "expected NotFound, got: {err:?}");
+    match &err {
+        KanbanError::Domain(DomainError::NotFound { entity, id }) => {
+            assert_eq!(*entity, "sprint", "wrong entity tag: {err:?}");
+            assert_eq!(*id, bogus, "wrong id in NotFound: {err:?}");
+        }
+        other => panic!("expected NotFound, got: {other:?}"),
+    }
+}
+
+/// Negative path: a sprint belonging to board B cannot be used when
+/// creating a card on board A. The error is the typed
+/// `SprintBoardMismatch` variant (not a stringly-typed Validation),
+/// so callers and tests can match on it structurally.
+#[tokio::test(flavor = "multi_thread")]
+async fn create_card_with_cross_board_sprint_returns_typed_mismatch() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.kanban").to_string_lossy().to_string();
+
+    let mut ctx = open_context(&path, AppConfig::default()).await.unwrap();
+
+    let board_a = ctx.create_board("A".into(), None).unwrap();
+    let board_b = ctx.create_board("B".into(), None).unwrap();
+    let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
+    let sprint_b = ctx.create_sprint(board_b.id, None, None).unwrap();
+
+    let err = ctx
+        .create_card(
+            board_a.id,
+            col_a.id,
+            "Card".into(),
+            CreateCardOptions {
+                sprint_id: Some(sprint_b.id),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(
+        err.is_sprint_board_mismatch(),
+        "expected SprintBoardMismatch, got: {err:?}"
+    );
+    match &err {
+        KanbanError::Domain(DomainError::SprintBoardMismatch {
+            sprint_id,
+            sprint_board,
+            card_board,
+        }) => {
+            assert_eq!(*sprint_id, sprint_b.id);
+            assert_eq!(*sprint_board, board_b.id);
+            assert_eq!(*card_board, board_a.id);
+        }
+        other => panic!("expected SprintBoardMismatch, got: {other:?}"),
+    }
 }


### PR DESCRIPTION
Closes a coverage gap on `card create --assign` across all three surfaces (service / CLI / MCP) and promotes the cross-board sprint check to a typed `DomainError` variant so library consumers can match on it structurally.

- Add `DomainError::SprintBoardMismatch { sprint_id, sprint_board, card_board }` + `is_sprint_board_mismatch()` predicate
- Swap the cross-board branch in `CreateCard::execute` from `KanbanError::validation(format!(...))` to the new typed variant
- Update the existing inline cross-board test to assert the typed variant
- Add 2 negative-path service-layer tests, 2 CLI integration tests (via `assert_cmd`), and 2 MCP integration tests (via real `tool_create_card`)
- Bump this changeset to `minor` (variant addition breaks downstream exhaustive matches; consistent with KAN-249)
- **Bundled hygiene retro-fix:** also bump KAN-522 and KAN-644 changesets to `minor` for the same reason (both added public enum variants under `patch`)

**What**: Two production changes (new typed error variant, updated call site) plus six new tests plus three changeset bumps. Three new unit tests in `error.rs` cover the variant's Display + predicate. The KAN-522 and KAN-644 retro-fixes are doc-only edits to already-merged changesets; they fix a semver-hygiene gap without changing any code.

**Why**: KAN-556 shipped sprint-at-card-creation across TUI / CLI / MCP. Happy paths were covered; every error branch was untested. The cross-board check returned an untyped `Validation` error that could only be asserted by message substring — brittle to wording and impossible to introspect for library consumers. KAN-655 closes both gaps in one cohesive change. The bundled hygiene retro-fixes correct two earlier changesets that added public enum variants but used `patch` — same hygiene rule as this PR's own primary fix; reviewing them together keeps the rule consistent across the release.

**How**:
1. Add the new variant and predicate in `kanban-domain/src/error.rs`. Display impl reproduces the existing message verbatim so end-user error text is unchanged across CLI / MCP / TUI.
2. Switch the call site at `kanban-domain/src/commands/card_commands.rs:259-264` to return the typed variant.
3. Update the inline cross-board test (line 1288) to assert the new variant structurally.
4. Add `error.rs` unit tests for the Display and predicate.
5. Add service-layer negative-path tests in `kanban-service/tests/create_card_with_sprint.rs` (unknown UUID → `NotFound { entity: "sprint" }`; cross-board UUID → `SprintBoardMismatch`).
6. Add CLI integration tests in `kanban-cli/tests/cli_integration.rs` (unknown name + unknown UUID, both asserting stderr substrings via `predicate::str::contains`).
7. Add MCP integration tests in `kanban-mcp/tests/integration.rs` exercising `tool_create_card` directly with bogus sprint identifiers, asserting the surfaced error message.
8. Bump this PR's changeset to `minor` + add a one-sentence note about the exhaustive-match break.
9. Retro-fix KAN-522 changeset to `minor` + add a one-sentence note about `UnsupportedFutureVersion`.
10. Retro-fix KAN-644 changeset to `minor` + add a one-sentence note about `SortField`/`SortBy::DueDate`.

The card's original draft also listed "ambiguous sprint name" and "sprint number lookup without board context"; discovery showed those live in the resolver (`resolve_sprint_id_global`), not in the create-card command — `CreateCard::execute` only ever receives a UUID. Out of scope for this PR; would be a separate ticket for resolver-level negative coverage if needed.

**Note on the release version**: practical impact on 0.7.0 is zero. The release PR is already cutting a minor bump (highest changeset wins), so the three `patch → minor` corrections do not change the released version. They are documentation/hygiene corrections that establish the "variant additions are minor bumps" rule consistently across pending changesets.

**Testing**: `cargo test -p kanban-domain` (new variant + updated inline test), `cargo test -p kanban-service --test create_card_with_sprint` (5 passing including 2 new), `cargo test -p kanban-cli --test cli_integration test_card_create_with_assign_unknown` (2 new), `cargo test -p kanban-mcp --test integration tool_create_card_with_` (4 passing including 2 new), `cargo test --workspace` (no regressions), `cargo fmt --all -- --check` (clean), `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean). The three hygiene retro-fix commits touch only `.md` changeset files and require no code testing.