### PR TITLE
KAN-833 feat(service): board-scoped archived-card queries + cascade orphan fix (B5)

### DIFF
--- a/.changeset/kan-833-board-scoped-archived-queries.md
+++ b/.changeset/kan-833-board-scoped-archived-queries.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+---
+
+Board-scoped archived-card listing now reads the first-class `board_id` field
+instead of inferring the board from each archived card's (possibly stale)
+original column, so an archived card whose original column was later deleted
+still appears in its board's archived list. `DeleteColumn` no longer blocks on
+archived cards: an archived card's `original_column_id` is historical, not a
+live foreign key, so a column that holds only archived cards can be deleted. The
+board-delete cascade now gathers archived cards by `board_id` and removes both
+their records and their dependency-graph edges via a new `DeleteArchivedCards`
+cascade command, closing an orphan leak that occurred when a card's original
+column had been deleted after archival.

--- a/.changeset/kan-833-board-scoped-archived-queries.md
+++ b/.changeset/kan-833-board-scoped-archived-queries.md
@@ -11,4 +11,11 @@ live foreign key, so a column that holds only archived cards can be deleted. The
 board-delete cascade now gathers archived cards by `board_id` and removes both
 their records and their dependency-graph edges via a new `DeleteArchivedCards`
 cascade command, closing an orphan leak that occurred when a card's original
-column had been deleted after archival.
+column had been deleted after archival. Importing a board now backfills
+`board_id` on archived cards that predate the first-class field (reconstructing
+it from the archived card's original column), so a legacy export's archived
+cards remain visible in board-scoped listing and are not leaked on board delete.
+The board-delete cascade also no longer short-circuits a board that has sprints
+but no columns or archived cards, so deleting such a board removes its sprints
+and undo restores them. The now-unused `DeleteArchivedCardsByColumns` cascade
+command and the `list_archived_cards_by_columns` store method have been removed.

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -166,6 +166,9 @@ impl KanbanOperations for CliContext {
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         self.inner.list_archived_cards()
     }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.inner.list_archived_cards_by_board(board_id)
+    }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
         self.inner.assign_card_to_sprint(card_id, sprint_id)

