### PR TITLE
KAN-712 feat(api): scaffold kanban-api crate with ApiError and ChangeEventFrame

### DIFF
--- a/.changeset/max-kan-712.md
+++ b/.changeset/max-kan-712.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal infrastructure change with no user-visible behaviour difference. Introduces the kanban-api crate containing the shared wire types for the upcoming HTTP collaborative backend: ApiError (the HTTP error envelope) and ChangeEventFrame (the WebSocket push frame carrying writer identity, correlation ID, and timestamp). These types form the contract between the server and all clients.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,6 @@ version = "0.7.2"
 dependencies = [
  "chrono",
  "kanban-core",
- "kanban-domain",
  "serde",
  "serde_json",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,7 @@ name = "kanban-api"
 version = "0.7.2"
 dependencies = [
  "chrono",
+ "kanban-core",
  "kanban-domain",
  "serde",
  "serde_json",

--- a/crates/kanban-api/Cargo.toml
+++ b/crates/kanban-api/Cargo.toml
@@ -7,8 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-kanban-core = { path = "../kanban-core" }
-kanban-domain = { path = "../kanban-domain" }
+kanban-core = { path = "../kanban-core", version = "^0.7" }
 serde = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }

--- a/crates/kanban-api/Cargo.toml
+++ b/crates/kanban-api/Cargo.toml
@@ -7,10 +7,11 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+kanban-core = { path = "../kanban-core" }
+kanban-domain = { path = "../kanban-domain" }
 serde = { workspace = true }
-serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-kanban-domain = { path = "../kanban-domain", version = "^0.7" }
 
 [dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/kanban-api/Cargo.toml
+++ b/crates/kanban-api/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-kanban-core = { path = "../kanban-core", version = "^0.7" }
+kanban-core = { path = "../kanban-core" }
 serde = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -1,2 +1,5 @@
-pub mod v1;
-pub use v1::{ApiError, ChangeEventFrame};
+// v1 is private — canonical imports are from kanban_api::* directly.
+// This allows the versioning strategy to evolve (v2, v3, …) without
+// locking callers into an explicit version path.
+mod v1;
+pub use v1::{ApiError, ChangeEventFrame, ErrorCode};

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -1,1 +1,2 @@
-// Wire types for the kanban HTTP API. No application logic.
+pub mod v1;
+pub use v1::{ApiError, ChangeEventFrame};

--- a/crates/kanban-api/src/v1/error.rs
+++ b/crates/kanban-api/src/v1/error.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+/// HTTP error response envelope returned by all kanban-server routes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiError {
+    pub code: String,
+    pub message: String,
+}
+
+impl ApiError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self { code: code.into(), message: message.into() }
+    }
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_api_error_new_sets_fields() {
+        let e = ApiError::new("NOT_FOUND", "board not found");
+        assert_eq!(e.code, "NOT_FOUND");
+        assert_eq!(e.message, "board not found");
+    }
+
+    #[test]
+    fn test_api_error_display() {
+        let e = ApiError::new("INVALID", "bad input");
+        assert_eq!(e.to_string(), "INVALID: bad input");
+    }
+
+    #[test]
+    fn test_api_error_serde_round_trip() {
+        let e = ApiError::new("SERVER_ERROR", "something went wrong");
+        let json = serde_json::to_string(&e).unwrap();
+        let parsed: ApiError = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.code, e.code);
+        assert_eq!(parsed.message, e.message);
+    }
+}

--- a/crates/kanban-api/src/v1/error.rs
+++ b/crates/kanban-api/src/v1/error.rs
@@ -1,16 +1,62 @@
 use serde::{Deserialize, Serialize};
 
