### PR TITLE
KAN-879 feat(service): CardResponse.archived_at additive DTO consolidation (D1)

### DIFF
--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -27,6 +27,23 @@ pub struct CardResponse {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub completed_at: Option<DateTime<Utc>>,
+    /// `Some` iff this card is archived (the marker's `archived_at`); `None` for
+    /// a live card. Skipped on the wire when `None` so live-card payloads are
+    /// byte-identical to before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
+}
+
+impl CardResponse {
+    /// Project a live card and stamp it as archived at `archived_at`. Under the
+    /// reference-marker model an archived card IS a live card plus a marker, so
+    /// the archived wire shape is the live projection with `archived_at` set.
+    pub fn archived(card: &Card, archived_at: DateTime<Utc>) -> Self {
+        Self {
+            archived_at: Some(archived_at),
+            ..Self::from(card)
+        }
+    }
 }
 
 impl From<&Card> for CardResponse {
@@ -63,6 +80,7 @@ impl From<&Card> for CardResponse {
             created_at: *created_at,
             updated_at: *updated_at,
             completed_at: *completed_at,
+            archived_at: None,
         }
     }
 }

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -167,6 +167,50 @@ mod tests {
         assert_eq!(back, resp);
     }
 
+    // D1 (KAN-879): CardResponse gains an optional `archived_at` so the live
+    // response is the single wire type for both live and archived cards. Live
+    // payloads stay byte-identical (the key is skipped when absent).
+    #[test]
+    fn test_card_response_from_card_has_null_archived_at() {
+        let resp = CardResponse::from(&sample_card());
+        assert_eq!(resp.archived_at, None);
+    }
+
+    #[test]
+    fn test_card_response_archived_stamps_archived_at() {
+        let card = sample_card();
+        let at = Utc::now();
+        let archived = CardResponse::archived(&card, at);
+        assert_eq!(archived.archived_at, Some(at));
+        // Every other field matches the live projection.
+        assert_eq!(
+            CardResponse {
+                archived_at: None,
+                ..archived.clone()
+            },
+            CardResponse::from(&card)
+        );
+    }
+
+    #[test]
+    fn test_card_response_archived_at_serde_round_trip() {
+        let archived = CardResponse::archived(&sample_card(), Utc::now());
+        let json = serde_json::to_string(&archived).unwrap();
+        assert!(json.contains("archived_at"));
+        let back: CardResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, archived);
+    }
+
+    #[test]
+    fn test_card_response_live_omits_archived_at_key() {
+        let live = CardResponse::from(&sample_card());
+        let value = serde_json::to_value(&live).unwrap();
+        assert!(
+            value.get("archived_at").is_none(),
+            "a live card payload must not carry an archived_at key"
+        );
+    }
+
     #[test]
     fn test_archived_card_response_carries_board_id_and_archived_meta() {
         use kanban_domain::ArchivedCard;


### PR DESCRIPTION
## What

DTO-D1 (KAN-879), additive slice of the archival unification (root KAN-864). `CardResponse` gains an optional `archived_at` so a single live response type can represent both live and archived cards; consumers tell them apart by the presence of the field rather than a separate DTO.

## Changes

- `CardResponse.archived_at: Option<DateTime<Utc>>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`.
- `From<&Card>` sets `archived_at: None`.
- `CardResponse::archived(card, at)` stamps an archived projection (the live projection plus `archived_at`).

## Scope

Additive only. `ArchivedCardResponse` and its `From<&ArchivedCard>` remain untouched, per the verified sequencing note on the card: retiring them and migrating the CLI/MCP archived-list handlers is the atomic collapse in F3b (KAN-884), so this PR carries no consumer changes and leaves the workspace green at the boundary.

## Invariant

A live-card payload is byte-identical to before this field existed (the key is skipped when `None`); an archived-card payload is a flat `CardResponse` with `archived_at` set.

## Tests

Four DTO unit tests: `From<&Card>` leaves `archived_at` `None`; `archived()` stamps it and matches the live projection on every other field; the archived variant serde round-trips; a live payload omits the `archived_at` key. Full `kanban-service` suite, clippy `-D warnings`, and fmt are green.
