### PR TITLE
KAN-650 fix(persistence-json): mirror .v{N}.backup writes in sync migration path

### DIFF
--- a/.changeset/kan-650-sync-migration-backups.md
+++ b/.changeset/kan-650-sync-migration-backups.md
@@ -1,0 +1,26 @@
+---
+bump: patch
+---
+
+The synchronous JSON migration path used by `kanban` (CLI), the TUI
+startup, and `kanban-mcp` now writes a `.v{N}.backup` file before
+running the shape-changing V→V7 migration chain, removes it on
+success, and preserves it on failure. Previously only the asynchronous
+load path produced these rollback artefacts; the sync path would
+overwrite files in place with no recourse if a step failed
+mid-chain.
+
+End users upgrading a V3/V4/V5/V6 JSON file to V7 via any sync entry
+point now see the same backup-and-cleanup behaviour as users who go
+through the async path: a successful migration leaves no extra files
+on disk, and a failed migration leaves a `.v3.backup` / `.v4.backup`
+/ `.v5.backup` / `.v6.backup` alongside the original file with the
+path surfaced in the error log.
+
+V1→V2 keeps its existing in-step `.v1.backup`; V2→V3 is shape-stable
+and continues to need no backup.
+
+No API or message changes for library consumers. The
+source-version-to-backup-path policy is now shared by both
+orchestrators in a single `migration::backup::pre_v7_backup_path_for`
+helper so future migration additions only need to update one site.

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -102,8 +102,9 @@ fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec
 
     // Backup-and-cleanup wrap around the shape-changing steps
     // (split_graph_sync and/or v6_to_v7_rename_sync). Identical in shape
-    // to the async orchestrator in `Migrator::migrate`.
-    let backup_path = pre_v7_backup_path_for_sync(from, path);
+    // to the async orchestrator in `Migrator::migrate`; both call sites
+    // share the source-version → backup-path policy in `migration::backup`.
+    let backup_path = crate::migration::pre_v7_backup_path_for(from, path);
     if let Some(backup) = &backup_path {
         std::fs::copy(path, backup)?;
         tracing::info!("Created pre-V7 backup at {} (sync)", backup.display());
@@ -139,23 +140,6 @@ fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec
             Err(e)
         }
         (Err(e), None) => Err(e),
