### PR TITLE
KAN-828 feat(domain): shared archival abstraction + KanbanError::unsupported

### DIFF
--- a/.changeset/kan-828-shared-archival-abstraction.md
+++ b/.changeset/kan-828-shared-archival-abstraction.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal foundation with no user-visible behaviour change. Adds a bounded shared archival abstraction to the domain layer: an `ArchiveMetadata` envelope and a thin `ArchivedEntity` trait (stable id + metadata), implemented first by `ArchivedCard`. Also adds a `KanbanError::unsupported` affordance (a `DomainError::Unsupported` variant) that later slices use as the default body for backend methods not yet implemented, so trait extensions compile cleanly. This is the groundwork the archived-cards retrofit and board archival build on; nothing changes for users yet.

--- a/crates/kanban-domain/src/archival.rs
+++ b/crates/kanban-domain/src/archival.rs
@@ -1,0 +1,87 @@
+//! Bounded shared archival abstraction.
+//!
+//! Scope is deliberately minimal (validated by two execution spikes): the only
+//! genuinely cross-cutting pieces are the archived-metadata envelope and a thin
+//! trait exposing an archived record's stable key + metadata. The lifecycle
+//! (archive / restore / permanent-delete) and the entity-specific restore
+//! context stay specialized on the concrete types and the command tier — a
+//! store-generic `ArchiveCollection` trait was found to be dead abstraction (no
+//! backend would implement it) and is intentionally NOT provided.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Shared archival metadata envelope. Common to every archived entity; the
+/// entity-specific restore context is NOT stored here (it stays on the concrete
+/// archived type, e.g. `ArchivedCard::original_column_id`). Kept a one-field
+/// struct on purpose: it is the seam where a future `archived_by`/reason would
+/// live without touching call sites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchiveMetadata {
+    pub archived_at: DateTime<Utc>,
+}
+
+impl ArchiveMetadata {
+    pub fn now() -> Self {
+        Self {
+            archived_at: Utc::now(),
+        }
+    }
+
+    pub fn at(archived_at: DateTime<Utc>) -> Self {
+        Self { archived_at }
+    }
+}
+
+/// A discrete archived record: knows the live entity's stable id (its archive
+/// key) and its shared metadata. Payload beyond this stays specialized on the
+/// concrete type — the trait covers the envelope + key, not the payload.
+pub trait ArchivedEntity {
+    /// Stable id of the live entity this record archives (card id / board id).
+    fn entity_id(&self) -> Uuid;
+
+    fn metadata(&self) -> ArchiveMetadata;
+
+    fn archived_at(&self) -> DateTime<Utc> {
+        self.metadata().archived_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_archive_metadata_now_sets_recent_timestamp() {
+        let before = Utc::now();
+        let meta = ArchiveMetadata::now();
+        assert!(meta.archived_at >= before);
+        assert!(meta.archived_at <= Utc::now());
+    }
+
+    struct Dummy {
+        id: Uuid,
+        at: DateTime<Utc>,
+    }
+
+    impl ArchivedEntity for Dummy {
+        fn entity_id(&self) -> Uuid {
+            self.id
+        }
+        fn metadata(&self) -> ArchiveMetadata {
+            ArchiveMetadata::at(self.at)
+        }
+    }
+
+    #[test]
+    fn test_archived_entity_exposes_entity_id_and_archived_at() {
+        let id = Uuid::new_v4();
+        let at = Utc::now();
+        let d = Dummy { id, at };
+        assert_eq!(d.entity_id(), id);
+        assert_eq!(d.metadata().archived_at, at);
+        // The default `archived_at()` delegates to `metadata()`.
+        assert_eq!(d.archived_at(), at);
+    }
+}

--- a/crates/kanban-domain/src/archived_card.rs
+++ b/crates/kanban-domain/src/archived_card.rs
@@ -51,6 +51,16 @@ impl Borrow<Card> for ArchivedCard {
     }
 }
 
