### PR TITLE
KAN-752 chore(http-backend): drop tokio-tungstenite; transport is SSE not WebSocket

### DIFF
--- a/.changeset/kan-752-drop-tokio-tungstenite-from-http-backend.md
+++ b/.changeset/kan-752-drop-tokio-tungstenite-from-http-backend.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Dropped the `tokio-tungstenite` dependency from `kanban-http-backend`. The collaborative transport is server-sent events (SSE), not WebSocket, so the dependency was unused.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,7 +1471,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "tokio-tungstenite",
  "tracing",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ tower-http = { version = "0.6", features = ["trace", "cors"] }
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }
-tokio-tungstenite = "0.29"
 
 # Observability
 prometheus = "0.13"

--- a/crates/kanban-http-backend/Cargo.toml
+++ b/crates/kanban-http-backend/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 [dependencies]
 reqwest = { workspace = true }
 tokio = { workspace = true }
-tokio-tungstenite = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
tokio-tungstenite was added when kanban-http-backend was scaffolded (KAN-742), anticipating WebSocket-based push notifications. During sprint 19 planning the transport decision was revised to SSE: it is unidirectional (server to client), sufficient for kanban change notifications, simpler to implement, and works through any HTTP proxy without special handling.

The only card that would have consumed tungstenite was KAN-701 (WebSocketChangeDetector), which is superseded by KAN-749 (SSE-based push via subscribe_changes() on KanbanBackend). The dependency is now unused.

## Change

- Remove `tokio-tungstenite` from `crates/kanban-http-backend/Cargo.toml`
- Update `Cargo.lock`

## Testing

`cargo check --package kanban-http-backend` passes clean.