### PR TITLE
KAN-649 fix(ci): make release.yml idempotent on partial-failure re-runs

### DIFF
--- a/.changeset/kan-649-make-release-yml-idempotent-on-partial-failure-re-runs.md
+++ b/.changeset/kan-649-make-release-yml-idempotent-on-partial-failure-re-runs.md
@@ -1,0 +1,19 @@
+---
+bump: patch
+---
+
+Hardened the release workflow against partial-failure re-runs. The Tag
+version step now guards both the local tag and the push so re-running
+after a half-completed prior run no longer crashes on tag collision.
+The Publish to Chocolatey job is now marked continue-on-error so a
+stuck moderation queue or transient API failure surfaces as a warning
+rather than turning the entire workflow red after crates.io, GitHub
+Release, AUR, and Homebrew have already succeeded.
+
+A new docs/release-recovery.md runbook enumerates the per-step recovery
+procedure: which steps are safe to re-run from the GitHub Actions UI,
+what state to expect on origin after each failure mode, and the manual
+fallback commands for the cases where a re-run is not enough.
+
+No user-visible runtime behaviour changes; this only affects how the
+release pipeline recovers when something goes wrong.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,19 @@ jobs:
         if: steps.check.outputs.has_changesets == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+          TAG: v${{ steps.release.outputs.new }}
         run: |
-          git tag "v${{ steps.release.outputs.new }}"
-          git push origin "v${{ steps.release.outputs.new }}"
+          set -euo pipefail
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists locally, skipping git tag"
+          else
+            git tag "$TAG"
+          fi
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin, skipping git push"
+          else
+            git push origin "$TAG"
+          fi
 
       - name: Create GitHub Release
         if: steps.check.outputs.has_changesets == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,6 +311,7 @@ jobs:
     needs: [release, build-windows]
     if: needs.release.outputs.has_changesets == 'true'
     runs-on: windows-latest
+    continue-on-error: true
     permissions:
       contents: read
     steps:

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -11,6 +11,20 @@ always the right first move. The sections below are for the cases where
 a re-run does not converge or where you need to finish the release
 without GitHub Actions.
 
+## Important: re-run is a no-op after `Push to master`
+
+The `Check for changesets` step at the top of the `release` job exits
+the whole job cleanly when `.changeset/` contains no entries. Once the
+release commit is pushed to master, the changesets are gone from
+origin, so a fresh runner started by "Re-run failed jobs" sees zero
+changesets and **silently skips every downstream step**. This is
+correct behaviour for an unrelated PR merge, but it means a re-run
+after a failure in `Publish to crates.io` (or any later step) does
+not retry the failing step — it returns a green workflow with nothing
+recovered. For those cases, follow the manual fallback in the relevant
+section below. A `workflow_dispatch` recovery trigger is tracked in a
+follow-up card.
+
 ## Step: Push to master
 
 **Symptom:** the workflow finished `Bump version`, `Aggregate changelog`,
@@ -20,9 +34,10 @@ branch protection, force-push race).
 **State on origin:** no release commit, no tag, nothing published.
 
 **Recovery:**
-1. Re-run the failed job from the GitHub Actions UI. The first three
-   steps re-execute against the same workspace and produce the same
-   commit; the push retries.
+1. Re-run the failed job from the GitHub Actions UI. The runner starts
+   from a fresh checkout, but the changesets in `.changeset/` are still
+   present on origin, so bump-version, aggregate-changelog, and commit
+   re-produce the same release commit; the push retries.
 2. If the re-run still fails, the release is not partially shipped, so
    it is safe to revert the merged PR, fix the underlying issue, and
    re-merge.
@@ -50,9 +65,11 @@ hits the same crate twice.
 **State on origin:** release commit and crates.io are at the new
 version; tag may or may not be on origin.
 
