### PR TITLE
KAN-659 fix(domain): capitalize entity tags in KanbanError::not_found

### DIFF
--- a/.changeset/kan-659-capitalize-not-found-entity-tags.md
+++ b/.changeset/kan-659-capitalize-not-found-entity-tags.md
@@ -1,0 +1,23 @@
+---
+bump: patch
+---
+
+Error messages for "not found" lookups now use consistent capitalization
+across all code paths. Previously the same error category rendered
+differently depending on whether the lookup was by UUID
+(`"sprint <uuid> not found"`, lowercase) or by name
+(`"Sprint 'foo' not found"`, capitalized). Both forms now read with the
+sentence-leading capitalized noun.
+
+User-visible impact: error messages for unknown card / column / sprint
+/ board UUIDs now start with a capital letter to match the existing
+name-lookup messages. No structural change to error types or
+diagnostics; only the first letter of the entity name in the rendered
+message changes.
+
+Library consumers exhaustively matching on `DomainError::NotFound`
+should note that the `entity` field is now always a capitalized noun
+(`"Card"`, `"Column"`, `"Sprint"`, `"Board"`) rather than the previous
+lowercase form. The `NotFoundByName` variant's casing is unchanged. A
+doc comment on both variants now documents the convention so future
+not-found additions inherit the same casing.

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1888,9 +1888,11 @@ mod card_tests {
     }
 
     /// Negative path: `--assign <random-uuid>` produces an error mentioning
-    /// both "sprint" and the offending UUID. Same surface contract as the
+    /// both "Sprint" and the offending UUID. Same surface contract as the
     /// name case above; the resolver accepts UUIDs first, so this exercises
-    /// a different code path inside `resolve_sprint_id`.
+    /// a different code path inside `resolve_sprint_id`. Post-KAN-659,
+    /// both this test and the name-path sibling assert on the same
+    /// capitalized "Sprint" tag.
     #[test]
     fn test_card_create_with_assign_unknown_uuid_fails_with_useful_error() {
         let dir = tempdir().unwrap();
@@ -1914,7 +1916,7 @@ mod card_tests {
             ])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("sprint"))
