### PR TITLE
KAN-667 ci(release): surface chocolatey publish failure with warning annotation

### DIFF
--- a/.changeset/kan-667-visible-failure-notification-for-publish-chocolatey.md
+++ b/.changeset/kan-667-visible-failure-notification-for-publish-chocolatey.md
@@ -1,0 +1,25 @@
+---
+bump: patch
+---
+
+The release workflow's `publish-chocolatey` job now surfaces a visible
+warning when it fails, instead of silently going green at the workflow
+level.
+
+Background: KAN-649 marked the job `continue-on-error: true` so that a
+stuck Chocolatey moderation queue would not turn the entire release
+workflow red after crates.io, GitHub Release, AUR, and Homebrew had
+already succeeded. The trade-off was that GitHub Actions only sends
+notifications on workflow-level failures, so a failed Chocolatey
+publish could become a silent miss for weeks.
+
+A new `Surface chocolatey failure` step runs `if: failure()` at the
+end of the job and writes a `::warning::` annotation plus a
+`$GITHUB_STEP_SUMMARY` markdown block linking to
+`packaging/chocolatey/RECOVERY.md`. The annotation is visible at the
+top of the workflow run page and on the PR's checks panel without
+clicking through. The step is itself `continue-on-error: true` so a
+failure to write the annotation does not defeat the purpose of the
+parent flag.
+
+No behavioural change for end users installing the package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,3 +437,24 @@ jobs:
           Write-Output "Status:"
           Write-Output "  https://community.chocolatey.org/packages/kanban/$env:VERSION"
           Write-Output "==="
+
+      - name: Surface chocolatey failure
+        if: failure()
+        continue-on-error: true
+        shell: bash
+        env:
+          VERSION: ${{ needs.release.outputs.new }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          echo "::warning title=Chocolatey publish failed::v${VERSION} did not publish to Chocolatey. See packaging/chocolatey/RECOVERY.md for recovery steps."
+          {
+            echo "## Chocolatey publish failed for v${VERSION}"
+            echo ""
+            echo "The \`publish-chocolatey\` job exited non-zero. The rest of the"
+            echo "release (crates.io, GitHub Release, AUR, Homebrew) is unaffected"
+            echo "because this job is \`continue-on-error: true\`."
+            echo ""
+            echo "**Workflow run:** ${RUN_URL}"
+            echo ""
+            echo "**Next step:** follow [\`packaging/chocolatey/RECOVERY.md\`](../packaging/chocolatey/RECOVERY.md)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,20 +441,22 @@ jobs:
       - name: Surface chocolatey failure
         if: failure()
         continue-on-error: true
-        shell: bash
+        shell: pwsh
         env:
           VERSION: ${{ needs.release.outputs.new }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUNBOOK_URL: ${{ github.server_url }}/${{ github.repository }}/blob/v${{ needs.release.outputs.new }}/packaging/chocolatey/RECOVERY.md
         run: |
-          echo "::warning title=Chocolatey publish failed::v${VERSION} did not publish to Chocolatey. See packaging/chocolatey/RECOVERY.md for recovery steps."
-          {
-            echo "## Chocolatey publish failed for v${VERSION}"
-            echo ""
-            echo "The \`publish-chocolatey\` job exited non-zero. The rest of the"
-            echo "release (crates.io, GitHub Release, AUR, Homebrew) is unaffected"
-            echo "because this job is \`continue-on-error: true\`."
-            echo ""
-            echo "**Workflow run:** ${RUN_URL}"
-            echo ""
-            echo "**Next step:** follow [\`packaging/chocolatey/RECOVERY.md\`](../packaging/chocolatey/RECOVERY.md)."
-          } >> "$GITHUB_STEP_SUMMARY"
+          Write-Output "::warning title=Chocolatey publish failed::v$env:VERSION did not publish to Chocolatey. See packaging/chocolatey/RECOVERY.md for recovery steps."
+          $lines = @(
+            "## Chocolatey publish failed for v$env:VERSION",
+            "",
+            "The ``publish-chocolatey`` job exited non-zero. The rest of the",
+            "release (crates.io, GitHub Release, AUR, Homebrew) is unaffected",
+            "because this job is ``continue-on-error: true``.",
+            "",
+            "**Workflow run:** $env:RUN_URL",
+            "",
+            "**Next step:** follow [``packaging/chocolatey/RECOVERY.md``]($env:RUNBOOK_URL)."
+          )
+          $lines | Add-Content -Path $env:GITHUB_STEP_SUMMARY -Encoding utf8

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -174,7 +174,11 @@ queue.
 Chocolatey package may or may not be published.
 
 The job is marked `continue-on-error: true`, so this failure surfaces
-as a warning rather than blocking the workflow.
+as a warning rather than blocking the workflow. To keep the failure
+visible despite that, the job ends with a `Surface chocolatey failure`
+step that fires `if: failure()` and writes a `::warning::` annotation
+plus a `$GITHUB_STEP_SUMMARY` block linking back to this runbook. Look
+for the yellow warning banner at the top of the workflow run page.
 
 **Recovery:** see [`packaging/chocolatey/RECOVERY.md`](../packaging/chocolatey/RECOVERY.md)
 for the full Chocolatey-specific flowchart. The short version:


### PR DESCRIPTION
Make a failed `publish-chocolatey` run visible without rolling back the `continue-on-error: true` flag from KAN-649:

- Add a `Surface chocolatey failure` step at the end of `publish-chocolatey` that runs `if: failure()` and writes a `::warning::` annotation plus a `$GITHUB_STEP_SUMMARY` markdown block linking to `packaging/chocolatey/RECOVERY.md`.
- The new step is itself `continue-on-error: true` so a failure to emit the annotation cannot defeat the parent flag.
- Update `docs/release-recovery.md` so the `## Job: publish-chocolatey` section names the new warning-banner surface instead of implying the failure is silent at the workflow level.
- Patch-bump changeset.

**What**: When the Chocolatey publish job fails, the workflow run page now shows a yellow warning banner ("Chocolatey publish failed for vX.Y.Z") with a link to the recovery runbook. No other surface changes.

**Why**: KAN-649 marked `publish-chocolatey` `continue-on-error: true` so a stuck moderation queue would not turn the entire release workflow red after crates.io, GitHub Release, AUR, and Homebrew had already succeeded. The trade-off was that GitHub Actions only sends notifications on workflow-level failures, so a failed Chocolatey publish could go unnoticed for weeks. This PR closes that gap with zero new permissions, secrets, or infrastructure.

**How**: Layer 1 from the card spec. A single new step in `release.yml` writes a `::warning::` annotation and a step summary, both standard GitHub Actions surfaces. The step's own `continue-on-error: true` keeps the safety property of KAN-649 intact even if `echo` or `>>` somehow fails. Layers 2 (auto-file issue) and 3 (Slack webhook) from the card were intentionally deferred as out of scope.

**Testing**: `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo test --workspace` (no regressions). The deliberate-failure verification step from the card spec is gated on the next real release run, which the recovery runbook now documents.

Refs KAN-667