### PR TITLE
KAN-838 feat(persistence-sqlite): board_archival marker table + schema 3→4 [C5]

### DIFF
--- a/.changeset/kan-838-sqlite-board-archival.md
+++ b/.changeset/kan-838-sqlite-board-archival.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Board archiving now works on the SQLite backend. Archiving a board persists it as archived, keeps its columns and cards in place, and reloads correctly; restore and permanent-delete (with undo) all behave the same as on the other backends. The database schema version is raised so an older version of the app safely refuses to open a database that uses this feature instead of misreading it; upgrading writes a one-time backup first.

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -426,8 +426,13 @@ impl RestoreBoard {
             .store
             .get_archived_board(self.board_id)?
             .ok_or_else(|| KanbanError::not_found("archived board", self.board_id))?;
-        context.store.upsert_board(archived.into_entity())?;
+        // Order matters for a marker-style backend (SQLite): the board row is
+        // SHARED, and `delete_archived_board` removes the marker AND the row.
+        // Remove the archived record FIRST, then re-insert the board as live —
+        // mirroring `RestoreCard`. (On the in-memory move-model the two touch
+        // separate maps, so this order is also correct there.)
         context.store.delete_archived_board(self.board_id)?;
+        context.store.upsert_board(archived.into_entity())?;
         Ok(())
     }
 

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -109,6 +109,13 @@ pub trait DataStore: Send + Sync {
     fn insert_archived_board(&self, _ab: crate::ArchivedBoard) -> KanbanResult<()> {
         Err(crate::KanbanError::unsupported("insert_archived_board"))
     }
+    /// Remove a board from the archived collection **only**. On a marker-style
+    /// backend (SQLite) this also removes the shared entity row, so it MUST be a
+    /// no-op on a *live* (non-archived) board — matching the in-memory store,
+    /// which only touches its archived map. `RestoreBoard` relies on this: it
+    /// calls `delete_archived_board` BEFORE re-inserting the board as live
+    /// (delete-then-upsert), so re-adding it doesn't collide with the archived
+    /// row on a shared-row backend.
     fn delete_archived_board(&self, _board_id: Uuid) -> KanbanResult<()> {
         Ok(())
     }

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -201,6 +201,18 @@ CREATE INDEX IF NOT EXISTS idx_cards_updated_at ON cards(updated_at);
 CREATE INDEX IF NOT EXISTS idx_archived_cards_board_id ON archived_cards(board_id);
 CREATE INDEX IF NOT EXISTS idx_archived_cards_archived_at ON archived_cards(archived_at);
 
+-- board_archival (C5/KAN-838): marks a board out of the live set. The board row
+-- stays in `boards`; live-board reads filter `NOT EXISTS (board_archival)`, and
+-- list/get_archived_board reconstitute Archived<Board> by join. The table is
+-- additive, but SUPPORTED_SCHEMA_VERSION is bumped 3->4 alongside it so an older
+-- binary REJECTS a v4 DB rather than misreading archived boards as live.
+CREATE TABLE IF NOT EXISTS board_archival (
+    board_id TEXT PRIMARY KEY,
+    archived_at TEXT NOT NULL,
+    FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_board_archival_archived_at ON board_archival(archived_at);
+
 -- Command log: per-batch JSON serialisation for cross-session undo (KAN-191).
 -- batch_index is a logical, dense, monotonically increasing cursor — it does
 -- not need to match SQLite's ROWID. Truncate-after-N is implemented with a

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult, Snapshot, Sprint,
+    Archived, ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult,
+    Snapshot, Sprint,
 };
 use sqlx::Row;
 use uuid::Uuid;
@@ -9,7 +10,7 @@ use uuid::Uuid;
 use super::conversions::{
     row_to_archived_card, row_to_board, row_to_card, row_to_column, row_to_sprint,
 };
-use super::helpers::{db_err, fmt_dt, run};
+use super::helpers::{db_err, fmt_dt, p_dt, run};
 use super::SqliteStore;
 
 impl DataStore for SqliteStore {
@@ -24,7 +25,9 @@ impl DataStore for SqliteStore {
                         next_sprint_number, active_sprint_id, task_list_view,
                         COALESCE(card_counter, 1) as card_counter,
                         completion_column_id, position, created_at, updated_at
-                 FROM boards WHERE id = ?",
+                 FROM boards
+                 WHERE id = ?
+                   AND NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)",
             )
             .bind(&id_str)
             .fetch_optional(&self.pool)
@@ -51,11 +54,15 @@ impl DataStore for SqliteStore {
 
     fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
         run(async {
-            sqlx::query("DELETE FROM boards WHERE id = ?")
-                .bind(id.to_string())
-                .execute(&self.pool)
-                .await
-                .map_err(db_err)?;
+            sqlx::query(
+                "DELETE FROM boards
+                 WHERE id = ?
+                   AND NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)",
+            )
+            .bind(id.to_string())
+            .execute(&self.pool)
+            .await
+            .map_err(db_err)?;
             Ok(())
         })
     }