+            .stderr(predicate::str::contains("Sprint"))
             .stderr(predicate::str::contains(bogus));
     }
 }

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -161,7 +161,7 @@ impl UpdateBoard {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let board = match store.get_board(self.board_id)? {
             Some(b) => b,
-            None => return Err(KanbanError::not_found("board", self.board_id)),
+            None => return Err(KanbanError::not_found("Board", self.board_id)),
         };
         let upd = &self.updates;
         let inverse = crate::BoardUpdate {
@@ -244,7 +244,7 @@ impl SetBoardTaskSort {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let board = match store.get_board(self.board_id)? {
             Some(b) => b,
-            None => return Err(KanbanError::not_found("board", self.board_id)),
+            None => return Err(KanbanError::not_found("Board", self.board_id)),
         };
         Ok(vec![Command::Board(BoardCommand::SetTaskSort(
             SetBoardTaskSort {
@@ -279,7 +279,7 @@ impl SetBoardTaskListView {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let board = match store.get_board(self.board_id)? {
             Some(b) => b,
-            None => return Err(KanbanError::not_found("board", self.board_id)),
+            None => return Err(KanbanError::not_found("Board", self.board_id)),
         };
         Ok(vec![Command::Board(BoardCommand::SetTaskListView(
             SetBoardTaskListView {
@@ -316,7 +316,7 @@ impl DeleteBoard {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let board = match store.get_board(self.board_id)? {
             Some(b) => b,
-            None => return Err(KanbanError::not_found("board", self.board_id)),
+            None => return Err(KanbanError::not_found("Board", self.board_id)),
         };
         Ok(vec![Command::Board(BoardCommand::Import(ImportEntities {
             boards: vec![board],
@@ -351,7 +351,7 @@ impl ApplyBoardSettings {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let board = match store.get_board(self.board_id)? {
             Some(b) => b,
-            None => return Err(KanbanError::not_found("board", self.board_id)),
+            None => return Err(KanbanError::not_found("Board", self.board_id)),
         };
         let prior_dto = crate::editable::BoardSettingsDto::from_entity(&board);
         Ok(vec![Command::Board(BoardCommand::ApplySettings(

--- a/crates/kanban-domain/src/commands/card_commands.rs
+++ b/crates/kanban-domain/src/commands/card_commands.rs
@@ -137,7 +137,7 @@ impl UpdateCard {
         use crate::field_update::FieldUpdate;
         let card = match store.get_card(self.card_id)? {
             Some(c) => c,
-            None => return Err(KanbanError::not_found("card", self.card_id)),
+            None => return Err(KanbanError::not_found("Card", self.card_id)),
         };
 
         let upd = &self.updates;
@@ -319,7 +319,7 @@ impl MoveCard {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let card = match store.get_card(self.card_id)? {
             Some(c) => c,
-            None => return Err(KanbanError::not_found("card", self.card_id)),
+            None => return Err(KanbanError::not_found("Card", self.card_id)),
         };
         Ok(vec![Command::Card(CardCommand::Move(MoveCard {
             card_id: self.card_id,
@@ -410,7 +410,7 @@ impl DeleteCard {
         let live = store.get_card(self.card_id)?;
         let archived = store.get_archived_card(self.card_id)?;
         if live.is_none() && archived.is_none() {
-            return Err(KanbanError::not_found("card", self.card_id));
+            return Err(KanbanError::not_found("Card", self.card_id));
         }
         let mut commands: Vec<Command> = vec![Command::Board(super::BoardCommand::Import(
             super::ImportEntities {
@@ -467,7 +467,7 @@ impl ArchiveCards {
             let card = context
                 .store
                 .get_card(*id)?
-                .ok_or_else(|| KanbanError::not_found("card", *id))?;
+                .ok_or_else(|| KanbanError::not_found("Card", *id))?;
             let original_column_id = card.column_id;
             let original_position = card.position;
             let archived = crate::ArchivedCard::new(card, original_column_id, original_position);
@@ -594,7 +594,7 @@ impl UnassignCardFromSprint {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let card = match store.get_card(self.card_id)? {
             Some(c) => c,
-            None => return Err(KanbanError::not_found("card", self.card_id)),
+            None => return Err(KanbanError::not_found("Card", self.card_id)),
         };
         if card.sprint_id.is_none() {
             return Ok(vec![]);
@@ -638,7 +638,7 @@ impl ApplyCardMetadata {
         use crate::field_update::FieldUpdate;
         let card = match store.get_card(self.card_id)? {
             Some(c) => c,
-            None => return Err(KanbanError::not_found("card", self.card_id)),
+            None => return Err(KanbanError::not_found("Card", self.card_id)),
         };
         let updates = CardUpdate {
             // priority / status are always written by apply_to (when the

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -68,7 +68,7 @@ impl UpdateColumn {
             Some(c) => c,
             // The column doesn't exist — execute() will fail with NotFound
             // and rollback will take over. No inverse to capture.
-            None => return Err(KanbanError::not_found("column", self.column_id)),
+            None => return Err(KanbanError::not_found("Column", self.column_id)),
         };
 
         let inverse_updates = ColumnUpdate {
@@ -133,7 +133,7 @@ impl DeleteColumn {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let column = match store.get_column(self.column_id)? {
             Some(c) => c,
-            None => return Err(KanbanError::not_found("column", self.column_id)),
+            None => return Err(KanbanError::not_found("Column", self.column_id)),
         };
         let mut commands = vec![Command::Column(ColumnCommand::Create(CreateColumn {
             id: column.id,

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -80,25 +80,25 @@ impl<'a> CommandContext<'a> {
     pub fn get_board(&self, id: Uuid) -> KanbanResult<crate::Board> {
         self.store
             .get_board(id)?
-            .ok_or_else(|| KanbanError::not_found("board", id))
+            .ok_or_else(|| KanbanError::not_found("Board", id))
     }
 
     pub fn get_card(&self, id: Uuid) -> KanbanResult<crate::Card> {
         self.store
             .get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))
+            .ok_or_else(|| KanbanError::not_found("Card", id))
     }
 
     pub fn get_column(&self, id: Uuid) -> KanbanResult<crate::Column> {
         self.store
             .get_column(id)?
-            .ok_or_else(|| KanbanError::not_found("column", id))
+            .ok_or_else(|| KanbanError::not_found("Column", id))
     }
 
     pub fn get_sprint(&self, id: Uuid) -> KanbanResult<crate::Sprint> {
         self.store
             .get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))
     }
 
     pub fn filter_valid_card_ids(&self, ids: &[Uuid], command_name: &str) -> Vec<Uuid> {

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -98,14 +98,14 @@ impl UpdateSprint {
         use crate::field_update::FieldUpdate;
         let sprint = match store.get_sprint(self.sprint_id)? {
             Some(s) => s,
-            None => return Err(KanbanError::not_found("sprint", self.sprint_id)),
+            None => return Err(KanbanError::not_found("Sprint", self.sprint_id)),
         };
 
         // If the forward sets `name`, capture board pool pre-state too.
         let board_restore: Option<Command> = if self.updates.name.is_some() {
             let board = match store.get_board(sprint.board_id)? {
                 Some(b) => b,
-                None => return Err(KanbanError::not_found("board", sprint.board_id)),
+                None => return Err(KanbanError::not_found("Board", sprint.board_id)),
             };
             Some(Command::Board(super::BoardCommand::RestoreSprintPool(
                 super::RestoreSprintPool {
@@ -405,7 +405,7 @@ fn capture_status_revert(store: &dyn DataStore, sprint_id: Uuid) -> KanbanResult
     use crate::field_update::FieldUpdate;
     let sprint = match store.get_sprint(sprint_id)? {
         Some(s) => s,
-        None => return Err(KanbanError::not_found("sprint", sprint_id)),
+        None => return Err(KanbanError::not_found("Sprint", sprint_id)),
     };
     Ok(vec![Command::Sprint(SprintCommand::Update(UpdateSprint {
         sprint_id,
@@ -459,7 +459,7 @@ impl DeleteSprint {
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let sprint = match store.get_sprint(self.sprint_id)? {
             Some(s) => s,
-            None => return Err(KanbanError::not_found("sprint", self.sprint_id)),
+            None => return Err(KanbanError::not_found("Sprint", self.sprint_id)),
         };
         let assigned_card_ids: Vec<Uuid> = store
             .list_cards_by_sprint(self.sprint_id)?

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -83,11 +83,18 @@ pub enum DependencyError {
 
 #[derive(Error, Debug)]
 pub enum DomainError {
+    /// `entity` is rendered as a sentence-leading noun (e.g. `"Card"`,
+    /// `"Sprint"`). All call sites of `KanbanError::not_found(entity, id)`
+    /// must pass a capitalized noun so the rendered message reads
+    /// `"Card <uuid> not found"`, matching the sibling `NotFoundByName`
+    /// convention. See KAN-659 for the normalization history.
     #[error("{entity} {id} not found")]
     NotFound { entity: &'static str, id: Uuid },
 
     /// Returned when a name- or identifier-based lookup misses. The `available`
     /// vector is appended to the message so users see what they could have typed.
+    /// `entity` follows the same capitalized-noun convention as
+    /// [`NotFound`](Self::NotFound).
     #[error("{}", DomainError::fmt_not_found_by_name(entity, name, available))]
     NotFoundByName {
         entity: &'static str,
@@ -372,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_is_not_found_returns_true_for_card_not_found() {
-        let err = KanbanError::not_found("card", Uuid::new_v4());
+        let err = KanbanError::not_found("Card", Uuid::new_v4());
         assert!(err.is_not_found());
     }
 
@@ -408,13 +415,13 @@ mod tests {
 
     #[test]
     fn test_is_self_reference_returns_false_for_other_error() {
-        let err = KanbanError::not_found("card", Uuid::new_v4());
+        let err = KanbanError::not_found("Card", Uuid::new_v4());
         assert!(!err.is_self_reference());
     }
 
     #[test]
     fn test_is_edge_not_found_returns_false_for_other_error() {
-        let err = KanbanError::not_found("card", Uuid::new_v4());
+        let err = KanbanError::not_found("Card", Uuid::new_v4());
         assert!(!err.is_edge_not_found());
     }
 
@@ -485,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_is_unsupported_future_version_returns_false_for_other_error() {
-        let err = KanbanError::not_found("card", Uuid::new_v4());
+        let err = KanbanError::not_found("Card", Uuid::new_v4());
         assert!(!err.is_unsupported_future_version());
     }
 
@@ -728,7 +735,7 @@ mod tests {
 
     #[test]
     fn test_is_not_found_true_for_uuid_variant_too() {
-        let err = KanbanError::not_found("card", Uuid::new_v4());
+        let err = KanbanError::not_found("Card", Uuid::new_v4());
         assert!(err.is_not_found(), "umbrella predicate covers Uuid variant");
         assert!(!err.is_not_found_by_name());
     }
@@ -736,9 +743,9 @@ mod tests {
     #[test]
     fn test_not_found_display_includes_entity_and_id() {
         let id = Uuid::new_v4();
-        let err = KanbanError::not_found("card", id);
+        let err = KanbanError::not_found("Card", id);
         let msg = err.to_string();
-        assert!(msg.contains("card"));
+        assert!(msg.contains("Card"));
         assert!(msg.contains(&id.to_string()));
     }
 

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -239,7 +239,7 @@ pub trait KanbanOperations {
         let sprints = self.list_sprints(board_id)?;
         let board = self
             .get_board(board_id)?
-            .ok_or_else(|| KanbanError::not_found("board", board_id))?;
+            .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
         let matches = crate::search::find_sprints_by_query_on_board(raw, &sprints, &board);
         match matches.as_slice() {
             [] => {
@@ -409,11 +409,11 @@ pub trait KanbanOperations {
         for cid in card_ids {
             let card = card_index
                 .get(cid)
-                .ok_or_else(|| KanbanError::not_found("card", *cid))?;
+                .ok_or_else(|| KanbanError::not_found("Card", *cid))?;
             let board_id = col_to_board
                 .get(&card.column_id)
                 .copied()
-                .ok_or_else(|| KanbanError::not_found("column", card.column_id))?;
+                .ok_or_else(|| KanbanError::not_found("Column", card.column_id))?;
             if seen.insert(board_id) {
                 found_boards.push(board_id);
             }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -1972,9 +1972,9 @@ mod tests {
     #[test]
     fn err_not_found_maps_to_invalid_params() {
         use rmcp::model::ErrorCode;
-        let err = kanban_err_to_mcp(KanbanError::not_found("board", uuid::Uuid::new_v4()));
+        let err = kanban_err_to_mcp(KanbanError::not_found("Board", uuid::Uuid::new_v4()));
         assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
-        assert!(err.message.contains("board"));
+        assert!(err.message.contains("Board"));
     }
 
     #[test]

--- a/crates/kanban-service/src/context.rs
+++ b/crates/kanban-service/src/context.rs
@@ -352,7 +352,7 @@ impl KanbanContext {
             } else {
                 failed.push(BatchOperationFailure {
                     id,
-                    error: KanbanError::not_found("card", id).to_string(),
+                    error: KanbanError::not_found("Card", id).to_string(),
                 });
             }
         }
@@ -396,7 +396,7 @@ impl KanbanContext {
                 Ok(Some(_)) => to_move.push(id),
                 Ok(None) => failed.push(BatchOperationFailure {
                     id,
-                    error: KanbanError::not_found("card", id).to_string(),
+                    error: KanbanError::not_found("Card", id).to_string(),
                 }),
                 Err(e) => failed.push(BatchOperationFailure {
                     id,
@@ -490,7 +490,7 @@ impl KanbanContext {
                     .into_iter()
                     .map(|id| BatchOperationFailure {
                         id,
-                        error: KanbanError::not_found("sprint", sprint_id).to_string(),
+                        error: KanbanError::not_found("Sprint", sprint_id).to_string(),
                     })
                     .collect(),
             };
@@ -519,7 +519,7 @@ impl KanbanContext {
             } else {
                 failed.push(BatchOperationFailure {
                     id,
-                    error: KanbanError::not_found("card", id).to_string(),
+                    error: KanbanError::not_found("Card", id).to_string(),
                 });
             }
         }
@@ -625,7 +625,7 @@ impl KanbanContext {
 
         for &id in ids {
             if self.backend.get_card(id)?.is_none() {
-                return Err(KanbanError::not_found("card", id));
+                return Err(KanbanError::not_found("Card", id));
             }
         }
 
@@ -633,7 +633,7 @@ impl KanbanContext {
         let column = self
             .backend
             .get_column(column_id)?
-            .ok_or_else(|| KanbanError::not_found("column", column_id))?;
+            .ok_or_else(|| KanbanError::not_found("Column", column_id))?;
 
         if let Some(limit) = column.wip_limit {
             // `moving_set.len()` is the post-dedup mover count — `compute_move_positions`
@@ -765,7 +765,7 @@ impl KanbanOperations for KanbanContext {
         }));
         self.execute(vec![cmd])?;
         self.get_board(id)?
-            .ok_or_else(|| KanbanError::not_found("board", id))
+            .ok_or_else(|| KanbanError::not_found("Board", id))
     }
 
     fn delete_board(&mut self, id: Uuid) -> KanbanResult<()> {
@@ -813,7 +813,7 @@ impl KanbanOperations for KanbanContext {
         }));
         self.execute(vec![cmd])?;
         self.get_column(id)?
-            .ok_or_else(|| KanbanError::not_found("column", id))
+            .ok_or_else(|| KanbanError::not_found("Column", id))
     }
 
     fn delete_column(&mut self, id: Uuid) -> KanbanResult<()> {
@@ -898,7 +898,7 @@ impl KanbanOperations for KanbanContext {
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
         self.update_cards(vec![(id, updates)])?;
         self.get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))
+            .ok_or_else(|| KanbanError::not_found("Card", id))
     }
 
     fn move_card(
@@ -930,13 +930,13 @@ impl KanbanOperations for KanbanContext {
 
         self.execute(batch)?;
         self.get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))
+            .ok_or_else(|| KanbanError::not_found("Card", id))
     }
 
     fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
         match self.archive_cards(vec![id]) {
             Ok(0) | Err(KanbanError::Domain(kanban_domain::DomainError::Validation(_))) => {
-                Err(KanbanError::not_found("card", id))
+                Err(KanbanError::not_found("Card", id))
             }
             Ok(_) => Ok(()),
             Err(e) => Err(e),
@@ -952,7 +952,7 @@ impl KanbanOperations for KanbanContext {
 
         let target_column = if let Some(col_id) = column_id {
             if self.backend.get_column(col_id)?.is_none() {
-                return Err(KanbanError::not_found("column", col_id));
+                return Err(KanbanError::not_found("Column", col_id));
             }
             col_id
         } else if self
@@ -974,7 +974,7 @@ impl KanbanOperations for KanbanContext {
         }));
         self.execute(vec![cmd])?;
         self.get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))
+            .ok_or_else(|| KanbanError::not_found("Card", id))
     }
 
     fn delete_card(&mut self, id: Uuid) -> KanbanResult<()> {
@@ -990,7 +990,7 @@ impl KanbanOperations for KanbanContext {
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
         self.assign_cards_to_sprint(vec![card_id], sprint_id)?;
         self.get_card(card_id)?
-            .ok_or_else(|| KanbanError::not_found("card", card_id))
+            .ok_or_else(|| KanbanError::not_found("Card", card_id))
     }
 
     fn unassign_card_from_sprint(&mut self, card_id: Uuid) -> KanbanResult<Card> {
@@ -1001,21 +1001,21 @@ impl KanbanOperations for KanbanContext {
         }));
         self.execute(vec![cmd])?;
         self.get_card(card_id)?
-            .ok_or_else(|| KanbanError::not_found("card", card_id))
+            .ok_or_else(|| KanbanError::not_found("Card", card_id))
     }
 
     fn get_card_branch_name(&self, id: Uuid) -> KanbanResult<String> {
         let card = self
             .get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))?;
+            .ok_or_else(|| KanbanError::not_found("Card", id))?;
         let column = self
             .backend
             .get_column(card.column_id)?
-            .ok_or_else(|| KanbanError::not_found("column", card.column_id))?;
+            .ok_or_else(|| KanbanError::not_found("Column", card.column_id))?;
         let board = self
             .backend
             .get_board(column.board_id)?
-            .ok_or_else(|| KanbanError::not_found("board", column.board_id))?;
+            .ok_or_else(|| KanbanError::not_found("Board", column.board_id))?;
         let sprints = self.backend.list_all_sprints()?;
         Ok(card.branch_name(
             &board,
@@ -1027,15 +1027,15 @@ impl KanbanOperations for KanbanContext {
     fn get_card_git_checkout(&self, id: Uuid) -> KanbanResult<String> {
         let card = self
             .get_card(id)?
-            .ok_or_else(|| KanbanError::not_found("card", id))?;
+            .ok_or_else(|| KanbanError::not_found("Card", id))?;
         let column = self
             .backend
             .get_column(card.column_id)?
-            .ok_or_else(|| KanbanError::not_found("column", card.column_id))?;
+            .ok_or_else(|| KanbanError::not_found("Column", card.column_id))?;
         let board = self
             .backend
             .get_board(column.board_id)?
-            .ok_or_else(|| KanbanError::not_found("board", column.board_id))?;
+            .ok_or_else(|| KanbanError::not_found("Board", column.board_id))?;
         let sprints = self.backend.list_all_sprints()?;
         Ok(card.git_checkout_command(
             &board,
@@ -1146,7 +1146,7 @@ impl KanbanOperations for KanbanContext {
 
         let from_sprint = self
             .get_sprint(from_sprint_id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", from_sprint_id))?;
+            .ok_or_else(|| KanbanError::not_found("Sprint", from_sprint_id))?;
         if from_sprint.status != kanban_domain::SprintStatus::Completed
             && from_sprint.status != kanban_domain::SprintStatus::Cancelled
         {
@@ -1157,7 +1157,7 @@ impl KanbanOperations for KanbanContext {
         }
         let to_sprint = self
             .get_sprint(to_sprint_id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", to_sprint_id))?;
+            .ok_or_else(|| KanbanError::not_found("Sprint", to_sprint_id))?;
         if to_sprint.status != kanban_domain::SprintStatus::Planning {
             return Err(KanbanError::validation(format!(
                 "Target sprint must be Planning, got {:?}",
@@ -1217,7 +1217,7 @@ impl KanbanOperations for KanbanContext {
         }));
         self.execute(vec![cmd])?;
         self.get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))
     }
 
     fn activate_sprint(&mut self, id: Uuid, duration_days: Option<i32>) -> KanbanResult<Sprint> {
@@ -1229,7 +1229,7 @@ impl KanbanOperations for KanbanContext {
         }));
         self.execute(vec![cmd])?;
         self.get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))
     }
 
     fn complete_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
@@ -1237,7 +1237,7 @@ impl KanbanOperations for KanbanContext {
         let cmd = Command::Sprint(SprintCommand::Complete(CompleteSprint { sprint_id: id }));
         self.execute(vec![cmd])?;
         self.get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))
     }
 
     fn cancel_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
@@ -1245,7 +1245,7 @@ impl KanbanOperations for KanbanContext {
         let cmd = Command::Sprint(SprintCommand::Cancel(CancelSprint { sprint_id: id }));
         self.execute(vec![cmd])?;
         self.get_sprint(id)?
-            .ok_or_else(|| KanbanError::not_found("sprint", id))
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))
     }
 
     fn delete_sprint(&mut self, id: Uuid) -> KanbanResult<()> {
@@ -1356,7 +1356,7 @@ impl KanbanContext {
     fn require_card_exists(&self, id: Uuid) -> KanbanResult<()> {
         match self.backend.get_card(id)? {
             Some(_) => Ok(()),
-            None => Err(KanbanError::not_found("card", id)),
+            None => Err(KanbanError::not_found("Card", id)),
         }
     }
 }

--- a/crates/kanban-service/tests/create_card_with_sprint.rs
+++ b/crates/kanban-service/tests/create_card_with_sprint.rs
@@ -115,7 +115,7 @@ async fn create_card_with_unknown_sprint_uuid_returns_not_found() {
     assert!(err.is_not_found(), "expected NotFound, got: {err:?}");
     match &err {
         KanbanError::Domain(DomainError::NotFound { entity, id }) => {
-            assert_eq!(*entity, "sprint", "wrong entity tag: {err:?}");
+            assert_eq!(*entity, "Sprint", "wrong entity tag: {err:?}");
             assert_eq!(*id, bogus, "wrong id in NotFound: {err:?}");
         }
         other => panic!("expected NotFound, got: {other:?}"),


### PR DESCRIPTION
Normalizes the entity-tag casing asymmetry between `DomainError::NotFound` (was lowercase) and `DomainError::NotFoundByName` (already capitalized). Both now use sentence-leading capitalized nouns. Surfaces follow-up from KAN-655 review.

- 59 `KanbanError::not_found(...)` call sites updated to use capitalized entity tags ("Board" / "Card" / "Column" / "Sprint")
- 3 test assertions updated to match
- Doc-comments on both `NotFound` and `NotFoundByName` variants now document the capitalized-noun convention
- KAN-655's CLI test pair (which pinned the asymmetric casing one per code path) now asserts the same "Sprint" on both name and UUID paths

**What**: Bulk-renames the entity tag passed to `KanbanError::not_found(...)` from lowercase to capitalized across all production call sites. End-user-visible error text changes only in the first letter (`"sprint X not found"` → `"Sprint X not found"`). The variant's structural shape is unchanged.

**Why**: The pre-fix asymmetry was caught in the KAN-655 PR review — its new CLI tests had to assert on `"Sprint"` for the name-lookup path and `"sprint"` for the UUID-lookup path, which is the moment the inconsistency stopped being a paper concern and started being a maintenance burden (every new not-found test would have to pick a casing). KAN-655 deliberately deferred the fix; KAN-659 is that fix. Now the same logical error reads the same way regardless of lookup mechanism.

**How**:
1. `sed`-replace `KanbanError::not_found("board"|"card"|"column"|"sprint",` → `KanbanError::not_found("Board"|"Card"|"Column"|"Sprint",` across all crates. 59 sites in 10 files.
2. Doc-comments added to `DomainError::NotFound` and `NotFoundByName` documenting the capitalized-noun convention so future variants don't reintroduce the asymmetry.
3. Three test assertions that pinned the lowercase form updated:
   - `kanban-domain::error::tests::test_not_found_display_includes_entity_and_id` (`contains("card")` → `contains("Card")`)
   - `kanban-mcp::err_not_found_maps_to_invalid_params` (`contains("board")` → `contains("Board")`)
   - `kanban-cli::test_card_create_with_assign_unknown_uuid_fails_with_useful_error` (`contains("sprint")` → `contains("Sprint")`, with comment updated to note the symmetry)
4. The `kanban-service::create_card_with_unknown_sprint_uuid_returns_not_found` test (also from KAN-655) updated to expect `entity == "Sprint"` instead of `"sprint"`.

The `data_integrity_tests.rs` test that already calls `.to_lowercase()` before asserting needed no change.

**Library API impact**: `DomainError::NotFound { entity, .. }` consumers who pattern-match on the `entity` field will see capitalized strings instead of lowercase. Documented in the changeset under "library consumers" guidance.

**Testing**: `cargo test --workspace` (all green after the test updates above), `cargo fmt --all -- --check` (clean), `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean).