### PR TITLE
KAN-871 test(service): pin JSON seam round-trips the reference archival model (F2)

### DIFF
--- a/crates/kanban-persistence/src/snapshot_serde.rs
+++ b/crates/kanban-persistence/src/snapshot_serde.rs
@@ -33,6 +33,57 @@ mod tests {
         assert_eq!(restored.boards[0].name, "Test Board");
     }
 
+    /// F2 (KAN-871): a `Snapshot` produced by `InMemoryStore::snapshot()` with
+    /// one live and one archived card serializes the archived entity under
+    /// `archived_cards` ONLY. Guards the reference-model exclusion at the serde
+    /// seam: no card id may appear in both on-disk collections.
+    #[test]
+    fn test_snapshot_serde_excludes_archived_from_cards() {
+        use kanban_domain::{ArchivedCard, Card, DataStore, InMemoryStore};
+        use uuid::Uuid;
+
+        let store = InMemoryStore::new();
+        let mut board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let live = Card::new(&mut board, col_id, "Live", 0);
+        let archived = Card::new(&mut board, col_id, "Archived", 1);
+        let archived_id = archived.id;
+        store.upsert_card(live).unwrap();
+        store.upsert_card(archived.clone()).unwrap();
+        store
+            .insert_archived_card(ArchivedCard::new(archived, board.id, col_id, 1))
+            .unwrap();
+
+        let snapshot = store.snapshot().unwrap();
+        let bytes = snapshot_to_json_bytes(&snapshot).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(
+            value["cards"].as_array().unwrap().len(),
+            1,
+            "only the live card is serialized under cards"
+        );
+        assert_eq!(
+            value["archived_cards"].as_array().unwrap().len(),
+            1,
+            "the archived card is serialized under archived_cards"
+        );
+        let id_str = archived_id.to_string();
+        assert!(
+            value["cards"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|c| c["id"].as_str() != Some(id_str.as_str())),
+            "archived card id must not be duplicated under cards"
+        );
+        assert_eq!(
+            value["archived_cards"][0]["entity"]["id"].as_str(),
+            Some(id_str.as_str()),
+            "archived entity travels under archived_cards"
+        );
+    }
+
     #[test]
     fn test_snapshot_from_invalid_json_returns_error() {
         let result = snapshot_from_json_bytes(b"not json");

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -614,6 +614,129 @@ mod tests {
         assert!(jds.needs_flush(), "apply_snapshot must mark backend dirty");
     }
 
+    // ─── F2 (KAN-871): JSON file seam round-trips the reference archival model ──
+    //
+    // After F1 an archived card stays LIVE in `cards` behind a marker. These
+    // pin that the V9 on-disk shape carries the archived entity under
+    // `archived_cards` ONLY (never duplicated in `cards`), and that a
+    // save->load cycle re-establishes the reference model: the card is live
+    // (source of truth, reachable by id), hidden from the live list, and
+    // retrievable as archived. Whole-entity fidelity is asserted through
+    // `get_card` (the live entity IS the source of truth) so the tests stay
+    // correct through the F3b `Archived<T>` collapse.
+
+    /// Seed one live card and one archived card, flush, and inspect the raw
+    /// on-disk JSON: the archived card's id lives under `archived_cards.entity`
+    /// and MUST NOT also appear under `cards`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_archived_card_not_duplicated_in_ondisk_cards() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("arch_dedup.json");
+        let jds = make_store(&path);
+
+        let mut board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let live = Card::new(&mut board, col_id, "Live", 0);
+        let archived = Card::new(&mut board, col_id, "Archived", 1);
+        let archived_id = archived.id;
+        jds.upsert_card(live).unwrap();
+        jds.upsert_card(archived.clone()).unwrap();
+        jds.insert_archived_card(ArchivedCard::new(archived, board.id, col_id, 1))
+            .unwrap();
+        jds.flush().await.unwrap();
+
+        let on_disk: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        let cards = on_disk["data"]["cards"].as_array().unwrap();
+        let archived_cards = on_disk["data"]["archived_cards"].as_array().unwrap();
+        let id_str = archived_id.to_string();
+
+        assert!(
+            archived_cards
+                .iter()
+                .any(|a| a["entity"]["id"].as_str() == Some(id_str.as_str())),
+            "archived card entity must be serialized under archived_cards"
+        );
+        assert!(
+            cards
+                .iter()
+                .all(|c| c["id"].as_str() != Some(id_str.as_str())),
+            "archived card id must NOT be duplicated under on-disk cards"
+        );
+        assert_eq!(
+            cards.len(),
+            1,
+            "only the live card stays under on-disk cards"
+        );
+    }
+
+    /// Archive a card, flush, drop the store, reload: the card is live
+    /// (reachable by id), hidden from `list_all_cards`, and retrievable as
+    /// archived. This is the reference model re-established through the file.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_json_save_load_preserves_reference_archival() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ref_model.json");
+        let jds = make_store(&path);
+
+        let mut board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let card = Card::new(&mut board, col_id, "ToArchive", 0);
+        let card_id = card.id;
+        jds.upsert_card(card.clone()).unwrap();
+        jds.insert_archived_card(ArchivedCard::new(card, board.id, col_id, 0))
+            .unwrap();
+        jds.flush().await.unwrap();
+
+        let reader = make_store(&path);
+        let live = reader
+            .get_card(card_id)
+            .unwrap()
+            .expect("archived card stays live and reachable by id after reload");
+        assert_eq!(live.title, "ToArchive");
+        assert!(
+            reader
+                .list_all_cards()
+                .unwrap()
+                .iter()
+                .all(|c| c.id != card_id),
+            "archived card must be hidden from the live list after reload"
+        );
+        assert!(
+            reader.get_archived_card(card_id).unwrap().is_some(),
+            "archived card must be retrievable as archived after reload"
+        );
+    }
+
+    /// Every `Card` field survives the file round-trip losslessly. Read the
+    /// whole entity back through `get_card` (the live source of truth) so the
+    /// assertion holds after the F3b marker collapse.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_json_roundtrip_archived_card_whole_entity_stable() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("whole_entity.json");
+        let jds = make_store(&path);
+
+        let mut board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let mut card = Card::new(&mut board, col_id, "Full", 3);
+        card.description = Some("rich body".into());
+        card.priority = kanban_domain::CardPriority::High;
+        card.sprint_id = Some(Uuid::new_v4());
+        let original = card.clone();
+        jds.upsert_card(card.clone()).unwrap();
+        jds.insert_archived_card(ArchivedCard::new(card, board.id, col_id, 3))
+            .unwrap();
+        jds.flush().await.unwrap();
+
+        let reader = make_store(&path);
+        let reloaded = reader
+            .get_card(original.id)
+            .unwrap()
+            .expect("archived card is reachable as a live entity by id");
+        assert_eq!(reloaded, original, "no Card field may be lost or altered");
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_ensure_loaded_is_idempotent_under_concurrent_access() {
         use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};