@@ -314,6 +321,100 @@ impl DataStore for SqliteStore {
                 .map_err(db_err)?;
             sqlx::query("DELETE FROM cards WHERE id = ?")
                 .bind(card_id.to_string())
+                .execute(&mut *tx)
+                .await
+                .map_err(db_err)?;
+            tx.commit().await.map_err(db_err)
+        })
+    }
+
+    // Archived board (C5): board row stays in `boards`; a `board_archival` marker
+    // row marks it out of the live set. Reconstitute Archived<Board> by join.
+
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        run(async {
+            let id_str = board_id.to_string();
+            let row = sqlx::query(
+                "SELECT b.id, b.name, b.description, b.sprint_prefix, b.card_prefix, b.task_sort_field,
+                        b.task_sort_order, b.sprint_duration_days, b.sprint_name_used_count,
+                        b.next_sprint_number, b.active_sprint_id, b.task_list_view,
+                        COALESCE(b.card_counter, 1) as card_counter,
+                        b.completion_column_id, b.position, b.created_at, b.updated_at, ba.archived_at
+                 FROM board_archival ba JOIN boards b ON ba.board_id = b.id
+                 WHERE ba.board_id = ?",
+            )
+            .bind(&id_str)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(db_err)?;
+            match row {
+                Some(row) => {
+                    let (names, counters) = self.fetch_board_aux(&id_str).await?;
+                    let board = row_to_board(&row, names, counters)?;
+                    let at: String = row.try_get("archived_at").map_err(db_err)?;
+                    Ok(Some(Archived::at(board, p_dt(&at)?)))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        run(async {
+            let rows = sqlx::query(
+                "SELECT b.id, b.name, b.description, b.sprint_prefix, b.card_prefix, b.task_sort_field,
+                        b.task_sort_order, b.sprint_duration_days, b.sprint_name_used_count,
+                        b.next_sprint_number, b.active_sprint_id, b.task_list_view,
+                        COALESCE(b.card_counter, 1) as card_counter,
+                        b.completion_column_id, b.position, b.created_at, b.updated_at, ba.archived_at
+                 FROM board_archival ba JOIN boards b ON ba.board_id = b.id
+                 ORDER BY ba.archived_at ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(db_err)?;
+            let (mut names_map, mut counters_map) = self.fetch_all_board_aux().await?;
+            let mut out = Vec::with_capacity(rows.len());
+            for row in &rows {
+                let id_str: String = row.try_get("id").map_err(db_err)?;
+                let names = names_map.remove(&id_str).unwrap_or_default();
+                let counters = counters_map.remove(&id_str).unwrap_or_default();
+                let board = row_to_board(row, names, counters)?;
+                let at: String = row.try_get("archived_at").map_err(db_err)?;
+                out.push(Archived::at(board, p_dt(&at)?));
+            }
+            Ok(out)
+        })
+    }
+
+    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        run(async {
+            let mut tx = self.pool.begin().await.map_err(db_err)?;
+            Self::write_board_with_conn(&mut tx, &ab.entity).await?;
+            sqlx::query(
+                "INSERT INTO board_archival (board_id, archived_at) VALUES (?, ?)
+                 ON CONFLICT(board_id) DO UPDATE SET archived_at = excluded.archived_at",
+            )
+            .bind(ab.entity.id.to_string())
+            .bind(fmt_dt(&ab.metadata.archived_at))
+            .execute(&mut *tx)
+            .await
+            .map_err(db_err)?;
+            tx.commit().await.map_err(db_err)
+        })
+    }
+
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        run(async {
+            let id_str = board_id.to_string();
+            let mut tx = self.pool.begin().await.map_err(db_err)?;
+            sqlx::query("DELETE FROM board_archival WHERE board_id = ?")
+                .bind(&id_str)
+                .execute(&mut *tx)
+                .await
+                .map_err(db_err)?;
+            sqlx::query("DELETE FROM boards WHERE id = ?")
+                .bind(&id_str)
                 .execute(&mut *tx)
                 .await
                 .map_err(db_err)?;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -408,12 +408,22 @@ impl DataStore for SqliteStore {
         run(async {
             let id_str = board_id.to_string();
             let mut tx = self.pool.begin().await.map_err(db_err)?;
+            // Only remove the board row if it is actually archived — parity with
+            // the in-memory store, whose delete_archived_board touches only the
+            // archived collection and no-ops on a live board. Guarded delete runs
+            // FIRST (the marker still exists to satisfy the EXISTS check); the
+            // board_archival FK (ON DELETE CASCADE) drops the marker with the row,
+            // and the explicit marker delete below is belt-and-suspenders.
+            sqlx::query(
+                "DELETE FROM boards
+                 WHERE id = ?
+                   AND EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)",
+            )
+            .bind(&id_str)
+            .execute(&mut *tx)
+            .await
+            .map_err(db_err)?;
             sqlx::query("DELETE FROM board_archival WHERE board_id = ?")
-                .bind(&id_str)
-                .execute(&mut *tx)
-                .await
-                .map_err(db_err)?;
-            sqlx::query("DELETE FROM boards WHERE id = ?")
                 .bind(&id_str)
                 .execute(&mut *tx)
                 .await

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -13,7 +13,9 @@ impl SqliteStore {
                     next_sprint_number, active_sprint_id, task_list_view,
                     COALESCE(card_counter, 1) as card_counter,
                     completion_column_id, position, created_at, updated_at
-             FROM boards ORDER BY position ASC",
+             FROM boards
+             WHERE NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)
+             ORDER BY position ASC",
         )
         .fetch_all(&self.pool)
         .await

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -31,7 +31,7 @@ const SCHEMA: &str = include_str!("../schema.sql");
 /// added to `init::migrate` or a sibling `migrate_*` function MUST be
 /// paired with bumping this constant, or it will run unbacked-up — the two
 /// are intentionally coupled but not enforced by the type system.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 3;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 4;
 
 /// (instance_id, saved_at, writer_version, writer_commit, schema_version).
 /// Tuple shape returned by the metadata-singleton SELECT — extracted to a

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -1,0 +1,81 @@
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+use super::migration_v2_to_v3::seed_v2_db;
+use kanban_domain::{Archived, Board, DataStore};
+
+#[test]
+fn test_archived_board_roundtrip_through_board_archival_table() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("archival.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let board = Board::new("Proj", None::<String>);
+        let id = board.id;
+        store.upsert_board(board.clone()).unwrap();
+        assert_eq!(store.list_boards().unwrap().len(), 1);
+
+        // Archive: board stays in `boards`, a marker row appears; live reads
+        // exclude it, archived reads reconstitute it.
+        store.insert_archived_board(Archived::now(board)).unwrap();
+        assert!(
+            store.list_boards().unwrap().is_empty(),
+            "NOT EXISTS filter hides the archived board from live reads"
+        );
+        assert!(store.get_board(id).unwrap().is_none());
+        let archived = store.list_archived_boards().unwrap();
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0].entity.id, id);
+        assert!(store.get_archived_board(id).unwrap().is_some());
+
+        // delete_board is a NOT-EXISTS no-op on an archived board.
+        store.delete_board(id).unwrap();
+        assert_eq!(
+            store.list_archived_boards().unwrap().len(),
+            1,
+            "delete_board no-op"
+        );
+
+        // delete_archived_board removes marker + row (permanent).
+        store.delete_archived_board(id).unwrap();
+        assert!(store.list_archived_boards().unwrap().is_empty());
+        assert!(store.get_board(id).unwrap().is_none());
+    });
+}
+
+#[test]
+fn test_open_migrates_old_db_to_v4_with_board_archival_and_backup() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("old.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        // Bumped to the current version.
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(version, 4, "old DB migrates to current schema v4");
+
+        // board_archival table exists after the schema step.
+        let has_table: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='board_archival'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert!(has_table, "board_archival table created on open");
+
+        // The pre-migration durable backup was written (from v2).
+        assert!(
+            SqliteStore::backup_path_for(&path, 2).exists(),
+            "an upgrade from an older schema writes a pre-migration backup"
+        );
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -79,3 +79,26 @@ fn test_open_migrates_old_db_to_v4_with_board_archival_and_backup() {
         );
     });
 }