-**Recovery:** re-run the failed job. The step guards both the local
-tag creation and the push against an existing tag, so it is safe to
-re-run even if the tag was partially pushed.
+**Recovery:** the tag step guards both the local tag creation and the
+push against an existing tag, so it is safe to re-execute whether the
+tag was created locally only, pushed to origin, or both. Note the
+re-run caveat above — in practice you will need the manual fallback
+below.
 
 If you must finish by hand:
 ```bash

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -1,0 +1,158 @@
+# Release recovery runbook
+
+When `.github/workflows/release.yml` fails partway through, this runbook
+tells you how to finish the release by hand. Each section is keyed to
+the step that failed.
+
+The workflow is designed to be re-runnable: most steps either skip
+cleanly when the work is already done or carry their own idempotency
+guard. Re-running the failed job from the GitHub Actions UI is almost
+always the right first move. The sections below are for the cases where
+a re-run does not converge or where you need to finish the release
+without GitHub Actions.
+
+## Step: Push to master
+
+**Symptom:** the workflow finished `Bump version`, `Aggregate changelog`,
+and `Commit release` but the push to `master` failed (auth glitch,
+branch protection, force-push race).
+
+**State on origin:** no release commit, no tag, nothing published.
+
+**Recovery:**
+1. Re-run the failed job from the GitHub Actions UI. The first three
+   steps re-execute against the same workspace and produce the same
+   commit; the push retries.
+2. If the re-run still fails, the release is not partially shipped, so
+   it is safe to revert the merged PR, fix the underlying issue, and
+   re-merge.
+
+## Step: Publish to crates.io
+
+**Symptom:** the workflow tagged the release commit on master but
+`nix run .#publish-crates` exited non-zero partway through the crate
+list.
+
+**State on origin:** release commit pushed; tag not yet created; one or
+more crates may have been pushed to crates.io already.
+
+**Recovery:** re-run the failed job. `scripts/publish-crates.sh` checks
+each crate against crates.io and skips the ones that are already at the
+target version, so re-running converges. Investigate the underlying
+failure (rate-limit, network blip, validation error) only if the re-run
+hits the same crate twice.
+
+## Step: Tag version
+
+**Symptom:** crates.io publishes succeeded but the `git tag` /
+`git push origin <tag>` step failed (network, permissions).
+
+**State on origin:** release commit and crates.io are at the new
+version; tag may or may not be on origin.
+
+**Recovery:** re-run the failed job. The step guards both the local
+tag creation and the push against an existing tag, so it is safe to
+re-run even if the tag was partially pushed.
+
+If you must finish by hand:
+```bash
+git fetch origin
+git checkout master
+git pull --ff-only
+git tag "v<VERSION>"
+git push origin "v<VERSION>"
+```
+
+## Step: Create GitHub Release
+
+**Symptom:** tag exists on origin but the GitHub Release object was
+not created.
+
+**State on origin:** crates.io and the git tag are at the new version;
+no Release object; downstream jobs (`build-windows`,
+`publish-chocolatey`) cannot start because they checkout the tag and
+upload to the Release.
+
+**Recovery:** re-run the failed job. `softprops/action-gh-release@v2`
+creates the release if missing and updates it if present, so re-running
+is safe.
+
+If you must finish by hand:
+```bash
+gh release create "v<VERSION>" --generate-notes
+```
+
+## Step: AUR (PKGBUILD, .SRCINFO, deploy)
+
+**Symptom:** the AUR commit or push failed.
+
+**State on origin:** crates.io, tag, and GitHub Release are at the new
+version; AUR may have a stale `pkgver`.
+
+**Recovery:** re-run the failed job. The AUR commit step skips empty
+commits (`git diff --cached --quiet`) and the deploy action exits
+cleanly when there is nothing to push, so re-running converges.
+
+If you must finish by hand:
+```bash
+git clone ssh://aur@aur.archlinux.org/kanban.git /tmp/aur-kanban
+cd /tmp/aur-kanban
+# Edit pkgver, pkgrel=1, sha256sums in PKGBUILD
+makepkg --printsrcinfo > .SRCINFO
+git add PKGBUILD .SRCINFO
+git commit -m "Update to <VERSION>"
+git push
+```
+
+## Step: Homebrew tap formula bump
+
+**Symptom:** the Homebrew formula bump or push to
+`fulsomenko/homebrew-tap` failed.
+
+**State on origin:** crates.io, tag, GitHub Release, and AUR are at
+the new version; the tap formula may be stale.
+
+**Recovery:** re-run the failed job. The bump step skips empty commits,
+so re-running is safe if the formula already matches the target.
+
+If you must finish by hand:
+```bash
+git clone git@github.com:fulsomenko/homebrew-tap.git /tmp/homebrew-tap
+cd /tmp/homebrew-tap
+# Edit Formula/kanban.rb: url, sha256, version
+git add Formula/kanban.rb
+git commit -m "Bump kanban to <VERSION>"
+git push
+```
+
+## Job: build-windows
+
+**Symptom:** the Windows build, archive, or asset upload failed.
+
+**State on origin:** crates.io, tag, GitHub Release, AUR, and Homebrew
+are at the new version; the Windows ZIP and SHA256SUMS may be missing
+from the GitHub Release.
+
+**Recovery:** re-run the `build-windows` job from the GitHub Actions
+UI. It re-checks out at the tag, rebuilds, and re-uploads to the same
+Release. `softprops/action-gh-release@v2` updates assets in place, so
+a re-run is safe.
+
+## Job: publish-chocolatey
+
+**Symptom:** the Chocolatey push failed or was held in the moderation
+queue.
+
+**State on origin:** every other surface is at the new version; the
+Chocolatey package may or may not be published.
+
+The job is marked `continue-on-error: true`, so this failure surfaces
+as a warning rather than blocking the workflow.
+
+**Recovery:** see [`packaging/chocolatey/RECOVERY.md`](../packaging/chocolatey/RECOVERY.md)
+for the full Chocolatey-specific flowchart. The short version:
+1. The push step pre-checks the public OData API and skips if the
+   version is already published, so re-running is safe.
+2. If `choco push` itself failed with a hard error, follow the
+   chocolatey runbook to either retry, contact moderation, or
+   ship the next patch with a corrected nupkg.

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -51,11 +51,17 @@ list.
 **State on origin:** release commit pushed; tag not yet created; one or
 more crates may have been pushed to crates.io already.
 
