### PR TITLE
KAN-674 ci(release): escape $asset variable in chocolatey digest read step

### DIFF
--- a/.changeset/kan-674-fix-powershell-parser-error-in-chocolatey-digest-read-step.md
+++ b/.changeset/kan-674-fix-powershell-parser-error-in-chocolatey-digest-read-step.md
@@ -1,0 +1,21 @@
+---
+bump: patch
+---
+
+The Chocolatey publish job now succeeds past the asset-readiness poll
+step. A latent PowerShell parser bug in the `Read Windows ZIP digest
+from GitHub Release` step (introduced by KAN-656) was masking the rest
+of the Chocolatey publish path on every release since that change
+landed: PowerShell interpreted `$asset:` as a scoped variable
+reference (the same syntax as `$env:VAR`), so the step exited with a
+parser error before the SHA256 could be written to the step outputs.
+
+The user-facing effect was that Chocolatey was stuck at the last
+version published before KAN-656, even though crates.io, AUR,
+Homebrew, and GitHub Release shipped each new version normally. The
+silent-failure caveat from KAN-649 plus the warning annotation from
+KAN-667 made this visible at release time, but no actual fix for the
+parser bug had landed until now.
+
+The fix is one character — wrapping `$asset` in braces (`${asset}`) so
+PowerShell stops looking for a scope qualifier after the colon.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,7 @@ jobs:
               $obj = $json | ConvertFrom-Json
               if ($obj.state -eq 'uploaded' -and $obj.digest) {
                 $sha = $obj.digest -replace '^sha256:', ''
-                Write-Output "Found $asset: sha=$sha"
+                Write-Output "Found ${asset}: sha=$sha"
                 "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
                 $ok = $true
                 break


### PR DESCRIPTION
Fix the PowerShell parser error that has been silently blocking every Chocolatey publish since KAN-656 ([#317](https://github.com/fulsomenko/kanban/pull/317)) landed.

- Wrap `$asset` in braces (`${asset}`) at release.yml:339 so PowerShell does not interpret `$asset:` as a scoped variable lookup.
- Audited the rest of `release.yml` for the same pattern (`$var:` followed by a non-variable-name character, excluding legitimate scope qualifiers like `$env:`, `$global:`, `$script:`). KAN-656's diff was the only place that introduced it.
- Patch-bump changeset.

**What**: One-character fix in the `Read Windows ZIP digest from GitHub Release` step of the `publish-chocolatey` job. The Chocolatey publish path now actually reaches `choco push`.

**Why**: Empirically observed in run [27147588129](https://github.com/fulsomenko/kanban/actions/runs/27147588129) (release of 0.7.1) — the step exited with `Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.` before writing the digest to step outputs. KAN-667's warning annotation surface fired correctly, which is how we caught this in time rather than discovering it weeks later from a Chocolatey user.

The bug has been latent on master since KAN-656 merged. It did not surface in 0.7.0 because the hotfix-branch release run failed earlier at `Bump formula in homebrew-tap` (the unset `HOMEBREW_TAP_DEPLOY_KEY` secret), so the Chocolatey job never got to its parser-broken step. 0.7.1 was the first release where the Homebrew step passed cleanly, exposing this bug as the next downstream failure.

**How**: PowerShell's `$name:suffix` syntax is reserved for scope/drive-qualified variable references (`$env:PATH`, `$global:foo`, `$script:bar`, `$using:x`). When `$asset:` appears in a double-quoted string and is followed by a non-variable-name character (`space`, `=`, etc), the parser still tries the scope-lookup branch and errors out. Brace delimitation (`${asset}`) tells the parser exactly where the variable name ends. The parser's own error message suggests this fix.

**Testing**: `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo test --workspace` (no regressions). The actual fix can only be exercised end-to-end by the next release running on master; if that fails again at `Read Windows ZIP digest`, this PR did not solve the problem and the warning annotation from KAN-667 will surface it the same way.

Refs KAN-674