+
+#[test]
+fn test_delete_archived_board_is_noop_on_a_live_board() {
+    // Parity with the in-memory store: delete_archived_board must only remove an
+    // ARCHIVED board, never a live one.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("live.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let board = Board::new("Live", None::<String>);
+        let id = board.id;
+        store.upsert_board(board).unwrap();
+
+        store.delete_archived_board(id).unwrap();
+
+        assert!(
+            store.get_board(id).unwrap().is_some(),
+            "a live board must survive delete_archived_board"
+        );
+        assert_eq!(store.list_boards().unwrap().len(), 1);
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
@@ -79,7 +79,7 @@ fn test_open_drops_legacy_card_edges_table() {
 }
 
 #[test]
-fn test_fresh_db_records_schema_version_3() {
+fn test_fresh_db_records_schema_version_4() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("fresh.db");
     let rt = make_rt();
@@ -90,7 +90,7 @@ fn test_fresh_db_records_schema_version_3() {
             .await
             .unwrap();
         assert_eq!(version, SUPPORTED_SCHEMA_VERSION);
-        assert_eq!(version, 3, "fresh DB stamps schema_version 3");
+        assert_eq!(version, 4, "fresh DB stamps schema_version 4");
     });
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
@@ -79,7 +79,11 @@ fn test_migration_base_case_empty_db_backs_up_and_migrates_clean() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 3, "migrated to v3");
+        assert_eq!(
+            store_schema_version(&store).await,
+            4,
+            "migrated to current v4"
+        );
         assert_eq!(
             backup_schema_version(&path).await,
             2,
@@ -126,7 +130,7 @@ fn test_migration_cards_case_preserves_live_and_archived_cards() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 3);
+        assert_eq!(store_schema_version(&store).await, 4);
         assert_eq!(backup_schema_version(&path).await, 2);
 
         // Board survived.
