### PR TITLE
KAN-856 test(service): JSON V7→V8 migration coexists with archived boards

### DIFF
--- a/.changeset/kan-856-json-v7-migration-test.md
+++ b/.changeset/kan-856-json-v7-migration-test.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal test coverage (no user-facing change): adds an end-to-end regression test that a legacy JSON file (format V7) migrates forward correctly and coexists with board archiving — archived cards keep their data with the board reference backfilled, the archived-boards collection defaults to empty, and archiving a board works on the migrated file.

--- a/crates/kanban-service/tests/json_v7_migration.rs
+++ b/crates/kanban-service/tests/json_v7_migration.rs
@@ -27,7 +27,10 @@ fn downgrade_to_v7(path: &std::path::Path) {
     env["version"] = serde_json::json!(7);
     let data = env["data"].as_object_mut().unwrap();
     data.remove("archived_boards");
-    if let Some(acs) = data.get_mut("archived_cards").and_then(|v| v.as_array_mut()) {
+    if let Some(acs) = data
+        .get_mut("archived_cards")
+        .and_then(|v| v.as_array_mut())
+    {
         for ac in acs {
             ac.as_object_mut().unwrap().remove("board_id");
         }
@@ -101,7 +104,11 @@ async fn test_v7_json_migrates_and_preserves_cards_and_boards() -> KanbanResult<
     let reloaded = JsonDataStore::new(Arc::new(JsonFileStore::new(&path)));
     assert_eq!(reloaded.list_boards()?.len(), 1);
     let ab = reloaded.list_archived_boards()?;
-    assert_eq!(ab.len(), 1, "archived board persisted after migrating a V7 file");
+    assert_eq!(
+        ab.len(),
+        1,
+        "archived board persisted after migrating a V7 file"
+    );
     assert_eq!(ab[0].entity.id, board_a);
     // The originally-archived card is still archived on the reloaded store.
     assert_eq!(reloaded.list_archived_cards()?.len(), 1);

--- a/crates/kanban-service/tests/json_v7_migration.rs
+++ b/crates/kanban-service/tests/json_v7_migration.rs
@@ -1,0 +1,109 @@
+//! End-to-end JSON legacy-file migration (V7 -> V8) coexisting with the
+//! archived-board feature (C1-C4). A V7 envelope predates both
+//! `archived_cards.board_id` (V8 backfill) and the `archived_boards` collection.
+//! Loading it must: run the V7->V8 chain, backfill `board_id` on archived
+//! cards, default `archived_boards` to empty, preserve live/board data, and
+//! leave the store fully able to archive a board afterward.
+//!
+//! Fixtures are built by saving a real (current) file and downgrading it, so
+//! the envelope is guaranteed structurally valid.
+
+use kanban_domain::{DataStore, KanbanOperations, KanbanResult};
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn make_json_backend(path: &std::path::Path) -> Arc<dyn KanbanBackend> {
+    Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))))
+}
+
+/// Rewrite a current (V8) file to look like a legacy V7 file: bump the version
+/// down, drop `board_id` from every archived card, and remove the whole
+/// `archived_boards` key. Returns the board_id the archived card belonged to.
+fn downgrade_to_v7(path: &std::path::Path) {
+    let raw = std::fs::read_to_string(path).unwrap();
+    let mut env: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    env["version"] = serde_json::json!(7);
+    let data = env["data"].as_object_mut().unwrap();
+    data.remove("archived_boards");
+    if let Some(acs) = data.get_mut("archived_cards").and_then(|v| v.as_array_mut()) {
+        for ac in acs {
+            ac.as_object_mut().unwrap().remove("board_id");
+        }
+    }
+    std::fs::write(path, serde_json::to_string(&env).unwrap()).unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v7_json_migrates_and_preserves_cards_and_boards() -> KanbanResult<()> {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("legacy.json");
+
+    // --- Build a realistic current file: 2 boards, columns, live card + an
+    //     archived card, then save. ---
+    let (board_a, live_card, archived_card) = {
+        let mut ctx = KanbanContext::open(make_json_backend(&path), AppConfig::default()).await?;
+        let board_a = ctx.create_board("Alpha".into(), None)?;
+        let col = ctx.create_column(board_a.id, "Todo".into(), None)?;
+        let live = ctx.create_card(board_a.id, col.id, "Live".into(), Default::default())?;
+        let arch = ctx.create_card(board_a.id, col.id, "ToArchive".into(), Default::default())?;
+        ctx.archive_card(arch.id)?;
+
+        // A second live board to prove board data survives the migration.
+        ctx.create_board("Beta".into(), None)?;
+        ctx.save().await?;
+        (board_a.id, live.id, arch.id)
+    };
+
+    // --- Downgrade the saved file to a legacy V7 shape. ---
+    downgrade_to_v7(&path);
+    let v7_raw = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        v7_raw.contains("\"version\":7"),
+        "fixture must be version 7"
+    );
+    assert!(
+        !v7_raw.contains("archived_boards"),
+        "V7 fixture must not carry archived_boards"
+    );
+
+    // --- Reopen: loading triggers the V7 -> V8 migration chain. ---
+    let mut ctx = KanbanContext::open(make_json_backend(&path), AppConfig::default()).await?;
+
+    // Boards survived (2 live boards).
+    assert_eq!(ctx.boards()?.len(), 2, "both boards survived migration");
+    // Live card survived; archived card is not in the live set.
+    let live = ctx.list_all_cards()?;
+    assert!(live.iter().any(|c| c.id == live_card), "live card survived");
+    assert!(!live.iter().any(|c| c.id == archived_card));
+    // Archived card survived AND its board_id was backfilled by V7->V8.
+    let archived = ctx.list_archived_cards()?;
+    assert_eq!(archived.len(), 1, "archived card survived migration");
+    assert_eq!(archived[0].entity.id, archived_card);
+    assert_eq!(
+        archived[0].context.board_id, board_a,
+        "V7->V8 backfilled archived_cards.board_id"
+    );
+    // archived_boards defaulted to empty (the V7 file had no such key).
+    assert!(
+        ctx.list_archived_boards()?.is_empty(),
+        "archived_boards defaults empty on a migrated legacy file"
+    );
+
+    // --- The migrated store is fully functional: archive a board, save,
+    //     reload, and confirm it round-trips (C4 path on migrated data). ---
+    ctx.archive_board(board_a)?;
+    assert_eq!(ctx.boards()?.len(), 1, "Alpha left the live set");
+    assert_eq!(ctx.list_archived_boards()?.len(), 1);
+    ctx.save().await?;
+
+    let reloaded = JsonDataStore::new(Arc::new(JsonFileStore::new(&path)));
+    assert_eq!(reloaded.list_boards()?.len(), 1);
+    let ab = reloaded.list_archived_boards()?;
+    assert_eq!(ab.len(), 1, "archived board persisted after migrating a V7 file");
+    assert_eq!(ab[0].entity.id, board_a);
+    // The originally-archived card is still archived on the reloaded store.
+    assert_eq!(reloaded.list_archived_cards()?.len(), 1);
+    Ok(())
+}


