### PR TITLE
KAN-834 feat(domain): first-class ArchivedBoard = Archived<Board> + Snapshot.archived_boards [C1]

### DIFF
--- a/.changeset/kan-834-archived-board.md
+++ b/.changeset/kan-834-archived-board.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal foundation for board archiving (no user-facing change): boards can now be represented as first-class archived records via the shared archival abstraction (`ArchivedBoard = Archived<Board>`), and snapshots gain a discrete `archived_boards` collection alongside `archived_cards`. Older data without it loads unchanged. Commands, persistence, and UI for board archiving arrive in later slices.

--- a/crates/kanban-domain/src/archived_board.rs
+++ b/crates/kanban-domain/src/archived_board.rs
@@ -1,0 +1,56 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    archival::{ArchivableEntity, Archived},
+    board::{Board, BoardId},
+};
+
+impl ArchivableEntity for Board {
+    fn entity_id(&self) -> Uuid {
+        self.id
+    }
+
+    fn serialize_entity<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        crate::board_factory::board_serde::serialize(self, s)
+    }
+
+    fn deserialize_entity<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        crate::board_factory::board_serde::deserialize(d)
+    }
+}
+
+/// An archived board: the shared [`Archived`] wrapper specialized to `Board`. A
+/// board is a scoping ROOT — its subtree (columns / cards / archived_cards /
+/// sprints / edges) stays in place in the flat collections — so it needs no
+/// restore context (`NoContext`). Archiving moves the board head into the
+/// wrapper; restore (`into_entity`) unwraps it, losslessly. On the wire: the
+/// board under `entity`, a flat `archived_at`, no context.
+pub type ArchivedBoard = Archived<Board>;
+
+/// Lightweight projection for the archived-boards list view. Reads the board
+/// head plus archive time only — no subtree counts (never gathered under the
+/// discrete-collection model). `archived_at` is non-optional (it always exists
+/// on an archived record).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArchivedBoardSummary {
+    pub board_id: BoardId,
+    pub name: String,
+    pub description: Option<String>,
+    pub archived_at: DateTime<Utc>,
+    pub position: i32,
+}
+
+impl From<&ArchivedBoard> for ArchivedBoardSummary {
+    fn from(ab: &ArchivedBoard) -> Self {
+        Self {
+            board_id: ab.entity.id,
+            name: ab.entity.name.clone(),
+            description: ab.entity.description.clone(),
+            archived_at: ab.metadata.archived_at,
+            position: ab.entity.position,
+        }
+    }
+}
+

--- a/crates/kanban-domain/src/archived_board.rs
+++ b/crates/kanban-domain/src/archived_board.rs
@@ -54,3 +54,47 @@ impl From<&ArchivedBoard> for ArchivedBoardSummary {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::archival::ArchivedEntity;
+
+    #[test]
+    fn test_archived_board_wraps_and_restores_losslessly() {
+        let board = Board::new("Proj", Some("KAN"));
+        let ab = ArchivedBoard::now(board.clone());
+        assert_eq!(ab.entity_id(), board.id);
+        assert_eq!(
+            ab.into_entity(),
+            board,
+            "restore returns the board verbatim"
+        );
+    }
+
+    #[test]
+    fn test_archived_board_round_trips_json_entity_keyed_flat_archived_at() {
+        let ts = Utc::now();
+        let ab = ArchivedBoard::at(Board::new("B", Some("KAN")), ts);
+        let v = serde_json::to_value(&ab).unwrap();
+        assert!(v.get("entity").is_some(), "board is under the entity key");
+        assert!(v.get("archived_at").is_some(), "archived_at is flat");
+        let back: ArchivedBoard = serde_json::from_value(v).unwrap();
+        assert_eq!(back, ab);
+        assert_eq!(back.archived_at(), ts);
+    }
+
+    #[test]
+    fn test_archived_board_summary_projects_head_and_archived_at() {
+        let ts = Utc::now();
+        let mut board = Board::new("Proj", None::<String>);
+        board.description = Some("d".to_string());
+        board.position = 4;
+        let ab = ArchivedBoard::at(board.clone(), ts);
+        let s = ArchivedBoardSummary::from(&ab);
+        assert_eq!(s.board_id, board.id);
+        assert_eq!(s.name, "Proj");
+        assert_eq!(s.description, Some("d".to_string()));
+        assert_eq!(s.position, 4);
+        assert_eq!(s.archived_at, ts);
+    }
+}

--- a/crates/kanban-domain/src/export/importer.rs
+++ b/crates/kanban-domain/src/export/importer.rs
@@ -245,6 +245,7 @@ mod tests {
         let column = Column::new(board.id, "Todo", 0);
 
         let snapshot = Snapshot {
+            archived_boards: Vec::new(),
             boards: vec![board.clone()],
             columns: vec![column.clone()],
             cards: vec![],

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod error;
 
 pub mod archival;
+pub mod archived_board;
 pub mod archived_card;
 pub mod board;
 pub mod board_factory;
@@ -32,6 +33,7 @@ pub mod tag;
 pub mod task_list_view;
 
 pub use archival::{ArchivableEntity, ArchiveMetadata, Archived, ArchivedEntity, NoContext};
+pub use archived_board::{ArchivedBoard, ArchivedBoardSummary};
 pub use archived_card::{ArchivedCard, CardRestoreContext};
 pub use board::{
     get_active_sprint_card_prefix_override, get_active_sprint_prefix_override, Board, BoardId,

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -614,4 +614,31 @@ mod tests {
         assert_eq!(restored.columns[0], column);
     }
 
+    #[test]
+    fn test_snapshot_archived_boards_defaults_when_absent_in_json() {
+        let snap: Snapshot = serde_json::from_str(r#"{"boards": []}"#).unwrap();
+        assert!(snap.archived_boards.is_empty());
+    }
+
+    #[test]
+    fn test_snapshot_archived_boards_round_trips_wrapper() {
+        let ab = crate::ArchivedBoard::now(Board::new("Archived", Some("KAN")));
+        let mut snap = Snapshot::new();
+        snap.archived_boards = vec![ab.clone()];
+
+        let json = serde_json::to_string(&snap).unwrap();
+        let restored: Snapshot = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.archived_boards.len(), 1);
+        assert_eq!(restored.archived_boards[0], ab);
+    }
+
+    #[test]
+    fn test_snapshot_is_empty_false_when_only_archived_boards_present() {
+        let mut snap = Snapshot::new();
+        assert!(snap.is_empty());
+        snap.archived_boards
+            .push(crate::ArchivedBoard::now(Board::new("A", None::<String>)));
+        assert!(!snap.is_empty());
+    }
 }

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -9,7 +9,7 @@
 //! This type is pure data with no UI dependencies, making it suitable for
 //! use by both TUI and future API server implementations.
 
-use crate::{ArchivedCard, Board, Card, Column, DependencyGraph, Sprint};
+use crate::{ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, Sprint};
 use serde::{Deserialize, Serialize};
 
 /// Point-in-time capture of all kanban data.
@@ -39,6 +39,14 @@ pub struct Snapshot {
     #[serde(default, with = "crate::sprint_factory::sprint_vec_serde")]
     pub sprints: Vec<Sprint>,
 
+    /// Archived boards — the discrete, first-class peer collection to `boards`,
+    /// holding `Archived<Board>` wrappers just as `archived_cards` holds
+    /// `Archived<Card, _>`. Each board's subtree (columns/cards/archived_cards/
+    /// sprints/edges) stays in place in the flat collections above; only the
+    /// board head moves into its wrapper.
+    #[serde(default)]
+    pub archived_boards: Vec<ArchivedBoard>,
+
     /// Card dependency graph (blocks, relates-to, parent-child).
     #[serde(default)]
     pub graph: DependencyGraph,
@@ -66,6 +74,7 @@ impl Snapshot {
             archived_cards,
             sprints,
             graph,
+            archived_boards: Vec::new(),
         }
     }
 
@@ -76,6 +85,7 @@ impl Snapshot {
             && self.cards.is_empty()
             && self.archived_cards.is_empty()
             && self.sprints.is_empty()
+            && self.archived_boards.is_empty()
     }
 }
 
@@ -603,4 +613,5 @@ mod tests {
         assert_eq!(restored.columns.len(), 1);
         assert_eq!(restored.columns[0], column);
     }
+
 }

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -140,6 +140,7 @@ pub fn fully_populated_snapshot() -> Snapshot {
     .expect("test fixture edges must validate");
 
     Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board],
         columns: vec![column],
         cards: vec![card],

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -248,6 +248,7 @@ impl KanbanContext {
             let sprints = self.backend.list_sprints_by_board(id)?;
             let graph = self.backend.get_graph()?;
             Snapshot {
+                archived_boards: Vec::new(),
                 boards,
                 columns,
                 cards,

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -487,6 +487,7 @@ mod tests {
             let store = JsonFileStore::new(&path);
             let board = Board::new("Alpha", None::<String>);
             let snap = Snapshot {
+                archived_boards: Vec::new(),
                 boards: vec![board],
                 ..Snapshot::new()
             };
@@ -610,6 +611,7 @@ mod tests {
             let store = Arc::new(JsonFileStore::new(&path));
             let board = Board::new("ConcurrentBoard", None::<String>);
             let snap = kanban_domain::Snapshot {
+                archived_boards: Vec::new(),
                 boards: vec![board],
                 ..kanban_domain::Snapshot::new()
             };

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -212,6 +212,7 @@ impl StoreManager {
 
             let entities = BoardImporter::extract_entities(export);
             let snapshot = Snapshot {
+                archived_boards: Vec::new(),
                 boards: entities.boards,
                 columns: entities.columns,
                 cards: entities.cards,

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -159,6 +159,7 @@ async fn test_open_context_first_list_boards_triggers_load() -> KanbanResult<()>
         use kanban_persistence::{snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot};
 
         let snap = Snapshot {
+            archived_boards: Vec::new(),
             boards: vec![Board::new("Alpha", None::<String>)],
             ..Snapshot::new()
         };

--- a/crates/kanban-service/tests/data_integrity_tests.rs
+++ b/crates/kanban-service/tests/data_integrity_tests.rs
@@ -173,6 +173,7 @@ async fn test_import_with_invalid_column_reference_fails() -> KanbanResult<()> {
         kanban_domain::Card::new(&mut orphan_board, nonexistent_column_id, "Orphan", 0);
 
     let snapshot = kanban_domain::Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board],
         columns: vec![],
         cards: vec![orphan_card],
@@ -222,6 +223,7 @@ async fn test_import_backfills_board_id_on_legacy_archived_card() -> KanbanResul
     let archived = kanban_domain::ArchivedCard::new(card, Uuid::nil(), column_id, 0);
 
     let snapshot = kanban_domain::Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board],
         columns: vec![column],
         cards: vec![],

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -21,6 +21,7 @@ async fn test_import_board_checkpoints_wal_on_sqlite_path() {
         .await
         .unwrap();
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![Board::new("Imported", None::<String>)],
         columns: vec![],
         cards: vec![],

--- a/crates/kanban-service/tests/validate_and_load.rs
+++ b/crates/kanban-service/tests/validate_and_load.rs
@@ -166,6 +166,7 @@ async fn create_test_sqlite(dir: &std::path::Path, name: &str, boards: &[&str]) 
         .map(|name| kanban_domain::Board::new(name.to_string(), None::<String>))
         .collect();
     let snapshot = kanban_domain::Snapshot {
+        archived_boards: Vec::new(),
         boards: domain_boards,
         columns: vec![],
         cards: vec![],

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -216,6 +216,7 @@ mod active_card_helpers {
             )
             .unwrap();
         let snap = Snapshot {
+            archived_boards: Vec::new(),
             boards: app.ctx.data_store().list_boards().unwrap(),
             columns: app.ctx.data_store().list_all_columns().unwrap(),
             cards: app.ctx.data_store().list_all_cards().unwrap(),

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -101,6 +101,7 @@ mod tests {
         let board = Board::new("B", None::<String>);
         let col = Column::new(board.id, "Col", 0);
         m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
             boards: vec![board.clone()],
             columns: vec![col.clone()],
             ..Default::default()
@@ -120,6 +121,7 @@ mod tests {
         let card_b = make_card(&mut board, col_id);
         let card_b_id = card_b.id;
         m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
             cards: vec![card_a, card_b],
             ..Default::default()
         });
@@ -142,6 +144,7 @@ mod tests {
         let card_id = card.id;
         let archived = ArchivedCard::new(card, uuid::Uuid::nil(), col_id, 0);
         m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
             archived_cards: vec![archived],
             ..Default::default()
         });
@@ -163,6 +166,7 @@ mod tests {
         let card = make_card(&mut board, col_id);
         let card_id = card.id;
         m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
             archived_cards: vec![ArchivedCard::new(card, uuid::Uuid::nil(), col_id, 0)],
             ..Default::default()
         });
@@ -175,6 +179,7 @@ mod tests {
         let mut m = Model::default();
         let board_a = Board::new("A", None::<String>);
         m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
             boards: vec![board_a],
             ..Default::default()
         });
@@ -183,6 +188,7 @@ mod tests {
         let board_b = Board::new("B", None::<String>);
         let board_c = Board::new("C", None::<String>);
         m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
             boards: vec![board_b, board_c],
             ..Default::default()
         });
@@ -198,6 +204,7 @@ mod tests {
         let card = make_card(&mut board, col_id);
         let old_id = card.id;
         m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
             cards: vec![card],
             ..Default::default()
         });

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1186,6 +1186,7 @@ mod tests {
 
     fn reload_snapshot(app: &mut App) {
         let snap = Snapshot {
+            archived_boards: Vec::new(),
             boards: app.ctx.data_store().list_boards().unwrap(),
             columns: app.ctx.data_store().list_all_columns().unwrap(),
             cards: app.ctx.data_store().list_all_cards().unwrap(),

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -48,6 +48,7 @@ mod tests {
         use kanban_persistence::{snapshot_from_json_bytes, snapshot_to_json_bytes};
 
         let snapshot = Snapshot {
+            archived_boards: Vec::new(),
             boards: vec![],
             columns: vec![],
             cards: vec![],
@@ -69,6 +70,7 @@ mod tests {
         board.update_task_sort(SortField::Position, kanban_domain::SortOrder::Ascending);
 
         let snapshot = Snapshot {
+            archived_boards: Vec::new(),
             boards: vec![board],
             columns: vec![],
             cards: vec![],

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -15,6 +15,7 @@ pub fn load_with_card_order(app: &mut App, order: &[uuid::Uuid]) {
         })
         .collect();
     let snap = Snapshot {
+        archived_boards: Vec::new(),
         boards: app.ctx.data_store().list_boards().unwrap(),
         columns: app.ctx.data_store().list_all_columns().unwrap(),
         cards: ordered,

--- a/crates/kanban-tui/tests/card_detail_tests.rs
+++ b/crates/kanban-tui/tests/card_detail_tests.rs
@@ -14,6 +14,7 @@ fn test_active_card_detail_shows_selected_card() {
     let card_b_id = card_b.id;
 
     app.model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         cards: vec![card_a, card_b],
         ..Default::default()
     });

--- a/crates/kanban-tui/tests/conflict_detection_tests.rs
+++ b/crates/kanban-tui/tests/conflict_detection_tests.rs
@@ -17,6 +17,7 @@ async fn test_conflict_detection_on_concurrent_modification() {
     let card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot1 = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board.clone()],
         columns: vec![column.clone()],
         cards: vec![card.clone()],
@@ -85,6 +86,7 @@ async fn test_no_conflict_when_file_unchanged() {
     let card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board.clone()],
         columns: vec![column.clone()],
         cards: vec![card.clone()],
@@ -120,6 +122,7 @@ async fn test_conflict_detection_tracks_file_metadata() {
     let _card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board.clone()],
         columns: vec![column.clone()],
         cards: vec![],
@@ -178,6 +181,7 @@ async fn test_multiple_instances_with_different_ids() {
     let card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board.clone()],
         columns: vec![column.clone()],
         cards: vec![card],
@@ -222,6 +226,7 @@ async fn test_conflict_resolution_with_force_overwrite() {
     let card = Card::new(&mut board, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board.clone()],
         columns: vec![column.clone()],
         cards: vec![card],
@@ -279,6 +284,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let card2 = Card::new(&mut board1, column2.id, "Task B", 0);
 
     let snapshot1 = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board1.clone()],
         columns: vec![column1.clone(), column2.clone()],
         cards: vec![card1.clone(), card2.clone()],

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -243,6 +243,7 @@ async fn test_async_load_initial_state_sqlite() {
     let column = Column::new(board.id, "Backlog", 0);
 
     let snapshot = kanban_domain::Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board.clone()],
         columns: vec![column.clone()],
         cards: vec![],

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -102,6 +102,7 @@ pub async fn create_test_json_file(dir: &std::path::Path, name: &str, boards: &[
         .map(|n| kanban_domain::Board::new(n.to_string(), None::<String>))
         .collect();
     let snapshot = kanban_domain::Snapshot {
+        archived_boards: Vec::new(),
         boards: domain_boards,
         columns: vec![],
         cards: vec![],
@@ -133,6 +134,7 @@ pub async fn create_test_sqlite_file(dir: &std::path::Path, name: &str, boards: 
         .map(|n| kanban_domain::Board::new(n.to_string(), None::<String>))
         .collect();
     let snapshot = kanban_domain::Snapshot {
+        archived_boards: Vec::new(),
         boards: domain_boards,
         columns: vec![],
         cards: vec![],

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -14,6 +14,7 @@ async fn test_import_failure_prevents_empty_state_save() {
 
     // Create snapshot with one board
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board.clone()],
         columns: vec![column.clone()],
         cards: vec![],
@@ -89,6 +90,7 @@ async fn test_v2_format_is_imported_correctly() {
 
     // Create snapshot with board, column, and card
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board],
         columns: vec![column],
         cards: vec![card],

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -28,6 +28,7 @@ async fn test_load_initial_state_with_boards_refreshes_card_view() -> KanbanResu
     let column = Column::new(board.id, "Todo", 0);
     let card = Card::new(&mut board, column.id, "Task One", 0);
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board],
         columns: vec![column],
         cards: vec![card],

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -27,6 +27,7 @@ fn test_load_from_snapshot_populates_all_fields() {
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: vec![board],
         columns: vec![column],
         cards: vec![card],
@@ -59,6 +60,7 @@ fn test_card_lookup_by_id() {
     let id2 = card2.id;
 
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         cards: vec![card1, card2],
         ..Default::default()
     });
@@ -74,6 +76,7 @@ fn test_card_lookup_missing_id_returns_none() {
     let mut board = Board::new("B", None::<String>);
     let card = make_card(&mut board, Uuid::new_v4(), "Exists", 0);
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         cards: vec![card],
         ..Default::default()
     });
@@ -91,6 +94,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
     let id_a = card_a.id;
 
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         cards: vec![card_a],
         ..Default::default()
     });
@@ -99,6 +103,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
     let card_b = make_card(&mut board, column_id, "B", 0);
     let id_b = card_b.id;
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         cards: vec![card_b],
         ..Default::default()
     });
@@ -119,6 +124,7 @@ fn test_archived_cards_flat_returns_card_data() {
     let ac2 = ArchivedCard::new(card2.clone(), uuid::Uuid::nil(), column_id, 1);
 
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         archived_cards: vec![ac1, ac2],
         ..Default::default()
     });
@@ -139,6 +145,7 @@ fn test_archived_cards_flat_rebuilds_on_reload() {
     let card1 = make_card(&mut board, column_id, "First", 0);
     let ac1 = ArchivedCard::new(card1.clone(), uuid::Uuid::nil(), column_id, 0);
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         archived_cards: vec![ac1],
         ..Default::default()
     });
@@ -150,6 +157,7 @@ fn test_archived_cards_flat_rebuilds_on_reload() {
     let ac2 = ArchivedCard::new(card2.clone(), uuid::Uuid::nil(), column_id, 0);
     let ac3 = ArchivedCard::new(card3.clone(), uuid::Uuid::nil(), column_id, 1);
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         archived_cards: vec![ac2, ac3],
         ..Default::default()
     });
@@ -174,6 +182,7 @@ fn test_archived_card_lookup_by_id() {
     let ac2 = ArchivedCard::new(card2, uuid::Uuid::nil(), column_id, 1);
 
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         archived_cards: vec![ac1, ac2],
         ..Default::default()
     });
@@ -192,6 +201,7 @@ fn test_archived_card_lookup_missing_returns_none() {
     let ac = ArchivedCard::new(card, uuid::Uuid::nil(), column_id, 0);
 
     model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
         archived_cards: vec![ac],
         ..Default::default()
     });

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -95,6 +95,7 @@ fn test_manage_parents_popup_enter_creates_parent_edge() {
     // Wire the model so popup_handlers' `self.model.cards()` reflects
     // the data store. `selection.active_card` points at child.
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: app.ctx.data_store().list_boards().unwrap(),
         columns: app.ctx.data_store().list_all_columns().unwrap(),
         cards: app.ctx.data_store().list_all_cards().unwrap(),
@@ -182,6 +183,7 @@ fn test_manage_parents_popup_cycle_surfaces_error_banner_to_user() {
     app.ctx.attach_child(b.id, c.id).unwrap();
 
     let snapshot = Snapshot {
+        archived_boards: Vec::new(),
         boards: app.ctx.data_store().list_boards().unwrap(),
         columns: app.ctx.data_store().list_all_columns().unwrap(),
         cards: app.ctx.data_store().list_all_cards().unwrap(),


### PR DESCRIPTION
## What
Domain foundation for board archiving, now built on the **F1b generic archival abstraction** (KAN-855, merged): boards are first-class archived records via `ArchivedBoard = Archived<Board>` — NOT a bespoke wrapper, and NOT a marker on the live `Board`.

- `impl ArchivableEntity for Board` (id + `board_serde` bridge) — the one thing boards add.
- `pub type ArchivedBoard = Archived<Board>` — a scoping-**root** archive (`NoContext`, no restore context). The board head moves into the wrapper; its subtree (columns/cards/archived_cards/sprints/edges) stays in place in the flat collections; restore (`into_entity`) unwraps losslessly.
- `ArchivedBoardSummary` listing DTO (non-optional `archived_at`).
- `Snapshot.archived_boards: Vec<ArchivedBoard>` — discrete peer to `archived_cards` (`#[serde(default)]`); `is_empty()` covers it; `from_data` stays 6-arg.
- Live `Board` is untouched. No board back-compat/alias/migration — `ArchivedBoard` is brand-new (never shipped).

## Design history (superseded)
This PR started as a `Board.archived_at` marker, then a bespoke `ArchivedBoard` struct. Both are superseded: the epic settled on first-class discrete archived collections (D3′) implemented via one reusable generic (D13). F1b landed that generic and migrated `ArchivedCard` onto it; C1 is now the trivial board adoption, so cards and boards are instances of the same abstraction.

## Testing
`test(domain)`: Board `ArchivableEntity` bridge round-trip (board under the `entity` key, flat `archived_at`), lossless wrap/restore via `now`/`into_entity`, `ArchivedBoardSummary` projection, and `Snapshot.archived_boards` default/round-trip/`is_empty`. The generic root path (now/at/into_entity/NoContext) is already covered in F1b's `archival.rs`. `kanban-domain` green (590); full workspace production build + all test targets compile clean; clippy `-D warnings` + fmt clean.

Part of epic KAN-821. Next: C2 (ArchiveBoard/RestoreBoard commands as collection moves + symmetric undo).
