### PR TITLE
KAN-675 docs: advertise nixpkgs 26.05 stable in README and web install

### DIFF
--- a/.changeset/kan-675-add-nixpkgs-stable-badge-to-readme-and-switch-web-nix-install-to-stable.md
+++ b/.changeset/kan-675-add-nixpkgs-stable-badge-to-readme-and-switch-web-nix-install-to-stable.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+kanban is now packaged in nixpkgs 26.05 stable. The README gains a dedicated
+"nixpkgs stable" version badge alongside the existing unstable one, so you can
+see the latest version available on each channel at a glance. The project
+website's install instructions now point at the stable channel, installing with
+`nix run nixpkgs#kanban` instead of the unstable flake reference.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![CI](https://github.com/fulsomenko/kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/fulsomenko/kanban/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/kanban-cli.svg)](https://crates.io/crates/kanban-cli)
 [![AUR](https://img.shields.io/aur/version/kanban?label=AUR)](https://aur.archlinux.org/packages/kanban)
-[![nixpkgs](https://repology.org/badge/version-for-repo/nix_unstable/kanban.svg?header=nixpkgs%20unstable)](https://search.nixos.org/packages?show=kanban&channel=unstable)
+[![nixpkgs stable](https://repology.org/badge/version-for-repo/nix_stable_26_05/kanban.svg?header=nixpkgs%20stable)](https://search.nixos.org/packages?show=kanban&channel=26.05)
+[![nixpkgs unstable](https://repology.org/badge/version-for-repo/nix_unstable/kanban.svg?header=nixpkgs%20unstable)](https://search.nixos.org/packages?show=kanban&channel=unstable)
 [![Homebrew](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffulsomenko%2Fhomebrew-tap%2Fmaster%2FFormula%2Fkanban.rb&search=refs%2Ftags%2Fv%28.%2A%29%5C.tar%5C.gz&replace=%241&label=homebrew)](https://github.com/fulsomenko/homebrew-tap)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.md)
 

--- a/web/index.html
+++ b/web/index.html
@@ -101,7 +101,7 @@
 <span class="prompt">$</span> brew install fulsomenko/tap/kanban
 
 <span class="comment"># Nix</span>
-<span class="prompt">$</span> nix run nixpkgs/nixpkgs-unstable#kanban
+<span class="prompt">$</span> nix run nixpkgs#kanban
 
 <span class="comment"># AUR (Arch Linux)</span>
 <span class="prompt">$</span> yay -S kanban


### PR DESCRIPTION
Surface that kanban is now packaged in nixpkgs 26.05 stable across the README and the project website:

- Add a `nixpkgs stable` repology version badge (`nix_stable_26_05`) in the README badge row, kept alongside the existing `nixpkgs unstable` badge so each channel's version is visible at a glance.
- Switch the website install instructions from `nix run nixpkgs/nixpkgs-unstable#kanban` to the stable `nix run nixpkgs#kanban`.

**What**: Documentation-only update reflecting kanban's availability in nixpkgs 26.05 stable.

**Why**: kanban landed in nixpkgs stable, but the README only advertised the unstable channel and the website still pointed users at the unstable flake reference.

**How**: `README.md` adds a second repology badge linking to `channel=stable-26.05`; `web/index.html` updates the single Nix install line to the stable channel. No banner or extra install variants were added, keeping both surfaces minimal. No Rust or binary changes.

**Testing**: `cargo fmt --all` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo test --workspace` (passes, no regressions). Changes are docs-only.