### PR TITLE
fix(tui): declutter footer by dropping `panel N` hints (fixes #361)

### DIFF
--- a/crates/kanban-tui/src/components/footer.rs
+++ b/crates/kanban-tui/src/components/footer.rs
@@ -101,6 +101,12 @@ pub fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
         let keybindings = context
             .bindings
             .iter()
+            .filter(|b| {
+                !matches!(
+                    b.action,
+                    crate::keybindings::KeybindingAction::FocusPanel(_)
+                )
+            })
             .map(|b| format!("{}: {}", b.key, b.short_description))
             .collect::<Vec<_>>()
             .join(" | ");
@@ -115,6 +121,12 @@ pub fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
         let keybindings = context
             .bindings
             .iter()
+            .filter(|b| {
+                !matches!(
+                    b.action,
+                    crate::keybindings::KeybindingAction::FocusPanel(_)
+                )
+            })
             .map(|b| format!("{}: {}", b.key, b.short_description))
             .collect::<Vec<_>>()
             .join(" | ");

--- a/crates/kanban-tui/tests/footer_panel_hints_tests.rs
+++ b/crates/kanban-tui/tests/footer_panel_hints_tests.rs
@@ -1,0 +1,60 @@
+mod helpers;
+
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::App;
+
+fn render_footer_text(app: &App) -> String {
+    helpers::render_widget_to_string(600, 3, |frame| {
+        kanban_tui::components::render_footer(app, frame, frame.area());
+    })
+}
+
+/// Issue #361: the footer showed `1: panel 1`, `2: panel 2`, ... on every
+/// screen. Panel numbers are already rendered as `[1]`/`[2]` indicators in
+/// the panel titles, so the footer hints are pure clutter. They must be
+/// filtered out of the footer bar.
+#[test]
+fn test_footer_omits_panel_switch_hints_on_cards_panel() {
+    let mut app = App::test_default();
+    app.mode = AppMode::Normal;
+    app.focus.active = Focus::Cards;
+
+    let footer = render_footer_text(&app);
+
+    assert!(
+        !footer.contains("panel 1") && !footer.contains("panel 2"),
+        "footer must not advertise `panel N` hints, got: {footer}"
+    );
+}
+
+/// The declutter must not swallow genuinely useful hints: on the cards panel
+/// the priority shortcut (issue #360) must remain visible in the footer.
+#[test]
+fn test_footer_keeps_useful_hints_on_cards_panel() {
+    let mut app = App::test_default();
+    app.mode = AppMode::Normal;
+    app.focus.active = Focus::Cards;
+
+    let footer = render_footer_text(&app);
+
+    assert!(
+        footer.contains("p: priority"),
+        "footer must still show the priority hint, got: {footer}"
+    );
+}
+
+/// The edit-task (card detail) screen is the worst offender — it defined five
+/// `panel N` hints that crowded out useful shortcuts. Those must be gone.
+#[test]
+fn test_footer_omits_panel_switch_hints_on_card_detail() {
+    let mut app = App::test_default();
+    app.mode = AppMode::CardDetail;
+
+    let footer = render_footer_text(&app);
+
+    assert!(
+        !footer.contains("panel 1") && !footer.contains("panel 3") && !footer.contains("panel 5"),
+        "card detail footer must not advertise `panel N` hints, got: {footer}"
+    );
+}


### PR DESCRIPTION
## Problem
Fixes #361 — the footer shows `1: panel 1`, `2: panel 2`, … on every screen. They're low-value, and on the edit-task screen the five `panel N` hints crowd out useful shortcuts (e.g. `p` for priority).

## Fix
Filter `KeybindingAction::FocusPanel(_)` out of the **footer bar** in `components/footer.rs`. This is safe and non-lossy:
- Panel numbers are already shown as `[1]`/`[2]` focus indicators in the panel titles.
- The numeric keys still switch panels (dispatched directly in the input router, independent of the hint list).
- The `?` help popup still lists panel switches for discoverability.

## Tests
- `tests/footer_panel_hints_tests.rs`: cards-panel and card-detail footers no longer contain `panel N`; useful hints like `p: priority` remain.