### PR TITLE
KAN-732 feat(core): add HealthStatus enum and HealthChecker trait

### DIFF
--- a/.changeset/max-kan-732.md
+++ b/.changeset/max-kan-732.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Added a `HealthStatus` enum and `HealthChecker` trait to `kanban-core`, and an optional `health_checker()` hook on the `KanbanBackend` trait. This is an internal infrastructure addition with no user-visible behaviour change. It will be used by the upcoming HTTP collaborative backend to power the `GET /health` endpoint, letting the server report whether its underlying storage backend is reachable and healthy.

--- a/crates/kanban-core/src/health.rs
+++ b/crates/kanban-core/src/health.rs
@@ -1,3 +1,36 @@
+/// The health state of a backend or server component.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HealthStatus {
+    Healthy,
+    Degraded(String),
+    Unhealthy(String),
+}
+
+impl HealthStatus {
+    pub fn is_healthy(&self) -> bool {
+        matches!(self, Self::Healthy)
+    }
+
+    pub fn is_degraded(&self) -> bool {
+        matches!(self, Self::Degraded(_))
+    }
+}
+
+impl std::fmt::Display for HealthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Healthy => write!(f, "healthy"),
+            Self::Degraded(reason) => write!(f, "degraded: {reason}"),
+            Self::Unhealthy(reason) => write!(f, "unhealthy: {reason}"),
+        }
+    }
+}
+
+/// Implemented by backends that can report their own health.
+pub trait HealthChecker: Send + Sync {
+    fn check(&self) -> HealthStatus;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-core/src/health.rs
+++ b/crates/kanban-core/src/health.rs
@@ -1,0 +1,56 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_healthy_status_is_healthy() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Healthy.is_degraded());
+    }
+
+    #[test]
+    fn test_degraded_status_is_degraded() {
+        let s = HealthStatus::Degraded("disk full".into());
+        assert!(s.is_degraded());
+        assert!(!s.is_healthy());
+    }
+
+    #[test]
+    fn test_unhealthy_is_neither_healthy_nor_degraded() {
+        let s = HealthStatus::Unhealthy("connection lost".into());
+        assert!(!s.is_healthy());
+        assert!(!s.is_degraded());
+    }
+
+    #[test]
+    fn test_health_status_display_healthy() {
+        assert_eq!(HealthStatus::Healthy.to_string(), "healthy");
+    }
+
+    #[test]
+    fn test_health_status_display_degraded() {
+        assert_eq!(
+            HealthStatus::Degraded("slow".into()).to_string(),
+            "degraded: slow"
+        );
+    }
+
+    #[test]
+    fn test_health_status_display_unhealthy() {
+        assert_eq!(
+            HealthStatus::Unhealthy("gone".into()).to_string(),
+            "unhealthy: gone"
+        );
+    }
+
+    #[test]
+    fn test_health_checker_trait_is_object_safe() {
+        struct AlwaysHealthy;
+        impl HealthChecker for AlwaysHealthy {
+            fn check(&self) -> HealthStatus {
+                HealthStatus::Healthy
+            }
+        }
+        let _: &dyn HealthChecker = &AlwaysHealthy;
+    }
+}

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod health;
 pub mod datetime_input;
 pub mod error;
 pub mod graph;
@@ -28,4 +29,5 @@ pub use paginated_list::{
 pub use pagination::{Page, PageInfo};
 pub use selection::SelectionState;
 pub use traits::Editable;
+pub use health::{HealthChecker, HealthStatus};
 pub use version::{CLI_VERSION_DISPLAY, KANBAN_COMMIT, KANBAN_VERSION};

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod config;
-pub mod health;
 pub mod datetime_input;
 pub mod error;
 pub mod graph;
+pub mod health;
 pub mod input;
 pub mod logging;
 pub mod paginated_list;
@@ -21,6 +21,7 @@ pub use graph::{
     Cascadable, DagGraph, Directed, Edge, EdgeBase, EdgeSet, EdgeStore, Graph, GraphError,
     GraphNode, Undirected, UndirectedGraph,
 };
+pub use health::{HealthChecker, HealthStatus};
 pub use input::InputState;
 pub use logging::{LogEntry, Loggable};
 pub use paginated_list::{
@@ -29,5 +30,4 @@ pub use paginated_list::{
 pub use pagination::{Page, PageInfo};
 pub use selection::SelectionState;
 pub use traits::Editable;
-pub use health::{HealthChecker, HealthStatus};
 pub use version::{CLI_VERSION_DISPLAY, KANBAN_COMMIT, KANBAN_VERSION};

--- a/crates/kanban-service/src/backend.rs
+++ b/crates/kanban-service/src/backend.rs
@@ -60,6 +60,13 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
         None
     }
 
+    /// Returns a health checker for this backend, if supported.
+    /// The default returns `None`; backends that can self-diagnose
+    /// (file readable, connection pool alive) override this.
+    fn health_checker(&self) -> Option<Box<dyn kanban_core::HealthChecker>> {
+        None
+    }
+
     /// Run `f` as an atomic batch: every mutation commits or rolls
     /// back together. The default impl snapshots state before `f`
     /// runs and restores it on failure — cheap for in-memory backends,
@@ -138,6 +145,13 @@ mod tests {
         let store = InMemoryStore::new();
         let backend: &dyn KanbanBackend = &store;
         assert!(backend.persistence_metadata().is_none());
+    }
+
+    #[test]
+    fn test_in_memory_backend_health_checker_returns_none() {
+        let store = InMemoryStore::new();
+        let backend: &dyn KanbanBackend = &store;
+        assert!(backend.health_checker().is_none());
     }
 
     // SQLite KanbanBackend lifecycle tests


### PR DESCRIPTION
Add health check abstractions to `kanban-core` and wire an optional hook into `KanbanBackend`:

- Add `crates/kanban-core/src/health.rs` with `HealthStatus` enum (`Healthy`, `Degraded(String)`, `Unhealthy(String)`) including `is_healthy()`, `is_degraded()`, and `Display`
- Add `HealthChecker` trait (`fn check(&self) -> HealthStatus`, object-safe via `Send + Sync`)
- Re-export both from `kanban_core::` via `lib.rs`
- Add `fn health_checker(&self) -> Option<Box<dyn kanban_core::HealthChecker>>` default method (returns `None`) to `KanbanBackend` in `crates/kanban-service/src/backend.rs`
- Add 7 tests in `health.rs` and 1 test in `backend.rs` verifying the default returns `None`

**What**: New `HealthStatus` / `HealthChecker` types in `kanban-core` and an optional hook on `KanbanBackend`. No existing behaviour changes; all current backends return `None`.

**Why**: The HTTP collaborative backend (KAN-684) needs a `GET /health` endpoint that reflects whether the underlying storage is reachable. Placing the abstraction in `kanban-core` keeps it dependency-free and lets any future backend implement self-diagnosis independently.

**How**: New module in kanban-core with a default-returning hook on the trait. Server-side implementations of `HealthChecker` come in later cards once the server crate exists.

**Testing**: `cargo test --package kanban-core` (181 tests, 7 new), `cargo test --package kanban-service` (88+ tests, 1 new), `cargo clippy --all-targets --all-features -- -D warnings` (clean).