--- a/crates/kanban-domain/src/commands/cascade_commands.rs
+++ b/crates/kanban-domain/src/commands/cascade_commands.rs
@@ -23,7 +23,6 @@ use uuid::Uuid;
 pub enum CascadeCommand {
     DeleteCardEdges(DeleteCardEdges),
     DeleteCardsByColumns(DeleteCardsByColumns),
-    DeleteArchivedCardsByColumns(DeleteArchivedCardsByColumns),
     DeleteArchivedCards(DeleteArchivedCards),
     DeleteColumnsByBoard(DeleteColumnsByBoard),
     DeleteSprintsByBoard(DeleteSprintsByBoard),
@@ -39,7 +38,6 @@ impl CascadeCommand {
         match self {
             CascadeCommand::DeleteCardEdges(c) => c.execute(context),
             CascadeCommand::DeleteCardsByColumns(c) => c.execute(context),
-            CascadeCommand::DeleteArchivedCardsByColumns(c) => c.execute(context),
             CascadeCommand::DeleteArchivedCards(c) => c.execute(context),
             CascadeCommand::DeleteColumnsByBoard(c) => c.execute(context),
             CascadeCommand::DeleteSprintsByBoard(c) => c.execute(context),
@@ -51,7 +49,6 @@ impl CascadeCommand {
         match self {
             CascadeCommand::DeleteCardEdges(c) => c.description(),
             CascadeCommand::DeleteCardsByColumns(c) => c.description(),
-            CascadeCommand::DeleteArchivedCardsByColumns(c) => c.description(),
             CascadeCommand::DeleteArchivedCards(c) => c.description(),
             CascadeCommand::DeleteColumnsByBoard(c) => c.description(),
             CascadeCommand::DeleteSprintsByBoard(c) => c.description(),
@@ -63,7 +60,6 @@ impl CascadeCommand {
         match self {
             CascadeCommand::DeleteCardEdges(c) => c.capture_inverse(store),
             CascadeCommand::DeleteCardsByColumns(c) => c.capture_inverse(store),
-            CascadeCommand::DeleteArchivedCardsByColumns(c) => c.capture_inverse(store),
             CascadeCommand::DeleteArchivedCards(c) => c.capture_inverse(store),
             CascadeCommand::DeleteColumnsByBoard(c) => c.capture_inverse(store),
             CascadeCommand::DeleteSprintsByBoard(c) => c.capture_inverse(store),
@@ -137,49 +133,12 @@ impl DeleteCardsByColumns {
     }
 }
 
-/// Delete all archived cards belonging to the given columns.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct DeleteArchivedCardsByColumns {
-    pub column_ids: Vec<Uuid>,
-}
-
-impl DeleteArchivedCardsByColumns {
-    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
-        let archived = context
-            .store
-            .list_archived_cards_by_columns(&self.column_ids)?;
-        for ac in archived {
-            context.store.delete_archived_card(ac.card.id)?;
-        }
-        Ok(())
-    }
-
-    pub fn description(&self) -> String {
-        format!(
-            "Delete archived cards in {} column(s)",
-            self.column_ids.len()
-        )
-    }
-
-    pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
-        let archived_cards = store.list_archived_cards_by_columns(&self.column_ids)?;
-        if archived_cards.is_empty() {
-            return Ok(Vec::new());
-        }
-        Ok(vec![Command::Board(BoardCommand::Import(ImportEntities {
-            archived_cards,
-            ..Default::default()
-        }))])
-    }
-}
-
 /// Delete a specific set of archived cards by id.
 ///
 /// The board-delete cascade uses this to remove archived cards gathered by the
 /// first-class `board_id` field (which catches records whose `original_column_id`
-/// dangles because the column was deleted after archival). Unlike
-/// [`DeleteArchivedCardsByColumns`], it does not re-derive the target set from
-/// (possibly stale) column membership, so no record is leaked.
+/// dangles because the column was deleted after archival). It does not re-derive
+/// the target set from (possibly stale) column membership, so no record is leaked.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeleteArchivedCards {
     pub card_ids: Vec<Uuid>,
@@ -399,36 +358,6 @@ mod tests {
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].id, card3_id);
         assert_eq!(remaining[0].column_id, col3_id);
-    }
-
-    #[test]
-    fn test_delete_archived_cards_by_columns_removes_only_archived_in_given_columns() {
-        let tc = TestContext::new();
-        let mut board = crate::Board::new("B", Some("TST"));
-        let col1 = crate::Column::new(board.id, "C1", 0);
-        let col2 = crate::Column::new(board.id, "C2", 1);
-        let col1_id = col1.id;
-        let col2_id = col2.id;
-        let card1 = crate::Card::new(&mut board, col1_id, "1", 0);
-        let card2 = crate::Card::new(&mut board, col2_id, "2", 0);
-        let arch1 = crate::ArchivedCard::new(card1, uuid::Uuid::nil(), col1_id, 0);
-        let arch2 = crate::ArchivedCard::new(card2, uuid::Uuid::nil(), col2_id, 0);
-        let arch2_card_id = arch2.card.id;
-        tc.store.upsert_board(board).unwrap();
-        tc.store.upsert_column(col1).unwrap();
-        tc.store.upsert_column(col2).unwrap();
-        tc.store.insert_archived_card(arch1).unwrap();
-        tc.store.insert_archived_card(arch2).unwrap();
-
-        let context = tc.as_command_context();
-        let cmd = DeleteArchivedCardsByColumns {
-            column_ids: vec![col1_id],
-        };
-        cmd.execute(&context).unwrap();
-
-        let remaining = tc.store.list_archived_cards().unwrap();
-        assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].card.id, arch2_card_id);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/cascade_commands.rs
+++ b/crates/kanban-domain/src/commands/cascade_commands.rs
@@ -24,6 +24,7 @@ pub enum CascadeCommand {
     DeleteCardEdges(DeleteCardEdges),
     DeleteCardsByColumns(DeleteCardsByColumns),
     DeleteArchivedCardsByColumns(DeleteArchivedCardsByColumns),
+    DeleteArchivedCards(DeleteArchivedCards),
     DeleteColumnsByBoard(DeleteColumnsByBoard),
     DeleteSprintsByBoard(DeleteSprintsByBoard),
     /// Internal: set `sprint_id` on a list of archived cards. Used by
@@ -39,6 +40,7 @@ impl CascadeCommand {
             CascadeCommand::DeleteCardEdges(c) => c.execute(context),
             CascadeCommand::DeleteCardsByColumns(c) => c.execute(context),
             CascadeCommand::DeleteArchivedCardsByColumns(c) => c.execute(context),
+            CascadeCommand::DeleteArchivedCards(c) => c.execute(context),
             CascadeCommand::DeleteColumnsByBoard(c) => c.execute(context),
             CascadeCommand::DeleteSprintsByBoard(c) => c.execute(context),
             CascadeCommand::SetArchivedCardsSprint(c) => c.execute(context),
@@ -50,6 +52,7 @@ impl CascadeCommand {
             CascadeCommand::DeleteCardEdges(c) => c.description(),
             CascadeCommand::DeleteCardsByColumns(c) => c.description(),
             CascadeCommand::DeleteArchivedCardsByColumns(c) => c.description(),
+            CascadeCommand::DeleteArchivedCards(c) => c.description(),
             CascadeCommand::DeleteColumnsByBoard(c) => c.description(),
             CascadeCommand::DeleteSprintsByBoard(c) => c.description(),
             CascadeCommand::SetArchivedCardsSprint(c) => c.description(),
@@ -61,6 +64,7 @@ impl CascadeCommand {
             CascadeCommand::DeleteCardEdges(c) => c.capture_inverse(store),
             CascadeCommand::DeleteCardsByColumns(c) => c.capture_inverse(store),
             CascadeCommand::DeleteArchivedCardsByColumns(c) => c.capture_inverse(store),
+            CascadeCommand::DeleteArchivedCards(c) => c.capture_inverse(store),
             CascadeCommand::DeleteColumnsByBoard(c) => c.capture_inverse(store),
             CascadeCommand::DeleteSprintsByBoard(c) => c.capture_inverse(store),
             CascadeCommand::SetArchivedCardsSprint(c) => c.capture_inverse(store),
@@ -159,6 +163,49 @@ impl DeleteArchivedCardsByColumns {
 
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let archived_cards = store.list_archived_cards_by_columns(&self.column_ids)?;
+        if archived_cards.is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(vec![Command::Board(BoardCommand::Import(ImportEntities {
+            archived_cards,
+            ..Default::default()
+        }))])
+    }
+}
+
+/// Delete a specific set of archived cards by id.
+///
+/// The board-delete cascade uses this to remove archived cards gathered by the
+/// first-class `board_id` field (which catches records whose `original_column_id`
+/// dangles because the column was deleted after archival). Unlike
+/// [`DeleteArchivedCardsByColumns`], it does not re-derive the target set from
+/// (possibly stale) column membership, so no record is leaked.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeleteArchivedCards {
+    pub card_ids: Vec<Uuid>,
+}
+
+impl DeleteArchivedCards {
+    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
+        for id in &self.card_ids {
+            context.store.delete_archived_card(*id)?;
+        }
+        Ok(())
+    }
+
+    pub fn description(&self) -> String {
+        format!("Delete {} archived card(s)", self.card_ids.len())
+    }
+
+    /// Inverse: read each still-present archived card (captured before the
+    /// forward execution runs) and re-import it.
+    pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
+        let mut archived_cards = Vec::new();
+        for id in &self.card_ids {
+            if let Some(ac) = store.get_archived_card(*id)? {
+                archived_cards.push(ac);
+            }
+        }
         if archived_cards.is_empty() {
             return Ok(Vec::new());
         }
@@ -382,6 +429,39 @@ mod tests {
         let remaining = tc.store.list_archived_cards().unwrap();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].card.id, arch2_card_id);
+    }
+
+    #[test]
+    fn test_delete_archived_cards_removes_only_listed_ids_ignoring_columns() {
+        // Board-scoped id list must delete archived records even when their
+        // `original_column_id` dangles (column already gone).
+        let tc = TestContext::new();
+        let board_id = Uuid::new_v4();
+        let mut board = crate::Board::new("B", Some("TST"));
+        let dangling_col = Uuid::new_v4();
+        let live_col = crate::Column::new(board_id, "Live", 0);
+        let card1 = crate::Card::new(&mut board, dangling_col, "1", 0);
+        let card2 = crate::Card::new(&mut board, live_col.id, "2", 0);
+        let keep = crate::Card::new(&mut board, live_col.id, "keep", 1);
+        let arch1 = crate::ArchivedCard::new(card1, board_id, dangling_col, 0);
+        let arch2 = crate::ArchivedCard::new(card2, board_id, live_col.id, 0);
+        let keep_arch = crate::ArchivedCard::new(keep, board_id, live_col.id, 1);
+        let arch1_id = arch1.card.id;
+        let arch2_id = arch2.card.id;
+        let keep_id = keep_arch.card.id;
+        tc.store.insert_archived_card(arch1).unwrap();
+        tc.store.insert_archived_card(arch2).unwrap();
+        tc.store.insert_archived_card(keep_arch).unwrap();
+
+        let context = tc.as_command_context();
+        let cmd = DeleteArchivedCards {
+            card_ids: vec![arch1_id, arch2_id],
+        };
+        cmd.execute(&context).unwrap();
+
+        let remaining = tc.store.list_archived_cards().unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].card.id, keep_id);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -235,6 +235,37 @@ mod tests {
     }
 
     #[test]
