### PR TITLE
KAN-880 feat(service): BoardResponse.archived_at additive DTO consolidation (D2)

### DIFF
--- a/crates/kanban-service/src/api/v1/boards/response.rs
+++ b/crates/kanban-service/src/api/v1/boards/response.rs
@@ -122,6 +122,49 @@ mod tests {
         assert!(json.contains("\"task_list_view\":\"flat\""), "json: {json}");
     }
 
+    // D2 (KAN-880): BoardResponse gains an optional `archived_at` so the live
+    // response is the single wire type for both live and archived boards. Live
+    // payloads stay byte-identical (the key is skipped when absent).
+    #[test]
+    fn test_board_response_from_board_has_null_archived_at() {
+        let resp = BoardResponse::from(&Board::new("B", Some("KAN")));
+        assert_eq!(resp.archived_at, None);
+    }
+
+    #[test]
+    fn test_board_response_archived_stamps_archived_at() {
+        let board = Board::new("B", Some("KAN"));
+        let at = Utc::now();
+        let archived = BoardResponse::archived(&board, at);
+        assert_eq!(archived.archived_at, Some(at));
+        assert_eq!(
+            BoardResponse {
+                archived_at: None,
+                ..archived.clone()
+            },
+            BoardResponse::from(&board)
+        );
+    }
+
+    #[test]
+    fn test_board_response_archived_at_serde_round_trip() {
+        let archived = BoardResponse::archived(&Board::new("B", Some("KAN")), Utc::now());
+        let json = serde_json::to_string(&archived).unwrap();
+        assert!(json.contains("archived_at"));
+        let back: BoardResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, archived);
+    }
+
+    #[test]
+    fn test_board_response_live_omits_archived_at_key() {
+        let live = BoardResponse::from(&Board::new("B", Some("KAN")));
+        let value = serde_json::to_value(&live).unwrap();
+        assert!(
+            value.get("archived_at").is_none(),
+            "a live board payload must not carry an archived_at key"
+        );
+    }
+
     #[test]
     fn test_archived_board_response_projects_board_and_archived_at() {
         use chrono::{TimeZone, Utc};

--- a/crates/kanban-service/src/api/v1/boards/response.rs
+++ b/crates/kanban-service/src/api/v1/boards/response.rs
@@ -26,6 +26,23 @@ pub struct BoardResponse {
     pub position: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// `Some` iff this board is archived (the marker's `archived_at`); `None`
+    /// for a live board. Skipped on the wire when `None` so live-board payloads
+    /// are byte-identical to before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
+}
+
+impl BoardResponse {
+    /// Project a live board and stamp it as archived at `archived_at`. Under the
+    /// reference-marker model an archived board IS a live board plus a marker, so
+    /// the archived wire shape is the live projection with `archived_at` set.
+    pub fn archived(board: &Board, archived_at: DateTime<Utc>) -> Self {
+        Self {
+            archived_at: Some(archived_at),
+            ..Self::from(board)
+        }
+    }
 }
 
 impl From<&Board> for BoardResponse {
@@ -45,6 +62,7 @@ impl From<&Board> for BoardResponse {
             position: b.position,
             created_at: b.created_at,
             updated_at: b.updated_at,
+            archived_at: None,
         }
     }
 }


### PR DESCRIPTION
## What

DTO-D2 (KAN-880), the board sibling of D1 in the archival unification (root KAN-864). `BoardResponse` gains an optional `archived_at` so a single live response type can represent both live and archived boards; consumers tell them apart by the presence of the field rather than a separate DTO.

## Changes

- `BoardResponse.archived_at: Option<DateTime<Utc>>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`.
- `From<&Board>` sets `archived_at: None`.
- `BoardResponse::archived(board, at)` stamps an archived projection (the live projection plus `archived_at`).

## Scope

Additive only. Following the verified-sequencing note on the card, `ArchivedBoardResponse` and its `From<&ArchivedBoard>` are kept even though they have no surface consumers, so the entire DTO retirement stays atomic in F3b (KAN-884) alongside the `Archived<T>` collapse. This departs from the card body's steps 3-4 (which described retiring `ArchivedBoardResponse` here); the appended verified note supersedes them, and the "ArchivedBoardResponse removed" acceptance item moves to F3b.

Independent of D1 (disjoint files: `boards/` vs `cards/`), so the two can land in any order.

## Invariant

A live-board payload is byte-identical to before this field existed (the key is skipped when `None`); an archived-board payload is a flat `BoardResponse` with `archived_at` set.

## Tests

Four DTO unit tests: `From<&Board>` leaves `archived_at` `None`; `archived()` stamps it and matches the live projection on every other field; the archived variant serde round-trips; a live payload omits the `archived_at` key. Full `kanban-service` suite, clippy `-D warnings`, and fmt are green.
