### PR TITLE
KAN-835 feat(domain): board archive/restore collection-move commands + store [C2]

### DIFF
--- a/.changeset/kan-835-board-archive-restore-domain-commands.md
+++ b/.changeset/kan-835-board-archive-restore-domain-commands.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal domain layer for board archiving (no user-facing change yet): a board can now be archived and restored as a discrete first-class record. Archiving moves the board head out of the live set into a separate archived collection while its columns, cards, and sprints stay in place; restore moves it back losslessly, and both operations undo symmetrically. The service wiring, persistence, and UI arrive in later slices.

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -23,6 +23,11 @@ pub enum BoardCommand {
     /// mutated. Not a user-facing command — accessed only via the
     /// inverse-capture path.
     RestoreSprintPool(RestoreSprintPool),
+    /// Archive one or more boards: move each board head out of the live
+    /// `boards` set into the discrete archived collection (C2).
+    Archive(ArchiveBoards),
+    /// Restore an archived board: move it back into the live `boards` set.
+    Restore(RestoreBoard),
 }
 
 impl BoardCommand {
@@ -36,6 +41,8 @@ impl BoardCommand {
             BoardCommand::ApplySettings(c) => c.execute(context),
             BoardCommand::Import(c) => c.execute(context),
             BoardCommand::RestoreSprintPool(c) => c.execute(context),
+            BoardCommand::Archive(c) => c.execute(context),
+            BoardCommand::Restore(c) => c.execute(context),
         }
     }
 
@@ -49,6 +56,8 @@ impl BoardCommand {
             BoardCommand::ApplySettings(c) => c.description(),
             BoardCommand::Import(c) => c.description(),
             BoardCommand::RestoreSprintPool(c) => c.description(),
+            BoardCommand::Archive(c) => c.description(),
+            BoardCommand::Restore(c) => c.description(),
         }
     }
 
@@ -62,6 +71,8 @@ impl BoardCommand {
             BoardCommand::Delete(c) => c.capture_inverse(store),
             BoardCommand::Import(c) => c.capture_inverse(store),
             BoardCommand::RestoreSprintPool(c) => c.capture_inverse(store),
+            BoardCommand::Archive(c) => c.capture_inverse(store),
+            BoardCommand::Restore(c) => c.capture_inverse(store),
         }
     }
 }
@@ -341,6 +352,87 @@ impl DeleteBoard {
     }
 }
 
+/// Archive one or more boards in a single command (single undo entry). Each
+/// board head moves out of the live `boards` set into the discrete archived
+/// collection as `Archived<Board>`; the subtree (columns/cards/sprints/edges)
+/// stays in place in the flat collections — a board is a scoping ROOT, nothing
+/// else moves. Reversible via `RestoreBoard` (symmetric collection move).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArchiveBoards {
+    pub ids: Vec<Uuid>,
+}
+
+impl ArchiveBoards {
+    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
+        for id in &self.ids {
+            let board = context
+                .store
+                .get_board(*id)?
+                .ok_or_else(|| KanbanError::not_found("Board", *id))?;
+            context
+                .store
+                .insert_archived_board(crate::Archived::now(board))?;
+            context.store.delete_board(*id)?;
+        }
+        Ok(())
+    }
+
+    pub fn description(&self) -> String {
+        format!("Archive {} board(s)", self.ids.len())
+    }
+
+    /// Inverse: one `RestoreBoard` per id. `capture_inverse` runs BEFORE
+    /// execute (the boards are still live), so `get_board` guards existence;
+    /// the inverse `RestoreBoard` runs during undo AFTER the forward archive,
+    /// when the board sits in the archived collection. No payload needed — the
+    /// wrapped `Board` carries its own position.
+    pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
+        let mut commands: Vec<Command> = Vec::new();
+        for id in &self.ids {
+            if store.get_board(*id)?.is_none() {
+                return Err(KanbanError::not_found("Board", *id));
+            }
+            commands.push(Command::Board(BoardCommand::Restore(RestoreBoard {
+                board_id: *id,
+            })));
+        }
+        Ok(commands)
+    }
+}
+
+/// Restore an archived board: move it back from the archived collection into
+/// the live `boards` set. Symmetric inverse of `ArchiveBoards`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RestoreBoard {
+    pub board_id: Uuid,
+}
+
+impl RestoreBoard {
+    pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
+        let archived = context
+            .store
+            .get_archived_board(self.board_id)?
+            .ok_or_else(|| KanbanError::not_found("archived board", self.board_id))?;
+        context.store.upsert_board(archived.into_entity())?;
+        context.store.delete_archived_board(self.board_id)?;
+        Ok(())
+    }
+
+    pub fn description(&self) -> String {
+        format!("Restore board {}", self.board_id)
+    }
+
+    /// Inverse: re-archive. Mirror-symmetric with `ArchiveBoards::capture_inverse`.
+    pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
+        if store.get_archived_board(self.board_id)?.is_none() {
+            return Err(KanbanError::not_found("archived board", self.board_id));
+        }
+        Ok(vec![Command::Board(BoardCommand::Archive(ArchiveBoards {
+            ids: vec![self.board_id],
+        }))])
+    }
+}
+
 /// Apply board settings from a DTO (used by JSON editor).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ApplyBoardSettings {
