### PR TITLE
KAN-831/832 feat(persistence): board_id backfill migrations — JSON V7→V8 (B3) + SQLite 2→3 (B4)

### DIFF
--- a/.changeset/kan-831-json-board-id-backfill.md
+++ b/.changeset/kan-831-json-board-id-backfill.md
@@ -1,0 +1,15 @@
+---
+bump: patch
+---
+
+Internal persistence change with no user-visible behaviour. The JSON backend
+gains a V7->V8 format migration that backfills `board_id` onto historical
+`archived_cards` entries that predate the first-class field, reconstructing the
+value from each entry's `original_column_id` -> column -> board mapping. An
+archived card whose original column no longer resolves keeps a nil board id
+(unrecoverable, tolerated under the first-class model rather than failing the
+load). The migration also defensively drops any live `cards` entry that shadows
+an archived card by id, hardening the "archived cards are a discrete peer
+collection" invariant. A `.v7.backup` is written before the destructive step
+and removed on success, matching the existing chain policy. The board-scoping
+consumer that reads the backfilled field is deferred to a later slice.

--- a/.changeset/kan-832-sqlite-board-id-column.md
+++ b/.changeset/kan-832-sqlite-board-id-column.md
@@ -13,7 +13,12 @@ database, and preserves archived sprint logs. The `cards.column_id -> columns(id
 foreign key is dropped (the value stays `TEXT NOT NULL` and intact) so an
 archived card survives deletion of its original column; live-card cleanup on
 column delete is already explicit via the command tier, so the cascade was
-redundant. `list_archived_cards_by_board` now overrides with a direct `WHERE
+redundant. Because dropping that FK also removed the database-level backstop
+that rejected an orphaned live card, cross-backend store migration now enforces
+live-card column integrity explicitly: an orphaned live card is repaired to the
+first available column and, if none exists, the migration fails cleanly instead
+of writing an orphan (archived cards remain exempt, keeping their historical
+column). `list_archived_cards_by_board` now overrides with a direct `WHERE
 board_id = ?` query, and the archived-card exclusion filters switch to `NOT
 EXISTS`. The board-scoping consumer that reads the backfilled field is deferred
 to a later slice.

--- a/.changeset/kan-832-sqlite-board-id-column.md
+++ b/.changeset/kan-832-sqlite-board-id-column.md
@@ -1,0 +1,19 @@
+---
+bump: patch
+---
+
+Internal persistence change with no user-visible behaviour. The SQLite backend
+schema advances 2 -> 3: `archived_cards` gains a first-class `board_id TEXT NOT
+NULL` column (indexed via `idx_archived_cards_board_id`) and the 2 -> 3
+migration backfills it from each row's `original_column_id` -> `columns.board_id`
+mapping, falling back to a nil board id when the original column no longer
+resolves (unrecoverable, tolerated rather than failing the open). The migration
+runs before the schema is (re)applied, is idempotent on an already-migrated
+database, and preserves archived sprint logs. The `cards.column_id -> columns(id)`
+foreign key is dropped (the value stays `TEXT NOT NULL` and intact) so an
+archived card survives deletion of its original column; live-card cleanup on
+column delete is already explicit via the command tier, so the cascade was
+redundant. `list_archived_cards_by_board` now overrides with a direct `WHERE
+board_id = ?` query, and the archived-card exclusion filters switch to `NOT
+EXISTS`. The board-scoping consumer that reads the backfilled field is deferred
+to a later slice.

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -1309,7 +1309,7 @@ mod tests {
         );
     }
 
-    /// KAN-650: successful V6→V7 sync migration must clean up its
+    /// KAN-650: successful V6→V8 sync migration must clean up its
     /// `.v6.backup` once the chain completes. Mirrors the async
     /// `test_migrate_v6_to_v7_renames_parent_child_and_writes_backup`
     /// assertion that the backup is removed on success.
@@ -1343,7 +1343,7 @@ mod tests {
 
         assert!(
             !path.with_extension("v6.backup").exists(),
-            ".v6.backup must be removed after successful V6→V7 sync migration"
+            ".v6.backup must be removed after successful V6→V8 sync migration"
         );
     }
 
@@ -1376,7 +1376,7 @@ mod tests {
 
         assert!(
             !path.with_extension("v5.backup").exists(),
-            ".v5.backup must be removed after successful V5→V7 sync migration"
+            ".v5.backup must be removed after successful V5→V8 sync migration"
         );
     }
 
@@ -1407,7 +1407,7 @@ mod tests {
 
         assert!(
             !path.with_extension("v4.backup").exists(),
-            ".v4.backup must be removed after successful V4→V7 sync migration"
+            ".v4.backup must be removed after successful V4→V8 sync migration"
         );
     }
 
@@ -1438,13 +1438,13 @@ mod tests {
 
         assert!(
             !path.with_extension("v3.backup").exists(),
-            ".v3.backup must be removed after successful V3→V7 sync migration"
+            ".v3.backup must be removed after successful V3→V8 sync migration"
         );
     }
 
     /// KAN-660: V2 sources are now covered by the outer pre-V7 backup wrap.
     /// The wrap takes the backup BEFORE migrate_v2_to_v3_sync runs, so the
-    /// V2 original is captured. On successful V2→V7 the wrap cleans it up.
+    /// V2 original is captured. On successful V2→V8 the wrap cleans it up.
     /// (No paired failure-preservation test for V2: the V2 envelope shape
     /// can't cleanly inject the V6 both-keys ambiguity that drives the
     /// existing V6 failure test, and the outer-wrap failure-handling code
@@ -1475,13 +1475,13 @@ mod tests {
 
         assert!(
             !path.with_extension("v2.backup").exists(),
-            ".v2.backup must be removed after successful V2→V7 sync migration"
+            ".v2.backup must be removed after successful V2→V8 sync migration"
         );
     }
 
     /// KAN-660: V1 sources are now covered by the outer pre-V7 backup wrap.
     /// The .v1.backup is taken BEFORE migrate_v1_to_v2_sync runs and only
-    /// cleaned up after the entire V1→V7 chain succeeds — not after the
+    /// cleaned up after the entire V1→V8 chain succeeds — not after the
     /// V1→V2 step like the pre-KAN-660 per-step mechanism did. This means
     /// a mid-chain failure (e.g. during split_graph or v6_to_v7_rename)
     /// preserves the V1 original instead of losing it after V1→V2.