@@ -214,7 +218,7 @@ fn test_migration_boards_case_preserves_multiple_board_subtrees() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 3);
+        assert_eq!(store_schema_version(&store).await, 4);
         assert_eq!(backup_schema_version(&path).await, 2);
 
         // Both boards survived with their subtrees.
@@ -245,7 +249,7 @@ fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
         // First open: migrates + writes the v2 backup.
         {
             let store = SqliteStore::open(&path).await.unwrap();
-            assert_eq!(store_schema_version(&store).await, 3);
+            assert_eq!(store_schema_version(&store).await, 4);
         }
         let backup = SqliteStore::backup_path_for(&path, 2);
         assert!(backup.exists());
@@ -254,7 +258,7 @@ fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
         // Second open on the now-v3 DB: no migration, backup untouched.
         {
             let store = SqliteStore::open(&path).await.unwrap();
-            assert_eq!(store_schema_version(&store).await, 3);
+            assert_eq!(store_schema_version(&store).await, 4);
             assert_eq!(store.list_archived_cards().unwrap().len(), 1, "data intact");
         }
         assert_eq!(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
@@ -207,7 +207,10 @@ fn test_migrate_v2_db_adds_board_id_and_backfills() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 3, "schema_version bumped to 3");
+        assert_eq!(
+            version, 4,
+            "schema_version bumped to 4 (2->3 archived_cards then generic bump)"
+        );
     });
 }
 
