### PR TITLE
KAN-857 feat(persistence-json): bump save format V8→V9 for archived-board capability

### DIFF
--- a/.changeset/kan-857-json-v9-format-bump.md
+++ b/.changeset/kan-857-json-v9-format-bump.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+The JSON save format is now version 9, marking files as archived-board-capable. An older version of the app that predates board archiving will cleanly refuse to open a version-9 file instead of loading it and silently discarding archived boards on its next save. Existing files upgrade automatically on open, writing a one-time backup first.

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -2,7 +2,7 @@ use crate::atomic_writer::AtomicWriter;
 use crate::conflict::FileMetadata;
 use crate::migration::{
     transform_to_v6_split_graph_value, transform_v2_to_v3_value, transform_v6_to_v7_value,
-    transform_v7_to_v8_value, Migrator,
+    transform_v7_to_v8_value, transform_v8_to_v9_value, Migrator,
 };
 use kanban_persistence::{
     FormatVersion, PersistenceError, PersistenceMetadata, PersistenceResult, PersistenceStore,
@@ -148,7 +148,8 @@ fn run_split_and_upgrade_chain_sync(
         split_graph_sync(path)?;
     }
     v6_to_v7_rename_sync(path)?;
-    v7_to_v8_archived_cards_sync(path)
+    v7_to_v8_archived_cards_sync(path)?;
+    v8_to_v9_archived_boards_sync(path)
 }
 
 fn migrate_v1_to_v2_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
@@ -177,6 +178,21 @@ fn migrate_v2_to_v3_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
     let json_bytes = json_str.into_bytes();
     AtomicWriter::write_atomic_sync(path, &json_bytes)?;
     tracing::info!("Migrated {} from V2 to V3 (sync)", path.display());
+    Ok(json_bytes)
+}
+
+fn v8_to_v9_archived_boards_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
+    let content = std::fs::read_to_string(path)?;
+    let mut envelope: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    if !transform_v8_to_v9_value(&mut envelope)? {
+        return Ok(content.into_bytes());
+    }
+    let json_str = serde_json::to_string_pretty(&envelope)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    let json_bytes = json_str.into_bytes();
+    AtomicWriter::write_atomic_sync(path, &json_bytes)?;
+    tracing::info!("Migrated {} from V8 to V9 (sync)", path.display());
     Ok(json_bytes)
 }
 
