### PR TITLE
KAN-862 feat(service): gate content mutations on archived boards — read-only shelf (C10-Foundation)

### DIFF
--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -140,6 +140,12 @@ pub enum DomainError {
     #[error("column {column_id} has reached its WIP limit of {limit}")]
     WipLimitExceeded { column_id: Uuid, limit: u32 },
 
+    /// Returned when a content mutation targets an archived board (or an entity
+    /// belonging to one). Archived boards are a read-only shelf; the client must
+    /// restore the board before editing its contents.
+    #[error("board {board_id} is archived; restore it before editing its contents")]
+    BoardArchived { board_id: Uuid },
+
     #[error(
         "sprint {sprint_id} belongs to board {sprint_board} but card is being created on board {card_board}"
     )]
@@ -291,6 +297,14 @@ impl KanbanError {
 
     pub fn validation(msg: impl Into<String>) -> Self {
         Self::Domain(DomainError::Validation(msg.into()))
+    }
+
+    pub fn board_archived(board_id: Uuid) -> Self {
+        Self::Domain(DomainError::BoardArchived { board_id })
+    }
+
+    pub fn is_board_archived(&self) -> bool {
+        matches!(self, KanbanError::Domain(DomainError::BoardArchived { .. }))
     }
 
     /// A backend method that has not been implemented yet. The shared affordance

--- a/crates/kanban-service/src/api/v1/error.rs
+++ b/crates/kanban-service/src/api/v1/error.rs
@@ -14,6 +14,7 @@ pub enum ErrorCode {
     Ambiguous,
     WipLimitExceeded,
     SprintBoardMismatch,
+    BoardArchived,
     ValidationFailed,
     BatchResolutionFailed,
     DependencyError,
@@ -38,6 +39,7 @@ impl std::fmt::Display for ErrorCode {
             Self::Ambiguous => "AMBIGUOUS",
             Self::WipLimitExceeded => "WIP_LIMIT_EXCEEDED",
             Self::SprintBoardMismatch => "SPRINT_BOARD_MISMATCH",
+            Self::BoardArchived => "BOARD_ARCHIVED",
             Self::ValidationFailed => "VALIDATION_FAILED",
             Self::BatchResolutionFailed => "BATCH_RESOLUTION_FAILED",
             Self::DependencyError => "DEPENDENCY_ERROR",
@@ -75,7 +77,8 @@ impl ErrorCode {
             | Self::UnsupportedVersion
             | Self::DependencyError
             | Self::CycleDetected
-            | Self::DuplicateEdge => 409,
+            | Self::DuplicateEdge
+            | Self::BoardArchived => 409,
             Self::IoError
             | Self::SerializationError
             | Self::DatabaseError

--- a/crates/kanban-service/src/api/v1/error_mapping.rs
+++ b/crates/kanban-service/src/api/v1/error_mapping.rs
@@ -31,6 +31,7 @@ impl From<&KanbanError> for ApiError {
                 },
                 DomainError::WipLimitExceeded { .. } => ErrorCode::WipLimitExceeded,
                 DomainError::SprintBoardMismatch { .. } => ErrorCode::SprintBoardMismatch,
+                DomainError::BoardArchived { .. } => ErrorCode::BoardArchived,
             },
             KanbanError::Io(_) => ErrorCode::IoError,
             KanbanError::Serialization(_) => ErrorCode::SerializationError,
@@ -53,6 +54,7 @@ impl From<&KanbanError> for ApiError {
             | ErrorCode::ValidationFailed
             | ErrorCode::WipLimitExceeded
             | ErrorCode::SprintBoardMismatch
+            | ErrorCode::BoardArchived
             | ErrorCode::DependencyError
             | ErrorCode::CycleDetected
             | ErrorCode::SelfReference

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -60,10 +60,18 @@ impl KanbanContext {
             return Err(KanbanError::already_exists("Card", id));
         }
 
-        let board = self
-            .backend
-            .get_board(board_id)?
-            .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
+        // The board must exist, but it may be archived: resolve from either
+        // collection so a create on an archived board reaches the read-only-shelf
+        // guard in `execute` (BoardArchived) instead of failing early with a
+        // misleading NotFound (KAN-862).
+        let board = match self.backend.get_board(board_id)? {
+            Some(b) => b,
+            None => self
+                .backend
+                .get_archived_board(board_id)?
+                .map(|ab| ab.entity)
+                .ok_or_else(|| KanbanError::not_found("Board", board_id))?,
+        };
         let card_number = board.card_counter;
         let position = self.backend.list_cards_by_column(spec.column_id)?.len() as i32;
 

--- a/crates/kanban-service/src/context/gate.rs
+++ b/crates/kanban-service/src/context/gate.rs
@@ -1,0 +1,169 @@
+use super::KanbanContext;
+use kanban_domain::commands::{
+    BoardCommand, CardCommand, ColumnCommand, Command, DependencyCommand, SprintCommand,
+};
+use kanban_domain::{KanbanError, KanbanResult};
+use std::collections::HashSet;
+use uuid::Uuid;
+
+impl KanbanContext {
+    /// Read-only-shelf guard (KAN-862): reject a batch that mutates content on an
+    /// ARCHIVED board. Runs BEFORE the transaction so nothing is written.
+    /// Lifecycle (archive/restore/delete-board) and internal/synthetic commands
+    /// resolve to no gated board and pass through.
+    pub(super) fn reject_content_mutation_on_archived_board(
+        &self,
+        commands: &[Command],
+    ) -> KanbanResult<()> {
+        let archived: HashSet<Uuid> = self
+            .backend
+            .list_archived_boards()?
+            .iter()
+            .map(|ab| ab.entity.id)
+            .collect();
+        if archived.is_empty() {
+            return Ok(());
+        }
+        for cmd in commands {
+            for board_id in self.content_target_boards(cmd)? {
+                if archived.contains(&board_id) {
+                    return Err(KanbanError::board_archived(board_id));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// A `Card` is column-scoped, not board-scoped: hop card -> column -> board.
+    fn board_of_card(&self, id: Uuid) -> KanbanResult<Option<Uuid>> {
+        match self.backend.get_card(id)? {
+            Some(card) => self.board_of_column(card.column_id),
+            None => Ok(None),
+        }
+    }
+    fn board_of_column(&self, id: Uuid) -> KanbanResult<Option<Uuid>> {
+        Ok(self.backend.get_column(id)?.map(|c| c.board_id))
+    }
+    fn board_of_sprint(&self, id: Uuid) -> KanbanResult<Option<Uuid>> {
+        Ok(self.backend.get_sprint(id)?.map(|s| s.board_id))
+    }
+
+    fn push_board_of_card(&self, id: Uuid, out: &mut Vec<Uuid>) -> KanbanResult<()> {
+        if let Some(b) = self.board_of_card(id)? {
+            out.push(b);
+        }
+        Ok(())
+    }
+    fn push_board_of_column(&self, id: Uuid, out: &mut Vec<Uuid>) -> KanbanResult<()> {
+        if let Some(b) = self.board_of_column(id)? {
+            out.push(b);
+        }
+        Ok(())
+    }
+    fn push_board_of_sprint(&self, id: Uuid, out: &mut Vec<Uuid>) -> KanbanResult<()> {
+        if let Some(b) = self.board_of_sprint(id)? {
+            out.push(b);
+        }
+        Ok(())
+    }
+
+    /// The board(s) a CONTENT mutation writes to. Empty for lifecycle/internal
+    /// commands and for creating a brand-new board. Exhaustive match — a new
+    /// command variant must declare its class here (fail-closed).
+    fn content_target_boards(&self, cmd: &Command) -> KanbanResult<Vec<Uuid>> {
+        let mut boards: Vec<Uuid> = Vec::new();
+        match cmd {
+            Command::Board(b) => match b {
+                BoardCommand::Update(c) => boards.push(c.board_id),
+                BoardCommand::SetTaskSort(c) => boards.push(c.board_id),
+                BoardCommand::SetTaskListView(c) => boards.push(c.board_id),
+                BoardCommand::ApplySettings(c) => boards.push(c.board_id),
+                // lifecycle + internal + create-of-new-board (not yet archived):
+                BoardCommand::Create(_)
+                | BoardCommand::Delete(_)
+                | BoardCommand::Archive(_)
+                | BoardCommand::Restore(_)
+                | BoardCommand::Import(_)
+                | BoardCommand::RestoreSprintPool(_) => {}
+            },
+            Command::Column(c) => match c {
+                ColumnCommand::Create(cc) => boards.push(cc.board_id),
+                ColumnCommand::Update(cc) => {
+                    self.push_board_of_column(cc.column_id, &mut boards)?
+                }
+                ColumnCommand::Delete(cc) => {
+                    self.push_board_of_column(cc.column_id, &mut boards)?
+                }
+            },
+            Command::Card(c) => match c {
+                CardCommand::Create(cc) => boards.push(cc.board_id),
+                CardCommand::Update(cc) => self.push_board_of_card(cc.card_id, &mut boards)?,
+                CardCommand::Move(cc) => {
+                    self.push_board_of_card(cc.card_id, &mut boards)?;
+                    self.push_board_of_column(cc.new_column_id, &mut boards)?;
+                }
+                CardCommand::Delete(cc) => self.push_board_of_card(cc.card_id, &mut boards)?,
+                CardCommand::Archive(cc) => {
+                    for id in &cc.ids {
+                        self.push_board_of_card(*id, &mut boards)?;
+                    }
+                }
+                CardCommand::AssignToSprint(cc) => {
+                    for id in &cc.ids {
+                        self.push_board_of_card(*id, &mut boards)?;
+                    }
+                }
+                CardCommand::UnassignFromSprint(cc) => {
+                    self.push_board_of_card(cc.card_id, &mut boards)?
+                }
+                CardCommand::ApplyMetadata(cc) => {
+                    self.push_board_of_card(cc.card_id, &mut boards)?
+                }
+                CardCommand::CompactPositions(cc) => {
+                    self.push_board_of_column(cc.column_id, &mut boards)?
+                }
+                CardCommand::Restore(cc) => self.push_board_of_card(cc.card_id, &mut boards)?,
+                // internal/synthetic:
+                CardCommand::RestoreSprintAttachment(_) => {}
+            },
+            Command::Sprint(s) => match s {
+                SprintCommand::Create(sc) => boards.push(sc.board_id),
+                SprintCommand::Update(sc) => {
+                    self.push_board_of_sprint(sc.sprint_id, &mut boards)?
+                }
+                SprintCommand::Activate(sc) => {
+                    self.push_board_of_sprint(sc.sprint_id, &mut boards)?
+                }
+                SprintCommand::Complete(sc) => {
+                    self.push_board_of_sprint(sc.sprint_id, &mut boards)?
+                }
+                SprintCommand::Cancel(sc) => {
+                    self.push_board_of_sprint(sc.sprint_id, &mut boards)?
+                }
+                SprintCommand::Delete(sc) => {
+                    self.push_board_of_sprint(sc.sprint_id, &mut boards)?
+                }
+            },
+            Command::Dependency(d) => {
+                let (s, t) = match d {
+                    DependencyCommand::AddSpawns(e) => (e.source, e.target),
+                    DependencyCommand::RemoveSpawns(e) => (e.source, e.target),
+                    DependencyCommand::AddBlocks(e) => (e.source, e.target),
+                    DependencyCommand::RemoveBlocks(e) => (e.source, e.target),
+                    DependencyCommand::AddRelates(e) => (e.source, e.target),
+                    DependencyCommand::RemoveRelates(e) => (e.source, e.target),
+                    // Creating a subcard writes to its board directly.
+                    DependencyCommand::CreateSubcard(sc) => {
+                        boards.push(sc.board_id);
+                        return Ok(boards);
+                    }
+                };
+                self.push_board_of_card(s, &mut boards)?;
+                self.push_board_of_card(t, &mut boards)?;
+            }
+            // Cascade commands are internal sub-steps of delete/undo flows.
+            Command::Cascade(_) => {}
+        }
+        Ok(boards)
+    }
+}

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -18,6 +18,7 @@ mod columns;
 pub use columns::ColumnCreateOutcome;
 mod core;
 mod filters;
+mod gate;
 mod graph;
 pub use graph::BoardRelations;
 mod persistence;

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -74,8 +74,13 @@ impl KanbanContext {
     ) -> KanbanResult<Sprint> {
         use kanban_domain::commands::CreateSprint;
 
-        // FK: the owning board must exist before we mint anything.
-        if self.backend.get_board(board_id)?.is_none() {
+        // FK: the owning board must exist before we mint anything. Accept an
+        // archived board too, so a create on one reaches the read-only-shelf
+        // guard in `execute` (BoardArchived) rather than a misleading NotFound
+        // (KAN-862).
+        if self.backend.get_board(board_id)?.is_none()
+            && self.backend.get_archived_board(board_id)?.is_none()
+        {
             return Err(KanbanError::not_found("Board", board_id));
         }
 

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -15,6 +15,7 @@ impl KanbanContext {
     /// per-command inverses in reverse order, so undoing each `Fk_inv`
     /// runs against the state `Fk` itself saw at capture time.
     pub fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<()> {
+        self.reject_content_mutation_on_archived_board(&commands)?;
         let backend = Arc::clone(&self.backend);
         let cmds = &commands;
         let mut per_cmd_inverses: Vec<Vec<Command>> = Vec::new();

--- a/crates/kanban-service/tests/archived_board_write_gate.rs
+++ b/crates/kanban-service/tests/archived_board_write_gate.rs
@@ -1,0 +1,204 @@
+//! C10-Foundation (KAN-862): an archived board is a READ-ONLY SHELF. Content
+//! mutations targeting an archived board (or an entity belonging to one) are
+//! rejected with `BoardArchived`; lifecycle ops (restore, permanent-delete) and
+//! reads stay allowed. Enforced once at the service `execute` seam so every
+//! surface inherits identical behavior.
+
+use kanban_domain::{
+    BoardUpdate, CardListFilter, ColumnUpdate, InMemoryStore, KanbanOperations, KanbanResult,
+};
+use kanban_service::{AppConfig, KanbanContext};
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn ctx() -> KanbanContext {
+    KanbanContext::open(Arc::new(InMemoryStore::new()), AppConfig::default())
+        .await
+        .unwrap()
+}
+
+/// Board with two columns and one card, then archived.
+/// Returns (board_id, col_a, col_b, card_id).
+fn seed_archived(c: &mut KanbanContext) -> KanbanResult<(Uuid, Uuid, Uuid, Uuid)> {
+    let b = c.create_board("Proj".into(), None)?;
+    let col_a = c.create_column(b.id, "Todo".into(), None)?;
+    let col_b = c.create_column(b.id, "Doing".into(), None)?;
+    let card = c.create_card(b.id, col_a.id, "task".into(), Default::default())?;
+    c.archive_board(b.id)?;
+    Ok((b.id, col_a.id, col_b.id, card.id))
+}
+
+// ── Rejected: content mutations on an archived board ───────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_card_on_archived_board_is_rejected() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (board, col_a, _col_b, _card) = seed_archived(&mut c)?;
+    let err = c
+        .create_card(board, col_a, "new".into(), Default::default())
+        .expect_err("create_card on an archived board must be rejected");
+    assert!(err.is_board_archived(), "got: {err}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_move_card_within_archived_board_is_rejected() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (_board, _col_a, col_b, card) = seed_archived(&mut c)?;
+    let err = c
+        .move_card(card, col_b, None)
+        .expect_err("moving a card in an archived board must be rejected");
+    assert!(err.is_board_archived(), "got: {err}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_column_on_archived_board_is_rejected() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (_board, col_a, _col_b, _card) = seed_archived(&mut c)?;
+    let err = c
+        .update_column(
+            col_a,
+            ColumnUpdate {
+                name: Some("Renamed".into()),
+                ..Default::default()
+            },
+        )
+        .expect_err("editing an archived board's column must be rejected");
+    assert!(err.is_board_archived(), "got: {err}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_board_settings_on_archived_board_is_rejected() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (board, _col_a, _col_b, _card) = seed_archived(&mut c)?;
+    let err = c
+        .update_board(
+            board,
+            BoardUpdate {
+                name: Some("Renamed".into()),
+                ..Default::default()
+            },
+        )
+        .expect_err("editing an archived board's settings must be rejected");
+    assert!(err.is_board_archived(), "got: {err}");
+    Ok(())
+}
+
+// ── Allowed: lifecycle ops + live boards + post-restore ────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_restore_archived_board_is_allowed() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (board, _col_a, _col_b, _card) = seed_archived(&mut c)?;
+    c.restore_board(board)?; // lifecycle op must NOT be gated
+    assert!(c.get_board(board)?.is_some(), "board is live again");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_permanent_delete_of_archived_board_is_allowed() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (board, _col_a, _col_b, _card) = seed_archived(&mut c)?;
+    c.delete_board(board)?; // permanent delete of an archived board is a lifecycle op
+    assert!(c.get_board(board)?.is_none());
+    assert!(c
+        .list_archived_boards()?
+        .iter()
+        .all(|ab| ab.entity.id != board));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_card_on_live_board_still_works() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let b = c.create_board("Live".into(), None)?;
+    let col = c.create_column(b.id, "Todo".into(), None)?;
+    let card = c.create_card(b.id, col.id, "task".into(), Default::default())?;
+    assert!(c.get_card(card.id)?.is_some());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_sprint_on_archived_board_is_rejected() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (board, _col_a, _col_b, _card) = seed_archived(&mut c)?;
+    let err = c
+        .create_sprint(board, None, None)
+        .expect_err("creating a sprint on an archived board must be rejected");
+    assert!(err.is_board_archived(), "got: {err}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mutation_after_restore_succeeds() -> KanbanResult<()> {
+    let mut c = ctx().await;
+    let (board, col_a, _col_b, _card) = seed_archived(&mut c)?;
+    c.restore_board(board)?;
+    // Now editable again.
+    let card = c.create_card(board, col_a, "new".into(), Default::default())?;
+    let listed = c.list_cards(CardListFilter {
+        board_id: Some(board),
+        ..Default::default()
+    })?;
+    assert!(listed.iter().any(|s| s.id == card.id));
+    Ok(())
+}
+
+// ── Through the real SQLite backend ────────────────────────────────────────
+// All-backend coverage (CLAUDE.md): the guard reads via the backend, and the
+// "editable after restore" case only reaches SQLite because KAN-863 fixed
+// restore to preserve the subtree.
+mod sqlite_gate {
+    use super::*;
+    use kanban_service::open_context;
+    use tempfile::TempDir;
+
+    async fn open_sqlite(path: &std::path::Path) -> KanbanContext {
+        open_context(path.to_str().unwrap(), AppConfig::default())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_write_gate_through_sqlite() -> KanbanResult<()> {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("gate.sqlite3");
+        let mut c = open_sqlite(&path).await;
+        let b = c.create_board("Proj".into(), None)?;
+        let col = c.create_column(b.id, "Todo".into(), None)?;
+        c.create_card(b.id, col.id, "task".into(), Default::default())?;
+        c.archive_board(b.id)?;
+
+        // Content mutations rejected with BoardArchived through SQLite.
+        assert!(c
+            .create_card(b.id, col.id, "new".into(), Default::default())
+            .expect_err("create rejected")
+            .is_board_archived());
+        assert!(c
+            .update_column(
+                col.id,
+                ColumnUpdate {
+                    name: Some("x".into()),
+                    ..Default::default()
+                }
+            )
+            .expect_err("update rejected")
+            .is_board_archived());
+
+        // Lifecycle allowed, then editable again after restore.
+        c.restore_board(b.id)?;
+        c.create_card(b.id, col.id, "after".into(), Default::default())?;
+        let listed = c.list_cards(CardListFilter {
+            board_id: Some(b.id),
+            ..Default::default()
+        })?;
+        assert_eq!(
+            listed.len(),
+            2,
+            "subtree preserved + editable after restore"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What & why

An archived board is a **read-only shelf** (DECIDED on the SE-C epic): it can be listed, viewed, restored, or permanently deleted, but its contents cannot be edited in place — to change it, restore it first. This is the enforcement (write-gate) half of the C10 read-only-shelf model; C10a (#388) was the read half. Without it, an archived board's content was silently mutable by UUID (the surfaces aren't shipped yet, so real exposure is ~0 — this lands the guard before they do).

Spiked in a throwaway worktree through both backends before implementing; that spike also uncovered and got the SQLite restore data-loss bug fixed first (KAN-863, #389).

## Approach — one seam, fail-closed

Enforced once at the command-execution seam (`KanbanContext::execute`) so every surface (TUI/CLI/MCP) inherits identical behavior — no per-operation scatter. Before the transaction, a guard resolves each command's target board(s) and rejects the batch with a new `BoardArchived` error if any is archived.

- The classifier is an **exhaustive match** over every `Command` variant — a new variant won't compile until it declares its class (fail-closed). Lifecycle (archive/restore/delete-board) and internal/synthetic commands resolve to no gated board and pass through.
- A `Card` is column-scoped, so `card -> board` hops through the column.
- New `DomainError::BoardArchived` (+ `is_board_archived()` predicate, `ErrorCode::BOARD_ARCHIVED`, HTTP 409, client-safe message).
- `create_card`/`create_sprint` resolve the owning board from the archived collection too, so a create on an archived board reaches the guard (`BoardArchived`) instead of failing early with a misleading `NotFound`.

## Tests (TDD, red first)

`crates/kanban-service/tests/archived_board_write_gate.rs` — content mutations (create card/sprint, move card, edit column, edit board settings) rejected with `BoardArchived`; lifecycle ops, live-board mutations, and post-restore edits allowed. Covered **in-memory and through the real SQLite backend** (per the new all-backend CLAUDE.md rule). Full kanban-service + kanban-domain suites green; clippy `-D warnings` + fmt clean; CLI/MCP/TUI build clean.

## Follow-ups

The read-only shelf is now enforced service-side. The surface slices (C10b CLI, C10c MCP, C10d TUI) expose the archived-board views on top; C7/C8/C6a add the archive lifecycle surfaces.