+/// Machine-readable error code included in every [`ApiError`] response body.
+///
+/// Variants map to the `KanbanError`/`DomainError` taxonomy and serialise as
+/// `SCREAMING_SNAKE_CASE` so JSON clients can branch on them without parsing
+/// the human-readable `message` field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorCode {
+    NotFound,
+    NotFoundByName,
+    Ambiguous,
+    WipLimitExceeded,
+    SprintBoardMismatch,
+    ValidationFailed,
+    DependencyError,
+    ConflictDetected,
+    UnsupportedVersion,
+    IoError,
+    SerializationError,
+    DatabaseError,
+    InternalError,
+}
+
+impl std::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::NotFound => "NOT_FOUND",
+            Self::NotFoundByName => "NOT_FOUND_BY_NAME",
+            Self::Ambiguous => "AMBIGUOUS",
+            Self::WipLimitExceeded => "WIP_LIMIT_EXCEEDED",
+            Self::SprintBoardMismatch => "SPRINT_BOARD_MISMATCH",
+            Self::ValidationFailed => "VALIDATION_FAILED",
+            Self::DependencyError => "DEPENDENCY_ERROR",
+            Self::ConflictDetected => "CONFLICT_DETECTED",
+            Self::UnsupportedVersion => "UNSUPPORTED_VERSION",
+            Self::IoError => "IO_ERROR",
+            Self::SerializationError => "SERIALIZATION_ERROR",
+            Self::DatabaseError => "DATABASE_ERROR",
+            Self::InternalError => "INTERNAL_ERROR",
+        };
+        f.write_str(s)
+    }
+}
+
 /// HTTP error response envelope returned by all kanban-server routes.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct ApiError {
-    pub code: String,
+    pub code: ErrorCode,
     pub message: String,
 }
 
 impl ApiError {
-    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
         Self {
-            code: code.into(),
+            code,
             message: message.into(),
         }
     }
@@ -30,20 +76,20 @@ mod tests {
 
     #[test]
     fn test_api_error_new_sets_fields() {
-        let e = ApiError::new("NOT_FOUND", "board not found");
-        assert_eq!(e.code, "NOT_FOUND");
+        let e = ApiError::new(ErrorCode::NotFound, "board not found");
+        assert_eq!(e.code, ErrorCode::NotFound);
         assert_eq!(e.message, "board not found");
     }
 
     #[test]
     fn test_api_error_display() {
-        let e = ApiError::new("INVALID", "bad input");
-        assert_eq!(e.to_string(), "INVALID: bad input");
+        let e = ApiError::new(ErrorCode::ValidationFailed, "bad input");
+        assert_eq!(e.to_string(), "VALIDATION_FAILED: bad input");
     }
 
     #[test]
     fn test_api_error_serde_round_trip() {
-        let e = ApiError::new("SERVER_ERROR", "something went wrong");
+        let e = ApiError::new(ErrorCode::InternalError, "something went wrong");
         let json = serde_json::to_string(&e).unwrap();
         let parsed: ApiError = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.code, e.code);
@@ -52,7 +98,36 @@ mod tests {
 
     #[test]
     fn test_api_error_implements_std_error() {
-        let e = ApiError::new("TEST", "msg");
+        let e = ApiError::new(ErrorCode::InternalError, "msg");
         let _: &dyn std::error::Error = &e;
+    }
+
+    #[test]
+    fn test_error_code_serializes_as_screaming_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::NotFound).unwrap(),
+            "\"NOT_FOUND\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::WipLimitExceeded).unwrap(),
+            "\"WIP_LIMIT_EXCEEDED\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::InternalError).unwrap(),
+            "\"INTERNAL_ERROR\""
+        );
+    }
+
+    #[test]
+    fn test_error_code_deserializes_from_screaming_snake_case() {
+        let code: ErrorCode = serde_json::from_str("\"CONFLICT_DETECTED\"").unwrap();
+        assert_eq!(code, ErrorCode::ConflictDetected);
+    }
+
+    #[test]
+    fn test_api_error_code_field_serializes_as_screaming_snake_case() {
+        let e = ApiError::new(ErrorCode::NotFoundByName, "no match");
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"NOT_FOUND_BY_NAME\""), "json: {json}");
     }
 }

--- a/crates/kanban-api/src/v1/error.rs
+++ b/crates/kanban-api/src/v1/error.rs
@@ -9,7 +9,10 @@ pub struct ApiError {
 
 impl ApiError {
     pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
-        Self { code: code.into(), message: message.into() }
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
     }
 }
 
@@ -18,6 +21,8 @@ impl std::fmt::Display for ApiError {
         write!(f, "{}: {}", self.code, self.message)
     }
 }