+    fn test_delete_column_with_archived_cards_now_succeeds() {
+        // Under the D2 first-class model, an archived card's `original_column_id`
+        // is historical (not a live FK), so a column that only holds archived
+        // cards can be deleted. Board-scoped cleanup handles the archived record.
+        let tc = TestContext::new();
+        let mut board = crate::Board::new("B", Some("TST"));
+        let board_id = board.id;
+        let col = crate::Column::new(board_id, "C", 0);
+        let col_id = col.id;
+        let card = crate::Card::new(&mut board, col_id, "archived", 0);
+        let archived = crate::ArchivedCard::new(card, board_id, col_id, 0);
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+        tc.store.insert_archived_card(archived).unwrap();
+
+        let context = tc.as_command_context();
+        let cmd = DeleteColumn { column_id: col_id };
+        cmd.execute(&context).unwrap();
+
+        assert!(
+            tc.store.get_column(col_id).unwrap().is_none(),
+            "column with only archived cards must be deletable"
+        );
+        assert_eq!(
+            tc.store.list_archived_cards().unwrap().len(),
+            1,
+            "the archived record survives the column deletion (dangling original_column_id)"
+        );
+    }
+
+    #[test]
     fn test_create_column_command_rejects_negative_position_via_factory_validation() {
         let tc = TestContext::new();
         let context = tc.as_command_context();

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -172,18 +172,9 @@ impl DeleteColumn {
             )));
         }
 
