### PR TITLE
KAN-668 fix(release-tooling): make validate-release Step 5 actually validate

### DIFF
--- a/.changeset/kan-668-fix-validate-release-sh-step-5-silently-passing-when-every-dry-run-fails.md
+++ b/.changeset/kan-668-fix-validate-release-sh-step-5-silently-passing-when-every-dry-run-fails.md
@@ -1,0 +1,23 @@
+---
+bump: patch
+---
+
+The release-tooling pre-publish validation now actually catches packaging
+defects. Step 5 of `validate-release` previously ran `cargo publish --dry-run`
+in offline mode and swallowed the resulting failure, so every release reported
+"All crates passed dry-run validation" regardless of manifest state. Step 5
+now runs `cargo package --no-verify` and fails the release on any non-zero
+exit, so packaging defects (missing required fields, broken readme/license
+file references, file-exclusion regressions) are caught before crates.io
+publish rather than mid-publish where some sibling crates have already
+shipped.
+
+Internal dev-dependencies on sibling workspace crates are now path-only
+(no version constraint), per the existing project convention. The previous
+version constraints made `cargo package` fail to resolve sibling features
+added between releases against the published version. Step 3 of
+`validate-release` now enforces this convention so the regression cannot
+recur.
+
+No user-visible runtime change; this only affects the release pipeline's
+ability to detect manifest defects before publishing.