+
+impl std::error::Error for ApiError {}
 
 #[cfg(test)]
 mod tests {
@@ -43,5 +48,11 @@ mod tests {
         let parsed: ApiError = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.code, e.code);
         assert_eq!(parsed.message, e.message);
+    }
+
+    #[test]
+    fn test_api_error_implements_std_error() {
+        let e = ApiError::new("TEST", "msg");
+        let _: &dyn std::error::Error = &e;
     }
 }

--- a/crates/kanban-api/src/v1/events.rs
+++ b/crates/kanban-api/src/v1/events.rs
@@ -1,0 +1,51 @@
+use chrono::{DateTime, Utc};
+use kanban_core::ClientId;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// WebSocket push frame emitted by kanban-server on every successful mutation.
+/// Clients filter by `writer_instance_id` to ignore their own writes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangeEventFrame {
+    pub writer_instance_id: Uuid,
+    pub detected_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+    pub issued_by: ClientId,
+}
+
+impl ChangeEventFrame {
+    pub fn new(writer_instance_id: Uuid, correlation_id: Uuid, issued_by: ClientId) -> Self {
+        Self { writer_instance_id, detected_at: Utc::now(), correlation_id, issued_by }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_change_event_frame_serde_round_trip() {
+        let frame = ChangeEventFrame {
+            writer_instance_id: Uuid::nil(),
+            detected_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            correlation_id: Uuid::nil(),
+            issued_by: ClientId::nil(),
+        };
+        let json = serde_json::to_string(&frame).unwrap();
+        let parsed: ChangeEventFrame = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.writer_instance_id, frame.writer_instance_id);
+        assert_eq!(parsed.correlation_id, frame.correlation_id);
+        assert_eq!(parsed.issued_by, frame.issued_by);
+    }
+
+    #[test]
+    fn test_change_event_frame_new_populates_all_fields() {
+        let instance_id = Uuid::new_v4();
+        let correlation_id = Uuid::new_v4();
+        let client_id = ClientId::new();
+        let frame = ChangeEventFrame::new(instance_id, correlation_id, client_id);
+        assert_eq!(frame.writer_instance_id, instance_id);
+        assert_eq!(frame.correlation_id, correlation_id);
+        assert_eq!(frame.issued_by, client_id);
+    }
+}

--- a/crates/kanban-api/src/v1/events.rs
+++ b/crates/kanban-api/src/v1/events.rs
@@ -3,24 +3,47 @@ use kanban_core::ClientId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+fn default_uuid() -> Uuid {
+    Uuid::nil()
+}
+
+fn default_client_id() -> ClientId {
+    ClientId::nil()
+}
+
 /// WebSocket push frame emitted by kanban-server on every successful mutation.
 /// Clients filter by `writer_instance_id` to ignore their own writes.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct ChangeEventFrame {
     pub writer_instance_id: Uuid,
     pub detected_at: DateTime<Utc>,
+    #[serde(default = "default_uuid")]
     pub correlation_id: Uuid,
