### PR TITLE
KAN-842 refactor(service): hide archived-board descendants from live cross-board reads [C3b]

### DIFF
--- a/.changeset/kan-842-hide-archived-board-descendants.md
+++ b/.changeset/kan-842-hide-archived-board-descendants.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Archiving a board now hides its columns, cards, and sprints from every live cross-board view (card lists, search, filters, and the TUI displays), instead of leaving them visible as if the board were still active. Restoring the board brings them back. Save/export/import still see the full contents so nothing is lost while a board is archived.

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -52,14 +52,17 @@ pub trait KanbanOperations {
     fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>>;
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>>;
     fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>>;
-    /// Single-query snapshot of every card across all boards. Used by
-    /// resolvers and batch operations that need to scan once and reason
-    /// in memory. Implementors must back this with a single backend
-    /// query — do not compose from `list_cards_by_column`.
+    /// LIVE-scoped snapshot of cards across all LIVE boards (C3b): descendants
+    /// of ARCHIVED boards are excluded, so this is the user-facing "all cards"
+    /// used by resolvers and batch operations. For a TRUE all-cards read
+    /// (fidelity: snapshot/export/import/migrate), use the `DataStore` backend
+    /// method `list_all_cards` directly, which is unfiltered.
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>>;
-    /// Single-query snapshot of every column across all boards.
+    /// LIVE-scoped columns across all live boards (excludes archived-board
+    /// columns). Raw all-columns is the `DataStore` backend method.
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>>;
-    /// Single-query snapshot of every sprint across all boards.
+    /// LIVE-scoped sprints across all live boards (excludes archived-board
+    /// sprints). Raw all-sprints is the `DataStore` backend method.
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>>;
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card>;
     fn move_card(&mut self, id: Uuid, column_id: Uuid, position: Option<i32>)

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -166,7 +166,7 @@ impl KanbanContext {
         let cards = self.list_live_cards_impl()?;
         let columns = self.list_live_columns_impl()?;
         let boards = self.backend.list_boards()?;
-        let sprints = self.backend.list_all_sprints()?;
+        let sprints = self.list_live_sprints_impl()?;
         Ok(search(identifier, &cards, &columns, &boards, &sprints)
             .into_iter()
             .cloned()
@@ -228,18 +228,22 @@ impl KanbanContext {
         if archived.is_empty() {
             return self.backend.list_all_cards();
         }
-        let live_cols: std::collections::HashSet<Uuid> = self
+        // Exclude ONLY cards whose column belongs to an archived board. Build
+        // the (small) archived-column set and drop cards in it — this keeps a
+        // card with a dangling/deleted column (an orphan on a LIVE board) as
+        // live, matching the pre-C3b behavior for such cards.
+        let archived_cols: std::collections::HashSet<Uuid> = self
             .backend
             .list_all_columns()?
             .into_iter()
-            .filter(|c| !archived.contains(&c.board_id))
+            .filter(|c| archived.contains(&c.board_id))
             .map(|c| c.id)
             .collect();
         Ok(self
             .backend
             .list_all_cards()?
             .into_iter()
-            .filter(|c| live_cols.contains(&c.column_id))
+            .filter(|c| !archived_cols.contains(&c.column_id))
             .collect())
     }
 

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -163,8 +163,8 @@ impl KanbanContext {
         identifier: &str,
     ) -> KanbanResult<Vec<Card>> {
         use kanban_domain::search::find_cards_by_identifier as search;
-        let cards = self.backend.list_all_cards()?;
-        let columns = self.backend.list_all_columns()?;
+        let cards = self.list_live_cards_impl()?;
+        let columns = self.list_live_columns_impl()?;
         let boards = self.backend.list_boards()?;
         let sprints = self.backend.list_all_sprints()?;
         Ok(search(identifier, &cards, &columns, &boards, &sprints)
@@ -173,16 +173,74 @@ impl KanbanContext {
             .collect())
     }
 
+    /// LIVE-scoped (C3b): the user-facing "list all cards" excludes archived-
+    /// board descendants. Raw all-cards is `self.backend.list_all_cards()`.
     pub(super) fn list_all_cards_impl(&self) -> KanbanResult<Vec<Card>> {
-        self.backend.list_all_cards()
+        self.list_live_cards_impl()
     }
 
     pub(super) fn list_all_columns_impl(&self) -> KanbanResult<Vec<Column>> {
-        self.backend.list_all_columns()
+        self.list_live_columns_impl()
     }
 
     pub(super) fn list_all_sprints_impl(&self) -> KanbanResult<Vec<Sprint>> {
-        self.backend.list_all_sprints()
+        self.list_live_sprints_impl()
+    }
+
+    // C3b: canonical LIVE-scoped cross-board reads — exclude descendants of
+    // ARCHIVED boards (whose subtree stays in the flat collections). Fidelity
+    // paths (snapshot/import/export/migrate) keep reading `self.backend.list_all_*`
+    // raw. This is a service-tier filter, uniform across all backends.
+    fn archived_board_id_set(&self) -> KanbanResult<std::collections::HashSet<Uuid>> {
+        Ok(self
+            .backend
+            .list_archived_boards()?
+            .iter()
+            .map(|ab| ab.entity.id)
+            .collect())
+    }
+    pub(super) fn list_live_columns_impl(&self) -> KanbanResult<Vec<Column>> {
+        let archived = self.archived_board_id_set()?;
+        if archived.is_empty() {
+            return self.backend.list_all_columns();
+        }
+        Ok(self
+            .backend
+            .list_all_columns()?
+            .into_iter()
+            .filter(|c| !archived.contains(&c.board_id))
+            .collect())
+    }
+    pub(super) fn list_live_sprints_impl(&self) -> KanbanResult<Vec<Sprint>> {
+        let archived = self.archived_board_id_set()?;
+        if archived.is_empty() {
+            return self.backend.list_all_sprints();
+        }
+        Ok(self
+            .backend
+            .list_all_sprints()?
+            .into_iter()
+            .filter(|s| !archived.contains(&s.board_id))
+            .collect())
+    }
+    pub(super) fn list_live_cards_impl(&self) -> KanbanResult<Vec<Card>> {
+        let archived = self.archived_board_id_set()?;
+        if archived.is_empty() {
+            return self.backend.list_all_cards();
+        }
+        let live_cols: std::collections::HashSet<Uuid> = self
+            .backend
+            .list_all_columns()?
+            .into_iter()
+            .filter(|c| !archived.contains(&c.board_id))
+            .map(|c| c.id)
+            .collect();
+        Ok(self
+            .backend
+            .list_all_cards()?
+            .into_iter()
+            .filter(|c| live_cols.contains(&c.column_id))
+            .collect())
     }
 
     pub(super) fn update_card_impl(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {

--- a/crates/kanban-service/src/context/cards_batch_detailed.rs
+++ b/crates/kanban-service/src/context/cards_batch_detailed.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 impl KanbanContext {
     pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {
         use kanban_domain::commands::ArchiveCards;
-        let all_cards = match self.backend.list_all_cards() {
+        let all_cards = match self.list_live_cards_impl() {
             Ok(c) => c,
             Err(e) => {
                 return BatchOperationResult {
@@ -146,7 +146,7 @@ impl KanbanContext {
         sprint_id: Uuid,
     ) -> BatchOperationResult {
         use kanban_domain::commands::AssignCardsToSprint;
-        let all_sprints = match self.backend.list_all_sprints() {
+        let all_sprints = match self.list_live_sprints_impl() {
             Ok(s) => s,
             Err(e) => {
                 return BatchOperationResult {
@@ -173,7 +173,7 @@ impl KanbanContext {
                     .collect(),
             };
         }
-        let all_cards = match self.backend.list_all_cards() {
+        let all_cards = match self.list_live_cards_impl() {
             Ok(c) => c,
             Err(e) => {
                 return BatchOperationResult {

--- a/crates/kanban-service/src/context/core.rs
+++ b/crates/kanban-service/src/context/core.rs
@@ -79,16 +79,18 @@ impl KanbanContext {
         self.backend.list_boards()
     }
 
+    /// LIVE-scoped (C3b): excludes archived-board columns. TUI/display reads use
+    /// this; raw all-columns is `self.backend.list_all_columns()`.
     pub fn columns(&self) -> KanbanResult<Vec<Column>> {
-        self.backend.list_all_columns()
+        self.list_live_columns_impl()
     }
 
     pub fn cards(&self) -> KanbanResult<Vec<Card>> {
-        self.backend.list_all_cards()
+        self.list_live_cards_impl()
     }
 
     pub fn sprints(&self) -> KanbanResult<Vec<Sprint>> {
-        self.backend.list_all_sprints()
+        self.list_live_sprints_impl()
     }
 
     pub fn archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {

--- a/crates/kanban-service/src/context/filters.rs
+++ b/crates/kanban-service/src/context/filters.rs
@@ -3,7 +3,7 @@ use kanban_domain::{Card, CardListFilter, KanbanResult};
 
 impl KanbanContext {
     pub(super) fn filter_cards(&self, filter: &CardListFilter) -> KanbanResult<Vec<Card>> {
-        let cards = self.backend.list_all_cards()?;
+        let cards = self.list_live_cards_impl()?;
         let board = match filter.board_id {
             Some(bid) => self.backend.get_board(bid)?,
             None => None,

--- a/crates/kanban-service/src/context/persistence.rs
+++ b/crates/kanban-service/src/context/persistence.rs
@@ -16,6 +16,7 @@ impl KanbanContext {
     ///
     /// Returns the number of cards that received a backfilled log.
     pub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {
+        // C3b FIDELITY: raw reads — sprint-log migration must touch ALL cards.
         let mut cards = self.backend.list_all_cards()?;
         let sprints = self.backend.list_all_sprints()?;
         let boards = self.backend.list_boards()?;

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -45,7 +45,8 @@ impl KanbanContext {
             )));
         }
 
-        let all_cards = self.backend.list_all_cards()?;
+        // C3b: live-scoped — never carry over an archived board's cards.
+        let all_cards = self.list_live_cards_impl()?;
         let ids: Vec<Uuid> = get_sprint_uncompleted_cards(from_sprint_id, &all_cards)
             .iter()
             .map(|c| c.id)
@@ -239,6 +240,8 @@ impl KanbanContext {
                 .collect();
             let columns = self.backend.list_columns_by_board(id)?;
             let column_ids: Vec<_> = columns.iter().map(|c| c.id).collect();
+            // C3b FIDELITY: raw read — exporting a board (even an archived one)
+            // must include its full subtree; do NOT live-scope here.
             let cards: Vec<_> = self
                 .backend
                 .list_all_cards()?
@@ -278,6 +281,8 @@ impl KanbanContext {
             .cloned()
             .ok_or_else(|| KanbanError::validation("No board in import data"))?;
 
+        // C3b FIDELITY: raw read — import dedup must see ALL columns
+        // (live AND archived-board) to reject id collisions.
         let existing_columns = self.backend.list_all_columns()?;
         let imported_column_ids: HashSet<Uuid> = imported.columns.iter().map(|c| c.id).collect();
         let existing_column_ids: HashSet<Uuid> = existing_columns.iter().map(|c| c.id).collect();

--- a/crates/kanban-service/tests/board_archive.rs
+++ b/crates/kanban-service/tests/board_archive.rs
@@ -37,9 +37,15 @@ async fn test_archive_board_hides_from_boards_and_lists_in_archived() -> KanbanR
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1);
     assert_eq!(archived[0].entity.id, board_id);
-    // Subtree stays in place (still in the flat collections).
-    assert_eq!(ctx.list_all_columns()?.len(), 1);
-    assert_eq!(ctx.list_all_cards()?.len(), 1);
+    // Subtree stays in place — hidden from live cross-board views (C3b) but
+    // preserved in the snapshot (fidelity).
+    assert!(
+        ctx.list_all_columns()?.is_empty(),
+        "archived board's columns hidden from live view"
+    );
+    let snap = ctx.snapshot()?;
+    assert_eq!(snap.columns.len(), 1, "subtree preserved in snapshot");
+    assert_eq!(snap.cards.len(), 1);
     Ok(())
 }
 
@@ -99,8 +105,13 @@ async fn test_delete_archived_board_undo_restores_as_archived() -> KanbanResult<
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1);
     assert_eq!(archived[0].entity.id, board_id);
-    assert_eq!(ctx.list_all_columns()?.len(), 1, "subtree restored");
-    assert_eq!(ctx.list_all_cards()?.len(), 1, "subtree restored");
+    assert!(
+        ctx.list_all_columns()?.is_empty(),
+        "still archived: subtree hidden from live view"
+    );
+    let snap = ctx.snapshot()?;
+    assert_eq!(snap.columns.len(), 1, "subtree preserved");
+    assert_eq!(snap.cards.len(), 1);
     Ok(())
 }
 

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -36,8 +36,11 @@ async fn test_archive_hides_from_live_lists_and_persists_across_reload() -> Kanb
         let archived = ctx.list_archived_boards()?;
         assert_eq!(archived.len(), 1);
         assert_eq!(archived[0].entity.id, board_id);
-        assert_eq!(ctx.list_all_columns()?.len(), 1, "subtree stays in place");
-        assert_eq!(ctx.list_all_cards()?.len(), 1);
+        assert!(
+            ctx.list_all_columns()?.is_empty(),
+            "subtree hidden from live view (C3b)"
+        );
+        assert_eq!(ctx.snapshot()?.columns.len(), 1, "subtree stays in place");
         ctx.save().await?;
         board_id
     };
@@ -48,7 +51,11 @@ async fn test_archive_hides_from_live_lists_and_persists_across_reload() -> Kanb
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1, "archived board persisted");
     assert_eq!(archived[0].entity.id, board_id);
-    assert_eq!(ctx.list_all_columns()?.len(), 1, "subtree persisted");
+    assert!(
+        ctx.list_all_columns()?.is_empty(),
+        "subtree hidden from live view"
+    );
+    assert_eq!(ctx.snapshot()?.columns.len(), 1, "subtree persisted");
     Ok(())
 }
 
@@ -91,6 +98,10 @@ async fn test_delete_works_on_archived_board_and_undo_restores_as_archived() -> 
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1, "restored as archived");
     assert_eq!(archived[0].entity.id, board_id);
-    assert_eq!(ctx.list_all_columns()?.len(), 1, "subtree restored");
+    assert!(
+        ctx.list_all_columns()?.is_empty(),
+        "still archived: hidden from live"
+    );
+    assert_eq!(ctx.snapshot()?.columns.len(), 1, "subtree restored");
     Ok(())
 }

--- a/crates/kanban-service/tests/board_query_audit.rs
+++ b/crates/kanban-service/tests/board_query_audit.rs
@@ -1,0 +1,98 @@
+//! C3b: archived-board descendants are hidden from user-facing cross-board reads
+//! (list_cards, find-by-identifier, list_all_*, accessors, resolvers) but
+//! preserved on fidelity paths (snapshot, export).
+
+use kanban_domain::{CardListFilter, InMemoryStore, KanbanOperations, KanbanResult};
+use kanban_service::{AppConfig, KanbanContext};
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn ctx() -> KanbanContext {
+    KanbanContext::open(Arc::new(InMemoryStore::new()), AppConfig::default())
+        .await
+        .unwrap()
+}
+
+/// Returns (archived_board_id, archived_card_id, live_card_id).
+fn seed(c: &mut KanbanContext) -> KanbanResult<(Uuid, Uuid, Uuid)> {
+    let a = c.create_board("A".into(), None)?;
+    let a_col = c.create_column(a.id, "Todo".into(), None)?;
+    let a_card = c.create_card(a.id, a_col.id, "A-card".into(), Default::default())?;
+    let b = c.create_board("B".into(), None)?;
+    let b_col = c.create_column(b.id, "Todo".into(), None)?;
+    let b_card = c.create_card(b.id, b_col.id, "B-card".into(), Default::default())?;
+    c.archive_board(a.id)?;
+    Ok((a.id, a_card.id, b_card.id))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archived_board_cards_hidden_from_list_cards() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (_a, a_card, b_card) = seed(&mut c)?;
+    let ids: Vec<_> = c
+        .list_cards(CardListFilter::default())?
+        .iter()
+        .map(|s| s.id)
+        .collect();
+    assert!(
+        !ids.contains(&a_card),
+        "archived board's card hidden from list_cards"
+    );
+    assert!(ids.contains(&b_card));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archived_board_cards_hidden_from_list_all_cards_and_accessor() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (_a, a_card, b_card) = seed(&mut c)?;
+    // Public trait method (live-scoped).
+    let all = c.list_all_cards()?;
+    assert!(!all.iter().any(|x| x.id == a_card));
+    assert!(all.iter().any(|x| x.id == b_card));
+    // Inherent accessor (used by the TUI) — also live.
+    let acc = c.cards()?;
+    assert!(!acc.iter().any(|x| x.id == a_card));
+    // Columns + sprints accessors exclude the archived board too.
+    assert_eq!(c.columns()?.len(), 1, "only the live board's column");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archived_board_card_not_resolvable_by_identifier() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (_a, a_card, _b) = seed(&mut c)?;
+    let found = c.find_cards_by_identifier(&a_card.to_string())?;
+    assert!(
+        found.is_empty(),
+        "an archived board's card must not resolve in a user-facing lookup"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_snapshot_and_export_still_carry_archived_board_subtree() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (_a, a_card, _b) = seed(&mut c)?;
+    // FIDELITY: snapshot keeps the archived board's card (no data loss).
+    let snap = c.snapshot()?;
+    assert!(
+        snap.cards.iter().any(|x| x.id == a_card),
+        "snapshot must preserve the archived board's card"
+    );
+    assert_eq!(snap.archived_boards.len(), 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_restore_board_returns_cards_to_live_views() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (a, a_card, _b) = seed(&mut c)?;
+    c.restore_board(a)?;
+    let all = c.list_all_cards()?;
+    assert!(
+        all.iter().any(|x| x.id == a_card),
+        "restoring the board returns its cards to live views"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## What

Stops an archived board's leftovers from leaking into live cross-board views (SE-C card C3b, KAN-842). Spike-validated first; this was flagged as the risk surface of the epic.

## Why

Archiving a board moves the board head into the archived collection but **keeps its columns/cards/sprints in the flat live tables** (so restore is lossless). The side effect: every unscoped "list all cards / columns / sprints" still returned the archived board's content, showing it in live views as if nothing were archived (the C2 spike confirmed the leak).

## The mechanism

Three service-tier helpers on `KanbanContext` — `list_live_cards` / `list_live_columns` / `list_live_sprints` — filter `list_all_*` by the archived-board-id set (`card→column→board` for cards; `board_id` directly for columns/sprints; fast-path when nothing is archived). **Uniform across all backends — no per-backend SQL** (the groom's "SQLite `NOT EXISTS`" hint turned out unnecessary).

## The audit (EXCLUDE vs INCLUDE)

- **Made live (EXCLUDE):**
  - `KanbanOperations::list_all_*` trait methods **and** the `core.rs` `cards()/columns()/sprints()` accessors → live. This makes the domain resolvers (`resolve_card_ids`, `require_same_board`, `resolve_column/sprint_id_global`) and the **~15 TUI accessor call-sites** live *transitively*. "List all" as a user-facing API now means live; raw all-reads remain the `DataStore` backend methods.
  - Direct sites repointed: `filter_cards`, `find_cards_by_identifier`, `carry_over_sprint_cards`, `archive_cards_detailed`.
- **Left raw (INCLUDE, fidelity — filtering would lose data), each with a one-line why:** `export_board`, `import_board` dedup, `migrate_sprint_logs`, snapshot.

The spike corrected the card here: the original "repoint one method, get transitivity" plan was wrong (most sites hit `self.backend` directly), and the ~15 TUI accessor sites weren't in the card at all.

## Tests

- Per-surface hiding: `list_cards`, `list_all_cards`, the `cards()` accessor, `find_by_identifier`.
- Fidelity preserved: snapshot still carries the archived board's subtree; restore returns cards to live views.
- Strengthened the existing C3a/C5 subtree tests — they previously asserted "subtree stays" via the now-live-scoped `list_all_*`; they now assert **hidden-from-live AND preserved-in-snapshot**.

`cargo test --workspace` (2549 passing), clippy `-D warnings`, fmt all green.
