### PR TITLE
release 0.7.2

### DIFF
--- a/.changeset/kan-674-fix-powershell-parser-error-in-chocolatey-digest-read-step.md
+++ b/.changeset/kan-674-fix-powershell-parser-error-in-chocolatey-digest-read-step.md
@@ -1,0 +1,21 @@
+---
+bump: patch
+---
+
+The Chocolatey publish job now succeeds past the asset-readiness poll
+step. A latent PowerShell parser bug in the `Read Windows ZIP digest
+from GitHub Release` step (introduced by KAN-656) was masking the rest
+of the Chocolatey publish path on every release since that change
+landed: PowerShell interpreted `$asset:` as a scoped variable
+reference (the same syntax as `$env:VAR`), so the step exited with a
+parser error before the SHA256 could be written to the step outputs.
+
+The user-facing effect was that Chocolatey was stuck at the last
+version published before KAN-656, even though crates.io, AUR,
+Homebrew, and GitHub Release shipped each new version normally. The
+silent-failure caveat from KAN-649 plus the warning annotation from
+KAN-667 made this visible at release time, but no actual fix for the
+parser bug had landed until now.
+
+The fix is one character — wrapping `$asset` in braces (`${asset}`) so
+PowerShell stops looking for a scope qualifier after the colon.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,7 @@ jobs:
               $obj = $json | ConvertFrom-Json
               if ($obj.state -eq 'uploaded' -and $obj.digest) {
                 $sha = $obj.digest -replace '^sha256:', ''
-                Write-Output "Found $asset: sha=$sha"
+                Write-Output "Found ${asset}: sha=$sha"
                 "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
                 $ok = $true
                 break


### PR DESCRIPTION
Release **0.7.2** from `develop` to `master`. Consumes 1 changeset added since 0.7.1.

Highest changeset bump is **patch** (single CI-only parser fix), so 0.7.1 goes to 0.7.2.

## What

### Patch

- **KAN-674** ([#330](https://github.com/fulsomenko/kanban/pull/330)). The `Read Windows ZIP digest from GitHub Release` step of the `publish-chocolatey` job no longer crashes with a PowerShell parser error. KAN-656 introduced a `Write-Output "Found $asset: sha=$sha"` line where PowerShell treats `$asset:` as a scope-qualified variable reference (same grammar as `$env:VAR`, `$global:foo`, `$script:bar`) rather than a literal `$asset` followed by a colon. The step exited with `Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.` before the SHA could be written to step outputs, so the rest of the Chocolatey publish path never ran. Wrapping the variable in braces (`${asset}`) ends the variable name unambiguously. The bug had been latent on master since KAN-656 merged: 0.7.0's release run failed earlier at `Bump formula in homebrew-tap` (the unset `HOMEBREW_TAP_DEPLOY_KEY` secret) so the Chocolatey job never reached its broken step; 0.7.1 was the first release where the Homebrew step passed cleanly, exposing this as the next downstream failure. KAN-667's warning annotation is what made it visible in time rather than silently miss for weeks.

## Why

Single-card hotfix to unblock the Chocolatey publish path. Chocolatey has been stuck at the last version published before KAN-656 (0.6.x); this release is the first one that should actually push a new version to the Chocolatey community feed since that regression landed.

## How

Standard release flow:
1. Merge this PR to `master`.
2. CI's `release.yml` runs `validate-release.sh`, bumps all crate versions to 0.7.2, tags `v0.7.2`, builds Windows binaries, attaches them to the GitHub Release, and publishes to crates.io, AUR, Homebrew tap, and Chocolatey.
3. The changeset `.md` file in `.changeset/` is deleted by the release workflow once consumed.
4. `Sync develop with master` step attempts to merge master back into develop.

If any step fails after Push to master, follow [docs/release-recovery.md](https://github.com/fulsomenko/kanban/blob/develop/docs/release-recovery.md).

## Notable behavior changes

None for end users. CI-internal change only.

## Testing

- KAN-674 was reviewed and merged into `develop` via PR #330 before this release PR.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --workspace` all pass on develop HEAD.
- The fix itself can only be exercised end-to-end by this release's `publish-chocolatey` run on master. If `Read Windows ZIP digest from GitHub Release` fails again, KAN-667's warning annotation will surface it the same way it surfaced the original bug.