-        let has_archived_cards = context
-            .store
-            .list_archived_cards()?
-            .iter()
-            .any(|ac| ac.original_column_id == self.column_id);
-        if has_archived_cards {
-            return Err(crate::KanbanError::validation(format!(
-                "Cannot delete column {}: column contains archived cards",
-                self.column_id
-            )));
-        }
-
+        // Archived cards no longer block column deletion (D2 first-class model):
+        // an `ArchivedCard` carries its own `board_id` and its `original_column_id`
+        // is historical, not a live FK — it may dangle after the column is gone.
         context.store.delete_column(self.column_id)?;
         Ok(())
     }

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -57,17 +57,6 @@ pub trait DataStore: Send + Sync {
     fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()>;
     fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()>;
 
-    fn list_archived_cards_by_columns(
-        &self,
-        column_ids: &[Uuid],
-    ) -> KanbanResult<Vec<ArchivedCard>> {
-        let all = self.list_archived_cards()?;
-        Ok(all
-            .into_iter()
-            .filter(|ac| column_ids.contains(&ac.original_column_id))
-            .collect())
-    }
-
     /// Board-scoped archived cards. Default filters the full list by the
     /// `board_id` field now carried on each `ArchivedCard` (B1). SQL backends
     /// override with a single `WHERE board_id = ?` query.

--- a/crates/kanban-domain/src/in_memory_store/archived_cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_cards.rs
@@ -42,21 +42,6 @@ impl InMemoryStore {
         Ok(acs)
     }
 
-    pub(super) fn list_archived_cards_by_columns_impl(
-        &self,
-        column_ids: &[Uuid],
-    ) -> KanbanResult<Vec<ArchivedCard>> {
-        let state = self.read_state()?;
-        let mut acs: Vec<ArchivedCard> = state
-            .archived_cards
-            .values()
-            .filter(|ac| column_ids.contains(&ac.original_column_id))
-            .cloned()
-            .collect();
-        acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
-        Ok(acs)
-    }
-
     pub(super) fn clear_sprint_from_archived_cards_impl(
         &self,
         sprint_id: Uuid,
@@ -114,40 +99,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(store.list_archived_cards().unwrap().len(), 2);
-    }
-
-    #[test]
-    fn test_list_archived_cards_by_columns_filters_correctly() {
-        let store = InMemoryStore::new();
-        let mut board = make_board("B");
-        let col1 = make_column(board.id, "C1", 0);
-        let col2 = make_column(board.id, "C2", 1);
-        let card1 = make_card(&mut board, col1.id, "Card1", 0);
-        let card2 = make_card(&mut board, col2.id, "Card2", 0);
-        store
-            .insert_archived_card(ArchivedCard::new(card1, uuid::Uuid::nil(), col1.id, 0))
-            .unwrap();
-        store
-            .insert_archived_card(ArchivedCard::new(card2, uuid::Uuid::nil(), col2.id, 0))
-            .unwrap();
-
-        let result = store.list_archived_cards_by_columns(&[col1.id]).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].original_column_id, col1.id);
-    }
-
-    #[test]
-    fn test_list_archived_cards_by_columns_empty_ids_returns_empty() {
-        let store = InMemoryStore::new();
-        let mut board = make_board("B");
-        let col = make_column(board.id, "C", 0);
-        let card = make_card(&mut board, col.id, "Card", 0);
-        store
-            .insert_archived_card(ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0))
-            .unwrap();
-
-        let result = store.list_archived_cards_by_columns(&[]).unwrap();
-        assert!(result.is_empty());
     }
 
     #[test]

--- a/crates/kanban-domain/src/in_memory_store/mod.rs
+++ b/crates/kanban-domain/src/in_memory_store/mod.rs
@@ -194,13 +194,6 @@ impl DataStore for InMemoryStore {
         self.insert_archived_card_impl(ac)
     }
 
