### PR TITLE
fix(tui): set task priority with `p` from the card list (fixes #360)

### DIFF
--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -201,6 +201,12 @@ impl App {
                     self.pending_key = None;
                     self.handle_toggle_task_list_view();
                 }
+                KeyCode::Char('p') => {
+                    self.pending_key = None;
+                    if self.focus.active == Focus::Cards {
+                        self.handle_set_card_priority_key();
+                    }
+                }
                 KeyCode::Char('P') => {
                     self.pending_key = None;
                     self.handle_set_selected_cards_priority();

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -98,6 +98,7 @@ impl App {
             KeybindingAction::ToggleCardSelection => self.handle_card_selection_toggle(),
             KeybindingAction::ClearCardSelection => self.handle_clear_card_selection(),
             KeybindingAction::SelectAllCards => self.handle_select_all_cards_in_view(),
+            KeybindingAction::SetCardPriority => self.handle_set_card_priority_key(),
             KeybindingAction::SetSelectedCardsPriority => self.handle_set_selected_cards_priority(),
             KeybindingAction::Search => {
                 if self.focus.active == Focus::Cards {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -80,6 +80,20 @@ impl App {
         }
     }
 
+    pub fn handle_set_card_priority_key(&mut self) {
+        if self.focus.active != Focus::Cards {
+            return;
+        }
+        let Some(card_id) = self.get_selected_card_id() else {
+            return;
+        };
+        if self.activate_card(card_id) {
+            let priority_idx = self.get_current_priority_selection_index();
+            self.dialog_input.priority_selection.set(Some(priority_idx));
+            self.open_dialog(DialogMode::SetCardPriority);
+        }
+    }
+
     pub fn handle_set_selected_cards_priority(&mut self) {
         if self.focus.active != Focus::Cards || self.multi_select.selected_cards.is_empty() {
             return;

--- a/crates/kanban-tui/src/keybindings/card_list.rs
+++ b/crates/kanban-tui/src/keybindings/card_list.rs
@@ -167,7 +167,7 @@ impl KeybindingProvider for CardListProvider {
                     "p",
                     "priority",
                     "Set task priority",
-                    KeybindingAction::EditCard,
+                    KeybindingAction::SetCardPriority,
                 ),
                 Keybinding::new(
                     "s",

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -47,6 +47,7 @@ pub enum KeybindingAction {
     ToggleCardSelection,
     ClearCardSelection,
     SelectAllCards,
+    SetCardPriority,
     SetSelectedCardsPriority,
     Search,
     ShowHelp,

--- a/crates/kanban-tui/tests/card_priority_key_tests.rs
+++ b/crates/kanban-tui/tests/card_priority_key_tests.rs
@@ -1,0 +1,88 @@
+use kanban_domain::{CardPriority, CreateCardOptions, KanbanOperations};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+
+/// Issue #360: the cards list advertises `p: priority`, but pressing `p`
+/// did nothing — the binding pointed at `EditCard` and the input router had
+/// no lowercase `p` arm. `handle_set_card_priority_key` must open the
+/// single-card priority dialog for the highlighted card, with the dialog
+/// preselecting that card's current priority.
+#[test]
+fn test_p_on_cards_list_opens_single_card_priority_dialog() {
+    let mut app = App::test_default();
+
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Task".to_string(),
+            CreateCardOptions {
+                priority: Some(CardPriority::High),
+                ..CreateCardOptions::default()
+            },
+        )
+        .unwrap();
+
+    app.selection.active_board_index = Some(0);
+    app.focus.active = Focus::Cards;
+    app.prepare_frame();
+    app.select_card_by_id(card.id);
+
+    app.handle_set_card_priority_key();
+
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::SetCardPriority),
+        "pressing p on a highlighted card must open the single-card priority dialog"
+    );
+    assert_eq!(
+        app.selection.active_card_id,
+        Some(card.id),
+        "the highlighted card must become the active card for the priority dialog"
+    );
+    assert_eq!(
+        app.dialog_input.priority_selection.get(),
+        Some(2),
+        "the dialog must preselect the card's current priority (High -> index 2)"
+    );
+}
+
+/// Guard: `p` is a cards-panel action. With focus on the projects panel it
+/// must be inert (no priority dialog, no mode change).
+#[test]
+fn test_p_on_boards_panel_does_not_open_priority_dialog() {
+    let mut app = App::test_default();
+
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Task".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_index = Some(0);
+    app.focus.active = Focus::Boards;
+    app.prepare_frame();
+
+    app.handle_set_card_priority_key();
+
+    assert_eq!(
+        app.mode,
+        AppMode::Normal,
+        "p on the projects panel must not open the priority dialog"
+    );
+}


### PR DESCRIPTION
## Problem
Fixes #360 — the task list shows the hint `p Set task priority`, but pressing `p` does nothing.

## Root cause
Two bugs:
1. The `p` keybinding in `card_list.rs` pointed at `KeybindingAction::EditCard` instead of a priority action.
2. `app/input_router.rs` had no `KeyCode::Char('p')` arm in Normal mode (only `P` for bulk), so `p` fell through to the no-op catch-all.

## Fix
- New `handle_set_card_priority_key`: activates the highlighted card and opens the single-card `SetCardPriority` dialog with the card's current priority preselected — mirroring the existing `CardListAction::TogglePriority` flow.
- New `KeybindingAction::SetCardPriority`, mapped in `execute_action` and repointed from the `card_list` binding.
- Router arm for lowercase `p`, gated to the cards panel.

## Tests
- `tests/card_priority_key_tests.rs`: `p` on a highlighted card opens the dialog with the right preselection; `p` on the projects panel is inert.