### PR TITLE
KAN-861 feat(service): view archived-board constituents — board-scoped card reads + relations (C10a)

### DIFF
--- a/crates/kanban-service/src/context/filters.rs
+++ b/crates/kanban-service/src/context/filters.rs
@@ -1,16 +1,24 @@
 use super::KanbanContext;
 use kanban_domain::{Card, CardListFilter, KanbanResult};
+use uuid::Uuid;
 
 impl KanbanContext {
     pub(super) fn filter_cards(&self, filter: &CardListFilter) -> KanbanResult<Vec<Card>> {
-        let cards = self.list_live_cards_impl()?;
-        let board = match filter.board_id {
-            Some(bid) => self.backend.get_board(bid)?,
-            None => None,
-        };
-        let columns = match filter.board_id {
-            Some(bid) => self.backend.list_columns_by_board(bid)?,
-            None => Vec::new(),
+        // C10a: an explicit `board_id` is a deliberate scoped request, so base the
+        // card set on THAT board's own cards (raw) — honoring the board whether it
+        // is live or archived. Only the UNSCOPED read stays live-scoped (C3b).
+        let (cards, columns, board) = match filter.board_id {
+            Some(bid) => {
+                let columns = self.backend.list_columns_by_board(bid)?;
+                let col_ids: Vec<Uuid> = columns.iter().map(|c| c.id).collect();
+                let cards = self.backend.list_cards_by_columns(&col_ids)?;
+                let board = match self.backend.get_board(bid)? {
+                    Some(b) => Some(b),
+                    None => self.backend.get_archived_board(bid)?.map(|ab| ab.entity),
+                };
+                (cards, columns, board)
+            }
+            None => (self.list_live_cards_impl()?, Vec::new(), None),
         };
         let sprints = match (board.as_ref(), filter.search.as_deref()) {
             (Some(b), Some(q)) if !q.is_empty() => self.backend.list_sprints_by_board(b.id)?,

--- a/crates/kanban-service/src/context/graph.rs
+++ b/crates/kanban-service/src/context/graph.rs
@@ -3,8 +3,73 @@ use kanban_domain::commands::{
     AddBlocks, AddRelates, AddSpawns, Command, DependencyCommand, RemoveBlocks, RemoveRelates,
     RemoveSpawns,
 };
-use kanban_domain::{GraphOperations, KanbanError, KanbanResult, RelatesKind, Severity};
+use kanban_domain::{
+    BlocksEdge, GraphOperations, KanbanError, KanbanResult, RelatesEdge, RelatesKind, Severity,
+    SpawnsEdge,
+};
+use std::collections::HashSet;
 use uuid::Uuid;
+
+/// The dependency edges whose BOTH endpoints belong to a single board's cards
+/// (live + archived). The global [`kanban_domain::DependencyGraph`] is keyed on
+/// card id with no board dimension, so board-scoping is the caller's concern
+/// (see `GraphOperations::list_parents_of`); this bundle is that scoped view,
+/// used to render an archived board's relations without leaking cross-board
+/// edges (C10a).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BoardRelations {
+    pub spawns: Vec<SpawnsEdge>,
+    pub blocks: Vec<BlocksEdge>,
+    pub relates: Vec<RelatesEdge>,
+}
+
+impl KanbanContext {
+    /// All dependency edges internal to `board_id` (both endpoints among the
+    /// board's live or archived cards). Works for a live OR an archived board.
+    pub fn list_relations_for_board(&self, board_id: Uuid) -> KanbanResult<BoardRelations> {
+        let col_ids: Vec<Uuid> = self
+            .backend
+            .list_columns_by_board(board_id)?
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        let mut members: HashSet<Uuid> = self
+            .backend
+            .list_cards_by_columns(&col_ids)?
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        members.extend(
+            self.backend
+                .list_archived_cards_by_board(board_id)?
+                .iter()
+                .map(|ac| ac.entity.id),
+        );
+
+        let internal = |s: Uuid, t: Uuid| members.contains(&s) && members.contains(&t);
+        let graph = self.backend.get_graph()?;
+        Ok(BoardRelations {
+            spawns: graph
+                .spawns_edges()
+                .iter()
+                .filter(|e| internal(e.base.source, e.base.target))
+                .cloned()
+                .collect(),
+            blocks: graph
+                .blocks_edges()
+                .iter()
+                .filter(|e| internal(e.base.source, e.base.target))
+                .cloned()
+                .collect(),
+            relates: graph
+                .relates_edges()
+                .iter()
+                .filter(|e| internal(e.base.source, e.base.target))
+                .cloned()
+                .collect(),
+        })
+    }
+}
 
 impl KanbanContext {
     /// Reject edge mutations against unknown card ids before the

--- a/crates/kanban-service/src/context/graph.rs
+++ b/crates/kanban-service/src/context/graph.rs
@@ -10,12 +10,14 @@ use kanban_domain::{
 use std::collections::HashSet;
 use uuid::Uuid;
 
-/// The dependency edges whose BOTH endpoints belong to a single board's cards
-/// (live + archived). The global [`kanban_domain::DependencyGraph`] is keyed on
-/// card id with no board dimension, so board-scoping is the caller's concern
-/// (see `GraphOperations::list_parents_of`); this bundle is that scoped view,
-/// used to render an archived board's relations without leaking cross-board
-/// edges (C10a).
+/// The ACTIVE dependency edges whose BOTH endpoints belong to a single board's
+/// cards (live + archived). The global [`kanban_domain::DependencyGraph`] is
+/// keyed on card id with no board dimension, so board-scoping is the caller's
+/// concern (see `GraphOperations::list_parents_of`); this bundle is that scoped
+/// view, used to render a board's relations without leaking cross-board edges
+/// (C10a). Tombstoned edges (soft-deleted by an incident card's archival) are
+/// excluded, matching every other user-facing graph read
+/// (`children`/`related`/`blocked` all traverse active edges only).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct BoardRelations {
     pub spawns: Vec<SpawnsEdge>,
@@ -52,19 +54,19 @@ impl KanbanContext {
             spawns: graph
                 .spawns_edges()
                 .iter()
-                .filter(|e| internal(e.base.source, e.base.target))
+                .filter(|e| e.base.archived_at.is_none() && internal(e.base.source, e.base.target))
                 .cloned()
                 .collect(),
             blocks: graph
                 .blocks_edges()
                 .iter()
-                .filter(|e| internal(e.base.source, e.base.target))
+                .filter(|e| e.base.archived_at.is_none() && internal(e.base.source, e.base.target))
                 .cloned()
                 .collect(),
             relates: graph
                 .relates_edges()
                 .iter()
-                .filter(|e| internal(e.base.source, e.base.target))
+                .filter(|e| e.base.archived_at.is_none() && internal(e.base.source, e.base.target))
                 .cloned()
                 .collect(),
         })

--- a/crates/kanban-service/src/context/graph.rs
+++ b/crates/kanban-service/src/context/graph.rs
@@ -1,4 +1,5 @@
 use super::KanbanContext;
+use kanban_core::graph::Edge;
 use kanban_domain::commands::{
     AddBlocks, AddRelates, AddSpawns, Command, DependencyCommand, RemoveBlocks, RemoveRelates,
     RemoveSpawns,
@@ -9,6 +10,19 @@ use kanban_domain::{
 };
 use std::collections::HashSet;
 use uuid::Uuid;
+
+/// Active edges (not tombstoned) whose BOTH endpoints are in `members`.
+/// Shared by the three edge kinds so the scope+liveness predicate lives once.
+fn scoped_active_edges<E>(edges: &[E], members: &HashSet<Uuid>) -> Vec<E>
+where
+    E: Edge<NodeId = Uuid> + Clone,
+{
+    edges
+        .iter()
+        .filter(|e| e.is_active() && members.contains(&e.source()) && members.contains(&e.target()))
+        .cloned()
+        .collect()
+}
 
 /// The ACTIVE dependency edges whose BOTH endpoints belong to a single board's
 /// cards (live + archived). The global [`kanban_domain::DependencyGraph`] is
@@ -41,6 +55,11 @@ impl KanbanContext {
             .iter()
             .map(|c| c.id)
             .collect();
+        // Include the board's archived cards so `members` is "all cards of the
+        // board", independent of the archival model. They never actually admit
+        // an edge here (archiving a card tombstones its incident edges, and you
+        // cannot add an edge to an already-archived card), but scoping to the
+        // full card set keeps this read correct if that invariant ever changes.
         members.extend(
             self.backend
                 .list_archived_cards_by_board(board_id)?
@@ -48,27 +67,11 @@ impl KanbanContext {
                 .map(|ac| ac.entity.id),
         );
 
-        let internal = |s: Uuid, t: Uuid| members.contains(&s) && members.contains(&t);
         let graph = self.backend.get_graph()?;
         Ok(BoardRelations {
-            spawns: graph
-                .spawns_edges()
-                .iter()
-                .filter(|e| e.base.archived_at.is_none() && internal(e.base.source, e.base.target))
-                .cloned()
-                .collect(),
-            blocks: graph
-                .blocks_edges()
-                .iter()
-                .filter(|e| e.base.archived_at.is_none() && internal(e.base.source, e.base.target))
-                .cloned()
-                .collect(),
-            relates: graph
-                .relates_edges()
-                .iter()
-                .filter(|e| e.base.archived_at.is_none() && internal(e.base.source, e.base.target))
-                .cloned()
-                .collect(),
+            spawns: scoped_active_edges(graph.spawns_edges(), &members),
+            blocks: scoped_active_edges(graph.blocks_edges(), &members),
+            relates: scoped_active_edges(graph.relates_edges(), &members),
         })
     }
 }

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -19,6 +19,7 @@ pub use columns::ColumnCreateOutcome;
 mod core;
 mod filters;
 mod graph;
+pub use graph::BoardRelations;
 mod persistence;
 mod sprints;
 pub use sprints::SprintCreateOutcome;

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -25,8 +25,8 @@ pub mod undo_stack;
 pub use backend::KanbanBackend;
 pub use config::AppConfigDto;
 pub use context::{
-    BatchOperationFailure, BatchOperationResult, BoardCreateOutcome, CardCreateOutcome,
-    ColumnCreateOutcome, KanbanContext, SprintCreateOutcome,
+    BatchOperationFailure, BatchOperationResult, BoardCreateOutcome, BoardRelations,
+    CardCreateOutcome, ColumnCreateOutcome, KanbanContext, SprintCreateOutcome,
 };
 pub use path::validate_path;
 pub use store_manager::StoreManager;

--- a/crates/kanban-service/tests/board_query_audit.rs
+++ b/crates/kanban-service/tests/board_query_audit.rs
@@ -2,7 +2,9 @@
 //! (list_cards, find-by-identifier, list_all_*, accessors, resolvers) but
 //! preserved on fidelity paths (snapshot, export).
 
-use kanban_domain::{CardListFilter, InMemoryStore, KanbanOperations, KanbanResult};
+use kanban_domain::{
+    CardListFilter, GraphOperations, InMemoryStore, KanbanOperations, KanbanResult, RelatesKind,
+};
 use kanban_service::{AppConfig, KanbanContext};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -81,6 +83,40 @@ async fn test_snapshot_and_export_still_carry_archived_board_subtree() -> Kanban
         "snapshot must preserve the archived board's card"
     );
     assert_eq!(snap.archived_boards.len(), 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_relations_for_board_keeps_internal_edges_drops_cross_board() -> KanbanResult<()>
+{
+    // C10a: an archived board's relations view must show edges internal to the
+    // board and MUST NOT leak a cross-board edge (the global graph is card-keyed
+    // with no board dimension, so scoping is this read's job).
+    let mut c = ctx().await;
+    let a = c.create_board("A".into(), None)?;
+    let a_col = c.create_column(a.id, "Todo".into(), None)?;
+    let a1 = c.create_card(a.id, a_col.id, "a1".into(), Default::default())?;
+    let a2 = c.create_card(a.id, a_col.id, "a2".into(), Default::default())?;
+    let b = c.create_board("B".into(), None)?;
+    let b_col = c.create_column(b.id, "Todo".into(), None)?;
+    let b1 = c.create_card(b.id, b_col.id, "b1".into(), Default::default())?;
+
+    c.attach_children(a1.id, vec![a2.id])?; // internal spawns a1 -> a2
+    c.relate(a1.id, b1.id, RelatesKind::default())?; // cross-board relate a1 <-> b1
+    c.archive_board(a.id)?;
+
+    let rel = c.list_relations_for_board(a.id)?;
+    assert!(
+        rel.spawns
+            .iter()
+            .any(|e| e.base.source == a1.id && e.base.target == a2.id),
+        "internal spawns edge is present for the archived board"
+    );
+    assert!(
+        rel.relates.is_empty(),
+        "cross-board relate must be excluded (b1 is not in board A)"
+    );
+    assert!(rel.blocks.is_empty());
     Ok(())
 }
 

--- a/crates/kanban-service/tests/board_query_audit.rs
+++ b/crates/kanban-service/tests/board_query_audit.rs
@@ -121,6 +121,28 @@ async fn test_list_relations_for_board_keeps_internal_edges_drops_cross_board() 
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_list_relations_for_board_excludes_tombstoned_edges() -> KanbanResult<()> {
+    // C10a: the relations view is a USER-FACING read and must return ACTIVE
+    // edges only, like children()/related()/blocked(). Archiving a card
+    // soft-deletes (tombstones) its incident edges; those must not resurface.
+    let mut c = ctx().await;
+    let a = c.create_board("A".into(), None)?;
+    let a_col = c.create_column(a.id, "Todo".into(), None)?;
+    let a1 = c.create_card(a.id, a_col.id, "a1".into(), Default::default())?;
+    let a2 = c.create_card(a.id, a_col.id, "a2".into(), Default::default())?;
+
+    c.attach_children(a1.id, vec![a2.id])?; // spawns a1 -> a2 (active)
+    c.archive_card(a2.id)?; // tombstones the incident edge
+
+    let rel = c.list_relations_for_board(a.id)?;
+    assert!(
+        rel.spawns.is_empty(),
+        "a tombstoned spawns edge must not appear in the relations view"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_list_cards_scoped_to_archived_board_returns_its_cards() -> KanbanResult<()> {
     // C10a keystone: an UNSCOPED read hides archived-board cards (C3b), but an
     // EXPLICIT board_id filter is a deliberate scoped request ("show me this

--- a/crates/kanban-service/tests/board_query_audit.rs
+++ b/crates/kanban-service/tests/board_query_audit.rs
@@ -85,6 +85,34 @@ async fn test_snapshot_and_export_still_carry_archived_board_subtree() -> Kanban
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_scoped_to_archived_board_returns_its_cards() -> KanbanResult<()> {
+    // C10a keystone: an UNSCOPED read hides archived-board cards (C3b), but an
+    // EXPLICIT board_id filter is a deliberate scoped request ("show me this
+    // board") and must honor the board whether it is live or archived.
+    let mut c = ctx().await;
+    let (a, a_card, b_card) = seed(&mut c)?;
+
+    let scoped = c.list_cards(CardListFilter {
+        board_id: Some(a),
+        ..Default::default()
+    })?;
+    assert!(
+        scoped.iter().any(|s| s.id == a_card),
+        "scoping to an archived board must return its cards"
+    );
+    assert!(
+        !scoped.iter().any(|s| s.id == b_card),
+        "scoping to board A must not leak board B's card"
+    );
+
+    // C3b invariant preserved: the UNSCOPED list still hides the archived card.
+    let unscoped = c.list_cards(CardListFilter::default())?;
+    assert!(!unscoped.iter().any(|s| s.id == a_card));
+    assert!(unscoped.iter().any(|s| s.id == b_card));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_restore_board_returns_cards_to_live_views() -> KanbanResult<()> {
     let mut c = ctx().await;
     let (a, a_card, _b) = seed(&mut c)?;


### PR DESCRIPTION
## What & why

An archived board could not have its contents queried, even though every row stays in the flat collections after archive. Investigation traced this to the service tier, not the data: most board-scoped reads already worked for an archived board, and only one path refused.

This is the C10a service-layer slice (KAN-861) of the board-archive epic (SE-C). It makes the service fully support viewing an archived board's constituents. No persistence, schema, or migration change.

## The two fixes

**1. Board-scoped card reads honor an archived board.** `filter_cards` started its base set from the workspace-wide live list (which excludes every archived board by C3b) and then narrowed by `board_id`, so an explicit filter for an archived board intersected an already-emptied set and returned nothing. It now bases the scoped branch on the requested board's own columns and cards (raw), resolving the board head from the archived collection when it is not live. The unscoped read stays live-scoped, so C3b's cross-board hiding is unchanged. This also drops the waste of computing the whole live set just to discard most of it on every board-scoped query.

**2. `list_relations_for_board`.** The dependency graph is workspace-global and keyed on card id with no board dimension, so an archived board's relations view needs an explicit scope. The new read builds the board's card set (live + archived) and returns only the spawns/blocks/relates edges whose both endpoints are inside it, as a `BoardRelations` bundle. Surfaces forward it as they consume it.

## Why the other constituents needed no change

`list_columns(board_id)`, `list_sprints(board_id)`, `list_archived_cards_by_board`, and `get_archived_board` were already raw/board-scoped and already returned an archived board's data.

## Tests (TDD)

- `test_list_cards_scoped_to_archived_board_returns_its_cards` — scoping to an archived board returns its cards; the unscoped list still hides them (C3b intact).
- `test_list_relations_for_board_keeps_internal_edges_drops_cross_board` — internal edge kept, cross-board relate excluded (verified red before the filter).
- Full `kanban-service` suite green; clippy `-D warnings` and fmt clean.

## Follow-ups (separate slices on KAN-861)

- C10b (CLI) `board show-archived`, C10c (MCP) `tool_view_archived_board`, C10d (TUI) read-only archived-board detail.