### PR TITLE
KAN-872 refactor(domain): archived-card sprint mutations edit the live card (F3a)

### DIFF
--- a/crates/kanban-domain/src/commands/cascade_commands.rs
+++ b/crates/kanban-domain/src/commands/cascade_commands.rs
@@ -244,11 +244,15 @@ pub struct SetArchivedCardsSprint {
 
 impl SetArchivedCardsSprint {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
+        // F3a (KAN-872): an archived card is an ordinary editable card, so
+        // re-attach the sprint by editing the LIVE card rather than the old
+        // delete-then-reinsert dance over the embedded `Archived::entity`. This
+        // drops a `.entity` consumer ahead of the F3b collapse and stops abusing
+        // the permanent-delete path as a transient step.
         for id in &self.archived_card_ids {
-            if let Some(mut ac) = context.store.get_archived_card(*id)? {
-                ac.entity.sprint_id = Some(self.sprint_id);
-                context.store.delete_archived_card(ac.entity.id)?;
-                context.store.insert_archived_card(ac)?;
+            if let Some(mut card) = context.store.get_card(*id)? {
+                card.sprint_id = Some(self.sprint_id);
+                context.store.upsert_card(card)?;
             }
         }
         Ok(())

--- a/crates/kanban-service/tests/archived_card_sprint_reattach_sqlite.rs
+++ b/crates/kanban-service/tests/archived_card_sprint_reattach_sqlite.rs
@@ -1,0 +1,138 @@
+//! F3a (KAN-872): both archived-card sprint mutation sites edit the LIVE card
+//! rather than the embedded `Archived::entity` copy or a destructive
+//! delete-then-reinsert dance. The re-route is behavior-preserving prep for the
+//! F3b `Archived<T>` collapse: it removes a `.entity` consumer and stops abusing
+//! the permanent-delete path (`delete_archived_card`) as a transient step.
+//!
+//! These run through the real SQLite backend on purpose. On SQLite
+//! `delete_archived_card` deletes the `cards` row (permanent delete); the old
+//! `SetArchivedCardsSprint` dance deleted then reinserted it. Dependency edges
+//! are workspace-global and NOT FK-owned by `cards`, so they orphan-survive a
+//! card-row delete rather than cascading — these guards pin that the re-routed
+//! command leaves the live card's sprint set, the marker intact, and the edges
+//! untouched on the backend whose delete semantics differ from in-memory.
+
+use kanban_domain::commands::{CommandContext, SetArchivedCardsSprint};
+use kanban_domain::{ArchivedCard, KanbanOperations, KanbanResult};
+use kanban_service::{open_context, AppConfig, KanbanContext};
+use tempfile::TempDir;
+
+async fn open(path: &std::path::Path) -> KanbanContext {
+    open_context(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap()
+}
+
+/// Re-attaching a sprint to an archived card (as `DeleteSprint` undo does) must
+/// edit the live card and leave its dependency edges intact.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_archived_cards_sprint_edits_live_card_and_preserves_edges() -> KanbanResult<()> {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("reattach.sqlite3");
+    let mut ctx = open(&path).await;
+
+    let board = ctx.create_board("Proj".into(), None)?;
+    let col = ctx.create_column(board.id, "Todo".into(), None)?;
+    let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+    let card_b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
+    let sprint = ctx.create_sprint(board.id, None, None)?;
+
+    let backend = ctx.backend();
+    let ds = backend.as_data_store();
+
+    // A blocks B — a workspace-global edge keyed on card id.
+    {
+        let mut graph = ds.get_graph()?;
+        graph.set_block(card_a.id, card_b.id)?;
+        ds.set_graph(graph)?;
+    }
+    assert!(
+        ds.get_graph()?.contains(card_a.id, card_b.id),
+        "edge A->B seeded"
+    );
+
+    // Archive card A (marker over the still-live card).
+    ds.insert_archived_card(ArchivedCard::new(
+        card_a.clone(),
+        board.id,
+        col.id,
+        card_a.position,
+    ))?;
+
+    // Re-attach the sprint (the synthetic inverse command under test).
+    let cmd = SetArchivedCardsSprint {
+        archived_card_ids: vec![card_a.id],
+        sprint_id: sprint.id,
+    };
+    cmd.execute(&CommandContext { store: ds })?;
+
+    // The LIVE card carries the sprint...
+    let live = ds
+        .get_card(card_a.id)?
+        .expect("archived card A is still live and reachable by id");
+    assert_eq!(
+        live.sprint_id,
+        Some(sprint.id),
+        "the live card must carry the re-attached sprint"
+    );
+    // ...the marker is untouched...
+    assert!(
+        ds.get_archived_card(card_a.id)?.is_some(),
+        "card A must remain archived after re-attach"
+    );
+    // ...and the dependency edge survived (the regression this card fixes).
+    assert!(
+        ds.get_graph()?.contains(card_a.id, card_b.id),
+        "the archived card's dependency edge must survive sprint re-attach"
+    );
+    Ok(())
+}
+
+/// Clearing a sprint from archived cards edits the live card and touches
+/// nothing else. Conformance guard on the divergent backend.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_clear_sprint_from_archived_cards_edits_live_card() -> KanbanResult<()> {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("clear.sqlite3");
+    let mut ctx = open(&path).await;
+
+    let board = ctx.create_board("Proj".into(), None)?;
+    let col = ctx.create_column(board.id, "Todo".into(), None)?;
+    let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+    let card_b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
+    let sprint = ctx.create_sprint(board.id, None, None)?;
+
+    let backend = ctx.backend();
+    let ds = backend.as_data_store();
+
+    {
+        let mut graph = ds.get_graph()?;
+        graph.set_block(card_a.id, card_b.id)?;
+        ds.set_graph(graph)?;
+    }
+
+    // Bind A to the sprint, then archive it.
+    let mut bound = card_a.clone();
+    bound.sprint_id = Some(sprint.id);
+    ds.upsert_card(bound.clone())?;
+    ds.insert_archived_card(ArchivedCard::new(bound, board.id, col.id, card_a.position))?;
+
+    ds.clear_sprint_from_archived_cards(sprint.id, chrono::Utc::now())?;
+
+    let live = ds
+        .get_card(card_a.id)?
+        .expect("archived card A is still live");
+    assert_eq!(
+        live.sprint_id, None,
+        "clearing must null the live card's sprint"
+    );
+    assert!(
+        ds.get_archived_card(card_a.id)?.is_some(),
+        "card A must remain archived"
+    );
+    assert!(
+        ds.get_graph()?.contains(card_a.id, card_b.id),
+        "clearing a sprint must not disturb dependency edges"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## What

FOUND-F3a (KAN-872), Foundation area of the archival unification (root KAN-864). Additive prep for the F3b `Archived<T>` collapse: move the last archived-card sprint mutation site off the embedded `Archived::entity` copy onto the live card.

`SetArchivedCardsSprint` (the synthetic command that `DeleteSprint` undo uses to re-attach a sprint to archived cards) previously did a `get_archived_card` -> mutate `ac.entity.sprint_id` -> `delete_archived_card` -> `insert_archived_card` dance. Under the reference model an archived card is an ordinary editable card, so this is now a plain fetch-live-card, set sprint, upsert.

## Why

- Removes one `Archived::entity` consumer ahead of F3b, which collapses `Archived<T>` to a pure marker and has to migrate every `.entity` consumer.
- Stops abusing `delete_archived_card` (documented as a permanent delete of card row plus marker) as a transient step inside a sprint re-attach.
- The in-memory `clear_sprint_from_archived_cards` site already edits the live card (landed in F1); this brings the last site into line. `entity_id()` already exists and is collapse-stable, so that part of the original card is a no-op.

## Behavior

Behavior-preserving. The old dance reconstructed the same card row on reinsert. Dependency edges are workspace-global and not FK-owned by `cards`, so a card-row delete orphan-survives rather than cascading; the marker and sprint outcome are unchanged either way.

## Tests

New all-backend guards through the real SQLite backend (the one whose `delete_archived_card` deletes the `cards` row, so its delete semantics differ from in-memory):

- `test_set_archived_cards_sprint_edits_live_card_and_preserves_edges` seeds an `A blocks B` edge, archives A, runs the command, and asserts A is still live with the re-attached sprint, still archived, and the edge survives.
- `test_clear_sprint_from_archived_cards_edits_live_card` asserts clearing nulls the live card's sprint, keeps the marker, and leaves edges untouched.

Split into a `test(service)` commit and a `refactor(domain)` commit. Full `kanban-domain` and `kanban-service` suites, clippy `-D warnings`, and fmt are green.
