### PR TITLE
KAN-855 feat(domain): generalize archival to Archived<T,C> + migrate ArchivedCard [F1b]

### DIFF
--- a/.changeset/kan-855-generic-archival-abstraction.md
+++ b/.changeset/kan-855-generic-archival-abstraction.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal refactor (no user-facing change): archival is now a single reusable abstraction. Archived records are modeled generically as an entity plus its shared archive metadata and an entity-specific restore context, so archiving any entity is a matter of implementing one small trait rather than hand-rolling a bespoke type. Archived cards move onto this abstraction; already-saved archived-card data keeps loading unchanged.

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -269,9 +269,9 @@ fn card_board_id(ctx: &CliContext, card_id: Uuid) -> Result<Uuid, String> {
                 .list_archived_cards()
                 .map_err(|e| e.to_string())?
                 .into_iter()
-                .find(|a| a.card.id == card_id)
+                .find(|a| a.entity.id == card_id)
                 .ok_or_else(|| format!("Card not found: {}", card_id))?;
-            archived.original_column_id
+            archived.context.original_column_id
         }
     };
     let column = ctx

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -3557,7 +3557,7 @@ mod name_resolution_tests {
 
     /// Regression: `card restore <archived_uuid> --column <name>` must work.
     /// The board-derivation helper used to chain via active cards only, which
-    /// failed for archived cards. It now falls back to archived_card.original_column_id.
+    /// failed for archived cards. It now falls back to archived_card.context.original_column_id.
     #[test]
     fn test_card_restore_archived_with_column_name() {
         let (_dir, file, _b, _c) = setup_named_board("B", "KAN");

--- a/crates/kanban-domain/src/archival.rs
+++ b/crates/kanban-domain/src/archival.rs
@@ -1,12 +1,18 @@
-//! Bounded shared archival abstraction.
+//! Shared archival abstraction.
 //!
-//! Scope is deliberately minimal (validated by two execution spikes): the only
-//! genuinely cross-cutting pieces are the archived-metadata envelope and a thin
-//! trait exposing an archived record's stable key + metadata. The lifecycle
-//! (archive / restore / permanent-delete) and the entity-specific restore
-//! context stay specialized on the concrete types and the command tier — a
-//! store-generic `ArchiveCollection` trait was found to be dead abstraction (no
-//! backend would implement it) and is intentionally NOT provided.
+//! Archived records are modeled generically as [`Archived<T, C>`]: any live
+//! entity `T` (serialized through the [`ArchivableEntity`] bridge) plus its
+//! shared [`ArchiveMetadata`] envelope and an entity-specific restore context
+//! `C` ([`NoContext`] for scoping roots). `ArchivedCard`, `ArchivedBoard`, and
+//! any future archived type are aliases of it, so archiving a new entity means
+//! implementing one trait — the wrapper, the metadata envelope, and the
+//! archive/restore lifecycle come for free.
+//!
+//! Deliberately bounded to the DOMAIN shape. A store-generic
+//! `ArchiveCollection` trait was found (across two execution spikes) to be dead
+//! abstraction — no backend would implement it — so persistence stays
+//! entity-specific (each backend discerns the type via its own tables/queries)
+//! and that trait is intentionally NOT provided.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -186,5 +192,77 @@ mod tests {
         assert_eq!(d.metadata().archived_at, at);
         // The default `archived_at()` delegates to `metadata()`.
         assert_eq!(d.archived_at(), at);
+    }
+
+    // A throwaway archivable entity. Real entities (Board/Card) route their
+    // serde through a record bridge; a self-serializing one is enough to
+    // exercise the generic wrapper, the `entity_serde` bridge, and the
+    // `NoContext` root path independently of any concrete domain type.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TestEntity {
+        id: Uuid,
+        name: String,
+    }
+
+    impl ArchivableEntity for TestEntity {
+        fn entity_id(&self) -> Uuid {
+            self.id
+        }
+        fn serialize_entity<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            self.serialize(s)
+        }
+        fn deserialize_entity<'de, D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            Self::deserialize(d)
+        }
+    }
+
+    fn entity() -> TestEntity {
+        TestEntity {
+            id: Uuid::new_v4(),
+            name: "e".into(),
+        }
+    }
+
+    #[test]
+    fn test_archived_now_sets_recent_metadata_and_no_context() {
+        let e = entity();
+        let before = Utc::now();
+        let a = Archived::now(e.clone());
+        assert_eq!(a.entity, e);
+        assert_eq!(a.context, NoContext {});
+        assert!(a.metadata.archived_at >= before && a.metadata.archived_at <= Utc::now());
+    }
+
+    #[test]
+    fn test_archived_at_uses_injected_time_and_into_entity_restores() {
+        let e = entity();
+        let ts = Utc::now();
+        let a = Archived::at(e.clone(), ts);
+        assert_eq!(a.metadata.archived_at, ts);
+        // Restore returns the live entity verbatim.
+        assert_eq!(a.into_entity(), e);
+    }
+
+    #[test]
+    fn test_archived_root_blanket_archived_entity_impl() {
+        let e = entity();
+        let id = e.id;
+        let ts = Utc::now();
+        let a = Archived::at(e, ts);
+        assert_eq!(a.entity_id(), id);
+        assert_eq!(a.archived_at(), ts);
+    }
+
+    #[test]
+    fn test_archived_nocontext_round_trips_json_entity_keyed_flat_metadata() {
+        let ts = Utc::now();
+        let a = Archived::at(entity(), ts);
+        let v = serde_json::to_value(&a).unwrap();
+        // Entity under the `entity` key, archived_at flat, no context fields.
+        assert!(v.get("entity").is_some(), "entity is keyed, got: {v}");
+        assert!(v.get("archived_at").is_some(), "metadata flattens");
+        assert!(v.get("context").is_none(), "NoContext flattens to nothing");
+        let back: Archived<TestEntity> = serde_json::from_value(v).unwrap();
+        assert_eq!(back, a);
     }
 }

--- a/crates/kanban-domain/src/archival.rs
+++ b/crates/kanban-domain/src/archival.rs
@@ -9,7 +9,7 @@
 //! backend would implement it) and is intentionally NOT provided.
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
 /// Shared archival metadata envelope. Common to every archived entity; the