@@ -1505,7 +1505,7 @@ mod tests {
 
         assert!(
             !path.with_extension("v1.backup").exists(),
-            ".v1.backup must be removed after successful V1→V7 sync migration"
+            ".v1.backup must be removed after successful V1→V8 sync migration"
         );
     }
 

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -1,7 +1,8 @@
 use crate::atomic_writer::AtomicWriter;
 use crate::conflict::FileMetadata;
 use crate::migration::{
-    transform_to_v6_split_graph_value, transform_v2_to_v3_value, transform_v6_to_v7_value, Migrator,
+    transform_to_v6_split_graph_value, transform_v2_to_v3_value, transform_v6_to_v7_value,
+    transform_v7_to_v8_value, Migrator,
 };
 use kanban_persistence::{
     FormatVersion, PersistenceError, PersistenceMetadata, PersistenceResult, PersistenceStore,
@@ -84,19 +85,19 @@ impl JsonEnvelope {
 
 // ─── Sync migration helpers ───────────────────────────────────────────────────
 
-/// Synchronous V*→V7 migration chain used by [`JsonFileStore::load_sync`].
+/// Synchronous V*→latest migration chain used by [`JsonFileStore::load_sync`].
 /// See [`migration::backup`] for the backup-path policy shared with the
 /// async [`Migrator::migrate`] orchestrator.
-fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec<u8>> {
+fn migrate_to_latest_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec<u8>> {
     // Take the outer backup BEFORE any per-step migration runs. The chain
-    // (V1→V2, V2→V3, split_graph, v6_to_v7_rename) overwrites the file in
-    // place at each step; without this outer backup a mid-chain failure
-    // would leave the user with a partially-transformed file and no
-    // rollback artifact. The backup is removed only on full V→V7 success.
-    let backup_path = crate::migration::pre_v7_backup_path_for(from, path);
+    // (V1→V2, V2→V3, split_graph, v6_to_v7_rename, v7_to_v8) overwrites the
+    // file in place at each step; without this outer backup a mid-chain
+    // failure would leave the user with a partially-transformed file and no
+    // rollback artifact. The backup is removed only on full V→latest success.
+    let backup_path = crate::migration::pre_latest_backup_path_for(from, path);
     if let Some(backup) = &backup_path {
         std::fs::copy(path, backup)?;
-        tracing::info!("Created pre-V7 backup at {}", backup.display());
+        tracing::info!("Created pre-V8 backup at {}", backup.display());
     }
 
     let result = (|| -> PersistenceResult<Vec<u8>> {
@@ -106,7 +107,7 @@ fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec
         if from <= FormatVersion::V2 {
             migrate_v2_to_v3_sync(path)?;
         }
-        run_split_and_rename_chain_sync(from, path)
+        run_split_and_upgrade_chain_sync(from, path)
     })();
 
     match (result, backup_path) {
@@ -118,14 +119,14 @@ fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec
                     e
                 );
             } else {
-                tracing::info!("Migration to V7 verified, backup removed");
+                tracing::info!("Migration to V8 verified, backup removed");
             }
             Ok(bytes)
         }
         (Ok(bytes), None) => Ok(bytes),
         (Err(e), Some(backup)) => {
             tracing::error!(
-                "Migration to V7 failed: {}. Backup preserved at {}",
+                "Migration to V8 failed: {}. Backup preserved at {}",
                 e,
                 backup.display()
             );
@@ -135,18 +136,23 @@ fn migrate_to_v7_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec
     }
 }
 
-/// Sync sibling of [`Migrator::run_split_and_rename_chain`]. Runs the V6
-/// split-graph transform (only if the file is pre-V6) and then the v6→v7
-/// spawns-bucket rename, returning the final on-disk bytes.
-fn run_split_and_rename_chain_sync(from: FormatVersion, path: &Path) -> PersistenceResult<Vec<u8>> {
+/// Sync sibling of [`Migrator::run_split_and_upgrade_chain`]. Runs the V6
+/// split-graph transform (only if the file is pre-V6), the v6→v7
+/// spawns-bucket rename, then the v7→v8 archived-cards backfill, returning
+/// the final on-disk bytes.
+fn run_split_and_upgrade_chain_sync(
+    from: FormatVersion,
+    path: &Path,
+) -> PersistenceResult<Vec<u8>> {
     if from < FormatVersion::V6 {
         split_graph_sync(path)?;
     }
-    v6_to_v7_rename_sync(path)
+    v6_to_v7_rename_sync(path)?;
+    v7_to_v8_archived_cards_sync(path)
 }
 
 fn migrate_v1_to_v2_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
-    // Per-step backup removed: the outer migrate_to_v7_sync wrap owns the
+    // Per-step backup removed: the outer migrate_to_latest_sync wrap owns the
     // .v1.backup now and keeps it for the entire chain, not just this step.
     let content = std::fs::read_to_string(path)?;
     let v1_data: serde_json::Value = serde_json::from_str(&content)
@@ -198,6 +204,22 @@ fn v6_to_v7_rename_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
     AtomicWriter::write_atomic_sync(path, &json_bytes)?;
     tracing::info!(
         "Applied v6→v7 spawns-rename migration to {} (sync)",
+        path.display()
+    );
+    Ok(json_bytes)
+}
+
+fn v7_to_v8_archived_cards_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
+    let content = std::fs::read_to_string(path)?;
+    let mut envelope: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    transform_v7_to_v8_value(&mut envelope)?;
+    let json_str = serde_json::to_string_pretty(&envelope)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    let json_bytes = json_str.into_bytes();
+    AtomicWriter::write_atomic_sync(path, &json_bytes)?;
+    tracing::info!(
+        "Applied v7→v8 archived-cards board_id backfill to {} (sync)",
         path.display()
     );
     Ok(json_bytes)
@@ -309,7 +331,7 @@ impl PersistenceStore for JsonFileStore {
         let data_value: serde_json::Value = serde_json::from_slice(&snapshot.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
         let envelope = JsonEnvelope {
-            version: 7,
+            version: 8,
             metadata: snapshot.metadata.clone(),
             data: data_value,
         };
@@ -339,14 +361,14 @@ impl PersistenceStore for JsonFileStore {
     async fn load(&self) -> PersistenceResult<(StoreSnapshot, PersistenceMetadata)> {
         let current_version = Migrator::detect_version(&self.path).await?;
 
-        if current_version < FormatVersion::V7 {
+        if current_version < FormatVersion::MAX {
             tracing::info!(
-                "Detected {:?} format at {}. Migrating to V7...",
+                "Detected {:?} format at {}. Migrating to V8...",
                 current_version,
                 self.path.display()
             );
-            Migrator::migrate(current_version, FormatVersion::V7, &self.path).await?;
-            tracing::info!("Migration to V7 completed successfully");
+            Migrator::migrate(current_version, FormatVersion::MAX, &self.path).await?;
+            tracing::info!("Migration to V8 completed successfully");
         }
 
         let file_bytes = tokio::fs::read(&self.path).await?;
@@ -399,13 +421,13 @@ impl PersistenceStore for JsonFileStore {
 
         let current_version = Migrator::detect_version_from_value(&value)?;
 
-        let final_bytes = if current_version < FormatVersion::V7 {
+        let final_bytes = if current_version < FormatVersion::MAX {
             tracing::info!(
-                "Detected {:?} format at {}. Migrating to V7 (sync)...",
+                "Detected {:?} format at {}. Migrating to V8 (sync)...",
                 current_version,
                 self.path.display()
             );
-            migrate_to_v7_sync(current_version, &self.path)?
+            migrate_to_latest_sync(current_version, &self.path)?
         } else {
             file_bytes
         };
@@ -552,7 +574,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 7
+                    binary_max: 8
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -582,7 +604,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 7
+                    binary_max: 8
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -685,7 +707,7 @@ mod tests {
 
         let after = tokio::fs::read_to_string(&file_path).await.unwrap();
         let v: serde_json::Value = serde_json::from_str(&after).unwrap();
-        assert_eq!(v["version"], 7, "load must migrate V6 to V7 on disk");
+        assert_eq!(v["version"], 8, "load must migrate V6 to V8 on disk");
         let graph = v["data"]["graph"].as_object().expect("graph object");
         assert!(
             graph.contains_key("spawns"),
@@ -745,7 +767,7 @@ mod tests {
 
         let after = std::fs::read_to_string(&file_path).unwrap();
         let v: serde_json::Value = serde_json::from_str(&after).unwrap();
-        assert_eq!(v["version"], 7, "load_sync must migrate V6 to V7 on disk");
+        assert_eq!(v["version"], 8, "load_sync must migrate V6 to V8 on disk");
         let graph = v["data"]["graph"].as_object().expect("graph object");
         assert!(
             graph.contains_key("spawns"),
@@ -762,6 +784,169 @@ mod tests {
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0]["source"], parent);
         assert_eq!(edges[0]["target"], child);
+    }
+
+    fn v7_fixture_with_archived_card(
+        board: &str,
+        column: &str,
+        original_column: &str,
+    ) -> serde_json::Value {
+        json!({
+            "version": 7,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [{ "id": board, "name": "B" }],
+                "columns": [{ "id": column, "board_id": board }],
+                "cards": [],
+                "archived_cards": [{
+                    "card": { "id": "33333333-3333-3333-3333-333333333333", "title": "T" },
+                    "archived_at": "2024-01-01T00:00:00Z",
+                    "original_column_id": original_column,
+                    "original_position": 0
+                }],
+                "sprints": [],
+                "graph": {
+                    "spawns": { "edges": [] },
+                    "blocks": { "edges": [] },
+                    "relates": { "edges": [] }
+                }
+            }
+        })
+    }
+
+    /// D7 round-trip: a historical V7 file whose archived card has NO
+    /// `board_id` must, on load, migrate to V8 on disk AND backfill the
+    /// board_id from `original_column_id` -> column.board_id. Then a
+    /// subsequent save+reload must preserve the backfilled value (byte-stable
+    /// archived_cards), proving the migration is data-preserving.
+    #[tokio::test]
+    async fn test_json_archived_card_v7_file_migrates_and_backfills_board_id() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("v7_archived.json");
+        let board = "11111111-1111-1111-1111-111111111111";
+        let column = "22222222-2222-2222-2222-222222222222";
+        let fixture = v7_fixture_with_archived_card(board, column, column);
+        tokio::fs::write(&file_path, serde_json::to_string_pretty(&fixture).unwrap())
+            .await
+            .unwrap();
+
+        let store = JsonFileStore::new(&file_path);
+        let (snapshot, metadata) = store.load().await.unwrap();
+
+        // On-disk: migrated to V8 with board_id backfilled.
+        let on_disk: serde_json::Value =
+            serde_json::from_slice(&tokio::fs::read(&file_path).await.unwrap()).unwrap();
+        assert_eq!(on_disk["version"], 8, "load must migrate V7 to V8 on disk");
+        assert_eq!(
+            on_disk["data"]["archived_cards"][0]["board_id"]
+                .as_str()
+                .unwrap(),
+            board,
+            "board_id must be backfilled from original_column_id"
+        );
+
+        // The loaded snapshot data carries the backfilled board_id.
+        let loaded_data: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
+        let archived_before: serde_json::Value = loaded_data["archived_cards"].clone();
+        assert_eq!(archived_before[0]["board_id"].as_str().unwrap(), board);
+
+        // Save the reloaded snapshot and read it back: archived_cards stable.
+        store
+            .save(StoreSnapshot {
+                data: snapshot.data.clone(),
+                metadata,
+            })
+            .await
+            .unwrap();
+        let (reloaded, _) = store.load().await.unwrap();
+        let reloaded_data: serde_json::Value = serde_json::from_slice(&reloaded.data).unwrap();
+        assert_eq!(
+            reloaded_data["archived_cards"], archived_before,
+            "archived_cards must survive save->reload byte-stable"
+        );
+    }
+
+    /// A V7 archived card whose `original_column_id` no longer resolves to a
+    /// column keeps a nil `board_id` (unrecoverable, acceptable) and the load
+    /// still succeeds.
+    #[tokio::test]
+    async fn test_json_archived_card_v7_dangling_column_keeps_nil_board_id() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("v7_dangling.json");
+        let board = "11111111-1111-1111-1111-111111111111";
+        let column = "22222222-2222-2222-2222-222222222222";
+        let missing = "99999999-9999-9999-9999-999999999999";
+        let fixture = v7_fixture_with_archived_card(board, column, missing);
+        tokio::fs::write(&file_path, serde_json::to_string_pretty(&fixture).unwrap())
+            .await
+            .unwrap();
+
+        let store = JsonFileStore::new(&file_path);
+        let (snapshot, _) = store.load().await.unwrap();
+
+        let loaded_data: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
+        assert_eq!(
+            loaded_data["archived_cards"][0]["board_id"]
+                .as_str()
+                .unwrap(),
+            uuid::Uuid::nil().to_string(),
+            "a dangling original_column_id yields nil board_id, not a load failure"
+        );
+    }
+
+    /// The V7->V8 migration writes a `.v7.backup` before the destructive
+    /// step and removes it on success.
+    #[tokio::test]
+    async fn test_load_v7_to_v8_cleans_up_v7_backup_on_success() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("v7_backup.json");
+        let board = "11111111-1111-1111-1111-111111111111";
+        let column = "22222222-2222-2222-2222-222222222222";
+        let fixture = v7_fixture_with_archived_card(board, column, column);
+        tokio::fs::write(&file_path, serde_json::to_string_pretty(&fixture).unwrap())
+            .await
+            .unwrap();
+
+        let store = JsonFileStore::new(&file_path);
+        let _ = store.load().await.unwrap();
+
+        assert!(
+            !file_path.with_extension("v7.backup").exists(),
+            ".v7.backup must be removed after a successful V7->V8 load"
+        );
+    }
+
+    /// Sync analogue: `load_sync` must migrate V7->V8 and backfill board_id
+    /// with the same observable result as the async path.
+    #[test]
+    fn test_load_sync_v7_to_v8_backfills_board_id() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("v7_sync.json");
+        let board = "11111111-1111-1111-1111-111111111111";
+        let column = "22222222-2222-2222-2222-222222222222";
+        let fixture = v7_fixture_with_archived_card(board, column, column);
+        std::fs::write(&file_path, serde_json::to_string_pretty(&fixture).unwrap()).unwrap();
+
+        let store = JsonFileStore::new(&file_path);
+        let (snapshot, _) = store.load_sync().unwrap().expect("file exists");
+
+        let on_disk: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&file_path).unwrap()).unwrap();
+        assert_eq!(on_disk["version"], 8, "load_sync must migrate V7 to V8");
+        let loaded_data: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
+        assert_eq!(
+            loaded_data["archived_cards"][0]["board_id"]
+                .as_str()
+                .unwrap(),
+            board
+        );
+        assert!(
+            !file_path.with_extension("v7.backup").exists(),
+            ".v7.backup must be removed after a successful V7->V8 load_sync"
+        );
     }
 
     /// Files with stale `commands`/`undo_cursor`/`baseline_data`/
@@ -889,7 +1074,7 @@ mod tests {
         let file_path = dir.path().join("clean.json");
 
         let clean = json!({
-            "version": 7,
+            "version": 8,
             "metadata": {
                 "instance_id": "550e8400-e29b-41d4-a716-446655440000",
                 "saved_at": "2024-01-01T00:00:00Z"
@@ -1154,7 +1339,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
 
         assert!(
             !path.with_extension("v6.backup").exists(),
@@ -1187,7 +1372,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
 
         assert!(
             !path.with_extension("v5.backup").exists(),
@@ -1218,7 +1403,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
 
         assert!(
             !path.with_extension("v4.backup").exists(),
@@ -1249,7 +1434,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
 
         assert!(
             !path.with_extension("v3.backup").exists(),
@@ -1286,7 +1471,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
 
         assert!(
             !path.with_extension("v2.backup").exists(),
@@ -1316,7 +1501,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
 
         assert!(
             !path.with_extension("v1.backup").exists(),

--- a/crates/kanban-persistence-json/src/migration/backup.rs
+++ b/crates/kanban-persistence-json/src/migration/backup.rs
@@ -1,20 +1,21 @@
 //! Shared backup-path policy used by both the async `Migrator::migrate`
-//! orchestrator and the sync `migrate_to_v7_sync` chain.
+//! orchestrator and the sync `migrate_to_latest_sync` chain.
 //!
-//! The destructive V→V7 chain (per-step migrations plus `split_graph`
-//! and `v6_to_v7_rename`) runs against a freshly-written file via the
-//! atomic temp+rename pattern. A pre-chain `.v{N}.backup` is the user's
-//! rollback artifact if any step fails mid-chain. The backup is taken
-//! before the first per-step migration runs and removed only on full
-//! V→V7 success, so it covers the entire chain from V1/V2/V3/V4/V5/V6
-//! all the way to V7.
+//! The destructive V→MAX chain (per-step migrations plus `split_graph`,
+//! `v6_to_v7_rename`, and `v7_to_v8_archived_cards`) runs against a
+//! freshly-written file via the atomic temp+rename pattern. A pre-chain
+//! `.v{N}.backup` is the user's rollback artifact if any step fails
+//! mid-chain. The backup is taken before the first per-step migration
+//! runs and removed only on full V→MAX success, so it covers the entire
+//! chain from V1/V2/V3/V4/V5/V6/V7 all the way to the latest version.
 
 use kanban_persistence::FormatVersion;
 use std::path::{Path, PathBuf};
 
 /// Return `Some(path.vN.backup)` for source versions that need a
-/// pre-V7-chain backup; `None` for V7 (no migration needed).
-pub(crate) fn pre_v7_backup_path_for(from: FormatVersion, path: &Path) -> Option<PathBuf> {
+/// pre-latest-chain backup; `None` for the current MAX version (no
+/// migration needed).
+pub(crate) fn pre_latest_backup_path_for(from: FormatVersion, path: &Path) -> Option<PathBuf> {
     match from {
         FormatVersion::V1 => Some(path.with_extension("v1.backup")),
         FormatVersion::V2 => Some(path.with_extension("v2.backup")),
@@ -22,6 +23,7 @@ pub(crate) fn pre_v7_backup_path_for(from: FormatVersion, path: &Path) -> Option
         FormatVersion::V4 => Some(path.with_extension("v4.backup")),
         FormatVersion::V5 => Some(path.with_extension("v5.backup")),
         FormatVersion::V6 => Some(path.with_extension("v6.backup")),
+        FormatVersion::V7 => Some(path.with_extension("v7.backup")),
         _ => None,
     }
 }
@@ -38,7 +40,7 @@ mod tests {
     #[test]
     fn returns_some_for_v1() {
         assert_eq!(
-            pre_v7_backup_path_for(FormatVersion::V1, &p()),
+            pre_latest_backup_path_for(FormatVersion::V1, &p()),
             Some(PathBuf::from("/tmp/board.v1.backup"))
         );
     }
@@ -46,7 +48,7 @@ mod tests {
     #[test]
     fn returns_some_for_v2() {
         assert_eq!(
-            pre_v7_backup_path_for(FormatVersion::V2, &p()),
+            pre_latest_backup_path_for(FormatVersion::V2, &p()),
             Some(PathBuf::from("/tmp/board.v2.backup"))
         );
     }
@@ -54,7 +56,7 @@ mod tests {
     #[test]
     fn returns_some_for_v3() {
         assert_eq!(
-            pre_v7_backup_path_for(FormatVersion::V3, &p()),
+            pre_latest_backup_path_for(FormatVersion::V3, &p()),
             Some(PathBuf::from("/tmp/board.v3.backup"))
         );
     }
@@ -62,7 +64,7 @@ mod tests {
     #[test]
     fn returns_some_for_v4() {
         assert_eq!(
-            pre_v7_backup_path_for(FormatVersion::V4, &p()),
+            pre_latest_backup_path_for(FormatVersion::V4, &p()),
             Some(PathBuf::from("/tmp/board.v4.backup"))
         );
     }
@@ -70,7 +72,7 @@ mod tests {
     #[test]
     fn returns_some_for_v5() {
         assert_eq!(
-            pre_v7_backup_path_for(FormatVersion::V5, &p()),
+            pre_latest_backup_path_for(FormatVersion::V5, &p()),
             Some(PathBuf::from("/tmp/board.v5.backup"))
         );
     }
@@ -78,14 +80,23 @@ mod tests {
     #[test]
     fn returns_some_for_v6() {
         assert_eq!(
-            pre_v7_backup_path_for(FormatVersion::V6, &p()),
+            pre_latest_backup_path_for(FormatVersion::V6, &p()),
             Some(PathBuf::from("/tmp/board.v6.backup"))
         );
     }
 
     #[test]
-    fn returns_none_for_v7() {
-        // V7→V7 is a no-op upstream; should never reach the chain.
-        assert_eq!(pre_v7_backup_path_for(FormatVersion::V7, &p()), None);
+    fn returns_some_for_v7() {
+        // V7 is now a migratable source (V7→V8 archived-cards backfill).
+        assert_eq!(
+            pre_latest_backup_path_for(FormatVersion::V7, &p()),
+            Some(PathBuf::from("/tmp/board.v7.backup"))
+        );
+    }
+
+    #[test]
+    fn returns_none_for_v8() {
+        // V8→V8 is a no-op upstream; should never reach the chain.
+        assert_eq!(pre_latest_backup_path_for(FormatVersion::V8, &p()), None);
     }
 }

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -62,18 +62,18 @@ impl Migrator {
                 super::v2_to_v3::migrate_v2_to_v3(path).await
             }
             (FormatVersion::V2, FormatVersion::V3) => super::v2_to_v3::migrate_v2_to_v3(path).await,
-            (_, FormatVersion::V7) if from < FormatVersion::V7 => {
+            (_, FormatVersion::V8) if from < FormatVersion::V8 => {
                 // See `migration::backup` for the source-version → backup-path
                 // policy shared with the sync orchestrator. A `.v{N}.backup`
                 // is the user's escape hatch if the upgrade has to be rolled
-                // back, since V7 files cannot be opened by pre-V7 binaries.
+                // back, since V8 files cannot be opened by pre-V8 binaries.
                 // The backup is taken BEFORE any per-step migration runs so
                 // it covers the entire chain (V1→V2, V2→V3, split_graph,
-                // v6→v7), not just the destructive tail.
-                let backup_path = super::pre_v7_backup_path_for(from, path);
+                // v6→v7, v7→v8), not just the destructive tail.
+                let backup_path = super::pre_latest_backup_path_for(from, path);
                 if let Some(backup) = &backup_path {
                     tokio::fs::copy(path, backup).await?;
-                    tracing::info!("Created pre-V7 backup at {}", backup.display());
+                    tracing::info!("Created pre-V8 backup at {}", backup.display());
                 }
 
                 let result: PersistenceResult<()> = async {
@@ -85,9 +85,9 @@ impl Migrator {
                     }
                     // V3, V4, and V5 all share the pre-split graph schema; the
                     // split-graph transform is the only step that distinguishes
-                    // them. V6 files skip the split-graph step entirely and go
-                    // straight to the v6→v7 rename.
-                    Self::run_split_and_rename_chain(from, path).await
+                    // them. V6 files skip the split-graph step entirely; V7
+                    // files skip straight to the v7→v8 archived-cards backfill.
+                    Self::run_split_and_upgrade_chain(from, path).await
                 }
                 .await;
 
@@ -100,14 +100,14 @@ impl Migrator {
                                 e
                             );
                         } else {
-                            tracing::info!("Migration to V7 verified, backup removed");
+                            tracing::info!("Migration to V8 verified, backup removed");
                         }
                         Ok(())
                     }
                     (Ok(()), None) => Ok(()),
                     (Err(e), Some(backup)) => {
                         tracing::error!(
-                            "Migration to V7 failed: {}. Backup preserved at {}",
+                            "Migration to V8 failed: {}. Backup preserved at {}",
                             e,
                             backup.display()
                         );
@@ -123,15 +123,20 @@ impl Migrator {
         }
     }
 
-    /// Run the V6 split-graph transform (only if the file is pre-V6) and
-    /// then the v6→v7 spawns-bucket rename. Both steps are no-ops when
-    /// they don't apply (split_graph short-circuits on V6, v6_to_v7 on V7),
-    /// so this is safe to call for any `from < V7`.
-    async fn run_split_and_rename_chain(from: FormatVersion, path: &Path) -> PersistenceResult<()> {
+    /// Run the V6 split-graph transform (only if the file is pre-V6), the
+    /// v6→v7 spawns-bucket rename, then the v7→v8 archived-cards backfill.
+    /// Every step is a no-op when it doesn't apply (split_graph
+    /// short-circuits on V6, v6_to_v7 on V7, v7_to_v8 on V8), so this is
+    /// safe to call for any `from < V8` and always leaves the file at V8.
+    async fn run_split_and_upgrade_chain(
+        from: FormatVersion,
+        path: &Path,
+    ) -> PersistenceResult<()> {
         if from < FormatVersion::V6 {
             super::split_graph::migrate_to_v6_split_graph(path).await?;
         }
-        super::v6_to_v7_rename::migrate_v6_to_v7(path).await
+        super::v6_to_v7_rename::migrate_v6_to_v7(path).await?;
+        super::v7_to_v8_archived_cards::migrate_v7_to_v8(path).await
     }
 
     /// Migrate from V1 format to V2 format. Per-step backup removed: the
@@ -336,13 +341,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V4, FormatVersion::V7, &path)
+        Migrator::migrate(FormatVersion::V4, FormatVersion::V8, &path)
             .await
             .unwrap();
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(
             after["data"]["graph"]
@@ -381,13 +386,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V5, FormatVersion::V7, &path)
+        Migrator::migrate(FormatVersion::V5, FormatVersion::V8, &path)
             .await
             .unwrap();
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(after["data"]["graph"]["relates"].is_object());
         assert!(
@@ -424,13 +429,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V6, FormatVersion::V7, &path)
+        Migrator::migrate(FormatVersion::V6, FormatVersion::V8, &path)
             .await
             .unwrap();
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(after["data"]["graph"]
             .as_object()
@@ -493,7 +498,7 @@ mod tests {
             .await
             .unwrap();
 
-        let err = Migrator::migrate(FormatVersion::V6, FormatVersion::V7, &path)
+        let err = Migrator::migrate(FormatVersion::V6, FormatVersion::V8, &path)
             .await
             .expect_err("migration must refuse a V6 envelope carrying both bucket keys");
         let msg = err.to_string();
@@ -521,7 +526,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 7
+                    binary_max: 8
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -543,7 +548,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                PersistenceError::UnsupportedFutureVersion { binary_max: 7, .. }
+                PersistenceError::UnsupportedFutureVersion { binary_max: 8, .. }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
         );
@@ -568,7 +573,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 7
+                    binary_max: 8
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -663,13 +668,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V2, FormatVersion::V7, &path)
+        Migrator::migrate(FormatVersion::V2, FormatVersion::V8, &path)
             .await
             .expect("V2→V7 must succeed");
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
 
         assert!(
             !path.with_extension("v2.backup").exists(),
@@ -691,17 +696,73 @@ mod tests {
         });
         tokio::fs::write(&path, v1.to_string()).await.unwrap();
 
-        Migrator::migrate(FormatVersion::V1, FormatVersion::V7, &path)
+        Migrator::migrate(FormatVersion::V1, FormatVersion::V8, &path)
             .await
             .expect("V1→V7 must succeed");
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 7);
+        assert_eq!(after["version"], 8);
 
         assert!(
             !path.with_extension("v1.backup").exists(),
             ".v1.backup must be removed after successful V1→V7 migration"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_migrate_v7_to_v8_backfills_and_writes_backup() {
+        // The new V7→V8 step: backfill board_id from the column graph, take a
+        // .v7.backup before the destructive write, and clean it up on success.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v7.json");
+        let board = "11111111-1111-1111-1111-111111111111";
+        let column = "22222222-2222-2222-2222-222222222222";
+        let v7 = json!({
+            "version": 7,
+            "metadata": {
+                "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [{ "id": board, "name": "B" }],
+                "columns": [{ "id": column, "board_id": board }],
+                "cards": [],
+                "archived_cards": [{
+                    "card": { "id": "33333333-3333-3333-3333-333333333333", "title": "T" },
+                    "archived_at": "2024-01-01T00:00:00Z",
+                    "original_column_id": column,
+                    "original_position": 0
+                }],
+                "sprints": [],
+                "graph": {
+                    "spawns": { "edges": [] },
+                    "blocks": { "edges": [] },
+                    "relates": { "edges": [] }
+                }
+            }
+        });
+        tokio::fs::write(&path, serde_json::to_string_pretty(&v7).unwrap())
+            .await
+            .unwrap();
+
+        Migrator::migrate(FormatVersion::V7, FormatVersion::V8, &path)
+            .await
+            .expect("V7→V8 must succeed");
+
+        let after: Value =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert_eq!(after["version"], 8);
+        assert_eq!(
+            after["data"]["archived_cards"][0]["board_id"]
+                .as_str()
+                .unwrap(),
+            board,
+            "board_id must be backfilled from original_column_id"
+        );
+        assert!(
+            !path.with_extension("v7.backup").exists(),
+            ".v7.backup must be removed after successful V7→V8 migration"
         );
     }
 }

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -141,7 +141,7 @@ impl Migrator {
 
     /// Migrate from V1 format to V2 format. Per-step backup removed: the
     /// outer `Migrator::migrate` wrap owns the `.v1.backup` now and keeps
-    /// it for the entire V1→V7 chain, not just this step.
+    /// it for the entire V1→V8 chain, not just this step.
     async fn migrate_v1_to_v2(path: &Path) -> PersistenceResult<()> {
         let content = tokio::fs::read_to_string(path).await?;
         let v1_data: Value = serde_json::from_str(&content)
@@ -643,7 +643,7 @@ mod tests {
         assert_eq!(card["card_number"], 1);
     }
 
-    /// KAN-660: V2 source migrating to V7 via Migrator::migrate is now
+    /// KAN-660: V2 source migrating to V8 via Migrator::migrate is now
     /// covered by the outer backup wrap. .v2.backup is created before
     /// migrate_v2_to_v3 runs and cleaned up after the full chain succeeds.
     /// (No paired failure-preservation test: the V2 envelope shape can't
@@ -670,7 +670,7 @@ mod tests {
 
         Migrator::migrate(FormatVersion::V2, FormatVersion::V8, &path)
             .await
-            .expect("V2→V7 must succeed");
+            .expect("V2→V8 must succeed");
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
@@ -678,13 +678,13 @@ mod tests {
 
         assert!(
             !path.with_extension("v2.backup").exists(),
-            ".v2.backup must be removed after successful V2→V7 migration"
+            ".v2.backup must be removed after successful V2→V8 migration"
         );
     }
 
-    /// KAN-660: V1 source migrating to V7 via Migrator::migrate is now
+    /// KAN-660: V1 source migrating to V8 via Migrator::migrate is now
     /// covered by the outer backup wrap. The .v1.backup persists across
-    /// the entire V1→V7 chain rather than being removed after V1→V2.
+    /// the entire V1→V8 chain rather than being removed after V1→V2.
     #[tokio::test]
     async fn test_migrate_v1_to_v7_cleans_up_v1_backup_on_success() {
         let dir = tempdir().unwrap();
@@ -698,7 +698,7 @@ mod tests {
 
         Migrator::migrate(FormatVersion::V1, FormatVersion::V8, &path)
             .await
-            .expect("V1→V7 must succeed");
+            .expect("V1→V8 must succeed");
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
@@ -706,7 +706,7 @@ mod tests {
 
         assert!(
             !path.with_extension("v1.backup").exists(),
-            ".v1.backup must be removed after successful V1→V7 migration"
+            ".v1.backup must be removed after successful V1→V8 migration"
         );
     }
 

--- a/crates/kanban-persistence-json/src/migration/mod.rs
+++ b/crates/kanban-persistence-json/src/migration/mod.rs
@@ -6,11 +6,10 @@ pub mod v2_to_v3;
 pub mod v6_to_v7_rename;
 pub mod v7_to_v8_archived_cards;
 
-pub(crate) use backup::pre_v7_backup_path_for;
+pub(crate) use backup::pre_latest_backup_path_for;
 pub use migrator::Migrator;
 pub(crate) use split_graph::transform_to_v6_split_graph_value;
 pub use v1_to_v2::V1ToV2Migration;
 pub(crate) use v2_to_v3::transform_v2_to_v3_value;
 pub(crate) use v6_to_v7_rename::transform_v6_to_v7_value;
-#[allow(unused_imports)]
 pub(crate) use v7_to_v8_archived_cards::transform_v7_to_v8_value;

--- a/crates/kanban-persistence-json/src/migration/mod.rs
+++ b/crates/kanban-persistence-json/src/migration/mod.rs
@@ -4,6 +4,7 @@ pub mod split_graph;
 pub mod v1_to_v2;
 pub mod v2_to_v3;
 pub mod v6_to_v7_rename;
+pub mod v7_to_v8_archived_cards;
 
 pub(crate) use backup::pre_v7_backup_path_for;
 pub use migrator::Migrator;
@@ -11,3 +12,5 @@ pub(crate) use split_graph::transform_to_v6_split_graph_value;
 pub use v1_to_v2::V1ToV2Migration;
 pub(crate) use v2_to_v3::transform_v2_to_v3_value;
 pub(crate) use v6_to_v7_rename::transform_v6_to_v7_value;
+#[allow(unused_imports)]
+pub(crate) use v7_to_v8_archived_cards::transform_v7_to_v8_value;

--- a/crates/kanban-persistence-json/src/migration/v7_to_v8_archived_cards.rs
+++ b/crates/kanban-persistence-json/src/migration/v7_to_v8_archived_cards.rs
@@ -24,15 +24,106 @@
 //!                      "original_column_id": "col-1", ... }]
 //! ```
 
-use kanban_persistence::PersistenceResult;
+use kanban_persistence::{PersistenceError, PersistenceResult};
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+/// Apply the V8 archived-cards backfill migration to a JSON file in-place,
+/// atomic write. Output is V8.
+pub(crate) async fn migrate_v7_to_v8(path: &Path) -> PersistenceResult<()> {
+    let content = tokio::fs::read_to_string(path).await?;
+    let mut envelope: Value = serde_json::from_str(&content)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+
+    transform_v7_to_v8_value(&mut envelope)?;
+
+    let json_str = serde_json::to_string_pretty(&envelope)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    crate::atomic_writer::AtomicWriter::write_atomic(path, json_str.as_bytes()).await?;
+    tracing::info!(
+        "Applied v7→v8 archived-cards board_id backfill to {}",
+        path.display()
+    );
+    Ok(())
+}
 
 /// Pure transform on an already-parsed envelope.
 ///
-/// STUB (red): does nothing. The real V7→V8 backfill is implemented in the
-/// green step. Kept as a no-op so the failing unit tests compile and pin the
-/// expected behavior.
-pub(crate) fn transform_v7_to_v8_value(_envelope: &mut Value) -> PersistenceResult<()> {
+/// Idempotent: if the envelope already declares `version: 8` (or higher)
+/// it is returned unchanged.
+///
+/// For each archived card lacking a `board_id` key, backfills it from the
+/// `original_column_id`→column→`board_id` map. A dangling `original_column_id`
+/// (no matching column) yields a nil UUID, which the domain treats as
+/// "unknown board" and omits from summaries.
+pub(crate) fn transform_v7_to_v8_value(envelope: &mut Value) -> PersistenceResult<()> {
+    if envelope
+        .get("version")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0)
+        >= 8
+    {
+        return Ok(());
+    }
+
+    if let Some(data) = envelope.get_mut("data").and_then(|d| d.as_object_mut()) {
+        // Build column_id -> board_id map from the live column graph.
+        let col_to_board: HashMap<String, Value> = data
+            .get("columns")
+            .and_then(|c| c.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|c| {
+                let id = c.get("id")?.as_str()?.to_string();
+                let board_id = c.get("board_id")?.clone();
+                Some((id, board_id))
+            })
+            .collect();
+
+        let nil = || Value::String(uuid::Uuid::nil().to_string());
+
+        // Backfill board_id and collect archived card ids for the de-dup step.
+        let mut archived_ids: HashSet<String> = HashSet::new();
+        if let Some(archived) = data
+            .get_mut("archived_cards")
+            .and_then(|a| a.as_array_mut())
+        {
+            for ac in archived.iter_mut() {
+                if let Some(id) = ac
+                    .get("card")
+                    .and_then(|c| c.get("id"))
+                    .and_then(|v| v.as_str())
+                {
+                    archived_ids.insert(id.to_string());
+                }
+                if ac.get("board_id").is_none() {
+                    let board_id = ac
+                        .get("original_column_id")
+                        .and_then(|v| v.as_str())
+                        .and_then(|c| col_to_board.get(c))
+                        .cloned()
+                        .unwrap_or_else(nil);
+                    if let Some(obj) = ac.as_object_mut() {
+                        obj.insert("board_id".to_string(), board_id);
+                    }
+                }
+            }
+        }
+
+        // Defensive: an archived card must never also appear in the live
+        // `cards` array. Drop any shadowing entry to enforce the invariant.
+        if let Some(cards) = data.get_mut("cards").and_then(|c| c.as_array_mut()) {
+            cards.retain(|c| {
+                c.get("id")
+                    .and_then(|v| v.as_str())
+                    .map(|id| !archived_ids.contains(id))
+                    .unwrap_or(true)
+            });
+        }
+    }
+
+    envelope["version"] = Value::Number(8.into());
     Ok(())
 }
 
@@ -40,6 +131,7 @@ pub(crate) fn transform_v7_to_v8_value(_envelope: &mut Value) -> PersistenceResu
 mod tests {
     use super::*;
     use serde_json::json;
+    use tempfile::tempdir;
 
     const BOARD: &str = "11111111-1111-1111-1111-111111111111";
     const COLUMN: &str = "22222222-2222-2222-2222-222222222222";
@@ -164,6 +256,28 @@ mod tests {
                 .unwrap(),
             existing,
             "an already-present board_id must be preserved, not clobbered"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_migrate_v7_to_v8_writes_file_with_version_8() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v7.json");
+        let env = make_v7_envelope(json!([archived_card(COLUMN)]), json!([]));
+        tokio::fs::write(&path, serde_json::to_string_pretty(&env).unwrap())
+            .await
+            .unwrap();
+
+        migrate_v7_to_v8(&path).await.unwrap();
+
+        let after: Value =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert_eq!(after["version"], 8);
+        assert_eq!(
+            after["data"]["archived_cards"][0]["board_id"]
+                .as_str()
+                .unwrap(),
+            BOARD
         );
     }
 }

--- a/crates/kanban-persistence-json/src/migration/v7_to_v8_archived_cards.rs
+++ b/crates/kanban-persistence-json/src/migration/v7_to_v8_archived_cards.rs
@@ -1,0 +1,169 @@
+//! V8 archived-cards first-class retrofit: backfills `board_id` onto each
+//! historical `archived_cards` entry that lacks it, reconstructing the value
+//! from `original_column_id`→`columns[].board_id`. An archived card whose
+//! `original_column_id` no longer resolves to a column keeps a nil `board_id`
+//! (unrecoverable, acceptable under the first-class model). Also defensively
+//! drops any `cards`-array entry that shadows an archived card by id (JSON
+//! never duplicated archived cards in `cards`, so this is a no-op on
+//! well-formed files, but it hardens the "archived cards are a discrete peer
+//! collection, never duplicated in `cards`" invariant).
+//!
+//! V7 envelopes carry archived cards without a `board_id` key:
+//!
+//! ```json
+//! "data": {
+//!   "columns": [{ "id": "col-1", "board_id": "board-1" }],
+//!   "archived_cards": [{ "card": {...}, "original_column_id": "col-1", ... }]
+//! }
+//! ```
+//!
+//! V8 envelopes carry the backfilled `board_id`:
+//!
+//! ```json
+//! "archived_cards": [{ "card": {...}, "board_id": "board-1",
+//!                      "original_column_id": "col-1", ... }]
+//! ```
+
+use kanban_persistence::PersistenceResult;
+use serde_json::Value;
+
+/// Pure transform on an already-parsed envelope.
+///
+/// STUB (red): does nothing. The real V7→V8 backfill is implemented in the
+/// green step. Kept as a no-op so the failing unit tests compile and pin the
+/// expected behavior.
+pub(crate) fn transform_v7_to_v8_value(_envelope: &mut Value) -> PersistenceResult<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const BOARD: &str = "11111111-1111-1111-1111-111111111111";
+    const COLUMN: &str = "22222222-2222-2222-2222-222222222222";
+    const CARD: &str = "33333333-3333-3333-3333-333333333333";
+
+    fn make_v7_envelope(archived: Value, cards: Value) -> Value {
+        json!({
+            "version": 7,
+            "metadata": {
+                "instance_id": "00000000-0000-0000-0000-000000000001",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [{ "id": BOARD, "name": "B" }],
+                "columns": [{ "id": COLUMN, "board_id": BOARD }],
+                "cards": cards,
+                "archived_cards": archived,
+                "sprints": [],
+                "graph": {
+                    "spawns": { "edges": [] },
+                    "blocks": { "edges": [] },
+                    "relates": { "edges": [] }
+                }
+            }
+        })
+    }
+
+    fn archived_card(original_column_id: &str) -> Value {
+        json!({
+            "card": { "id": CARD, "title": "T" },
+            "archived_at": "2024-01-01T00:00:00Z",
+            "original_column_id": original_column_id,
+            "original_position": 0
+        })
+    }
+
+    #[test]
+    fn test_transform_backfills_board_id_from_original_column() {
+        let mut env = make_v7_envelope(json!([archived_card(COLUMN)]), json!([]));
+
+        transform_v7_to_v8_value(&mut env).unwrap();
+
+        assert_eq!(env["version"], 8);
+        assert_eq!(
+            env["data"]["archived_cards"][0]["board_id"]
+                .as_str()
+                .unwrap(),
+            BOARD,
+            "board_id must be backfilled from original_column_id -> column.board_id"
+        );
+    }
+
+    #[test]
+    fn test_transform_sets_nil_board_id_when_original_column_missing() {
+        let missing = "99999999-9999-9999-9999-999999999999";
+        let mut env = make_v7_envelope(json!([archived_card(missing)]), json!([]));
+
+        transform_v7_to_v8_value(&mut env).unwrap();
+
+        assert_eq!(env["version"], 8);
+        assert_eq!(
+            env["data"]["archived_cards"][0]["board_id"]
+                .as_str()
+                .unwrap(),
+            uuid::Uuid::nil().to_string(),
+            "a dangling original_column_id yields a nil board_id, not an error"
+        );
+    }
+
+    #[test]
+    fn test_transform_drops_cards_array_entry_shadowing_archived_card() {
+        // An entry present in BOTH cards and archived_cards (by id) must be
+        // removed from cards post-transform (defensive first-class invariant).
+        let live = json!([{ "id": CARD, "title": "shadow" }, { "id": "keep", "title": "K" }]);
+        let mut env = make_v7_envelope(json!([archived_card(COLUMN)]), live);
+
+        transform_v7_to_v8_value(&mut env).unwrap();
+
+        let cards = env["data"]["cards"].as_array().unwrap();
+        assert_eq!(cards.len(), 1, "the shadowing live-cards entry is dropped");
+        assert_eq!(cards[0]["id"], "keep");
+    }
+
+    #[test]
+    fn test_transform_is_noop_on_v8_envelope() {
+        let v8 = json!({
+            "version": 8,
+            "data": {
+                "columns": [{ "id": COLUMN, "board_id": BOARD }],
+                "archived_cards": [archived_card(COLUMN)],
+                "cards": []
+            }
+        });
+        let mut env = v8.clone();
+        transform_v7_to_v8_value(&mut env).unwrap();
+        assert_eq!(env, v8, "a version:8 envelope must be returned unchanged");
+    }
+
+    #[test]
+    fn test_transform_bumps_version_when_no_archived_cards() {
+        let mut env = make_v7_envelope(json!([]), json!([]));
+        transform_v7_to_v8_value(&mut env).unwrap();
+        assert_eq!(env["version"], 8);
+    }
+
+    #[test]
+    fn test_transform_preserves_existing_board_id() {
+        // If a board_id is already present (e.g. a card archived by a V8
+        // binary before the migration ran), it must not be overwritten.
+        let existing = "44444444-4444-4444-4444-444444444444";
+        let mut ac = archived_card(COLUMN);
+        ac.as_object_mut()
+            .unwrap()
+            .insert("board_id".to_string(), json!(existing));
+        let mut env = make_v7_envelope(json!([ac]), json!([]));
+
+        transform_v7_to_v8_value(&mut env).unwrap();
+
+        assert_eq!(
+            env["data"]["archived_cards"][0]["board_id"]
+                .as_str()
+                .unwrap(),
+            existing,
+            "an already-present board_id must be preserved, not clobbered"
+        );
+    }
+}

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -90,6 +90,10 @@ CREATE TABLE IF NOT EXISTS sprints (
 -- delete the archived card's row when its column is dropped; instead, live-card
 -- cleanup on column delete is performed explicitly by the command tier
 -- (DeleteCardsByColumns), so no cascade is needed here.
+-- KEEP IN SYNC: the 2->3 migration rebuilds this table as `cards_new` in
+-- `init.rs::migrate_v2_to_v3_archived_cards` (same columns, same non-FK shape).
+-- Adding/removing a column here must be mirrored in that CREATE + its INSERT
+-- SELECT list, or migrating users silently lose the column's data on the swap.
 CREATE TABLE IF NOT EXISTS cards (
     id TEXT PRIMARY KEY,
     column_id TEXT NOT NULL,

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -1,4 +1,6 @@
 -- SQLite schema for kanban persistence
+-- Version: 3 (KAN-832: archived_cards.board_id + cards column_id FK dropped so
+-- archived cards survive column deletion — see migrate_v2_to_v3_archived_cards.
 -- Version: 2 (KAN-522: writer-stamp columns added; schema_version begins
 -- to be authoritative — see SqliteStore::migrate for the ALTER fallbacks)
 
@@ -7,7 +9,7 @@ CREATE TABLE IF NOT EXISTS metadata (
     id INTEGER PRIMARY KEY CHECK (id = 1),  -- Singleton row
     instance_id TEXT NOT NULL,
     saved_at TEXT NOT NULL,
-    schema_version INTEGER NOT NULL DEFAULT 2,
+    schema_version INTEGER NOT NULL DEFAULT 3,
     writer_version TEXT,
     writer_commit TEXT
 );
@@ -82,6 +84,12 @@ CREATE TABLE IF NOT EXISTS sprints (
 );
 
 -- Cards table (holds both active and archived cards)
+-- NOTE (schema 3): column_id carries NO foreign key to columns. An archived
+-- card keeps its (now historical, possibly dangling) column_id in this table,
+-- and must survive deletion of that column. A live-card FK cascade would
+-- delete the archived card's row when its column is dropped; instead, live-card
+-- cleanup on column delete is performed explicitly by the command tier
+-- (DeleteCardsByColumns), so no cascade is needed here.
 CREATE TABLE IF NOT EXISTS cards (
     id TEXT PRIMARY KEY,
     column_id TEXT NOT NULL,
@@ -97,7 +105,6 @@ CREATE TABLE IF NOT EXISTS cards (
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     completed_at TEXT,
-    FOREIGN KEY (column_id) REFERENCES columns(id) ON DELETE CASCADE,
     FOREIGN KEY (sprint_id) REFERENCES sprints(id) ON DELETE SET NULL
 );
 
@@ -119,8 +126,11 @@ CREATE TABLE IF NOT EXISTS sprint_logs (
 CREATE INDEX IF NOT EXISTS idx_sprint_logs_card_id ON sprint_logs(card_id);
 
 -- Archived cards metadata (card data lives in cards table)
+-- Extension table over `cards` (1:0..1). board_id (schema 3) makes board
+-- scoping a direct WHERE rather than a column walk.
 CREATE TABLE IF NOT EXISTS archived_cards (
     card_id TEXT PRIMARY KEY,
+    board_id TEXT NOT NULL,
     archived_at TEXT NOT NULL,
     original_column_id TEXT NOT NULL,
     original_position INTEGER NOT NULL,
@@ -184,6 +194,7 @@ CREATE INDEX IF NOT EXISTS idx_cards_status ON cards(status);
 CREATE INDEX IF NOT EXISTS idx_cards_priority ON cards(priority);
 CREATE INDEX IF NOT EXISTS idx_cards_updated_at ON cards(updated_at);
 
+CREATE INDEX IF NOT EXISTS idx_archived_cards_board_id ON archived_cards(board_id);
 CREATE INDEX IF NOT EXISTS idx_archived_cards_archived_at ON archived_cards(archived_at);
 
 -- Command log: per-batch JSON serialisation for cross-session undo (KAN-191).

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -119,13 +119,12 @@ pub(crate) fn row_to_archived_card(
 ) -> KanbanResult<ArchivedCard> {
     let card = row_to_card(row, sprint_logs)?;
     let archived_at_str: String = row.try_get("archived_at").map_err(db_err)?;
+    let board_id_str: String = row.try_get("board_id").map_err(db_err)?;
     let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
     Ok(ArchivedCard {
         card,
         metadata: ArchiveMetadata::at(p_dt(&archived_at_str)?),
-        // Placeholder until B4 adds the `board_id` column: read it here and
-        // drop this nil, mirroring the writer in entities/archived_card.rs.
-        board_id: uuid::Uuid::nil(),
+        board_id: p_uuid(&board_id_str)?,
         original_column_id: p_uuid(&orig_col_str)?,
         original_position: row.try_get("original_position").map_err(db_err)?,
     })

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -130,7 +130,7 @@ impl DataStore for SqliteStore {
                         due_date, points, card_number, sprint_id, created_at, updated_at,
                         completed_at
                  FROM cards
-                 WHERE id = ? AND id NOT IN (SELECT card_id FROM archived_cards)",
+                 WHERE id = ? AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
             )
             .bind(&id_str)
             .fetch_optional(&self.pool)
@@ -173,7 +173,7 @@ impl DataStore for SqliteStore {
         run(async {
             let row = sqlx::query(
                 "SELECT COUNT(*) as cnt FROM cards
-                 WHERE column_id = ? AND id NOT IN (SELECT card_id FROM archived_cards)",
+                 WHERE column_id = ? AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
             )
             .bind(column_id.to_string())
             .fetch_one(&self.pool)
@@ -196,7 +196,7 @@ impl DataStore for SqliteStore {
             let sql = format!(
                 "SELECT COUNT(*) as cnt FROM cards
                  WHERE column_id = ?
-                   AND id NOT IN (SELECT card_id FROM archived_cards)
+                   AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)
                    AND id NOT IN ({placeholders})"
             );
             let mut query = sqlx::query(&sql).bind(column_id.to_string());
@@ -216,7 +216,7 @@ impl DataStore for SqliteStore {
         run(async {
             sqlx::query(
                 "DELETE FROM cards
-                 WHERE id = ? AND id NOT IN (SELECT card_id FROM archived_cards)",
+                 WHERE id = ? AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
             )
             .bind(id.to_string())
             .execute(&self.pool)
@@ -235,7 +235,7 @@ impl DataStore for SqliteStore {
             let sql = format!(
                 "DELETE FROM cards
                  WHERE column_id IN ({placeholders})
-                   AND id NOT IN (SELECT card_id FROM archived_cards)"
+                   AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)"
             );
             let mut query = sqlx::query(&sql);
             for id in column_ids {
@@ -256,7 +256,7 @@ impl DataStore for SqliteStore {
             sqlx::query(
                 "UPDATE cards SET sprint_id = NULL, updated_at = ?
                  WHERE sprint_id = ?
-                   AND id NOT IN (SELECT card_id FROM archived_cards)",
+                   AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
             )
             .bind(&now)
             .bind(sprint_id.to_string())
@@ -276,7 +276,7 @@ impl DataStore for SqliteStore {
                 "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                         c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                         c.created_at, c.updated_at, c.completed_at,
-                        ac.archived_at, ac.original_column_id, ac.original_position
+                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
                  FROM archived_cards ac
                  JOIN cards c ON ac.card_id = c.id
                  WHERE ac.card_id = ?",
@@ -334,7 +334,7 @@ impl DataStore for SqliteStore {
                 "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                         c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                         c.created_at, c.updated_at, c.completed_at,
-                        ac.archived_at, ac.original_column_id, ac.original_position
+                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
                  FROM archived_cards ac
                  JOIN cards c ON ac.card_id = c.id
                  WHERE ac.original_column_id IN ({})
@@ -363,6 +363,42 @@ impl DataStore for SqliteStore {
         })
     }
 
+    /// Board-scoped archived cards. Overrides the trait default (which filters
+    /// the full list) with a direct `WHERE board_id = ?` on the extension table,
+    /// so board scoping is a single indexed query.
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        run(async {
+            let rows = sqlx::query(
+                "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
+                        c.position, c.due_date, c.points, c.card_number, c.sprint_id,
+                        c.created_at, c.updated_at, c.completed_at,
+                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
+                 FROM archived_cards ac
+                 JOIN cards c ON ac.card_id = c.id
+                 WHERE ac.board_id = ?
+                 ORDER BY ac.archived_at",
+            )
+            .bind(board_id.to_string())
+            .fetch_all(&self.pool)
+            .await
+            .map_err(db_err)?;
+
+            let card_ids: Vec<String> = rows
+                .iter()
+                .map(|r| r.try_get("id").map_err(db_err))
+                .collect::<KanbanResult<_>>()?;
+            let mut logs_map = self.fetch_sprint_logs_batch(&card_ids).await?;
+
+            let mut result = Vec::with_capacity(rows.len());
+            for row in &rows {
+                let id_str: String = row.try_get("id").map_err(db_err)?;
+                let logs = logs_map.remove(&id_str).unwrap_or_default();
+                result.push(row_to_archived_card(row, logs)?);
+            }
+            Ok(result)
+        })
+    }
+
     fn clear_sprint_from_archived_cards(
         &self,
         sprint_id: Uuid,
@@ -373,7 +409,7 @@ impl DataStore for SqliteStore {
             sqlx::query(
                 "UPDATE cards SET sprint_id = NULL, updated_at = ?
                  WHERE sprint_id = ?
-                   AND id IN (SELECT card_id FROM archived_cards)",
+                   AND EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
             )
             .bind(&now)
             .bind(sprint_id.to_string())

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
@@ -10,14 +10,16 @@ impl SqliteStore {
     ) -> KanbanResult<()> {
         Self::write_card_with_conn(conn, &ac.card).await?;
         sqlx::query(
-            "INSERT INTO archived_cards (card_id, archived_at, original_column_id, original_position)
-             VALUES (?, ?, ?, ?)
+            "INSERT INTO archived_cards (card_id, board_id, archived_at, original_column_id, original_position)
+             VALUES (?, ?, ?, ?, ?)
              ON CONFLICT(card_id) DO UPDATE SET
+                board_id=excluded.board_id,
                 archived_at=excluded.archived_at,
                 original_column_id=excluded.original_column_id,
                 original_position=excluded.original_position",
         )
         .bind(ac.card.id.to_string())
+        .bind(ac.board_id.to_string())
         .bind(fmt_dt(&ac.metadata.archived_at))
         .bind(ac.original_column_id.to_string())
         .bind(ac.original_position)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
@@ -126,7 +126,7 @@ impl SqliteStore {
         let sql = format!(
             "SELECT id, column_id, title, description, priority, status, position,
                     due_date, points, card_number, sprint_id, created_at, updated_at, completed_at
-             FROM cards WHERE id NOT IN (SELECT card_id FROM archived_cards) {}
+             FROM cards WHERE NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id) {}
              ORDER BY position ASC, created_at ASC",
             where_clause
         );

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use kanban_domain::KanbanResult;
-use sqlx::{Acquire, Pool, Sqlite};
+use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
 use super::helpers::{db_err, p_uuid};
@@ -190,52 +190,53 @@ impl SqliteStore {
             "migrating SQLite schema 2 -> 3: archived_cards.board_id + cards FK decouple"
         );
 
-        let mut conn = pool.acquire().await.map_err(db_err)?;
-        sqlx::query("PRAGMA foreign_keys = OFF")
-            .execute(&mut *conn)
-            .await
-            .map_err(db_err)?;
-
-        let mut tx = conn.begin().await.map_err(db_err)?;
-
-        // 1a. Add board_id (nullable ADD; backfilled next).
-        sqlx::query("ALTER TABLE archived_cards ADD COLUMN board_id TEXT")
-            .execute(&mut *tx)
-            .await
-            .map_err(db_err)?;
-        // 1b. Backfill from original_column_id -> columns.board_id.
-        sqlx::query(
-            "UPDATE archived_cards
-                SET board_id = (SELECT c.board_id FROM columns c
-                                WHERE c.id = archived_cards.original_column_id)",
+        // Count the rows whose `original_column_id` no longer resolves to a
+        // column (the backfill subquery would yield NULL) so we can warn. This
+        // is computed up front against the pre-migration table; the count is
+        // identical to the post-backfill `board_id IS NULL` count.
+        let unresolved: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM archived_cards
+              WHERE (SELECT c.board_id FROM columns c
+                       WHERE c.id = archived_cards.original_column_id) IS NULL",
         )
-        .execute(&mut *tx)
+        .fetch_one(pool)
         .await
         .map_err(db_err)?;
-        // 1c. Rows whose original column is gone: nil + warn (matches D2's "may
-        // dangle").
-        let unresolved: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM archived_cards WHERE board_id IS NULL")
-                .fetch_one(&mut *tx)
-                .await
-                .map_err(db_err)?;
         if unresolved > 0 {
             tracing::warn!(
                 count = unresolved,
                 "archived_cards board_id backfill: unresolvable original_column_id; \
                  setting board_id = nil"
             );
-            sqlx::query("UPDATE archived_cards SET board_id = ? WHERE board_id IS NULL")
-                .bind(uuid::Uuid::nil().to_string())
-                .execute(&mut *tx)
-                .await
-                .map_err(db_err)?;
         }
 
-        // 2. Table-swap `cards` to drop the column_id -> columns FK. Indexes are
-        //    recreated by SCHEMA (CREATE INDEX IF NOT EXISTS) after this runs.
+        // Run the whole migration as one `raw_sql` batch on the pool executor.
+        // `&Pool` acquires a SINGLE connection for the entire multi-statement
+        // string and runs it in one await, so:
+        //   * `PRAGMA foreign_keys = OFF` applies to the same connection that
+        //     performs the `cards` table swap (a table-swap under FK ON fires
+        //     ON DELETE CASCADE on sprint_logs/archived_cards and wipes them);
+        //     the pragma is issued OUTSIDE the transaction (before BEGIN), where
+        //     it is not a no-op, and restored afterwards.
+        //   * the future stays `Send`-provable for the `tokio::spawn`ed
+        //     store-open path. Holding an acquired `&mut SqliteConnection`
+        //     executor across multiple awaits instead leaves the higher-ranked
+        //     `for<'c> &'c mut SqliteConnection: Executor<'c>` / `Send` bound
+        //     unresolved, and `tokio::spawn` fails with "implementation of
+        //     `Executor`/`Send` is not general enough".
+        // The unresolvable rows are set to `Uuid::nil()` via a SQL literal so
+        // the batch needs no dynamic binds.
         sqlx::raw_sql(
-            "CREATE TABLE cards_new (
+            "PRAGMA foreign_keys = OFF;
+            BEGIN;
+            ALTER TABLE archived_cards ADD COLUMN board_id TEXT;
+            UPDATE archived_cards
+               SET board_id = (SELECT c.board_id FROM columns c
+                                 WHERE c.id = archived_cards.original_column_id);
+            UPDATE archived_cards
+               SET board_id = '00000000-0000-0000-0000-000000000000'
+             WHERE board_id IS NULL;
+            CREATE TABLE cards_new (
                 id TEXT PRIMARY KEY,
                 column_id TEXT NOT NULL,
                 title TEXT NOT NULL,
@@ -258,18 +259,13 @@ impl SqliteStore {
                 completed_at
               FROM cards;
             DROP TABLE cards;
-            ALTER TABLE cards_new RENAME TO cards;",
+            ALTER TABLE cards_new RENAME TO cards;
+            COMMIT;
+            PRAGMA foreign_keys = ON;",
         )
-        .execute(&mut *tx)
+        .execute(pool)
         .await
         .map_err(db_err)?;
-
-        tx.commit().await.map_err(db_err)?;
-
-        sqlx::query("PRAGMA foreign_keys = ON")
-            .execute(&mut *conn)
-            .await
-            .map_err(db_err)?;
         Ok(())
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use kanban_domain::KanbanResult;
-use sqlx::{Pool, Sqlite};
+use sqlx::{Acquire, Pool, Sqlite};
 use uuid::Uuid;
 
 use super::helpers::{db_err, p_uuid};
@@ -143,6 +143,133 @@ impl SqliteStore {
             .await
             .map_err(db_err)?;
 
+        Ok(())
+    }
+
+    /// schema 2 -> 3 (KAN-832). Idempotent, additive-in-place (no `.backup`,
+    /// SQLite has no backup mechanism). Two structural changes:
+    ///   1. `archived_cards` gains `board_id`, backfilled from the archived
+    ///      card's `original_column_id -> columns.board_id`. A row whose
+    ///      original column no longer exists gets `Uuid::nil()` + a warning.
+    ///   2. `cards` is table-swapped to DROP the `column_id -> columns` FK, so
+    ///      deleting a column no longer cascade-deletes an archived card's row.
+    ///
+    /// Must run BEFORE SCHEMA (SCHEMA's `idx_archived_cards_board_id` fails
+    /// against the pre-3 `board_id`-less table).
+    ///
+    /// FK note (spike-validated): `DROP TABLE cards` with `foreign_keys` ON
+    /// fires `ON DELETE CASCADE` on `sprint_logs`/`archived_cards` and WIPES
+    /// them. `PRAGMA defer_foreign_keys` defers CHECKING, not cascade ACTIONS,
+    /// so it does NOT help. We disable enforcement with `PRAGMA foreign_keys =
+    /// OFF` on a dedicated connection OUTSIDE any transaction (the pragma is a
+    /// no-op inside a tx), then restore it.
+    pub(crate) async fn migrate_v2_to_v3_archived_cards(pool: &Pool<Sqlite>) -> KanbanResult<()> {
+        // Fresh DB: archived_cards does not exist yet (SCHEMA creates it in the
+        // correct v3 shape). Nothing to migrate.
+        let has_archived_cards: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='archived_cards'",
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
+        if !has_archived_cards {
+            return Ok(());
+        }
+        // Idempotent: already migrated if board_id is present.
+        let has_board_id: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('archived_cards') WHERE name = 'board_id'",
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
+        if has_board_id {
+            return Ok(());
+        }
+
+        tracing::info!(
+            "migrating SQLite schema 2 -> 3: archived_cards.board_id + cards FK decouple"
+        );
+
+        let mut conn = pool.acquire().await.map_err(db_err)?;
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&mut *conn)
+            .await
+            .map_err(db_err)?;
+
+        let mut tx = conn.begin().await.map_err(db_err)?;
+
+        // 1a. Add board_id (nullable ADD; backfilled next).
+        sqlx::query("ALTER TABLE archived_cards ADD COLUMN board_id TEXT")
+            .execute(&mut *tx)
+            .await
+            .map_err(db_err)?;
+        // 1b. Backfill from original_column_id -> columns.board_id.
+        sqlx::query(
+            "UPDATE archived_cards
+                SET board_id = (SELECT c.board_id FROM columns c
+                                WHERE c.id = archived_cards.original_column_id)",
+        )
+        .execute(&mut *tx)
+        .await
+        .map_err(db_err)?;
+        // 1c. Rows whose original column is gone: nil + warn (matches D2's "may
+        // dangle").
+        let unresolved: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM archived_cards WHERE board_id IS NULL")
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(db_err)?;
+        if unresolved > 0 {
+            tracing::warn!(
+                count = unresolved,
+                "archived_cards board_id backfill: unresolvable original_column_id; \
+                 setting board_id = nil"
+            );
+            sqlx::query("UPDATE archived_cards SET board_id = ? WHERE board_id IS NULL")
+                .bind(uuid::Uuid::nil().to_string())
+                .execute(&mut *tx)
+                .await
+                .map_err(db_err)?;
+        }
+
+        // 2. Table-swap `cards` to drop the column_id -> columns FK. Indexes are
+        //    recreated by SCHEMA (CREATE INDEX IF NOT EXISTS) after this runs.
+        sqlx::raw_sql(
+            "CREATE TABLE cards_new (
+                id TEXT PRIMARY KEY,
+                column_id TEXT NOT NULL,
+                title TEXT NOT NULL,
+                description TEXT,
+                priority TEXT NOT NULL DEFAULT 'Medium',
+                status TEXT NOT NULL DEFAULT 'Todo',
+                position INTEGER NOT NULL,
+                due_date TEXT,
+                points INTEGER CHECK (points >= 0 AND points <= 255),
+                card_number INTEGER NOT NULL DEFAULT 0,
+                sprint_id TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                completed_at TEXT,
+                FOREIGN KEY (sprint_id) REFERENCES sprints(id) ON DELETE SET NULL
+            );
+            INSERT INTO cards_new SELECT
+                id, column_id, title, description, priority, status, position,
+                due_date, points, card_number, sprint_id, created_at, updated_at,
+                completed_at
+              FROM cards;
+            DROP TABLE cards;
+            ALTER TABLE cards_new RENAME TO cards;",
+        )
+        .execute(&mut *tx)
+        .await
+        .map_err(db_err)?;
+
+        tx.commit().await.map_err(db_err)?;
+
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&mut *conn)
+            .await
+            .map_err(db_err)?;
         Ok(())
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -59,7 +59,7 @@ impl SqliteStore {
             "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                     c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                     c.created_at, c.updated_at, c.completed_at,
-                    ac.archived_at, ac.original_column_id, ac.original_position
+                    ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
              FROM archived_cards ac
              JOIN cards c ON ac.card_id = c.id
              ORDER BY ac.archived_at",

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -24,7 +24,7 @@ const SCHEMA: &str = include_str!("../schema.sql");
 
 /// The highest schema_version this binary understands. Used both to
 /// stamp fresh databases and to refuse files written by a future binary.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 2;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 3;
 
 /// (instance_id, saved_at, writer_version, writer_commit, schema_version).
 /// Tuple shape returned by the metadata-singleton SELECT — extracted to a
@@ -103,6 +103,12 @@ impl SqliteStore {
         // can be created cleanly. Detected by absence of the new
         // `batch_index` column on an existing command_log table.
         Self::drop_legacy_command_log_if_present(&pool).await?;
+
+        // schema 2 -> 3: add archived_cards.board_id (+ backfill) and break the
+        // cards -> columns delete cascade so archived cards survive column
+        // deletion. Must run BEFORE SCHEMA: SCHEMA declares
+        // idx_archived_cards_board_id, which fails against the old-shape table.
+        Self::migrate_v2_to_v3_archived_cards(&pool).await?;
 
         sqlx::raw_sql(SCHEMA)
             .execute(&pool)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
@@ -1,0 +1,162 @@
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{
+    ArchiveMetadata, ArchivedCard, Board, Card, CardPriority, CardRecord, CardStatus, Column,
+    ColumnRecord,
+};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+fn seed_board_and_column(store: &SqliteStore, board_name: &str) -> (Uuid, Uuid) {
+    let board = Board::new(board_name, None::<String>);
+    let board_id = board.id;
+    store.upsert_board(board).unwrap();
+
+    let column = Column::reconstitute(ColumnRecord {
+        id: Uuid::new_v4(),
+        board_id,
+        name: "Todo".to_string(),
+        position: 0,
+        wip_limit: None,
+        created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+        updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+    })
+    .unwrap();
+    let column_id = column.id;
+    store.upsert_column(column).unwrap();
+    (board_id, column_id)
+}
+
+fn card_in(column_id: Uuid, title: &str) -> Card {
+    Card::reconstitute(CardRecord {
+        id: Uuid::new_v4(),
+        column_id,
+        title: title.to_string(),
+        description: Some("body".to_string()),
+        priority: CardPriority::High,
+        status: CardStatus::Done,
+        position: 3,
+        due_date: Some("2024-05-05T00:00:00Z".parse().unwrap()),
+        points: Some(3),
+        card_number: 42,
+        sprint_id: None,
+        created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+        updated_at: "2024-02-02T00:00:00Z".parse().unwrap(),
+        completed_at: Some("2024-03-03T00:00:00Z".parse().unwrap()),
+        sprint_logs: vec![],
+    })
+    .unwrap()
+}
+
+#[test]
+fn test_archived_card_round_trip_preserves_board_id_and_all_fields() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let (board_id, column_id) = seed_board_and_column(&store, "B");
+
+        let ac = ArchivedCard {
+            card: card_in(column_id, "Archived"),
+            metadata: ArchiveMetadata::at("2024-06-01T00:00:00Z".parse().unwrap()),
+            board_id,
+            original_column_id: column_id,
+            original_position: 7,
+        };
+        let card_id = ac.card.id;
+        store.insert_archived_card(ac.clone()).unwrap();
+
+        let loaded = store
+            .get_archived_card(card_id)
+            .unwrap()
+            .expect("archived card should load");
+        assert_eq!(loaded.board_id, board_id, "board_id must round-trip");
+        assert_eq!(loaded, ac, "all archived-card fields must round-trip");
+    });
+}
+
+#[test]
+fn test_list_archived_cards_by_board_filters_by_board_id() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let (board_a, col_a) = seed_board_and_column(&store, "A");
+        let (board_b, col_b) = seed_board_and_column(&store, "B");
+
+        let a = ArchivedCard::new(card_in(col_a, "A1"), board_a, col_a, 0);
+        let a_id = a.card.id;
+        let b = ArchivedCard::new(card_in(col_b, "B1"), board_b, col_b, 0);
+        store.insert_archived_card(a).unwrap();
+        store.insert_archived_card(b).unwrap();
+
+        let only_a = store.list_archived_cards_by_board(board_a).unwrap();
+        assert_eq!(only_a.len(), 1, "only board A's archived card");
+        assert_eq!(only_a[0].card.id, a_id);
+        assert!(only_a.iter().all(|ac| ac.board_id == board_a));
+    });
+}
+
+#[test]
+fn test_delete_column_does_not_cascade_delete_archived_card() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let (board_id, column_id) = seed_board_and_column(&store, "B");
+
+        let ac = ArchivedCard::new(card_in(column_id, "Survivor"), board_id, column_id, 0);
+        let card_id = ac.card.id;
+        store.insert_archived_card(ac).unwrap();
+
+        // Raw column delete (bypasses the domain guard) must NOT orphan the
+        // archived card via the cards -> columns cascade.
+        store.delete_column(column_id).unwrap();
+
+        let survived = store
+            .get_archived_card(card_id)
+            .unwrap()
+            .expect("archived card must survive its column's deletion");
+        assert_eq!(survived.board_id, board_id);
+        assert_eq!(
+            survived.original_column_id, column_id,
+            "historical column preserved on the extension row"
+        );
+        assert_eq!(
+            survived.card.column_id, column_id,
+            "card.column_id is retained (dangling), matching in-memory/JSON semantics"
+        );
+    });
+}
+
+#[test]
+fn test_list_all_cards_excludes_archived_via_not_exists() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let (board_id, column_id) = seed_board_and_column(&store, "B");
+
+        let live = card_in(column_id, "Live");
+        let live_id = live.id;
+        store.upsert_card(live).unwrap();
+
+        let ac = ArchivedCard::new(card_in(column_id, "Archived"), board_id, column_id, 0);
+        let archived_id = ac.card.id;
+        store.insert_archived_card(ac).unwrap();
+
+        let all = store.list_all_cards().unwrap();
+        let ids: Vec<Uuid> = all.iter().map(|c| c.id).collect();
+        assert!(ids.contains(&live_id), "live card is listed");
+        assert!(
+            !ids.contains(&archived_id),
+            "archived card is excluded from live listings"
+        );
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
@@ -79,7 +79,7 @@ fn test_open_drops_legacy_card_edges_table() {
 }
 
 #[test]
-fn test_fresh_db_records_schema_version_2() {
+fn test_fresh_db_records_schema_version_3() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("fresh.db");
     let rt = make_rt();
@@ -90,6 +90,7 @@ fn test_fresh_db_records_schema_version_2() {
             .await
             .unwrap();
         assert_eq!(version, SUPPORTED_SCHEMA_VERSION);
+        assert_eq!(version, 3, "fresh DB stamps schema_version 3");
     });
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
@@ -1,0 +1,284 @@
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::Row;
+use std::path::Path;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+/// Seed a schema_version-2 shaped DB directly (no board_id on archived_cards,
+/// cards.column_id carrying the ON DELETE CASCADE FK). Returns
+/// (board_id, column_id, card_id). `original_column_id` on the archived row is
+/// taken from `orig_col` so a caller can simulate a since-deleted column.
+async fn seed_v2_db(path: &Path, orig_col: Uuid) -> (Uuid, Uuid, Uuid) {
+    // foreign_keys(false): the seed inserts forward references and the v2 shape
+    // is asserted structurally, not enforced here.
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        "CREATE TABLE metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            instance_id TEXT NOT NULL,
+            saved_at TEXT NOT NULL,
+            schema_version INTEGER NOT NULL DEFAULT 2,
+            writer_version TEXT,
+            writer_commit TEXT
+        );
+        CREATE TABLE boards (
+            id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT,
+            sprint_prefix TEXT, card_prefix TEXT,
+            task_sort_field TEXT NOT NULL DEFAULT 'Default',
+            task_sort_order TEXT NOT NULL DEFAULT 'Ascending',
+            sprint_duration_days INTEGER,
+            sprint_name_used_count INTEGER NOT NULL DEFAULT 0,
+            next_sprint_number INTEGER NOT NULL DEFAULT 1,
+            active_sprint_id TEXT,
+            task_list_view TEXT NOT NULL DEFAULT 'Flat',
+            card_counter INTEGER NOT NULL DEFAULT 1,
+            completion_column_id TEXT,
+            position INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE columns (
+            id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
+            position INTEGER NOT NULL, wip_limit INTEGER,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+        );
+        CREATE TABLE cards (
+            id TEXT PRIMARY KEY, column_id TEXT NOT NULL, title TEXT NOT NULL,
+            description TEXT, priority TEXT NOT NULL DEFAULT 'Medium',
+            status TEXT NOT NULL DEFAULT 'Todo', position INTEGER NOT NULL,
+            due_date TEXT, points INTEGER, card_number INTEGER NOT NULL DEFAULT 0,
+            sprint_id TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            completed_at TEXT,
+            FOREIGN KEY (column_id) REFERENCES columns(id) ON DELETE CASCADE
+        );
+        CREATE TABLE sprint_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, card_id TEXT NOT NULL,
+            sprint_id TEXT NOT NULL, sprint_number INTEGER NOT NULL,
+            sprint_name TEXT, started_at TEXT NOT NULL, ended_at TEXT,
+            status TEXT NOT NULL,
+            FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE
+        );
+        CREATE TABLE archived_cards (
+            card_id TEXT PRIMARY KEY, archived_at TEXT NOT NULL,
+            original_column_id TEXT NOT NULL, original_position INTEGER NOT NULL,
+            FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE
+        );",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let board_id = Uuid::new_v4();
+    let column_id = Uuid::new_v4();
+    let card_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+         VALUES (1, ?, '2024-01-01T00:00:00Z', 2)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO boards (id, name, created_at, updated_at)
+         VALUES (?, 'B', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+         VALUES (?, ?, 'Todo', 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(column_id.to_string())
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO cards (id, column_id, title, position, card_number, created_at, updated_at)
+         VALUES (?, ?, 'Archived', 0, 1, '2024-01-01T00:00:00Z', '2024-02-02T00:00:00Z')",
+    )
+    .bind(card_id.to_string())
+    .bind(column_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO sprint_logs (card_id, sprint_id, sprint_number, sprint_name, started_at, status)
+         VALUES (?, ?, 1, 'S1', '2024-01-10T00:00:00Z', 'Completed')",
+    )
+    .bind(card_id.to_string())
+    .bind(Uuid::new_v4().to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO archived_cards (card_id, archived_at, original_column_id, original_position)
+         VALUES (?, '2024-03-03T00:00:00Z', ?, 0)",
+    )
+    .bind(card_id.to_string())
+    .bind(orig_col.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    pool.close().await;
+    (board_id, column_id, card_id)
+}
+
+async fn archived_board_id(store: &SqliteStore, card_id: Uuid) -> String {
+    sqlx::query("SELECT board_id FROM archived_cards WHERE card_id = ?")
+        .bind(card_id.to_string())
+        .fetch_one(store.pool())
+        .await
+        .unwrap()
+        .try_get::<String, _>("board_id")
+        .unwrap()
+}
+
+#[test]
+fn test_migrate_v2_db_adds_board_id_and_backfills() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (board_id, column_id, card_id) = seed_v2_db(&path, /* orig_col = */ Uuid::nil()).await;
+        // Point the archived row's original_column_id at the real column so the
+        // backfill has something to resolve.
+        let seed = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(
+                SqliteConnectOptions::new()
+                    .filename(&path)
+                    .foreign_keys(false),
+            )
+            .await
+            .unwrap();
+        sqlx::query("UPDATE archived_cards SET original_column_id = ? WHERE card_id = ?")
+            .bind(column_id.to_string())
+            .bind(card_id.to_string())
+            .execute(&seed)
+            .await
+            .unwrap();
+        seed.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let has_board_id: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('archived_cards') WHERE name = 'board_id'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert!(has_board_id, "board_id column must be added");
+
+        assert_eq!(
+            archived_board_id(&store, card_id).await,
+            board_id.to_string(),
+            "board_id backfilled from original_column_id -> columns.board_id"
+        );
+
+        // Card row still lives in `cards` (no row move under D10).
+        let card_still_present: bool =
+            sqlx::query_scalar("SELECT COUNT(*) > 0 FROM cards WHERE id = ?")
+                .bind(card_id.to_string())
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+        assert!(card_still_present, "card row must remain in cards");
+
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(version, 3, "schema_version bumped to 3");
+    });
+}
+
+#[test]
+fn test_migrate_v2_db_backfills_nil_when_original_column_missing() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        // original_column_id points at a column that never existed.
+        let (_board_id, _column_id, card_id) = seed_v2_db(&path, Uuid::new_v4()).await;
+        let store = SqliteStore::open(&path).await.unwrap();
+        assert_eq!(
+            archived_board_id(&store, card_id).await,
+            Uuid::nil().to_string(),
+            "unresolvable column -> nil board_id"
+        );
+    });
+}
+
+#[test]
+fn test_migrate_v2_db_preserves_archived_sprint_logs() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (_b, _c, card_id) = seed_v2_db(&path, Uuid::nil()).await;
+        let store = SqliteStore::open(&path).await.unwrap();
+        // D10 regression guard: the card never left `cards`, so its sprint_logs
+        // (FK -> cards) must survive the migration untouched.
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sprint_logs WHERE card_id = ?")
+            .bind(card_id.to_string())
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "archived card's sprint_logs must be preserved");
+    });
+}
+
+#[test]
+fn test_migrate_is_idempotent_on_v3_db() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (_b, _c, card_id) = seed_v2_db(&path, Uuid::nil()).await;
+        // First open migrates to v3.
+        SqliteStore::open(&path).await.unwrap();
+        // Second open must be a no-op: no duplicate board_id column, version stays 3.
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let board_id_cols: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('archived_cards') WHERE name = 'board_id'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(board_id_cols, 1, "board_id column must not be duplicated");
+
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(version, 3);
+
+        let still_there: bool =
+            sqlx::query_scalar("SELECT COUNT(*) > 0 FROM archived_cards WHERE card_id = ?")
+                .bind(card_id.to_string())
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+        assert!(still_there, "archived card survives idempotent re-open");
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -1,3 +1,4 @@
+mod archived_cards;
 mod boards;
 mod cards;
 mod columns;
@@ -5,6 +6,7 @@ mod entities;
 mod graph;
 mod init;
 mod metadata;
+mod migration_v2_to_v3;
 mod persistence_store;
 
 pub(crate) fn make_rt() -> tokio::runtime::Runtime {

--- a/crates/kanban-persistence/src/traits.rs
+++ b/crates/kanban-persistence/src/traits.rs
@@ -173,11 +173,17 @@ pub enum FormatVersion {
     /// the `spawns_edges()` accessor, and the SQLite `spawns_edges`
     /// table. Pure key rename — edge contents are unchanged.
     V7,
+    /// V8 promotes archived cards to a first-class discrete collection:
+    /// each `archived_cards` entry carries its own `board_id`, backfilled
+    /// from `original_column_id`→column→board for historical files (nil
+    /// when the original column no longer resolves), and is guaranteed not
+    /// to be duplicated inside the `cards` array.
+    V8,
 }
 
 impl FormatVersion {
     /// The highest format version this binary can read or produce.
-    pub const MAX: Self = Self::V7;
+    pub const MAX: Self = Self::V8;
 
     pub fn as_u32(self) -> u32 {
         match self {
@@ -188,6 +194,7 @@ impl FormatVersion {
             Self::V5 => 5,
             Self::V6 => 6,
             Self::V7 => 7,
+            Self::V8 => 8,
         }
     }
 
@@ -200,6 +207,7 @@ impl FormatVersion {
             5 => Some(Self::V5),
             6 => Some(Self::V6),
             7 => Some(Self::V7),
+            8 => Some(Self::V8),
             _ => None,
         }
     }
@@ -244,13 +252,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_format_version_max_equals_v7() {
-        assert_eq!(FormatVersion::MAX, FormatVersion::V7);
+    fn test_format_version_max_equals_v8() {
+        assert_eq!(FormatVersion::MAX, FormatVersion::V8);
     }
 
     #[test]
     fn test_format_version_max_as_u32_matches_largest_variant() {
-        assert_eq!(FormatVersion::MAX.as_u32(), 7);
+        assert_eq!(FormatVersion::MAX.as_u32(), 8);
+    }
+
+    #[test]
+    fn test_from_u32_accepts_8() {
+        assert_eq!(FormatVersion::from_u32(8), Some(FormatVersion::V8));
+        assert_eq!(FormatVersion::from_u32(9), None);
     }
 
     #[test]

--- a/crates/kanban-service/src/api/v1/error_mapping.rs
+++ b/crates/kanban-service/src/api/v1/error_mapping.rs
@@ -181,7 +181,7 @@ mod tests {
             (
                 KanbanError::UnsupportedFutureVersion {
                     file_version: 9,
-                    binary_max: 7,
+                    binary_max: 8,
                 },
                 ErrorCode::UnsupportedVersion,
             ),

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -404,6 +404,28 @@ fn repair_snapshot_fks(snapshot: &mut StoreSnapshot) -> Result<(), KanbanError> 
                 fallback_column.as_deref(),
             );
         }
+        // Live cards must land in a real column. The SQLite `cards.column_id`
+        // FK used to reject an orphan on save; it was dropped (KAN-832) so an
+        // archived card can keep a dangling historical column, which also
+        // removed that backstop for LIVE cards. `fix_card_fks` moved every
+        // fixable card to the fallback column, so a card still pointing outside
+        // `valid_columns` had no column to reassign to and is unrepairable —
+        // fail explicitly (archived cards are intentionally exempt: their
+        // column reference is historical and may dangle).
+        let orphaned = cards
+            .iter()
+            .filter(|card| {
+                card["column_id"]
+                    .as_str()
+                    .is_some_and(|c| !valid_columns.contains(c))
+            })
+            .count();
+        if orphaned > 0 {
+            return Err(KanbanError::validation(format!(
+                "cannot migrate: {orphaned} live card(s) reference a column that does not \
+                 exist and there is no column to reassign them to"
+            )));
+        }
     }
 
     if let Some(archived) = data["archived_cards"].as_array_mut() {


### PR DESCRIPTION
## What

Combined persistence board_id backfill on one branch, TDD-staged:
- **B3 (KAN-831)** — JSON V7→V8 migration backfilling `board_id` onto historical archived cards from `original_column_id → column.board_id` (nil when the column is gone), `.v7.backup`.
- **B4 (KAN-832)** — SQLite schema 2→3: `board_id` column + backfill + `WHERE board_id = ?` override, and the corrected cascade design — **drop the `cards.column_id` FK** so archived cards survive column deletion (not the superseded SET-NULL mechanism).

Both are the persistence prerequisite for B5's board-scoped behavior switch.

## Progress
- [x] B3 red / green — `53071c95`, `d688d326`
- [x] B4 red / green — `f2481f72`, `ad2f611b`
- [x] Cross-crate fallout the crate-scoped spikes missed, both fixed:
  - [x] `842bc6da` — `kanban-tui` HRTB/`Send` build break (the schema 2→3 migration future must stay `Send` for the store-open path used under `tokio::spawn`)
  - [x] `669e5614` — dropping the SQLite FK removed the backstop rejecting orphaned **live** cards on migration; restore it explicitly in `repair_snapshot_fks` (archived cards stay exempt)

## Verification
- `cargo test --workspace` green
- `cargo clippy --workspace --tests -- -D warnings` clean
- `cargo fmt --all --check` clean

Design re-spike-validated; the two fallout fixes are new (crate-scoped spikes don't build dependents). Refs KAN-831, KAN-832.