### PR TITLE
KAN-863 fix(persistence-sqlite): board restore data-loss — restore no longer cascades the subtree away

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,16 @@ cargo tarpaulin        # Code coverage
 
 **Coverage:** Use `cargo tarpaulin` to verify no untested paths exist. 100% line coverage is the floor, not the goal — every assertion must verify observable behavior or an invariant, not just execute a code path.
 
+**Full-graph, all-backend coverage (mandatory before implementation):**
+
+Red tests written before the implementation must prove the behavior for the *entire* entity graph on *every* backend — not a representative entity on one backend. This is a hard requirement, not aspirational: the gaps below are exactly how a silent SQLite data-loss bug shipped (KAN-863 — restoring an archived board cascaded its whole subtree away — while a green in-memory suite gave false confidence).
+
+- **Every backend, not just in-memory.** Any operation whose persistence semantics can differ by backend — anything touching relational cascades (`ON DELETE CASCADE`), foreign keys, marker/join tables, or migrations — MUST have a red test against `SqliteStore` (and the JSON backend) too. In-memory maps do not model FK cascade, so a green in-memory test is necessary but never sufficient. When a `DataStore` method is overridden per backend, each override earns its own test; prefer extending the shared contract tests (`kanban-service/src/test_helpers/contract`) so all backends are held to one spec.
+- **Assert the whole graph, not the root.** For any operation on an entity that OWNS a subtree (board → columns → cards; board → sprints; card → sprint logs) — and for the dependency edges among a board's cards, which live in the workspace-global graph keyed on card id rather than being FK-owned — asserting the root returned to a collection (e.g. `boards().len() == 1`) does NOT prove its contents survived. "The container came back" is not "the container's contents came back." Seed a NON-TRIVIAL graph (≥1 column, card, sprint, and a dependency edge) and assert every owned-or-referenced entity type is present/absent as expected.
+- **Reversibility is an identity invariant.** `archive`↔`restore` and `delete`↔`undo` must be the identity over the FULL entity graph. Every reversible operation gets a round-trip test per backend: seed graph → forward → assert hidden/removed → inverse → assert the ENTIRE graph is back (ids, positions, WIP limits, sprint bindings, edges), reloading from disk where the backend persists.
+- **Enumerate every entity the change can touch.** Before writing code, list each entity type the operation reads or writes — the entity itself plus everything it owns or references — and write a red assertion for each. A test that covers `columns` but not `cards`/`sprints`/`edges` is under-specified; enrich it before implementing.
+- **New primitives get a semantic floor, not a token test.** When a change adds a `DataStore` method with a per-backend default (e.g. a marker-only vs row-deleting split), the red suite must pin the SEMANTIC difference on the backend that diverges — a default that delegates to the wrong sibling is a silent data-loss footgun, so test the override, not just the default.
+
 **Refactoring for testability:** If a function cannot be tested in isolation, refactor before writing tests:
 - Extract logic from handlers/renderers into pure functions
 - Introduce trait abstractions for dependencies (e.g. I/O, time)

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -426,12 +426,14 @@ impl RestoreBoard {
             .store
             .get_archived_board(self.board_id)?
             .ok_or_else(|| KanbanError::not_found("archived board", self.board_id))?;
-        // Order matters for a marker-style backend (SQLite): the board row is
-        // SHARED, and `delete_archived_board` removes the marker AND the row.
-        // Remove the archived record FIRST, then re-insert the board as live —
-        // mirroring `RestoreCard`. (On the in-memory move-model the two touch
-        // separate maps, so this order is also correct there.)
-        context.store.delete_archived_board(self.board_id)?;
+        // Unarchive (drop the archived marker) then re-insert the board as live.
+        // Use `unarchive_board`, NOT `delete_archived_board`: on a shared-row
+        // backend (SQLite) the latter deletes the entity ROW and would CASCADE
+        // the still-present subtree away (KAN-863). `unarchive_board` keeps the
+        // row + subtree; the upsert then refreshes the live head. (On the
+        // in-memory move-model both touch only the archived map, so this is also
+        // correct there.)
+        context.store.unarchive_board(self.board_id)?;
         context.store.upsert_board(archived.into_entity())?;
         Ok(())
     }

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -120,6 +120,19 @@ pub trait DataStore: Send + Sync {
         Ok(())
     }
 
+    /// Remove a board from the archived collection while KEEPING its shared
+    /// entity row and subtree (the RESTORE path). The default delegates to
+    /// [`delete_archived_board`](Self::delete_archived_board), which is correct
+    /// for map-style backends (in-memory/JSON) whose `delete_archived_board`
+    /// only drops the head from the archived map and never touches the subtree.
+    /// A shared-row backend (SQLite), whose `delete_archived_board` deletes the
+    /// entity row (needed for permanent delete), MUST override this to drop only
+    /// the archived marker — otherwise `RestoreBoard` (delete-archived then
+    /// upsert-head) would CASCADE the still-present subtree away (KAN-863).
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.delete_archived_board(board_id)
+    }
+
     // Sprint
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>>;
     fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>>;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -408,6 +408,21 @@ impl DataStore for SqliteStore {
         })
     }
 
+    /// RESTORE path: drop only the archived MARKER, leaving the shared board row
+    /// and its subtree intact. `delete_archived_board` above deletes the row
+    /// (cascading the subtree) which is right for permanent delete but would
+    /// destroy the subtree on restore (KAN-863). No-op on a live board.
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        run(async {
+            sqlx::query("DELETE FROM board_archival WHERE board_id = ?")
+                .bind(board_id.to_string())
+                .execute(&self.pool)
+                .await
+                .map_err(db_err)?;
+            Ok(())
+        })
+    }
+
     /// Board-scoped archived cards. Overrides the trait default (which filters
     /// the full list) with a direct `WHERE board_id = ?` on the extension table,
     /// so board scoping is a single indexed query.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use super::super::SqliteStore;
 use super::make_rt;
 use super::migration_v2_to_v3::seed_v2_db;
-use kanban_domain::{Archived, Board, DataStore};
+use kanban_domain::{Archived, Board, Column, DataStore};
 
 #[test]
 fn test_archived_board_roundtrip_through_board_archival_table() {
@@ -43,6 +43,41 @@ fn test_archived_board_roundtrip_through_board_archival_table() {
         store.delete_archived_board(id).unwrap();
         assert!(store.list_archived_boards().unwrap().is_empty());
         assert!(store.get_board(id).unwrap().is_none());
+    });
+}
+
+#[test]
+fn test_unarchive_board_drops_marker_keeps_row_and_subtree() {
+    // KAN-863: RESTORE goes through unarchive_board, which must drop only the
+    // marker. Deleting the board row (as delete_archived_board does, for
+    // permanent delete) would CASCADE the subtree away.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("unarchive.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let board = Board::new("Proj", None::<String>);
+        let id = board.id;
+        store.upsert_board(board.clone()).unwrap();
+        let col = Column::new(id, "Todo", 0);
+        let col_id = col.id;
+        store.upsert_column(col).unwrap();
+        store.insert_archived_board(Archived::now(board)).unwrap();
+        assert!(store.list_boards().unwrap().is_empty(), "archived: hidden");
+
+        store.unarchive_board(id).unwrap();
+
+        assert!(
+            store.list_archived_boards().unwrap().is_empty(),
+            "marker removed"
+        );
+        assert!(
+            store.get_board(id).unwrap().is_some(),
+            "board row survived and is live again"
+        );
+        let cols = store.list_columns_by_board(id).unwrap();
+        assert_eq!(cols.len(), 1, "subtree survived unarchive");
+        assert_eq!(cols[0].id, col_id);
     });
 }
 

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -263,6 +263,9 @@ impl DataStore for JsonDataStore {
     fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
         self.with_mutate(|s| s.delete_archived_board(board_id))
     }
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.with_mutate(|s| s.unarchive_board(board_id))
+    }
     fn clear_sprint_from_archived_cards(
         &self,
         sprint_id: Uuid,

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -137,6 +137,9 @@ impl DataStore for SqliteBackend {
     fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
         self.db.delete_archived_board(board_id)
     }
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.db.unarchive_board(board_id)
+    }
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
         self.db.list_archived_cards_by_board(board_id)
     }

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -80,6 +80,39 @@ async fn test_archive_undo_and_restore_return_board_to_live() -> KanbanResult<()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_restore_preserves_board_subtree() -> KanbanResult<()> {
+    // KAN-863: restoring an archived board on SQLite must NOT destroy its
+    // subtree. `delete_archived_board` used to DELETE the shared board row,
+    // and `columns/cards/sprints REFERENCES boards ON DELETE CASCADE` wiped the
+    // subtree; `RestoreBoard` then re-inserted only the head.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("restore_subtree.sqlite3");
+    let mut ctx = open(&path).await;
+
+    let b = ctx.create_board("Proj".into(), None)?;
+    let col = ctx.create_column(b.id, "Todo".into(), None)?;
+    let card = ctx.create_card(b.id, col.id, "Task".into(), Default::default())?;
+    let sprint = ctx.create_sprint(b.id, None, None)?;
+
+    ctx.archive_board(b.id)?;
+    ctx.restore_board(b.id)?;
+
+    assert_eq!(ctx.boards()?.len(), 1, "board head restored");
+    let cols = ctx.list_columns(b.id)?;
+    assert_eq!(cols.len(), 1, "column survived restore");
+    assert_eq!(cols[0].id, col.id);
+    assert!(
+        ctx.list_all_cards()?.iter().any(|c| c.id == card.id),
+        "card survived restore"
+    );
+    assert!(
+        ctx.list_sprints(b.id)?.iter().any(|s| s.id == sprint.id),
+        "sprint survived restore"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_delete_works_on_archived_board_and_undo_restores_as_archived() -> KanbanResult<()> {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("delete.sqlite3");

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -71,11 +71,17 @@ async fn test_archive_undo_and_restore_return_board_to_live() -> KanbanResult<()
     assert!(ctx.undo()?);
     assert_eq!(ctx.boards()?.len(), 1, "undo returned the board to live");
     assert!(ctx.list_archived_boards()?.is_empty());
+    // The subtree must survive undo-of-archive, not just the head (KAN-863).
+    assert_eq!(ctx.list_all_columns()?.len(), 1, "undo preserved the subtree");
+    assert_eq!(ctx.list_all_cards()?.len(), 1);
 
     ctx.archive_board(board_id)?;
     ctx.restore_board(board_id)?;
     assert_eq!(ctx.boards()?.len(), 1, "restore returned the board to live");
     assert!(ctx.list_archived_boards()?.is_empty());
+    // ...and survive an explicit restore too.
+    assert_eq!(ctx.list_all_columns()?.len(), 1, "restore preserved the subtree");
+    assert_eq!(ctx.list_all_cards()?.len(), 1);
     Ok(())
 }
 

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -72,7 +72,11 @@ async fn test_archive_undo_and_restore_return_board_to_live() -> KanbanResult<()
     assert_eq!(ctx.boards()?.len(), 1, "undo returned the board to live");
     assert!(ctx.list_archived_boards()?.is_empty());
     // The subtree must survive undo-of-archive, not just the head (KAN-863).
-    assert_eq!(ctx.list_all_columns()?.len(), 1, "undo preserved the subtree");
+    assert_eq!(
+        ctx.list_all_columns()?.len(),
+        1,
+        "undo preserved the subtree"
+    );
     assert_eq!(ctx.list_all_cards()?.len(), 1);
 
     ctx.archive_board(board_id)?;
@@ -80,7 +84,11 @@ async fn test_archive_undo_and_restore_return_board_to_live() -> KanbanResult<()
     assert_eq!(ctx.boards()?.len(), 1, "restore returned the board to live");
     assert!(ctx.list_archived_boards()?.is_empty());
     // ...and survive an explicit restore too.
-    assert_eq!(ctx.list_all_columns()?.len(), 1, "restore preserved the subtree");
+    assert_eq!(
+        ctx.list_all_columns()?.len(),
+        1,
+        "restore preserved the subtree"
+    );
     assert_eq!(ctx.list_all_cards()?.len(), 1);
     Ok(())
 }


### PR DESCRIPTION
## What & why

Archiving a board and then restoring it on the **SQLite** backend silently destroyed its entire subtree: all columns, cards, sprints, and dependency edges were lost, and only the board head came back. JSON and in-memory backends were unaffected. This is data loss in shipped code (the board-archive C5 slice), found while spiking the archived-board write-gate (KAN-862) through the real SQLite backend.

Reproduce (before this PR): create board → column → archive → restore → the column is gone.

## Root cause

`RestoreBoard::execute` did `delete_archived_board` then `upsert_board(head)`. On SQLite `delete_archived_board` deletes the shared board **row**, and `columns/cards/sprints ... REFERENCES boards(id) ON DELETE CASCADE` then wiped the subtree; re-upserting only restored the head. In-memory/JSON `delete_archived_board` touch only the archived map, so their restore was correct.

`delete_archived_board` cannot simply stop deleting the row: **permanent delete** of an archived board depends on it. `delete_board` is deliberately guarded to live-only (`AND NOT EXISTS (marker)`) so that `ArchiveBoards` can do insert-marker-then-delete-board as a no-op collection move. With that guard, the archived board's row is removed only by `delete_archived_board`.

## Fix

Give restore its own primitive: `DataStore::unarchive_board`.
- Default impl delegates to `delete_archived_board` (correct for the map-style in-memory/JSON stores, whose `delete_archived_board` already leaves the subtree in place).
- `SqliteStore` overrides it to drop **only** the archived marker, keeping the row and subtree.
- `RestoreBoard` calls `unarchive_board`; the service `SqliteBackend`/`JsonBackend` forward it.

`delete_archived_board` is unchanged, so permanent delete (which removes the subtree via explicit cascade commands first, then the head) still works.

## Tests (TDD, red first)

- `board_archive_sqlite::test_restore_preserves_board_subtree` — archive then restore, assert columns/cards/sprints survive (failed before the fix).
- `board_archival::test_unarchive_board_drops_marker_keeps_row_and_subtree` — store-level: marker gone, row + column survive.
- Existing SQLite restore test only asserted the head returned — that gap is why this shipped.
- Full kanban-domain (609), kanban-persistence-sqlite (74), and kanban-service suites green; clippy `-D warnings` + fmt clean.