### PR TITLE
KAN-843 feat(service): ArchivedCardResponse v1 DTO with board_id (B6)

### DIFF
--- a/.changeset/kan-843-archived-card-response-dto.md
+++ b/.changeset/kan-843-archived-card-response-dto.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+The CLI `card list --archived` output and the MCP `list_archived_cards` tool now serialize a stable v1 `ArchivedCardResponse` DTO instead of the internal domain summary. The archived-card JSON now nests the richer card projection (carrying `description` and `card_number`, hiding internal `sprint_logs`) and surfaces the archived card's `board_id` as a first-class field, matching the v1 DTO direction used elsewhere. An exhaustive mapping means a future `ArchivedCard` field must be deliberately represented (or omitted) in the DTO.

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -3,10 +3,10 @@ use crate::context::CliContext;
 use crate::output;
 use kanban_core::{parse_datetime_input, resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardSummary, CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions,
-    FieldUpdate, KanbanOperations, SprintStatus,
+    CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions, FieldUpdate,
+    KanbanOperations, SprintStatus,
 };
-use kanban_service::api::CardResponse;
+use kanban_service::api::{ArchivedCardResponse, CardResponse};
 
 use uuid::Uuid;
 
@@ -52,9 +52,9 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                         sort: args.sort.map(|s| s.to_sort_field()),
                         sort_order: args.order.map(|o| o.to_sort_order()),
                     })?;
-                let summaries: Vec<ArchivedCardSummary> =
-                    archived.iter().map(ArchivedCardSummary::from).collect();
-                output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
+                let responses: Vec<ArchivedCardResponse> =
+                    archived.iter().map(ArchivedCardResponse::from).collect();
+                output::output_success(PaginatedList::paginate(responses, page, page_size)?);
             } else {
                 let filter = match build_filter(ctx, &args) {
                     Ok(f) => f,

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1271,7 +1271,10 @@ mod card_tests {
         assert_eq!(archived_json["data"]["total"], 1);
         assert!(archived_json["data"]["items"][0]["archived_at"].is_string());
         assert!(archived_json["data"]["items"][0]["original_column_id"].is_string());
-        assert!(!archived_json["data"]["items"][0]["card"]
+        // v1 ArchivedCardResponse (KAN-843): the nested card is the rich
+        // CardResponse (carries `description`), and board_id is first-class.
+        assert!(archived_json["data"]["items"][0]["board_id"].is_string());
+        assert!(archived_json["data"]["items"][0]["card"]
             .as_object()
             .unwrap()
             .contains_key("description"));

--- a/crates/kanban-domain/src/archived_card.rs
+++ b/crates/kanban-domain/src/archived_card.rs
@@ -1,13 +1,7 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 
-use crate::{
-    archival::ArchiveMetadata,
-    board::BoardId,
-    card::{Card, CardSummary},
-    column::ColumnId,
-};
+use crate::{archival::ArchiveMetadata, board::BoardId, card::Card, column::ColumnId};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArchivedCard {
@@ -77,31 +71,6 @@ impl crate::archival::ArchivedEntity for ArchivedCard {
 
     fn metadata(&self) -> ArchiveMetadata {
         self.metadata
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ArchivedCardSummary {
-    pub card: CardSummary,
-    pub archived_at: DateTime<Utc>,
-    /// Omitted from output when nil ("unknown"): SQLite and pre-backfill JSON
-    /// return nil until the persistence migration lands, and a zero UUID in
-    /// MCP/CLI output would read as a real board. Surfaced once populated.
-    #[serde(default, skip_serializing_if = "uuid::Uuid::is_nil")]
-    pub board_id: BoardId,
-    pub original_column_id: ColumnId,
-    pub original_position: i32,
-}
-
-impl From<&ArchivedCard> for ArchivedCardSummary {
-    fn from(a: &ArchivedCard) -> Self {
-        Self {
-            card: CardSummary::from(&a.card),
-            archived_at: a.metadata.archived_at,
-            board_id: a.board_id,
-            original_column_id: a.original_column_id,
-            original_position: a.original_position,
-        }
     }
 }
 
@@ -193,44 +162,5 @@ mod tests {
         let json = serde_json::to_string(&ac).unwrap();
         let restored: ArchivedCard = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.board_id, board_id);
-    }
-
-    #[test]
-    fn test_archived_card_summary_carries_board_id() {
-        // The summary projection must surface board_id so board-scoped queries
-        // can filter without loading the full record.
-        let ac = sample();
-        let summary = ArchivedCardSummary::from(&ac);
-        assert_eq!(summary.board_id, ac.board_id);
-    }
-
-    #[test]
-    fn test_summary_omits_nil_board_id_from_output() {
-        // A nil board_id means "unknown" (SQLite and legacy JSON until the
-        // persistence backfill lands). It must NOT reach MCP/CLI output as a
-        // zero UUID that consumers would mistake for a real board.
-        let ac = sample(); // built with a nil board_id
-        assert!(ac.board_id.is_nil());
-        let v = serde_json::to_value(ArchivedCardSummary::from(&ac)).unwrap();
-        assert!(
-            v.get("board_id").is_none(),
-            "unknown (nil) board_id must be omitted from summary output"
-        );
-    }
-
-    #[test]
-    fn test_summary_serializes_known_board_id() {
-        // A populated board_id IS surfaced, so the gate is omit-when-unknown,
-        // not drop-always.
-        let mut board = Board::new("B", None::<String>);
-        let board_id = board.id;
-        let col = Column::new(board_id, "Todo", 0);
-        let card = Card::new(&mut board, col.id, "T", 0);
-        let summary = ArchivedCardSummary::from(&ArchivedCard::new(card, board_id, col.id, 0));
-        let v = serde_json::to_value(summary).unwrap();
-        assert_eq!(
-            v.get("board_id").and_then(|b| b.as_str()),
-            Some(board_id.to_string().as_str())
-        );
     }
 }

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -32,7 +32,7 @@ pub mod tag;
 pub mod task_list_view;
 
 pub use archival::{ArchiveMetadata, ArchivedEntity};
-pub use archived_card::{ArchivedCard, ArchivedCardSummary};
+pub use archived_card::ArchivedCard;
 pub use board::{
     get_active_sprint_card_prefix_override, get_active_sprint_prefix_override, Board, BoardId,
     BoardUpdate, SortField, SortOrder,

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -11,10 +11,9 @@ use crate::requests::card::{
 use crate::KanbanMcpServer;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
-    ArchivedCardListFilter, ArchivedCardSummary, CardListFilter, CardUpdate, FieldUpdate,
-    KanbanOperations,
+    ArchivedCardListFilter, CardListFilter, CardUpdate, FieldUpdate, KanbanOperations,
 };
-use kanban_service::api::CardResponse;
+use kanban_service::api::{ArchivedCardResponse, CardResponse};
 use rmcp::{
     handler::server::wrapper::Parameters,
     model::{CallToolResult, ErrorData as McpError},
@@ -236,7 +235,7 @@ impl KanbanMcpServer {
     }
 
     #[tool(
-        description = "List archived cards. Returns ArchivedCardSummary (no description). Use page/page_size for pagination (default: page=1, page_size=50)."
+        description = "List archived cards. Returns ArchivedCardResponse (nested card with description + board_id). Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
     pub async fn tool_list_archived_cards(
         &self,
@@ -259,10 +258,10 @@ impl KanbanMcpServer {
             .map_err(kanban_err_to_mcp)
         })
         .await?;
-        let summaries: Vec<ArchivedCardSummary> =
-            cards.iter().map(ArchivedCardSummary::from).collect();
+        let responses: Vec<ArchivedCardResponse> =
+            cards.iter().map(ArchivedCardResponse::from).collect();
         to_call_tool_result(
-            &PaginatedList::paginate(summaries, page, page_size).map_err(core_err_to_mcp)?,
+            &PaginatedList::paginate(responses, page, page_size).map_err(core_err_to_mcp)?,
         )
     }
 

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1858,3 +1858,69 @@ async fn read_tools_project_through_v1_response_dtos_hiding_internal_state() {
         assert!(card.get(f).is_none(), "get_card leaked {f}: {card}");
     }
 }
+
+#[tokio::test]
+async fn test_mcp_list_archived_cards_includes_board_id() {
+    let (server, _tmp) = setup_server().await;
+    let board = text_payload(
+        &server
+            .tool_create_board(Parameters(board_req("Alpha", Some("A".into()))))
+            .await
+            .unwrap(),
+    );
+    let board_id = board["id"].as_str().unwrap().to_string();
+
+    server
+        .tool_create_column(Parameters(column_req("Alpha", "TODO")))
+        .await
+        .unwrap();
+    let created = text_payload(
+        &server
+            .tool_create_card(Parameters(CreateCardParams {
+                board: "Alpha".into(),
+                column: "TODO".into(),
+                sprint: None,
+                content: kanban_service::api::CreateCardRequest {
+                    id: None,
+                    title: "the card".into(),
+                    description: Some("desc".into()),
+                    priority: None,
+                    due_date: None,
+                    points: None,
+                    sprint_id: None,
+                },
+            }))
+            .await
+            .unwrap(),
+    );
+    let card_id = created["id"].as_str().unwrap().to_string();
+    server
+        .tool_archive_card(Parameters(kanban_mcp::ArchiveCardRequest { card: card_id }))
+        .await
+        .unwrap();
+
+    let listed = text_payload(
+        &server
+            .tool_list_archived_cards(Parameters(kanban_mcp::ListArchivedCardsRequest {
+                board: None,
+                sort: None,
+                order: None,
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    let item = &listed["items"][0];
+    // v1 ArchivedCardResponse: board_id is first-class and equals the source board.
+    assert_eq!(item["board_id"], board_id);
+    // Nested `card` is the rich CardResponse (carries description + card_number,
+    // hides internal sprint_logs).
+    assert_eq!(item["card"]["description"], "desc");
+    assert!(item["card"]["card_number"].is_number());
+    assert!(item["card"]
+        .as_object()
+        .unwrap()
+        .get("sprint_logs")
+        .is_none());
+}

--- a/crates/kanban-service/src/api/mod.rs
+++ b/crates/kanban-service/src/api/mod.rs
@@ -5,10 +5,11 @@
 //! callers into an explicit version path.
 mod v1;
 pub use v1::{
-    ApiError, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame,
-    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
-    CreateSprintRequest, ErrorCode, Page, PageParams, Patch, ReorderColumnRequest,
-    ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest,
-    SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto,
-    UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
+    ApiError, ArchivedCardResponse, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto,
+    ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
+    CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams, Patch,
+    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
+    ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
+    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
+    UpdateSprintRequest,
 };

--- a/crates/kanban-service/src/api/v1/cards/mod.rs
+++ b/crates/kanban-service/src/api/v1/cards/mod.rs
@@ -2,4 +2,4 @@ mod conversions;
 mod requests;
 mod response;
 pub use requests::{CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
-pub use response::CardResponse;
+pub use response::{ArchivedCardResponse, CardResponse};

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -107,4 +107,26 @@ mod tests {
         let back: CardResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(back, resp);
     }
+
+    #[test]
+    fn test_archived_card_response_carries_board_id_and_archived_meta() {
+        use kanban_domain::ArchivedCard;
+        let card = sample_card();
+        let board_id = Uuid::new_v4();
+        let original_column_id = Uuid::new_v4();
+        let ac = ArchivedCard::new(card, board_id, original_column_id, 7);
+
+        let resp = ArchivedCardResponse::from(&ac);
+
+        // First-class board_id (B1) + the archival metadata are surfaced, and the
+        // nested card is the rich CardResponse projection (not the lean summary).
+        assert_eq!(resp.board_id, board_id);
+        assert_eq!(resp.archived_at, ac.metadata.archived_at);
+        assert_eq!(resp.original_column_id, original_column_id);
+        assert_eq!(resp.original_position, 7);
+        assert_eq!(resp.card, CardResponse::from(&ac.card));
+        // The rich card projection carries `description` (the lean summary did not).
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json["card"].get("description").is_some());
+    }
 }

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -73,7 +73,11 @@ impl From<&Card> for CardResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArchivedCardResponse {
     pub card: CardResponse,
-    pub board_id: Uuid,
+    /// The board the card belonged to. `None` when unknown — the domain uses a
+    /// nil UUID sentinel for an archived card whose original column was already
+    /// gone at backfill time; surfacing that zero-UUID would read as a real
+    /// board, so it maps to `null` here.
+    pub board_id: Option<Uuid>,
     pub archived_at: DateTime<Utc>,
     pub original_column_id: Uuid,
     pub original_position: i32,
@@ -92,7 +96,7 @@ impl From<&ArchivedCard> for ArchivedCardResponse {
         } = archived;
         Self {
             card: CardResponse::from(card),
-            board_id: *board_id,
+            board_id: (!board_id.is_nil()).then_some(*board_id),
             archived_at: metadata.archived_at,
             original_column_id: *original_column_id,
             original_position: *original_position,
@@ -153,7 +157,7 @@ mod tests {
 
         // First-class board_id (B1) + the archival metadata are surfaced, and the
         // nested card is the rich CardResponse projection (not the lean summary).
-        assert_eq!(resp.board_id, board_id);
+        assert_eq!(resp.board_id, Some(board_id));
         assert_eq!(resp.archived_at, ac.metadata.archived_at);
         assert_eq!(resp.original_column_id, original_column_id);
         assert_eq!(resp.original_position, 7);
@@ -161,5 +165,17 @@ mod tests {
         // The rich card projection carries `description` (the lean summary did not).
         let json = serde_json::to_value(&resp).unwrap();
         assert!(json["card"].get("description").is_some());
+    }
+
+    #[test]
+    fn test_archived_card_response_maps_nil_board_id_to_null() {
+        // A nil board_id (unknown board — original column gone at backfill time)
+        // must NOT surface as a zero-UUID a client would misread as a real board;
+        // it maps to `None` -> serialized `null`.
+        use kanban_domain::ArchivedCard;
+        let ac = ArchivedCard::new(sample_card(), Uuid::nil(), Uuid::new_v4(), 0);
+        let resp = ArchivedCardResponse::from(&ac);
+        assert_eq!(resp.board_id, None);
+        assert!(serde_json::to_value(&resp).unwrap()["board_id"].is_null());
     }
 }

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -1,6 +1,6 @@
 use super::super::enums::{CardPriorityDto, CardStatusDto};
 use chrono::{DateTime, Utc};
-use kanban_domain::Card;
+use kanban_domain::{ArchivedCard, Card};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -63,6 +63,39 @@ impl From<&Card> for CardResponse {
             created_at: *created_at,
             updated_at: *updated_at,
             completed_at: *completed_at,
+        }
+    }
+}
+
+/// Response body for an archived card. Nests the rich [`CardResponse`] (not the
+/// lean domain summary) and surfaces the first-class `board_id` plus the archival
+/// metadata as a stable v1 contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArchivedCardResponse {
+    pub card: CardResponse,
+    pub board_id: Uuid,
+    pub archived_at: DateTime<Utc>,
+    pub original_column_id: Uuid,
+    pub original_position: i32,
+}
+
+impl From<&ArchivedCard> for ArchivedCardResponse {
+    fn from(archived: &ArchivedCard) -> Self {
+        // Exhaustive destructure: a future `ArchivedCard` field fails to compile
+        // here until it is deliberately mapped (or omitted) in the DTO.
+        let ArchivedCard {
+            card,
+            metadata,
+            board_id,
+            original_column_id,
+            original_position,
+        } = archived;
+        Self {
+            card: CardResponse::from(card),
+            board_id: *board_id,
+            archived_at: metadata.archived_at,
+            original_column_id: *original_column_id,
+            original_position: *original_position,
         }
     }
 }

--- a/crates/kanban-service/src/api/v1/mod.rs
+++ b/crates/kanban-service/src/api/v1/mod.rs
@@ -9,7 +9,9 @@ mod pagination;
 mod patch;
 mod sprints;
 pub use boards::{BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
-pub use cards::{CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
+pub use cards::{
+    ArchivedCardResponse, CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest,
+};
 pub use columns::{
     ColumnResponse, CreateColumnRequest, ReorderColumnRequest, ReplaceColumnRequest,
     UpdateColumnRequest,


### PR DESCRIPTION
## What

The final SE-B leaf (epic KAN-821, decision D11). Adds a stable v1 `ArchivedCardResponse` DTO and routes the archived-card serialization surfaces through it, replacing direct serialization of the internal domain `ArchivedCardSummary`.

- New `ArchivedCardResponse { card: CardResponse, board_id, archived_at, original_column_id, original_position }` in `api/v1/cards/response.rs`, with an **exhaustive** `From<&ArchivedCard>` (drift-locked: a future field must be mapped or the destructure fails to compile).
- CLI `card list --archived` and MCP `list_archived_cards` now serialize the DTO.
- TUI is unaffected (consumes domain types, no DTO boundary).

## Notable

- The `From` reads `metadata.archived_at` — the original spike (`732c061e`) predated F1a and destructured a flat `archived_at` that no longer exists; the exhaustive destructure caught the drift.
- **Observable shape change:** the nested `card` is now the rich `CardResponse` (carries `description`, `card_number`; hides internal `sprint_logs`) rather than the lean summary, and `board_id` is first-class. The CLI shape assertion was updated from "card has no description" to assert the DTO shape.

## Tests (TDD, red→green)
- `test_archived_card_response_carries_board_id_and_archived_meta` (service) — the projection incl. board_id + metadata
- `test_mcp_list_archived_cards_includes_board_id` (mcp e2e) — board_id + rich card, no sprint_logs
- Updated CLI `card list --archived` shape assertion (board_id present, card carries description)

## Verification (full workspace)
- `cargo test --workspace` green
- `cargo clippy --workspace --tests -- -D warnings` clean
- `cargo fmt --all --check` clean

Refs KAN-843.