### PR TITLE
KAN-860 fix(persistence-sqlite): carry archived_boards through snapshot + apply (data loss)

### DIFF
--- a/.changeset/kan-860-sqlite-snapshot-archived-boards.md
+++ b/.changeset/kan-860-sqlite-snapshot-archived-boards.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Fixes data loss where exporting or snapshotting a SQLite database silently dropped every archived board. Archived boards are now included in a SQLite snapshot and restored on import, so exporting a SQLite board to JSON (or copying between backends) preserves them.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -360,31 +360,7 @@ impl DataStore for SqliteStore {
     }
 
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
-        run(async {
-            let rows = sqlx::query(
-                "SELECT b.id, b.name, b.description, b.sprint_prefix, b.card_prefix, b.task_sort_field,
-                        b.task_sort_order, b.sprint_duration_days, b.sprint_name_used_count,
-                        b.next_sprint_number, b.active_sprint_id, b.task_list_view,
-                        COALESCE(b.card_counter, 1) as card_counter,
-                        b.completion_column_id, b.position, b.created_at, b.updated_at, ba.archived_at
-                 FROM board_archival ba JOIN boards b ON ba.board_id = b.id
-                 ORDER BY ba.archived_at ASC",
-            )
-            .fetch_all(&self.pool)
-            .await
-            .map_err(db_err)?;
-            let (mut names_map, mut counters_map) = self.fetch_all_board_aux().await?;
-            let mut out = Vec::with_capacity(rows.len());
-            for row in &rows {
-                let id_str: String = row.try_get("id").map_err(db_err)?;
-                let names = names_map.remove(&id_str).unwrap_or_default();
-                let counters = counters_map.remove(&id_str).unwrap_or_default();
-                let board = row_to_board(row, names, counters)?;
-                let at: String = row.try_get("archived_at").map_err(db_err)?;
-                out.push(Archived::at(board, p_dt(&at)?));
-            }
-            Ok(out)
-        })
+        run(self.list_archived_boards_async())
     }
 
     fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
@@ -1,9 +1,38 @@
-use kanban_domain::{KanbanResult, Snapshot};
+use sqlx::Row;
 