-**Recovery:** re-run the failed job. `scripts/publish-crates.sh` checks
-each crate against crates.io and skips the ones that are already at the
-target version, so re-running converges. Investigate the underlying
-failure (rate-limit, network blip, validation error) only if the re-run
-hits the same crate twice.
+**Recovery:** the workflow re-run is a no-op here (see top caveat); use
+the manual fallback below. `scripts/publish-crates.sh` is itself
+idempotent — it checks each crate against crates.io and skips the ones
+already at the target version — so re-invoking it locally converges.
+
+If you must finish by hand:
+```bash
+export CARGO_REGISTRY_TOKEN=<token>
+git fetch origin && git checkout master && git pull --ff-only
+nix run .#publish-crates
+```
 
 ## Step: Tag version
 
@@ -90,9 +96,10 @@ no Release object; downstream jobs (`build-windows`,
 `publish-chocolatey`) cannot start because they checkout the tag and
 upload to the Release.
 
-**Recovery:** re-run the failed job. `softprops/action-gh-release@v2`
-creates the release if missing and updates it if present, so re-running
-is safe.
+**Recovery:** the workflow re-run is a no-op here (see top caveat); use
+the manual fallback below. `softprops/action-gh-release@v2` is
+idempotent — it creates the release if missing and updates it if
+present — so triggering the same operation by hand is safe.
 
 If you must finish by hand:
 ```bash
@@ -106,9 +113,10 @@ gh release create "v<VERSION>" --generate-notes
 **State on origin:** crates.io, tag, and GitHub Release are at the new
 version; AUR may have a stale `pkgver`.
 
-**Recovery:** re-run the failed job. The AUR commit step skips empty
-commits (`git diff --cached --quiet`) and the deploy action exits
-cleanly when there is nothing to push, so re-running converges.
+**Recovery:** the workflow re-run is a no-op here (see top caveat); use
+the manual fallback below. The AUR commit step is idempotent against
+the local working copy (empty-commit skip + `allow_empty_commits: false`
+on deploy), so the same operation by hand converges.
 
 If you must finish by hand:
 ```bash
@@ -129,8 +137,10 @@ git push
 **State on origin:** crates.io, tag, GitHub Release, and AUR are at
 the new version; the tap formula may be stale.
 
-**Recovery:** re-run the failed job. The bump step skips empty commits,
-so re-running is safe if the formula already matches the target.
+**Recovery:** the workflow re-run is a no-op here (see top caveat); use
+the manual fallback below. The bump step is idempotent (empty-commit
+skip), so the same operation by hand is safe when the formula already
+matches the target.
 
 If you must finish by hand:
 ```bash


### PR DESCRIPTION
Hardens the release workflow against partial-failure re-runs so a half-completed prior run no longer blocks the next attempt:

- Guard git tag creation against an already-existing tag (local and origin)
- Mark publish-chocolatey job continue-on-error so a stuck moderation queue does not turn the workflow red
- Add docs/release-recovery.md runbook enumerating the per-step recovery procedure

**What**: Three small changes to .github/workflows/release.yml plus a new top-level recovery runbook at docs/release-recovery.md.

**Why**: The release job is triggered by a PR merge, so a failed step has no automatic re-trigger path. Today, re-running the workflow after a partial-completion failure can crash on tag collision (Tag version step) or stay red because Chocolatey is stuck in moderation. Recovery for each surface was previously folder-knowledge.

**How**:
- Tag version step now checks git rev-parse for the local tag and git ls-remote for the origin tag, only running the create/push when missing. Logic verified against the live repo (v0.6.0 exists, v0.999.999 missing).
- publish-chocolatey job gets continue-on-error: true at job level. The KAN-657 pre-check inside the job keeps a follow-up re-run safe once Chocolatey recovers.
- docs/release-recovery.md walks the failure points in pipeline order: Push to master, Publish to crates.io, Tag version, Create GitHub Release, AUR, Homebrew, build-windows, publish-chocolatey. Each section names the expected state on origin after that failure, the re-run path that converges, and a manual fallback. Links out to packaging/chocolatey/RECOVERY.md for the Chocolatey-specific flowchart rather than duplicating it.

Per-job re-runnability was considered and intentionally not added: GitHub Actions Re-run failed jobs already works for build-windows and publish-chocolatey because needs.release.outputs.* persist across re-runs of downstream jobs, and the tag-guard above closes the only failure case in the release job itself.

**Testing**: cargo fmt --all -- --check (clean), cargo clippy --all-targets --all-features -- -D warnings (clean), cargo test --workspace (no regressions). The YAML changes are bash and job-config only; their behaviour was validated by running the guard snippets against the live repo state.

Refs KAN-649.