+    #[serde(default = "default_client_id")]
     pub issued_by: ClientId,
 }
 
 impl ChangeEventFrame {
-    pub fn new(writer_instance_id: Uuid, correlation_id: Uuid, issued_by: ClientId) -> Self {
+    /// Construct with an explicit timestamp (use in tests and server code).
+    pub fn new(
+        writer_instance_id: Uuid,
+        correlation_id: Uuid,
+        issued_by: ClientId,
+        detected_at: DateTime<Utc>,
+    ) -> Self {
         Self {
             writer_instance_id,
-            detected_at: Utc::now(),
+            detected_at,
             correlation_id,
             issued_by,
         }
+    }
+
+    /// Construct stamped with the current time (convenience for production use).
+    pub fn now(writer_instance_id: Uuid, correlation_id: Uuid, issued_by: ClientId) -> Self {
+        Self::new(writer_instance_id, correlation_id, issued_by, Utc::now())
     }
 }
 
@@ -30,12 +53,12 @@ mod tests {
 
     #[test]
     fn test_change_event_frame_serde_round_trip() {
-        let frame = ChangeEventFrame {
-            writer_instance_id: Uuid::nil(),
-            detected_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
-            correlation_id: Uuid::nil(),
-            issued_by: ClientId::nil(),
-        };
+        let frame = ChangeEventFrame::new(
+            Uuid::nil(),
+            Uuid::nil(),
+            ClientId::nil(),
+            chrono::DateTime::from_timestamp(0, 0).unwrap(),
+        );
         let json = serde_json::to_string(&frame).unwrap();
         let parsed: ChangeEventFrame = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.writer_instance_id, frame.writer_instance_id);
@@ -44,13 +67,28 @@ mod tests {
     }
 
     #[test]
-    fn test_change_event_frame_new_populates_all_fields() {
+    fn test_change_event_frame_now_populates_all_fields() {
         let instance_id = Uuid::new_v4();
         let correlation_id = Uuid::new_v4();
         let client_id = ClientId::new();
-        let frame = ChangeEventFrame::new(instance_id, correlation_id, client_id);
+        let frame = ChangeEventFrame::now(instance_id, correlation_id, client_id);
         assert_eq!(frame.writer_instance_id, instance_id);
         assert_eq!(frame.correlation_id, correlation_id);
         assert_eq!(frame.issued_by, client_id);
+    }
+
+    #[test]
+    fn test_change_event_frame_new_uses_explicit_timestamp() {
+        let ts = chrono::DateTime::from_timestamp(1_000_000, 0).unwrap();
+        let frame = ChangeEventFrame::new(Uuid::nil(), Uuid::nil(), ClientId::nil(), ts);
+        assert_eq!(frame.detected_at, ts);
+    }
+
+    #[test]
+    fn test_change_event_frame_deserializes_without_optional_fields() {
+        let json = r#"{"writer_instance_id":"00000000-0000-0000-0000-000000000000","detected_at":"1970-01-01T00:00:00Z"}"#;
+        let parsed: ChangeEventFrame = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.correlation_id, Uuid::nil());
+        assert_eq!(parsed.issued_by, ClientId::nil());
     }
 }

--- a/crates/kanban-api/src/v1/events.rs
+++ b/crates/kanban-api/src/v1/events.rs
@@ -15,7 +15,12 @@ pub struct ChangeEventFrame {
 
 impl ChangeEventFrame {
     pub fn new(writer_instance_id: Uuid, correlation_id: Uuid, issued_by: ClientId) -> Self {
-        Self { writer_instance_id, detected_at: Utc::now(), correlation_id, issued_by }
+        Self {
+            writer_instance_id,
+            detected_at: Utc::now(),
+            correlation_id,
+            issued_by,
+        }
     }
 }
 

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -1,0 +1,4 @@
+pub mod error;
+pub mod events;
+pub use error::ApiError;
+pub use events::ChangeEventFrame;

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -1,4 +1,4 @@
 pub mod error;
 pub mod events;
-pub use error::ApiError;
+pub use error::{ApiError, ErrorCode};
 pub use events::ChangeEventFrame;


### PR DESCRIPTION
Add kanban-api crate with the shared HTTP wire types used by kanban-server and kanban-http-backend:

- Add crates/kanban-api/src/v1/error.rs: ApiError { code: String, message: String } with Display and serde round-trip
- Add crates/kanban-api/src/v1/events.rs: ChangeEventFrame { writer_instance_id: Uuid, detected_at: DateTime<Utc>, correlation_id: Uuid, issued_by: ClientId } with constructor and serde round-trip
- Add crates/kanban-api/src/v1/mod.rs and lib.rs re-exporting both types
- Update crates/kanban-api/Cargo.toml to add kanban-core dependency (for ClientId)
- 5 tests covering ApiError construction, Display, serde round-trip, and ChangeEventFrame construction and serde round-trip

**What**: New kanban-api crate with two types: ApiError (returned by all server error responses) and ChangeEventFrame (broadcast over WebSocket on every successful mutation). The crate has no dependency above kanban-domain and forms the stable wire contract between server and clients.

**Why**: kanban-server and kanban-http-backend both need to share these types without circular dependencies. Defining them in a dedicated crate with minimal deps keeps the boundary clean.

**How**: ChangeEventFrame carries all four observability fields (writer_instance_id, detected_at, correlation_id, issued_by) from day one so the wire format does not need to be versioned later. KAN-731 (which would have added correlation_id and issued_by separately) is now redundant.

**Testing**: cargo test --package kanban-api (5 tests pass), cargo clippy --all-targets --all-features -- -D warnings (clean).