### PR DESCRIPTION
## What

Adds an end-to-end regression test that the JSON backend's legacy migration (V7 → V8) coexists cleanly with board archiving (SE-C epic, C1–C4). Test-only — no production code change.

Surfaced by "did we test JSON migration too?": SQLite migration is covered by KAN-845 (#370); this closes the JSON side.

## Why

A legacy **V7** JSON file predates two epic-era additions:
- `archived_cards.board_id` (backfilled by the V7→V8 step, B3/KAN-832)
- the additive `archived_boards` collection (C1/C4)

We want a guard that loading such a file migrates forward *and* leaves the store fully able to archive a board.

## How

`crates/kanban-service/tests/json_v7_migration.rs` builds a real current file (2 boards, columns, a live card, an archived card), then **downgrades it to a structurally-valid V7 shape** (version→7, strip `archived_cards.board_id`, remove the `archived_boards` key). Reopening triggers `Migrator::migrate(V7→V8)` on load. Asserts:

- V7 file loads; migration runs.
- `archived_cards.board_id` is backfilled by V7→V8.
- `archived_boards` defaults to empty (absent in V7).
- Both boards + live card + archived card survive; live vs archived stay separated.
- **Post-migration the store is fully functional:** archiving a board works (the C4 path) and persists through save/reload.

Covers **both cards** (archived-card `board_id` backfill) **and boards** (live boards survive + archive-a-board afterward). Scope is the V7→V8 step — the one relevant to archived entities; each individual chain step is already unit-tested in `kanban-persistence-json`.

## Tests

`cargo test -p kanban-service --test json_v7_migration` green; clippy + fmt clean.