@@ -271,7 +274,7 @@ fn test_migrate_is_idempotent_on_v3_db() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 3);
+        assert_eq!(version, 4);
 
         let still_there: bool =
             sqlx::query_scalar("SELECT COUNT(*) > 0 FROM archived_cards WHERE card_id = ?")

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -1,4 +1,5 @@
 mod archived_cards;
+mod board_archival;
 mod boards;
 mod cards;
 mod columns;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
@@ -127,7 +127,7 @@ fn test_existing_backup_not_clobbered() {
             .await
             .unwrap();
         assert_eq!(
-            version, 3,
+            version, 4,
             "main DB must still migrate to the current schema even when the backup is skipped"
         );
     });

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -4,8 +4,8 @@ use kanban_domain::command_batch::CommandBatch;
 use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, DependencyGraph, GraphMutFn, InMemoryStore, KanbanError,
-    KanbanResult, Snapshot, Sprint,
+    ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, GraphMutFn, InMemoryStore,
+    KanbanError, KanbanResult, Snapshot, Sprint,
 };
 use kanban_persistence::{PersistenceMetadata, PersistenceStore};
 use kanban_persistence_sqlite::SqliteStore;
@@ -124,6 +124,18 @@ impl DataStore for SqliteBackend {
     }
     fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
         self.db.delete_archived_card(card_id)