-    }
-}
-
-/// Sync sibling of the async backup-path policy. Returns
-/// `Some(path.vN.backup)` for V3/V4/V5/V6 source versions where the
-/// shape-changing chain runs; `None` for V1/V2 which manage their own
-/// backups inside their per-step functions.
-///
-/// Temporary inline duplicate — the refactor in the next commit
-/// extracts this and its async equivalent to `migration/backup.rs`.
-fn pre_v7_backup_path_for_sync(from: FormatVersion, path: &Path) -> Option<PathBuf> {
-    match from {
-        FormatVersion::V3 => Some(path.with_extension("v3.backup")),
-        FormatVersion::V4 => Some(path.with_extension("v4.backup")),
-        FormatVersion::V5 => Some(path.with_extension("v5.backup")),
-        FormatVersion::V6 => Some(path.with_extension("v6.backup")),
-        _ => None,
     }
 }
 

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -86,17 +86,12 @@ impl JsonEnvelope {
 
 /// Synchronous V*→V7 migration chain used by [`JsonFileStore::load_sync`].
 ///
-/// Asymmetry vs the async `Migrator::migrate` orchestrator: this chain does
-/// **not** create a `.v{N}.backup` around the shape-changing steps
-/// (`split_graph_sync`, `v6_to_v7_rename_sync`). Only the V1→V2 step writes
-/// a backup (in `migrate_v1_to_v2_sync`); the later steps overwrite the
-/// file atomically without one. A mid-chain crash therefore leaves the
-/// file in whatever intermediate state the last successful step produced,
-/// and the user would need an external backup to roll back.
-///
-/// Closing this gap requires a shared backup helper that both the sync
-/// and async chains can call; it's deferred rather than open-coded here
-/// to avoid duplicating the orchestrator logic.
+/// Mirrors the async `Migrator::migrate` orchestrator's `.v{N}.backup`
+/// behaviour: for V3/V4/V5/V6 sources a backup of the original file is
+/// written before the shape-changing chain runs. On success the backup
+/// is removed; on failure it is preserved so the user can roll back.
+/// V1→V2 manages its own backup inside `migrate_v1_to_v2_sync`; V2→V3
+/// is shape-stable and needs none.
 fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec<u8>> {
     if from == FormatVersion::V1 {
         migrate_v1_to_v2_sync(path)?;
@@ -104,10 +99,64 @@ fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec
     if from <= FormatVersion::V2 {
         migrate_v2_to_v3_sync(path)?;
     }
-    if from < FormatVersion::V6 {
-        split_graph_sync(path)?;
+
+    // Backup-and-cleanup wrap around the shape-changing steps
+    // (split_graph_sync and/or v6_to_v7_rename_sync). Identical in shape
+    // to the async orchestrator in `Migrator::migrate`.
+    let backup_path = pre_v7_backup_path_for_sync(from, path);
+    if let Some(backup) = &backup_path {
+        std::fs::copy(path, backup)?;
+        tracing::info!("Created pre-V7 backup at {} (sync)", backup.display());
     }
-    v6_to_v7_rename_sync(path)
+
+    let result: PersistenceResult<Vec<u8>> = (|| {
+        if from < FormatVersion::V6 {
+            split_graph_sync(path)?;
+        }
+        v6_to_v7_rename_sync(path)
+    })();
+
+    match (result, backup_path) {
+        (Ok(bytes), Some(backup)) => {
+            if let Err(e) = std::fs::remove_file(&backup) {
+                tracing::warn!(
+                    "Sync migration successful but failed to remove backup at {}: {}",
+                    backup.display(),
+                    e
+                );
+            } else {
+                tracing::info!("Sync migration to V7 verified, backup removed");
+            }
+            Ok(bytes)
+        }
+        (Ok(bytes), None) => Ok(bytes),
+        (Err(e), Some(backup)) => {
+            tracing::error!(
+                "Sync migration to V7 failed: {}. Backup preserved at {}",
+                e,
+                backup.display()
+            );
+            Err(e)
+        }
+        (Err(e), None) => Err(e),
+    }
+}
+
+/// Sync sibling of the async backup-path policy. Returns
+/// `Some(path.vN.backup)` for V3/V4/V5/V6 source versions where the
+/// shape-changing chain runs; `None` for V1/V2 which manage their own
+/// backups inside their per-step functions.
+///
+/// Temporary inline duplicate — the refactor in the next commit
+/// extracts this and its async equivalent to `migration/backup.rs`.
+fn pre_v7_backup_path_for_sync(from: FormatVersion, path: &Path) -> Option<PathBuf> {
+    match from {
+        FormatVersion::V3 => Some(path.with_extension("v3.backup")),
+        FormatVersion::V4 => Some(path.with_extension("v4.backup")),
+        FormatVersion::V5 => Some(path.with_extension("v5.backup")),
+        FormatVersion::V6 => Some(path.with_extension("v6.backup")),
+        _ => None,
+    }
 }
 
 fn migrate_v1_to_v2_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
@@ -1033,6 +1082,193 @@ mod tests {
         assert!(
             !tmp_path.exists(),
             ".tmp must not remain after successful migration"
+        );
+    }
+
+    /// KAN-650: the sync migration path must mirror the async orchestrator's
+    /// `.v{N}.backup` behaviour. A V6 file with both `parent_child` AND
+    /// `spawns` buckets is the canonical mid-V6 failure case (the v6→v7
+    /// rename refuses it). Without a pre-chain backup, the user has nothing
+    /// to roll back to. With one, the broken envelope on disk plus the
+    /// `.v6.backup` together reconstruct the original state.
+    #[test]
+    fn test_load_sync_v6_to_v7_preserves_v6_backup_on_failure() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v6_ambiguous_sync.json");
+        let v6 = json!({
+            "version": 6,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [], "columns": [], "cards": [], "archived_cards": [], "sprints": [],
+                "graph": {
+                    "parent_child": { "edges": [{
+                        "source": "11111111-1111-1111-1111-111111111111",
+                        "target": "22222222-2222-2222-2222-222222222222",
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "archived_at": null
+                    }]},
+                    "spawns": { "edges": [{
+                        "source": "33333333-3333-3333-3333-333333333333",
+                        "target": "44444444-4444-4444-4444-444444444444",
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "archived_at": null
+                    }]},
+                    "blocks": { "edges": [] },
+                    "relates": { "edges": [] }
+                }
+            }
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&v6).unwrap()).unwrap();
+
+        let store = JsonFileStore::new(&path);
+        let err = store
+            .load_sync()
+            .expect_err("load_sync must refuse a V6 envelope carrying both bucket keys");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parent_child") && msg.contains("spawns"),
+            "diagnostic should name both colliding keys; got: {msg}"
+        );
+
+        assert!(
+            path.with_extension("v6.backup").exists(),
+            ".v6.backup must be preserved when the V6→V7 sync step fails so the user can recover"
+        );
+    }
+
+    /// KAN-650: successful V6→V7 sync migration must clean up its
+    /// `.v6.backup` once the chain completes. Mirrors the async
+    /// `test_migrate_v6_to_v7_renames_parent_child_and_writes_backup`
+    /// assertion that the backup is removed on success.
+    #[test]
+    fn test_load_sync_v6_to_v7_cleans_up_v6_backup_on_success() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v6_clean_sync.json");
+        let v6 = json!({
+            "version": 6,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [], "columns": [], "cards": [], "archived_cards": [], "sprints": [],
+                "graph": {
+                    "parent_child": { "edges": [] },
+                    "blocks": { "edges": [] },
+                    "relates": { "edges": [] }
+                }
+            }
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&v6).unwrap()).unwrap();
+
+        let store = JsonFileStore::new(&path);
+        let _ = store.load_sync().unwrap().expect("file exists");
+
+        let after: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(after["version"], 7);
+
+        assert!(
+            !path.with_extension("v6.backup").exists(),
+            ".v6.backup must be removed after successful V6→V7 sync migration"
+        );
+    }
+
+    /// KAN-650: V5 files go through split_graph then v6→v7. The backup
+    /// keyed to the *source* version is `.v5.backup`, written before
+    /// the destructive chain runs and removed on success.
+    #[test]
+    fn test_load_sync_v5_to_v7_cleans_up_v5_backup_on_success() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v5_clean_sync.json");
+        let v5 = json!({
+            "version": 5,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [], "columns": [], "cards": [], "archived_cards": [], "sprints": [],
+                "graph": { "cards": { "edges": [] } }
+            }
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&v5).unwrap()).unwrap();
+
+        let store = JsonFileStore::new(&path);
+        let _ = store.load_sync().unwrap().expect("file exists");
+
+        let after: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(after["version"], 7);
+
+        assert!(
+            !path.with_extension("v5.backup").exists(),
+            ".v5.backup must be removed after successful V5→V7 sync migration"
+        );
+    }
+
+    /// KAN-650: V4 backup keyed to the source version.
+    #[test]
+    fn test_load_sync_v4_to_v7_cleans_up_v4_backup_on_success() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v4_clean_sync.json");
+        let v4 = json!({
+            "version": 4,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [], "columns": [], "cards": [], "archived_cards": [], "sprints": [],
+                "graph": { "cards": { "edges": [] } }
+            }
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&v4).unwrap()).unwrap();
+
+        let store = JsonFileStore::new(&path);
+        let _ = store.load_sync().unwrap().expect("file exists");
+
+        let after: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(after["version"], 7);
+
+        assert!(
+            !path.with_extension("v4.backup").exists(),
+            ".v4.backup must be removed after successful V4→V7 sync migration"
+        );
+    }
+
+    /// KAN-650: V3 backup keyed to the source version.
+    #[test]
+    fn test_load_sync_v3_to_v7_cleans_up_v3_backup_on_success() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v3_clean_sync.json");
+        let v3 = json!({
+            "version": 3,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [], "columns": [], "cards": [], "archived_cards": [], "sprints": [],
+                "graph": { "cards": { "edges": [] } }
+            }
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&v3).unwrap()).unwrap();
+
+        let store = JsonFileStore::new(&path);
+        let _ = store.load_sync().unwrap().expect("file exists");
+
+        let after: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(after["version"], 7);
+
+        assert!(
+            !path.with_extension("v3.backup").exists(),
+            ".v3.backup must be removed after successful V3→V7 sync migration"
         );
     }
 }

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -85,13 +85,8 @@ impl JsonEnvelope {
 // ─── Sync migration helpers ───────────────────────────────────────────────────
 
 /// Synchronous V*→V7 migration chain used by [`JsonFileStore::load_sync`].
-///
-/// Mirrors the async `Migrator::migrate` orchestrator's `.v{N}.backup`
-/// behaviour: for V3/V4/V5/V6 sources a backup of the original file is
-/// written before the shape-changing chain runs. On success the backup
-/// is removed; on failure it is preserved so the user can roll back.
-/// V1→V2 manages its own backup inside `migrate_v1_to_v2_sync`; V2→V3
-/// is shape-stable and needs none.
+/// See [`migration::backup`] for the backup-path policy shared with the
+/// async [`Migrator::migrate`] orchestrator.
 fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec<u8>> {
     if from == FormatVersion::V1 {
         migrate_v1_to_v2_sync(path)?;
@@ -100,40 +95,31 @@ fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec
         migrate_v2_to_v3_sync(path)?;
     }
 
-    // Backup-and-cleanup wrap around the shape-changing steps
-    // (split_graph_sync and/or v6_to_v7_rename_sync). Identical in shape
-    // to the async orchestrator in `Migrator::migrate`; both call sites
-    // share the source-version → backup-path policy in `migration::backup`.
     let backup_path = crate::migration::pre_v7_backup_path_for(from, path);
     if let Some(backup) = &backup_path {
         std::fs::copy(path, backup)?;
-        tracing::info!("Created pre-V7 backup at {} (sync)", backup.display());
+        tracing::info!("Created pre-V7 backup at {}", backup.display());
     }
 
-    let result: PersistenceResult<Vec<u8>> = (|| {
-        if from < FormatVersion::V6 {
-            split_graph_sync(path)?;
-        }
-        v6_to_v7_rename_sync(path)
-    })();
+    let result = run_split_and_rename_chain_sync(from, path);
 
     match (result, backup_path) {
         (Ok(bytes), Some(backup)) => {
             if let Err(e) = std::fs::remove_file(&backup) {
                 tracing::warn!(
-                    "Sync migration successful but failed to remove backup at {}: {}",
+                    "Migration successful but failed to remove backup at {}: {}",
                     backup.display(),
                     e
                 );
             } else {
-                tracing::info!("Sync migration to V7 verified, backup removed");
+                tracing::info!("Migration to V7 verified, backup removed");
             }
             Ok(bytes)
         }
         (Ok(bytes), None) => Ok(bytes),
         (Err(e), Some(backup)) => {
             tracing::error!(
-                "Sync migration to V7 failed: {}. Backup preserved at {}",
+                "Migration to V7 failed: {}. Backup preserved at {}",
                 e,
                 backup.display()
             );
@@ -141,6 +127,16 @@ fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec
         }
         (Err(e), None) => Err(e),
     }
+}
+
+/// Sync sibling of [`Migrator::run_split_and_rename_chain`]. Runs the V6
+/// split-graph transform (only if the file is pre-V6) and then the v6→v7
+/// spawns-bucket rename, returning the final on-disk bytes.
+fn run_split_and_rename_chain_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec<u8>> {
+    if from < FormatVersion::V6 {
+        split_graph_sync(path)?;
+    }
+    v6_to_v7_rename_sync(path)
 }
 
 fn migrate_v1_to_v2_sync(path: &Path) -> PersistenceResult<Vec<u8>> {

--- a/crates/kanban-persistence-json/src/migration/backup.rs
+++ b/crates/kanban-persistence-json/src/migration/backup.rs
@@ -1,0 +1,79 @@
+//! Shared backup-path policy used by both the async `Migrator::migrate`
+//! orchestrator and the sync `migrate_to_v7_sync` chain.
+//!
+//! The destructive V→V7 chain (`split_graph` and/or `v6_to_v7_rename`)
+//! runs against a freshly-written file via the atomic temp+rename
+//! pattern. A pre-chain `.v{N}.backup` is the user's rollback artifact
+//! if a step fails mid-chain. V1→V2 and V2→V3 manage their own backups
+//! (or none — V2→V3 is shape-stable) and are excluded from this policy.
+
+use kanban_persistence::FormatVersion;
+use std::path::{Path, PathBuf};
+
+/// Return `Some(path.vN.backup)` for source versions that need a
+/// pre-V7-chain backup; `None` otherwise.
+pub(crate) fn pre_v7_backup_path_for(from: FormatVersion, path: &Path) -> Option<PathBuf> {
+    match from {
+        FormatVersion::V3 => Some(path.with_extension("v3.backup")),
+        FormatVersion::V4 => Some(path.with_extension("v4.backup")),
+        FormatVersion::V5 => Some(path.with_extension("v5.backup")),
+        FormatVersion::V6 => Some(path.with_extension("v6.backup")),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn p() -> PathBuf {
+        PathBuf::from("/tmp/board.json")
+    }
+
+    #[test]
+    fn returns_some_for_v3() {
+        assert_eq!(
+            pre_v7_backup_path_for(FormatVersion::V3, &p()),
+            Some(PathBuf::from("/tmp/board.v3.backup"))
+        );
+    }
+
+    #[test]
+    fn returns_some_for_v4() {
+        assert_eq!(
+            pre_v7_backup_path_for(FormatVersion::V4, &p()),
+            Some(PathBuf::from("/tmp/board.v4.backup"))
+        );
+    }
+
+    #[test]
+    fn returns_some_for_v5() {
+        assert_eq!(
+            pre_v7_backup_path_for(FormatVersion::V5, &p()),
+            Some(PathBuf::from("/tmp/board.v5.backup"))
+        );
+    }
+
+    #[test]
+    fn returns_some_for_v6() {
+        assert_eq!(
+            pre_v7_backup_path_for(FormatVersion::V6, &p()),
+            Some(PathBuf::from("/tmp/board.v6.backup"))
+        );
+    }
+
+    #[test]
+    fn returns_none_for_v1_and_v2() {
+        // V1 manages its own .v1.backup inside migrate_v1_to_v2; V2 is
+        // shape-stable through V2→V3 and needs no backup.
+        assert_eq!(pre_v7_backup_path_for(FormatVersion::V1, &p()), None);
+        assert_eq!(pre_v7_backup_path_for(FormatVersion::V2, &p()), None);
+    }
+
+    #[test]
+    fn returns_none_for_v7() {
+        // V7→V7 is a no-op upstream; should never reach the chain.
+        assert_eq!(pre_v7_backup_path_for(FormatVersion::V7, &p()), None);
+    }
+}

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -82,14 +82,10 @@ impl Migrator {
                 // A `.v{N}.backup` is created before the shape-changing step
                 // and removed on successful migration. V7 files cannot be
                 // opened by pre-V7 binaries, so this is the user's escape
-                // hatch if the upgrade has to be rolled back.
-                let backup_path = match from {
-                    FormatVersion::V3 => Some(path.with_extension("v3.backup")),
-                    FormatVersion::V4 => Some(path.with_extension("v4.backup")),
-                    FormatVersion::V5 => Some(path.with_extension("v5.backup")),
-                    FormatVersion::V6 => Some(path.with_extension("v6.backup")),
-                    _ => None,
-                };
+                // hatch if the upgrade has to be rolled back. The
+                // source-version → backup-path policy is shared with the
+                // sync orchestrator in `json_file_store::migrate_to_v7_sync`.
+                let backup_path = super::pre_v7_backup_path_for(from, path);
                 if let Some(backup) = &backup_path {
                     tokio::fs::copy(path, backup).await?;
                     tracing::info!("Created pre-V7 backup at {}", backup.display());

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -79,12 +79,10 @@ impl Migrator {
                 // them. V6 files skip the split-graph step entirely and go
                 // straight to the v6→v7 rename.
                 //
-                // A `.v{N}.backup` is created before the shape-changing step
-                // and removed on successful migration. V7 files cannot be
-                // opened by pre-V7 binaries, so this is the user's escape
-                // hatch if the upgrade has to be rolled back. The
-                // source-version → backup-path policy is shared with the
-                // sync orchestrator in `json_file_store::migrate_to_v7_sync`.
+                // See `migration::backup` for the source-version → backup-path
+                // policy shared with the sync orchestrator. A `.v{N}.backup`
+                // is the user's escape hatch if the upgrade has to be rolled
+                // back, since V7 files cannot be opened by pre-V7 binaries.
                 let backup_path = super::pre_v7_backup_path_for(from, path);
                 if let Some(backup) = &backup_path {
                     tokio::fs::copy(path, backup).await?;

--- a/crates/kanban-persistence-json/src/migration/mod.rs
+++ b/crates/kanban-persistence-json/src/migration/mod.rs
@@ -1,9 +1,11 @@
+pub(crate) mod backup;
 pub mod migrator;
 pub mod split_graph;
 pub mod v1_to_v2;
 pub mod v2_to_v3;
 pub mod v6_to_v7_rename;
 
+pub(crate) use backup::pre_v7_backup_path_for;
 pub use migrator::Migrator;
 pub(crate) use split_graph::transform_to_v6_split_graph_value;
 pub use v1_to_v2::V1ToV2Migration;


### PR DESCRIPTION
Closes the data-safety gap in the synchronous JSON migration chain: it now writes a `.v{N}.backup` before the destructive V→V7 steps and preserves it on failure, mirroring the async orchestrator's existing behaviour. DRYed via a shared `pre_v7_backup_path_for` helper used by both call sites, with the sync orchestrator now structurally identical to the async one modulo I/O API.

- Sync orchestrator (`migrate_to_v7_sync`) wraps the chain with backup + cleanup
- Async orchestrator (`Migrator::migrate`) now reads the source-version → backup-path policy from the same shared helper
- New `migration/backup.rs` module with the pure policy function + 6 unit tests pinning V1..V7 coverage
- 5 new sync-path tests pin the failure-preservation and success-cleanup contracts for V3/V4/V5/V6 sources
- Sync chain extracted as a named `run_split_and_rename_chain_sync` helper (sibling of the async `run_split_and_rename_chain`); log-message convention normalized

**What**: The sync V*→V7 migration chain used by CLI / TUI / MCP startup gains the same `.v{N}.backup` write-and-cleanup behaviour the async path already had. A new pure-logic helper consolidates the source-version → backup-path policy in one place; both orchestrators call it. The destructive chain itself is now a named function on both sides.

**Why**: Pre-KAN-650 the sync path documented its own gap in a multi-paragraph doc comment: split_graph_sync and v6_to_v7_rename_sync overwrote files in place without a backup, so a mid-chain failure (e.g. the V6 both-keys ambiguity) left the user with no rollback artifact. 0.7.0 is the release that introduces the V6→V7 spawns-bucket rename (KAN-530), making this exactly the wrong moment to ship the gap. The async path already does the right thing; this PR brings the sync path to parity.

**How**:
1. Commit `a912496` (fix + tests): `migrate_to_v7_sync` now computes a backup path for V3/V4/V5/V6 sources, copies the file to that path before the chain runs, removes it on success, preserves it on failure with the path logged. V1→V2 keeps its existing per-step `.v1.backup`; V2→V3 is shape-stable for that step (but see V2→V7 follow-up below). Five new tests in `json_file_store.rs` pin the contract: one failure-preservation (V6 both-keys ambiguity), four success-cleanup (V3, V4, V5, V6).
2. Commit `6f57b7a3` (refactor): the source-version → backup-path match expression that was duplicated between async (`migrator.rs:86-92`) and sync was extracted to `migration/backup.rs::pre_v7_backup_path_for`. Both orchestrators now call it.
3. Commit `4de627e` (changeset): `bump: patch`.
4. Commit `7ed1a1d` (review cleanup): extracted `run_split_and_rename_chain_sync` (sibling of the async `run_split_and_rename_chain`) — removes the IIFE-style closure that was holding the sync chain inline, brings both orchestrators to the same shape modulo I/O API. Normalized the new backup-log messages (dropped the `(sync)` suffix to match async). Consolidated the backup-policy explanation: canonical doc lives in `migration::backup`; both call sites now point readers there.

**Known pre-existing gap (out of scope, follow-up filed)**: V2 → V7 migration still runs the destructive chain with no backup at any point. `migrate_v2_to_v3*` overwrites the V2 file in place before the backup policy is consulted, and `pre_v7_backup_path_for(V2, path)` returns `None`. Both async and sync share the gap; KAN-650 mirrors async behaviour rather than introducing a divergent fix. Follow-up filed as **KAN-660** on sprint 18 (medium, 3pt).

**Testing**: `cargo test -p kanban-persistence-json` (focused, 79 passing including 11 new: 5 sync-path + 6 unit tests on the helper), `cargo test --workspace` (no regressions), `cargo fmt --all -- --check` (clean), `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean).