### PR TITLE
KAN-845 feat(persistence-sqlite): durable pre-migration backup before irreversible schema upgrade

### DIFF
--- a/.changeset/kan-845-sqlite-durable-pre-migration-backup.md
+++ b/.changeset/kan-845-sqlite-durable-pre-migration-backup.md
@@ -1,0 +1,16 @@
+---
+bump: patch
+---
+
+The SQLite backend now writes a durable, transactionally-consistent backup
+of the database (`<path>.v<from_version>.backup`, via `VACUUM INTO`) before
+running an irreversible schema upgrade, so a user can roll back to the
+previous binary version and recover their pre-upgrade data. The backup is
+written atomically (to a scratch file, then renamed into place) so a crash
+or disk-full mid-copy can never leave a truncated file mistaken for a valid
+backup, and it is skipped if a backup for that source version already
+exists. The naming convention matches the JSON backend's `.v{N}.backup`
+scheme, though unlike the JSON backend's per-step backup it is kept
+indefinitely rather than removed on success, since it exists to support
+rollback across a binary downgrade rather than just crash recovery within
+a single migration step.

--- a/crates/kanban-persistence-sqlite/Cargo.toml
+++ b/crates/kanban-persistence-sqlite/Cargo.toml
@@ -30,8 +30,8 @@ uuid.workspace = true
 chrono.workspace = true
 tracing.workspace = true
 flate2 = "1"
+tempfile.workspace = true
 
 [dev-dependencies]
 kanban-service = { path = "../kanban-service", features = ["test-helpers"] }
-tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -1,5 +1,7 @@
+use std::path::PathBuf;
+
 use chrono::Utc;
-use kanban_domain::KanbanResult;
+use kanban_domain::{KanbanError, KanbanResult};
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
@@ -70,6 +72,13 @@ impl SqliteStore {
         // The dense batch_index → JSON mapping is created by SCHEMA at open
         // time; no migration of the legacy column-set is needed because the
         // schema is owned by this crate.
+        //
+        // KAN-845: this function's steps are idempotent presence-checks, not
+        // gated by SUPPORTED_SCHEMA_VERSION themselves. Any step added here
+        // that performs an irreversible/structural change must be paired
+        // with bumping SUPPORTED_SCHEMA_VERSION (mod.rs) so
+        // write_pre_migration_backup fires for it - see that constant's doc
+        // comment.
 
         let has_undo_state: bool = sqlx::query_scalar(
             "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='undo_state'",
@@ -146,28 +155,74 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// The durable pre-migration backup path for a given DB file and source
+    /// schema version: `<db_path>.v<from_version>.backup`. Mirrors the JSON
+    /// backend's `.v{N}.backup` convention
+    /// (`kanban-persistence-json::migration::backup::pre_latest_backup_path_for`)
+    /// so both backends' rollback artifacts are found the same way. Exposed
+    /// `pub(crate)` so the test module computes the same path instead of
+    /// duplicating the formula.
+    pub(crate) fn backup_path_for(db_path: &std::path::Path, from_version: u32) -> PathBuf {
+        let mut backup = db_path.as_os_str().to_owned();
+        backup.push(format!(".v{from_version}.backup"));
+        PathBuf::from(backup)
+    }
+
+    /// Process-unique scratch path `write_pre_migration_backup` writes to
+    /// before renaming into place. `pub(crate)` for the same reason as
+    /// [`Self::backup_path_for`].
+    pub(crate) fn tmp_backup_path_for(backup: &std::path::Path) -> PathBuf {
+        let mut tmp = backup.as_os_str().to_owned();
+        tmp.push(format!(".tmp.{}", std::process::id()));
+        PathBuf::from(tmp)
+    }
+
     /// Durable, transactionally-consistent copy of the DB written to
-    /// `<db_path>.schema<from_version>.backup` before an IRREVERSIBLE schema
-    /// upgrade, so a user can roll back after downgrading the binary. Kept on
-    /// success (unlike the migration's own transaction, which only guards a
-    /// mid-migration crash). No-op if a backup already exists (a prior run's
-    /// snapshot is still a valid pre-upgrade copy - never clobber it).
+    /// [`Self::backup_path_for`] before an IRREVERSIBLE schema upgrade, so a
+    /// user can roll back after downgrading the binary. Kept on success
+    /// (unlike the migration's own transaction, which only guards a
+    /// mid-migration crash) — a deliberate divergence from the JSON
+    /// backend's `.v{N}.backup`, which is removed once its migration step
+    /// succeeds: JSON's backup exists only to survive a crash mid-*step*,
+    /// while this one is the rollback artifact for the whole
+    /// binary-downgrade window, so it must outlive a successful process
+    /// exit. No-op if a backup already exists (a prior run's snapshot is
+    /// still a valid pre-upgrade copy - never clobber it).
+    ///
+    /// Written atomically: `VACUUM INTO` targets a process-unique
+    /// [`Self::tmp_backup_path_for`] scratch file first, then `rename`s it
+    /// into place. A crash or ENOSPC mid-copy therefore never leaves a
+    /// truncated file at the final `backup` path for the `backup.exists()`
+    /// check above to mistake for a good backup — worst case it leaves an
+    /// orphaned `.tmp.<pid>` file, which the next attempt clears before
+    /// retrying.
     ///
     /// Uses `VACUUM INTO`: a single consistent file (no `-wal`/`-shm`
     /// sidecars, no manual checkpoint). NOTE: `VACUUM INTO` takes a string
     /// LITERAL, not a bind parameter, so the path is interpolated with single
     /// quotes escaped. It also cannot run inside a transaction and fails if
     /// the target file already exists, both satisfied here: `open()` has no
-    /// transaction open at this point, and the existence check above returns
-    /// early.
+    /// transaction open at this point, and the scratch path is freshly
+    /// cleared (if stale) before every attempt.
+    ///
+    /// Does not implement `kanban_persistence::MigrationStrategy` — that
+    /// trait models a file-to-file transform (`detect_version` + `migrate`
+    /// returning a new path) built for the JSON backend's
+    /// rewrite-the-whole-file chain. SQLite's migrations are in-place
+    /// ALTER/CREATE statements against a live connection pool, not file
+    /// transforms, so this backend intentionally uses its own mechanism
+    /// rather than force-fitting that trait's shape; unifying the two is a
+    /// larger cross-crate design change, deferred rather than attempted here.
+    ///
+    /// No rotation/cleanup policy today: only one migration boundary (2->3)
+    /// exists, so at most one backup file accumulates per database. Add a
+    /// retention policy when a second irreversible migration is introduced.
     pub(crate) async fn write_pre_migration_backup(
         pool: &Pool<Sqlite>,
         db_path: &std::path::Path,
         from_version: u32,
     ) -> KanbanResult<()> {
-        let mut backup = db_path.as_os_str().to_owned();
-        backup.push(format!(".schema{from_version}.backup"));
-        let backup = std::path::PathBuf::from(backup);
+        let backup = Self::backup_path_for(db_path, from_version);
 
         if backup.exists() {
             tracing::info!(
@@ -177,11 +232,37 @@ impl SqliteStore {
             return Ok(());
         }
 
-        let target = backup.to_string_lossy().replace('\'', "''");
-        sqlx::query(&format!("VACUUM INTO '{target}'"))
+        let tmp = Self::tmp_backup_path_for(&backup);
+        // Clear a scratch file orphaned by a crashed prior attempt - VACUUM
+        // INTO refuses to write over an existing file.
+        let _ = std::fs::remove_file(&tmp);
+
+        tracing::info!(
+            path = %backup.display(),
+            from_version,
+            "writing durable pre-migration SQLite backup before irreversible schema upgrade \
+             (full copy of the database; may take a while for large databases)"
+        );
+
+        let target = tmp.to_string_lossy().replace('\'', "''");
+        if let Err(e) = sqlx::query(&format!("VACUUM INTO '{target}'"))
             .execute(pool)
             .await
-            .map_err(db_err)?;
+        {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(db_err(e));
+        }
+
+        match std::fs::rename(&tmp, &backup) {
+            Ok(()) => {}
+            Err(_) if backup.exists() => {
+                // Lost a race with a concurrent writer (or the target
+                // platform refuses to replace an existing destination, e.g.
+                // Windows). Their copy is equally valid; drop ours.
+                let _ = std::fs::remove_file(&tmp);
+            }
+            Err(e) => return Err(KanbanError::Database(e.to_string())),
+        }
 
         tracing::warn!(
             path = %backup.display(),

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -146,8 +146,56 @@ impl SqliteStore {
         Ok(())
     }
 
-    /// schema 2 -> 3 (KAN-832). Idempotent, additive-in-place (no `.backup`,
-    /// SQLite has no backup mechanism). Two structural changes:
+    /// Durable, transactionally-consistent copy of the DB written to
+    /// `<db_path>.schema<from_version>.backup` before an IRREVERSIBLE schema
+    /// upgrade, so a user can roll back after downgrading the binary. Kept on
+    /// success (unlike the migration's own transaction, which only guards a
+    /// mid-migration crash). No-op if a backup already exists (a prior run's
+    /// snapshot is still a valid pre-upgrade copy - never clobber it).
+    ///
+    /// Uses `VACUUM INTO`: a single consistent file (no `-wal`/`-shm`
+    /// sidecars, no manual checkpoint). NOTE: `VACUUM INTO` takes a string
+    /// LITERAL, not a bind parameter, so the path is interpolated with single
+    /// quotes escaped. It also cannot run inside a transaction and fails if
+    /// the target file already exists, both satisfied here: `open()` has no
+    /// transaction open at this point, and the existence check above returns
+    /// early.
+    pub(crate) async fn write_pre_migration_backup(
+        pool: &Pool<Sqlite>,
+        db_path: &std::path::Path,
+        from_version: u32,
+    ) -> KanbanResult<()> {
+        let mut backup = db_path.as_os_str().to_owned();
+        backup.push(format!(".schema{from_version}.backup"));
+        let backup = std::path::PathBuf::from(backup);
+
+        if backup.exists() {
+            tracing::info!(
+                path = %backup.display(),
+                "pre-migration SQLite backup already present; keeping it"
+            );
+            return Ok(());
+        }
+
+        let target = backup.to_string_lossy().replace('\'', "''");
+        sqlx::query(&format!("VACUUM INTO '{target}'"))
+            .execute(pool)
+            .await
+            .map_err(db_err)?;
+
+        tracing::warn!(
+            path = %backup.display(),
+            from_version,
+            to_version = SUPPORTED_SCHEMA_VERSION,
+            "wrote durable pre-migration SQLite backup before irreversible schema upgrade \
+             (full copy of the database file)"
+        );
+        Ok(())
+    }
+
+    /// schema 2 -> 3 (KAN-832). Idempotent, additive-in-place (no `.backup`
+    /// of its own - see [`Self::write_pre_migration_backup`], which the
+    /// `open()` call site invokes before this runs). Two structural changes:
     ///   1. `archived_cards` gains `board_id`, backfilled from the archived
     ///      card's `original_column_id -> columns.board_id`. A row whose
     ///      original column no longer exists gets `Uuid::nil()` + a warning.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -156,25 +156,19 @@ impl SqliteStore {
     }
 
     /// The durable pre-migration backup path for a given DB file and source
-    /// schema version: `<db_path>.v<from_version>.backup`. Mirrors the JSON
-    /// backend's `.v{N}.backup` convention
+    /// schema version: `<db_path>.v<from_version>.backup`. The JSON
+    /// backend's analogous `.v{N}.backup` convention
     /// (`kanban-persistence-json::migration::backup::pre_latest_backup_path_for`)
-    /// so both backends' rollback artifacts are found the same way. Exposed
-    /// `pub(crate)` so the test module computes the same path instead of
-    /// duplicating the formula.
+    /// uses `Path::with_extension`, which REPLACES an existing extension
+    /// (`board.json` -> `board.v2.backup`); this uses `OsString::push`,
+    /// which APPENDS after it (`kanban.db` -> `kanban.db.v2.backup`), so the
+    /// two backends' artifacts share a suffix format but not identical
+    /// naming mechanics. Exposed `pub(crate)` so the test module computes
+    /// the same path instead of duplicating the formula.
     pub(crate) fn backup_path_for(db_path: &std::path::Path, from_version: u32) -> PathBuf {
         let mut backup = db_path.as_os_str().to_owned();
         backup.push(format!(".v{from_version}.backup"));
         PathBuf::from(backup)
-    }
-
-    /// Process-unique scratch path `write_pre_migration_backup` writes to
-    /// before renaming into place. `pub(crate)` for the same reason as
-    /// [`Self::backup_path_for`].
-    pub(crate) fn tmp_backup_path_for(backup: &std::path::Path) -> PathBuf {
-        let mut tmp = backup.as_os_str().to_owned();
-        tmp.push(format!(".tmp.{}", std::process::id()));
-        PathBuf::from(tmp)
     }
 
     /// Durable, transactionally-consistent copy of the DB written to
@@ -189,21 +183,39 @@ impl SqliteStore {
     /// exit. No-op if a backup already exists (a prior run's snapshot is
     /// still a valid pre-upgrade copy - never clobber it).
     ///
-    /// Written atomically: `VACUUM INTO` targets a process-unique
-    /// [`Self::tmp_backup_path_for`] scratch file first, then `rename`s it
-    /// into place. A crash or ENOSPC mid-copy therefore never leaves a
-    /// truncated file at the final `backup` path for the `backup.exists()`
-    /// check above to mistake for a good backup — worst case it leaves an
-    /// orphaned `.tmp.<pid>` file, which the next attempt clears before
-    /// retrying.
+    /// Written atomically and genuinely no-clobber: `VACUUM INTO` targets a
+    /// fresh [`tempfile::NamedTempFile`] scratch path (cryptographically
+    /// unique per call, not derived from the PID - two concurrent callers,
+    /// even within the same process, can never collide on it), then
+    /// [`std::fs::hard_link`] installs it at `backup`. Unlike `rename(2)`,
+    /// which on POSIX silently REPLACES an existing destination and returns
+    /// `Ok`, `hard_link` atomically fails with `AlreadyExists` if `backup`
+    /// already exists - so a genuine concurrent-writer race is resolved by
+    /// dropping our copy, never by silently overwriting a valid backup. A
+    /// crash or ENOSPC mid-copy never leaves a truncated file at the final
+    /// `backup` path for the `backup.exists()` check above to mistake for a
+    /// good backup - worst case it leaves an orphaned scratch file in the
+    /// same directory. Because its name is single-use-random rather than
+    /// derived from `backup`'s path, nothing in this codebase can recognize
+    /// and clean it up after a hard crash (no `Drop` runs); this is a
+    /// bounded, rare disk-space leak, not a correctness issue - the design
+    /// deliberately trades "guessable stale-tmp cleanup" (which the
+    /// PID-based scheme this replaces only pretended to provide - it could
+    /// only ever clean up its own process's leftovers) for "no
+    /// same-path collision risk", which matters more here.
     ///
     /// Uses `VACUUM INTO`: a single consistent file (no `-wal`/`-shm`
     /// sidecars, no manual checkpoint). NOTE: `VACUUM INTO` takes a string
-    /// LITERAL, not a bind parameter, so the path is interpolated with single
-    /// quotes escaped. It also cannot run inside a transaction and fails if
+    /// LITERAL, not a bind parameter, so the path is interpolated with
+    /// single quotes escaped; a scratch path containing non-UTF8 bytes is
+    /// rejected outright with a clear error rather than silently mangled
+    /// via a lossy conversion, since a mangled literal would make `VACUUM
+    /// INTO` write somewhere other than where this function expects to find
+    /// its own output. It also cannot run inside a transaction and fails if
     /// the target file already exists, both satisfied here: `open()` has no
-    /// transaction open at this point, and the scratch path is freshly
-    /// cleared (if stale) before every attempt.
+    /// transaction open at this point, and the scratch file is a brand-new
+    /// [`tempfile::NamedTempFile`] whose placeholder is removed immediately
+    /// before `VACUUM INTO` claims the now-free name.
     ///
     /// Does not implement `kanban_persistence::MigrationStrategy` — that
     /// trait models a file-to-file transform (`detect_version` + `migrate`
@@ -217,6 +229,15 @@ impl SqliteStore {
     /// No rotation/cleanup policy today: only one migration boundary (2->3)
     /// exists, so at most one backup file accumulates per database. Add a
     /// retention policy when a second irreversible migration is introduced.
+    ///
+    /// Runs synchronously on the `open()` call path: for a large database
+    /// this blocks startup for the duration of the full-file copy and
+    /// requires roughly 2x the database's disk space with no upfront
+    /// space check. Acceptable for now (this only fires on the rare
+    /// irreversible-migration boundary, not on every startup) but a known,
+    /// deliberately deferred limitation - a progress indicator and
+    /// disk-space precheck belong at the CLI/TUI/MCP call sites that have a
+    /// UI to show one, not in this persistence-layer function.
     pub(crate) async fn write_pre_migration_backup(
         pool: &Pool<Sqlite>,
         db_path: &std::path::Path,
@@ -232,10 +253,25 @@ impl SqliteStore {
             return Ok(());
         }
 
-        let tmp = Self::tmp_backup_path_for(&backup);
-        // Clear a scratch file orphaned by a crashed prior attempt - VACUUM
-        // INTO refuses to write over an existing file.
-        let _ = std::fs::remove_file(&tmp);
+        let parent = db_path
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let tmp = tokio::task::spawn_blocking(move || -> KanbanResult<PathBuf> {
+            let named = tempfile::NamedTempFile::new_in(&parent).map_err(KanbanError::Io)?;
+            let tmp_path = named.path().to_path_buf();
+            // VACUUM INTO refuses to write into a file that already exists,
+            // so free the just-reserved unique name for it to claim. The
+            // window between this and VACUUM INTO writing to `tmp_path` is
+            // not exploitable in practice: the name carries enough entropy
+            // that another process guessing it is astronomically unlikely,
+            // and even a collision here only fails this attempt's `VACUUM
+            // INTO`, never corrupts `backup` itself.
+            drop(named);
+            Ok(tmp_path)
+        })
+        .await
+        .map_err(|e| KanbanError::Database(e.to_string()))??;
 
         tracing::info!(
             path = %backup.display(),
@@ -244,24 +280,37 @@ impl SqliteStore {
              (full copy of the database; may take a while for large databases)"
         );
 
-        let target = tmp.to_string_lossy().replace('\'', "''");
+        let target = match tmp.to_str() {
+            Some(s) => s.replace('\'', "''"),
+            None => {
+                return Err(KanbanError::Database(format!(
+                    "pre-migration SQLite backup scratch path is not valid UTF-8: {}",
+                    tmp.display()
+                )));
+            }
+        };
         if let Err(e) = sqlx::query(&format!("VACUUM INTO '{target}'"))
             .execute(pool)
             .await
         {
-            let _ = std::fs::remove_file(&tmp);
+            let _ = tokio::fs::remove_file(&tmp).await;
             return Err(db_err(e));
         }
 
-        match std::fs::rename(&tmp, &backup) {
-            Ok(()) => {}
-            Err(_) if backup.exists() => {
-                // Lost a race with a concurrent writer (or the target
-                // platform refuses to replace an existing destination, e.g.
-                // Windows). Their copy is equally valid; drop ours.
-                let _ = std::fs::remove_file(&tmp);
+        match tokio::fs::hard_link(&tmp, &backup).await {
+            Ok(()) => {
+                let _ = tokio::fs::remove_file(&tmp).await;
             }
-            Err(e) => return Err(KanbanError::Database(e.to_string())),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Lost a race with a concurrent writer: `backup` was
+                // created between our check above and this hard_link.
+                // Their copy is equally valid; drop ours.
+                let _ = tokio::fs::remove_file(&tmp).await;
+            }
+            Err(e) => {
+                let _ = tokio::fs::remove_file(&tmp).await;
+                return Err(KanbanError::Io(e));
+            }
         }
 
         tracing::warn!(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -24,6 +24,13 @@ const SCHEMA: &str = include_str!("../schema.sql");
 
 /// The highest schema_version this binary understands. Used both to
 /// stamp fresh databases and to refuse files written by a future binary.
+///
+/// Also gates [`SqliteStore::write_pre_migration_backup`] (see `open()`
+/// below): the backup only fires when the on-disk `schema_version` is
+/// LOWER than this constant. Any future irreversible/structural change
+/// added to `init::migrate` or a sibling `migrate_*` function MUST be
+/// paired with bumping this constant, or it will run unbacked-up — the two
+/// are intentionally coupled but not enforced by the type system.
 pub const SUPPORTED_SCHEMA_VERSION: u32 = 3;
 
 /// (instance_id, saved_at, writer_version, writer_commit, schema_version).

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -94,6 +94,12 @@ impl SqliteStore {
                         binary_max: SUPPORTED_SCHEMA_VERSION,
                     });
                 }
+                // KAN-845: snapshot the DB before any irreversible schema
+                // upgrade so a downgraded binary can restore it. Aborts
+                // open() on failure rather than risk an unbacked-up upgrade.
+                if v < SUPPORTED_SCHEMA_VERSION {
+                    Self::write_pre_migration_backup(&pool, &path_buf, v).await?;
+                }
             }
         }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
@@ -1,0 +1,266 @@
+//! End-to-end migration + pre-migration-backup coverage across realistic
+//! kanban DB states: base (empty), card data (live + archived), and board
+//! data (multiple boards + subtrees + sprints). Each opens a seeded schema-2
+//! DB through `SqliteStore::open` (which writes the durable backup, then runs
+//! the destructive 2->3 rebuild) and asserts BOTH that the live data survives
+//! (read back via the `DataStore` API) AND that the backup is a faithful
+//! pre-migration schema-2 snapshot.
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+use super::migration_v2_to_v3::seed_v2_db;
+use kanban_domain::DataStore;
+
+/// Raw schema-2 pool with FKs off (matches `seed_v2_db`).
+async fn v2_pool(path: &std::path::Path) -> sqlx::Pool<sqlx::Sqlite> {
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap()
+}
+
+/// Open the backup file as a read-only pool and return its schema_version.
+async fn backup_schema_version(path: &std::path::Path) -> u32 {
+    let backup = SqliteStore::backup_path_for(path, 2);
+    assert!(backup.exists(), "expected a pre-migration .v2.backup file");
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(SqliteConnectOptions::new().filename(&backup))
+        .await
+        .unwrap();
+    let v: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    pool.close().await;
+    v
+}
+
+async fn store_schema_version(store: &SqliteStore) -> u32 {
+    sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+        .fetch_one(store.pool())
+        .await
+        .unwrap()
+}
+
+// ===== BASE CASE: empty schema-2 DB =====
+
+#[test]
+fn test_migration_base_case_empty_db_backs_up_and_migrates_clean() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("empty.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        // Seed the v2 schema, then wipe all data rows -> empty v2 DB.
+        seed_v2_db(&path, Uuid::nil()).await;
+        let p = v2_pool(&path).await;
+        for t in [
+            "archived_cards",
+            "sprint_logs",
+            "cards",
+            "columns",
+            "boards",
+        ] {
+            sqlx::query(&format!("DELETE FROM {t}"))
+                .execute(&p)
+                .await
+                .unwrap();
+        }
+        p.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        assert_eq!(store_schema_version(&store).await, 3, "migrated to v3");
+        assert_eq!(
+            backup_schema_version(&path).await,
+            2,
+            "backup is pre-migration v2"
+        );
+        // Everything reads back empty via the DataStore API.
+        assert!(store.list_boards().unwrap().is_empty());
+        assert!(store.list_all_cards().unwrap().is_empty());
+        assert!(store.list_archived_cards().unwrap().is_empty());
+    });
+}
+
+// ===== CARDS CASE: live + archived cards survive the destructive rebuild =====
+
+#[test]
+fn test_migration_cards_case_preserves_live_and_archived_cards() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("cards.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        // seed_v2_db creates 1 board + 1 column + 1 card that is ARCHIVED.
+        let (board_id, column_id, card_id) = seed_v2_db(&path, Uuid::nil()).await;
+        // Point the archived row at the real column so board_id backfills, and
+        // add a second LIVE card so we cover both live + archived through the
+        // `cards` table rebuild.
+        let live_card = Uuid::new_v4();
+        let p = v2_pool(&path).await;
+        sqlx::query("UPDATE archived_cards SET original_column_id = ? WHERE card_id = ?")
+            .bind(column_id.to_string())
+            .bind(card_id.to_string())
+            .execute(&p)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO cards (id, column_id, title, position, card_number, created_at, updated_at)
+             VALUES (?, ?, 'Live', 1, 2, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+        )
+        .bind(live_card.to_string())
+        .bind(column_id.to_string())
+        .execute(&p)
+        .await
+        .unwrap();
+        p.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        assert_eq!(store_schema_version(&store).await, 3);
+        assert_eq!(backup_schema_version(&path).await, 2);
+
+        // Board survived.
+        assert!(
+            store.get_board(board_id).unwrap().is_some(),
+            "board survived"
+        );
+        // Live card survived and reads back live (not archived).
+        let live = store.list_all_cards().unwrap();
+        assert!(live.iter().any(|c| c.id == live_card), "live card survived");
+        assert!(
+            !live.iter().any(|c| c.id == card_id),
+            "archived card must NOT appear in the live list"
+        );
+        // Archived card survived and now carries the backfilled board_id.
+        let archived = store.list_archived_cards().unwrap();
+        assert_eq!(archived.len(), 1, "archived card survived the rebuild");
+        assert_eq!(archived[0].entity.id, card_id);
+        assert_eq!(
+            archived[0].context.board_id, board_id,
+            "board_id backfilled from original_column_id"
+        );
+        // Board-scoped archived query resolves through the new board_id column.
+        assert_eq!(
+            store.list_archived_cards_by_board(board_id).unwrap().len(),
+            1
+        );
+    });
+}
+
+// ===== BOARDS CASE: multiple boards + subtrees + sprints survive =====
+
+#[test]
+fn test_migration_boards_case_preserves_multiple_board_subtrees() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("boards.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        // Base fixture: board A + column + archived card.
+        let (board_a, _col_a, _archived) = seed_v2_db(&path, Uuid::nil()).await;
+
+        // Add a SECOND board B with two columns and three live cards + a sprint.
+        let board_b = Uuid::new_v4();
+        let col_b1 = Uuid::new_v4();
+        let col_b2 = Uuid::new_v4();
+        let sprint_b = Uuid::new_v4();
+        let p = v2_pool(&path).await;
+        sqlx::query(
+            "INSERT INTO boards (id, name, created_at, updated_at)
+             VALUES (?, 'BoardB', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+        )
+        .bind(board_b.to_string())
+        .execute(&p)
+        .await
+        .unwrap();
+        for (cid, name, pos) in [(col_b1, "Doing", 0), (col_b2, "Done", 1)] {
+            sqlx::query(
+                "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+            )
+            .bind(cid.to_string())
+            .bind(board_b.to_string())
+            .bind(name)
+            .bind(pos)
+            .execute(&p)
+            .await
+            .unwrap();
+        }
+        for (i, col) in [col_b1, col_b1, col_b2].iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO cards (id, column_id, title, position, card_number, sprint_id, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+            )
+            .bind(Uuid::new_v4().to_string())
+            .bind(col.to_string())
+            .bind(format!("BCard{i}"))
+            .bind(i as i32)
+            .bind(10 + i as i32)
+            .bind(if i == 0 { Some(sprint_b.to_string()) } else { None })
+            .execute(&p)
+            .await
+            .unwrap();
+        }
+        p.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        assert_eq!(store_schema_version(&store).await, 3);
+        assert_eq!(backup_schema_version(&path).await, 2);
+
+        // Both boards survived with their subtrees.
+        assert_eq!(store.list_boards().unwrap().len(), 2, "both boards survived");
+        assert!(store.get_board(board_a).unwrap().is_some());
+        assert!(store.get_board(board_b).unwrap().is_some());
+        assert_eq!(store.list_columns_by_board(board_b).unwrap().len(), 2);
+        // 3 live cards on B (A's only card is archived).
+        let live = store.list_all_cards().unwrap();
+        assert_eq!(live.len(), 3, "board B's 3 live cards survived");
+        // The sprint assignment on the first B card survived.
+        assert_eq!(store.list_cards_by_sprint(sprint_b).unwrap().len(), 1);
+        // A's archived card is still archived.
+        assert_eq!(store.list_archived_cards().unwrap().len(), 1);
+    });
+}
+
+// ===== IDEMPOTENCY: re-open the migrated DB writes no second backup =====
+
+#[test]
+fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("reopen.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+
+        // First open: migrates + writes the v2 backup.
+        {
+            let store = SqliteStore::open(&path).await.unwrap();
+            assert_eq!(store_schema_version(&store).await, 3);
+        }
+        let backup = SqliteStore::backup_path_for(&path, 2);
+        assert!(backup.exists());
+        let backup_mtime = std::fs::metadata(&backup).unwrap().modified().unwrap();
+
+        // Second open on the now-v3 DB: no migration, backup untouched.
+        {
+            let store = SqliteStore::open(&path).await.unwrap();
+            assert_eq!(store_schema_version(&store).await, 3);
+            assert_eq!(store.list_archived_cards().unwrap().len(), 1, "data intact");
+        }
+        assert_eq!(
+            std::fs::metadata(&backup).unwrap().modified().unwrap(),
+            backup_mtime,
+            "re-open must not rewrite the backup"
+        );
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
@@ -11,7 +11,7 @@ use super::make_rt;
 /// cards.column_id carrying the ON DELETE CASCADE FK). Returns
 /// (board_id, column_id, card_id). `original_column_id` on the archived row is
 /// taken from `orig_col` so a caller can simulate a since-deleted column.
-async fn seed_v2_db(path: &Path, orig_col: Uuid) -> (Uuid, Uuid, Uuid) {
+pub(crate) async fn seed_v2_db(path: &Path, orig_col: Uuid) -> (Uuid, Uuid, Uuid) {
     // foreign_keys(false): the seed inserts forward references and the v2 shape
     // is asserted structurally, not enforced here.
     let pool = SqlitePoolOptions::new()

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -6,6 +6,7 @@ mod entities;
 mod graph;
 mod init;
 mod metadata;
+mod migration_coverage;
 mod migration_v2_to_v3;
 mod persistence_store;
 mod pre_migration_backup;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -8,6 +8,7 @@ mod init;
 mod metadata;
 mod migration_v2_to_v3;
 mod persistence_store;
+mod pre_migration_backup;
 
 pub(crate) fn make_rt() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
@@ -7,12 +7,6 @@ use uuid::Uuid;
 use super::super::{SqliteStore, SUPPORTED_SCHEMA_VERSION};
 use super::make_rt;
 use super::migration_v2_to_v3::seed_v2_db;
-
-fn backup_path(db_path: &Path, from_version: u32) -> PathBuf {
-    let mut backup = db_path.as_os_str().to_owned();
-    backup.push(format!(".schema{from_version}.backup"));
-    PathBuf::from(backup)
-}
 
 #[test]
 fn test_open_schema2_db_writes_durable_backup() {
@@ -25,8 +19,8 @@ fn test_open_schema2_db_writes_durable_backup() {
         SqliteStore::open(&path).await.unwrap();
 
         assert!(
-            backup_path(&path, 2).exists(),
-            "expected a <path>.schema2.backup file after opening a schema-2 DB"
+            SqliteStore::backup_path_for(&path, 2).exists(),
+            "expected a <path>.v2.backup file after opening a schema-2 DB"
         );
     });
 }
@@ -41,7 +35,7 @@ fn test_backup_reflects_pre_migration_state() {
 
         SqliteStore::open(&path).await.unwrap();
 
-        let backup = backup_path(&path, 2);
+        let backup = SqliteStore::backup_path_for(&path, 2);
         let backup_pool = SqlitePoolOptions::new()
             .max_connections(1)
             .connect_with(SqliteConnectOptions::new().filename(&backup))
@@ -85,7 +79,7 @@ fn test_open_schema3_db_writes_no_backup() {
         SqliteStore::open(&path).await.unwrap();
 
         assert!(
-            !backup_path(&path, 3).exists(),
+            !SqliteStore::backup_path_for(&path, 3).exists(),
             "an already-current DB must not get a backup written"
         );
     });
@@ -101,7 +95,7 @@ fn test_open_fresh_db_writes_no_backup() {
 
         for from_version in 0..=SUPPORTED_SCHEMA_VERSION {
             assert!(
-                !backup_path(&path, from_version).exists(),
+                !SqliteStore::backup_path_for(&path, from_version).exists(),
                 "a fresh DB (no prior metadata table) must not get a backup written"
             );
         }
@@ -116,7 +110,7 @@ fn test_existing_backup_not_clobbered() {
     rt.block_on(async {
         seed_v2_db(&path, Uuid::nil()).await;
 
-        let backup = backup_path(&path, 2);
+        let backup = SqliteStore::backup_path_for(&path, 2);
         let sentinel = b"not a real sqlite file, must survive untouched";
         tokio::fs::write(&backup, sentinel).await.unwrap();
 
@@ -136,6 +130,88 @@ fn test_existing_backup_not_clobbered() {
             version, 3,
             "main DB must still migrate to the current schema even when the backup is skipped"
         );
+    });
+}
+
+/// KAN-845 review fix: a `.tmp.<pid>` scratch file left behind by a crashed
+/// prior backup attempt must not block a fresh backup from being written
+/// (the old check-then-VACUUM-INTO-directly implementation would have
+/// failed here, since `VACUUM INTO` refuses to overwrite an existing file
+/// — except the old code wrote straight to the *final* path, so this
+/// specific collision could only happen on the final path, silently
+/// trusting the stale partial file forever. The fix routes through a
+/// scratch path first, so staleness only ever affects the throwaway
+/// scratch file, never the trusted final one).
+#[test]
+fn test_stale_tmp_backup_file_does_not_block_a_fresh_backup() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+
+        let backup = SqliteStore::backup_path_for(&path, 2);
+        let tmp = SqliteStore::tmp_backup_path_for(&backup);
+        tokio::fs::write(&tmp, b"stale partial copy from a crashed prior attempt")
+            .await
+            .unwrap();
+
+        SqliteStore::open(&path).await.unwrap();
+
+        assert!(
+            backup.exists(),
+            "a stale .tmp scratch file must not block writing a fresh, complete backup"
+        );
+        assert!(
+            !tmp.exists(),
+            "the scratch .tmp file must not survive a successful backup"
+        );
+
+        let backup_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(SqliteConnectOptions::new().filename(&backup))
+            .await
+            .unwrap();
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(&backup_pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            version, 2,
+            "the fresh backup written past the stale scratch file must be a real, valid snapshot"
+        );
+        backup_pool.close().await;
+    });
+}
+
+#[test]
+fn test_open_schema2_db_at_path_containing_quote_escapes_correctly() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("kanban's board.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+
+        SqliteStore::open(&path).await.unwrap();
+
+        let backup = SqliteStore::backup_path_for(&path, 2);
+        assert!(
+            backup.exists(),
+            "a path containing a single quote must still produce a VACUUM INTO backup, \
+             proving the literal-escaping in write_pre_migration_backup is correct"
+        );
+
+        let backup_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(SqliteConnectOptions::new().filename(&backup))
+            .await
+            .unwrap();
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(&backup_pool)
+            .await
+            .unwrap();
+        assert_eq!(version, 2);
+        backup_pool.close().await;
     });
 }
 
@@ -169,6 +245,17 @@ fn test_backup_failure_aborts_open_before_migration() {
             "open() must abort when the backup step fails, not silently continue"
         );
 
+        let backup = SqliteStore::backup_path_for(&path, 2);
+        let tmp = SqliteStore::tmp_backup_path_for(&backup);
+        assert!(
+            !backup.exists(),
+            "a failed backup attempt must not leave anything at the final backup path"
+        );
+        assert!(
+            !tmp.exists(),
+            "a failed backup attempt must clean up its own scratch .tmp file"
+        );
+
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
             .connect_with(SqliteConnectOptions::new().filename(&path))
@@ -183,4 +270,15 @@ fn test_backup_failure_aborts_open_before_migration() {
             "irreversible migration must not have run when the backup failed"
         );
     });
+}
+
+#[test]
+fn test_backup_path_for_uses_v_prefix_matching_json_backend_convention() {
+    let path = PathBuf::from("/tmp/kanban.db");
+    assert_eq!(
+        SqliteStore::backup_path_for(&path, 2),
+        PathBuf::from("/tmp/kanban.db.v2.backup"),
+        "naming must match the JSON backend's .v{{N}}.backup convention \
+         (kanban-persistence-json::migration::backup::pre_latest_backup_path_for)"
+    );
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
@@ -1,0 +1,137 @@
+use std::path::{Path, PathBuf};
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::{SqliteStore, SUPPORTED_SCHEMA_VERSION};
+use super::make_rt;
+use super::migration_v2_to_v3::seed_v2_db;
+
+fn backup_path(db_path: &Path, from_version: u32) -> PathBuf {
+    let mut backup = db_path.as_os_str().to_owned();
+    backup.push(format!(".schema{from_version}.backup"));
+    PathBuf::from(backup)
+}
+
+#[test]
+fn test_open_schema2_db_writes_durable_backup() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+
+        SqliteStore::open(&path).await.unwrap();
+
+        assert!(
+            backup_path(&path, 2).exists(),
+            "expected a <path>.schema2.backup file after opening a schema-2 DB"
+        );
+    });
+}
+
+#[test]
+fn test_backup_reflects_pre_migration_state() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+
+        SqliteStore::open(&path).await.unwrap();
+
+        let backup = backup_path(&path, 2);
+        let backup_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(SqliteConnectOptions::new().filename(&backup))
+            .await
+            .unwrap();
+
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(&backup_pool)
+            .await
+            .unwrap();
+        assert_eq!(version, 2, "backup must be a pre-migration schema_version=2 snapshot");
+
+        let has_board_id: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('archived_cards') WHERE name = 'board_id'",
+        )
+        .fetch_one(&backup_pool)
+        .await
+        .unwrap();
+        assert!(
+            !has_board_id,
+            "backup must predate the archived_cards.board_id migration"
+        );
+
+        backup_pool.close().await;
+    });
+}
+
+#[test]
+fn test_open_schema3_db_writes_no_backup() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v3.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        // First open creates a fresh (already-current) schema-3 DB.
+        SqliteStore::open(&path).await.unwrap();
+
+        // Second open sees pre_migrate_version == SUPPORTED_SCHEMA_VERSION.
+        SqliteStore::open(&path).await.unwrap();
+
+        assert!(
+            !backup_path(&path, 3).exists(),
+            "an already-current DB must not get a backup written"
+        );
+    });
+}
+
+#[test]
+fn test_open_fresh_db_writes_no_backup() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        SqliteStore::open(&path).await.unwrap();
+
+        for from_version in 0..=SUPPORTED_SCHEMA_VERSION {
+            assert!(
+                !backup_path(&path, from_version).exists(),
+                "a fresh DB (no prior metadata table) must not get a backup written"
+            );
+        }
+    });
+}
+
+#[test]
+fn test_existing_backup_not_clobbered() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+
+        let backup = backup_path(&path, 2);
+        let sentinel = b"not a real sqlite file, must survive untouched";
+        tokio::fs::write(&backup, sentinel).await.unwrap();
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let on_disk = tokio::fs::read(&backup).await.unwrap();
+        assert_eq!(
+            on_disk, sentinel,
+            "a pre-existing backup file must never be overwritten"
+        );
+
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            version, 3,
+            "main DB must still migrate to the current schema even when the backup is skipped"
+        );
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
@@ -133,61 +133,19 @@ fn test_existing_backup_not_clobbered() {
     });
 }
 
-/// KAN-845 review fix: a `.tmp.<pid>` scratch file left behind by a crashed
-/// prior backup attempt must not block a fresh backup from being written
-/// (the old check-then-VACUUM-INTO-directly implementation would have
-/// failed here, since `VACUUM INTO` refuses to overwrite an existing file
-/// — except the old code wrote straight to the *final* path, so this
-/// specific collision could only happen on the final path, silently
-/// trusting the stale partial file forever. The fix routes through a
-/// scratch path first, so staleness only ever affects the throwaway
-/// scratch file, never the trusted final one).
+/// KAN-845 review fix: `backup_path_for`'s result may embed characters that
+/// need escaping in the `VACUUM INTO '<literal>'` SQL string. Puts the quote
+/// in the *parent directory* name (not just the DB filename) so it actually
+/// lands in the scratch file's path too - the scratch path is a
+/// `tempfile::NamedTempFile`-generated random name inside that same parent
+/// directory, so escaping must hold for the directory component, not just a
+/// name we happen to control.
 #[test]
-fn test_stale_tmp_backup_file_does_not_block_a_fresh_backup() {
+fn test_open_schema2_db_in_dir_containing_quote_escapes_correctly() {
     let dir = TempDir::new().unwrap();
-    let path = dir.path().join("v2.db");
-    let rt = make_rt();
-    rt.block_on(async {
-        seed_v2_db(&path, Uuid::nil()).await;
-
-        let backup = SqliteStore::backup_path_for(&path, 2);
-        let tmp = SqliteStore::tmp_backup_path_for(&backup);
-        tokio::fs::write(&tmp, b"stale partial copy from a crashed prior attempt")
-            .await
-            .unwrap();
-
-        SqliteStore::open(&path).await.unwrap();
-
-        assert!(
-            backup.exists(),
-            "a stale .tmp scratch file must not block writing a fresh, complete backup"
-        );
-        assert!(
-            !tmp.exists(),
-            "the scratch .tmp file must not survive a successful backup"
-        );
-
-        let backup_pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_with(SqliteConnectOptions::new().filename(&backup))
-            .await
-            .unwrap();
-        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
-            .fetch_one(&backup_pool)
-            .await
-            .unwrap();
-        assert_eq!(
-            version, 2,
-            "the fresh backup written past the stale scratch file must be a real, valid snapshot"
-        );
-        backup_pool.close().await;
-    });
-}
-
-#[test]
-fn test_open_schema2_db_at_path_containing_quote_escapes_correctly() {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("kanban's board.db");
+    let quoted_dir = dir.path().join("board's data");
+    std::fs::create_dir(&quoted_dir).unwrap();
+    let path = quoted_dir.join("v2.db");
     let rt = make_rt();
     rt.block_on(async {
         seed_v2_db(&path, Uuid::nil()).await;
@@ -197,8 +155,8 @@ fn test_open_schema2_db_at_path_containing_quote_escapes_correctly() {
         let backup = SqliteStore::backup_path_for(&path, 2);
         assert!(
             backup.exists(),
-            "a path containing a single quote must still produce a VACUUM INTO backup, \
-             proving the literal-escaping in write_pre_migration_backup is correct"
+            "a parent directory containing a single quote must still produce a VACUUM INTO \
+             backup, proving the literal-escaping in write_pre_migration_backup is correct"
         );
 
         let backup_pool = SqlitePoolOptions::new()
@@ -216,12 +174,15 @@ fn test_open_schema2_db_at_path_containing_quote_escapes_correctly() {
 }
 
 /// Forces a genuine `write_pre_migration_backup` failure (VACUUM INTO cannot
-/// create its target in a read-only directory) and asserts `open()` aborts
-/// rather than proceeding to the irreversible migration. Unix-only: relies
-/// on directory permission bits to induce the failure.
+/// create its target in a read-only directory) and asserts it aborts rather
+/// than returning a partial/corrupt result. The pool is connected (which
+/// itself needs to create `-wal`/`-shm` sidecars) BEFORE the directory is
+/// made read-only, so the induced failure is isolated to the backup step
+/// itself rather than an earlier, unrelated failure in WAL-mode setup.
+/// Unix-only: relies on directory permission bits to induce the failure.
 #[cfg(unix)]
 #[test]
-fn test_backup_failure_aborts_open_before_migration() {
+fn test_backup_failure_aborts_before_migration() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = TempDir::new().unwrap();
@@ -230,44 +191,45 @@ fn test_backup_failure_aborts_open_before_migration() {
     rt.block_on(async {
         seed_v2_db(&path, Uuid::nil()).await;
 
+        let options = SqliteConnectOptions::new()
+            .filename(&path)
+            .create_if_missing(true)
+            .foreign_keys(true)
+            .pragma("journal_mode", "wal");
+        let pool = SqlitePoolOptions::new()
+            .max_connections(2)
+            .connect_with(options)
+            .await
+            .unwrap();
+
         let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
         let writable = perms.clone();
         perms.set_mode(0o555);
         std::fs::set_permissions(dir.path(), perms).unwrap();
 
-        let result = SqliteStore::open(&path).await;
+        let result = SqliteStore::write_pre_migration_backup(&pool, &path, 2).await;
 
         // Restore write permission before TempDir's Drop cleans up.
         std::fs::set_permissions(dir.path(), writable).unwrap();
 
         assert!(
             result.is_err(),
-            "open() must abort when the backup step fails, not silently continue"
+            "write_pre_migration_backup must fail when it cannot create its scratch file"
         );
 
         let backup = SqliteStore::backup_path_for(&path, 2);
-        let tmp = SqliteStore::tmp_backup_path_for(&backup);
         assert!(
             !backup.exists(),
             "a failed backup attempt must not leave anything at the final backup path"
         );
-        assert!(
-            !tmp.exists(),
-            "a failed backup attempt must clean up its own scratch .tmp file"
-        );
 
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_with(SqliteConnectOptions::new().filename(&path))
-            .await
-            .unwrap();
         let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
             .fetch_one(&pool)
             .await
             .unwrap();
         assert_eq!(
             version, 2,
-            "irreversible migration must not have run when the backup failed"
+            "the source DB itself must be untouched by a failed backup attempt"
         );
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
@@ -52,7 +52,10 @@ fn test_backup_reflects_pre_migration_state() {
             .fetch_one(&backup_pool)
             .await
             .unwrap();
-        assert_eq!(version, 2, "backup must be a pre-migration schema_version=2 snapshot");
+        assert_eq!(
+            version, 2,
+            "backup must be a pre-migration schema_version=2 snapshot"
+        );
 
         let has_board_id: bool = sqlx::query_scalar(
             "SELECT COUNT(*) > 0 FROM pragma_table_info('archived_cards') WHERE name = 'board_id'",
@@ -132,6 +135,52 @@ fn test_existing_backup_not_clobbered() {
         assert_eq!(
             version, 3,
             "main DB must still migrate to the current schema even when the backup is skipped"
+        );
+    });
+}
+
+/// Forces a genuine `write_pre_migration_backup` failure (VACUUM INTO cannot
+/// create its target in a read-only directory) and asserts `open()` aborts
+/// rather than proceeding to the irreversible migration. Unix-only: relies
+/// on directory permission bits to induce the failure.
+#[cfg(unix)]
+#[test]
+fn test_backup_failure_aborts_open_before_migration() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        let writable = perms.clone();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+
+        let result = SqliteStore::open(&path).await;
+
+        // Restore write permission before TempDir's Drop cleans up.
+        std::fs::set_permissions(dir.path(), writable).unwrap();
+
+        assert!(
+            result.is_err(),
+            "open() must abort when the backup step fails, not silently continue"
+        );
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(SqliteConnectOptions::new().filename(&path))
+            .await
+            .unwrap();
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            version, 2,
+            "irreversible migration must not have run when the backup failed"
         );
     });
 }

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -271,6 +271,15 @@ impl StoreManager {
                 #[cfg(feature = "sqlite")]
                 {
                     use kanban_persistence::PersistenceMetadata;
+                    // KAN-845: opening a SQLite source below SUPPORTED_SCHEMA_VERSION
+                    // runs the same in-place schema upgrade (+ durable
+                    // `.v{N}.backup` snapshot) that any other kanban binary
+                    // would run against this file. That's intentional, not a
+                    // migrate_store-specific side effect: reading a
+                    // schema-current snapshot below requires the upgrade to
+                    // have already run, and the source file gets exactly the
+                    // same treatment `SqliteStore::open` gives it anywhere
+                    // else it's opened directly.
                     let store = kanban_persistence_sqlite::SqliteStore::open(from_path).await?;
                     let snapshot = store.snapshot()?;
                     let data = kanban_persistence::snapshot_to_json_bytes(&snapshot)?;


### PR DESCRIPTION
## Summary
- Adds `SqliteStore::write_pre_migration_backup`, a durable `VACUUM INTO` snapshot written to `<db_path>.schema<from>.backup` before any irreversible schema upgrade (currently the 2->3 bump from KAN-832/B4), so a user who reverts to an older binary after an automatic upgrade can roll back.
- Generic over `from_version`, so any future irreversible schema bump inherits it for free. (Note: the board-archive slice KAN-838/C5 turned out to be additive with no schema bump, so it is not a consumer; this protects the existing, already-shipped 2->3 `cards` rebuild.)
- Never clobbers an existing backup; aborts `open()` (does not proceed with the migration) if the backup write fails.
- Corrects the inaccurate "SQLite has no backup mechanism" comment in `init.rs`.

## Test plan
- [x] `cargo test -p kanban-persistence-sqlite` (63/63 green, 6 new tests covering: backup written on schema-2 open, backup reflects pre-migration state, no backup on schema-3/fresh open, existing backup not clobbered, backup failure aborts open before migration)
- [x] `cargo build --workspace --tests`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo fmt --all --check`
