### PR TITLE
KAN-837 feat(service): forward archived-board methods through JsonDataStore [C4]

### DIFF
--- a/.changeset/kan-837-json-archived-boards.md
+++ b/.changeset/kan-837-json-archived-boards.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+The JSON file backend now supports archived boards: archiving a board persists it to the on-disk file and it reloads correctly, with the board's columns and cards kept in place. Older JSON files that predate this feature load unchanged. No file-format migration is needed.

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use kanban_domain::command_batch::CommandBatch;
 use kanban_domain::data_store::GraphMutFn;
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, CommandStore, DataStore, DependencyGraph, InMemoryStore,
-    KanbanError, KanbanResult, Snapshot, Sprint,
+    ArchivedBoard, ArchivedCard, Board, Card, Column, CommandStore, DataStore, DependencyGraph,
+    InMemoryStore, KanbanError, KanbanResult, Snapshot, Sprint,
 };
 use kanban_persistence::{
     snapshot_from_json_bytes, snapshot_to_json_bytes, PersistenceMetadata, PersistenceStore,
@@ -250,6 +250,18 @@ impl DataStore for JsonDataStore {
     }
     fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
         self.with_mutate(|s| s.delete_archived_card(card_id))
+    }
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        self.with_read(|s| s.get_archived_board(board_id))
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.with_read(|s| s.list_archived_boards())
+    }
+    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        self.with_mutate(|s| s.insert_archived_board(ab))
+    }
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.with_mutate(|s| s.delete_archived_board(board_id))
     }
     fn clear_sprint_from_archived_cards(
         &self,

--- a/crates/kanban-service/tests/board_archive_json.rs
+++ b/crates/kanban-service/tests/board_archive_json.rs
@@ -1,0 +1,89 @@
+//! Board archiving through the real JSON file backend (C4). Verifies the
+//! `JsonDataStore` archived-board forwards persist and reload correctly, and
+//! that legacy files without the `archived_boards` key still load.
+
+use kanban_domain::{DataStore, KanbanOperations, KanbanResult};
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn make_json_backend(path: &std::path::Path) -> Arc<dyn KanbanBackend> {
+    Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archived_board_survives_json_file_roundtrip() -> KanbanResult<()> {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("archive.json");
+
+    // Session 1: create a board + subtree, archive it, save to disk.
+    let board_id = {
+        let mut ctx = KanbanContext::open(make_json_backend(&path), AppConfig::default()).await?;
+        let board = ctx.create_board("Proj".into(), None)?;
+        ctx.create_column(board.id, "Todo".into(), None)?;
+        ctx.archive_board(board.id)?;
+
+        assert!(ctx.boards()?.is_empty(), "archived board left the live set");
+        assert_eq!(ctx.list_archived_boards()?.len(), 1);
+        ctx.save().await?;
+        board.id
+    };
+
+    // The on-disk JSON envelope must actually carry archived_boards.
+    let raw = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        raw.contains("archived_boards"),
+        "JSON envelope must carry archived_boards"
+    );
+
+    // Session 2: fresh independent store at the same path.
+    let jds = JsonDataStore::new(Arc::new(JsonFileStore::new(&path)));
+    assert!(
+        jds.list_boards()?.is_empty(),
+        "reloaded live boards must be empty"
+    );
+    let archived = jds.list_archived_boards()?;
+    assert_eq!(
+        archived.len(),
+        1,
+        "archived board must survive the JSON file round-trip"
+    );
+    assert_eq!(archived[0].entity.id, board_id);
+    assert_eq!(jds.list_all_columns()?.len(), 1, "subtree column survived");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_legacy_json_without_archived_boards_loads_empty() -> KanbanResult<()> {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("legacy.json");
+
+    {
+        let mut ctx = KanbanContext::open(make_json_backend(&path), AppConfig::default()).await?;
+        ctx.create_board("Legacy".into(), None)?;
+        ctx.save().await?;
+    }
+
+    // Remove the archived_boards key from the persisted data to simulate a
+    // pre-C4 file (robust to serde field order/formatting).
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let mut envelope: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let removed = envelope["data"]
+        .as_object_mut()
+        .and_then(|data| data.remove("archived_boards"))
+        .is_some();
+    assert!(
+        removed,
+        "test setup expected an archived_boards key to remove"
+    );
+    std::fs::write(&path, serde_json::to_string(&envelope).unwrap()).unwrap();
+
+    let jds = JsonDataStore::new(Arc::new(JsonFileStore::new(&path)));
+    assert_eq!(jds.list_boards()?.len(), 1);
+    assert!(
+        jds.list_archived_boards()?.is_empty(),
+        "missing archived_boards key must default to empty"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## What

Makes board archiving actually work on the JSON file backend (SE-C card C4, KAN-837).

`JsonDataStore` (kanban-service) hand-forwards every `DataStore` method to its inner `InMemoryStore`. The four archived-board methods added in C2 were never forwarded, so they fell through to the trait defaults — meaning `insert_archived_board` returned `unsupported` and **archiving a board on the JSON backend failed at runtime**. This adds the four forwards (`get` / `list` / `insert` / `delete_archived_board`), mirroring the existing archived-card block.

## How this was found

A throwaway worktree spike ran the flow end-to-end (archive a board through a real `JsonDataStore`-backed context, save, reload) and hit `Unsupported { operation: "insert_archived_board" }`. The earlier code-reading groom had concluded C4 was "purely additive, no code" — which was wrong for the `DataStore` forwarding. It was right that **no file-format migration or version bump is needed**: the domain `Snapshot` already serializes `archived_boards`, and older files load it as empty via `#[serde(default)]` (verified on the on-disk bytes and with a legacy-file test).

The spike also surfaced that the sibling `SqliteBackend` wrapper has the same gap — folded into the C5 card so its SQLite work covers the backend wrapper too, not just `SqliteStore`.

## Scope note

The change is entirely in `kanban-service/src/json_backend.rs`; `kanban-persistence-json` (the raw file store) needs nothing, since it persists the opaque serialized snapshot blob.

## Tests

Integration tests through the real JSON file backend:
- `test_archived_board_survives_json_file_roundtrip` — archive a board + subtree, save, reopen a fresh store: live boards empty, `list_archived_boards` has it, the on-disk envelope contains `archived_boards`, and the subtree column survived.
- `test_legacy_json_without_archived_boards_loads_empty` — a file with the `archived_boards` key removed loads with one live board and an empty archived collection.

`cargo test`, clippy `-D warnings`, fmt, and `cargo build --workspace` all green.