+impl crate::archival::ArchivedEntity for ArchivedCard {
+    fn entity_id(&self) -> uuid::Uuid {
+        self.card.id
+    }
+
+    fn metadata(&self) -> crate::archival::ArchiveMetadata {
+        crate::archival::ArchiveMetadata::at(self.archived_at)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArchivedCardSummary {
     pub card: CardSummary,
@@ -67,5 +77,29 @@ impl From<&ArchivedCard> for ArchivedCardSummary {
             original_column_id: a.original_column_id,
             original_position: a.original_position,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::archival::ArchivedEntity;
+    use crate::{board::Board, card::Card, column::Column};
+
+    #[test]
+    fn test_archived_card_implements_archived_entity() {
+        // Built via public constructors (the in-memory `test_support` module is
+        // private and not usable from here).
+        let mut board = Board::new("B", None::<String>);
+        let col = Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, col.id, "T", 0);
+        let card_id = card.id;
+
+        let ac = ArchivedCard::new(card, col.id, 0);
+        let field_archived_at = ac.archived_at;
+
+        assert_eq!(ArchivedEntity::entity_id(&ac), card_id);
+        // The trait method reflects the record's own `archived_at` field.
+        assert_eq!(ac.archived_at(), field_archived_at);
     }
 }

--- a/crates/kanban-domain/src/archived_card.rs
+++ b/crates/kanban-domain/src/archived_card.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 
 use crate::{
+    archival::ArchiveMetadata,
     card::{Card, CardSummary},
     column::ColumnId,
 };
@@ -11,7 +12,11 @@ use crate::{
 pub struct ArchivedCard {
     #[serde(with = "crate::card_factory::card_serde")]
     pub card: Card,
-    pub archived_at: DateTime<Utc>,
+    /// Shared archival envelope (`archived_at`, room to grow). `#[serde(flatten)]`
+    /// keeps the on-disk shape byte-identical to the previous flat `archived_at`
+    /// field, so no format bump / migration is needed.
+    #[serde(flatten)]
+    pub metadata: ArchiveMetadata,
     pub original_column_id: ColumnId,
     pub original_position: i32,
 }
@@ -20,7 +25,7 @@ impl ArchivedCard {
     pub fn new(card: Card, original_column_id: ColumnId, original_position: i32) -> Self {
         Self {
             card,
-            archived_at: Utc::now(),
+            metadata: ArchiveMetadata::now(),
             original_column_id,
             original_position,
         }
@@ -56,8 +61,8 @@ impl crate::archival::ArchivedEntity for ArchivedCard {
         self.card.id
     }
 
-    fn metadata(&self) -> crate::archival::ArchiveMetadata {
-        crate::archival::ArchiveMetadata::at(self.archived_at)
+    fn metadata(&self) -> ArchiveMetadata {
+        self.metadata
     }
 }
 
@@ -73,7 +78,7 @@ impl From<&ArchivedCard> for ArchivedCardSummary {
     fn from(a: &ArchivedCard) -> Self {
         Self {
             card: CardSummary::from(&a.card),
-            archived_at: a.archived_at,
+            archived_at: a.metadata.archived_at,
             original_column_id: a.original_column_id,
             original_position: a.original_position,
         }
@@ -86,20 +91,49 @@ mod tests {
     use crate::archival::ArchivedEntity;
     use crate::{board::Board, card::Card, column::Column};
 
-    #[test]
-    fn test_archived_card_implements_archived_entity() {
+    fn sample() -> ArchivedCard {
         // Built via public constructors (the in-memory `test_support` module is
         // private and not usable from here).
         let mut board = Board::new("B", None::<String>);
         let col = Column::new(board.id, "Todo", 0);
         let card = Card::new(&mut board, col.id, "T", 0);
-        let card_id = card.id;
+        ArchivedCard::new(card, col.id, 0)
+    }
 
-        let ac = ArchivedCard::new(card, col.id, 0);
-        let field_archived_at = ac.archived_at;
+    #[test]
+    fn test_archived_card_implements_archived_entity() {
+        let ac = sample();
+        assert_eq!(ArchivedEntity::entity_id(&ac), ac.card.id);
+        // The trait method returns the record's own metadata field.
+        assert_eq!(ac.archived_at(), ac.metadata.archived_at);
+    }
 
-        assert_eq!(ArchivedEntity::entity_id(&ac), card_id);
-        // The trait method reflects the record's own `archived_at` field.
-        assert_eq!(ac.archived_at(), field_archived_at);
+    #[test]
+    fn test_metadata_flatten_keeps_archived_at_flat_on_the_wire() {
+        // The `#[serde(flatten)]` metadata must serialize `archived_at` as a
+        // TOP-LEVEL key (not nested under "metadata"), so the on-disk shape is
+        // unchanged and no migration is needed.
+        let ac = sample();
+        let v = serde_json::to_value(&ac).unwrap();
+        assert!(
+            v.get("archived_at").is_some(),
+            "archived_at stays top-level"
+        );
+        assert!(
+            v.get("metadata").is_none(),
+            "not nested under a metadata key"
+        );
+    }
+
+    #[test]
+    fn test_pre_metadata_flat_json_still_deserializes() {
+        // A record written by the previous (flat `archived_at`) code round-trips
+        // into the new shape unchanged — the back-compat proof that this is not
+        // a breaking format change.
+        let ac = sample();
+        let json = serde_json::to_string(&ac).unwrap();
+        let back: ArchivedCard = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ac);
+        assert_eq!(back.metadata.archived_at, ac.metadata.archived_at);
     }
 }

--- a/crates/kanban-domain/src/archived_card.rs
+++ b/crates/kanban-domain/src/archived_card.rs
@@ -127,13 +127,24 @@ mod tests {
 
     #[test]
     fn test_pre_metadata_flat_json_still_deserializes() {
-        // A record written by the previous (flat `archived_at`) code round-trips
-        // into the new shape unchanged — the back-compat proof that this is not
-        // a breaking format change.
+        // A record written by the PREVIOUS (flat `archived_at`) code must still
+        // load. Hand-assemble that historical shape - `archived_at` as a sibling
+        // of `card`, NOT nested under a `metadata` key - so this genuinely fails
+        // if `#[serde(flatten)]` is ever dropped (the real back-compat guard,
+        // not a new->new round-trip that would move with the struct).
         let ac = sample();
-        let json = serde_json::to_string(&ac).unwrap();
-        let back: ArchivedCard = serde_json::from_str(&json).unwrap();
+        let card_value = serde_json::to_value(&ac)
+            .unwrap()
+            .get("card")
+            .cloned()
+            .expect("serialized card sub-object");
+        let flat = serde_json::json!({
+            "card": card_value,
+            "archived_at": ac.metadata.archived_at,
+            "original_column_id": ac.original_column_id,
+            "original_position": ac.original_position,
+        });
+        let back: ArchivedCard = serde_json::from_value(flat).unwrap();
         assert_eq!(back, ac);
-        assert_eq!(back.metadata.archived_at, ac.metadata.archived_at);
     }
 }

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -148,6 +148,12 @@ pub enum DomainError {
         sprint_board: Uuid,
         card_board: Uuid,
     },
+
+    /// A `DataStore`/backend method that a backend has not implemented yet.
+    /// The shared affordance behind default trait bodies added by later slices
+    /// (a backend gap, surfaced as a server fault at the wire boundary).
+    #[error("operation not supported by this backend: {operation}")]
+    Unsupported { operation: &'static str },
 }
 
 impl DomainError {
@@ -285,6 +291,16 @@ impl KanbanError {
         Self::Domain(DomainError::Validation(msg.into()))
     }
 
+    /// A backend method that has not been implemented yet. The shared affordance
+    /// consumed by default `DataStore` trait bodies added in later slices (D6).
+    pub fn unsupported(operation: &'static str) -> Self {
+        Self::Domain(DomainError::Unsupported { operation })
+    }
+
+    pub fn is_unsupported(&self) -> bool {
+        matches!(self, KanbanError::Domain(DomainError::Unsupported { .. }))
+    }
+
     /// True for both `NotFound` (by UUID) and `NotFoundByName`.
     pub fn is_not_found(&self) -> bool {
         matches!(
@@ -399,6 +415,14 @@ mod tests {
     fn test_is_not_found_returns_true_for_card_not_found() {
         let err = KanbanError::not_found("Card", Uuid::new_v4());
         assert!(err.is_not_found());
+    }
+
+    #[test]
+    fn test_unsupported_error_is_unsupported_and_not_not_found() {
+        let err = KanbanError::unsupported("archive_board");
+        assert!(err.is_unsupported());
+        assert!(!err.is_not_found());
+        assert!(err.to_string().contains("archive_board"));
     }
 
     #[test]

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -148,12 +148,6 @@ pub enum DomainError {
         sprint_board: Uuid,
         card_board: Uuid,
     },
-
-    /// A `DataStore`/backend method that a backend has not implemented yet.
-    /// The shared affordance behind default trait bodies added by later slices
-    /// (a backend gap, surfaced as a server fault at the wire boundary).
-    #[error("operation not supported by this backend: {operation}")]
-    Unsupported { operation: &'static str },
 }
 
 impl DomainError {
@@ -228,6 +222,14 @@ pub enum KanbanError {
     #[error("internal error: {0}")]
     Internal(String),
 
+    /// A `DataStore`/backend method that a backend has not implemented yet.
+    /// The shared affordance behind the default trait bodies added by later
+    /// slices (D6). This is a server/infrastructure fault (a backend gap), so
+    /// it lives at the top level alongside `Internal`/`Database`/`Io` rather
+    /// than in `DomainError` (which is client-actionable domain-rule violations).
+    #[error("operation not supported by this backend: {operation}")]
+    Unsupported { operation: &'static str },
+
     #[error(
         "file format v{file_version} is newer than this binary's max v{binary_max}; \
          please upgrade kanban"
@@ -294,11 +296,11 @@ impl KanbanError {
     /// A backend method that has not been implemented yet. The shared affordance
     /// consumed by default `DataStore` trait bodies added in later slices (D6).
     pub fn unsupported(operation: &'static str) -> Self {
-        Self::Domain(DomainError::Unsupported { operation })
+        Self::Unsupported { operation }
     }
 
     pub fn is_unsupported(&self) -> bool {
-        matches!(self, KanbanError::Domain(DomainError::Unsupported { .. }))
+        matches!(self, KanbanError::Unsupported { .. })
     }
 
     /// True for both `NotFound` (by UUID) and `NotFoundByName`.

--- a/crates/kanban-domain/src/in_memory_store/archived_cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_cards.rs
@@ -15,7 +15,7 @@ impl InMemoryStore {
     pub(super) fn list_archived_cards_impl(&self) -> KanbanResult<Vec<ArchivedCard>> {
         let state = self.read_state()?;
         let mut acs: Vec<ArchivedCard> = state.archived_cards.values().cloned().collect();
-        acs.sort_by(|a, b| a.archived_at.cmp(&b.archived_at));
+        acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
         Ok(acs)
     }
 
@@ -36,7 +36,7 @@ impl InMemoryStore {
             .filter(|ac| column_ids.contains(&ac.original_column_id))
             .cloned()
             .collect();
-        acs.sort_by(|a, b| a.archived_at.cmp(&b.archived_at));
+        acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
         Ok(acs)
     }
 

--- a/crates/kanban-domain/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-domain/src/in_memory_store/snapshot.rs
@@ -15,7 +15,7 @@ impl InMemoryStore {
         cards.sort_by_key(|c| c.position);
 
         let mut archived_cards: Vec<_> = state.archived_cards.values().cloned().collect();
-        archived_cards.sort_by(|a, b| a.archived_at.cmp(&b.archived_at));
+        archived_cards.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
 
         let mut sprints: Vec<_> = state.sprints.values().cloned().collect();
         sprints.sort_by_key(|s| s.sprint_number);

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 
+pub mod archival;
 pub mod archived_card;
 pub mod board;
 pub mod board_factory;
@@ -30,6 +31,7 @@ pub mod sprint_log;
 pub mod tag;
 pub mod task_list_view;
 
+pub use archival::{ArchiveMetadata, ArchivedEntity};
 pub use archived_card::{ArchivedCard, ArchivedCardSummary};
 pub use board::{
     get_active_sprint_card_prefix_override, get_active_sprint_prefix_override, Board, BoardId,

--- a/crates/kanban-mcp/src/error.rs
+++ b/crates/kanban-mcp/src/error.rs
@@ -116,4 +116,16 @@ mod tests {
             mcp.message
         );
     }
+
+    /// A backend gap (`KanbanError::unsupported`) is a server fault: it must map
+    /// to `INTERNAL_ERROR`, NOT `INVALID_PARAMS` (which would tell the client its
+    /// inputs were wrong). This holds because `Unsupported` is a top-level
+    /// `KanbanError`, not a `DomainError` (the `Domain(_)` blanket above routes
+    /// to `INVALID_PARAMS`).
+    #[test]
+    fn test_into_mcp_error_unsupported_maps_to_internal_error() {
+        let err: KanbanMcpError = KanbanError::unsupported("archive_board").into();
+        let mcp: McpError = err.into();
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use kanban_domain::{
-    Board, BoardRecord, Card, CardRecord, Column, ColumnRecord, KanbanResult, Sprint, SprintLog,
-    SprintRecord,
+    ArchiveMetadata, ArchivedCard, Board, BoardRecord, Card, CardRecord, Column, ColumnRecord,
+    KanbanResult, Sprint, SprintLog, SprintRecord,
 };
 use sqlx::sqlite::SqliteRow;
 use sqlx::Row;
@@ -108,6 +108,24 @@ pub(crate) fn row_to_card(row: &SqliteRow, sprint_logs: Vec<SprintLog>) -> Kanba
     };
 
     Card::reconstitute(record)
+}
+
+/// Build an `ArchivedCard` from a joined `cards` + `archived_cards` row. The one
+/// place that reconstructs the domain record, so a new archival column (or field)
+/// is added here once rather than at every reader.
+pub(crate) fn row_to_archived_card(
+    row: &SqliteRow,
+    sprint_logs: Vec<SprintLog>,
+) -> KanbanResult<ArchivedCard> {
+    let card = row_to_card(row, sprint_logs)?;
+    let archived_at_str: String = row.try_get("archived_at").map_err(db_err)?;
+    let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
+    Ok(ArchivedCard {
+        card,
+        metadata: ArchiveMetadata::at(p_dt(&archived_at_str)?),
+        original_column_id: p_uuid(&orig_col_str)?,
+        original_position: row.try_get("original_position").map_err(db_err)?,
+    })
 }
 
 pub(crate) fn row_to_sprint(row: &SqliteRow) -> KanbanResult<Sprint> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -6,8 +6,10 @@ use kanban_domain::{
 use sqlx::Row;
 use uuid::Uuid;
 
-use super::conversions::{row_to_board, row_to_card, row_to_column, row_to_sprint};
-use super::helpers::{db_err, fmt_dt, p_dt, p_uuid, run};
+use super::conversions::{
+    row_to_archived_card, row_to_board, row_to_card, row_to_column, row_to_sprint,
+};
+use super::helpers::{db_err, fmt_dt, run};
 use super::SqliteStore;
 
 impl DataStore for SqliteStore {
@@ -287,15 +289,7 @@ impl DataStore for SqliteStore {
             match row {
                 Some(row) => {
                     let logs = self.fetch_sprint_logs_for_card(&id_str).await?;
-                    let card = row_to_card(&row, logs)?;
-                    let archived_at_str: String = row.try_get("archived_at").map_err(db_err)?;
-                    let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
-                    Ok(Some(ArchivedCard {
-                        card,
-                        metadata: kanban_domain::ArchiveMetadata::at(p_dt(&archived_at_str)?),
-                        original_column_id: p_uuid(&orig_col_str)?,
-                        original_position: row.try_get("original_position").map_err(db_err)?,
-                    }))
+                    Ok(Some(row_to_archived_card(&row, logs)?))
                 }
                 None => Ok(None),
             }
@@ -363,15 +357,7 @@ impl DataStore for SqliteStore {
             for row in &rows {
                 let id_str: String = row.try_get("id").map_err(db_err)?;
                 let logs = logs_map.remove(&id_str).unwrap_or_default();
-                let card = row_to_card(row, logs)?;
-                let archived_at_str: String = row.try_get("archived_at").map_err(db_err)?;
-                let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
-                result.push(ArchivedCard {
-                    card,
-                    metadata: kanban_domain::ArchiveMetadata::at(p_dt(&archived_at_str)?),
-                    original_column_id: p_uuid(&orig_col_str)?,
-                    original_position: row.try_get("original_position").map_err(db_err)?,
-                });
+                result.push(row_to_archived_card(row, logs)?);
             }
             Ok(result)
         })

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -292,7 +292,7 @@ impl DataStore for SqliteStore {
                     let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
                     Ok(Some(ArchivedCard {
                         card,
-                        archived_at: p_dt(&archived_at_str)?,
+                        metadata: kanban_domain::ArchiveMetadata::at(p_dt(&archived_at_str)?),
                         original_column_id: p_uuid(&orig_col_str)?,
                         original_position: row.try_get("original_position").map_err(db_err)?,
                     }))
@@ -368,7 +368,7 @@ impl DataStore for SqliteStore {
                 let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
                 result.push(ArchivedCard {
                     card,
-                    archived_at: p_dt(&archived_at_str)?,
+                    metadata: kanban_domain::ArchiveMetadata::at(p_dt(&archived_at_str)?),
                     original_column_id: p_uuid(&orig_col_str)?,
                     original_position: row.try_get("original_position").map_err(db_err)?,
                 });

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
@@ -18,7 +18,7 @@ impl SqliteStore {
                 original_position=excluded.original_position",
         )
         .bind(ac.card.id.to_string())
-        .bind(fmt_dt(&ac.archived_at))
+        .bind(fmt_dt(&ac.metadata.archived_at))
         .bind(ac.original_column_id.to_string())
         .bind(ac.original_position)
         .execute(&mut *conn)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -1,8 +1,8 @@
 use kanban_domain::{ArchivedCard, Board, Column, DependencyGraph, KanbanResult, Sprint};
 use sqlx::Row;
 
-use super::conversions::{row_to_board, row_to_card, row_to_column, row_to_sprint};
-use super::helpers::{db_err, p_dt, p_uuid};
+use super::conversions::{row_to_archived_card, row_to_board, row_to_column, row_to_sprint};
+use super::helpers::db_err;
 use super::SqliteStore;
 
 impl SqliteStore {
@@ -78,15 +78,7 @@ impl SqliteStore {
         for row in &rows {
             let id_str: String = row.try_get("id").map_err(db_err)?;
             let logs = logs_map.remove(&id_str).unwrap_or_default();
-            let card = row_to_card(row, logs)?;
-            let archived_at_str: String = row.try_get("archived_at").map_err(db_err)?;
-            let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
-            result.push(ArchivedCard {
-                card,
-                metadata: kanban_domain::ArchiveMetadata::at(p_dt(&archived_at_str)?),
-                original_column_id: p_uuid(&orig_col_str)?,
-                original_position: row.try_get("original_position").map_err(db_err)?,
-            });
+            result.push(row_to_archived_card(row, logs)?);
         }
         Ok(result)
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -83,7 +83,7 @@ impl SqliteStore {
             let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
             result.push(ArchivedCard {
                 card,
-                archived_at: p_dt(&archived_at_str)?,
+                metadata: kanban_domain::ArchiveMetadata::at(p_dt(&archived_at_str)?),
                 original_column_id: p_uuid(&orig_col_str)?,
                 original_position: row.try_get("original_position").map_err(db_err)?,
             });

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -106,7 +106,7 @@ pub fn fully_populated_snapshot() -> Snapshot {
             completed_at: Some(now),
             sprint_logs: vec![],
         },
-        archived_at: now,
+        metadata: kanban_domain::ArchiveMetadata::at(now),
         original_column_id: col_id,
         original_position: 1,
     };

--- a/crates/kanban-service/src/api/v1/error_mapping.rs
+++ b/crates/kanban-service/src/api/v1/error_mapping.rs
@@ -31,14 +31,14 @@ impl From<&KanbanError> for ApiError {
                 },
                 DomainError::WipLimitExceeded { .. } => ErrorCode::WipLimitExceeded,
                 DomainError::SprintBoardMismatch { .. } => ErrorCode::SprintBoardMismatch,
-                // A backend gap is a server fault, not a client error.
-                DomainError::Unsupported { .. } => ErrorCode::InternalError,
             },
             KanbanError::Io(_) => ErrorCode::IoError,
             KanbanError::Serialization(_) => ErrorCode::SerializationError,
             KanbanError::ConflictDetected { .. } => ErrorCode::ConflictDetected,
             KanbanError::Database(_) => ErrorCode::DatabaseError,
             KanbanError::Internal(_) => ErrorCode::InternalError,
+            // A backend gap is a server fault, not a client error.
+            KanbanError::Unsupported { .. } => ErrorCode::InternalError,
             KanbanError::UnsupportedFutureVersion { .. } => ErrorCode::UnsupportedVersion,
         };
         // Public-message policy — exhaustive over `ErrorCode` so a new code must
@@ -170,6 +170,12 @@ mod tests {
             ),
             (
                 KanbanError::Internal("oops".into()),
+                ErrorCode::InternalError,
+            ),
+            (
+                // A backend gap is a server fault (and must NOT echo the
+                // operation string to the client - see the message policy).
+                KanbanError::unsupported("archive_board"),
                 ErrorCode::InternalError,
             ),
             (

--- a/crates/kanban-service/src/api/v1/error_mapping.rs
+++ b/crates/kanban-service/src/api/v1/error_mapping.rs
@@ -31,6 +31,8 @@ impl From<&KanbanError> for ApiError {
                 },
                 DomainError::WipLimitExceeded { .. } => ErrorCode::WipLimitExceeded,
                 DomainError::SprintBoardMismatch { .. } => ErrorCode::SprintBoardMismatch,
+                // A backend gap is a server fault, not a client error.
+                DomainError::Unsupported { .. } => ErrorCode::InternalError,
             },
             KanbanError::Io(_) => ErrorCode::IoError,
             KanbanError::Serialization(_) => ErrorCode::SerializationError,


### PR DESCRIPTION
Part of the board-removal epic (KAN-821). This is the foundation slice that SE-B (archived-cards retrofit) and SE-C (board archival) build on. No user-visible change.

## What this adds
- A bounded shared archival abstraction in `kanban-domain` (`archival.rs`): an `ArchiveMetadata` envelope (`archived_at`, with room to grow) and a thin `ArchivedEntity` trait exposing an archived record's stable entity id and its metadata. `ArchivedCard` is the first implementer.
- `KanbanError::unsupported(op)` and `is_unsupported()` (a new `DomainError::Unsupported { operation }` variant). Later slices use this as the default body for `DataStore` methods a backend has not implemented yet, so those trait extensions compile cleanly.

## Deliberately minimal
The abstraction is only the metadata envelope plus the id/metadata trait. It does not add a store-generic archive-collection trait or a generic archive/restore lifecycle: two execution spikes both found that no backend would implement a store-generic collection, so it would be dead abstraction. The lifecycle and each entity's restore context stay specialized on the concrete types and the command tier.

## Scope note
Additive within `kanban-domain`, with one required cross-crate edit: the new `DomainError` variant is caught by the exhaustive domain-error match in `crates/kanban-service/src/api/v1/error_mapping.rs`, which gains a `DomainError::Unsupported { .. } => ErrorCode::InternalError` arm (a backend gap is a server fault). `DataStore` is intentionally untouched here.

## Tests
- `kanban-domain` inline unit tests: `ArchiveMetadata::now` timestamp, the `ArchivedEntity` trait contract (via a dummy impl and the real `ArchivedCard`), and the `unsupported` error (predicate + `Display` names the operation).
- `cargo test -p kanban-domain` green; `cargo build --workspace --tests` green (the error-mapping arm keeps the whole workspace compiling); clippy `-D warnings` and fmt clean.