@@ -45,6 +45,109 @@ pub trait ArchivedEntity {
 
     fn archived_at(&self) -> DateTime<Utc> {
         self.metadata().archived_at
+    }
+}
+
+/// A live entity that can be archived: exposes its stable id and its own serde
+/// bridge. Live entities (`Board`/`Card`) have no `Deserialize` — they route
+/// through a record type for migration — so the bridge is explicit. Implementing
+/// this trait is the ONE thing a new archivable entity must do; the wrapper,
+/// metadata, and lifecycle come for free.
+pub trait ArchivableEntity: Sized {
+    fn entity_id(&self) -> Uuid;
+
+    fn serialize_entity<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error>;
+
+    fn deserialize_entity<'de, D: Deserializer<'de>>(d: D) -> Result<Self, D::Error>;
+}
+
+/// serde bridge that dispatches a generic entity field through its
+/// [`ArchivableEntity`] impl, so `Archived<T, _>` can `#[serde(with)]` a `T`
+/// it cannot name at derive time.
+pub mod entity_serde {
+    use super::ArchivableEntity;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<T: ArchivableEntity, S: Serializer>(t: &T, s: S) -> Result<S::Ok, S::Error> {
+        t.serialize_entity(s)
+    }
+
+    pub fn deserialize<'de, T: ArchivableEntity, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<T, D::Error> {
+        T::deserialize_entity(d)
+    }
+}
+
+/// Empty restore context for scoping-root entities (e.g. a board) that need no
+/// "where did it come from" data. Flattens to nothing on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct NoContext {}
+
+/// A generic archived record: any live entity `T` plus its shared
+/// [`ArchiveMetadata`] envelope and an entity-specific restore context `C`
+/// (`NoContext` for roots). The reusable archival shape — `ArchivedCard`,
+/// `ArchivedBoard`, and any future one are aliases. Storage stays
+/// entity-specific (backends discern the type); this is only the domain shape.
+///
+/// The entity serializes under the `entity` key; `alias = "card"` keeps
+/// already-shipped `archived_cards` blobs (which used a `card` key) loadable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "T: ArchivableEntity, C: Serialize",
+    deserialize = "T: ArchivableEntity, C: Deserialize<'de>"
+))]
+pub struct Archived<T, C = NoContext> {
+    #[serde(with = "entity_serde", alias = "card")]
+    pub entity: T,
+    #[serde(flatten)]
+    pub metadata: ArchiveMetadata,
+    #[serde(flatten)]
+    pub context: C,
+}
+
+impl<T: ArchivableEntity, C> Archived<T, C> {
+    pub fn with_context(entity: T, context: C, metadata: ArchiveMetadata) -> Self {
+        Self {
+            entity,
+            context,
+            metadata,
+        }
+    }
+}
+
+impl<T: ArchivableEntity> Archived<T, NoContext> {
+    /// Archive a scoping-root entity now (no restore context).
+    pub fn now(entity: T) -> Self {
+        Self {
+            entity,
+            context: NoContext {},
+            metadata: ArchiveMetadata::now(),
+        }
+    }
+
+    /// Archive a scoping-root entity at an explicit time.
+    pub fn at(entity: T, archived_at: DateTime<Utc>) -> Self {
+        Self {
+            entity,
+            context: NoContext {},
+            metadata: ArchiveMetadata::at(archived_at),
+        }
+    }
+
+    /// Restore: unwrap the live entity verbatim.
+    pub fn into_entity(self) -> T {
+        self.entity
+    }
+}
+
+impl<T: ArchivableEntity, C> ArchivedEntity for Archived<T, C> {
+    fn entity_id(&self) -> Uuid {
+        self.entity.entity_id()
+    }
+
+    fn metadata(&self) -> ArchiveMetadata {
+        self.metadata
     }
 }
 

--- a/crates/kanban-domain/src/archived_card.rs
+++ b/crates/kanban-domain/src/archived_card.rs
@@ -1,26 +1,45 @@
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 
-use crate::{archival::ArchiveMetadata, board::BoardId, card::Card, column::ColumnId};
+use crate::{
+    archival::{ArchivableEntity, ArchiveMetadata, Archived},
+    board::BoardId,
+    card::Card,
+    column::ColumnId,
+};
 
+/// Restore context for an archived card. A card is a LEAF sharing a live
+/// column, so it must remember where to go back. `board_id` is a direct field
+/// (D2 first-class model) so board-scoped queries need no column load;
+/// `#[serde(default)]` keeps pre-V8 files loadable (nil until backfilled).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ArchivedCard {
-    #[serde(with = "crate::card_factory::card_serde")]
-    pub card: Card,
-    /// Shared archival envelope (`archived_at`, room to grow). `#[serde(flatten)]`
-    /// keeps the on-disk shape byte-identical to the previous flat `archived_at`
-    /// field, so no format bump / migration is needed.
-    #[serde(flatten)]
-    pub metadata: ArchiveMetadata,
-    /// Board the card belonged to at archive time (D2 first-class model): a
-    /// direct field so board-scoped queries need no column load. `#[serde(default)]`
-    /// keeps pre-V8 files loadable (nil until the persistence migration backfills).
+pub struct CardRestoreContext {
     #[serde(default)]
     pub board_id: BoardId,
     /// Historical column at archive time — NOT a live FK. May dangle if the
-    /// column is later deleted; that is intentional under the first-class model.
+    /// column is later deleted; intentional under the first-class model.
     pub original_column_id: ColumnId,
     pub original_position: i32,
+}
+
+/// An archived card: the shared [`Archived`] wrapper specialized to `Card` plus
+/// its [`CardRestoreContext`]. On the wire: the card under `entity` (with a
+/// `card` alias for already-shipped blobs), a flat `archived_at`, and the
+/// flattened restore context.
+pub type ArchivedCard = Archived<Card, CardRestoreContext>;
+
+impl ArchivableEntity for Card {
+    fn entity_id(&self) -> uuid::Uuid {
+        self.id
+    }
+
+    fn serialize_entity<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        crate::card_factory::card_serde::serialize(self, s)
+    }
+
+    fn deserialize_entity<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        crate::card_factory::card_serde::deserialize(d)
+    }
 }
 
 impl ArchivedCard {
@@ -30,47 +49,39 @@ impl ArchivedCard {
         original_column_id: ColumnId,
         original_position: i32,
     ) -> Self {
-        Self {
+        Archived::with_context(
             card,
-            metadata: ArchiveMetadata::now(),
-            board_id,
-            original_column_id,
-            original_position,
-        }
+            CardRestoreContext {
+                board_id,
+                original_column_id,
+                original_position,
+            },
+            ArchiveMetadata::now(),
+        )
     }
 
     pub fn into_card(self) -> Card {
-        self.card
+        self.entity
     }
 
     pub fn card_ref(&self) -> &Card {
-        &self.card
+        &self.entity
     }
 
     pub fn card_mut(&mut self) -> &mut Card {
-        &mut self.card
+        &mut self.entity
     }
 }
 
 impl From<ArchivedCard> for Card {
     fn from(archived_card: ArchivedCard) -> Self {
-        archived_card.card
+        archived_card.entity
     }
 }
 
 impl Borrow<Card> for ArchivedCard {
     fn borrow(&self) -> &Card {
-        &self.card
-    }
-}
-
-impl crate::archival::ArchivedEntity for ArchivedCard {
-    fn entity_id(&self) -> uuid::Uuid {
-        self.card.id
-    }
-
-    fn metadata(&self) -> ArchiveMetadata {
-        self.metadata
+        &self.entity
     }
 }
 