-    fn list_archived_cards_by_columns(
-        &self,
-        column_ids: &[Uuid],
-    ) -> KanbanResult<Vec<ArchivedCard>> {
-        self.list_archived_cards_by_columns_impl(column_ids)
-    }
-
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
         self.list_archived_cards_by_board_impl(board_id)
     }

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -58,28 +58,39 @@ pub trait KanbanOperations {
     fn delete_card(&mut self, id: Uuid) -> KanbanResult<()>;
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>>;
 
+    /// Board-scoped archived cards via the first-class `board_id` field (D2).
+    /// Required so the discrete backend query (SQLite `WHERE board_id = ?`,
+    /// in-memory/JSON `board_id` filter) is reached instead of inferring the
+    /// board from each card's (possibly dangling) historical column. This is a
+    /// drift-lock: every `KanbanOperations` impl must provide it.
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>>;
+
     fn list_archived_cards_sorted(
         &self,
         filter: ArchivedCardListFilter,
     ) -> KanbanResult<Vec<ArchivedCard>> {
-        let cards = self.list_archived_cards()?;
+        // Scope by the first-class `board_id` field, not by column membership.
+        let cards = match filter.board_id {
+            Some(bid) => self.list_archived_cards_by_board(bid)?,
+            None => self.list_archived_cards()?,
+        };
         let board = match filter.board_id {
             Some(bid) => self.get_board(bid)?,
             None => None,
         };
-        let columns = match filter.board_id {
-            Some(bid) => self.list_columns(bid)?,
-            None => Vec::new(),
-        };
+        // Already board-scoped above: pass `board_id: None` and EMPTY columns so
+        // a dangling `original_column_id` (its column deleted after archival) is
+        // not re-dropped by column-membership filtering. `board` is retained only
+        // for board-default sort resolution.
         let card_filter = CardListFilter {
-            board_id: filter.board_id,
+            board_id: None,
             sort: filter.sort,
             sort_order: filter.sort_order,
             ..Default::default()
         };
         Ok(filter_and_sort_cards(
             &cards,
-            &columns,
+            &[],
             &[],
             board.as_ref(),
             &card_filter,

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -249,6 +249,9 @@ impl KanbanOperations for McpContext {
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         self.inner.list_archived_cards()
     }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.inner.list_archived_cards_by_board(board_id)
+    }
 
     // ========================================================================
     // Card Sprint Operations

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -321,48 +321,6 @@ impl DataStore for SqliteStore {
         })
     }
 
-    fn list_archived_cards_by_columns(
-        &self,
-        column_ids: &[Uuid],
-    ) -> KanbanResult<Vec<ArchivedCard>> {
-        if column_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-        run(async {
-            let placeholders: Vec<&str> = column_ids.iter().map(|_| "?").collect();
-            let sql = format!(
-                "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
-                        c.position, c.due_date, c.points, c.card_number, c.sprint_id,
-                        c.created_at, c.updated_at, c.completed_at,
-                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
-                 FROM archived_cards ac
-                 JOIN cards c ON ac.card_id = c.id
-                 WHERE ac.original_column_id IN ({})
-                 ORDER BY ac.archived_at",
-                placeholders.join(", ")
-            );
-            let mut query = sqlx::query(&sql);
-            for id in column_ids {
-                query = query.bind(id.to_string());
-            }
-            let rows = query.fetch_all(&self.pool).await.map_err(db_err)?;
-
-            let card_ids: Vec<String> = rows
-                .iter()
-                .map(|r| r.try_get("id").map_err(db_err))
-                .collect::<KanbanResult<_>>()?;
-            let mut logs_map = self.fetch_sprint_logs_batch(&card_ids).await?;
-
-            let mut result = Vec::with_capacity(rows.len());
-            for row in &rows {
-                let id_str: String = row.try_get("id").map_err(db_err)?;
-                let logs = logs_map.remove(&id_str).unwrap_or_default();
-                result.push(row_to_archived_card(row, logs)?);
-            }
-            Ok(result)
-        })
-    }
-
     /// Board-scoped archived cards. Overrides the trait default (which filters
     /// the full list) with a direct `WHERE board_id = ?` on the extension table,
     /// so board scoping is a single indexed query.

--- a/crates/kanban-service/src/cascade.rs
+++ b/crates/kanban-service/src/cascade.rs
@@ -1,5 +1,5 @@
 use kanban_domain::commands::cascade_commands::{
-    CascadeCommand, DeleteArchivedCardsByColumns, DeleteCardEdges, DeleteCardsByColumns,
+    CascadeCommand, DeleteArchivedCards, DeleteCardEdges, DeleteCardsByColumns,
     DeleteColumnsByBoard, DeleteSprintsByBoard,
 };
 use kanban_domain::commands::{BoardCommand, Command, DeleteBoard};
@@ -14,7 +14,22 @@ pub(crate) fn delete_board(store: &dyn DataStore, board_id: Uuid) -> KanbanResul
         .map(|c| c.id)
         .collect();
 
-    if column_ids.is_empty() {
+    // Gather archived cards by the first-class `board_id` field, not by (historical)
+    // column membership. A card whose column was deleted after archival — now
+    // possible since the DeleteColumn archived-cards guard is gone — has a dangling
+    // `original_column_id` and is missed by a by-columns gather, leaking its archived
+    // record plus its graph edges. Every backend populates `board_id` (B4), so the
+    // board-scoped query catches all of them.
+    let archived_card_ids: Vec<Uuid> = store
+        .list_archived_cards_by_board(board_id)?
+        .into_iter()
+        .map(|ac| ac.card.id)
+        .collect();
+
+    // Widened early-return guard: the only remaining board may hold nothing but
+    // archived cards whose column is already gone (column_ids empty) — do not skip
+    // the cascade in that case, or those records leak.
+    if column_ids.is_empty() && archived_card_ids.is_empty() {
         return Ok(vec![Command::Board(BoardCommand::Delete(DeleteBoard {
             board_id,
         }))]);
@@ -25,9 +40,7 @@ pub(crate) fn delete_board(store: &dyn DataStore, board_id: Uuid) -> KanbanResul
         .iter()
         .map(|c| c.id)
         .collect();
-    for ac in store.list_archived_cards_by_columns(&column_ids)? {
-        card_ids.push(ac.card.id);
-    }
+    card_ids.extend(archived_card_ids.iter().copied());
 
     Ok(vec![
         Command::Cascade(CascadeCommand::DeleteCardEdges(DeleteCardEdges {
@@ -36,11 +49,9 @@ pub(crate) fn delete_board(store: &dyn DataStore, board_id: Uuid) -> KanbanResul
         Command::Cascade(CascadeCommand::DeleteCardsByColumns(DeleteCardsByColumns {
             column_ids: column_ids.clone(),
         })),
-        Command::Cascade(CascadeCommand::DeleteArchivedCardsByColumns(
-            DeleteArchivedCardsByColumns {
-                column_ids: column_ids.clone(),
-            },
-        )),
+        Command::Cascade(CascadeCommand::DeleteArchivedCards(DeleteArchivedCards {
+            card_ids: archived_card_ids,
+        })),
         Command::Cascade(CascadeCommand::DeleteColumnsByBoard(DeleteColumnsByBoard {
             board_id,
         })),

--- a/crates/kanban-service/src/cascade.rs
+++ b/crates/kanban-service/src/cascade.rs
@@ -28,8 +28,12 @@ pub(crate) fn delete_board(store: &dyn DataStore, board_id: Uuid) -> KanbanResul
 
     // Widened early-return guard: the only remaining board may hold nothing but
     // archived cards whose column is already gone (column_ids empty) — do not skip
-    // the cascade in that case, or those records leak.
-    if column_ids.is_empty() && archived_card_ids.is_empty() {
+    // the cascade in that case, or those records leak. Likewise a board with only
+    // sprints (all columns emptied and deleted) must still emit
+    // `DeleteSprintsByBoard`, else its sprints leak (JSON/in-memory) or FK-cascade
+    // without undo capture (SQLite), so undo would restore the board without them.
+    let has_sprints = !store.list_sprints_by_board(board_id)?.is_empty();
+    if column_ids.is_empty() && archived_card_ids.is_empty() && !has_sprints {
         return Ok(vec![Command::Board(BoardCommand::Delete(DeleteBoard {
             board_id,
         }))]);

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -281,6 +281,13 @@ impl KanbanContext {
         self.backend.list_archived_cards()
     }
 
+    pub(super) fn list_archived_cards_by_board_impl(
+        &self,
+        board_id: Uuid,
+    ) -> KanbanResult<Vec<ArchivedCard>> {
+        self.backend.list_archived_cards_by_board(board_id)
+    }
+
     pub(super) fn assign_card_to_sprint_impl(
         &mut self,
         card_id: Uuid,

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -161,6 +161,9 @@ impl KanbanOperations for KanbanContext {
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         KanbanContext::list_archived_cards_impl(self)
     }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        KanbanContext::list_archived_cards_by_board_impl(self, board_id)
+    }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
         KanbanContext::assign_card_to_sprint_impl(self, card_id, sprint_id)

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -268,7 +268,7 @@ impl KanbanContext {
         use kanban_domain::commands::{Command, CommandContext, ImportEntities};
         use std::collections::HashSet;
 
-        let imported: Snapshot = serde_json::from_str(data)
+        let mut imported: Snapshot = serde_json::from_str(data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
 
         let board = imported
@@ -277,13 +277,29 @@ impl KanbanContext {
             .cloned()
             .ok_or_else(|| KanbanError::validation("No board in import data"))?;
 
+        let existing_columns = self.backend.list_all_columns()?;
         let imported_column_ids: HashSet<Uuid> = imported.columns.iter().map(|c| c.id).collect();
-        let existing_column_ids: HashSet<Uuid> = self
-            .backend
-            .list_all_columns()?
-            .into_iter()
-            .map(|c| c.id)
+        let existing_column_ids: HashSet<Uuid> = existing_columns.iter().map(|c| c.id).collect();
+
+        // Backfill board_id on archived cards that predate the first-class field
+        // (they deserialize to nil when the `board_id` key is absent). Reconstruct
+        // from original_column_id -> column.board_id using the imported columns
+        // unioned with the existing store columns; leave nil only when the original
+        // column resolves nowhere (mirrors the V8 / schema-3 migration rule).
+        let col_to_board: std::collections::HashMap<Uuid, Uuid> = imported
+            .columns
+            .iter()
+            .chain(existing_columns.iter())
+            .map(|c| (c.id, c.board_id))
             .collect();
+        for ac in &mut imported.archived_cards {
+            if ac.board_id.is_nil() {
+                if let Some(&board_id) = col_to_board.get(&ac.original_column_id) {
+                    ac.board_id = board_id;
+                }
+            }
+        }
+
         for card in &imported.cards {
             if !imported_column_ids.contains(&card.column_id)
                 && !existing_column_ids.contains(&card.column_id)

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -242,6 +242,9 @@ impl DataStore for JsonDataStore {
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         self.with_read(|s| s.list_archived_cards())
     }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.with_read(|s| s.list_archived_cards_by_board(board_id))
+    }
     fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
         self.with_mutate(|s| s.insert_archived_card(ac))
     }

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -131,6 +131,9 @@ impl DataStore for SqliteBackend {
     ) -> KanbanResult<Vec<ArchivedCard>> {
         self.db.list_archived_cards_by_columns(column_ids)
     }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.db.list_archived_cards_by_board(board_id)
+    }
     fn clear_sprint_from_archived_cards(
         &self,
         sprint_id: Uuid,

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -125,12 +125,6 @@ impl DataStore for SqliteBackend {
     fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
         self.db.delete_archived_card(card_id)
     }
-    fn list_archived_cards_by_columns(
-        &self,
-        column_ids: &[Uuid],
-    ) -> KanbanResult<Vec<ArchivedCard>> {
-        self.db.list_archived_cards_by_columns(column_ids)
-    }
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
         self.db.list_archived_cards_by_board(board_id)
     }

--- a/crates/kanban-service/tests/data_integrity_tests.rs
+++ b/crates/kanban-service/tests/data_integrity_tests.rs
@@ -202,6 +202,65 @@ async fn test_import_with_invalid_column_reference_fails() -> KanbanResult<()> {
     Ok(())
 }
 
+/// 7. KAN-833 (B5 review fix): importing a board from an export that predates
+///    the archived-card `board_id` field must backfill `board_id` from
+///    `original_column_id` -> imported column. Otherwise the card deserializes
+///    with `board_id = nil` and, since B5 scopes archived listing AND the
+///    board-delete cascade by `board_id`, becomes invisible / leaked.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_backfills_board_id_on_legacy_archived_card() -> KanbanResult<()> {
+    let (mut ctx, _dir) = open_json_ctx().await;
+
+    let mut board = kanban_domain::Board::new("Imported", Some("IMP"));
+    let board_id = board.id;
+    let column = kanban_domain::Column::new(board_id, "Todo", 0);
+    let column_id = column.id;
+    let card = kanban_domain::Card::new(&mut board, column_id, "Archived", 0);
+    let card_id = card.id;
+    // Archived card constructed with nil board_id, then its `board_id` key is
+    // stripped from the serialized JSON to emulate a pre-field export.
+    let archived = kanban_domain::ArchivedCard::new(card, Uuid::nil(), column_id, 0);
+
+    let snapshot = kanban_domain::Snapshot {
+        boards: vec![board],
+        columns: vec![column],
+        cards: vec![],
+        archived_cards: vec![archived],
+        sprints: vec![],
+        graph: kanban_domain::DependencyGraph::default(),
+    };
+
+    let mut value = serde_json::to_value(&snapshot).unwrap();
+    let removed = value["archived_cards"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("board_id");
+    assert!(
+        removed.is_some(),
+        "the export must omit board_id to emulate a legacy archived card"
+    );
+    let json = serde_json::to_string(&value).unwrap();
+
+    ctx.import_board(&json)?;
+
+    // Board-scoped listing must find the archived card, proving board_id was
+    // backfilled from original_column_id -> imported column. Before the fix this
+    // returns empty (board_id stayed nil).
+    let backend = ctx.backend();
+    let scoped = backend.list_archived_cards_by_board(board_id)?;
+    assert_eq!(
+        scoped.len(),
+        1,
+        "board-scoped archived listing must return the backfilled card"
+    );
+    assert_eq!(scoped[0].card.id, card_id);
+    assert_eq!(
+        scoped[0].board_id, board_id,
+        "board_id must be backfilled from the imported column"
+    );
+    Ok(())
+}
+
 /// 6. Queue 200+ rapid mutations, flush, then verify all updates persisted.
 ///    This exercises the save path under load and asserts no updates are dropped.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -379,6 +379,51 @@ macro_rules! cascade_tests {
                 );
                 assert_eq!(archived[0].card.id, card_id);
             }
+
+            /// KAN-833 (B5 review fix): a board with sprints but NO columns and
+            /// NO archived cards (reachable by deleting all empty columns) must
+            /// still cascade `DeleteSprintsByBoard`. The old widened guard
+            /// short-circuited to a bare `DeleteBoard`, leaking the sprints
+            /// (JSON/in-memory) or FK-cascading them without undo capture
+            /// (SQLite), so undo restored the board WITHOUT its sprint.
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_delete_board_with_only_sprints_cascades_and_undo_restores_sprint() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();
+                let board_id = board.id;
+                let sprint_id = ctx.create_sprint(board_id, None, None).unwrap().id;
+
+                assert!(
+                    backend.list_columns_by_board(board_id).unwrap().is_empty(),
+                    "board has no columns"
+                );
+                assert_eq!(
+                    backend.list_all_sprints().unwrap().len(),
+                    1,
+                    "the sprint exists pre-delete"
+                );
+
+                ctx.delete_board(board_id).unwrap();
+
+                assert!(
+                    backend.list_all_sprints().unwrap().is_empty(),
+                    "delete_board must remove the board's sprints even with no columns"
+                );
+
+                let undone = ctx.undo().unwrap();
+                assert!(undone, "undo should report success");
+
+                assert!(
+                    backend
+                        .list_all_sprints()
+                        .unwrap()
+                        .iter()
+                        .any(|s| s.id == sprint_id),
+                    "undo must restore the sprint by id"
+                );
+            }
         }
     };
 }

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -111,7 +111,7 @@ macro_rules! cascade_tests {
                 let col = Column::new(board_id, "Col", 0);
                 let col_id = col.id;
                 let card = Card::new(&mut board, col_id, "C", 0);
-                let archived = ArchivedCard::new(card, uuid::Uuid::nil(), col_id, 0);
+                let archived = ArchivedCard::new(card, board_id, col_id, 0);
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col).unwrap();
                 backend.insert_archived_card(archived).unwrap();
@@ -151,10 +151,7 @@ macro_rules! cascade_tests {
                 let arch_card_id = arch_card.id;
                 backend
                     .insert_archived_card(ArchivedCard::new(
-                        arch_card,
-                        uuid::Uuid::nil(),
-                        column.id,
-                        2,
+                        arch_card, board_id, column.id, 2,
                     ))
                     .unwrap();
 

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -5,7 +5,7 @@
 
 use kanban_domain::{
     commands::{Command, MoveCard},
-    ArchivedCard, Board, Card, Column, Sprint,
+    ArchivedCard, ArchivedCardListFilter, Board, Card, Column, Sprint,
 };
 use kanban_persistence_json::JsonFileStore;
 use kanban_service::{
@@ -281,6 +281,106 @@ macro_rules! cascade_tests {
                     commands_before,
                     "failed batch must not be appended to the command log"
                 );
+            }
+
+            /// KAN-833 regression (B5, confirmed orphan): once the DeleteColumn
+            /// archived-cards guard is gone, a card can be archived and then have
+            /// its original column deleted. The board-delete cascade must still
+            /// remove that archived record AND its dependency-graph edges. The old
+            /// by-columns gather scoped off live columns, so a dangling
+            /// `original_column_id` was missed and leaked. The fix gathers archived
+            /// cards by the first-class `board_id` field (populated at archive time
+            /// on both backends now that B4 has landed), so this passes on JSON and
+            /// SQLite alike.
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_delete_board_removes_archived_cards_whose_column_was_deleted() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();
+                let board_id = board.id;
+                let column = ctx.create_column(board_id, "X".into(), None).unwrap();
+                let card_c = ctx
+                    .create_card(board_id, column.id, "C".into(), Default::default())
+                    .unwrap();
+                let card_d = ctx
+                    .create_card(board_id, column.id, "D".into(), Default::default())
+                    .unwrap();
+
+                // An edge between the two cards so the cascade has graph state to clean.
+                let mut graph = backend.get_graph().unwrap();
+                graph.set_block(card_c.id, card_d.id).unwrap();
+                backend.set_graph(graph).unwrap();
+
+                // Archive both (populates board_id = board_id, original_column_id =
+                // column.id), then delete the column out from under them (now
+                // permitted post-guard-removal).
+                ctx.archive_card(card_c.id).unwrap();
+                ctx.archive_card(card_d.id).unwrap();
+                ctx.delete_column(column.id).unwrap();
+
+                // The column is gone, but the archived records and their (archived)
+                // edge remain.
+                assert!(
+                    backend.list_columns_by_board(board_id).unwrap().is_empty(),
+                    "column X was deleted"
+                );
+                assert_eq!(
+                    backend.list_archived_cards().unwrap().len(),
+                    2,
+                    "both archived records survive the column deletion"
+                );
+                assert!(
+                    !backend.get_graph().unwrap().is_empty(),
+                    "the edge between the archived cards is still present pre-cascade"
+                );
+
+                ctx.delete_board(board_id).unwrap();
+
+                // The confirmed regression: with the by-columns cascade these leaked.
+                assert!(
+                    backend.list_archived_cards().unwrap().is_empty(),
+                    "delete_board must remove archived records whose original column was deleted"
+                );
+                assert_eq!(
+                    backend.get_graph().unwrap().len(),
+                    0,
+                    "delete_board must remove the dependency-graph edges of those archived cards"
+                );
+            }
+
+            /// KAN-833 (B5): `list_archived_cards_sorted` scopes by the first-class
+            /// `board_id`, not by column membership, so an archived card whose
+            /// original column was later deleted is NOT dropped from the board's
+            /// archived list.
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_list_archived_cards_sorted_keeps_card_with_dangling_column() {
+                let (mut ctx, _dir) = $open_ctx.await;
+
+                let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();
+                let board_id = board.id;
+                let column = ctx.create_column(board_id, "X".into(), None).unwrap();
+                let card = ctx
+                    .create_card(board_id, column.id, "C".into(), Default::default())
+                    .unwrap();
+                let card_id = card.id;
+
+                ctx.archive_card(card_id).unwrap();
+                ctx.delete_column(column.id).unwrap();
+
+                let archived = ctx
+                    .list_archived_cards_sorted(ArchivedCardListFilter {
+                        board_id: Some(board_id),
+                        ..Default::default()
+                    })
+                    .unwrap();
+
+                assert_eq!(
+                    archived.len(),
+                    1,
+                    "board-scoped listing must keep the archived card despite its dangling original_column_id"
+                );
+                assert_eq!(archived[0].card.id, card_id);
             }
         }
     };

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -276,6 +276,9 @@ impl KanbanOperations for TuiContext {
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         self.inner.list_archived_cards()
     }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.inner.list_archived_cards_by_board(board_id)
+    }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
         let r = self.inner.assign_card_to_sprint(card_id, sprint_id);

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -84,7 +84,7 @@ fn test_delete_column_with_cards_fails() {
 }
 
 #[test]
-fn test_delete_column_with_archived_cards_fails() {
+fn test_delete_column_with_archived_cards_succeeds() {
     let store = InMemoryStore::new();
     let board = Board::new("Test Board", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
@@ -112,10 +112,17 @@ fn test_delete_column_with_archived_cards_fails() {
     cmd.execute(&ctx).unwrap();
 
     let cmd = DeleteColumn { column_id };
-    let result = cmd.execute(&ctx);
-    assert!(result.unwrap_err().is_validation());
+    cmd.execute(&ctx).unwrap();
 
-    assert!(store.get_column(column_id).unwrap().is_some());
+    assert!(
+        store.get_column(column_id).unwrap().is_none(),
+        "under the D2 first-class model a column with only archived cards is deletable"
+    );
+    assert_eq!(
+        store.list_archived_cards().unwrap().len(),
+        1,
+        "the archived record survives the column deletion (dangling original_column_id)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

The behavioral half of the archived-cards retrofit, now that B1–B4 have populated `board_id` in every backend (epic KAN-821, sub-epic SE-B). This was deferred out of B2 and gated on the persistence backfill.

Three changes:
1. **Board-scoped archived listing** — `list_archived_cards_sorted` scopes by the `board_id` field (empty columns passed to `filter_and_sort_cards` so a dangling `original_column_id` is not re-dropped). `list_archived_cards_by_board` is promoted to a **required** `KanbanOperations` method (drift-locked across all 4 impls) so the SQLite `WHERE board_id = ?` override is actually used.
2. **Column delete no longer blocked by archived cards** — the `DeleteColumn` guard is removed; archived cards are board-scoped historical records whose column reference may dangle.
3. **Board-delete cascade orphan fix** — the cascade previously gathered archived cards by *live columns*, so a card whose column was deleted after archival leaked (record + graph edges). It now gathers by `board_id` and deletes via a new `DeleteArchivedCards { card_ids }` command.

## Pure board-scoped (not the re-spike's union)

The re-spike used a `by-board ∪ by-columns` union as a bridge because it ran pre-B4 (SQLite read `board_id` as nil). With B4 merged, every backend populates `board_id` on open/migration, so the by-columns arm is redundant (a nil `board_id` implies the column is already gone, which by-columns can't catch either). The root spec anticipated this collapse. The json+sqlite cascade tests verify it on both backends.

## Tests (TDD)
- `test_delete_column_with_archived_cards_now_succeeds` (domain) + the flipped tui `test_delete_column_with_archived_cards_succeeds`
- `test_list_archived_cards_sorted_keeps_card_with_dangling_column`
- `test_delete_board_removes_archived_cards_whose_column_was_deleted` — the confirmed regression, proven fail-then-pass, on **both** backends
- Two pre-existing cascade tests updated from an artificial nil `board_id` fixture to a realistic populated one

## Verification (full workspace, not crate-scoped)
- `cargo build --workspace --tests` compiles
- `cargo test --workspace` — 2468 pass, 0 fail (delete_board_cascade 14/14, both backends)
- `cargo clippy --workspace --tests -- -D warnings` clean
- `cargo fmt --all --check` clean

Refs KAN-833.