### PR TITLE
KAN-870 refactor(domain): archive cards by reference — card stays live, get_card unfiltered (F1)

### DIFF
--- a/crates/kanban-domain/src/in_memory_store/archived_cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_cards.rs
@@ -1,7 +1,25 @@
 use uuid::Uuid;
 
+use super::state::StoreState;
 use super::InMemoryStore;
+use crate::archival::Archived;
 use crate::{ArchivedCard, KanbanResult};
+
+/// F1 (KAN-870): reconstruct the archived-card VIEW from the LIVE card in `cards`
+/// plus the stored marker's context + metadata. The card is the single source of
+/// truth, so an archived read never returns a stale embedded copy (no drift).
+/// Falls back to the stored record if the live card is somehow absent (defensive).
+fn reconstruct(state: &StoreState, id: Uuid) -> Option<ArchivedCard> {
+    let stored = state.archived_cards.get(&id)?;
+    match state.cards.get(&id) {
+        Some(card) => Some(Archived::with_context(
+            card.clone(),
+            stored.context.clone(),
+            stored.metadata,
+        )),
+        None => Some(stored.clone()),
+    }
+}
 
 impl InMemoryStore {
     pub(super) fn get_archived_card_impl(
@@ -9,12 +27,16 @@ impl InMemoryStore {
         card_id: Uuid,
     ) -> KanbanResult<Option<ArchivedCard>> {
         let state = self.read_state()?;
-        Ok(state.archived_cards.get(&card_id).cloned())
+        Ok(reconstruct(&state, card_id))
     }
 
     pub(super) fn list_archived_cards_impl(&self) -> KanbanResult<Vec<ArchivedCard>> {
         let state = self.read_state()?;
-        let mut acs: Vec<ArchivedCard> = state.archived_cards.values().cloned().collect();
+        let mut acs: Vec<ArchivedCard> = state
+            .archived_cards
+            .keys()
+            .filter_map(|id| reconstruct(&state, *id))
+            .collect();
         acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
         Ok(acs)
     }
@@ -23,6 +45,13 @@ impl InMemoryStore {
         use crate::archival::ArchivedEntity;
         let mut state = self.write_state()?;
         let key = ac.entity_id();
+        // Reference model: the entity lives in `cards`. Ensure it's present —
+        // direct callers (e.g. a DeleteCard inverse re-import) may archive a card
+        // not yet in the live map — matching SqliteStore, which upserts the card
+        // row alongside the marker.
+        let column_id = ac.entity.column_id;
+        state.add_card_to_column_index(key, column_id);
+        state.cards.insert(key, ac.entity.clone());
         state.archived_cards.insert(key, ac);
         Ok(())
     }
@@ -32,11 +61,15 @@ impl InMemoryStore {
         board_id: Uuid,
     ) -> KanbanResult<Vec<ArchivedCard>> {
         let state = self.read_state()?;
-        let mut acs: Vec<ArchivedCard> = state
+        let ids: Vec<Uuid> = state
             .archived_cards
-            .values()
-            .filter(|ac| ac.context.board_id == board_id)
-            .cloned()
+            .iter()
+            .filter(|(_, ac)| ac.context.board_id == board_id)
+            .map(|(id, _)| *id)
+            .collect();
+        let mut acs: Vec<ArchivedCard> = ids
+            .iter()
+            .filter_map(|id| reconstruct(&state, *id))
             .collect();
         acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
         Ok(acs)
@@ -48,10 +81,14 @@ impl InMemoryStore {
         timestamp: chrono::DateTime<chrono::Utc>,
     ) -> KanbanResult<()> {
         let mut state = self.write_state()?;
-        for ac in state.archived_cards.values_mut() {
-            if ac.entity.sprint_id == Some(sprint_id) {
-                ac.entity.sprint_id = None;
-                ac.entity.updated_at = timestamp;
+        // Edit the LIVE card — an archived card is an ordinary editable card.
+        let ids: Vec<Uuid> = state.archived_cards.keys().copied().collect();
+        for id in ids {
+            if let Some(card) = state.cards.get_mut(&id) {
+                if card.sprint_id == Some(sprint_id) {
+                    card.sprint_id = None;
+                    card.updated_at = timestamp;
+                }
             }
         }
         Ok(())
@@ -59,6 +96,10 @@ impl InMemoryStore {
 
     pub(super) fn delete_archived_card_impl(&self, card_id: Uuid) -> KanbanResult<()> {
         let mut state = self.write_state()?;
+        // Permanent delete = remove the marker AND the card row (matches SqliteStore).
+        if let Some(card) = state.cards.remove(&card_id) {
+            state.remove_card_from_column_index(card_id, card.column_id);
+        }
         state.archived_cards.remove(&card_id);
         Ok(())
     }
@@ -218,5 +259,119 @@ mod tests {
         let found = store.list_archived_cards_by_board(board.id).unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].entity.id, card_id);
+    }
+}
+
+#[cfg(test)]
+mod f1_reference_tests {
+    //! F1 (KAN-870): the in-memory store archives cards BY REFERENCE — the card
+    //! stays in the live `cards` collection, a marker records archival, `get_card`
+    //! is unfiltered, live lists hide archived, and archived reads reconstruct
+    //! from the live card (no embedded/stale copy). Matches SqliteStore.
+    use super::*;
+    use crate::data_store::DataStore;
+    use crate::in_memory_store::test_support::{make_board, make_card, make_column};
+    use crate::{Board, Card, Column};
+
+    /// Archive a live card the way the ArchiveCards command does: insert the
+    /// marker, then delete_card (which F1 makes a guarded no-op on archived ids).
+    fn archive(store: &InMemoryStore, card: &Card, board_id: uuid::Uuid, col_id: uuid::Uuid) {
+        store
+            .insert_archived_card(ArchivedCard::new(
+                card.clone(),
+                board_id,
+                col_id,
+                card.position,
+            ))
+            .unwrap();
+        store.delete_card(card.id).unwrap();
+    }
+
+    fn seed() -> (InMemoryStore, Board, Column, Card) {
+        let store = InMemoryStore::new();
+        let mut board = make_board("B");
+        let col = make_column(board.id, "Todo", 0);
+        let card = make_card(&mut board, col.id, "Card", 0);
+        store.upsert_board(board.clone()).unwrap();
+        store.upsert_column(col.clone()).unwrap();
+        store.upsert_card(card.clone()).unwrap();
+        (store, board, col, card)
+    }
+
+    #[test]
+    fn test_archived_card_stays_live_and_get_card_is_unfiltered() {
+        let (store, board, col, card) = seed();
+        archive(&store, &card, board.id, col.id);
+        assert!(
+            store.get_card(card.id).unwrap().is_some(),
+            "reference model: get_card returns the archived card unfiltered"
+        );
+        assert!(
+            store.list_all_cards().unwrap().is_empty(),
+            "hidden from the live list"
+        );
+        assert!(store.list_cards_by_column(col.id).unwrap().is_empty());
+        assert!(store.get_archived_card(card.id).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_archived_read_reconstructs_from_live_no_drift() {
+        let (store, board, col, card) = seed();
+        archive(&store, &card, board.id, col.id);
+        let mut edited = store.get_card(card.id).unwrap().unwrap();
+        edited.title = "edited".into();
+        store.upsert_card(edited).unwrap();
+        let ac = store.get_archived_card(card.id).unwrap().unwrap();
+        assert_eq!(
+            ac.into_card().title,
+            "edited",
+            "archived read reconstructs from the LIVE card (no stale copy)"
+        );
+    }
+
+    #[test]
+    fn test_delete_card_is_guarded_noop_on_archived() {
+        let (store, board, col, card) = seed();
+        archive(&store, &card, board.id, col.id);
+        store.delete_card(card.id).unwrap();
+        assert!(
+            store.get_card(card.id).unwrap().is_some(),
+            "delete_card is a no-op on an archived card"
+        );
+        assert!(store.get_archived_card(card.id).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_delete_archived_card_removes_marker_and_card() {
+        let (store, board, col, card) = seed();
+        archive(&store, &card, board.id, col.id);
+        store.delete_archived_card(card.id).unwrap();
+        assert!(
+            store.get_card(card.id).unwrap().is_none(),
+            "permanent delete removes the card row too"
+        );
+        assert!(store.get_archived_card(card.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_clear_sprint_from_archived_edits_the_live_card() {
+        let store = InMemoryStore::new();
+        let mut board = make_board("B");
+        let col = make_column(board.id, "Todo", 0);
+        let mut card = make_card(&mut board, col.id, "Card", 0);
+        let sprint_id = uuid::Uuid::new_v4();
+        card.sprint_id = Some(sprint_id);
+        store.upsert_board(board.clone()).unwrap();
+        store.upsert_column(col.clone()).unwrap();
+        store.upsert_card(card.clone()).unwrap();
+        archive(&store, &card, board.id, col.id);
+        store
+            .clear_sprint_from_archived_cards(sprint_id, chrono::Utc::now())
+            .unwrap();
+        assert_eq!(
+            store.get_card(card.id).unwrap().unwrap().sprint_id,
+            None,
+            "clearing the sprint edits the LIVE card"
+        );
     }
 }

--- a/crates/kanban-domain/src/in_memory_store/cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/cards.rs
@@ -10,9 +10,16 @@ impl InMemoryStore {
         Ok(state.cards.get(&id).cloned())
     }
 
+    // F1 (KAN-870): live list/count reads exclude archived cards (which now stay
+    // in `cards` behind a marker). `get_card` stays unfiltered.
     pub(super) fn list_all_cards_impl(&self) -> KanbanResult<Vec<Card>> {
         let state = self.read_state()?;
-        let mut cards: Vec<Card> = state.cards.values().cloned().collect();
+        let mut cards: Vec<Card> = state
+            .cards
+            .values()
+            .filter(|c| !state.is_card_archived(&c.id))
+            .cloned()
+            .collect();
         sort_by_position(&mut cards);
         Ok(cards)
     }
@@ -24,6 +31,7 @@ impl InMemoryStore {
             .get(&column_id)
             .map(|ids| {
                 ids.iter()
+                    .filter(|id| !state.is_card_archived(id))
                     .filter_map(|id| state.cards.get(id).cloned())
                     .collect()
             })
@@ -37,7 +45,7 @@ impl InMemoryStore {
         let mut cards: Vec<Card> = state
             .cards
             .values()
-            .filter(|c| c.sprint_id == Some(sprint_id))
+            .filter(|c| c.sprint_id == Some(sprint_id) && !state.is_card_archived(&c.id))
             .cloned()
             .collect();
         sort_by_position(&mut cards);
@@ -49,7 +57,7 @@ impl InMemoryStore {
         Ok(state
             .cards_by_column
             .get(&column_id)
-            .map(|s| s.len())
+            .map(|ids| ids.iter().filter(|id| !state.is_card_archived(id)).count())
             .unwrap_or(0))
     }
 
@@ -62,7 +70,11 @@ impl InMemoryStore {
         let count = state
             .cards_by_column
             .get(&column_id)
-            .map(|ids| ids.iter().filter(|id| !exclude.contains(id)).count())
+            .map(|ids| {
+                ids.iter()
+                    .filter(|id| !exclude.contains(id) && !state.is_card_archived(id))
+                    .count()
+            })
             .unwrap_or(0);
         Ok(count)
     }
@@ -82,6 +94,13 @@ impl InMemoryStore {
 
     pub(super) fn delete_card_impl(&self, id: Uuid) -> KanbanResult<()> {
         let mut state = self.write_state()?;
+        // F1 (KAN-870): guarded — an archived card is removed only via
+        // `delete_archived_card` (marker + row). This lets the ArchiveCards
+        // command's insert-marker-then-delete-card leave the card live (matching
+        // SqliteStore's `NOT EXISTS(archived_cards)` delete guard).
+        if state.is_card_archived(&id) {
+            return Ok(());
+        }
         if let Some(card) = state.cards.remove(&id) {
             state.remove_card_from_column_index(id, card.column_id);
         }

--- a/crates/kanban-domain/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-domain/src/in_memory_store/snapshot.rs
@@ -12,10 +12,29 @@ impl InMemoryStore {
         let mut columns: Vec<_> = state.columns.values().cloned().collect();
         sort_by_position(&mut columns);
 
-        let mut cards: Vec<_> = state.cards.values().cloned().collect();
+        // F1 (KAN-870): `state.cards` now holds live AND archived cards. Snapshot
+        // `.cards` is LIVE only; `.archived_cards` reconstructs each entity from
+        // the live card + the stored marker (so no stale copy is serialized).
+        let mut cards: Vec<_> = state
+            .cards
+            .values()
+            .filter(|c| !state.is_card_archived(&c.id))
+            .cloned()
+            .collect();
         sort_by_position(&mut cards);
 
-        let mut archived_cards: Vec<_> = state.archived_cards.values().cloned().collect();
+        let mut archived_cards: Vec<crate::ArchivedCard> = state
+            .archived_cards
+            .iter()
+            .map(|(id, stored)| match state.cards.get(id) {
+                Some(card) => crate::archival::Archived::with_context(
+                    card.clone(),
+                    stored.context.clone(),
+                    stored.metadata,
+                ),
+                None => stored.clone(),
+            })
+            .collect();
         archived_cards.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
 
         let mut sprints: Vec<_> = state.sprints.values().cloned().collect();
@@ -40,13 +59,16 @@ impl InMemoryStore {
         let mut state = self.write_state()?;
         state.boards = snapshot.boards.into_iter().map(|b| (b.id, b)).collect();
         state.columns = snapshot.columns.into_iter().map(|c| (c.id, c)).collect();
+        // F1 (KAN-870): archived cards' entities live in `cards` too (reference
+        // model). Load live cards, then merge the archived entities in, and keep
+        // the archived records as markers.
         state.cards = snapshot.cards.into_iter().map(|c| (c.id, c)).collect();
+        let archived = snapshot.archived_cards;
+        for ac in &archived {
+            state.cards.insert(ac.entity.id, ac.entity.clone());
+        }
         state.rebuild_card_column_index();
-        state.archived_cards = snapshot
-            .archived_cards
-            .into_iter()
-            .map(|ac| (ac.entity.id, ac))
-            .collect();
+        state.archived_cards = archived.into_iter().map(|ac| (ac.entity.id, ac)).collect();
         state.archived_boards = snapshot
             .archived_boards
             .into_iter()

--- a/crates/kanban-domain/src/in_memory_store/state.rs
+++ b/crates/kanban-domain/src/in_memory_store/state.rs
@@ -38,6 +38,13 @@ impl StoreState {
         }
     }
 
+    /// F1 (KAN-870): a card is archived iff it has a marker in `archived_cards`.
+    /// The card itself stays in `cards` (reference model), so live reads must
+    /// consult this to hide archived cards, and `delete_card` no-ops on them.
+    pub(super) fn is_card_archived(&self, card_id: &Uuid) -> bool {
+        self.archived_cards.contains_key(card_id)
+    }
+
     pub(super) fn add_card_to_column_index(&mut self, card_id: Uuid, column_id: Uuid) {
         self.cards_by_column
             .entry(column_id)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -132,12 +132,15 @@ impl DataStore for SqliteStore {
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
         run(async {
             let id_str = id.to_string();
+            // F1 (KAN-870): get_card is UNFILTERED — an archived card stays in
+            // `cards` behind a marker and is reachable by id (it is an ordinary,
+            // editable card). The archived/live distinction is a LIST-level filter.
             let row = sqlx::query(
                 "SELECT id, column_id, title, description, priority, status, position,
                         due_date, points, card_number, sprint_id, created_at, updated_at,
                         completed_at
                  FROM cards
-                 WHERE id = ? AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
+                 WHERE id = ?",
             )
             .bind(&id_str)
             .fetch_optional(&self.pool)

--- a/crates/kanban-persistence-sqlite/tests/data_store.rs
+++ b/crates/kanban-persistence-sqlite/tests/data_store.rs
@@ -293,8 +293,9 @@ async fn test_sqlite_insert_and_get_archived_card() {
     assert_eq!(fetched.entity.id, card_id);
     assert_eq!(fetched.context.original_column_id, col.id);
 
-    // Archived card should NOT appear in active card queries
-    assert!(store.get_card(card_id).unwrap().is_none());
+    // F1 (KAN-870): get_card is UNFILTERED (the card stays live behind a marker);
+    // only the LIVE list excludes archived cards.
+    assert!(store.get_card(card_id).unwrap().is_some());
     assert!(store.list_all_cards().unwrap().is_empty());
 }
 

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -34,7 +34,20 @@ pub async fn test_archive_card_roundtrip(factory: &BackendFactory) {
     ctx.save().await.unwrap();
     let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
 
-    assert!(ctx.get_card(card.id).unwrap().is_none());
+    // F1 (KAN-870): `get_card` is UNFILTERED — an archived card stays live behind
+    // a marker and is reachable by id (it is an ordinary, editable card). It is
+    // only hidden from the LIVE list.
+    assert!(
+        ctx.get_card(card.id).unwrap().is_some(),
+        "get_card returns the archived card unfiltered"
+    );
+    assert!(
+        !ctx.list_all_cards()
+            .unwrap()
+            .iter()
+            .any(|c| c.id == card.id),
+        "archived card is hidden from the live list"
+    );
 
     let archived = ctx.list_archived_cards().unwrap();
     assert_eq!(archived.len(), 1);

--- a/crates/kanban-service/tests/create_card_from_spec.rs
+++ b/crates/kanban-service/tests/create_card_from_spec.rs
@@ -145,7 +145,13 @@ async fn test_create_card_with_duplicate_archived_id_returns_conflict() {
         err.is_already_exists(),
         "expected AlreadyExists conflict against an archived id, got: {err:?}"
     );
-    assert!(ctx.get_card(id).unwrap().is_none());
+    // F1 (KAN-870): get_card is unfiltered — the archived card is still present
+    // and unchanged (the failed collision create did not overwrite it).
+    let existing = ctx
+        .get_card(id)
+        .unwrap()
+        .expect("the archived card is still reachable by id");
+    assert_eq!(existing.title, "ToArchive");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What & why

First slice (F1, KAN-870) of the unified-archival refactor — root spec **KAN-864**. It makes the in-memory store archive cards **by reference** (matching the SQLite backend), so an archived card is an ordinary `Card` behind a marker rather than a moved/embedded copy. This is the keystone the spike validated.

## Changes

- **Archiving keeps the card in `cards`.** `delete_card` is guarded to no-op on an archived id, so the `ArchiveCards` command's insert-marker-then-delete leaves the card live — exactly how `SqliteStore`'s `NOT EXISTS` delete guard already works.
- **`get_card` is unfiltered on both backends** (removed SQLite's `NOT EXISTS(archived_cards)` on the point read). An archived card is reachable and editable by id; the archived/live distinction is a **list-level** filter (`list`/`count` exclude archived via a new `StoreState::is_card_archived`).
- **No drift.** Archived reads reconstruct the `ArchivedCard` view from the **live** card + the stored marker's context/metadata, so editing an archived card is reflected. `clear_sprint_from_archived_cards` edits the live card; `delete_archived_card` removes marker + row.
- **Snapshot** round-trips the reference model (live cards in `.cards`, reconstructed markers in `.archived_cards`; apply merges archived entities back into `cards`).

`Archived<T>` still carries `entity` (populated by reconstruct) so the **whole workspace keeps compiling** — collapsing it to a pure marker is F3b.

## Tests

Red-first tests pin the invariant: unfiltered `get_card`, no-drift reconstruct, guarded delete, permanent-delete removes marker+row. The shared archive contract and a SQLite unit test move off the old `get_card -> None` assertion to the new `get_card is_some` + hidden-from-live-list.

Green: kanban-domain (614), persistence-json (52), persistence-sqlite (74+21), kanban-service (74+103); cli/mcp/tui build clean; clippy `-D warnings` + fmt clean.

## Sequence
Per the locked build order on KAN-864: F1 → F2 → (D1∥D2) → F3b (collapse `Archived<T>`) → …