@@ -81,8 +92,6 @@ mod tests {
     use crate::{board::Board, card::Card, column::Column};
 
     fn sample() -> ArchivedCard {
-        // Built via public constructors (the in-memory `test_support` module is
-        // private and not usable from here).
         let mut board = Board::new("B", None::<String>);
         let col = Column::new(board.id, "Todo", 0);
         let card = Card::new(&mut board, col.id, "T", 0);
@@ -92,16 +101,12 @@ mod tests {
     #[test]
     fn test_archived_card_implements_archived_entity() {
         let ac = sample();
-        assert_eq!(ArchivedEntity::entity_id(&ac), ac.card.id);
-        // The trait method returns the record's own metadata field.
+        assert_eq!(ArchivedEntity::entity_id(&ac), ac.entity.id);
         assert_eq!(ac.archived_at(), ac.metadata.archived_at);
     }
 
     #[test]
     fn test_metadata_flatten_keeps_archived_at_flat_on_the_wire() {
-        // The `#[serde(flatten)]` metadata must serialize `archived_at` as a
-        // TOP-LEVEL key (not nested under "metadata"), so the on-disk shape is
-        // unchanged and no migration is needed.
         let ac = sample();
         let v = serde_json::to_value(&ac).unwrap();
         assert!(
@@ -115,45 +120,40 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_metadata_flat_json_still_deserializes() {
-        // A record written by the PREVIOUS (flat `archived_at`) code must still
-        // load. Hand-assemble that historical shape - `archived_at` as a sibling
-        // of `card`, NOT nested under a `metadata` key - so this genuinely fails
-        // if `#[serde(flatten)]` is ever dropped (the real back-compat guard,
-        // not a new->new round-trip that would move with the struct).
+    fn test_legacy_card_keyed_json_still_deserializes() {
+        // A record written by the PREVIOUS (bespoke `ArchivedCard`) code used a
+        // `card` key for the entity. The `alias = "card"` on the generic must
+        // keep it loadable — this is the real back-compat guard for the
+        // migration to `Archived<Card, _>`.
         let ac = sample();
         let card_value = serde_json::to_value(&ac)
             .unwrap()
-            .get("card")
+            .get("entity")
             .cloned()
-            .expect("serialized card sub-object");
-        let flat = serde_json::json!({
+            .expect("serialized entity sub-object");
+        let legacy = serde_json::json!({
             "card": card_value,
             "archived_at": ac.metadata.archived_at,
-            "original_column_id": ac.original_column_id,
-            "original_position": ac.original_position,
+            "board_id": ac.context.board_id,
+            "original_column_id": ac.context.original_column_id,
+            "original_position": ac.context.original_position,
         });
-        let back: ArchivedCard = serde_json::from_value(flat).unwrap();
+        let back: ArchivedCard = serde_json::from_value(legacy).unwrap();
         assert_eq!(back, ac);
     }
 
     #[test]
     fn test_archived_card_retains_board_id() {
-        // An archived card records the board it belonged to as its own field,
-        // independent of any live column (D2 first-class model).
         let mut board = Board::new("B", None::<String>);
         let board_id = board.id;
         let col = Column::new(board_id, "Todo", 0);
         let card = Card::new(&mut board, col.id, "T", 0);
         let ac = ArchivedCard::new(card, board_id, col.id, 0);
-        assert_eq!(ac.board_id, board_id);
+        assert_eq!(ac.context.board_id, board_id);
     }
 
     #[test]
     fn test_archived_card_board_id_survives_json_round_trip() {
-        // `#[serde(default)]` guarantees read-defaulting but NOT that the field
-        // is written. Pin the write side too: a non-nil board_id must serialize
-        // and reload intact, so it can never be paired with a silent skip.
         let mut board = Board::new("B", None::<String>);
         let board_id = board.id;
         let col = Column::new(board_id, "Todo", 0);
@@ -161,6 +161,6 @@ mod tests {
         let ac = ArchivedCard::new(card, board_id, col.id, 0);
         let json = serde_json::to_string(&ac).unwrap();
         let restored: ArchivedCard = serde_json::from_str(&json).unwrap();
-        assert_eq!(restored.board_id, board_id);
+        assert_eq!(restored.context.board_id, board_id);
     }
 }

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -423,7 +423,7 @@ impl ImportEntities {
             .store
             .list_archived_cards()?
             .iter()
-            .map(|ac| ac.card.id)
+            .map(|ac| ac.entity.id)
             .collect();
 
         for b in &self.boards {
@@ -451,12 +451,12 @@ impl ImportEntities {
             }
         }
         for ac in &self.archived_cards {
-            if existing_archived_ids.contains(&ac.card.id)
-                || existing_card_ids.contains(&ac.card.id)
+            if existing_archived_ids.contains(&ac.entity.id)
+                || existing_card_ids.contains(&ac.entity.id)
             {
                 return Err(crate::KanbanError::validation(format!(
                     "Duplicate archived card ID (live or archived): {}",
-                    ac.card.id
+                    ac.entity.id
                 )));
             }
         }
@@ -516,7 +516,7 @@ impl ImportEntities {
         for ac in &self.archived_cards {
             commands.push(Command::Card(crate::commands::CardCommand::Delete(
                 crate::commands::DeleteCard {
-                    card_id: ac.card.id,
+                    card_id: ac.entity.id,
                 },
             )));
         }

--- a/crates/kanban-domain/src/commands/card/tests/archive_update.rs
+++ b/crates/kanban-domain/src/commands/card/tests/archive_update.rs
@@ -93,9 +93,9 @@ fn test_archive_captures_board_from_column() {
     // and the grown 4-arg signature still lands column/position correctly
     // (guards an arg-order swap at the production call site).
     let archived = tc.store.get_archived_card(card_id).unwrap().unwrap();
-    assert_eq!(archived.board_id, board_id);
-    assert_eq!(archived.original_column_id, col_id);
-    assert_eq!(archived.original_position, 0);
+    assert_eq!(archived.context.board_id, board_id);
+    assert_eq!(archived.context.original_column_id, col_id);
+    assert_eq!(archived.context.original_position, 0);
 }
 
 #[test]
@@ -130,8 +130,8 @@ fn test_archive_batch_captures_each_cards_own_board() {
     // board per-item rather than hoisting or reusing the first card's board.
     let arch_a = tc.store.get_archived_card(card_a_id).unwrap().unwrap();
     let arch_b = tc.store.get_archived_card(card_b_id).unwrap().unwrap();
-    assert_eq!(arch_a.board_id, board_a_id);
-    assert_eq!(arch_b.board_id, board_b_id);
+    assert_eq!(arch_a.context.board_id, board_a_id);
+    assert_eq!(arch_b.context.board_id, board_b_id);
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn test_archive_with_dangling_column_captures_nil_board_id() {
     assert!(cmd.execute(&context).is_ok());
 
     let archived = tc.store.get_archived_card(card_id).unwrap().unwrap();
-    assert_eq!(archived.board_id, Uuid::nil());
+    assert_eq!(archived.context.board_id, Uuid::nil());
 }
 
 #[test]

--- a/crates/kanban-domain/src/commands/cascade_commands.rs
+++ b/crates/kanban-domain/src/commands/cascade_commands.rs
@@ -246,8 +246,8 @@ impl SetArchivedCardsSprint {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         for id in &self.archived_card_ids {
             if let Some(mut ac) = context.store.get_archived_card(*id)? {
-                ac.card.sprint_id = Some(self.sprint_id);
-                context.store.delete_archived_card(ac.card.id)?;
+                ac.entity.sprint_id = Some(self.sprint_id);
+                context.store.delete_archived_card(ac.entity.id)?;
                 context.store.insert_archived_card(ac)?;
             }
         }
@@ -375,9 +375,9 @@ mod tests {
         let arch1 = crate::ArchivedCard::new(card1, board_id, dangling_col, 0);
         let arch2 = crate::ArchivedCard::new(card2, board_id, live_col.id, 0);
         let keep_arch = crate::ArchivedCard::new(keep, board_id, live_col.id, 1);
-        let arch1_id = arch1.card.id;
-        let arch2_id = arch2.card.id;
-        let keep_id = keep_arch.card.id;
+        let arch1_id = arch1.entity.id;
+        let arch2_id = arch2.entity.id;
+        let keep_id = keep_arch.entity.id;
         tc.store.insert_archived_card(arch1).unwrap();
         tc.store.insert_archived_card(arch2).unwrap();
         tc.store.insert_archived_card(keep_arch).unwrap();
@@ -390,7 +390,7 @@ mod tests {
 
         let remaining = tc.store.list_archived_cards().unwrap();
         assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].card.id, keep_id);
+        assert_eq!(remaining[0].entity.id, keep_id);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -192,7 +192,7 @@ fn validate_card_prefix_not_locked(sprint_id: Uuid, context: &CommandContext) ->
         .store
         .list_archived_cards()?
         .iter()
-        .any(|ac| ac.card.sprint_id == Some(sprint_id));
+        .any(|ac| ac.entity.sprint_id == Some(sprint_id));
     if has_active || has_archived {
         return Err(KanbanError::validation(
             "sprint card_prefix cannot be changed after cards have been assigned",
@@ -478,8 +478,8 @@ impl DeleteSprint {
         let archived_with_sprint: Vec<Uuid> = store
             .list_archived_cards()?
             .into_iter()
-            .filter(|ac| ac.card.sprint_id == Some(self.sprint_id))
-            .map(|ac| ac.card.id)
+            .filter(|ac| ac.entity.sprint_id == Some(self.sprint_id))
+            .map(|ac| ac.entity.id)
             .collect();
 
         let mut commands: Vec<Command> = vec![Command::Board(super::BoardCommand::Import(
@@ -872,8 +872,8 @@ mod tests {
 
         let archived_cards = tc.store.list_archived_cards().unwrap();
         assert_eq!(archived_cards.len(), 1);
-        assert_eq!(archived_cards[0].card.updated_at, fixed_time);
-        assert_eq!(archived_cards[0].card.sprint_id, None);
+        assert_eq!(archived_cards[0].entity.updated_at, fixed_time);
+        assert_eq!(archived_cards[0].entity.sprint_id, None);
     }
 
     #[test]

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -64,7 +64,7 @@ pub trait DataStore: Send + Sync {
         let all = self.list_archived_cards()?;
         Ok(all
             .into_iter()
-            .filter(|ac| ac.board_id == board_id)
+            .filter(|ac| ac.context.board_id == board_id)
             .collect())
     }
 
@@ -75,9 +75,9 @@ pub trait DataStore: Send + Sync {
     ) -> KanbanResult<()> {
         let all = self.list_archived_cards()?;
         for mut ac in all {
-            if ac.card.sprint_id == Some(sprint_id) {
-                ac.card.sprint_id = None;
-                ac.card.updated_at = timestamp;
+            if ac.entity.sprint_id == Some(sprint_id) {
+                ac.entity.sprint_id = None;
+                ac.entity.updated_at = timestamp;
                 self.insert_archived_card(ac)?;
             }
         }

--- a/crates/kanban-domain/src/export/exporter.rs
+++ b/crates/kanban-domain/src/export/exporter.rs
@@ -35,7 +35,7 @@ impl BoardExporter {
 
         let board_archived_cards: Vec<ArchivedCard> = all_archived_cards
             .iter()
-            .filter(|dc| column_ids.contains(&dc.original_column_id))
+            .filter(|dc| column_ids.contains(&dc.context.original_column_id))
             .cloned()
             .collect();
 

--- a/crates/kanban-domain/src/export/importer.rs
+++ b/crates/kanban-domain/src/export/importer.rs
@@ -104,7 +104,7 @@ impl BoardImporter {
                 .filter(|a| {
                     board_columns
                         .iter()
-                        .any(|col| col.id == a.original_column_id)
+                        .any(|col| col.id == a.context.original_column_id)
                 })
                 .cloned()
                 .collect();

--- a/crates/kanban-domain/src/in_memory_store/archived_cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_cards.rs
@@ -35,7 +35,7 @@ impl InMemoryStore {
         let mut acs: Vec<ArchivedCard> = state
             .archived_cards
             .values()
-            .filter(|ac| ac.board_id == board_id)
+            .filter(|ac| ac.context.board_id == board_id)
             .cloned()
             .collect();
         acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
@@ -49,9 +49,9 @@ impl InMemoryStore {
     ) -> KanbanResult<()> {
         let mut state = self.write_state()?;
         for ac in state.archived_cards.values_mut() {
-            if ac.card.sprint_id == Some(sprint_id) {
-                ac.card.sprint_id = None;
-                ac.card.updated_at = timestamp;
+            if ac.entity.sprint_id == Some(sprint_id) {
+                ac.entity.sprint_id = None;
+                ac.entity.updated_at = timestamp;
             }
         }
         Ok(())
@@ -81,7 +81,7 @@ mod tests {
         store.insert_archived_card(ac).unwrap();
 
         let fetched = store.get_archived_card(card_id).unwrap().unwrap();
-        assert_eq!(fetched.card.id, card_id);
+        assert_eq!(fetched.entity.id, card_id);
     }
 
     #[test]
@@ -120,9 +120,9 @@ mod tests {
             .unwrap();
 
         let ac = store.get_archived_card(card_id).unwrap().unwrap();
-        assert!(ac.card.sprint_id.is_none());
-        assert!(ac.card.updated_at > before);
-        assert_eq!(ac.card.updated_at, ts);
+        assert!(ac.entity.sprint_id.is_none());
+        assert!(ac.entity.updated_at > before);
+        assert_eq!(ac.entity.updated_at, ts);
     }
 
     #[test]
@@ -164,10 +164,10 @@ mod tests {
             .unwrap();
 
         let only_a = store.list_archived_cards_by_board(board_a.id).unwrap();
-        let ids: Vec<Uuid> = only_a.iter().map(|ac| ac.card.id).collect();
+        let ids: Vec<Uuid> = only_a.iter().map(|ac| ac.entity.id).collect();
         assert_eq!(only_a.len(), 2, "only board A's archived cards");
         assert!(ids.contains(&a1_id) && ids.contains(&a2_id));
-        assert!(only_a.iter().all(|ac| ac.board_id == board_a.id));
+        assert!(only_a.iter().all(|ac| ac.context.board_id == board_a.id));
     }
 
     #[test]
@@ -195,7 +195,7 @@ mod tests {
             .list_archived_cards()
             .unwrap()
             .into_iter()
-            .filter(|ac| ac.board_id == board_a.id)
+            .filter(|ac| ac.context.board_id == board_a.id)
             .collect();
         assert_eq!(via_query, via_full_filter);
         assert!(!via_query.is_empty());
@@ -217,6 +217,6 @@ mod tests {
 
         let found = store.list_archived_cards_by_board(board.id).unwrap();
         assert_eq!(found.len(), 1);
-        assert_eq!(found[0].card.id, card_id);
+        assert_eq!(found[0].entity.id, card_id);
     }
 }

--- a/crates/kanban-domain/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-domain/src/in_memory_store/snapshot.rs
@@ -40,7 +40,7 @@ impl InMemoryStore {
         state.archived_cards = snapshot
             .archived_cards
             .into_iter()
-            .map(|ac| (ac.card.id, ac))
+            .map(|ac| (ac.entity.id, ac))
             .collect();
         state.sprints = snapshot.sprints.into_iter().map(|s| (s.id, s)).collect();
         state.graph = snapshot.graph;

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -31,8 +31,8 @@ pub mod sprint_log;
 pub mod tag;
 pub mod task_list_view;
 
-pub use archival::{ArchiveMetadata, ArchivedEntity};
-pub use archived_card::ArchivedCard;
+pub use archival::{ArchivableEntity, ArchiveMetadata, Archived, ArchivedEntity, NoContext};
+pub use archived_card::{ArchivedCard, CardRestoreContext};
 pub use board::{
     get_active_sprint_card_prefix_override, get_active_sprint_prefix_override, Board, BoardId,
     BoardUpdate, SortField, SortOrder,

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -402,7 +402,7 @@ mod tests {
         let restored: Snapshot = serde_json::from_str(&json).unwrap();
 
         assert_eq!(restored.archived_cards.len(), 1);
-        assert_eq!(restored.archived_cards[0].card, card);
+        assert_eq!(restored.archived_cards[0].entity, card);
         assert_eq!(restored.archived_cards[0], archived);
     }
 
@@ -421,7 +421,7 @@ mod tests {
             .remove("board_id")
             .expect("serialized form carries board_id");
         let restored: ArchivedCard = serde_json::from_value(value).unwrap();
-        assert_eq!(restored.board_id, Uuid::nil());
+        assert_eq!(restored.context.board_id, Uuid::nil());
     }
 
     #[test]

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -192,7 +192,7 @@ async fn card_create_get_move_archive_restore() {
 
     ctx.archive_card(card.id).unwrap();
     let archived = ctx.list_archived_cards().unwrap();
-    assert!(archived.iter().any(|c| c.card.id == card.id));
+    assert!(archived.iter().any(|c| c.entity.id == card.id));
 
     let restored = ctx.restore_card(card.id, None).unwrap();
     assert_eq!(restored.id, card.id);

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -1639,7 +1639,7 @@ mod tests {
         let (loaded, _meta) = store.load().await.unwrap();
         let domain = snapshot_from_json_bytes(&loaded.data).unwrap();
         assert_eq!(domain.archived_cards.len(), 1);
-        assert_eq!(domain.archived_cards[0].card, card);
+        assert_eq!(domain.archived_cards[0].entity, card);
         assert_eq!(domain.archived_cards[0], archived);
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use kanban_domain::{
-    ArchiveMetadata, ArchivedCard, Board, BoardRecord, Card, CardRecord, Column, ColumnRecord,
+    ArchiveMetadata, Archived, ArchivedCard, Board, BoardRecord, Card, CardRecord, CardRestoreContext,
+    Column, ColumnRecord,
     KanbanResult, Sprint, SprintLog, SprintRecord,
 };
 use sqlx::sqlite::SqliteRow;
@@ -121,13 +122,15 @@ pub(crate) fn row_to_archived_card(
     let archived_at_str: String = row.try_get("archived_at").map_err(db_err)?;
     let board_id_str: String = row.try_get("board_id").map_err(db_err)?;
     let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
-    Ok(ArchivedCard {
+    Ok(Archived::with_context(
         card,
-        metadata: ArchiveMetadata::at(p_dt(&archived_at_str)?),
-        board_id: p_uuid(&board_id_str)?,
-        original_column_id: p_uuid(&orig_col_str)?,
-        original_position: row.try_get("original_position").map_err(db_err)?,
-    })
+        CardRestoreContext {
+            board_id: p_uuid(&board_id_str)?,
+            original_column_id: p_uuid(&orig_col_str)?,
+            original_position: row.try_get("original_position").map_err(db_err)?,
+        },
+        ArchiveMetadata::at(p_dt(&archived_at_str)?),
+    ))
 }
 
 pub(crate) fn row_to_sprint(row: &SqliteRow) -> KanbanResult<Sprint> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use kanban_domain::{
-    ArchiveMetadata, Archived, ArchivedCard, Board, BoardRecord, Card, CardRecord, CardRestoreContext,
-    Column, ColumnRecord,
-    KanbanResult, Sprint, SprintLog, SprintRecord,
+    ArchiveMetadata, Archived, ArchivedCard, Board, BoardRecord, Card, CardRecord,
+    CardRestoreContext, Column, ColumnRecord, KanbanResult, Sprint, SprintLog, SprintRecord,
 };
 use sqlx::sqlite::SqliteRow;
 use sqlx::Row;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -276,7 +276,7 @@ impl DataStore for SqliteStore {
                 "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                         c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                         c.created_at, c.updated_at, c.completed_at,
-                        ac.board_id, ac.archived_at, ac.context.original_column_id, ac.context.original_position
+                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
                  FROM archived_cards ac
                  JOIN cards c ON ac.card_id = c.id
                  WHERE ac.card_id = ?",
@@ -330,7 +330,7 @@ impl DataStore for SqliteStore {
                 "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                         c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                         c.created_at, c.updated_at, c.completed_at,
-                        ac.board_id, ac.archived_at, ac.context.original_column_id, ac.context.original_position
+                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
                  FROM archived_cards ac
                  JOIN cards c ON ac.card_id = c.id
                  WHERE ac.board_id = ?

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -276,7 +276,7 @@ impl DataStore for SqliteStore {
                 "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                         c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                         c.created_at, c.updated_at, c.completed_at,
-                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
+                        ac.board_id, ac.archived_at, ac.context.original_column_id, ac.context.original_position
                  FROM archived_cards ac
                  JOIN cards c ON ac.card_id = c.id
                  WHERE ac.card_id = ?",
@@ -330,7 +330,7 @@ impl DataStore for SqliteStore {
                 "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                         c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                         c.created_at, c.updated_at, c.completed_at,
-                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
+                        ac.board_id, ac.archived_at, ac.context.original_column_id, ac.context.original_position
                  FROM archived_cards ac
                  JOIN cards c ON ac.card_id = c.id
                  WHERE ac.board_id = ?

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
@@ -8,7 +8,7 @@ impl SqliteStore {
         conn: &mut sqlx::SqliteConnection,
         ac: &ArchivedCard,
     ) -> KanbanResult<()> {
-        Self::write_card_with_conn(conn, &ac.card).await?;
+        Self::write_card_with_conn(conn, &ac.entity).await?;
         sqlx::query(
             "INSERT INTO archived_cards (card_id, board_id, archived_at, original_column_id, original_position)
              VALUES (?, ?, ?, ?, ?)
@@ -18,11 +18,11 @@ impl SqliteStore {
                 original_column_id=excluded.original_column_id,
                 original_position=excluded.original_position",
         )
-        .bind(ac.card.id.to_string())
-        .bind(ac.board_id.to_string())
+        .bind(ac.entity.id.to_string())
+        .bind(ac.context.board_id.to_string())
         .bind(fmt_dt(&ac.metadata.archived_at))
-        .bind(ac.original_column_id.to_string())
-        .bind(ac.original_position)
+        .bind(ac.context.original_column_id.to_string())
+        .bind(ac.context.original_position)
         .execute(&mut *conn)
         .await
         .map_err(db_err)?;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -197,7 +197,7 @@ impl SqliteStore {
         let unresolved: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM archived_cards
               WHERE (SELECT c.board_id FROM columns c
-                       WHERE c.id = archived_cards.original_column_id) IS NULL",
+                       WHERE c.id = archived_cards.context.original_column_id) IS NULL",
         )
         .fetch_one(pool)
         .await
@@ -232,7 +232,7 @@ impl SqliteStore {
             ALTER TABLE archived_cards ADD COLUMN board_id TEXT;
             UPDATE archived_cards
                SET board_id = (SELECT c.board_id FROM columns c
-                                 WHERE c.id = archived_cards.original_column_id);
+                                 WHERE c.id = archived_cards.context.original_column_id);
             UPDATE archived_cards
                SET board_id = '00000000-0000-0000-0000-000000000000'
              WHERE board_id IS NULL;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -197,7 +197,7 @@ impl SqliteStore {
         let unresolved: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM archived_cards
               WHERE (SELECT c.board_id FROM columns c
-                       WHERE c.id = archived_cards.context.original_column_id) IS NULL",
+                       WHERE c.id = archived_cards.original_column_id) IS NULL",
         )
         .fetch_one(pool)
         .await
@@ -232,7 +232,7 @@ impl SqliteStore {
             ALTER TABLE archived_cards ADD COLUMN board_id TEXT;
             UPDATE archived_cards
                SET board_id = (SELECT c.board_id FROM columns c
-                                 WHERE c.id = archived_cards.context.original_column_id);
+                                 WHERE c.id = archived_cards.original_column_id);
             UPDATE archived_cards
                SET board_id = '00000000-0000-0000-0000-000000000000'
              WHERE board_id IS NULL;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -59,7 +59,7 @@ impl SqliteStore {
             "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                     c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                     c.created_at, c.updated_at, c.completed_at,
-                    ac.board_id, ac.archived_at, ac.context.original_column_id, ac.context.original_position
+                    ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
              FROM archived_cards ac
              JOIN cards c ON ac.card_id = c.id
              ORDER BY ac.archived_at",

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -59,7 +59,7 @@ impl SqliteStore {
             "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
                     c.position, c.due_date, c.points, c.card_number, c.sprint_id,
                     c.created_at, c.updated_at, c.completed_at,
-                    ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
+                    ac.board_id, ac.archived_at, ac.context.original_column_id, ac.context.original_position
              FROM archived_cards ac
              JOIN cards c ON ac.card_id = c.id
              ORDER BY ac.archived_at",

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
@@ -59,21 +59,23 @@ fn test_archived_card_round_trip_preserves_board_id_and_all_fields() {
         let store = SqliteStore::open(&path).await.unwrap();
         let (board_id, column_id) = seed_board_and_column(&store, "B");
 
-        let ac = ArchivedCard {
-            card: card_in(column_id, "Archived"),
-            metadata: ArchiveMetadata::at("2024-06-01T00:00:00Z".parse().unwrap()),
-            board_id,
-            original_column_id: column_id,
-            original_position: 7,
-        };
-        let card_id = ac.card.id;
+        let ac = kanban_domain::Archived::with_context(
+            card_in(column_id, "Archived"),
+            kanban_domain::CardRestoreContext {
+                board_id,
+                original_column_id: column_id,
+                original_position: 7,
+            },
+            ArchiveMetadata::at("2024-06-01T00:00:00Z".parse().unwrap()),
+        );
+        let card_id = ac.entity.id;
         store.insert_archived_card(ac.clone()).unwrap();
 
         let loaded = store
             .get_archived_card(card_id)
             .unwrap()
             .expect("archived card should load");
-        assert_eq!(loaded.board_id, board_id, "board_id must round-trip");
+        assert_eq!(loaded.context.board_id, board_id, "board_id must round-trip");
         assert_eq!(loaded, ac, "all archived-card fields must round-trip");
     });
 }
@@ -89,15 +91,15 @@ fn test_list_archived_cards_by_board_filters_by_board_id() {
         let (board_b, col_b) = seed_board_and_column(&store, "B");
 
         let a = ArchivedCard::new(card_in(col_a, "A1"), board_a, col_a, 0);
-        let a_id = a.card.id;
+        let a_id = a.entity.id;
         let b = ArchivedCard::new(card_in(col_b, "B1"), board_b, col_b, 0);
         store.insert_archived_card(a).unwrap();
         store.insert_archived_card(b).unwrap();
 
         let only_a = store.list_archived_cards_by_board(board_a).unwrap();
         assert_eq!(only_a.len(), 1, "only board A's archived card");
-        assert_eq!(only_a[0].card.id, a_id);
-        assert!(only_a.iter().all(|ac| ac.board_id == board_a));
+        assert_eq!(only_a[0].entity.id, a_id);
+        assert!(only_a.iter().all(|ac| ac.context.board_id == board_a));
     });
 }
 
@@ -111,7 +113,7 @@ fn test_delete_column_does_not_cascade_delete_archived_card() {
         let (board_id, column_id) = seed_board_and_column(&store, "B");
 
         let ac = ArchivedCard::new(card_in(column_id, "Survivor"), board_id, column_id, 0);
-        let card_id = ac.card.id;
+        let card_id = ac.entity.id;
         store.insert_archived_card(ac).unwrap();
 
         // Raw column delete (bypasses the domain guard) must NOT orphan the
@@ -122,13 +124,13 @@ fn test_delete_column_does_not_cascade_delete_archived_card() {
             .get_archived_card(card_id)
             .unwrap()
             .expect("archived card must survive its column's deletion");
-        assert_eq!(survived.board_id, board_id);
+        assert_eq!(survived.context.board_id, board_id);
         assert_eq!(
-            survived.original_column_id, column_id,
+            survived.context.original_column_id, column_id,
             "historical column preserved on the extension row"
         );
         assert_eq!(
-            survived.card.column_id, column_id,
+            survived.entity.column_id, column_id,
             "card.column_id is retained (dangling), matching in-memory/JSON semantics"
         );
     });
@@ -148,7 +150,7 @@ fn test_list_all_cards_excludes_archived_via_not_exists() {
         store.upsert_card(live).unwrap();
 
         let ac = ArchivedCard::new(card_in(column_id, "Archived"), board_id, column_id, 0);
-        let archived_id = ac.card.id;
+        let archived_id = ac.entity.id;
         store.insert_archived_card(ac).unwrap();
 
         let all = store.list_all_cards().unwrap();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
@@ -75,7 +75,10 @@ fn test_archived_card_round_trip_preserves_board_id_and_all_fields() {
             .get_archived_card(card_id)
             .unwrap()
             .expect("archived card should load");
-        assert_eq!(loaded.context.board_id, board_id, "board_id must round-trip");
+        assert_eq!(
+            loaded.context.board_id, board_id,
+            "board_id must round-trip"
+        );
         assert_eq!(loaded, ac, "all archived-card fields must round-trip");
     });
 }

--- a/crates/kanban-persistence-sqlite/tests/data_store.rs
+++ b/crates/kanban-persistence-sqlite/tests/data_store.rs
@@ -290,8 +290,8 @@ async fn test_sqlite_insert_and_get_archived_card() {
     store.insert_archived_card(ac).unwrap();
 
     let fetched = store.get_archived_card(card_id).unwrap().unwrap();
-    assert_eq!(fetched.card.id, card_id);
-    assert_eq!(fetched.original_column_id, col.id);
+    assert_eq!(fetched.entity.id, card_id);
+    assert_eq!(fetched.context.original_column_id, col.id);
 
     // Archived card should NOT appear in active card queries
     assert!(store.get_card(card_id).unwrap().is_none());

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -88,8 +88,8 @@ pub fn fully_populated_snapshot() -> Snapshot {
         }],
     };
 
-    let archived_card = ArchivedCard {
-        card: Card {
+    let archived_card = kanban_domain::Archived::with_context(
+        Card {
             id: archived_card_inner_id,
             column_id: col_id,
             title: "Archived Card".into(),
@@ -106,11 +106,13 @@ pub fn fully_populated_snapshot() -> Snapshot {
             completed_at: Some(now),
             sprint_logs: vec![],
         },
-        metadata: kanban_domain::ArchiveMetadata::at(now),
-        board_id: Uuid::nil(),
-        original_column_id: col_id,
-        original_position: 1,
-    };
+        kanban_domain::CardRestoreContext {
+            board_id: Uuid::nil(),
+            original_column_id: col_id,
+            original_position: 1,
+        },
+        kanban_domain::ArchiveMetadata::at(now),
+    );
 
     use kanban_core::EdgeBase;
     use kanban_domain::{BlocksEdge, RelatesEdge, RelatesKind, Severity};

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use kanban_domain::card::{Card, CardPriority, CardStatus};
 use kanban_domain::sprint::{Sprint, SprintStatus};
 use kanban_domain::Snapshot;
-use kanban_domain::{ArchivedCard, Board, Column, DependencyGraph, SprintLog};
+use kanban_domain::{Board, Column, DependencyGraph, SprintLog};
 use uuid::Uuid;
 
 pub fn fully_populated_snapshot() -> Snapshot {

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -1,6 +1,6 @@
 use super::super::enums::{CardPriorityDto, CardStatusDto};
 use chrono::{DateTime, Utc};
-use kanban_domain::{ArchivedCard, Card};
+use kanban_domain::{Archived, ArchivedCard, Card, CardRestoreContext};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -85,17 +85,21 @@ pub struct ArchivedCardResponse {
 
 impl From<&ArchivedCard> for ArchivedCardResponse {
     fn from(archived: &ArchivedCard) -> Self {
-        // Exhaustive destructure: a future `ArchivedCard` field fails to compile
-        // here until it is deliberately mapped (or omitted) in the DTO.
-        let ArchivedCard {
-            card,
+        // Exhaustive destructure: a future archived-card field (entity, metadata,
+        // or restore-context) fails to compile here until it is deliberately
+        // mapped (or omitted) in the DTO.
+        let Archived {
+            entity,
             metadata,
-            board_id,
-            original_column_id,
-            original_position,
+            context:
+                CardRestoreContext {
+                    board_id,
+                    original_column_id,
+                    original_position,
+                },
         } = archived;
         Self {
-            card: CardResponse::from(card),
+            card: CardResponse::from(entity),
             board_id: (!board_id.is_nil()).then_some(*board_id),
             archived_at: metadata.archived_at,
             original_column_id: *original_column_id,
@@ -161,7 +165,7 @@ mod tests {
         assert_eq!(resp.archived_at, ac.metadata.archived_at);
         assert_eq!(resp.original_column_id, original_column_id);
         assert_eq!(resp.original_position, 7);
-        assert_eq!(resp.card, CardResponse::from(&ac.card));
+        assert_eq!(resp.card, CardResponse::from(&ac.entity));
         // The rich card projection carries `description` (the lean summary did not).
         let json = serde_json::to_value(&resp).unwrap();
         assert!(json["card"].get("description").is_some());

--- a/crates/kanban-service/src/cascade.rs
+++ b/crates/kanban-service/src/cascade.rs
@@ -23,7 +23,7 @@ pub(crate) fn delete_board(store: &dyn DataStore, board_id: Uuid) -> KanbanResul
     let archived_card_ids: Vec<Uuid> = store
         .list_archived_cards_by_board(board_id)?
         .into_iter()
-        .map(|ac| ac.card.id)
+        .map(|ac| ac.entity.id)
         .collect();
 
     // Widened early-return guard: the only remaining board may hold nothing but

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -251,15 +251,15 @@ impl KanbanContext {
             col_id
         } else if self
             .backend
-            .get_column(archived.original_column_id)?
+            .get_column(archived.context.original_column_id)?
             .is_some()
         {
-            archived.original_column_id
+            archived.context.original_column_id
         } else {
             return Err(KanbanError::validation("Original column no longer exists. Specify --column-id to restore to a different column"));
         };
 
-        let position = archived.original_position;
+        let position = archived.context.original_position;
         let cmd = Command::Card(CardCommand::Restore(RestoreCard {
             card_id: id,
             column_id: target_column,

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -293,9 +293,9 @@ impl KanbanContext {
             .map(|c| (c.id, c.board_id))
             .collect();
         for ac in &mut imported.archived_cards {
-            if ac.board_id.is_nil() {
-                if let Some(&board_id) = col_to_board.get(&ac.original_column_id) {
-                    ac.board_id = board_id;
+            if ac.context.board_id.is_nil() {
+                if let Some(&board_id) = col_to_board.get(&ac.context.original_column_id) {
+                    ac.context.board_id = board_id;
                 }
             }
         }

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -40,12 +40,12 @@ pub async fn test_archive_card_roundtrip(factory: &BackendFactory) {
     assert_eq!(archived.len(), 1);
 
     let ac = &archived[0];
-    assert_eq!(ac.card.id, card.id);
-    assert_eq!(ac.card.title, "To Archive");
-    assert_eq!(ac.card.description.as_deref(), Some("archived desc"));
-    assert_eq!(ac.card.priority, CardPriority::High);
-    assert_eq!(ac.card.points, Some(3));
-    assert_eq!(ac.original_column_id, col.id);
+    assert_eq!(ac.entity.id, card.id);
+    assert_eq!(ac.entity.title, "To Archive");
+    assert_eq!(ac.entity.description.as_deref(), Some("archived desc"));
+    assert_eq!(ac.entity.priority, CardPriority::High);
+    assert_eq!(ac.entity.points, Some(3));
+    assert_eq!(ac.context.original_column_id, col.id);
 }
 
 pub async fn test_archive_card_with_sprint_logs_roundtrip(factory: &BackendFactory) {
@@ -76,7 +76,7 @@ pub async fn test_archive_card_with_sprint_logs_roundtrip(factory: &BackendFacto
 
     let archived = ctx.list_archived_cards().unwrap();
     assert_eq!(archived.len(), 1);
-    assert!(!archived[0].card.sprint_logs.is_empty());
+    assert!(!archived[0].entity.sprint_logs.is_empty());
 }
 
 pub async fn test_restore_archived_card_roundtrip(factory: &BackendFactory) {

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -360,11 +360,11 @@ pub async fn test_full_populated_context_roundtrip(factory: &BackendFactory) -> 
 
     let archived = loaded.list_archived_cards().unwrap();
     assert_eq!(archived.len(), 1);
-    assert_eq!(archived[0].card.id, card4.id);
-    assert_eq!(archived[0].card.title, "Archived Card");
-    assert_eq!(archived[0].card.priority, CardPriority::High);
-    assert_eq!(archived[0].card.points, Some(5));
-    assert_eq!(archived[0].original_column_id, col_todo.id);
+    assert_eq!(archived[0].entity.id, card4.id);
+    assert_eq!(archived[0].entity.title, "Archived Card");
+    assert_eq!(archived[0].entity.priority, CardPriority::High);
+    assert_eq!(archived[0].entity.points, Some(5));
+    assert_eq!(archived[0].context.original_column_id, col_todo.id);
 
     let graph = loaded.graph()?;
     assert_eq!(graph.len(), 3, "expected 3 edges total");

--- a/crates/kanban-service/tests/data_integrity_tests.rs
+++ b/crates/kanban-service/tests/data_integrity_tests.rs
@@ -253,9 +253,9 @@ async fn test_import_backfills_board_id_on_legacy_archived_card() -> KanbanResul
         1,
         "board-scoped archived listing must return the backfilled card"
     );
-    assert_eq!(scoped[0].card.id, card_id);
+    assert_eq!(scoped[0].entity.id, card_id);
     assert_eq!(
-        scoped[0].board_id, board_id,
+        scoped[0].context.board_id, board_id,
         "board_id must be backfilled from the imported column"
     );
     Ok(())

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -212,7 +212,7 @@ macro_rules! cascade_tests {
 
                 let archived = backend.list_archived_cards().unwrap();
                 assert!(
-                    archived.iter().any(|ac| ac.card.id == arch_card_id),
+                    archived.iter().any(|ac| ac.entity.id == arch_card_id),
                     "the deleted board's archived card is restored by id"
                 );
 
@@ -377,7 +377,7 @@ macro_rules! cascade_tests {
                     1,
                     "board-scoped listing must keep the archived card despite its dangling original_column_id"
                 );
-                assert_eq!(archived[0].card.id, card_id);
+                assert_eq!(archived[0].entity.id, card_id);
             }
 
             /// KAN-833 (B5 review fix): a board with sprints but NO columns and

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -1404,7 +1404,7 @@ async fn test_inverse_delete_board_restores_full_cascade() -> KanbanResult<()> {
     let baseline_archived_ids: std::collections::HashSet<_> = baseline
         .archived_cards
         .iter()
-        .map(|ac| ac.card.id)
+        .map(|ac| ac.entity.id)
         .collect();
     let baseline_sprint_ids: std::collections::HashSet<_> =
         baseline.sprints.iter().map(|s| s.id).collect();
@@ -1432,7 +1432,7 @@ async fn test_inverse_delete_board_restores_full_cascade() -> KanbanResult<()> {
     let restored_archived_ids: std::collections::HashSet<_> = restored
         .archived_cards
         .iter()
-        .map(|ac| ac.card.id)
+        .map(|ac| ac.entity.id)
         .collect();
     let restored_sprint_ids: std::collections::HashSet<_> =
         restored.sprints.iter().map(|s| s.id).collect();

--- a/crates/kanban-service/tests/list_archived_cards_sort.rs
+++ b/crates/kanban-service/tests/list_archived_cards_sort.rs
@@ -101,7 +101,7 @@ async fn test_list_archived_cards_sorted_uses_board_default() -> KanbanResult<()
         ..Default::default()
     })?;
 
-    let ids: Vec<Uuid> = archived.iter().map(|a| a.card.id).collect();
+    let ids: Vec<Uuid> = archived.iter().map(|a| a.entity.id).collect();
     assert_eq!(ids, vec![earliest, middle, latest]);
     Ok(())
 }
@@ -118,7 +118,7 @@ async fn test_list_archived_cards_sorted_explicit_override_wins() -> KanbanResul
         sort_order: Some(SortOrder::Descending),
     })?;
 
-    let ids: Vec<Uuid> = archived.iter().map(|a| a.card.id).collect();
+    let ids: Vec<Uuid> = archived.iter().map(|a| a.entity.id).collect();
     assert_eq!(ids, vec![latest, middle, earliest]);
     Ok(())
 }

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -97,7 +97,7 @@ impl App {
             .model
             .archived_cards()
             .iter()
-            .find(|dc| dc.card.id == card_id)
+            .find(|dc| dc.entity.id == card_id)
             .cloned()
         {
             self.restore_card(archived_card);

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -66,8 +66,8 @@ impl Model {
         self.archived_card_index.clear();
         let mut flat = Vec::with_capacity(snapshot.archived_cards.len());
         for (i, ac) in snapshot.archived_cards.iter().enumerate() {
-            self.archived_card_index.insert(ac.card.id, i);
-            flat.push(ac.card.clone());
+            self.archived_card_index.insert(ac.entity.id, i);
+            flat.push(ac.entity.clone());
         }
         self.archived_cards = Some(snapshot.archived_cards);
         self.archived_cards_flat = Some(flat);

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -195,7 +195,7 @@ impl App {
             .model
             .archived_cards()
             .iter()
-            .filter(|a| col_ids.contains(&a.original_column_id))
+            .filter(|a| col_ids.contains(&a.context.original_column_id))
             .count();
         let sprints = self
             .model

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -712,7 +712,7 @@ impl App {
             .model
             .archived_cards()
             .iter()
-            .any(|dc| dc.card.id == card_id)
+            .any(|dc| dc.entity.id == card_id)
         {
             self.animation.animating.insert(
                 card_id,
@@ -725,10 +725,10 @@ impl App {
     }
 
     pub fn restore_card(&mut self, archived_card: ArchivedCard) {
-        let card_id = archived_card.card.id;
-        let original_column_id = archived_card.original_column_id;
-        let original_position = archived_card.original_position;
-        let card_title = archived_card.card.title.clone();
+        let card_id = archived_card.entity.id;
+        let original_column_id = archived_card.context.original_column_id;
+        let original_position = archived_card.context.original_position;
+        let card_title = archived_card.entity.title.clone();
 
         let boards = self.model.boards();
         let board_id = self
@@ -794,7 +794,7 @@ impl App {
             .model
             .archived_cards()
             .iter()
-            .any(|dc| dc.card.id == card_id)
+            .any(|dc| dc.entity.id == card_id)
         {
             self.animation.animating.insert(
                 card_id,


### PR DESCRIPTION
## What
Makes archival a single reusable abstraction (epic KAN-821, F1 foundation; DECIDED D13), and migrates the shipped `ArchivedCard` onto it.

New in the archival module:
- `ArchivableEntity` — a live entity's stable id + its serde bridge (live entities have no `Deserialize`; they route through a record type for migration). Implementing this is the ONLY thing a new archivable entity needs.
- `entity_serde` — generic bridge dispatching a `#[serde(with)]` entity field through the trait.
- `NoContext` — empty restore context for scoping roots.
- `Archived<T, C = NoContext> { entity, metadata: ArchiveMetadata, context: C }` with a blanket `ArchivedEntity` impl.

`ArchivedCard` is now `type ArchivedCard = Archived<Card, CardRestoreContext>` (`CardRestoreContext = board_id + original_column_id + original_position`). `::new`, `into_card`, `card_ref`, `card_mut`, `From`, `Borrow` are preserved as inherent impls, so those call sites are unchanged; field access migrated to `.entity` / `.context.*` across the workspace.

## Why
Archival was card-specific (`ArchivedCard`) and about to be board-specific (`ArchivedBoard`). This lifts the shared shape into one generic type so archiving *any* entity is uniform, while keeping storage entity-specific (backends discern the type — upholds the D9 "no dead store-generic trait" finding). Validated by spike `spike/generic-archival` (generic serde bridge + flattened restore context round-trip clean).

## Migration / back-compat
The entity serializes under `entity` with `#[serde(alias = "card")]`, so already-shipped `archived_cards` JSON (which used a `card` key) still deserializes; on next save it rewrites to `entity`. No version bump. SQLite reconstitutes `ArchivedCard` from columns (not a JSON key), so it is unaffected. A back-compat test pins the legacy `card`-keyed load.

## Testing / verification
`kanban-domain` green (580); full `cargo build --workspace` (production) green; `kanban-service` test target (the `ArchivedCardResponse` consumer) compiles clean. The full `--workspace --tests` matrix is left to CI — the local box repeatedly exhausted disk building all test targets at once (documented worktree hazard). Any residual test-only field-shape misses will surface here and I'll clear them.

Sequencing: merges under F1 (KAN-825) BEFORE completing C1 (#377); C1 then reworks `ArchivedBoard` to `Archived<Board>` on top of this. Parent: F1 (KAN-825).