@@ -331,7 +347,7 @@ impl PersistenceStore for JsonFileStore {
         let data_value: serde_json::Value = serde_json::from_slice(&snapshot.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
         let envelope = JsonEnvelope {
-            version: 8,
+            version: FormatVersion::MAX.as_u32(),
             metadata: snapshot.metadata.clone(),
             data: data_value,
         };
@@ -574,7 +590,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 8
+                    binary_max: 9
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -604,7 +620,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 8
+                    binary_max: 9
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -707,7 +723,7 @@ mod tests {
 
         let after = tokio::fs::read_to_string(&file_path).await.unwrap();
         let v: serde_json::Value = serde_json::from_str(&after).unwrap();
-        assert_eq!(v["version"], 8, "load must migrate V6 to V8 on disk");
+        assert_eq!(v["version"], 9, "load must migrate V6 to V9 on disk");
         let graph = v["data"]["graph"].as_object().expect("graph object");
         assert!(
             graph.contains_key("spawns"),
@@ -767,7 +783,7 @@ mod tests {
 
         let after = std::fs::read_to_string(&file_path).unwrap();
         let v: serde_json::Value = serde_json::from_str(&after).unwrap();
-        assert_eq!(v["version"], 8, "load_sync must migrate V6 to V8 on disk");
+        assert_eq!(v["version"], 9, "load_sync must migrate V6 to V9 on disk");
         let graph = v["data"]["graph"].as_object().expect("graph object");
         assert!(
             graph.contains_key("spawns"),
@@ -818,7 +834,7 @@ mod tests {
     }
 
     /// D7 round-trip: a historical V7 file whose archived card has NO
-    /// `board_id` must, on load, migrate to V8 on disk AND backfill the
+    /// `board_id` must, on load, migrate to V9 on disk AND backfill the
     /// board_id from `original_column_id` -> column.board_id. Then a
     /// subsequent save+reload must preserve the backfilled value (byte-stable
     /// archived_cards), proving the migration is data-preserving.
@@ -839,7 +855,7 @@ mod tests {
         // On-disk: migrated to V8 with board_id backfilled.
         let on_disk: serde_json::Value =
             serde_json::from_slice(&tokio::fs::read(&file_path).await.unwrap()).unwrap();
-        assert_eq!(on_disk["version"], 8, "load must migrate V7 to V8 on disk");
+        assert_eq!(on_disk["version"], 9, "load must migrate V7 to V9 on disk");
         assert_eq!(
             on_disk["data"]["archived_cards"][0]["board_id"]
                 .as_str()
@@ -935,7 +951,7 @@ mod tests {
 
         let on_disk: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&file_path).unwrap()).unwrap();
-        assert_eq!(on_disk["version"], 8, "load_sync must migrate V7 to V8");
+        assert_eq!(on_disk["version"], 9, "load_sync must migrate V7 to V9");
         let loaded_data: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
         assert_eq!(
             loaded_data["archived_cards"][0]["board_id"]
@@ -1074,12 +1090,13 @@ mod tests {
         let file_path = dir.path().join("clean.json");
 
         let clean = json!({
-            "version": 8,
+            "version": 9,
             "metadata": {
                 "instance_id": "550e8400-e29b-41d4-a716-446655440000",
                 "saved_at": "2024-01-01T00:00:00Z"
             },
             "data": {
+                "archived_boards": [],
                 "boards": [], "columns": [], "cards": [], "archived_cards": [], "sprints": [],
                 "graph": {
                     "spawns": { "edges": [] },
@@ -1339,7 +1356,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
 
         assert!(
             !path.with_extension("v6.backup").exists(),
@@ -1372,7 +1389,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
 
         assert!(
             !path.with_extension("v5.backup").exists(),
@@ -1403,7 +1420,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
 
         assert!(
             !path.with_extension("v4.backup").exists(),
@@ -1434,7 +1451,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
 
         assert!(
             !path.with_extension("v3.backup").exists(),
@@ -1471,7 +1488,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
 
         assert!(
             !path.with_extension("v2.backup").exists(),
@@ -1501,7 +1518,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
 
         assert!(
             !path.with_extension("v1.backup").exists(),

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -62,7 +62,7 @@ impl Migrator {
                 super::v2_to_v3::migrate_v2_to_v3(path).await
             }
             (FormatVersion::V2, FormatVersion::V3) => super::v2_to_v3::migrate_v2_to_v3(path).await,
-            (_, FormatVersion::V8) if from < FormatVersion::V8 => {
+            (_, FormatVersion::V9) if from < FormatVersion::V9 => {
                 // See `migration::backup` for the source-version → backup-path
                 // policy shared with the sync orchestrator. A `.v{N}.backup`
                 // is the user's escape hatch if the upgrade has to be rolled
@@ -136,7 +136,8 @@ impl Migrator {
             super::split_graph::migrate_to_v6_split_graph(path).await?;
         }
         super::v6_to_v7_rename::migrate_v6_to_v7(path).await?;
-        super::v7_to_v8_archived_cards::migrate_v7_to_v8(path).await
+        super::v7_to_v8_archived_cards::migrate_v7_to_v8(path).await?;
+        super::v8_to_v9_archived_boards::migrate_v8_to_v9(path).await
     }
 
     /// Migrate from V1 format to V2 format. Per-step backup removed: the
@@ -341,13 +342,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V4, FormatVersion::V8, &path)
+        Migrator::migrate(FormatVersion::V4, FormatVersion::MAX, &path)
             .await
             .unwrap();
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(
             after["data"]["graph"]
@@ -386,13 +387,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V5, FormatVersion::V8, &path)
+        Migrator::migrate(FormatVersion::V5, FormatVersion::MAX, &path)
             .await
             .unwrap();
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(after["data"]["graph"]["relates"].is_object());
         assert!(
@@ -429,13 +430,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V6, FormatVersion::V8, &path)
+        Migrator::migrate(FormatVersion::V6, FormatVersion::MAX, &path)
             .await
             .unwrap();
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(after["data"]["graph"]
             .as_object()
@@ -498,7 +499,7 @@ mod tests {
             .await
             .unwrap();
 
-        let err = Migrator::migrate(FormatVersion::V6, FormatVersion::V8, &path)
+        let err = Migrator::migrate(FormatVersion::V6, FormatVersion::MAX, &path)
             .await
             .expect_err("migration must refuse a V6 envelope carrying both bucket keys");
         let msg = err.to_string();
@@ -526,7 +527,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 8
+                    binary_max: 9
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -548,7 +549,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                PersistenceError::UnsupportedFutureVersion { binary_max: 8, .. }
+                PersistenceError::UnsupportedFutureVersion { binary_max: 9, .. }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
         );
@@ -573,7 +574,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 8
+                    binary_max: 9
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -668,13 +669,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V2, FormatVersion::V8, &path)
+        Migrator::migrate(FormatVersion::V2, FormatVersion::MAX, &path)
             .await
             .expect("V2→V8 must succeed");
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
 
         assert!(
             !path.with_extension("v2.backup").exists(),
@@ -696,13 +697,13 @@ mod tests {
         });
         tokio::fs::write(&path, v1.to_string()).await.unwrap();
 
-        Migrator::migrate(FormatVersion::V1, FormatVersion::V8, &path)
+        Migrator::migrate(FormatVersion::V1, FormatVersion::MAX, &path)
             .await
             .expect("V1→V8 must succeed");
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
 
         assert!(
             !path.with_extension("v1.backup").exists(),
@@ -746,13 +747,13 @@ mod tests {
             .await
             .unwrap();
 
-        Migrator::migrate(FormatVersion::V7, FormatVersion::V8, &path)
+        Migrator::migrate(FormatVersion::V7, FormatVersion::MAX, &path)
             .await
             .expect("V7→V8 must succeed");
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 8);
+        assert_eq!(after["version"], 9);
         assert_eq!(
             after["data"]["archived_cards"][0]["board_id"]
                 .as_str()

--- a/crates/kanban-persistence-json/src/migration/mod.rs
+++ b/crates/kanban-persistence-json/src/migration/mod.rs
@@ -5,6 +5,7 @@ pub mod v1_to_v2;
 pub mod v2_to_v3;
 pub mod v6_to_v7_rename;
 pub mod v7_to_v8_archived_cards;
+pub mod v8_to_v9_archived_boards;
 
 pub(crate) use backup::pre_latest_backup_path_for;
 pub use migrator::Migrator;
@@ -13,3 +14,4 @@ pub use v1_to_v2::V1ToV2Migration;
 pub(crate) use v2_to_v3::transform_v2_to_v3_value;
 pub(crate) use v6_to_v7_rename::transform_v6_to_v7_value;
 pub(crate) use v7_to_v8_archived_cards::transform_v7_to_v8_value;
+pub(crate) use v8_to_v9_archived_boards::transform_v8_to_v9_value;

--- a/crates/kanban-persistence-json/src/migration/v8_to_v9_archived_boards.rs
+++ b/crates/kanban-persistence-json/src/migration/v8_to_v9_archived_boards.rs
@@ -1,0 +1,67 @@
+//! V9 marks the format as archived-board-capable. `archived_boards` is an
+//! additive, `#[serde(default)]` snapshot field (C1/C4), so no data transform
+//! is required; the bump exists so a pre-archived-board binary (max V8) REJECTS
+//! a V9 file instead of loading it and dropping the `archived_boards` array on
+//! its next save. The transform normalizes the key to `[]` when absent so a V9
+//! file is self-describing.
+
+use std::path::Path;
+
+use kanban_persistence::{PersistenceError, PersistenceResult};
+use serde_json::Value;
+
+pub(crate) async fn migrate_v8_to_v9(path: &Path) -> PersistenceResult<()> {
+    let content = tokio::fs::read_to_string(path).await?;
+    let mut envelope: Value = serde_json::from_str(&content)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    if !transform_v8_to_v9_value(&mut envelope)? {
+        return Ok(());
+    }
+    let out = serde_json::to_string_pretty(&envelope)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    tokio::fs::write(path, out).await?;
+    Ok(())
+}
+
+/// Returns `true` if the envelope was changed (needs writing back). Idempotent:
+/// a file already at version >= 9 is left untouched.
+pub(crate) fn transform_v8_to_v9_value(envelope: &mut Value) -> PersistenceResult<bool> {
+    let version = envelope.get("version").and_then(Value::as_u64).unwrap_or(0);
+    if version >= 9 {
+        return Ok(false);
+    }
+    if let Some(data) = envelope.get_mut("data").and_then(Value::as_object_mut) {
+        data.entry("archived_boards")
+            .or_insert_with(|| Value::Array(vec![]));
+    }
+    envelope["version"] = Value::Number(9.into());
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_v8_to_v9_bumps_version_and_defaults_archived_boards() {
+        let mut env = json!({ "version": 8, "data": { "boards": [] } });
+        assert!(transform_v8_to_v9_value(&mut env).unwrap());
+        assert_eq!(env["version"], 9);
+        assert_eq!(env["data"]["archived_boards"], json!([]));
+    }
+
+    #[test]
+    fn test_v8_to_v9_preserves_existing_archived_boards() {
+        let mut env =
+            json!({ "version": 8, "data": { "archived_boards": [{"entity":{"id":"x"}}] } });
+        transform_v8_to_v9_value(&mut env).unwrap();
+        assert_eq!(env["data"]["archived_boards"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_v8_to_v9_is_idempotent_on_v9() {
+        let mut env = json!({ "version": 9, "data": {} });
+        assert!(!transform_v8_to_v9_value(&mut env).unwrap());
+    }
+}

--- a/crates/kanban-persistence/src/traits.rs
+++ b/crates/kanban-persistence/src/traits.rs
@@ -179,11 +179,15 @@ pub enum FormatVersion {
     /// when the original column no longer resolves), and is guaranteed not
     /// to be duplicated inside the `cards` array.
     V8,
+    /// V9 marks the format as archived-board-capable. The `archived_boards`
+    /// collection is additive (serde-default), but the bump makes a pre-V9
+    /// binary reject the file rather than silently drop archived boards on save.
+    V9,
 }
 
 impl FormatVersion {
     /// The highest format version this binary can read or produce.
-    pub const MAX: Self = Self::V8;
+    pub const MAX: Self = Self::V9;
 
     pub fn as_u32(self) -> u32 {
         match self {
@@ -195,6 +199,7 @@ impl FormatVersion {
             Self::V6 => 6,
             Self::V7 => 7,
             Self::V8 => 8,
+            Self::V9 => 9,
         }
     }
 
@@ -208,6 +213,7 @@ impl FormatVersion {
             6 => Some(Self::V6),
             7 => Some(Self::V7),
             8 => Some(Self::V8),
+            9 => Some(Self::V9),
             _ => None,
         }
     }
@@ -252,19 +258,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_format_version_max_equals_v8() {
-        assert_eq!(FormatVersion::MAX, FormatVersion::V8);
+    fn test_format_version_max_equals_v9() {
+        assert_eq!(FormatVersion::MAX, FormatVersion::V9);
     }
 
     #[test]
     fn test_format_version_max_as_u32_matches_largest_variant() {
-        assert_eq!(FormatVersion::MAX.as_u32(), 8);
+        assert_eq!(FormatVersion::MAX.as_u32(), 9);
     }
 
     #[test]
-    fn test_from_u32_accepts_8() {
+    fn test_from_u32_accepts_9_rejects_10() {
         assert_eq!(FormatVersion::from_u32(8), Some(FormatVersion::V8));
-        assert_eq!(FormatVersion::from_u32(9), None);
+        assert_eq!(FormatVersion::from_u32(9), Some(FormatVersion::V9));
+        assert_eq!(FormatVersion::from_u32(10), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Bumps the JSON save format **V8 → V9** so an older binary refuses an archived-board file instead of silently losing data (SE-C card KAN-857). This is the JSON symmetric partner to C5's SQLite schema 3→4 reject-guard. Spike-validated first.

## Why

`archived_boards` is an additive `#[serde(default)]` snapshot field (C1/C4) that C4 shipped at V8 without a version bump. So a **pre-archived-board binary** loading a V8 file that contains archived boards ignores the unknown key and, on its next full-rewrite save, **drops the entire `archived_boards` array — permanent data loss**. Bumping the format makes the old binary reject the file (`is_unsupported_future_version`) rather than mangle it.

## How

- `FormatVersion::V9` (+ `as_u32`/`from_u32`), `MAX = V9`.
- New `v8_to_v9_archived_boards` migration: idempotent (skip if `version >= 9`), normalizes `data.archived_boards` to `[]` when absent, sets `version = 9`. No data transform — just the version marker + key normalization.
- Wired into **both** JSON migration chains: the async `Migrator::migrate` arm (retargeted to V9) **and** the sync `load_sync` chain (`run_split_and_upgrade_chain_sync`). The spike undercounted this — the JSON backend has two chains.
- Writer stamps `FormatVersion::MAX`. Old binaries reject V9 via the existing guard; upgrades write the existing `.v{N}.backup` downgrade escape hatch.

The opt-in *consent* for this upgrade (gate-at-open, choose-upgrade-or-downgrade) is deferred to its own sprint (KAN-858); this uses standard auto-migrate + the reject guard.

## Tests

- New v8→v9 transform unit tests (bump + default `archived_boards` + idempotent).
- Existing migration-chain assertions bumped 8→9 (migrated-version + `binary_max` in the reject tests; the reject *sentinel* stays `99`); the `kanban-persistence` `MAX`/`from_u32` tests updated; the no-op-load fixture regenerated to a current V9 file.

`cargo test --workspace` (2544 passing), clippy `-D warnings`, fmt all green.