+    }
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        self.db.get_archived_board(board_id)
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.db.list_archived_boards()
+    }
+    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        self.db.insert_archived_board(ab)
+    }
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.db.delete_archived_board(board_id)
     }
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
         self.db.list_archived_cards_by_board(board_id)

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -1,0 +1,96 @@
+//! Board archiving through the real SQLite backend (C5): `SqliteStore`
+//! board_archival marker table + `SqliteBackend` forwards + the collection-move
+//! commands. These are service-level (through the backend) on purpose — a
+//! store-only test would miss the `SqliteBackend` forwards and the
+//! `RestoreBoard` command ordering.
+
+use kanban_domain::{KanbanOperations, KanbanResult};
+use kanban_service::{open_context, AppConfig, KanbanContext};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn open(path: &std::path::Path) -> KanbanContext {
+    open_context(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap()
+}
+
+fn seed(ctx: &mut KanbanContext) -> KanbanResult<Uuid> {
+    let b = ctx.create_board("Proj".into(), None)?;
+    let col = ctx.create_column(b.id, "Todo".into(), None)?;
+    ctx.create_card(b.id, col.id, "Task".into(), Default::default())?;
+    Ok(b.id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_hides_from_live_lists_and_persists_across_reload() -> KanbanResult<()> {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("archive.sqlite3");
+
+    let board_id = {
+        let mut ctx = open(&path).await;
+        let board_id = seed(&mut ctx)?;
+        ctx.archive_board(board_id)?;
+
+        assert!(ctx.boards()?.is_empty(), "archived board left the live set");
+        let archived = ctx.list_archived_boards()?;
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0].entity.id, board_id);
+        assert_eq!(ctx.list_all_columns()?.len(), 1, "subtree stays in place");
+        assert_eq!(ctx.list_all_cards()?.len(), 1);
+        ctx.save().await?;
+        board_id
+    };
+
+    // Fresh open on the same file: the marker persisted.
+    let ctx = open(&path).await;
+    assert!(ctx.boards()?.is_empty(), "live boards empty after reload");
+    let archived = ctx.list_archived_boards()?;
+    assert_eq!(archived.len(), 1, "archived board persisted");
+    assert_eq!(archived[0].entity.id, board_id);
+    assert_eq!(ctx.list_all_columns()?.len(), 1, "subtree persisted");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_undo_and_restore_return_board_to_live() -> KanbanResult<()> {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("undo.sqlite3");
+    let mut ctx = open(&path).await;
+    let board_id = seed(&mut ctx)?;
+
+    ctx.archive_board(board_id)?;
+    assert!(ctx.boards()?.is_empty());
+    assert!(ctx.undo()?);
+    assert_eq!(ctx.boards()?.len(), 1, "undo returned the board to live");
+    assert!(ctx.list_archived_boards()?.is_empty());
+
+    ctx.archive_board(board_id)?;
+    ctx.restore_board(board_id)?;
+    assert_eq!(ctx.boards()?.len(), 1, "restore returned the board to live");
+    assert!(ctx.list_archived_boards()?.is_empty());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_works_on_archived_board_and_undo_restores_as_archived() -> KanbanResult<()> {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("delete.sqlite3");
+    let mut ctx = open(&path).await;
+    let board_id = seed(&mut ctx)?;
+    ctx.archive_board(board_id)?;
+
+    ctx.delete_board(board_id)?;
+    assert!(ctx.list_archived_boards()?.is_empty(), "board record gone");
+    assert!(ctx.boards()?.is_empty());
+    assert!(ctx.list_all_columns()?.is_empty(), "subtree cascaded");
+    assert!(ctx.list_all_cards()?.is_empty());
+
+    assert!(ctx.undo()?);
+    assert!(ctx.boards()?.is_empty(), "not restored to the live set");
+    let archived = ctx.list_archived_boards()?;
+    assert_eq!(archived.len(), 1, "restored as archived");
+    assert_eq!(archived[0].entity.id, board_id);
+    assert_eq!(ctx.list_all_columns()?.len(), 1, "subtree restored");
+    Ok(())
+}


### PR DESCRIPTION
## What

SQLite persistence for board archiving (SE-C card C5, KAN-838), mirroring how archived cards already work on SQLite. Spike-validated before execution.

### Storage (`kanban-persistence-sqlite`)
- New **`board_archival(board_id PK, archived_at)`** marker table. The board row **stays in `boards`**; a marker row marks it out of the live set. Live-board reads (`get_board`, `list_boards`) and `delete_board` filter `NOT EXISTS (board_archival)`; `get`/`list_archived_boards` reconstitute `Archived<Board>` by joining `boards` to `board_archival`.
- `insert_archived_board` upserts the board row (incl. sprint-name/counter aux tables) **then** the marker — works for both archive and re-import/undo. `delete_archived_board` removes marker + row (permanent); `delete_board` is a `NOT EXISTS` no-op on an archived board, so the collection-agnostic `DeleteBoard` works.
- **Bump `SUPPORTED_SCHEMA_VERSION` 3 → 4.** The table is additive, but the version bump makes an **older binary reject a v4 DB** instead of misreading archived boards as live. The existing machinery does the rest: opening a `<v4` DB writes the KAN-845 pre-migration `.v{N}.backup`, then the generic version-set stamps 4.

### Service (`kanban-service`)
- `SqliteBackend` forwards the four archived-board methods to its inner `SqliteStore`. (A store-only test would miss this wrapper — the C4 spike lesson.)

### Domain (`kanban-domain`) — a real bug the SQLite spike caught
- Fix `RestoreBoard::execute` ordering: **delete-archived first, then upsert**. The old order (upsert then delete) worked on the in-memory *move* model (separate maps) but on a *marker* backend `delete_archived_board` removes the **shared** board row *after* re-adding it — wiping the board on restore/undo. Mirrors `RestoreCard`. Only a through-SQLite test caught it; all 609 in-memory tests passed either way.

## Opt-in upgrade

Deferred: the gate-at-open **opt-in consent** for upgrades is its own later sprint (KAN-858). This PR uses standard auto-migrate; the version-bump reject guard already prevents old binaries from misreading/losing data.

## Tests

- SQLite: archived-board round-trip through `board_archival`; an old DB migrates to v4 with the table created and the pre-migration backup written.
- Service e2e through `SqliteBackend`: archive hides from live + persists across reopen; archive→undo and restore return to live; delete on an archived board cascades the subtree and undo restores it as archived.
- Existing schema-version assertions updated 3 → 4 (fresh/migrated DBs now stamp 4).

`cargo test --workspace`, clippy `-D warnings`, fmt all green.