--- a/crates/kanban-cli/Cargo.toml
+++ b/crates/kanban-cli/Cargo.toml
@@ -43,8 +43,8 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.6" }
-kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.6", features = ["test-helpers"] }
+kanban-persistence-json = { path = "../kanban-persistence-json" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", features = ["test-helpers"] }
 tempfile.workspace = true
 assert_cmd.workspace = true
 predicates.workspace = true

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -54,10 +54,10 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
-kanban-domain = { path = "../kanban-domain", version = "^0.6" }
-kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.6" }
-kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.6", features = ["test-helpers"] }
-kanban-service = { path = "../kanban-service", version = "^0.6" }
+kanban-domain = { path = "../kanban-domain" }
+kanban-persistence-json = { path = "../kanban-persistence-json" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", features = ["test-helpers"] }
+kanban-service = { path = "../kanban-service" }
 tempfile.workspace = true
 tokio.workspace = true
 chrono.workspace = true

--- a/crates/kanban-tui/Cargo.toml
+++ b/crates/kanban-tui/Cargo.toml
@@ -38,6 +38,6 @@ which = "^8.0"
 test-helpers = []
 
 [dev-dependencies]
-kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.6" }
-kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.6" }
+kanban-persistence-json = { path = "../kanban-persistence-json" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite" }
 tempfile = "3.13"

--- a/scripts/test-validate-release.sh
+++ b/scripts/test-validate-release.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Smoke test for validate-release: must fail when a crate has a packaging
+# defect that `cargo check` does not catch.
+#
+# Invoke from the repo root inside `nix develop`:
+#   nix develop --command bash scripts/test-validate-release.sh
+#
+# The test mutates crates/kanban-core/Cargo.toml to reference a nonexistent
+# readme file (rejected by cargo package, accepted by cargo check) and
+# asserts that validate-release exits non-zero. A trap restores the manifest
+# on any exit path.
+
+set -euo pipefail
+
+CRATE_FILE="crates/kanban-core/Cargo.toml"
+ORIG="$(mktemp)"
+
+cleanup() {
+  cp "$ORIG" "$CRATE_FILE"
+  rm -f "$ORIG"
+}
+trap cleanup EXIT
+
+if [ ! -f "$CRATE_FILE" ]; then
+  echo "❌ test setup: $CRATE_FILE not found (run from repo root)" >&2
+  exit 2
+fi
+
+cp "$CRATE_FILE" "$ORIG"
+
+# Inject a packaging-level defect that cargo check does not surface.
+sed -i '/^description = /a readme = "NONEXISTENT_README_FOR_TEST.md"' "$CRATE_FILE"
+
+if ! grep -q '^readme = "NONEXISTENT_README_FOR_TEST.md"$' "$CRATE_FILE"; then
+  echo "❌ test setup: failed to inject nonexistent-readme defect" >&2
+  exit 2
+fi
+
+if validate-release > /tmp/test-validate-release.out 2>&1; then
+  echo "❌ FAIL: validate-release returned success despite nonexistent readme on kanban-core"
+  echo "--- captured output ---"
+  cat /tmp/test-validate-release.out
+  exit 1
+fi
+
+echo "✓ PASS: validate-release correctly failed on the packaging defect"

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -40,11 +40,20 @@ mapfile -t INTERNAL_DEPS <<< "$deps_out"
 # kanban-service which itself depends on kanban-persistence-sqlite optionally).
 for crate in "${CRATES[@]}"; do
   deps_section=$(awk '/^\[dependencies\]/{flag=1; next} /^\[/{flag=0} flag' "$crate/Cargo.toml")
+  dev_deps_section=$(awk '/^\[dev-dependencies\]/{flag=1; next} /^\[/{flag=0} flag' "$crate/Cargo.toml")
   for dep in "${INTERNAL_DEPS[@]}"; do
     if echo "$deps_section" | grep -q "$dep = { path = "; then
       if ! echo "$deps_section" | grep "$dep = { path = " | grep -q 'version = '; then
         echo "❌ Error: $crate is missing version spec for $dep in [dependencies]"
         echo "   Use: $dep = { path = \"../$dep\", version = \"^0.1\" }"
+        exit 1
+      fi
+    fi
+    if echo "$dev_deps_section" | grep -q "$dep = { path = "; then
+      if echo "$dev_deps_section" | grep "$dep = { path = " | grep -q 'version = '; then
+        echo "❌ Error: $crate has version spec for $dep in [dev-dependencies]"
+        echo "   Path-only is required; sibling features added between releases cannot resolve against published versions."
+        echo "   Use: $dep = { path = \"../$dep\" }"
         exit 1
       fi
     fi
@@ -58,21 +67,28 @@ cargo check --workspace --all-features --quiet
 echo "✓ Workspace check passed"
 
 echo ""
-echo "Step 5: Validating individual crate dry-run publishes..."
-# --no-verify skips the per-crate compile during dry-run. This is necessary
-# because `cargo publish --dry-run` resolves path-deps to their crates.io
-# version, but workspace crates with API changes between releases can't
-# compile against their previously-published siblings until each is
-# published in dependency order. Step 4 (`cargo check --workspace`) already
-# verifies compile against the local source. Step 5's value here is the
-# manifest/package-shape check, not the build.
+echo "Step 5: Validating individual crate packages..."
+# `cargo package --no-verify` produces the same .crate tarball that
+# `cargo publish` would upload and runs the manifest/inclusion checks
+# (required fields, license-file / readme resolution, package size, file
+# exclusion rules) without touching the network or compiling. We skip
+# compile because workspace crates with API changes between releases
+# can't always compile against their previously-published siblings
+# until each is published in dependency order. Step 4
+# (`cargo check --workspace`) already verifies compile against the
+# local source.
 for crate in "${CRATES[@]}"; do
   echo "  Validating $crate..."
   cd "$crate"
-  cargo publish --dry-run --no-verify --offline --quiet --allow-dirty 2>&1 | grep -v "warning:" || true
+  if ! output=$(cargo package --no-verify --allow-dirty --quiet 2>&1); then
+    echo "$output"
+    echo "❌ cargo package failed for $crate"
+    exit 1
+  fi
+  echo "$output" | grep -v "^warning:" || true
   cd - > /dev/null
 done
-echo "✓ All crates passed dry-run validation"
+echo "✓ All crates passed package validation"
 
 echo ""
 echo "✅ Release validation complete - ready to publish!"


### PR DESCRIPTION
The release-tooling pre-publish validation now actually catches packaging defects before crates.io publish.

- Replace Step 5's silently-no-op `cargo publish --dry-run --no-verify --offline ... || true` with `cargo package --no-verify --allow-dirty` and let a non-zero exit fail the loop
- Add scripts/test-validate-release.sh smoke test: injects a nonexistent-readme defect into kanban-core and asserts validate-release exits non-zero
- Strip version constraints from 8 internal dev-dependencies across kanban-cli, kanban-mcp, kanban-tui (per existing project convention)
- Extend Step 3 to enforce path-only dev-deps so the manifest regression cannot recur

**What**: Step 5 now uses `cargo package --no-verify` which performs the manifest/inclusion checks (required fields, readme/license-file resolution, file exclusion rules) without network or compile. Step 3 grew a check that errors on `[dev-dependencies]` entries with `version = ...` on sibling crates.

**Why**: Smoke-testing on PR #324 surfaced that Step 5 was silently a no-op. Every `cargo publish --dry-run --offline` errored with `attempting to make an HTTP request, but --offline was specified` and the trailing `|| true` swallowed the failure, so the script reported `All crates passed dry-run validation` regardless of actual manifest state. The workflow then proceeded straight to real `cargo publish` calls with zero validation, meaning a manifest defect would surface mid-publish leaving the workspace torn between crates that shipped and crates that didn't.

The dev-dep cleanup was forced by the new validation: kanban-mcp / kanban-cli / kanban-tui carried `version = ^0.6` on their internal dev-deps, which made `cargo package` fail to resolve kanban-persistence-sqlite's `test-helpers` feature (added post-0.6.0) against the published 0.6.0 manifest. The project's own convention (documented at scripts/validate-release.sh:36-40) already required these to be path-only; the constraint had simply leaked back in.

**How**:
- Step 5: `cargo package --no-verify --allow-dirty --quiet`, captured output, `|| true` removed.
- Step 3: same `awk` pattern as the existing `[dependencies]` check, but inverted polarity for `[dev-dependencies]`.
- scripts/test-validate-release.sh: backs up `crates/kanban-core/Cargo.toml`, injects `readme = "NONEXISTENT_README_FOR_TEST.md"`, runs `validate-release`, asserts non-zero exit, restores via `trap`.
- Manifest cleanup: section-aware Python rewrite, only `[dev-dependencies]` touched, features preserved.

Smoke-tested locally inside `nix develop`:
- Before fix: deliberate defect injected, `validate-release` returns 0 → test fails (correctly catches the bug)
- After fix: same defect, `validate-release` returns 101 → test passes
- After fix on clean tree: all 9 crates pass validation through all 5 steps
- After fix with dev-dep regression deliberately reintroduced: Step 3 catches it with clear error message

**Testing**: `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo test --workspace` (no regressions). `nix develop --command bash scripts/test-validate-release.sh` (passes). `nix develop --command validate-release` (passes end-to-end).

Refs KAN-668. Surfaced during smoke-testing on PR #324 (KAN-649).