-use super::helpers::db_err;
+use kanban_domain::{Archived, ArchivedBoard, KanbanResult, Snapshot};
+
+use super::conversions::row_to_board;
+use super::helpers::{db_err, fmt_dt, p_dt};
 use super::SqliteStore;
 
 impl SqliteStore {
+    pub(crate) async fn list_archived_boards_async(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        let rows = sqlx::query(
+            "SELECT b.id, b.name, b.description, b.sprint_prefix, b.card_prefix, b.task_sort_field,
+                    b.task_sort_order, b.sprint_duration_days, b.sprint_name_used_count,
+                    b.next_sprint_number, b.active_sprint_id, b.task_list_view,
+                    COALESCE(b.card_counter, 1) as card_counter,
+                    b.completion_column_id, b.position, b.created_at, b.updated_at, ba.archived_at
+             FROM board_archival ba JOIN boards b ON ba.board_id = b.id
+             ORDER BY ba.archived_at ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(db_err)?;
+        let (mut names_map, mut counters_map) = self.fetch_all_board_aux().await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let id_str: String = row.try_get("id").map_err(db_err)?;
+            let names = names_map.remove(&id_str).unwrap_or_default();
+            let counters = counters_map.remove(&id_str).unwrap_or_default();
+            let board = row_to_board(row, names, counters)?;
+            let at: String = row.try_get("archived_at").map_err(db_err)?;
+            out.push(Archived::at(board, p_dt(&at)?));
+        }
+        Ok(out)
+    }
+
     pub(crate) async fn snapshot_async(&self) -> KanbanResult<Snapshot> {
         let boards = self.list_boards_async().await?;
         let columns = self.list_all_columns_async().await?;
@@ -11,14 +40,12 @@ impl SqliteStore {
         let archived_cards = self.list_archived_cards_async().await?;
         let sprints = self.list_all_sprints_async().await?;
         let graph = self.get_graph_async().await?;
-        Ok(Snapshot::from_data(
-            boards,
-            columns,
-            cards,
-            archived_cards,
-            sprints,
-            graph,
-        ))
+        // C3b/KAN-860 fidelity: carry archived boards (their subtree is already
+        // in the flat columns/cards/sprints reads above, which are unfiltered).
+        let archived_boards = self.list_archived_boards_async().await?;
+        let mut snap = Snapshot::from_data(boards, columns, cards, archived_cards, sprints, graph);
+        snap.archived_boards = archived_boards;
+        Ok(snap)
     }
 
     pub(crate) async fn apply_snapshot_async(&self, snapshot: Snapshot) -> KanbanResult<()> {
@@ -69,6 +96,10 @@ impl SqliteStore {
             .execute(&mut *tx)
             .await
             .map_err(db_err)?;
+        sqlx::query("DELETE FROM board_archival")
+            .execute(&mut *tx)
+            .await
+            .map_err(db_err)?;
         sqlx::query("DELETE FROM boards")
             .execute(&mut *tx)
             .await
@@ -88,6 +119,19 @@ impl SqliteStore {
         }
         for ac in &snapshot.archived_cards {
             Self::write_archived_card_with_conn(&mut tx, ac).await?;
+        }
+        // KAN-860: restore archived boards — the board row + its board_archival marker.
+        for ab in &snapshot.archived_boards {
+            Self::write_board_with_conn(&mut tx, &ab.entity).await?;
+            sqlx::query(
+                "INSERT INTO board_archival (board_id, archived_at) VALUES (?, ?)
+                 ON CONFLICT(board_id) DO UPDATE SET archived_at = excluded.archived_at",
+            )
+            .bind(ab.entity.id.to_string())
+            .bind(fmt_dt(&ab.metadata.archived_at))
+            .execute(&mut *tx)
+            .await
+            .map_err(db_err)?;
         }
         Self::write_graph_with_conn(&mut tx, &snapshot.graph).await?;
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -102,3 +102,50 @@ fn test_delete_archived_board_is_noop_on_a_live_board() {
         assert_eq!(store.list_boards().unwrap().len(), 1);
     });
 }
+
+#[test]
+fn test_snapshot_and_apply_round_trip_archived_boards() {
+    // Data-loss regression (KAN-860): a SQLite snapshot must carry archived
+    // boards, and apply_snapshot must restore them.
+    let rt = make_rt();
+    rt.block_on(async {
+        let dir1 = TempDir::new().unwrap();
+        let path1 = dir1.path().join("src.sqlite3");
+        let src = SqliteStore::open(&path1).await.unwrap();
+
+        let live = Board::new("Live", None::<String>);
+        let archived = Board::new("Archived", None::<String>);
+        let archived_id = archived.id;
+        src.upsert_board(live).unwrap();
+        src.upsert_board(archived.clone()).unwrap();
+        src.insert_archived_board(Archived::now(archived)).unwrap();
+
+        let snap = src.snapshot().unwrap();
+        assert_eq!(snap.boards.len(), 1, "only the live board in .boards");
+        assert_eq!(
+            snap.archived_boards.len(),
+            1,
+            "snapshot must carry the archived board (no data loss)"
+        );
+        assert_eq!(snap.archived_boards[0].entity.id, archived_id);
+
+        // Apply into a FRESH store — the archived board must round-trip.
+        let dir2 = TempDir::new().unwrap();
+        let path2 = dir2.path().join("dst.sqlite3");
+        let dst = SqliteStore::open(&path2).await.unwrap();
+        dst.apply_snapshot(snap).unwrap();
+
+        assert_eq!(dst.list_boards().unwrap().len(), 1);
+        let restored = dst.list_archived_boards().unwrap();
+        assert_eq!(
+            restored.len(),
+            1,
+            "archived board restored by apply_snapshot"
+        );
+        assert_eq!(restored[0].entity.id, archived_id);
+        assert!(
+            dst.get_board(archived_id).unwrap().is_none(),
+            "archived, not live"
+        );
+    });
+}


### PR DESCRIPTION
## What

Fixes a **data-loss** bug: exporting or snapshotting a SQLite database silently dropped every archived board (KAN-860). Found during the C3b (#386) review.

## Why it happened / why tests missed it

`SqliteStore::snapshot_async` built the snapshot with the 6-arg `Snapshot::from_data(...)` — which leaves `archived_boards` empty — and `list_boards_async` already excludes archived boards (C5's `NOT EXISTS`). So a SQLite snapshot carried **zero** archived boards: `ctx.snapshot()` and export-to-JSON dropped them permanently.

Normal SQLite reload was unaffected because it persists `board_archival` rows **directly** (a live DB, not a snapshot rewrite) — the snapshot path is only hit on export / import / `ctx.snapshot()`. The C3b snapshot-fidelity test used the in-memory backend, so it didn't cover this.

## Fix

- Extract `list_archived_boards_async`; `snapshot_async` now sets `snap.archived_boards` (mirroring the in-memory `snapshot_impl`). The subtree (columns/cards/sprints) was already captured by the unfiltered `list_all_*` reads — only the board heads were missing.
- `apply_snapshot_async` wipes `board_archival` and restores each archived board (board row + `board_archival` marker), so a snapshot round-trips both directions (incl. JSON → SQLite import).

## Tests

TDD red→green round-trip: archive a board, `snapshot()`, `apply_snapshot()` into a fresh store, assert it comes back **archived** (in `list_archived_boards`, absent from `list_boards`). `cargo test --workspace` (2550 passing), clippy `-D warnings`, fmt green.