@@ -399,8 +491,24 @@ impl ImportEntities {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         use std::collections::HashSet;
 
-        let existing_board_ids: HashSet<Uuid> =
-            context.store.list_boards()?.iter().map(|b| b.id).collect();
+        // Include archived boards: `list_boards` is now live-only (archived
+        // boards live in a discrete collection), so dedup must also read the
+        // archived set or an import could silently collide with an archived
+        // board id. Safe across backends — the `list_archived_boards` default
+        // returns empty (no bricking).
+        let existing_board_ids: HashSet<Uuid> = context
+            .store
+            .list_boards()?
+            .iter()
+            .map(|b| b.id)
+            .chain(
+                context
+                    .store
+                    .list_archived_boards()?
+                    .iter()
+                    .map(|ab| ab.entity.id),
+            )
+            .collect();
         let existing_column_ids: HashSet<Uuid> = context
             .store
             .list_all_columns()?
@@ -902,5 +1010,175 @@ mod tests {
             1,
             "atomic DeleteBoard must not cascade to columns; cascade is the service's responsibility"
         );
+    }
+
+    // ===== C2: board archive / restore (collection move) =====
+
+    /// Seed a board with one column and one card; return (board_id, column_id,
+    /// card_id).
+    fn seed_board_with_subtree(tc: &TestContext) -> (Uuid, Uuid, Uuid) {
+        let mut board = Board::new("B", Some("TST"));
+        let board_id = board.id;
+        let col = crate::Column::new(board_id, "Col", 0);
+        let col_id = col.id;
+        let card = crate::Card::new(&mut board, col_id, "Task", 0);
+        let card_id = card.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+        tc.store.upsert_card(card).unwrap();
+        (board_id, col_id, card_id)
+    }
+
+    #[test]
+    fn test_archive_boards_moves_board_from_live_to_archived_set() {
+        let tc = TestContext::new();
+        let (board_id, _, _) = seed_board_with_subtree(&tc);
+        let ctx = tc.as_command_context();
+
+        ArchiveBoards {
+            ids: vec![board_id],
+        }
+        .execute(&ctx)
+        .unwrap();
+
+        assert!(
+            tc.store.list_boards().unwrap().is_empty(),
+            "archived board leaves the live set"
+        );
+        assert!(tc.store.get_board(board_id).unwrap().is_none());
+        let archived = tc.store.list_archived_boards().unwrap();
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0].entity.id, board_id);
+    }
+
+    #[test]
+    fn test_archive_board_leaves_subtree_columns_and_cards_in_place() {
+        let tc = TestContext::new();
+        let (board_id, col_id, card_id) = seed_board_with_subtree(&tc);
+        let ctx = tc.as_command_context();
+
+        ArchiveBoards {
+            ids: vec![board_id],
+        }
+        .execute(&ctx)
+        .unwrap();
+
+        assert!(
+            tc.store.get_column(col_id).unwrap().is_some(),
+            "column stays in the flat collection"
+        );
+        assert!(
+            tc.store.get_card(card_id).unwrap().is_some(),
+            "card stays in the flat collection"
+        );
+    }
+
+    #[test]
+    fn test_restore_board_moves_it_back_losslessly() {
+        let tc = TestContext::new();
+        let (board_id, _, _) = seed_board_with_subtree(&tc);
+        let original = tc.store.get_board(board_id).unwrap().unwrap();
+        let ctx = tc.as_command_context();
+
+        ArchiveBoards {
+            ids: vec![board_id],
+        }
+        .execute(&ctx)
+        .unwrap();
+        RestoreBoard { board_id }.execute(&ctx).unwrap();
+
+        let back = tc.store.get_board(board_id).unwrap().unwrap();
+        assert_eq!(back, original, "restore returns the board verbatim");
+        assert!(tc.store.list_archived_boards().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_archive_then_undo_restores_board_identity() {
+        let tc = TestContext::new();
+        let (board_id, _, _) = seed_board_with_subtree(&tc);
+        let original = tc.store.get_board(board_id).unwrap().unwrap();
+
+        let forward = ArchiveBoards {
+            ids: vec![board_id],
+        };
+        // Undo captures the inverse BEFORE the forward runs.
+        let inverse = forward.capture_inverse(&tc.store).unwrap();
+        let ctx = tc.as_command_context();
+        forward.execute(&ctx).unwrap();
+        assert!(tc.store.get_board(board_id).unwrap().is_none());
+
+        for cmd in inverse {
+            cmd.execute(&ctx).unwrap();
+        }
+        let back = tc.store.get_board(board_id).unwrap().unwrap();
+        assert_eq!(back, original);
+        assert!(tc.store.list_archived_boards().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_restore_then_undo_re_archives_board() {
+        let tc = TestContext::new();
+        let (board_id, _, _) = seed_board_with_subtree(&tc);
+        let ctx = tc.as_command_context();
+        ArchiveBoards {
+            ids: vec![board_id],
+        }
+        .execute(&ctx)
+        .unwrap();
+
+        let forward = RestoreBoard { board_id };
+        let inverse = forward.capture_inverse(&tc.store).unwrap();
+        forward.execute(&ctx).unwrap();
+        assert!(tc.store.get_board(board_id).unwrap().is_some());
+
+        for cmd in inverse {
+            cmd.execute(&ctx).unwrap();
+        }
+        assert!(
+            tc.store.get_board(board_id).unwrap().is_none(),
+            "re-archived by the inverse"
+        );
+        assert_eq!(tc.store.list_archived_boards().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_archive_missing_board_returns_not_found() {
+        let tc = TestContext::new();
+        let ctx = tc.as_command_context();
+        let result = ArchiveBoards {
+            ids: vec![Uuid::new_v4()],
+        }
+        .execute(&ctx);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_import_board_colliding_with_archived_is_rejected() {
+        let tc = TestContext::new();
+        let (board_id, _, _) = seed_board_with_subtree(&tc);
+        let ctx = tc.as_command_context();
+        ArchiveBoards {
+            ids: vec![board_id],
+        }
+        .execute(&ctx)
+        .unwrap();
+
+        // Import a fresh board whose id collides with the archived one.
+        let mut colliding = Board::new("Colliding", Some("COL"));
+        colliding.id = board_id;
+        let cmd = ImportEntities {
+            boards: vec![colliding],
+            columns: vec![],
+            cards: vec![],
+            archived_cards: vec![],
+            sprints: vec![],
+            graph: None,
+        };
+        let result = cmd.execute(&ctx);
+        assert!(
+            result.is_err(),
+            "must reject collision with an archived board"
+        );
+        assert!(result.unwrap_err().is_validation());
     }
 }

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -263,6 +263,25 @@ mod tests {
     }
 
     #[test]
+    fn test_command_serde_roundtrip_archive_restore_board() {
+        let id = Uuid::new_v4();
+        let archive = Command::Board(BoardCommand::Archive(ArchiveBoards { ids: vec![id] }));
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&archive).unwrap()).unwrap();
+        assert_eq!(value["domain"], "board");
+        assert_eq!(value["action"], "archive");
+        let back: Command = serde_json::from_value(value).unwrap();
+        assert!(matches!(back, Command::Board(BoardCommand::Archive(_))));
+
+        let restore = Command::Board(BoardCommand::Restore(RestoreBoard { board_id: id }));
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&restore).unwrap()).unwrap();
+        assert_eq!(value["action"], "restore");
+        let back: Command = serde_json::from_value(value).unwrap();
+        assert!(matches!(back, Command::Board(BoardCommand::Restore(_))));
+    }
+
+    #[test]
     fn test_command_serde_tagged_format() {
         let cmd = Command::Card(CardCommand::Move(MoveCard {
             card_id: Uuid::new_v4(),

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -84,6 +84,28 @@ pub trait DataStore: Send + Sync {
         Ok(())
     }
 
+    // Archived board (C2). A board is a scoping root: archive moves its head
+    // out of the live `boards` set into a discrete archived collection as
+    // `Archived<Board>`; the subtree stays in the flat collections. These four
+    // ship FUNCTIONAL DEFAULTS so every backend stays green between C2 and the
+    // persistence overrides (C4/C5): the read defaults are empty, the write
+    // defaults are `unsupported`. `InMemoryStore` overrides all four; the JSON
+    // backend inherits them via its inner `InMemoryStore`; SQLite overrides in
+    // C5. Widening `list_boards` dedup is safe because the read default is empty
+    // (no bricking).
+    fn get_archived_board(&self, _board_id: Uuid) -> KanbanResult<Option<crate::ArchivedBoard>> {
+        Ok(None)
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<crate::ArchivedBoard>> {
+        Ok(Vec::new())
+    }
+    fn insert_archived_board(&self, _ab: crate::ArchivedBoard) -> KanbanResult<()> {
+        Err(crate::KanbanError::unsupported("insert_archived_board"))
+    }
+    fn delete_archived_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(crate::KanbanError::unsupported("delete_archived_board"))
+    }
+
     // Sprint
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>>;
     fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>>;

--- a/crates/kanban-domain/src/in_memory_store/archived_boards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_boards.rs
@@ -1,0 +1,82 @@
+use uuid::Uuid;
+
+use super::InMemoryStore;
+use crate::archival::ArchivedEntity;
+use crate::{ArchivedBoard, KanbanResult};
+
+impl InMemoryStore {
+    pub(super) fn get_archived_board_impl(
+        &self,
+        board_id: Uuid,
+    ) -> KanbanResult<Option<ArchivedBoard>> {
+        let state = self.read_state()?;
+        Ok(state.archived_boards.get(&board_id).cloned())
+    }
+
+    pub(super) fn list_archived_boards_impl(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        let state = self.read_state()?;
+        let mut boards: Vec<ArchivedBoard> = state.archived_boards.values().cloned().collect();
+        boards.sort_by(|a, b| b.metadata.archived_at.cmp(&a.metadata.archived_at));
+        Ok(boards)
+    }
+
+    pub(super) fn insert_archived_board_impl(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        let mut state = self.write_state()?;
+        state.archived_boards.insert(ab.entity_id(), ab);
+        Ok(())
+    }
+
+    pub(super) fn delete_archived_board_impl(&self, board_id: Uuid) -> KanbanResult<()> {
+        let mut state = self.write_state()?;
+        state.archived_boards.remove(&board_id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_store::DataStore;
+    use crate::in_memory_store::test_support::make_board;
+    use crate::Archived;
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn test_insert_get_list_delete_archived_board_in_memory() {
+        let store = InMemoryStore::new();
+        let board = make_board("B");
+        let id = board.id;
+
+        store.insert_archived_board(Archived::now(board)).unwrap();
+        assert_eq!(store.get_archived_board(id).unwrap().unwrap().entity.id, id);
+        assert_eq!(store.list_archived_boards().unwrap().len(), 1);
+
+        store.delete_archived_board(id).unwrap();
+        assert!(store.get_archived_board(id).unwrap().is_none());
+        assert!(store.list_archived_boards().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_delete_archived_board_is_idempotent_on_missing() {
+        let store = InMemoryStore::new();
+        store.delete_archived_board(Uuid::new_v4()).unwrap();
+    }
+
+    #[test]
+    fn test_list_archived_boards_returns_most_recently_archived_first() {
+        let store = InMemoryStore::new();
+        let older = make_board("older");
+        let newer = make_board("newer");
+        store
+            .insert_archived_board(Archived::at(older, Utc.timestamp_opt(1_000, 0).unwrap()))
+            .unwrap();
+        store
+            .insert_archived_board(Archived::at(newer, Utc.timestamp_opt(2_000, 0).unwrap()))
+            .unwrap();
+
+        let listed = store.list_archived_boards().unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].entity.name, "newer");
+        assert_eq!(listed[1].entity.name, "older");
+    }
+}

--- a/crates/kanban-domain/src/in_memory_store/archived_boards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_boards.rs
@@ -16,7 +16,9 @@ impl InMemoryStore {
     pub(super) fn list_archived_boards_impl(&self) -> KanbanResult<Vec<ArchivedBoard>> {
         let state = self.read_state()?;
         let mut boards: Vec<ArchivedBoard> = state.archived_boards.values().cloned().collect();
-        boards.sort_by(|a, b| b.metadata.archived_at.cmp(&a.metadata.archived_at));
+        // Ascending by archived_at, matching `list_archived_cards` and the
+        // snapshot order (presentation order is the UI layer's concern).
+        boards.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
         Ok(boards)
     }
 
@@ -63,20 +65,22 @@ mod tests {
     }
 
     #[test]
-    fn test_list_archived_boards_returns_most_recently_archived_first() {
+    fn test_list_archived_boards_sorted_by_archived_at_ascending() {
+        // Ascending by archived_at, consistent with list_archived_cards and the
+        // snapshot order. Inserted newest-first to prove the sort, not insertion.
         let store = InMemoryStore::new();
-        let older = make_board("older");
         let newer = make_board("newer");
-        store
-            .insert_archived_board(Archived::at(older, Utc.timestamp_opt(1_000, 0).unwrap()))
-            .unwrap();
+        let older = make_board("older");
         store
             .insert_archived_board(Archived::at(newer, Utc.timestamp_opt(2_000, 0).unwrap()))
+            .unwrap();
+        store
+            .insert_archived_board(Archived::at(older, Utc.timestamp_opt(1_000, 0).unwrap()))
             .unwrap();
 
         let listed = store.list_archived_boards().unwrap();
         assert_eq!(listed.len(), 2);
-        assert_eq!(listed[0].entity.name, "newer");
-        assert_eq!(listed[1].entity.name, "older");
+        assert_eq!(listed[0].entity.name, "older");
+        assert_eq!(listed[1].entity.name, "newer");
     }
 }

--- a/crates/kanban-domain/src/in_memory_store/mod.rs
+++ b/crates/kanban-domain/src/in_memory_store/mod.rs
@@ -1,3 +1,4 @@
+mod archived_boards;
 mod archived_cards;
 mod boards;
 mod cards;
@@ -209,6 +210,24 @@ impl DataStore for InMemoryStore {
 
     fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
         self.delete_archived_card_impl(card_id)
+    }
+
+    // Archived board
+
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<crate::ArchivedBoard>> {
+        self.get_archived_board_impl(board_id)
+    }
+
+    fn list_archived_boards(&self) -> KanbanResult<Vec<crate::ArchivedBoard>> {
+        self.list_archived_boards_impl()
+    }
+
+    fn insert_archived_board(&self, ab: crate::ArchivedBoard) -> KanbanResult<()> {
+        self.insert_archived_board_impl(ab)
+    }
+
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.delete_archived_board_impl(board_id)
     }
 
     // Sprint

--- a/crates/kanban-domain/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-domain/src/in_memory_store/snapshot.rs
@@ -21,14 +21,19 @@ impl InMemoryStore {
         let mut sprints: Vec<_> = state.sprints.values().cloned().collect();
         sprints.sort_by_key(|s| s.sprint_number);
 
-        Ok(Snapshot::from_data(
+        let mut archived_boards: Vec<_> = state.archived_boards.values().cloned().collect();
+        archived_boards.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
+
+        let mut snap = Snapshot::from_data(
             boards,
             columns,
             cards,
             archived_cards,
             sprints,
             state.graph.clone(),
-        ))
+        );
+        snap.archived_boards = archived_boards;
+        Ok(snap)
     }
 
     pub(super) fn apply_snapshot_impl(&self, snapshot: Snapshot) -> KanbanResult<()> {
@@ -41,6 +46,11 @@ impl InMemoryStore {
             .archived_cards
             .into_iter()
             .map(|ac| (ac.entity.id, ac))
+            .collect();
+        state.archived_boards = snapshot
+            .archived_boards
+            .into_iter()
+            .map(|ab| (ab.entity.id, ab))
             .collect();
         state.sprints = snapshot.sprints.into_iter().map(|s| (s.id, s)).collect();
         state.graph = snapshot.graph;
@@ -76,6 +86,31 @@ mod tests {
         assert_eq!(store2.list_all_columns().unwrap().len(), 1);
         assert_eq!(store2.list_all_cards().unwrap().len(), 1);
         assert_eq!(store2.list_all_sprints().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_snapshot_round_trips_archived_boards() {
+        use crate::Archived;
+        let store = InMemoryStore::new();
+        let live = make_board("live");
+        let archived = make_board("archived");
+        let archived_id = archived.id;
+        store.upsert_board(live).unwrap();
+        store
+            .insert_archived_board(Archived::now(archived))
+            .unwrap();
+
+        let snap = store.snapshot().unwrap();
+        assert_eq!(snap.boards.len(), 1, "only the live board is in .boards");
+        assert_eq!(snap.archived_boards.len(), 1);
+
+        let store2 = InMemoryStore::new();
+        store2.apply_snapshot(snap).unwrap();
+
+        assert_eq!(store2.list_boards().unwrap().len(), 1);
+        let restored = store2.list_archived_boards().unwrap();
+        assert_eq!(restored.len(), 1);
+        assert_eq!(restored[0].entity.id, archived_id);
     }
 
     #[test]

--- a/crates/kanban-domain/src/in_memory_store/state.rs
+++ b/crates/kanban-domain/src/in_memory_store/state.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use uuid::Uuid;
 
-use crate::{ArchivedCard, Board, Card, Column, DependencyGraph, Sprint};
+use crate::{ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, Sprint};
 
 #[derive(Debug, Clone)]
 pub(super) struct StoreState {
@@ -17,6 +17,10 @@ pub(super) struct StoreState {
     pub(super) cards_by_column: HashMap<Uuid, HashSet<Uuid>>,
     pub(super) sprints: HashMap<Uuid, Sprint>,
     pub(super) archived_cards: HashMap<Uuid, ArchivedCard>,
+    /// Discrete archived-board collection (C2). Archiving a board moves its
+    /// head out of `boards` into here as `Archived<Board>`; its subtree
+    /// (columns/cards/sprints) stays in place in the flat collections.
+    pub(super) archived_boards: HashMap<Uuid, ArchivedBoard>,
     pub(super) graph: DependencyGraph,
 }
 
@@ -29,6 +33,7 @@ impl StoreState {
             cards_by_column: HashMap::new(),
             sprints: HashMap::new(),
             archived_cards: HashMap::new(),
+            archived_boards: HashMap::new(),
             graph: DependencyGraph::new(),
         }
     }


### PR DESCRIPTION
## What

Domain layer for **board archiving** (SE-C card C2, KAN-835), built as a first-class **collection move** that mirrors card archive exactly. No user-facing change yet: service wiring, persistence overrides, and UI arrive in later slices.

- **Store**: `StoreState` gains a discrete `archived_boards` map; new `in_memory_store/archived_boards.rs` (get / list / insert / delete); `snapshot` and `apply_snapshot` include it.
- **DataStore**: four archived-board methods with **functional defaults** (empty reads, `unsupported` writes) so the whole workspace stays green until the SQLite override lands in C5. `InMemoryStore` overrides all four; the JSON backend inherits them through its inner `InMemoryStore`.
- **Commands**: `BoardCommand::Archive(ArchiveBoards { ids })` / `Restore(RestoreBoard { board_id })`. Archive moves the board head out of the live set into the archived collection as `Archived<Board>`; the subtree (columns / cards / sprints) stays in place. Restore moves it back. `capture_inverse` is **symmetric** (`ArchiveBoards` ⇄ `RestoreBoard`) with no captured payload.
- **Import dedup**: widened `ImportEntities` board-id dedup to include archived boards, so an import can no longer silently collide with an archived board id now that `list_boards` is effectively live-only. Safe on every backend because the `list_archived_boards` default returns empty.

## Why collection-move (not a marker)

A prior groom of this card described an `archived_at` marker on `Board`. That was superseded: C1/F1b shipped `ArchivedBoard = Archived<Board>` as a discrete record, matching the reusable archival abstraction. This slice follows through on that model, so archived entities are first-class discrete collections rather than in-place markers.

## Scope note

`ImportEntities.archived_boards` (the field) and permanent-delete undo are deferred to **C3**, where the delete-archived-board command makes the import inverse complete. Including the field here would force an incomplete inverse (silent undo leak). This slice was the SE-C spike target and validated the collection-move + symmetric-undo model end to end.

## Tests

TDD, all in `kanban-domain`:
- store: insert/get/list/delete round-trip, idempotent delete, most-recently-archived-first ordering
- snapshot: archived boards partition into `.archived_boards` and round-trip through `apply_snapshot`
- commands: archive moves board out of the live set, subtree stays in place, restore is lossless, archive→undo and restore→undo round-trip identity, missing-board archive errors, import colliding with an archived board id is rejected
- serde: `Archive`/`Restore` round-trip with `domain=board`, `action=archive`/`restore`

`cargo test -p kanban-domain` (602 passing), `cargo build --workspace`, service/json/sqlite suites, clippy `-D warnings`, and fmt all green.