### PR DESCRIPTION
## What

FOUND-F2 (KAN-871), Foundation area of the archival unification (root KAN-864). Pins that the JSON file seam round-trips the reference archival model landed in F1 (#391).

After F1 an archived card stays live in the `cards` collection behind a marker in `archived_cards`; visibility is a consumption-site filter. `JsonDataStore` is an `InMemoryStore` plus a serialize/deserialize seam, so it inherits that model for free. This card adds the tests that lock the on-disk contract.

## Tests

- `test_archived_card_not_duplicated_in_ondisk_cards` reads the raw on-disk JSON and asserts the archived card's id appears under `archived_cards[].entity` and never under `cards`.
- `test_json_save_load_preserves_reference_archival` flushes, drops the store, reloads, and asserts the archived card is live (reachable by id), hidden from `list_all_cards`, and retrievable as archived.
- `test_json_roundtrip_archived_card_whole_entity_stable` asserts every `Card` field survives the file round-trip losslessly.
- `test_snapshot_serde_excludes_archived_from_cards` asserts the `Snapshot` serialization excludes the archived card from `cards` while keeping it under `archived_cards`.

## Notes

- Test-only. No production code, no wire-format change: the V9 on-disk shape is unchanged (no field added or removed). The snapshot filter and decompose stay owned by F1 (`in_memory_store/snapshot.rs`), which is the shared-file coordination this card flagged.
- Whole-entity fidelity is read back through `get_card` (the live entity is the source of truth) rather than `get_archived_card().entity`, so these assertions remain correct through the later F3b `Archived<T>` marker collapse instead of adding new `.entity` consumers for F3b to migrate.
- Existing byte-stability and V7 to V8 backfill tests remain green.
