### PR TITLE
KAN-884 refactor(domain): collapse Archived<T> to a pure marker (F3b)

### DIFF
--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -6,7 +6,7 @@ use kanban_domain::{
     CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions, FieldUpdate,
     KanbanOperations, SprintStatus,
 };
-use kanban_service::api::{ArchivedCardResponse, CardResponse};
+use kanban_service::api::CardResponse;
 
 use uuid::Uuid;
 
@@ -52,8 +52,10 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                         sort: args.sort.map(|s| s.to_sort_field()),
                         sort_order: args.order.map(|o| o.to_sort_order()),
                     })?;
-                let responses: Vec<ArchivedCardResponse> =
-                    archived.iter().map(ArchivedCardResponse::from).collect();
+                let responses: Vec<CardResponse> = archived
+                    .iter()
+                    .map(|(card, at)| CardResponse::archived(card, *at))
+                    .collect();
                 output::output_success(PaginatedList::paginate(responses, page, page_size)?);
             } else {
                 let filter = match build_filter(ctx, &args) {
@@ -260,24 +262,25 @@ fn resolve_sprint_for_card(ctx: &CliContext, raw: &str, card_id: Uuid) -> Result
 }
 
 fn card_board_id(ctx: &CliContext, card_id: Uuid) -> Result<Uuid, String> {
-    // Try active cards first; if the card is archived, fall back via its
-    // original_column_id. Either path resolves to the card's board.
-    let column_id = match ctx.get_card(card_id).map_err(|e| e.to_string())? {
-        Some(card) => card.column_id,
-        None => {
-            let archived = ctx
-                .list_archived_cards()
-                .map_err(|e| e.to_string())?
-                .into_iter()
-                .find(|a| a.entity.id == card_id)
-                .ok_or_else(|| format!("Card not found: {}", card_id))?;
-            archived.context.original_column_id
-        }
-    };
-    let column = ctx
-        .get_column(column_id)
+    // Reference-marker model: an archived card carries its board on the marker
+    // (first-class `board_id`), which survives a deleted column. Prefer it; else
+    // resolve the LIVE card's column -> board (`get_card` is unfiltered).
+    if let Some(marker) = ctx
+        .list_archived_cards()
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Column not found: {}", column_id))?;
+        .into_iter()
+        .find(|a| a.entity_id == card_id)
+    {
+        return Ok(marker.context.board_id);
+    }
+    let card = ctx
+        .get_card(card_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Card not found: {}", card_id))?;
+    let column = ctx
+        .get_column(card.column_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Column not found: {}", card.column_id))?;
     Ok(column.board_id)
 }
 

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1269,15 +1269,19 @@ mod card_tests {
 
         let archived_json = parse_json_output(&String::from_utf8_lossy(&archived_output));
         assert_eq!(archived_json["data"]["total"], 1);
-        assert!(archived_json["data"]["items"][0]["archived_at"].is_string());
-        assert!(archived_json["data"]["items"][0]["original_column_id"].is_string());
-        // v1 ArchivedCardResponse (KAN-843): the nested card is the rich
-        // CardResponse (carries `description`), and board_id is first-class.
-        assert!(archived_json["data"]["items"][0]["board_id"].is_string());
-        assert!(archived_json["data"]["items"][0]["card"]
-            .as_object()
-            .unwrap()
-            .contains_key("description"));
+        let item = &archived_json["data"]["items"][0];
+        // Under DTO retirement the archived list item is the flat CardResponse
+        // shape: a top-level `archived_at` plus the normal card fields, with no
+        // nested `card`, no `original_column_id`, and no first-class `board_id`.
+        assert!(item["archived_at"].is_string());
+        assert!(item.get("title").is_some());
+        assert!(item.get("description").is_some());
+        assert!(item.get("card").is_none(), "no nested card object");
+        assert!(
+            item.get("original_column_id").is_none(),
+            "no original_column_id"
+        );
+        assert!(item.get("board_id").is_none(), "no first-class board_id");
 
         let restore_output = kanban()
             .args([file.to_str().unwrap(), "card", "restore", &card_id])
@@ -3557,7 +3561,8 @@ mod name_resolution_tests {
 
     /// Regression: `card restore <archived_uuid> --column <name>` must work.
     /// The board-derivation helper used to chain via active cards only, which
-    /// failed for archived cards. It now falls back to archived_card.context.original_column_id.
+    /// failed for archived cards. It now derives the board from the archived
+    /// marker's first-class `context.board_id` (the referenced card stays live).
     #[test]
     fn test_card_restore_archived_with_column_name() {
         let (_dir, file, _b, _c) = setup_named_board("B", "KAN");
@@ -3581,8 +3586,8 @@ mod name_resolution_tests {
             .assert()
             .success();
         // Archived cards aren't reachable via KAN-N identifier, so use UUID.
-        // The --column name resolution must still succeed by chaining via the
-        // archived card's original_column_id to derive the board.
+        // The --column name resolution must still succeed by deriving the board
+        // from the archived marker's first-class board_id.
         let rjson = parse_json_output(&String::from_utf8_lossy(
             &kanban()
                 .args([&file, "card", "restore", &card_uuid, "--column", "Doing"])

--- a/crates/kanban-domain/src/archival.rs
+++ b/crates/kanban-domain/src/archival.rs
@@ -1,11 +1,12 @@
 //! Shared archival abstraction.
 //!
-//! Archived records are modeled generically as [`Archived<T, C>`]: any live
-//! entity `T` (serialized through the [`ArchivableEntity`] bridge) plus its
-//! shared [`ArchiveMetadata`] envelope and an entity-specific restore context
-//! `C` ([`NoContext`] for scoping roots). `ArchivedCard`, `ArchivedBoard`, and
+//! Archived records are modeled generically as [`Archived<C>`]: a pure marker
+//! recording that a live entity (referenced by `entity_id`) was archived, plus
+//! its shared [`ArchiveMetadata`] envelope and an entity-specific restore
+//! context `C` ([`NoContext`] for scoping roots). The entity is NEVER embedded;
+//! it stays live in its own collection. `ArchivedCard`, `ArchivedBoard`, and
 //! any future archived type are aliases of it, so archiving a new entity means
-//! implementing one trait — the wrapper, the metadata envelope, and the
+//! choosing its restore context — the marker, the metadata envelope, and the
 //! archive/restore lifecycle come for free.
 //!
 //! Deliberately bounded to the DOMAIN shape. A store-generic
@@ -15,12 +16,12 @@
 //! and that trait is intentionally NOT provided.
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Shared archival metadata envelope. Common to every archived entity; the
 /// entity-specific restore context is NOT stored here (it stays on the concrete
-/// archived type, e.g. `ArchivedCard::original_column_id`). Kept a one-field
+/// archived type's context, e.g. `CardRestoreContext::board_id`). Kept a one-field
 /// struct on purpose: it is the seam where a future `archived_by`/reason would
 /// live without touching call sites.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,37 +55,6 @@ pub trait ArchivedEntity {
     }
 }
 
-/// A live entity that can be archived: exposes its stable id and its own serde
-/// bridge. Live entities (`Board`/`Card`) have no `Deserialize` — they route
-/// through a record type for migration — so the bridge is explicit. Implementing
-/// this trait is the ONE thing a new archivable entity must do; the wrapper,
-/// metadata, and lifecycle come for free.
-pub trait ArchivableEntity: Sized {
-    fn entity_id(&self) -> Uuid;
-
-    fn serialize_entity<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error>;
-
-    fn deserialize_entity<'de, D: Deserializer<'de>>(d: D) -> Result<Self, D::Error>;
-}
-
-/// serde bridge that dispatches a generic entity field through its
-/// [`ArchivableEntity`] impl, so `Archived<T, _>` can `#[serde(with)]` a `T`
-/// it cannot name at derive time.
-pub mod entity_serde {
-    use super::ArchivableEntity;
-    use serde::{Deserializer, Serializer};
-
-    pub fn serialize<T: ArchivableEntity, S: Serializer>(t: &T, s: S) -> Result<S::Ok, S::Error> {
-        t.serialize_entity(s)
-    }
-
-    pub fn deserialize<'de, T: ArchivableEntity, D: Deserializer<'de>>(
-        d: D,
-    ) -> Result<T, D::Error> {
-        T::deserialize_entity(d)
-    }
-}
-
 /// Empty restore context for scoping-root entities (e.g. a board) that need no
 /// "where did it come from" data. Flattens to nothing on the wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -95,61 +65,51 @@ pub struct NoContext {}
 /// (`NoContext` for roots). The reusable archival shape — `ArchivedCard`,
 /// `ArchivedBoard`, and any future one are aliases. Storage stays
 /// entity-specific (backends discern the type); this is only the domain shape.
-///
-/// The entity serializes under the `entity` key; `alias = "card"` keeps
-/// already-shipped `archived_cards` blobs (which used a `card` key) loadable.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(bound(
-    serialize = "T: ArchivableEntity, C: Serialize",
-    deserialize = "T: ArchivableEntity, C: Deserialize<'de>"
-))]
-pub struct Archived<T, C = NoContext> {
-    #[serde(with = "entity_serde", alias = "card")]
-    pub entity: T,
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Archived<C = NoContext> {
+    /// Stable id of the live entity this record archives (card id / board id).
+    /// The entity itself is NOT embedded — it stays live in its own collection
+    /// (reference-marker model); this is a pure marker.
+    pub entity_id: Uuid,
     #[serde(flatten)]
     pub metadata: ArchiveMetadata,
     #[serde(flatten)]
     pub context: C,
 }
 
-impl<T: ArchivableEntity, C> Archived<T, C> {
-    pub fn with_context(entity: T, context: C, metadata: ArchiveMetadata) -> Self {
+impl<C> Archived<C> {
+    pub fn with_context(entity_id: Uuid, context: C, metadata: ArchiveMetadata) -> Self {
         Self {
-            entity,
+            entity_id,
             context,
             metadata,
         }
     }
 }
 
-impl<T: ArchivableEntity> Archived<T, NoContext> {
+impl Archived<NoContext> {
     /// Archive a scoping-root entity now (no restore context).
-    pub fn now(entity: T) -> Self {
+    pub fn now(entity_id: Uuid) -> Self {
         Self {
-            entity,
+            entity_id,
             context: NoContext {},
             metadata: ArchiveMetadata::now(),
         }
     }
 
     /// Archive a scoping-root entity at an explicit time.
-    pub fn at(entity: T, archived_at: DateTime<Utc>) -> Self {
+    pub fn at(entity_id: Uuid, archived_at: DateTime<Utc>) -> Self {
         Self {
-            entity,
+            entity_id,
             context: NoContext {},
             metadata: ArchiveMetadata::at(archived_at),
         }
     }
-
-    /// Restore: unwrap the live entity verbatim.
-    pub fn into_entity(self) -> T {
-        self.entity
-    }
 }
 
-impl<T: ArchivableEntity, C> ArchivedEntity for Archived<T, C> {
+impl<C> ArchivedEntity for Archived<C> {
     fn entity_id(&self) -> Uuid {
-        self.entity.entity_id()
+        self.entity_id
     }
 
     fn metadata(&self) -> ArchiveMetadata {
@@ -194,75 +154,51 @@ mod tests {
         assert_eq!(d.archived_at(), at);
     }
 
-    // A throwaway archivable entity. Real entities (Board/Card) route their
-    // serde through a record bridge; a self-serializing one is enough to
-    // exercise the generic wrapper, the `entity_serde` bridge, and the
-    // `NoContext` root path independently of any concrete domain type.
-    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-    struct TestEntity {
-        id: Uuid,
-        name: String,
-    }
-
-    impl ArchivableEntity for TestEntity {
-        fn entity_id(&self) -> Uuid {
-            self.id
-        }
-        fn serialize_entity<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-            self.serialize(s)
-        }
-        fn deserialize_entity<'de, D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-            Self::deserialize(d)
-        }
-    }
-
-    fn entity() -> TestEntity {
-        TestEntity {
-            id: Uuid::new_v4(),
-            name: "e".into(),
-        }
-    }
-
     #[test]
     fn test_archived_now_sets_recent_metadata_and_no_context() {
-        let e = entity();
+        let id = Uuid::new_v4();
         let before = Utc::now();
-        let a = Archived::now(e.clone());
-        assert_eq!(a.entity, e);
+        let a = Archived::now(id);
+        assert_eq!(a.entity_id, id);
         assert_eq!(a.context, NoContext {});
         assert!(a.metadata.archived_at >= before && a.metadata.archived_at <= Utc::now());
     }
 
     #[test]
-    fn test_archived_at_uses_injected_time_and_into_entity_restores() {
-        let e = entity();
+    fn test_archived_at_uses_injected_time_and_exposes_entity_id() {
+        let id = Uuid::new_v4();
         let ts = Utc::now();
-        let a = Archived::at(e.clone(), ts);
+        let a = Archived::at(id, ts);
         assert_eq!(a.metadata.archived_at, ts);
-        // Restore returns the live entity verbatim.
-        assert_eq!(a.into_entity(), e);
+        assert_eq!(a.entity_id, id);
     }
 
     #[test]
     fn test_archived_root_blanket_archived_entity_impl() {
-        let e = entity();
-        let id = e.id;
+        let id = Uuid::new_v4();
         let ts = Utc::now();
-        let a = Archived::at(e, ts);
+        let a = Archived::at(id, ts);
         assert_eq!(a.entity_id(), id);
         assert_eq!(a.archived_at(), ts);
     }
 
     #[test]
-    fn test_archived_nocontext_round_trips_json_entity_keyed_flat_metadata() {
+    fn test_archived_nocontext_round_trips_json_referenced_flat_metadata() {
         let ts = Utc::now();
-        let a = Archived::at(entity(), ts);
-        let v = serde_json::to_value(&a).unwrap();
-        // Entity under the `entity` key, archived_at flat, no context fields.
-        assert!(v.get("entity").is_some(), "entity is keyed, got: {v}");
+        let a = Archived::at(Uuid::new_v4(), ts);
+        let v = serde_json::to_value(a).unwrap();
+        // Entity referenced by id (never embedded), archived_at flat, no context.
+        assert!(
+            v.get("entity").is_none(),
+            "entity is referenced, not embedded"
+        );
+        assert!(
+            v.get("entity_id").is_some(),
+            "entity_id is present, got: {v}"
+        );
         assert!(v.get("archived_at").is_some(), "metadata flattens");
         assert!(v.get("context").is_none(), "NoContext flattens to nothing");
-        let back: Archived<TestEntity> = serde_json::from_value(v).unwrap();
+        let back: Archived<NoContext> = serde_json::from_value(v).unwrap();
         assert_eq!(back, a);
     }
 }

--- a/crates/kanban-domain/src/archived_board.rs
+++ b/crates/kanban-domain/src/archived_board.rs
@@ -1,38 +1,22 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::{
-    archival::{ArchivableEntity, Archived},
+    archival::{Archived, NoContext},
     board::{Board, BoardId},
 };
 
-impl ArchivableEntity for Board {
-    fn entity_id(&self) -> Uuid {
-        self.id
-    }
+/// An archived board: the shared [`Archived`] marker for a scoping ROOT. A board
+/// needs no restore context (`NoContext`) — its subtree (columns / cards /
+/// sprints / edges) stays in place in the flat collections, and the board head
+/// itself stays LIVE in `boards` under the reference-marker model. `entity_id`
+/// points at that still-live board; the board is never embedded here.
+pub type ArchivedBoard = Archived<NoContext>;
 
-    fn serialize_entity<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        crate::board_factory::board_serde::serialize(self, s)
-    }
-
-    fn deserialize_entity<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        crate::board_factory::board_serde::deserialize(d)
-    }
-}
-
-/// An archived board: the shared [`Archived`] wrapper specialized to `Board`. A
-/// board is a scoping ROOT — its subtree (columns / cards / archived_cards /
-/// sprints / edges) stays in place in the flat collections — so it needs no
-/// restore context (`NoContext`). Archiving moves the board head into the
-/// wrapper; restore (`into_entity`) unwraps it, losslessly. On the wire: the
-/// board under `entity`, a flat `archived_at`, no context.
-pub type ArchivedBoard = Archived<Board>;
-
-/// Lightweight projection for the archived-boards list view. Reads the board
-/// head plus archive time only — no subtree counts (never gathered under the
-/// discrete-collection model). `archived_at` is non-optional (it always exists
-/// on an archived record).
+/// Lightweight projection for the archived-boards list view. Reads the live
+/// board head plus archive time only — no subtree counts (never gathered under
+/// the discrete-collection model). `archived_at` is non-optional (it always
+/// exists on an archived record).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArchivedBoardSummary {
     pub board_id: BoardId,
@@ -42,14 +26,17 @@ pub struct ArchivedBoardSummary {
     pub position: i32,
 }
 
-impl From<&ArchivedBoard> for ArchivedBoardSummary {
-    fn from(ab: &ArchivedBoard) -> Self {
+impl ArchivedBoardSummary {
+    /// Project the live board head plus the marker's archive time. The board is
+    /// no longer embedded in the marker, so the caller supplies the live `Board`
+    /// (fetched by `ab.entity_id`) explicitly.
+    pub fn from_marker(board: &Board, ab: &ArchivedBoard) -> Self {
         Self {
-            board_id: ab.entity.id,
-            name: ab.entity.name.clone(),
-            description: ab.entity.description.clone(),
+            board_id: board.id,
+            name: board.name.clone(),
+            description: board.description.clone(),
             archived_at: ab.metadata.archived_at,
-            position: ab.entity.position,
+            position: board.position,
         }
     }
 }
@@ -60,23 +47,23 @@ mod tests {
     use crate::archival::ArchivedEntity;
 
     #[test]
-    fn test_archived_board_wraps_and_restores_losslessly() {
-        let board = Board::new("Proj", Some("KAN"));
-        let ab = ArchivedBoard::now(board.clone());
-        assert_eq!(ab.entity_id(), board.id);
-        assert_eq!(
-            ab.into_entity(),
-            board,
-            "restore returns the board verbatim"
-        );
+    fn test_archived_board_marker_exposes_entity_id_and_archived_at() {
+        let ts = Utc::now();
+        let id = uuid::Uuid::new_v4();
+        let ab = ArchivedBoard::at(id, ts);
+        assert_eq!(ab.entity_id(), id);
+        assert_eq!(ab.archived_at(), ts);
     }
 
     #[test]
-    fn test_archived_board_round_trips_json_entity_keyed_flat_archived_at() {
+    fn test_archived_board_marker_round_trips_json_flat_archived_at() {
         let ts = Utc::now();
-        let ab = ArchivedBoard::at(Board::new("B", Some("KAN")), ts);
-        let v = serde_json::to_value(&ab).unwrap();
-        assert!(v.get("entity").is_some(), "board is under the entity key");
+        let ab = ArchivedBoard::at(uuid::Uuid::new_v4(), ts);
+        let v = serde_json::to_value(ab).unwrap();
+        assert!(
+            v.get("entity").is_none(),
+            "board is referenced, not embedded"
+        );
         assert!(v.get("archived_at").is_some(), "archived_at is flat");
         let back: ArchivedBoard = serde_json::from_value(v).unwrap();
         assert_eq!(back, ab);
@@ -84,13 +71,13 @@ mod tests {
     }
 
     #[test]
-    fn test_archived_board_summary_projects_head_and_archived_at() {
+    fn test_archived_board_summary_projects_live_head_and_archived_at() {
         let ts = Utc::now();
         let mut board = Board::new("Proj", None::<String>);
         board.description = Some("d".to_string());
         board.position = 4;
-        let ab = ArchivedBoard::at(board.clone(), ts);
-        let s = ArchivedBoardSummary::from(&ab);
+        let ab = ArchivedBoard::at(board.id, ts);
+        let s = ArchivedBoardSummary::from_marker(&board, &ab);
         assert_eq!(s.board_id, board.id);
         assert_eq!(s.name, "Proj");
         assert_eq!(s.description, Some("d".to_string()));

--- a/crates/kanban-domain/src/archived_card.rs
+++ b/crates/kanban-domain/src/archived_card.rs
@@ -1,87 +1,32 @@
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
 
 use crate::{
-    archival::{ArchivableEntity, ArchiveMetadata, Archived},
+    archival::{ArchiveMetadata, Archived},
     board::BoardId,
-    card::Card,
-    column::ColumnId,
 };
 
-/// Restore context for an archived card. A card is a LEAF sharing a live
-/// column, so it must remember where to go back. `board_id` is a direct field
-/// (D2 first-class model) so board-scoped queries need no column load;
-/// `#[serde(default)]` keeps pre-V8 files loadable (nil until backfilled).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Archive context for a card: the board it belonged to, kept so board-scoped
+/// archived queries need no column load (first-class `board_id`, KAN-829). The
+/// card itself stays LIVE in `cards` under the reference-marker model, so there
+/// is no original column/position to remember — nothing moves on archive.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct CardRestoreContext {
     #[serde(default)]
     pub board_id: BoardId,
-    /// Historical column at archive time — NOT a live FK. May dangle if the
-    /// column is later deleted; intentional under the first-class model.
-    pub original_column_id: ColumnId,
-    pub original_position: i32,
 }
 
-/// An archived card: the shared [`Archived`] wrapper specialized to `Card` plus
-/// its [`CardRestoreContext`]. On the wire: the card under `entity` (with a
-/// `card` alias for already-shipped blobs), a flat `archived_at`, and the
-/// flattened restore context.
-pub type ArchivedCard = Archived<Card, CardRestoreContext>;
-
-impl ArchivableEntity for Card {
-    fn entity_id(&self) -> uuid::Uuid {
-        self.id
-    }
-
-    fn serialize_entity<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        crate::card_factory::card_serde::serialize(self, s)
-    }
-
-    fn deserialize_entity<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        crate::card_factory::card_serde::deserialize(d)
-    }
-}
+/// An archived card: the shared [`Archived`] marker specialized with a card's
+/// board context. A pure reference — `entity_id` points at the still-live card
+/// in `cards`; the entity is never embedded here.
+pub type ArchivedCard = Archived<CardRestoreContext>;
 
 impl ArchivedCard {
-    pub fn new(
-        card: Card,
-        board_id: BoardId,
-        original_column_id: ColumnId,
-        original_position: i32,
-    ) -> Self {
+    pub fn new(card_id: uuid::Uuid, board_id: BoardId) -> Self {
         Archived::with_context(
-            card,
-            CardRestoreContext {
-                board_id,
-                original_column_id,
-                original_position,
-            },
+            card_id,
+            CardRestoreContext { board_id },
             ArchiveMetadata::now(),
         )
-    }
-
-    pub fn into_card(self) -> Card {
-        self.entity
-    }
-
-    pub fn card_ref(&self) -> &Card {
-        &self.entity
-    }
-
-    pub fn card_mut(&mut self) -> &mut Card {
-        &mut self.entity
-    }
-}
-
-impl From<ArchivedCard> for Card {
-    fn from(archived_card: ArchivedCard) -> Self {
-        archived_card.entity
-    }
-}
-
-impl Borrow<Card> for ArchivedCard {
-    fn borrow(&self) -> &Card {
-        &self.entity
     }
 }
 
@@ -89,30 +34,32 @@ impl Borrow<Card> for ArchivedCard {
 mod tests {
     use super::*;
     use crate::archival::ArchivedEntity;
-    use crate::{board::Board, card::Card, column::Column};
-
-    fn sample() -> ArchivedCard {
-        let mut board = Board::new("B", None::<String>);
-        let col = Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, col.id, "T", 0);
-        ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0)
-    }
 
     #[test]
-    fn test_archived_card_implements_archived_entity() {
-        let ac = sample();
-        assert_eq!(ArchivedEntity::entity_id(&ac), ac.entity.id);
+    fn test_archived_card_marker_exposes_entity_id_and_metadata() {
+        let id = uuid::Uuid::new_v4();
+        let ac = ArchivedCard::new(id, uuid::Uuid::nil());
+        assert_eq!(ArchivedEntity::entity_id(&ac), id);
+        assert_eq!(ac.entity_id, id);
         assert_eq!(ac.archived_at(), ac.metadata.archived_at);
     }
 
     #[test]
-    fn test_metadata_flatten_keeps_archived_at_flat_on_the_wire() {
-        let ac = sample();
-        let v = serde_json::to_value(&ac).unwrap();
+    fn test_archived_card_retains_board_id() {
+        let board_id = uuid::Uuid::new_v4();
+        let ac = ArchivedCard::new(uuid::Uuid::new_v4(), board_id);
+        assert_eq!(ac.context.board_id, board_id);
+    }
+
+    #[test]
+    fn test_metadata_and_context_flatten_flat_on_the_wire() {
+        let ac = ArchivedCard::new(uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+        let v = serde_json::to_value(ac).unwrap();
         assert!(
             v.get("archived_at").is_some(),
             "archived_at stays top-level"
         );
+        assert!(v.get("board_id").is_some(), "board_id stays top-level");
         assert!(
             v.get("metadata").is_none(),
             "not nested under a metadata key"
@@ -120,47 +67,24 @@ mod tests {
     }
 
     #[test]
-    fn test_legacy_card_keyed_json_still_deserializes() {
-        // A record written by the PREVIOUS (bespoke `ArchivedCard`) code used a
-        // `card` key for the entity. The `alias = "card"` on the generic must
-        // keep it loadable — this is the real back-compat guard for the
-        // migration to `Archived<Card, _>`.
-        let ac = sample();
-        let card_value = serde_json::to_value(&ac)
-            .unwrap()
-            .get("entity")
-            .cloned()
-            .expect("serialized entity sub-object");
-        let legacy = serde_json::json!({
-            "card": card_value,
-            "archived_at": ac.metadata.archived_at,
-            "board_id": ac.context.board_id,
-            "original_column_id": ac.context.original_column_id,
-            "original_position": ac.context.original_position,
-        });
-        let back: ArchivedCard = serde_json::from_value(legacy).unwrap();
-        assert_eq!(back, ac);
+    fn test_archived_card_marker_has_no_embedded_entity() {
+        let ac = ArchivedCard::new(uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+        let v = serde_json::to_value(ac).unwrap();
+        assert!(
+            v.get("entity").is_none() && v.get("card").is_none(),
+            "the entity is referenced by id, never embedded"
+        );
+        assert_eq!(
+            v.get("entity_id").and_then(|x| x.as_str()),
+            Some(ac.entity_id.to_string().as_str())
+        );
     }
 
     #[test]
-    fn test_archived_card_retains_board_id() {
-        let mut board = Board::new("B", None::<String>);
-        let board_id = board.id;
-        let col = Column::new(board_id, "Todo", 0);
-        let card = Card::new(&mut board, col.id, "T", 0);
-        let ac = ArchivedCard::new(card, board_id, col.id, 0);
-        assert_eq!(ac.context.board_id, board_id);
-    }
-
-    #[test]
-    fn test_archived_card_board_id_survives_json_round_trip() {
-        let mut board = Board::new("B", None::<String>);
-        let board_id = board.id;
-        let col = Column::new(board_id, "Todo", 0);
-        let card = Card::new(&mut board, col.id, "T", 0);
-        let ac = ArchivedCard::new(card, board_id, col.id, 0);
+    fn test_archived_card_marker_json_round_trip() {
+        let ac = ArchivedCard::new(uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
         let json = serde_json::to_string(&ac).unwrap();
         let restored: ArchivedCard = serde_json::from_str(&json).unwrap();
-        assert_eq!(restored.context.board_id, board_id);
+        assert_eq!(restored, ac);
     }
 }

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -349,19 +349,24 @@ impl DeleteBoard {
     /// it AS archived). The cascade siblings capture their own subtree
     /// entities, so undoing the full cascade restores everything.
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
-        if let Some(board) = store.get_board(self.board_id)? {
+        // `get_board` is unfiltered (returns archived boards too), so it can no
+        // longer discriminate. The MARKER is the discriminator: a board with an
+        // archival marker was archived, and its undo must re-import it AS
+        // archived (board row + marker) so archived-ness survives the round-trip.
+        let board = store
+            .get_board(self.board_id)?
+            .ok_or_else(|| KanbanError::not_found("Board", self.board_id))?;
+        if let Some(marker) = store.get_archived_board(self.board_id)? {
             return Ok(vec![Command::Board(BoardCommand::Import(ImportEntities {
                 boards: vec![board],
+                archived_boards: vec![marker],
                 ..Default::default()
             }))]);
         }
-        if let Some(archived) = store.get_archived_board(self.board_id)? {
-            return Ok(vec![Command::Board(BoardCommand::Import(ImportEntities {
-                archived_boards: vec![archived],
-                ..Default::default()
-            }))]);
-        }
-        Err(KanbanError::not_found("Board", self.board_id))
+        Ok(vec![Command::Board(BoardCommand::Import(ImportEntities {
+            boards: vec![board],
+            ..Default::default()
+        }))])
     }
 }
 
@@ -378,14 +383,17 @@ pub struct ArchiveBoards {
 impl ArchiveBoards {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         for id in &self.ids {
+            // Reference-marker model: the board head STAYS live in `boards`; we
+            // only record an archival marker (which hides it from live queries).
+            // Fetch to guard existence (get_board is unfiltered, so an already
+            // archived board also resolves — re-archiving is idempotent).
             let board = context
                 .store
                 .get_board(*id)?
                 .ok_or_else(|| KanbanError::not_found("Board", *id))?;
             context
                 .store
-                .insert_archived_board(crate::Archived::now(board))?;
-            context.store.delete_board(*id)?;
+                .insert_archived_board(crate::Archived::now(board.id))?;
         }
         Ok(())
     }
@@ -422,19 +430,17 @@ pub struct RestoreBoard {
 
 impl RestoreBoard {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
-        let archived = context
-            .store
-            .get_archived_board(self.board_id)?
-            .ok_or_else(|| KanbanError::not_found("archived board", self.board_id))?;
-        // Unarchive (drop the archived marker) then re-insert the board as live.
-        // Use `unarchive_board`, NOT `delete_archived_board`: on a shared-row
-        // backend (SQLite) the latter deletes the entity ROW and would CASCADE
-        // the still-present subtree away (KAN-863). `unarchive_board` keeps the
-        // row + subtree; the upsert then refreshes the live head. (On the
-        // in-memory move-model both touch only the archived map, so this is also
-        // correct there.)
+        // Guard existence, then drop the archival marker. Under the
+        // reference-marker model the board head already lives in `boards`;
+        // dropping the marker makes it visible to live queries again. Use
+        // `unarchive_board`, NOT `delete_archived_board`: on a shared-row backend
+        // (SQLite) the latter deletes the entity ROW and would CASCADE the
+        // still-present subtree away (KAN-863). `unarchive_board` removes only
+        // the marker, keeping the row + subtree.
+        if context.store.get_archived_board(self.board_id)?.is_none() {
+            return Err(KanbanError::not_found("archived board", self.board_id));
+        }
         context.store.unarchive_board(self.board_id)?;
-        context.store.upsert_board(archived.into_entity())?;
         Ok(())
     }
 
@@ -530,7 +536,7 @@ impl ImportEntities {
                     .store
                     .list_archived_boards()?
                     .iter()
-                    .map(|ab| ab.entity.id),
+                    .map(|ab| ab.entity_id),
             )
             .collect();
         let existing_column_ids: HashSet<Uuid> = context
@@ -555,7 +561,7 @@ impl ImportEntities {
             .store
             .list_archived_cards()?
             .iter()
-            .map(|ac| ac.entity.id)
+            .map(|ac| ac.entity_id)
             .collect();
 
         for b in &self.boards {
@@ -583,12 +589,12 @@ impl ImportEntities {
             }
         }
         for ac in &self.archived_cards {
-            if existing_archived_ids.contains(&ac.entity.id)
-                || existing_card_ids.contains(&ac.entity.id)
+            if existing_archived_ids.contains(&ac.entity_id)
+                || existing_card_ids.contains(&ac.entity_id)
             {
                 return Err(crate::KanbanError::validation(format!(
                     "Duplicate archived card ID (live or archived): {}",
-                    ac.entity.id
+                    ac.entity_id
                 )));
             }
         }
@@ -603,10 +609,10 @@ impl ImportEntities {
         // `existing_board_ids` already spans live + archived boards, so this
         // rejects an archived-board import colliding with either.
         for ab in &self.archived_boards {
-            if existing_board_ids.contains(&ab.entity.id) {
+            if existing_board_ids.contains(&ab.entity_id) {
                 return Err(crate::KanbanError::validation(format!(
                     "Duplicate board ID (live or archived): {}",
-                    ab.entity.id
+                    ab.entity_id
                 )));
             }
         }
@@ -621,10 +627,10 @@ impl ImportEntities {
             context.store.upsert_card(c.clone())?;
         }
         for ac in &self.archived_cards {
-            context.store.insert_archived_card(ac.clone())?;
+            context.store.insert_archived_card(*ac)?;
         }
         for ab in &self.archived_boards {
-            context.store.insert_archived_board(ab.clone())?;
+            context.store.insert_archived_board(*ab)?;
         }
         for s in &self.sprints {
             context.store.upsert_sprint(s.clone())?;
@@ -661,7 +667,7 @@ impl ImportEntities {
         for ac in &self.archived_cards {
             commands.push(Command::Card(crate::commands::CardCommand::Delete(
                 crate::commands::DeleteCard {
-                    card_id: ac.entity.id,
+                    card_id: ac.entity_id,
                 },
             )));
         }
@@ -693,7 +699,7 @@ impl ImportEntities {
         }
         for ab in &self.archived_boards {
             commands.push(Command::Board(BoardCommand::Delete(DeleteBoard {
-                board_id: ab.entity.id,
+                board_id: ab.entity_id,
             })));
         }
 
@@ -847,12 +853,7 @@ mod tests {
         tc.store.upsert_board(board.clone()).unwrap();
         tc.store.upsert_column(col.clone()).unwrap();
         tc.store
-            .insert_archived_card(crate::ArchivedCard::new(
-                archived,
-                uuid::Uuid::nil(),
-                col.id,
-                0,
-            ))
+            .insert_archived_card(crate::ArchivedCard::new(archived.id, uuid::Uuid::nil()))
             .unwrap();
 
         let mut imported_live = crate::Card::new(&mut board, col.id, "ImportedLive", 0);
@@ -892,10 +893,8 @@ mod tests {
             columns: vec![],
             cards: vec![],
             archived_cards: vec![crate::ArchivedCard::new(
-                imported_archived,
+                imported_archived.id,
                 uuid::Uuid::nil(),
-                col.id,
-                0,
             )],
             archived_boards: vec![],
             sprints: vec![],
@@ -917,12 +916,7 @@ mod tests {
         tc.store.upsert_board(board.clone()).unwrap();
         tc.store.upsert_column(col.clone()).unwrap();
         tc.store
-            .insert_archived_card(crate::ArchivedCard::new(
-                archived,
-                uuid::Uuid::nil(),
-                col.id,
-                0,
-            ))
+            .insert_archived_card(crate::ArchivedCard::new(archived.id, uuid::Uuid::nil()))
             .unwrap();
 
         let mut dup = crate::Card::new(&mut board, col.id, "Dup", 0);
@@ -932,7 +926,7 @@ mod tests {
             boards: vec![],
             columns: vec![],
             cards: vec![],
-            archived_cards: vec![crate::ArchivedCard::new(dup, uuid::Uuid::nil(), col.id, 0)],
+            archived_cards: vec![crate::ArchivedCard::new(dup.id, uuid::Uuid::nil())],
             archived_boards: vec![],
             sprints: vec![],
             graph: None,
@@ -1094,10 +1088,12 @@ mod tests {
             tc.store.list_boards().unwrap().is_empty(),
             "archived board leaves the live set"
         );
-        assert!(tc.store.get_board(board_id).unwrap().is_none());
+        // Reference-marker model: the board head STAYS in `boards`; `get_board` is
+        // unfiltered, so it still resolves (only the LIVE list hides it).
+        assert!(tc.store.get_board(board_id).unwrap().is_some());
         let archived = tc.store.list_archived_boards().unwrap();
         assert_eq!(archived.len(), 1);
-        assert_eq!(archived[0].entity.id, board_id);
+        assert_eq!(archived[0].entity_id, board_id);
     }
 
     #[test]
@@ -1154,7 +1150,10 @@ mod tests {
         let inverse = forward.capture_inverse(&tc.store).unwrap();
         let ctx = tc.as_command_context();
         forward.execute(&ctx).unwrap();
-        assert!(tc.store.get_board(board_id).unwrap().is_none());
+        assert!(
+            tc.store.list_boards().unwrap().is_empty(),
+            "archived: hidden from the live list"
+        );
 
         for cmd in inverse {
             cmd.execute(&ctx).unwrap();
@@ -1184,8 +1183,8 @@ mod tests {
             cmd.execute(&ctx).unwrap();
         }
         assert!(
-            tc.store.get_board(board_id).unwrap().is_none(),
-            "re-archived by the inverse"
+            tc.store.list_boards().unwrap().is_empty(),
+            "re-archived by the inverse: hidden from the live list"
         );
         assert_eq!(tc.store.list_archived_boards().unwrap().len(), 1);
     }
@@ -1239,8 +1238,11 @@ mod tests {
         let tc = TestContext::new();
         let board = Board::new("B", Some("TST"));
         let id = board.id;
+        // Reference-marker model: importing an archived board carries the board
+        // head (into `.boards`) AND the marker (into `.archived_boards`).
         let cmd = ImportEntities {
-            archived_boards: vec![crate::Archived::now(board)],
+            boards: vec![board.clone()],
+            archived_boards: vec![crate::Archived::now(id)],
             ..Default::default()
         };
         let ctx = tc.as_command_context();
@@ -1248,8 +1250,11 @@ mod tests {
 
         let archived = tc.store.list_archived_boards().unwrap();
         assert_eq!(archived.len(), 1);
-        assert_eq!(archived[0].entity.id, id);
-        assert!(tc.store.list_boards().unwrap().is_empty());
+        assert_eq!(archived[0].entity_id, id);
+        assert!(
+            tc.store.list_boards().unwrap().is_empty(),
+            "archived board hidden from the live list"
+        );
     }
 
     #[test]
@@ -1259,7 +1264,7 @@ mod tests {
         let mut colliding = Board::new("Dup", Some("DUP"));
         colliding.id = board_id;
         let cmd = ImportEntities {
-            archived_boards: vec![crate::Archived::now(colliding)],
+            archived_boards: vec![crate::Archived::now(colliding.id)],
             ..Default::default()
         };
         let ctx = tc.as_command_context();
@@ -1316,8 +1321,12 @@ mod tests {
             cmd.execute(&ctx).unwrap();
         }
         assert!(
-            tc.store.get_board(board_id).unwrap().is_none(),
-            "restored into the archived collection, not the live set"
+            tc.store.list_boards().unwrap().is_empty(),
+            "restored as archived: hidden from the live set"
+        );
+        assert!(
+            tc.store.get_board(board_id).unwrap().is_some(),
+            "board head is present (unfiltered) but marked archived"
         );
         assert_eq!(tc.store.list_archived_boards().unwrap().len(), 1);
     }

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -188,11 +188,18 @@ impl RestoreCard {
 
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         context.check_wip_limit(self.column_id, 1, &[])?;
-        let archived = context
+        if context.store.get_archived_card(self.card_id)?.is_none() {
+            return Err(KanbanError::not_found("archived card", self.card_id));
+        }
+        // Reference-marker model: the card is already LIVE in `cards`. Fetch it,
+        // apply the restore column/position, drop the marker, and re-upsert.
+        // `delete_archived_card` removes both the marker and the card row (both
+        // backends), so the following `upsert_card` re-materialises the live card
+        // in its restored position — net effect: marker gone, card visible again.
+        let mut card = context
             .store
-            .get_archived_card(self.card_id)?
-            .ok_or_else(|| KanbanError::not_found("archived card", self.card_id))?;
-        let mut card = archived.into_card();
+            .get_card(self.card_id)?
+            .ok_or_else(|| KanbanError::not_found("Card", self.card_id))?;
         card.column_id = self.column_id;
         card.position = self.position;
         card.updated_at = self.timestamp;
@@ -311,12 +318,11 @@ impl ArchiveCards {
                 .get_column(card.column_id)?
                 .map(|c| c.board_id)
                 .unwrap_or_else(Uuid::nil);
-            let original_column_id = card.column_id;
-            let original_position = card.position;
-            let archived =
-                crate::ArchivedCard::new(card, board_id, original_column_id, original_position);
+            // Reference-marker model: the card STAYS live in `cards`; we only
+            // record the marker. `delete_card` is a guarded no-op on an archived
+            // id (F1), so it is not called here — the card is the source of truth.
+            let archived = crate::ArchivedCard::new(card.id, board_id);
             context.store.insert_archived_card(archived)?;
-            context.store.delete_card(*id)?;
         }
         context.store.modify_graph(Box::new(move |graph| {
             for id in &valid_ids {

--- a/crates/kanban-domain/src/commands/card/tests/archive_update.rs
+++ b/crates/kanban-domain/src/commands/card/tests/archive_update.rs
@@ -89,13 +89,16 @@ fn test_archive_captures_board_from_column() {
     let cmd = ArchiveCards { ids: vec![card_id] };
     cmd.execute(&context).unwrap();
 
-    // Capture walks card -> column -> board rather than defaulting to nil,
-    // and the grown 4-arg signature still lands column/position correctly
-    // (guards an arg-order swap at the production call site).
+    // Capture walks card -> column -> board rather than defaulting to nil.
+    // Under the marker model there is no stored original col/pos: the card
+    // stays live in place and only board_id + archived_at are recorded.
     let archived = tc.store.get_archived_card(card_id).unwrap().unwrap();
     assert_eq!(archived.context.board_id, board_id);
-    assert_eq!(archived.context.original_column_id, col_id);
-    assert_eq!(archived.context.original_position, 0);
+    assert_eq!(archived.entity_id, card_id);
+    // The live card is untouched: still in its original column at position 0.
+    let live = tc.store.get_card(card_id).unwrap().unwrap();
+    assert_eq!(live.column_id, col_id);
+    assert_eq!(live.position, 0);
 }
 
 #[test]

--- a/crates/kanban-domain/src/commands/card/tests/restore.rs
+++ b/crates/kanban-domain/src/commands/card/tests/restore.rs
@@ -12,10 +12,13 @@ fn test_restore_card_to_deleted_column_returns_error() {
     let col_id = col.id;
     let card = crate::Card::new(&mut board, col_id, "Card", 0);
     let card_id = card.id;
-    let archived = crate::ArchivedCard::new(card, uuid::Uuid::nil(), col_id, 0);
+    let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
     // Column intentionally NOT added — it has been deleted
-    tc.store.insert_archived_card(archived).unwrap();
+    tc.store.upsert_card(card).unwrap();
+    tc.store
+        .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+        .unwrap();
 
     let context = tc.as_command_context();
     let cmd = RestoreCard {
@@ -36,10 +39,13 @@ fn test_restore_card_to_valid_column_succeeds() {
     let col_id = col.id;
     let card = crate::Card::new(&mut board, col_id, "Card", 0);
     let card_id = card.id;
-    let archived = crate::ArchivedCard::new(card, uuid::Uuid::nil(), col_id, 0);
+    let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
-    tc.store.insert_archived_card(archived).unwrap();
+    tc.store.upsert_card(card).unwrap();
+    tc.store
+        .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+        .unwrap();
 
     let context = tc.as_command_context();
     let cmd = RestoreCard {
@@ -63,11 +69,14 @@ fn test_restore_card_exceeding_wip_limit_returns_error() {
     let existing = crate::Card::new(&mut board, col_id, "Existing", 0);
     let card = crate::Card::new(&mut board, col_id, "Card", 1);
     let card_id = card.id;
-    let archived = crate::ArchivedCard::new(card, uuid::Uuid::nil(), col_id, 0);
+    let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
     tc.store.upsert_card(existing).unwrap();
-    tc.store.insert_archived_card(archived).unwrap();
+    tc.store.upsert_card(card).unwrap();
+    tc.store
+        .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+        .unwrap();
 
     let context = tc.as_command_context();
     let cmd = RestoreCard {
@@ -106,8 +115,11 @@ fn test_restore_card_uses_embedded_timestamp() {
     let mut board = crate::Board::new("B", Some("TST"));
     let card = crate::Card::new(&mut board, column_id, "Card", 0);
     let card_id = card.id;
-    let archived = crate::ArchivedCard::new(card, uuid::Uuid::nil(), column_id, 0);
-    tc.store.insert_archived_card(archived).unwrap();
+    let board_id = board.id;
+    tc.store.upsert_card(card).unwrap();
+    tc.store
+        .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+        .unwrap();
 
     let fixed_time = Utc.with_ymd_and_hms(2020, 6, 15, 12, 0, 0).unwrap();
     let context = tc.as_command_context();

--- a/crates/kanban-domain/src/commands/cascade_commands.rs
+++ b/crates/kanban-domain/src/commands/cascade_commands.rs
@@ -156,12 +156,19 @@ impl DeleteArchivedCards {
         format!("Delete {} archived card(s)", self.card_ids.len())
     }
 
-    /// Inverse: read each still-present archived card (captured before the
-    /// forward execution runs) and re-import it.
+    /// Inverse: reference-marker model. `delete_archived_card` removes BOTH the
+    /// marker and the underlying LIVE card row, so undo must re-import both — the
+    /// live card (into `cards`) and its marker (into `archived_cards`) — to be the
+    /// identity over the full card, including its edges. Captured before the
+    /// forward execution runs, while both still exist.
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
+        let mut cards = Vec::new();
         let mut archived_cards = Vec::new();
         for id in &self.card_ids {
             if let Some(ac) = store.get_archived_card(*id)? {
+                if let Some(card) = store.get_card(*id)? {
+                    cards.push(card);
+                }
                 archived_cards.push(ac);
             }
         }
@@ -169,6 +176,7 @@ impl DeleteArchivedCards {
             return Ok(Vec::new());
         }
         Ok(vec![Command::Board(BoardCommand::Import(ImportEntities {
+            cards,
             archived_cards,
             ..Default::default()
         }))])
@@ -376,15 +384,21 @@ mod tests {
         let card1 = crate::Card::new(&mut board, dangling_col, "1", 0);
         let card2 = crate::Card::new(&mut board, live_col.id, "2", 0);
         let keep = crate::Card::new(&mut board, live_col.id, "keep", 1);
-        let arch1 = crate::ArchivedCard::new(card1, board_id, dangling_col, 0);
-        let arch2 = crate::ArchivedCard::new(card2, board_id, live_col.id, 0);
-        let keep_arch = crate::ArchivedCard::new(keep, board_id, live_col.id, 1);
-        let arch1_id = arch1.entity.id;
-        let arch2_id = arch2.entity.id;
-        let keep_id = keep_arch.entity.id;
-        tc.store.insert_archived_card(arch1).unwrap();
-        tc.store.insert_archived_card(arch2).unwrap();
-        tc.store.insert_archived_card(keep_arch).unwrap();
+        let arch1_id = card1.id;
+        let arch2_id = card2.id;
+        let keep_id = keep.id;
+        tc.store.upsert_card(card1).unwrap();
+        tc.store.upsert_card(card2).unwrap();
+        tc.store.upsert_card(keep).unwrap();
+        tc.store
+            .insert_archived_card(crate::ArchivedCard::new(arch1_id, board_id))
+            .unwrap();
+        tc.store
+            .insert_archived_card(crate::ArchivedCard::new(arch2_id, board_id))
+            .unwrap();
+        tc.store
+            .insert_archived_card(crate::ArchivedCard::new(keep_id, board_id))
+            .unwrap();
 
         let context = tc.as_command_context();
         let cmd = DeleteArchivedCards {
@@ -394,7 +408,7 @@ mod tests {
 
         let remaining = tc.store.list_archived_cards().unwrap();
         assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].entity.id, keep_id);
+        assert_eq!(remaining[0].entity_id, keep_id);
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -236,10 +236,13 @@ mod tests {
         let col = crate::Column::new(board_id, "C", 0);
         let col_id = col.id;
         let card = crate::Card::new(&mut board, col_id, "archived", 0);
-        let archived = crate::ArchivedCard::new(card, board_id, col_id, 0);
+        let card_id = card.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
-        tc.store.insert_archived_card(archived).unwrap();
+        tc.store.upsert_card(card).unwrap();
+        tc.store
+            .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+            .unwrap();
 
         let context = tc.as_command_context();
         let cmd = DeleteColumn { column_id: col_id };

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -188,11 +188,17 @@ impl UpdateSprint {
 
 fn validate_card_prefix_not_locked(sprint_id: Uuid, context: &CommandContext) -> KanbanResult<()> {
     let has_active = !context.store.list_cards_by_sprint(sprint_id)?.is_empty();
-    let has_archived = context
-        .store
-        .list_archived_cards()?
-        .iter()
-        .any(|ac| ac.entity.sprint_id == Some(sprint_id));
+    // Reference-marker model: an archived card's sprint lives on the LIVE card,
+    // fetched by the marker's `entity_id`.
+    let mut has_archived = false;
+    for ac in context.store.list_archived_cards()? {
+        if let Some(card) = context.store.get_card(ac.entity_id)? {
+            if card.sprint_id == Some(sprint_id) {
+                has_archived = true;
+                break;
+            }
+        }
+    }
     if has_active || has_archived {
         return Err(KanbanError::validation(
             "sprint card_prefix cannot be changed after cards have been assigned",
@@ -475,12 +481,16 @@ impl DeleteSprint {
             .into_iter()
             .map(|c| c.id)
             .collect();
-        let archived_with_sprint: Vec<Uuid> = store
-            .list_archived_cards()?
-            .into_iter()
-            .filter(|ac| ac.entity.sprint_id == Some(self.sprint_id))
-            .map(|ac| ac.entity.id)
-            .collect();
+        // Reference-marker model: read the sprint binding from each marker's LIVE
+        // card (fetched by `entity_id`), not from the marker.
+        let mut archived_with_sprint: Vec<Uuid> = Vec::new();
+        for ac in store.list_archived_cards()? {
+            if let Some(card) = store.get_card(ac.entity_id)? {
+                if card.sprint_id == Some(self.sprint_id) {
+                    archived_with_sprint.push(ac.entity_id);
+                }
+            }
+        }
 
         let mut commands: Vec<Command> = vec![Command::Board(super::BoardCommand::Import(
             super::ImportEntities {
@@ -681,11 +691,15 @@ mod tests {
         let sprint_id = sprint.id;
         let mut card = crate::Card::new(&mut board, col.id, "C", 0);
         card.sprint_id = Some(sprint_id);
-        let archived = crate::ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0);
+        let card_id = card.id;
+        let board_id = board.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
-        tc.store.insert_archived_card(archived).unwrap();
+        tc.store.upsert_card(card).unwrap();
+        tc.store
+            .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+            .unwrap();
 
         let context = tc.as_command_context();
         let cmd = UpdateSprint {
@@ -860,8 +874,11 @@ mod tests {
             completed_at: None,
             sprint_logs: Vec::new(),
         };
-        let archived = crate::ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0);
-        tc.store.insert_archived_card(archived).unwrap();
+        let card_id = card.id;
+        tc.store.upsert_card(card).unwrap();
+        tc.store
+            .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+            .unwrap();
 
         let fixed_time = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
         let context = tc.as_command_context();
@@ -871,10 +888,17 @@ mod tests {
         };
         cmd.execute(&context).unwrap();
 
+        // Reference-marker model: the sprint binding cleared by DeleteSprint lives
+        // on the LIVE card (fetched by the marker's entity_id), not the marker.
         let archived_cards = tc.store.list_archived_cards().unwrap();
         assert_eq!(archived_cards.len(), 1);
-        assert_eq!(archived_cards[0].entity.updated_at, fixed_time);
-        assert_eq!(archived_cards[0].entity.sprint_id, None);
+        let live = tc
+            .store
+            .get_card(archived_cards[0].entity_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(live.updated_at, fixed_time);
+        assert_eq!(live.sprint_id, None);
     }
 
     #[test]
@@ -965,11 +989,15 @@ mod tests {
         let sprint_id = sprint.id;
         let mut card = crate::Card::new(&mut board, col.id, "C", 0);
         card.sprint_id = Some(sprint_id);
-        let archived = crate::ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0);
+        let card_id = card.id;
+        let board_id = board.id;
         tc.store.upsert_board(board).unwrap();
         tc.store.upsert_column(col).unwrap();
         tc.store.upsert_sprint(sprint).unwrap();
-        tc.store.insert_archived_card(archived).unwrap();
+        tc.store.upsert_card(card).unwrap();
+        tc.store
+            .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+            .unwrap();
 
         let context = tc.as_command_context();
         let err = validate_card_prefix_not_locked(sprint_id, &context).unwrap_err();

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -73,12 +73,17 @@ pub trait DataStore: Send + Sync {
         sprint_id: Uuid,
         timestamp: chrono::DateTime<chrono::Utc>,
     ) -> KanbanResult<()> {
-        let all = self.list_archived_cards()?;
-        for mut ac in all {
-            if ac.entity.sprint_id == Some(sprint_id) {
-                ac.entity.sprint_id = None;
-                ac.entity.updated_at = timestamp;
-                self.insert_archived_card(ac)?;
+        // Reference-marker model: an archived card is an ordinary LIVE card plus a
+        // marker. Clear the sprint on the live card fetched by the marker's
+        // `entity_id` (the card is the single source of truth).
+        let markers = self.list_archived_cards()?;
+        for marker in markers {
+            if let Some(mut card) = self.get_card(marker.entity_id)? {
+                if card.sprint_id == Some(sprint_id) {
+                    card.sprint_id = None;
+                    card.updated_at = timestamp;
+                    self.upsert_card(card)?;
+                }
             }
         }
         Ok(())

--- a/crates/kanban-domain/src/export/exporter.rs
+++ b/crates/kanban-domain/src/export/exporter.rs
@@ -33,9 +33,12 @@ impl BoardExporter {
             .cloned()
             .collect();
 
+        // Scope archived cards by the first-class `board_id` (their historical
+        // column may have been deleted after archival, so column membership is
+        // not reliable).
         let board_archived_cards: Vec<ArchivedCard> = all_archived_cards
             .iter()
-            .filter(|dc| column_ids.contains(&dc.context.original_column_id))
+            .filter(|dc| dc.context.board_id == board.id)
             .cloned()
             .collect();
 

--- a/crates/kanban-domain/src/export/importer.rs
+++ b/crates/kanban-domain/src/export/importer.rs
@@ -101,11 +101,7 @@ impl BoardImporter {
             let board_archived: Vec<_> = snapshot
                 .archived_cards
                 .iter()
-                .filter(|a| {
-                    board_columns
-                        .iter()
-                        .any(|col| col.id == a.context.original_column_id)
-                })
+                .filter(|a| a.context.board_id == board.id)
                 .cloned()
                 .collect();
 

--- a/crates/kanban-domain/src/in_memory_store/archived_boards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_boards.rs
@@ -48,9 +48,10 @@ mod tests {
         let store = InMemoryStore::new();
         let board = make_board("B");
         let id = board.id;
+        store.upsert_board(board).unwrap();
 
-        store.insert_archived_board(Archived::now(board)).unwrap();
-        assert_eq!(store.get_archived_board(id).unwrap().unwrap().entity.id, id);
+        store.insert_archived_board(Archived::now(id)).unwrap();
+        assert_eq!(store.get_archived_board(id).unwrap().unwrap().entity_id, id);
         assert_eq!(store.list_archived_boards().unwrap().len(), 1);
 
         store.delete_archived_board(id).unwrap();
@@ -71,16 +72,20 @@ mod tests {
         let store = InMemoryStore::new();
         let newer = make_board("newer");
         let older = make_board("older");
+        let newer_id = newer.id;
+        let older_id = older.id;
+        store.upsert_board(newer).unwrap();
+        store.upsert_board(older).unwrap();
         store
-            .insert_archived_board(Archived::at(newer, Utc.timestamp_opt(2_000, 0).unwrap()))
+            .insert_archived_board(Archived::at(newer_id, Utc.timestamp_opt(2_000, 0).unwrap()))
             .unwrap();
         store
-            .insert_archived_board(Archived::at(older, Utc.timestamp_opt(1_000, 0).unwrap()))
+            .insert_archived_board(Archived::at(older_id, Utc.timestamp_opt(1_000, 0).unwrap()))
             .unwrap();
 
         let listed = store.list_archived_boards().unwrap();
         assert_eq!(listed.len(), 2);
-        assert_eq!(listed[0].entity.name, "older");
-        assert_eq!(listed[1].entity.name, "newer");
+        assert_eq!(listed[0].entity_id, older_id);
+        assert_eq!(listed[1].entity_id, newer_id);
     }
 }

--- a/crates/kanban-domain/src/in_memory_store/archived_cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_cards.rs
@@ -1,58 +1,34 @@
 use uuid::Uuid;
 
-use super::state::StoreState;
 use super::InMemoryStore;
-use crate::archival::Archived;
 use crate::{ArchivedCard, KanbanResult};
 
-/// F1 (KAN-870): reconstruct the archived-card VIEW from the LIVE card in `cards`
-/// plus the stored marker's context + metadata. The card is the single source of
-/// truth, so an archived read never returns a stale embedded copy (no drift).
-/// Falls back to the stored record if the live card is somehow absent (defensive).
-fn reconstruct(state: &StoreState, id: Uuid) -> Option<ArchivedCard> {
-    let stored = state.archived_cards.get(&id)?;
-    match state.cards.get(&id) {
-        Some(card) => Some(Archived::with_context(
-            card.clone(),
-            stored.context.clone(),
-            stored.metadata,
-        )),
-        None => Some(stored.clone()),
-    }
-}
-
 impl InMemoryStore {
+    // F3b (KAN-884): archived cards are PURE MARKERS — `state.archived_cards`
+    // stores `ArchivedCard { entity_id, metadata, context }` with no embedded
+    // card. The card itself is the single source of truth, living in
+    // `state.cards`; callers that need card fields fetch it by `entity_id`.
     pub(super) fn get_archived_card_impl(
         &self,
         card_id: Uuid,
     ) -> KanbanResult<Option<ArchivedCard>> {
         let state = self.read_state()?;
-        Ok(reconstruct(&state, card_id))
+        Ok(state.archived_cards.get(&card_id).copied())
     }
 
     pub(super) fn list_archived_cards_impl(&self) -> KanbanResult<Vec<ArchivedCard>> {
         let state = self.read_state()?;
-        let mut acs: Vec<ArchivedCard> = state
-            .archived_cards
-            .keys()
-            .filter_map(|id| reconstruct(&state, *id))
-            .collect();
+        let mut acs: Vec<ArchivedCard> = state.archived_cards.values().copied().collect();
         acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
         Ok(acs)
     }
 
     pub(super) fn insert_archived_card_impl(&self, ac: ArchivedCard) -> KanbanResult<()> {
-        use crate::archival::ArchivedEntity;
         let mut state = self.write_state()?;
-        let key = ac.entity_id();
-        // Reference model: the entity lives in `cards`. Ensure it's present —
-        // direct callers (e.g. a DeleteCard inverse re-import) may archive a card
-        // not yet in the live map — matching SqliteStore, which upserts the card
-        // row alongside the marker.
-        let column_id = ac.entity.column_id;
-        state.add_card_to_column_index(key, column_id);
-        state.cards.insert(key, ac.entity.clone());
-        state.archived_cards.insert(key, ac);
+        // Reference model: the card stays live in `cards`; this only records the
+        // marker. Re-import paths (e.g. a DeleteCard inverse) upsert the live
+        // card themselves before recording the marker.
+        state.archived_cards.insert(ac.entity_id, ac);
         Ok(())
     }
 
@@ -61,15 +37,11 @@ impl InMemoryStore {
         board_id: Uuid,
     ) -> KanbanResult<Vec<ArchivedCard>> {
         let state = self.read_state()?;
-        let ids: Vec<Uuid> = state
+        let mut acs: Vec<ArchivedCard> = state
             .archived_cards
-            .iter()
-            .filter(|(_, ac)| ac.context.board_id == board_id)
-            .map(|(id, _)| *id)
-            .collect();
-        let mut acs: Vec<ArchivedCard> = ids
-            .iter()
-            .filter_map(|id| reconstruct(&state, *id))
+            .values()
+            .filter(|ac| ac.context.board_id == board_id)
+            .copied()
             .collect();
         acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
         Ok(acs)
@@ -118,11 +90,11 @@ mod tests {
         let col = make_column(board.id, "C", 0);
         let card = make_card(&mut board, col.id, "Card", 0);
         let card_id = card.id;
-        let ac = ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0);
+        let ac = ArchivedCard::new(card_id, uuid::Uuid::nil());
         store.insert_archived_card(ac).unwrap();
 
         let fetched = store.get_archived_card(card_id).unwrap().unwrap();
-        assert_eq!(fetched.entity.id, card_id);
+        assert_eq!(fetched.entity_id, card_id);
     }
 
     #[test]
@@ -133,10 +105,10 @@ mod tests {
         let card1 = make_card(&mut board, col.id, "C1", 0);
         let card2 = make_card(&mut board, col.id, "C2", 1);
         store
-            .insert_archived_card(ArchivedCard::new(card1, uuid::Uuid::nil(), col.id, 0))
+            .insert_archived_card(ArchivedCard::new(card1.id, uuid::Uuid::nil()))
             .unwrap();
         store
-            .insert_archived_card(ArchivedCard::new(card2, uuid::Uuid::nil(), col.id, 1))
+            .insert_archived_card(ArchivedCard::new(card2.id, uuid::Uuid::nil()))
             .unwrap();
 
         assert_eq!(store.list_archived_cards().unwrap().len(), 2);
@@ -152,18 +124,21 @@ mod tests {
         card.sprint_id = Some(sprint_id);
         let card_id = card.id;
         let before = card.updated_at;
-        let ac = ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0);
-        store.insert_archived_card(ac).unwrap();
+        // Reference-marker model: the card stays LIVE; the marker only references it.
+        store.upsert_card(card.clone()).unwrap();
+        store
+            .insert_archived_card(ArchivedCard::new(card_id, uuid::Uuid::nil()))
+            .unwrap();
 
         let ts = chrono::Utc::now() + chrono::Duration::seconds(10);
         store
             .clear_sprint_from_archived_cards(sprint_id, ts)
             .unwrap();
 
-        let ac = store.get_archived_card(card_id).unwrap().unwrap();
-        assert!(ac.entity.sprint_id.is_none());
-        assert!(ac.entity.updated_at > before);
-        assert_eq!(ac.entity.updated_at, ts);
+        let live = store.get_card(card_id).unwrap().unwrap();
+        assert!(live.sprint_id.is_none());
+        assert!(live.updated_at > before);
+        assert_eq!(live.updated_at, ts);
     }
 
     #[test]
@@ -174,7 +149,7 @@ mod tests {
         let card = make_card(&mut board, col.id, "Card", 0);
         let card_id = card.id;
         store
-            .insert_archived_card(ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0))
+            .insert_archived_card(ArchivedCard::new(card_id, uuid::Uuid::nil()))
             .unwrap();
         store.delete_archived_card(card_id).unwrap();
         assert!(store.get_archived_card(card_id).unwrap().is_none());
@@ -195,17 +170,17 @@ mod tests {
         let b1 = make_card(&mut board_b, col_b.id, "B1", 0);
 
         store
-            .insert_archived_card(ArchivedCard::new(a1, board_a.id, col_a.id, 0))
+            .insert_archived_card(ArchivedCard::new(a1.id, board_a.id))
             .unwrap();
         store
-            .insert_archived_card(ArchivedCard::new(a2, board_a.id, col_a.id, 1))
+            .insert_archived_card(ArchivedCard::new(a2.id, board_a.id))
             .unwrap();
         store
-            .insert_archived_card(ArchivedCard::new(b1, board_b.id, col_b.id, 0))
+            .insert_archived_card(ArchivedCard::new(b1.id, board_b.id))
             .unwrap();
 
         let only_a = store.list_archived_cards_by_board(board_a.id).unwrap();
-        let ids: Vec<Uuid> = only_a.iter().map(|ac| ac.entity.id).collect();
+        let ids: Vec<Uuid> = only_a.iter().map(|ac| ac.entity_id).collect();
         assert_eq!(only_a.len(), 2, "only board A's archived cards");
         assert!(ids.contains(&a1_id) && ids.contains(&a2_id));
         assert!(only_a.iter().all(|ac| ac.context.board_id == board_a.id));
@@ -225,10 +200,10 @@ mod tests {
         let col_b = make_column(board_b.id, "CB", 0);
         let card_b = make_card(&mut board_b, col_b.id, "B1", 0);
         store
-            .insert_archived_card(ArchivedCard::new(card_a, board_a.id, col_a.id, 0))
+            .insert_archived_card(ArchivedCard::new(card_a.id, board_a.id))
             .unwrap();
         store
-            .insert_archived_card(ArchivedCard::new(card_b, board_b.id, col_b.id, 0))
+            .insert_archived_card(ArchivedCard::new(card_b.id, board_b.id))
             .unwrap();
 
         let via_query = store.list_archived_cards_by_board(board_a.id).unwrap();
@@ -244,21 +219,21 @@ mod tests {
 
     #[test]
     fn test_list_archived_cards_by_board_includes_card_with_deleted_column() {
-        // Scope is by the board_id field, tolerating a dangling
-        // original_column_id (the column was deleted after archival). The
-        // record must still be returned — the load-bearing D2 behavior change.
+        // Scope is by the board_id field, tolerating a dangling historical column
+        // (the column was deleted after archival). The record must still be
+        // returned — the load-bearing D2 behavior change.
         let store = InMemoryStore::new();
         let mut board = make_board("B");
         let dangling_col = Uuid::new_v4(); // never inserted as a column
         let card = make_card(&mut board, dangling_col, "Orphan", 0);
         let card_id = card.id;
         store
-            .insert_archived_card(ArchivedCard::new(card, board.id, dangling_col, 0))
+            .insert_archived_card(ArchivedCard::new(card_id, board.id))
             .unwrap();
 
         let found = store.list_archived_cards_by_board(board.id).unwrap();
         assert_eq!(found.len(), 1);
-        assert_eq!(found[0].entity.id, card_id);
+        assert_eq!(found[0].entity_id, card_id);
     }
 }
 
@@ -275,14 +250,9 @@ mod f1_reference_tests {
 
     /// Archive a live card the way the ArchiveCards command does: insert the
     /// marker, then delete_card (which F1 makes a guarded no-op on archived ids).
-    fn archive(store: &InMemoryStore, card: &Card, board_id: uuid::Uuid, col_id: uuid::Uuid) {
+    fn archive(store: &InMemoryStore, card: &Card, board_id: uuid::Uuid, _col_id: uuid::Uuid) {
         store
-            .insert_archived_card(ArchivedCard::new(
-                card.clone(),
-                board_id,
-                col_id,
-                card.position,
-            ))
+            .insert_archived_card(ArchivedCard::new(card.id, board_id))
             .unwrap();
         store.delete_card(card.id).unwrap();
     }
@@ -321,9 +291,12 @@ mod f1_reference_tests {
         let mut edited = store.get_card(card.id).unwrap().unwrap();
         edited.title = "edited".into();
         store.upsert_card(edited).unwrap();
-        let ac = store.get_archived_card(card.id).unwrap().unwrap();
+        assert!(
+            store.get_archived_card(card.id).unwrap().is_some(),
+            "the marker still references the card"
+        );
         assert_eq!(
-            ac.into_card().title,
+            store.get_card(card.id).unwrap().unwrap().title,
             "edited",
             "archived read reconstructs from the LIVE card (no stale copy)"
         );

--- a/crates/kanban-domain/src/in_memory_store/boards.rs
+++ b/crates/kanban-domain/src/in_memory_store/boards.rs
@@ -12,7 +12,16 @@ impl InMemoryStore {
 
     pub(super) fn list_boards_impl(&self) -> KanbanResult<Vec<Board>> {
         let state = self.read_state()?;
-        let mut boards: Vec<Board> = state.boards.values().cloned().collect();
+        // Reference-marker model: the board head stays in `boards` while archived;
+        // an `archived_boards` marker hides it from the LIVE list (parity with the
+        // SQLite `NOT EXISTS (board_archival …)` filter). `get_board` stays
+        // unfiltered so archived boards remain fetchable by id.
+        let mut boards: Vec<Board> = state
+            .boards
+            .values()
+            .filter(|b| !state.archived_boards.contains_key(&b.id))
+            .cloned()
+            .collect();
         sort_by_position(&mut boards);
         Ok(boards)
     }

--- a/crates/kanban-domain/src/in_memory_store/cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/cards.rs
@@ -109,11 +109,23 @@ impl InMemoryStore {
 
     pub(super) fn delete_cards_by_columns_impl(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
         let mut state = self.write_state()?;
+        // Reference-marker model: this deletes only LIVE cards in the columns.
+        // Archived-but-live cards are owned by `delete_archived_card` (marker +
+        // row); deleting their row here would strip them from the cascade's
+        // archived-card inverse (which captures the still-live card just before it
+        // runs), breaking delete↔undo reversibility for archived cards.
+        let archived: std::collections::HashSet<Uuid> =
+            state.archived_cards.keys().copied().collect();
         state
             .cards
-            .retain(|_, c| !column_ids.contains(&c.column_id));
+            .retain(|id, c| !column_ids.contains(&c.column_id) || archived.contains(id));
         for col_id in column_ids {
-            state.cards_by_column.remove(col_id);
+            if let Some(ids) = state.cards_by_column.get_mut(col_id) {
+                ids.retain(|id| archived.contains(id));
+                if ids.is_empty() {
+                    state.cards_by_column.remove(col_id);
+                }
+            }
         }
         Ok(())
     }

--- a/crates/kanban-domain/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-domain/src/in_memory_store/snapshot.rs
@@ -12,29 +12,15 @@ impl InMemoryStore {
         let mut columns: Vec<_> = state.columns.values().cloned().collect();
         sort_by_position(&mut columns);
 
-        // F1 (KAN-870): `state.cards` now holds live AND archived cards. Snapshot
-        // `.cards` is LIVE only; `.archived_cards` reconstructs each entity from
-        // the live card + the stored marker (so no stale copy is serialized).
-        let mut cards: Vec<_> = state
-            .cards
-            .values()
-            .filter(|c| !state.is_card_archived(&c.id))
-            .cloned()
-            .collect();
+        // F3b (KAN-884): reference-marker model. Every card — live AND archived —
+        // is the single source of truth in `state.cards`, so `.cards` carries them
+        // all. `.archived_cards` is pure markers (`entity_id` references the card
+        // in `.cards`); nothing is embedded, nothing is duplicated.
+        let mut cards: Vec<_> = state.cards.values().cloned().collect();
         sort_by_position(&mut cards);
 
-        let mut archived_cards: Vec<crate::ArchivedCard> = state
-            .archived_cards
-            .iter()
-            .map(|(id, stored)| match state.cards.get(id) {
-                Some(card) => crate::archival::Archived::with_context(
-                    card.clone(),
-                    stored.context.clone(),
-                    stored.metadata,
-                ),
-                None => stored.clone(),
-            })
-            .collect();
+        let mut archived_cards: Vec<crate::ArchivedCard> =
+            state.archived_cards.values().copied().collect();
         archived_cards.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
 
         let mut sprints: Vec<_> = state.sprints.values().cloned().collect();
@@ -59,20 +45,20 @@ impl InMemoryStore {
         let mut state = self.write_state()?;
         state.boards = snapshot.boards.into_iter().map(|b| (b.id, b)).collect();
         state.columns = snapshot.columns.into_iter().map(|c| (c.id, c)).collect();
-        // F1 (KAN-870): archived cards' entities live in `cards` too (reference
-        // model). Load live cards, then merge the archived entities in, and keep
-        // the archived records as markers.
+        // F3b (KAN-884): `snapshot.cards` already carries every card (live AND
+        // archived — the source of truth); `archived_cards`/`archived_boards` are
+        // pure markers keyed by `entity_id`. Nothing to lift.
         state.cards = snapshot.cards.into_iter().map(|c| (c.id, c)).collect();
-        let archived = snapshot.archived_cards;
-        for ac in &archived {
-            state.cards.insert(ac.entity.id, ac.entity.clone());
-        }
         state.rebuild_card_column_index();
-        state.archived_cards = archived.into_iter().map(|ac| (ac.entity.id, ac)).collect();
+        state.archived_cards = snapshot
+            .archived_cards
+            .into_iter()
+            .map(|ac| (ac.entity_id, ac))
+            .collect();
         state.archived_boards = snapshot
             .archived_boards
             .into_iter()
-            .map(|ab| (ab.entity.id, ab))
+            .map(|ab| (ab.entity_id, ab))
             .collect();
         state.sprints = snapshot.sprints.into_iter().map(|s| (s.id, s)).collect();
         state.graph = snapshot.graph;
@@ -118,21 +104,26 @@ mod tests {
         let archived = make_board("archived");
         let archived_id = archived.id;
         store.upsert_board(live).unwrap();
+        store.upsert_board(archived).unwrap();
         store
-            .insert_archived_board(Archived::now(archived))
+            .insert_archived_board(Archived::now(archived_id))
             .unwrap();
 
         let snap = store.snapshot().unwrap();
-        assert_eq!(snap.boards.len(), 1, "only the live board is in .boards");
+        // Reference-marker model: BOTH board heads live in `.boards` (the archived
+        // one is the marker's referenced entity); `.archived_boards` holds the
+        // pure marker.
+        assert_eq!(snap.boards.len(), 2, "all board heads are in .boards");
         assert_eq!(snap.archived_boards.len(), 1);
 
         let store2 = InMemoryStore::new();
         store2.apply_snapshot(snap).unwrap();
 
+        // list_boards is live-scoped: only the non-archived board.
         assert_eq!(store2.list_boards().unwrap().len(), 1);
         let restored = store2.list_archived_boards().unwrap();
         assert_eq!(restored.len(), 1);
-        assert_eq!(restored[0].entity.id, archived_id);
+        assert_eq!(restored[0].entity_id, archived_id);
     }
 
     #[test]

--- a/crates/kanban-domain/src/in_memory_store/state.rs
+++ b/crates/kanban-domain/src/in_memory_store/state.rs
@@ -86,7 +86,7 @@ mod tests {
         let col = make_column(board.id, "C", 0);
         let card = make_card(&mut board, col.id, "Card", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
-        let ac = ArchivedCard::new(card.clone(), uuid::Uuid::nil(), col.id, 0);
+        let ac = ArchivedCard::new(card.id, uuid::Uuid::nil());
 
         assert!(store.upsert_board(board.clone()).is_ok());
         assert!(store.get_board(board.id).is_ok());

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -32,7 +32,7 @@ pub mod sprint_log;
 pub mod tag;
 pub mod task_list_view;
 
-pub use archival::{ArchivableEntity, ArchiveMetadata, Archived, ArchivedEntity, NoContext};
+pub use archival::{ArchiveMetadata, Archived, ArchivedEntity, NoContext};
 pub use archived_board::{ArchivedBoard, ArchivedBoardSummary};
 pub use archived_card::{ArchivedCard, CardRestoreContext};
 pub use board::{

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -79,12 +79,17 @@ pub trait KanbanOperations {
     /// drift-lock: every `KanbanOperations` impl must provide it.
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>>;
 
+    /// List archived cards as (live card, archived_at) pairs, sorted by the
+    /// requested card sort. Under the reference-marker model the marker no longer
+    /// embeds the card, so we fetch each marker's LIVE card by `entity_id` and
+    /// carry its archive time alongside.
     fn list_archived_cards_sorted(
         &self,
         filter: ArchivedCardListFilter,
-    ) -> KanbanResult<Vec<ArchivedCard>> {
+    ) -> KanbanResult<Vec<(Card, chrono::DateTime<chrono::Utc>)>> {
+        use std::collections::HashMap;
         // Scope by the first-class `board_id` field, not by column membership.
-        let cards = match filter.board_id {
+        let markers = match filter.board_id {
             Some(bid) => self.list_archived_cards_by_board(bid)?,
             None => self.list_archived_cards()?,
         };
@@ -92,23 +97,34 @@ pub trait KanbanOperations {
             Some(bid) => self.get_board(bid)?,
             None => None,
         };
+        // Fetch each marker's LIVE card (get_card is unfiltered), skipping any
+        // whose card has vanished, and index archived_at by entity_id.
+        let mut at_by_id: HashMap<Uuid, chrono::DateTime<chrono::Utc>> = HashMap::new();
+        let mut live_cards: Vec<Card> = Vec::with_capacity(markers.len());
+        for marker in &markers {
+            if let Some(card) = self.get_card(marker.entity_id)? {
+                at_by_id.insert(card.id, marker.metadata.archived_at);
+                live_cards.push(card);
+            }
+        }
         // Already board-scoped above: pass `board_id: None` and EMPTY columns so
-        // a dangling `original_column_id` (its column deleted after archival) is
-        // not re-dropped by column-membership filtering. `board` is retained only
-        // for board-default sort resolution.
+        // a dangling historical column (deleted after archival) is not re-dropped
+        // by column-membership filtering. `board` is retained only for
+        // board-default sort resolution.
         let card_filter = CardListFilter {
             board_id: None,
             sort: filter.sort,
             sort_order: filter.sort_order,
             ..Default::default()
         };
-        Ok(filter_and_sort_cards(
-            &cards,
-            &[],
-            &[],
-            board.as_ref(),
-            &card_filter,
-        ))
+        let sorted = filter_and_sort_cards(&live_cards, &[], &[], board.as_ref(), &card_filter);
+        Ok(sorted
+            .into_iter()
+            .map(|c| {
+                let at = at_by_id[&c.id];
+                (c, at)
+            })
+            .collect())
     }
 
     // Card sprint operations

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -397,13 +397,16 @@ mod tests {
     #[test]
     fn test_json_archived_card_round_trip_preserves_card() {
         use uuid::Uuid;
+        // Reference-marker model: the archived card stays LIVE in `cards`; the
+        // `archived_cards` entry is a pure marker referencing it by `entity_id`.
         let card = fully_populated_card();
-        let archived = ArchivedCard::new(card.clone(), Uuid::new_v4(), Uuid::new_v4(), 3);
+        let board_id = Uuid::new_v4();
+        let archived = ArchivedCard::new(card.id, board_id);
         let snapshot = Snapshot::from_data(
             vec![],
             vec![],
-            vec![],
-            vec![archived.clone()],
+            vec![card.clone()],
+            vec![archived],
             vec![],
             DependencyGraph::new(),
         );
@@ -411,8 +414,13 @@ mod tests {
         let json = serde_json::to_string(&snapshot).unwrap();
         let restored: Snapshot = serde_json::from_str(&json).unwrap();
 
+        // The live card survives verbatim in `cards`.
+        assert_eq!(restored.cards.len(), 1);
+        assert_eq!(restored.cards[0], card);
+        // The marker survives and references the live card by id.
         assert_eq!(restored.archived_cards.len(), 1);
-        assert_eq!(restored.archived_cards[0].entity, card);
+        assert_eq!(restored.archived_cards[0].entity_id, card.id);
+        assert_eq!(restored.archived_cards[0].context.board_id, board_id);
         assert_eq!(restored.archived_cards[0], archived);
     }
 
@@ -423,8 +431,8 @@ mod tests {
         // backfill is the persistence migration's job, D7), so old files parse.
         use uuid::Uuid;
         let card = fully_populated_card();
-        let archived = ArchivedCard::new(card, Uuid::new_v4(), Uuid::new_v4(), 3);
-        let mut value = serde_json::to_value(&archived).unwrap();
+        let archived = ArchivedCard::new(card.id, Uuid::new_v4());
+        let mut value = serde_json::to_value(archived).unwrap();
         value
             .as_object_mut()
             .unwrap()
@@ -622,9 +630,9 @@ mod tests {
 
     #[test]
     fn test_snapshot_archived_boards_round_trips_wrapper() {
-        let ab = crate::ArchivedBoard::now(Board::new("Archived", Some("KAN")));
+        let ab = crate::ArchivedBoard::now(Board::new("Archived", Some("KAN")).id);
         let mut snap = Snapshot::new();
-        snap.archived_boards = vec![ab.clone()];
+        snap.archived_boards = vec![ab];
 
         let json = serde_json::to_string(&snap).unwrap();
         let restored: Snapshot = serde_json::from_str(&json).unwrap();
@@ -637,8 +645,9 @@ mod tests {
     fn test_snapshot_is_empty_false_when_only_archived_boards_present() {
         let mut snap = Snapshot::new();
         assert!(snap.is_empty());
-        snap.archived_boards
-            .push(crate::ArchivedBoard::now(Board::new("A", None::<String>)));
+        snap.archived_boards.push(crate::ArchivedBoard::now(
+            Board::new("A", None::<String>).id,
+        ));
         assert!(!snap.is_empty());
     }
 }

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -13,7 +13,7 @@ use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{
     ArchivedCardListFilter, CardListFilter, CardUpdate, FieldUpdate, KanbanOperations,
 };
-use kanban_service::api::{ArchivedCardResponse, CardResponse};
+use kanban_service::api::CardResponse;
 use rmcp::{
     handler::server::wrapper::Parameters,
     model::{CallToolResult, ErrorData as McpError},
@@ -235,7 +235,7 @@ impl KanbanMcpServer {
     }
 
     #[tool(
-        description = "List archived cards. Returns ArchivedCardResponse (nested card with description + board_id). Use page/page_size for pagination (default: page=1, page_size=50)."
+        description = "List archived cards. Returns CardResponse items (the full card projection) each carrying an archived_at timestamp. Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
     pub async fn tool_list_archived_cards(
         &self,
@@ -258,8 +258,10 @@ impl KanbanMcpServer {
             .map_err(kanban_err_to_mcp)
         })
         .await?;
-        let responses: Vec<ArchivedCardResponse> =
-            cards.iter().map(ArchivedCardResponse::from).collect();
+        let responses: Vec<CardResponse> = cards
+            .iter()
+            .map(|(card, at)| CardResponse::archived(card, *at))
+            .collect();
         to_call_tool_result(
             &PaginatedList::paginate(responses, page, page_size).map_err(core_err_to_mcp)?,
         )

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -192,7 +192,7 @@ async fn card_create_get_move_archive_restore() {
 
     ctx.archive_card(card.id).unwrap();
     let archived = ctx.list_archived_cards().unwrap();
-    assert!(archived.iter().any(|c| c.entity.id == card.id));
+    assert!(archived.iter().any(|c| c.entity_id == card.id));
 
     let restored = ctx.restore_card(card.id, None).unwrap();
     assert_eq!(restored.id, card.id);
@@ -1912,15 +1912,18 @@ async fn test_mcp_list_archived_cards_includes_board_id() {
             .unwrap(),
     );
     let item = &listed["items"][0];
-    // v1 ArchivedCardResponse: board_id is first-class and equals the source board.
-    assert_eq!(item["board_id"], board_id);
-    // Nested `card` is the rich CardResponse (carries description + card_number,
-    // hides internal sprint_logs).
-    assert_eq!(item["card"]["description"], "desc");
-    assert!(item["card"]["card_number"].is_number());
-    assert!(item["card"]
-        .as_object()
-        .unwrap()
-        .get("sprint_logs")
-        .is_none());
+    // Under DTO retirement the archived list item is the flat CardResponse shape:
+    // a top-level `archived_at` timestamp plus the normal card fields, with no
+    // nested `card`, no `original_column_id`, and no first-class `board_id`.
+    assert!(item["archived_at"].is_string());
+    assert_eq!(item["title"], "the card");
+    assert_eq!(item["description"], "desc");
+    let obj = item.as_object().unwrap();
+    assert!(obj.get("card").is_none(), "no nested card object");
+    assert!(
+        obj.get("original_column_id").is_none(),
+        "no original_column_id"
+    );
+    assert!(obj.get("board_id").is_none(), "no first-class board_id");
+    let _ = board_id;
 }

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -1,8 +1,9 @@
 use crate::atomic_writer::AtomicWriter;
 use crate::conflict::FileMetadata;
 use crate::migration::{
-    transform_to_v6_split_graph_value, transform_v2_to_v3_value, transform_v6_to_v7_value,
-    transform_v7_to_v8_value, transform_v8_to_v9_value, Migrator,
+    normalize_embedded_archived_to_references, transform_to_v6_split_graph_value,
+    transform_v2_to_v3_value, transform_v6_to_v7_value, transform_v7_to_v8_value,
+    transform_v8_to_v9_value, Migrator,
 };
 use kanban_persistence::{
     FormatVersion, PersistenceError, PersistenceMetadata, PersistenceResult, PersistenceStore,
@@ -388,7 +389,7 @@ impl PersistenceStore for JsonFileStore {
         }
 
         let file_bytes = tokio::fs::read(&self.path).await?;
-        let envelope = Self::parse_envelope(&file_bytes)?;
+        let mut envelope = Self::parse_envelope(&file_bytes)?;
 
         let raw_value: serde_json::Value = serde_json::from_slice(&file_bytes)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
@@ -402,6 +403,12 @@ impl PersistenceStore for JsonFileStore {
                 );
             }
         }
+
+        // F3b read-shim: lift any embedded archived entities (old on-disk shape)
+        // to the pure reference-marker shape before handing bytes to the collapsed
+        // `Snapshot` deserializer. Runs after the version-migration chain; does not
+        // bump the version. Idempotent on already-marker files.
+        normalize_embedded_archived_to_references(&mut envelope.data);
 
         let data = serde_json::to_vec(&envelope.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
@@ -448,7 +455,7 @@ impl PersistenceStore for JsonFileStore {
             file_bytes
         };
 
-        let envelope = Self::parse_envelope(&final_bytes)?;
+        let mut envelope = Self::parse_envelope(&final_bytes)?;
 
         let raw_value: serde_json::Value = serde_json::from_slice(&final_bytes)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
@@ -462,6 +469,10 @@ impl PersistenceStore for JsonFileStore {
                 );
             }
         }
+
+        // F3b read-shim (see async `load`): lift embedded archived entities to the
+        // reference-marker shape before the collapsed `Snapshot` deserializer.
+        normalize_embedded_archived_to_references(&mut envelope.data);
 
         let data = serde_json::to_vec(&envelope.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
@@ -1637,13 +1648,14 @@ mod tests {
         let store = JsonFileStore::new(&file_path);
 
         let card = fully_populated_card();
-        let archived =
-            kanban_domain::ArchivedCard::new(card.clone(), Uuid::new_v4(), Uuid::new_v4(), 3);
+        // Reference-marker model: the card stays LIVE in `.cards`; `archived_cards`
+        // carries a pure marker referencing it by `entity_id`.
+        let archived = kanban_domain::ArchivedCard::new(card.id, Uuid::new_v4());
         let snapshot = kanban_domain::Snapshot::from_data(
             vec![],
             vec![],
-            vec![],
-            vec![archived.clone()],
+            vec![card.clone()],
+            vec![archived],
             vec![],
             kanban_domain::DependencyGraph::new(),
         );
@@ -1655,8 +1667,12 @@ mod tests {
 
         let (loaded, _meta) = store.load().await.unwrap();
         let domain = snapshot_from_json_bytes(&loaded.data).unwrap();
+        // The live card round-trips verbatim under `.cards`; the marker round-trips
+        // under `.archived_cards` referencing it by id (no embedded entity).
+        assert_eq!(domain.cards.len(), 1);
+        assert_eq!(domain.cards[0], card);
         assert_eq!(domain.archived_cards.len(), 1);
-        assert_eq!(domain.archived_cards[0].entity, card);
+        assert_eq!(domain.archived_cards[0].entity_id, card.id);
         assert_eq!(domain.archived_cards[0], archived);
     }
 }

--- a/crates/kanban-persistence-json/src/migration/mod.rs
+++ b/crates/kanban-persistence-json/src/migration/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod backup;
 pub mod migrator;
+pub(crate) mod normalize_archived;
 pub mod split_graph;
 pub mod v1_to_v2;
 pub mod v2_to_v3;
@@ -9,6 +10,7 @@ pub mod v8_to_v9_archived_boards;
 
 pub(crate) use backup::pre_latest_backup_path_for;
 pub use migrator::Migrator;
+pub(crate) use normalize_archived::normalize_embedded_archived_to_references;
 pub(crate) use split_graph::transform_to_v6_split_graph_value;
 pub use v1_to_v2::V1ToV2Migration;
 pub(crate) use v2_to_v3::transform_v2_to_v3_value;

--- a/crates/kanban-persistence-json/src/migration/normalize_archived.rs
+++ b/crates/kanban-persistence-json/src/migration/normalize_archived.rs
@@ -1,0 +1,256 @@
+//! Temporary F3b read-shim: lift EMBEDDED archived entities to the pure
+//! reference-marker shape at load time.
+//!
+//! Historical on-disk files embed the archived entity inside each
+//! `archived_cards[]` / `archived_boards[]` entry (under the key `entity`, with
+//! the legacy alias `card` for cards / `board` for boards) and do NOT carry that
+//! entity in the top-level `cards` / `boards` arrays. The collapsed `Snapshot`
+//! deserializer (F3b) expects PURE MARKERS (`entity_id`) with every entity
+//! living in `cards` / `boards`. This pass normalizes the former to the latter,
+//! in place, at read time.
+//!
+//! It runs AFTER the version-migration chain and BEFORE the bytes are handed to
+//! the `Snapshot` deserializer. It does NOT bump `FormatVersion` — this is a
+//! transparent read-time normalize.
+//!
+//! TEMPORARY: MIGRATION-M1 (KAN-874) replaces this with a formal, version-bumped
+//! V9 → V10 migration step (embed → reference) that rewrites the file on disk.
+//! Until then, this shim keeps genuine old files loadable without a version bump.
+
+use serde_json::Value;
+
+/// Normalize an envelope's `data` object in place: lift any embedded archived
+/// entity into the live collection and collapse the entry to a pure marker.
+/// Idempotent — a file already in marker shape passes through unchanged.
+/// Defensive — missing keys / non-array values are no-ops.
+pub(crate) fn normalize_embedded_archived_to_references(data: &mut Value) {
+    let Some(obj) = data.as_object_mut() else {
+        return;
+    };
+
+    lift_embedded(
+        obj,
+        "archived_cards",
+        "cards",
+        &["entity", "card"],
+        card_marker,
+    );
+    lift_embedded(
+        obj,
+        "archived_boards",
+        "boards",
+        &["entity", "board"],
+        board_marker,
+    );
+}
+
+/// For each entry in `archived_key`, if it embeds an entity under any of
+/// `embed_keys`, move that entity into `live_key` (unless already present by id)
+/// and replace the entry with the marker produced by `to_marker`.
+fn lift_embedded(
+    data: &mut serde_json::Map<String, Value>,
+    archived_key: &str,
+    live_key: &str,
+    embed_keys: &[&str],
+    to_marker: fn(&Value, &Value) -> Option<Value>,
+) {
+    // Pull the archived array out so we can also mutate the live array.
+    let Some(mut archived) = data
+        .get_mut(archived_key)
+        .and_then(|v| v.as_array_mut())
+        .map(std::mem::take)
+    else {
+        return;
+    };
+
+    // Snapshot the ids already present in the live collection.
+    let mut live_ids: std::collections::HashSet<String> = data
+        .get(live_key)
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.get("id").and_then(|v| v.as_str()).map(str::to_string))
+        .collect();
+
+    let mut lifted: Vec<Value> = Vec::new();
+
+    for entry in archived.iter_mut() {
+        // Already a marker (has entity_id, no embed) → leave unchanged.
+        let embedded = embed_keys.iter().find_map(|k| entry.get(*k)).cloned();
+        let Some(embedded) = embedded else {
+            continue;
+        };
+
+        if let Some(marker) = to_marker(&embedded, entry) {
+            // Lift the entity into the live collection (dedup by id).
+            if let Some(id) = embedded.get("id").and_then(|v| v.as_str()) {
+                if live_ids.insert(id.to_string()) {
+                    lifted.push(embedded.clone());
+                }
+            }
+            *entry = marker;
+        }
+    }
+
+    if !lifted.is_empty() {
+        let live = data
+            .entry(live_key.to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        if let Some(arr) = live.as_array_mut() {
+            arr.extend(lifted);
+        }
+    }
+
+    data.insert(archived_key.to_string(), Value::Array(archived));
+}
+
+/// Build a card marker `{ entity_id, archived_at, board_id? }` from the embedded
+/// card and the original archived-card entry (carries `archived_at` / `board_id`).
+fn card_marker(embedded: &Value, entry: &Value) -> Option<Value> {
+    let id = embedded.get("id")?.clone();
+    let mut marker = serde_json::Map::new();
+    marker.insert("entity_id".to_string(), id);
+    if let Some(at) = entry.get("archived_at") {
+        marker.insert("archived_at".to_string(), at.clone());
+    }
+    if let Some(board_id) = entry.get("board_id") {
+        marker.insert("board_id".to_string(), board_id.clone());
+    }
+    Some(Value::Object(marker))
+}
+
+/// Build a board marker `{ entity_id, archived_at }` (NoContext — no extra
+/// fields) from the embedded board and the original archived-board entry.
+fn board_marker(embedded: &Value, entry: &Value) -> Option<Value> {
+    let id = embedded.get("id")?.clone();
+    let mut marker = serde_json::Map::new();
+    marker.insert("entity_id".to_string(), id);
+    if let Some(at) = entry.get("archived_at") {
+        marker.insert("archived_at".to_string(), at.clone());
+    }
+    Some(Value::Object(marker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const CARD: &str = "33333333-3333-3333-3333-333333333333";
+    const BOARD: &str = "11111111-1111-1111-1111-111111111111";
+
+    #[test]
+    fn test_embedded_archived_card_is_lifted_to_reference() {
+        // Embed shape: the archived card carries the full entity under `card`, is
+        // NOT present in `cards`, and has board_id + original_column_id.
+        let mut data = json!({
+            "cards": [],
+            "archived_cards": [{
+                "card": { "id": CARD, "title": "T", "column_id": "col-1", "position": 3 },
+                "archived_at": "2024-01-01T00:00:00Z",
+                "board_id": BOARD,
+                "original_column_id": "col-1",
+                "original_position": 3
+            }]
+        });
+
+        normalize_embedded_archived_to_references(&mut data);
+
+        // The card was lifted into the live `cards` array.
+        let cards = data["cards"].as_array().unwrap();
+        assert_eq!(cards.len(), 1, "the embedded card is lifted into cards");
+        assert_eq!(cards[0]["id"].as_str(), Some(CARD));
+        assert_eq!(cards[0]["title"].as_str(), Some("T"));
+
+        // The archived entry became a pure marker: entity_id + archived_at +
+        // board_id, with NO embedded entity / original_* leftovers.
+        let ac = &data["archived_cards"][0];
+        assert_eq!(ac["entity_id"].as_str(), Some(CARD));
+        assert_eq!(ac["archived_at"].as_str(), Some("2024-01-01T00:00:00Z"));
+        assert_eq!(ac["board_id"].as_str(), Some(BOARD), "board_id preserved");
+        assert!(ac.get("card").is_none(), "no embedded card key");
+        assert!(ac.get("entity").is_none(), "no embedded entity key");
+        assert!(ac.get("original_column_id").is_none());
+        assert!(ac.get("original_position").is_none());
+    }
+
+    #[test]
+    fn test_marker_shape_archived_card_passes_through_unchanged() {
+        // Already a marker (entity_id, no embed): idempotent no-op, and the card
+        // already in `cards` is not duplicated.
+        let mut data = json!({
+            "cards": [{ "id": CARD, "title": "T" }],
+            "archived_cards": [{
+                "entity_id": CARD,
+                "archived_at": "2024-01-01T00:00:00Z",
+                "board_id": BOARD
+            }]
+        });
+        let before = data.clone();
+
+        normalize_embedded_archived_to_references(&mut data);
+
+        assert_eq!(data, before, "a marker-shape file is unchanged");
+        assert_eq!(
+            data["cards"].as_array().unwrap().len(),
+            1,
+            "the live card is not duplicated"
+        );
+    }
+
+    #[test]
+    fn test_embedded_archived_board_is_lifted_to_reference() {
+        let mut data = json!({
+            "boards": [],
+            "archived_boards": [{
+                "board": { "id": BOARD, "name": "B" },
+                "archived_at": "2024-02-02T00:00:00Z"
+            }]
+        });
+
+        normalize_embedded_archived_to_references(&mut data);
+
+        let boards = data["boards"].as_array().unwrap();
+        assert_eq!(boards.len(), 1, "the embedded board is lifted into boards");
+        assert_eq!(boards[0]["id"].as_str(), Some(BOARD));
+
+        let ab = &data["archived_boards"][0];
+        assert_eq!(ab["entity_id"].as_str(), Some(BOARD));
+        assert_eq!(ab["archived_at"].as_str(), Some("2024-02-02T00:00:00Z"));
+        assert!(ab.get("board").is_none());
+        assert!(ab.get("entity").is_none());
+    }
+
+    #[test]
+    fn test_missing_keys_are_noop() {
+        let mut data = json!({ "boards": [{ "id": BOARD }] });
+        let before = data.clone();
+        normalize_embedded_archived_to_references(&mut data);
+        assert_eq!(data, before, "no archived arrays → nothing changes");
+    }
+
+    #[test]
+    fn test_embed_not_duplicated_when_card_already_present() {
+        // Defensive: if the embed's id already exists in `cards`, don't push a
+        // second copy — just collapse the entry to a marker.
+        let mut data = json!({
+            "cards": [{ "id": CARD, "title": "live" }],
+            "archived_cards": [{
+                "card": { "id": CARD, "title": "embedded" },
+                "archived_at": "2024-01-01T00:00:00Z",
+                "board_id": BOARD
+            }]
+        });
+
+        normalize_embedded_archived_to_references(&mut data);
+
+        let cards = data["cards"].as_array().unwrap();
+        assert_eq!(cards.len(), 1, "no duplicate card row");
+        assert_eq!(
+            cards[0]["title"].as_str(),
+            Some("live"),
+            "existing row kept"
+        );
+        assert_eq!(data["archived_cards"][0]["entity_id"].as_str(), Some(CARD));
+    }
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -110,23 +110,17 @@ pub(crate) fn row_to_card(row: &SqliteRow, sprint_logs: Vec<SprintLog>) -> Kanba
     Card::reconstitute(record)
 }
 
-/// Build an `ArchivedCard` from a joined `cards` + `archived_cards` row. The one
-/// place that reconstructs the domain record, so a new archival column (or field)
-/// is added here once rather than at every reader.
-pub(crate) fn row_to_archived_card(
-    row: &SqliteRow,
-    sprint_logs: Vec<SprintLog>,
-) -> KanbanResult<ArchivedCard> {
-    let card = row_to_card(row, sprint_logs)?;
+/// Build an `ArchivedCard` MARKER from an `archived_cards` row (reference-marker
+/// model: the card itself is NOT embedded — it stays live in `cards`). Only the
+/// card id, board scope, and archive time are carried.
+pub(crate) fn row_to_archived_card(row: &SqliteRow) -> KanbanResult<ArchivedCard> {
+    let id_str: String = row.try_get("id").map_err(db_err)?;
     let archived_at_str: String = row.try_get("archived_at").map_err(db_err)?;
     let board_id_str: String = row.try_get("board_id").map_err(db_err)?;
-    let orig_col_str: String = row.try_get("original_column_id").map_err(db_err)?;
     Ok(Archived::with_context(
-        card,
+        p_uuid(&id_str)?,
         CardRestoreContext {
             board_id: p_uuid(&board_id_str)?,
-            original_column_id: p_uuid(&orig_col_str)?,
-            original_position: row.try_get("original_position").map_err(db_err)?,
         },
         ArchiveMetadata::at(p_dt(&archived_at_str)?),
     ))

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -19,6 +19,10 @@ impl DataStore for SqliteStore {
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         run(async {
             let id_str = id.to_string();
+            // Reference-marker model: `get_board` is UNFILTERED — it returns the
+            // head whether the board is live OR archived (an `archived_board`
+            // marker hides it only from the LIVE `list_boards`). Callers
+            // discriminate archived-ness via `get_archived_board`.
             let row = sqlx::query(
                 "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
                         task_sort_order, sprint_duration_days, sprint_name_used_count,
@@ -26,8 +30,7 @@ impl DataStore for SqliteStore {
                         COALESCE(card_counter, 1) as card_counter,
                         completion_column_id, position, created_at, updated_at
                  FROM boards
-                 WHERE id = ?
-                   AND NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)",
+                 WHERE id = ?",
             )
             .bind(&id_str)
             .fetch_optional(&self.pool)
@@ -282,14 +285,12 @@ impl DataStore for SqliteStore {
     fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
         run(async {
             let id_str = card_id.to_string();
+            // Reference-marker model: a marker needs only card id, board scope, and
+            // archive time. No card JOIN required.
             let row = sqlx::query(
-                "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
-                        c.position, c.due_date, c.points, c.card_number, c.sprint_id,
-                        c.created_at, c.updated_at, c.completed_at,
-                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
-                 FROM archived_cards ac
-                 JOIN cards c ON ac.card_id = c.id
-                 WHERE ac.card_id = ?",
+                "SELECT card_id AS id, board_id, archived_at
+                 FROM archived_cards
+                 WHERE card_id = ?",
             )
             .bind(&id_str)
             .fetch_optional(&self.pool)
@@ -297,10 +298,7 @@ impl DataStore for SqliteStore {
             .map_err(db_err)?;
 
             match row {
-                Some(row) => {
-                    let logs = self.fetch_sprint_logs_for_card(&id_str).await?;
-                    Ok(Some(row_to_archived_card(&row, logs)?))
-                }
+                Some(row) => Ok(Some(row_to_archived_card(&row)?)),
                 None => Ok(None),
             }
         })
@@ -337,25 +335,18 @@ impl DataStore for SqliteStore {
     fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
         run(async {
             let id_str = board_id.to_string();
-            let row = sqlx::query(
-                "SELECT b.id, b.name, b.description, b.sprint_prefix, b.card_prefix, b.task_sort_field,
-                        b.task_sort_order, b.sprint_duration_days, b.sprint_name_used_count,
-                        b.next_sprint_number, b.active_sprint_id, b.task_list_view,
-                        COALESCE(b.card_counter, 1) as card_counter,
-                        b.completion_column_id, b.position, b.created_at, b.updated_at, ba.archived_at
-                 FROM board_archival ba JOIN boards b ON ba.board_id = b.id
-                 WHERE ba.board_id = ?",
-            )
-            .bind(&id_str)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(db_err)?;
+            // Reference-marker model: the marker carries only the board id + archive
+            // time. The board row stays live in `boards`.
+            let row =
+                sqlx::query("SELECT board_id, archived_at FROM board_archival WHERE board_id = ?")
+                    .bind(&id_str)
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(db_err)?;
             match row {
                 Some(row) => {
-                    let (names, counters) = self.fetch_board_aux(&id_str).await?;
-                    let board = row_to_board(&row, names, counters)?;
                     let at: String = row.try_get("archived_at").map_err(db_err)?;
-                    Ok(Some(Archived::at(board, p_dt(&at)?)))
+                    Ok(Some(Archived::at(board_id, p_dt(&at)?)))
                 }
                 None => Ok(None),
             }
@@ -368,18 +359,18 @@ impl DataStore for SqliteStore {
 
     fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
         run(async {
-            let mut tx = self.pool.begin().await.map_err(db_err)?;
-            Self::write_board_with_conn(&mut tx, &ab.entity).await?;
+            // Reference-marker model: the board row must already be live in
+            // `boards` (archive keeps the head in place). Only record the marker.
             sqlx::query(
                 "INSERT INTO board_archival (board_id, archived_at) VALUES (?, ?)
                  ON CONFLICT(board_id) DO UPDATE SET archived_at = excluded.archived_at",
             )
-            .bind(ab.entity.id.to_string())
+            .bind(ab.entity_id.to_string())
             .bind(fmt_dt(&ab.metadata.archived_at))
-            .execute(&mut *tx)
+            .execute(&self.pool)
             .await
             .map_err(db_err)?;
-            tx.commit().await.map_err(db_err)
+            Ok(())
         })
     }
 
@@ -431,34 +422,20 @@ impl DataStore for SqliteStore {
     /// so board scoping is a single indexed query.
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
         run(async {
+            // Reference-marker model: markers only, scoped by the first-class
+            // `board_id`. Single indexed query, no card JOIN.
             let rows = sqlx::query(
-                "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
-                        c.position, c.due_date, c.points, c.card_number, c.sprint_id,
-                        c.created_at, c.updated_at, c.completed_at,
-                        ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
-                 FROM archived_cards ac
-                 JOIN cards c ON ac.card_id = c.id
-                 WHERE ac.board_id = ?
-                 ORDER BY ac.archived_at",
+                "SELECT card_id AS id, board_id, archived_at
+                 FROM archived_cards
+                 WHERE board_id = ?
+                 ORDER BY archived_at",
             )
             .bind(board_id.to_string())
             .fetch_all(&self.pool)
             .await
             .map_err(db_err)?;
 
-            let card_ids: Vec<String> = rows
-                .iter()
-                .map(|r| r.try_get("id").map_err(db_err))
-                .collect::<KanbanResult<_>>()?;
-            let mut logs_map = self.fetch_sprint_logs_batch(&card_ids).await?;
-
-            let mut result = Vec::with_capacity(rows.len());
-            for row in &rows {
-                let id_str: String = row.try_get("id").map_err(db_err)?;
-                let logs = logs_map.remove(&id_str).unwrap_or_default();
-                result.push(row_to_archived_card(row, logs)?);
-            }
-            Ok(result)
+            rows.iter().map(row_to_archived_card).collect()
         })
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
@@ -8,21 +8,22 @@ impl SqliteStore {
         conn: &mut sqlx::SqliteConnection,
         ac: &ArchivedCard,
     ) -> KanbanResult<()> {
-        Self::write_card_with_conn(conn, &ac.entity).await?;
+        // Reference-marker model: the card itself is NOT written here — it is a
+        // live row in `cards` (the archive command upserts it). We only record the
+        // marker. `original_column_id`/`original_position` are legacy NOT NULL
+        // columns no longer carried by the domain marker; write inert placeholders
+        // (they are never read back — reads reconstruct from the live card).
         sqlx::query(
             "INSERT INTO archived_cards (card_id, board_id, archived_at, original_column_id, original_position)
-             VALUES (?, ?, ?, ?, ?)
+             VALUES (?, ?, ?, ?, 0)
              ON CONFLICT(card_id) DO UPDATE SET
                 board_id=excluded.board_id,
-                archived_at=excluded.archived_at,
-                original_column_id=excluded.original_column_id,
-                original_position=excluded.original_position",
+                archived_at=excluded.archived_at",
         )
-        .bind(ac.entity.id.to_string())
+        .bind(ac.entity_id.to_string())
         .bind(ac.context.board_id.to_string())
         .bind(fmt_dt(&ac.metadata.archived_at))
-        .bind(ac.context.original_column_id.to_string())
-        .bind(ac.context.original_position)
+        .bind(uuid::Uuid::nil().to_string())
         .execute(&mut *conn)
         .await
         .map_err(db_err)?;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -33,6 +33,36 @@ impl SqliteStore {
         Ok(boards)
     }
 
+    /// ALL board heads, live AND archived (unfiltered). Snapshot/export fidelity:
+    /// under the reference-marker model an archived board's head stays in `boards`
+    /// and must be carried in `snapshot.boards`, with archived-ness recorded
+    /// separately via the `board_archival` markers.
+    pub(crate) async fn all_boards_async(&self) -> KanbanResult<Vec<Board>> {
+        let rows = sqlx::query(
+            "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
+                    task_sort_order, sprint_duration_days, sprint_name_used_count,
+                    next_sprint_number, active_sprint_id, task_list_view,
+                    COALESCE(card_counter, 1) as card_counter,
+                    completion_column_id, position, created_at, updated_at
+             FROM boards
+             ORDER BY position ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(db_err)?;
+
+        let (mut names_map, mut counters_map) = self.fetch_all_board_aux().await?;
+
+        let mut boards = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let id_str: String = row.try_get("id").map_err(db_err)?;
+            let names = names_map.remove(&id_str).unwrap_or_default();
+            let counters = counters_map.remove(&id_str).unwrap_or_default();
+            boards.push(row_to_board(row, names, counters)?);
+        }
+        Ok(boards)
+    }
+
     pub(crate) async fn list_all_columns_async(&self) -> KanbanResult<Vec<Column>> {
         let rows = sqlx::query(
             "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
@@ -57,32 +87,18 @@ impl SqliteStore {
     }
 
     pub(crate) async fn list_archived_cards_async(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        // Reference-marker model: markers only. No card JOIN — the live cards stay
+        // in `cards` and are read there when their fields are needed.
         let rows = sqlx::query(
-            "SELECT c.id, c.column_id, c.title, c.description, c.priority, c.status,
-                    c.position, c.due_date, c.points, c.card_number, c.sprint_id,
-                    c.created_at, c.updated_at, c.completed_at,
-                    ac.board_id, ac.archived_at, ac.original_column_id, ac.original_position
-             FROM archived_cards ac
-             JOIN cards c ON ac.card_id = c.id
-             ORDER BY ac.archived_at",
+            "SELECT card_id AS id, board_id, archived_at
+             FROM archived_cards
+             ORDER BY archived_at",
         )
         .fetch_all(&self.pool)
         .await
         .map_err(db_err)?;
 
-        let card_ids: Vec<String> = rows
-            .iter()
-            .map(|r| r.try_get("id").map_err(db_err))
-            .collect::<KanbanResult<_>>()?;
-        let mut logs_map = self.fetch_sprint_logs_batch(&card_ids).await?;
-
-        let mut result = Vec::with_capacity(rows.len());
-        for row in &rows {
-            let id_str: String = row.try_get("id").map_err(db_err)?;
-            let logs = logs_map.remove(&id_str).unwrap_or_default();
-            result.push(row_to_archived_card(row, logs)?);
-        }
-        Ok(result)
+        rows.iter().map(row_to_archived_card).collect()
     }
 
     pub(crate) async fn get_graph_async(&self) -> KanbanResult<DependencyGraph> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
@@ -2,39 +2,32 @@ use sqlx::Row;
 
 use kanban_domain::{Archived, ArchivedBoard, KanbanResult, Snapshot};
 
-use super::conversions::row_to_board;
-use super::helpers::{db_err, fmt_dt, p_dt};
+use super::helpers::{db_err, fmt_dt, p_dt, p_uuid};
 use super::SqliteStore;
 
 impl SqliteStore {
     pub(crate) async fn list_archived_boards_async(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        // Reference-marker model: markers only. The board heads live in `boards`.
         let rows = sqlx::query(
-            "SELECT b.id, b.name, b.description, b.sprint_prefix, b.card_prefix, b.task_sort_field,
-                    b.task_sort_order, b.sprint_duration_days, b.sprint_name_used_count,
-                    b.next_sprint_number, b.active_sprint_id, b.task_list_view,
-                    COALESCE(b.card_counter, 1) as card_counter,
-                    b.completion_column_id, b.position, b.created_at, b.updated_at, ba.archived_at
-             FROM board_archival ba JOIN boards b ON ba.board_id = b.id
-             ORDER BY ba.archived_at ASC",
+            "SELECT board_id, archived_at FROM board_archival ORDER BY archived_at ASC",
         )
         .fetch_all(&self.pool)
         .await
         .map_err(db_err)?;
-        let (mut names_map, mut counters_map) = self.fetch_all_board_aux().await?;
         let mut out = Vec::with_capacity(rows.len());
         for row in &rows {
-            let id_str: String = row.try_get("id").map_err(db_err)?;
-            let names = names_map.remove(&id_str).unwrap_or_default();
-            let counters = counters_map.remove(&id_str).unwrap_or_default();
-            let board = row_to_board(row, names, counters)?;
+            let id_str: String = row.try_get("board_id").map_err(db_err)?;
             let at: String = row.try_get("archived_at").map_err(db_err)?;
-            out.push(Archived::at(board, p_dt(&at)?));
+            out.push(Archived::at(p_uuid(&id_str)?, p_dt(&at)?));
         }
         Ok(out)
     }
 
     pub(crate) async fn snapshot_async(&self) -> KanbanResult<Snapshot> {
-        let boards = self.list_boards_async().await?;
+        // Reference-marker model: carry ALL board heads (live + archived) so an
+        // archived board's row survives the round-trip; archived-ness rides on the
+        // separate `archived_boards` markers.
+        let boards = self.all_boards_async().await?;
         let columns = self.list_all_columns_async().await?;
         let cards = self.fetch_cards_with_filter("", &[]).await?;
         let archived_cards = self.list_archived_cards_async().await?;
@@ -120,14 +113,15 @@ impl SqliteStore {
         for ac in &snapshot.archived_cards {
             Self::write_archived_card_with_conn(&mut tx, ac).await?;
         }
-        // KAN-860: restore archived boards — the board row + its board_archival marker.
+        // Reference-marker model: the board head is already written from
+        // `snapshot.boards` above (which now carries archived heads too). Here we
+        // only record the archival marker.
         for ab in &snapshot.archived_boards {
-            Self::write_board_with_conn(&mut tx, &ab.entity).await?;
             sqlx::query(
                 "INSERT INTO board_archival (board_id, archived_at) VALUES (?, ?)
                  ON CONFLICT(board_id) DO UPDATE SET archived_at = excluded.archived_at",
             )
-            .bind(ab.entity.id.to_string())
+            .bind(ab.entity_id.to_string())
             .bind(fmt_dt(&ab.metadata.archived_at))
             .execute(&mut *tx)
             .await

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
@@ -59,17 +59,16 @@ fn test_archived_card_round_trip_preserves_board_id_and_all_fields() {
         let store = SqliteStore::open(&path).await.unwrap();
         let (board_id, column_id) = seed_board_and_column(&store, "B");
 
+        let card = card_in(column_id, "Archived");
+        let card_id = card.id;
+        store.upsert_card(card).unwrap();
+
         let ac = kanban_domain::Archived::with_context(
-            card_in(column_id, "Archived"),
-            kanban_domain::CardRestoreContext {
-                board_id,
-                original_column_id: column_id,
-                original_position: 7,
-            },
+            card_id,
+            kanban_domain::CardRestoreContext { board_id },
             ArchiveMetadata::at("2024-06-01T00:00:00Z".parse().unwrap()),
         );
-        let card_id = ac.entity.id;
-        store.insert_archived_card(ac.clone()).unwrap();
+        store.insert_archived_card(ac).unwrap();
 
         let loaded = store
             .get_archived_card(card_id)
@@ -79,7 +78,18 @@ fn test_archived_card_round_trip_preserves_board_id_and_all_fields() {
             loaded.context.board_id, board_id,
             "board_id must round-trip"
         );
-        assert_eq!(loaded, ac, "all archived-card fields must round-trip");
+        assert_eq!(
+            loaded, ac,
+            "all archived-card marker fields must round-trip"
+        );
+
+        // The live card row survives behind the marker and keeps its fields.
+        let live = store
+            .get_card(card_id)
+            .unwrap()
+            .expect("live card survives");
+        assert_eq!(live.title, "Archived");
+        assert_eq!(live.column_id, column_id);
     });
 }
 
@@ -93,15 +103,21 @@ fn test_list_archived_cards_by_board_filters_by_board_id() {
         let (board_a, col_a) = seed_board_and_column(&store, "A");
         let (board_b, col_b) = seed_board_and_column(&store, "B");
 
-        let a = ArchivedCard::new(card_in(col_a, "A1"), board_a, col_a, 0);
-        let a_id = a.entity.id;
-        let b = ArchivedCard::new(card_in(col_b, "B1"), board_b, col_b, 0);
+        let card_a = card_in(col_a, "A1");
+        let a_id = card_a.id;
+        store.upsert_card(card_a).unwrap();
+        let card_b = card_in(col_b, "B1");
+        let b_id = card_b.id;
+        store.upsert_card(card_b).unwrap();
+
+        let a = ArchivedCard::new(a_id, board_a);
+        let b = ArchivedCard::new(b_id, board_b);
         store.insert_archived_card(a).unwrap();
         store.insert_archived_card(b).unwrap();
 
         let only_a = store.list_archived_cards_by_board(board_a).unwrap();
         assert_eq!(only_a.len(), 1, "only board A's archived card");
-        assert_eq!(only_a[0].entity.id, a_id);
+        assert_eq!(only_a[0].entity_id, a_id);
         assert!(only_a.iter().all(|ac| ac.context.board_id == board_a));
     });
 }
@@ -115,9 +131,12 @@ fn test_delete_column_does_not_cascade_delete_archived_card() {
         let store = SqliteStore::open(&path).await.unwrap();
         let (board_id, column_id) = seed_board_and_column(&store, "B");
 
-        let ac = ArchivedCard::new(card_in(column_id, "Survivor"), board_id, column_id, 0);
-        let card_id = ac.entity.id;
-        store.insert_archived_card(ac).unwrap();
+        let card = card_in(column_id, "Survivor");
+        let card_id = card.id;
+        store.upsert_card(card).unwrap();
+        store
+            .insert_archived_card(ArchivedCard::new(card_id, board_id))
+            .unwrap();
 
         // Raw column delete (bypasses the domain guard) must NOT orphan the
         // archived card via the cards -> columns cascade.
@@ -126,15 +145,18 @@ fn test_delete_column_does_not_cascade_delete_archived_card() {
         let survived = store
             .get_archived_card(card_id)
             .unwrap()
-            .expect("archived card must survive its column's deletion");
+            .expect("archived card marker must survive its column's deletion");
         assert_eq!(survived.context.board_id, board_id);
+
+        // The live card row survives too and retains its (now-dangling)
+        // column_id, matching in-memory/JSON semantics.
+        let live = store
+            .get_card(card_id)
+            .unwrap()
+            .expect("live card row must survive its column's deletion");
         assert_eq!(
-            survived.context.original_column_id, column_id,
-            "historical column preserved on the extension row"
-        );
-        assert_eq!(
-            survived.entity.column_id, column_id,
-            "card.column_id is retained (dangling), matching in-memory/JSON semantics"
+            live.column_id, column_id,
+            "card.column_id is retained (dangling)"
         );
     });
 }
@@ -152,9 +174,12 @@ fn test_list_all_cards_excludes_archived_via_not_exists() {
         let live_id = live.id;
         store.upsert_card(live).unwrap();
 
-        let ac = ArchivedCard::new(card_in(column_id, "Archived"), board_id, column_id, 0);
-        let archived_id = ac.entity.id;
-        store.insert_archived_card(ac).unwrap();
+        let archived_card = card_in(column_id, "Archived");
+        let archived_id = archived_card.id;
+        store.upsert_card(archived_card).unwrap();
+        store
+            .insert_archived_card(ArchivedCard::new(archived_id, board_id))
+            .unwrap();
 
         let all = store.list_all_cards().unwrap();
         let ids: Vec<Uuid> = all.iter().map(|c| c.id).collect();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -20,15 +20,18 @@ fn test_archived_board_roundtrip_through_board_archival_table() {
 
         // Archive: board stays in `boards`, a marker row appears; live reads
         // exclude it, archived reads reconstitute it.
-        store.insert_archived_board(Archived::now(board)).unwrap();
+        store.insert_archived_board(Archived::now(id)).unwrap();
         assert!(
             store.list_boards().unwrap().is_empty(),
             "NOT EXISTS filter hides the archived board from live reads"
         );
-        assert!(store.get_board(id).unwrap().is_none());
+        assert!(
+            store.get_board(id).unwrap().is_some(),
+            "get_board is UNFILTERED: the head survives behind the marker"
+        );
         let archived = store.list_archived_boards().unwrap();
         assert_eq!(archived.len(), 1);
-        assert_eq!(archived[0].entity.id, id);
+        assert_eq!(archived[0].entity_id, id);
         assert!(store.get_archived_board(id).unwrap().is_some());
 
         // delete_board is a NOT-EXISTS no-op on an archived board.
@@ -62,7 +65,7 @@ fn test_unarchive_board_drops_marker_keeps_row_and_subtree() {
         let col = Column::new(id, "Todo", 0);
         let col_id = col.id;
         store.upsert_column(col).unwrap();
-        store.insert_archived_board(Archived::now(board)).unwrap();
+        store.insert_archived_board(Archived::now(id)).unwrap();
         assert!(store.list_boards().unwrap().is_empty(), "archived: hidden");
 
         store.unarchive_board(id).unwrap();
@@ -153,16 +156,21 @@ fn test_snapshot_and_apply_round_trip_archived_boards() {
         let archived_id = archived.id;
         src.upsert_board(live).unwrap();
         src.upsert_board(archived.clone()).unwrap();
-        src.insert_archived_board(Archived::now(archived)).unwrap();
+        src.insert_archived_board(Archived::now(archived_id))
+            .unwrap();
 
         let snap = src.snapshot().unwrap();
-        assert_eq!(snap.boards.len(), 1, "only the live board in .boards");
+        assert_eq!(
+            snap.boards.len(),
+            2,
+            "reference-marker model: .boards carries ALL heads (live + archived)"
+        );
         assert_eq!(
             snap.archived_boards.len(),
             1,
-            "snapshot must carry the archived board (no data loss)"
+            "snapshot must carry the archived-board marker (no data loss)"
         );
-        assert_eq!(snap.archived_boards[0].entity.id, archived_id);
+        assert_eq!(snap.archived_boards[0].entity_id, archived_id);
 
         // Apply into a FRESH store — the archived board must round-trip.
         let dir2 = TempDir::new().unwrap();
@@ -177,10 +185,17 @@ fn test_snapshot_and_apply_round_trip_archived_boards() {
             1,
             "archived board restored by apply_snapshot"
         );
-        assert_eq!(restored[0].entity.id, archived_id);
+        assert_eq!(restored[0].entity_id, archived_id);
         assert!(
-            dst.get_board(archived_id).unwrap().is_none(),
-            "archived, not live"
+            dst.get_board(archived_id).unwrap().is_some(),
+            "head round-trips (get_board is unfiltered)"
+        );
+        assert!(
+            !dst.list_boards()
+                .unwrap()
+                .iter()
+                .any(|b| b.id == archived_id),
+            "archived, so excluded from the live list"
         );
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/entities.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/entities.rs
@@ -13,17 +13,17 @@ fn test_delete_archived_card_orphaned_cards_row_is_still_cleaned_up() {
         let store = SqliteStore::open(&path).await.unwrap();
 
         let mut board = kanban_domain::Board::new("B", None::<String>);
+        let board_id = board.id;
         let column = kanban_domain::Column::new(board.id, "Col", 0);
         let card = kanban_domain::Card::new(&mut board, column.id, "Task", 0);
         let card_id = card.id;
-        let column_id = column.id;
         store.upsert_board(board).unwrap();
         store.upsert_column(column).unwrap();
         store.upsert_card(card.clone()).unwrap();
 
-        // Insert into archived_cards WITHOUT calling delete_card first,
-        // leaving an orphaned row in the cards table.
-        let archived = kanban_domain::ArchivedCard::new(card, uuid::Uuid::nil(), column_id, 0);
+        // Mark the (live-upserted) card as archived. The card row stays live
+        // behind the marker; delete_archived_card must clean up both.
+        let archived = kanban_domain::ArchivedCard::new(card_id, board_id);
         store.insert_archived_card(archived).unwrap();
 
         store.delete_archived_card(card_id).unwrap();
@@ -49,15 +49,15 @@ fn test_delete_archived_card_removes_from_cards_table() {
         let store = SqliteStore::open(&path).await.unwrap();
 
         let mut board = kanban_domain::Board::new("B", None::<String>);
+        let board_id = board.id;
         let column = kanban_domain::Column::new(board.id, "Col", 0);
         let card = kanban_domain::Card::new(&mut board, column.id, "Task", 0);
         let card_id = card.id;
-        let column_id = column.id;
         store.upsert_board(board).unwrap();
         store.upsert_column(column).unwrap();
         store.upsert_card(card.clone()).unwrap();
 
-        let archived = kanban_domain::ArchivedCard::new(card, uuid::Uuid::nil(), column_id, 0);
+        let archived = kanban_domain::ArchivedCard::new(card_id, board_id);
         store.insert_archived_card(archived).unwrap();
         store.delete_card(card_id).unwrap();
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
@@ -148,7 +148,7 @@ fn test_migration_cards_case_preserves_live_and_archived_cards() {
         // Archived card survived and now carries the backfilled board_id.
         let archived = store.list_archived_cards().unwrap();
         assert_eq!(archived.len(), 1, "archived card survived the rebuild");
-        assert_eq!(archived[0].entity.id, card_id);
+        assert_eq!(archived[0].entity_id, card_id);
         assert_eq!(
             archived[0].context.board_id, board_id,
             "board_id backfilled from original_column_id"

--- a/crates/kanban-persistence-sqlite/tests/data_store.rs
+++ b/crates/kanban-persistence-sqlite/tests/data_store.rs
@@ -284,14 +284,19 @@ async fn test_sqlite_insert_and_get_archived_card() {
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
 
+    let board_id = board.id;
     let card = make_card(&mut board, col.id, "Card", 0);
     let card_id = card.id;
-    let ac = ArchivedCard::new(card, uuid::Uuid::nil(), col.id, 0);
+    store.upsert_card(card).unwrap();
+    let ac = ArchivedCard::new(card_id, board_id);
     store.insert_archived_card(ac).unwrap();
 
     let fetched = store.get_archived_card(card_id).unwrap().unwrap();
-    assert_eq!(fetched.entity.id, card_id);
-    assert_eq!(fetched.context.original_column_id, col.id);
+    assert_eq!(fetched.entity_id, card_id);
+    assert_eq!(fetched.context.board_id, board_id);
+    // The live card row survives behind the marker.
+    let live = store.get_card(card_id).unwrap().unwrap();
+    assert_eq!(live.column_id, col.id);
 
     // F1 (KAN-870): get_card is UNFILTERED (the card stays live behind a marker);
     // only the LIVE list excludes archived cards.

--- a/crates/kanban-persistence/src/snapshot_serde.rs
+++ b/crates/kanban-persistence/src/snapshot_serde.rs
@@ -38,7 +38,10 @@ mod tests {
     /// `archived_cards` ONLY. Guards the reference-model exclusion at the serde
     /// seam: no card id may appear in both on-disk collections.
     #[test]
-    fn test_snapshot_serde_excludes_archived_from_cards() {
+    fn test_snapshot_serde_carries_archived_card_as_live_plus_marker() {
+        // Reference-marker model (F3b): EVERY card — live and archived — is the
+        // single source of truth in `cards`. `archived_cards` holds a pure marker
+        // (`entity_id` references the card in `cards`); nothing is embedded.
         use kanban_domain::{ArchivedCard, Card, DataStore, InMemoryStore};
         use uuid::Uuid;
 
@@ -51,7 +54,7 @@ mod tests {
         store.upsert_card(live).unwrap();
         store.upsert_card(archived.clone()).unwrap();
         store
-            .insert_archived_card(ArchivedCard::new(archived, board.id, col_id, 1))
+            .insert_archived_card(ArchivedCard::new(archived_id, board.id))
             .unwrap();
 
         let snapshot = store.snapshot().unwrap();
@@ -60,13 +63,13 @@ mod tests {
 
         assert_eq!(
             value["cards"].as_array().unwrap().len(),
-            1,
-            "only the live card is serialized under cards"
+            2,
+            "both the live and the archived card are serialized under cards"
         );
         assert_eq!(
             value["archived_cards"].as_array().unwrap().len(),
             1,
-            "the archived card is serialized under archived_cards"
+            "the archived card's marker is serialized under archived_cards"
         );
         let id_str = archived_id.to_string();
         assert!(
@@ -74,13 +77,17 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .iter()
-                .all(|c| c["id"].as_str() != Some(id_str.as_str())),
-            "archived card id must not be duplicated under cards"
+                .any(|c| c["id"].as_str() == Some(id_str.as_str())),
+            "the archived card's row is present under cards (source of truth)"
         );
         assert_eq!(
-            value["archived_cards"][0]["entity"]["id"].as_str(),
+            value["archived_cards"][0]["entity_id"].as_str(),
             Some(id_str.as_str()),
-            "archived entity travels under archived_cards"
+            "the marker references the live card by entity_id, never embeds it"
+        );
+        assert!(
+            value["archived_cards"][0]["entity"].is_null(),
+            "no embedded entity under the marker"
         );
     }
 

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -88,28 +88,29 @@ pub fn fully_populated_snapshot() -> Snapshot {
         }],
     };
 
+    // Reference-marker model: the archived card stays LIVE in `.cards`; the marker
+    // only references it by id.
+    let archived_live_card = Card {
+        id: archived_card_inner_id,
+        column_id: col_id,
+        title: "Archived Card".into(),
+        description: Some("archived desc".into()),
+        priority: CardPriority::Critical,
+        status: CardStatus::Done,
+        position: 1,
+        due_date: Some(now),
+        points: Some(5),
+        card_number: 2,
+        sprint_id: Some(sprint_id),
+        created_at: now,
+        updated_at: now,
+        completed_at: Some(now),
+        sprint_logs: vec![],
+    };
     let archived_card = kanban_domain::Archived::with_context(
-        Card {
-            id: archived_card_inner_id,
-            column_id: col_id,
-            title: "Archived Card".into(),
-            description: Some("archived desc".into()),
-            priority: CardPriority::Critical,
-            status: CardStatus::Done,
-            position: 1,
-            due_date: Some(now),
-            points: Some(5),
-            card_number: 2,
-            sprint_id: Some(sprint_id),
-            created_at: now,
-            updated_at: now,
-            completed_at: Some(now),
-            sprint_logs: vec![],
-        },
+        archived_card_inner_id,
         kanban_domain::CardRestoreContext {
             board_id: Uuid::nil(),
-            original_column_id: col_id,
-            original_position: 1,
         },
         kanban_domain::ArchiveMetadata::at(now),
     );
@@ -143,7 +144,7 @@ pub fn fully_populated_snapshot() -> Snapshot {
         archived_boards: Vec::new(),
         boards: vec![board],
         columns: vec![column],
-        cards: vec![card],
+        cards: vec![card, archived_live_card],
         archived_cards: vec![archived_card],
         sprints: vec![sprint],
         graph,

--- a/crates/kanban-service/src/api/mod.rs
+++ b/crates/kanban-service/src/api/mod.rs
@@ -5,11 +5,10 @@
 //! callers into an explicit version path.
 mod v1;
 pub use v1::{
-    ApiError, ArchivedBoardResponse, ArchivedCardResponse, BoardResponse, CardPriorityDto,
-    CardResponse, CardStatusDto, ChangeEventFrame, ColumnResponse, CreateBoardRequest,
-    CreateCardRequest, CreateColumnRequest, CreateSprintParts, CreateSprintRequest, ErrorCode,
-    Page, PageParams, Patch, ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest,
-    ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse,
-    SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
-    UpdateSprintRequest,
+    ApiError, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame,
+    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
+    CreateSprintRequest, ErrorCode, Page, PageParams, Patch, ReorderColumnRequest,
+    ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest,
+    SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto,
+    UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
 };

--- a/crates/kanban-service/src/api/v1/boards/mod.rs
+++ b/crates/kanban-service/src/api/v1/boards/mod.rs
@@ -2,4 +2,4 @@ mod conversions;
 mod requests;
 mod response;
 pub use requests::{CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
-pub use response::{ArchivedBoardResponse, BoardResponse};
+pub use response::BoardResponse;

--- a/crates/kanban-service/src/api/v1/boards/response.rs
+++ b/crates/kanban-service/src/api/v1/boards/response.rs
@@ -1,6 +1,6 @@
 use super::super::{SortFieldDto, SortOrderDto, TaskListViewDto};
 use chrono::{DateTime, Utc};
-use kanban_domain::{Archived, ArchivedBoard, Board, NoContext};
+use kanban_domain::Board;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -63,34 +63,6 @@ impl From<&Board> for BoardResponse {
             created_at: b.created_at,
             updated_at: b.updated_at,
             archived_at: None,
-        }
-    }
-}
-
-/// Response body for an archived board: the board projection plus when it was
-/// archived. Mirrors [`ArchivedCardResponse`](super::super::ArchivedCardResponse).
-/// A board is a scoping root, so there is no restore context to surface
-/// (`Archived<Board, NoContext>`); the wire shape is just the board and its
-/// `archived_at`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ArchivedBoardResponse {
-    pub board: BoardResponse,
-    pub archived_at: DateTime<Utc>,
-}
-
-impl From<&ArchivedBoard> for ArchivedBoardResponse {
-    fn from(archived: &ArchivedBoard) -> Self {
-        // Exhaustive destructure (drift-lock, matching ArchivedCardResponse): a
-        // future `Archived` field — or a change to the board's `NoContext` —
-        // fails to compile here until it is deliberately mapped.
-        let Archived {
-            entity,
-            metadata,
-            context: NoContext {},
-        } = archived;
-        Self {
-            board: BoardResponse::from(entity),
-            archived_at: metadata.archived_at,
         }
     }
 }
@@ -166,22 +138,22 @@ mod tests {
     }
 
     #[test]
-    fn test_archived_board_response_projects_board_and_archived_at() {
+    fn test_board_response_archived_projects_board_and_archived_at() {
         use chrono::{TimeZone, Utc};
         let board = Board::new("Archived", Some("ARC"));
         let board_id = board.id;
         let at = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
-        let archived = kanban_domain::Archived::at(board, at);
 
-        let resp = ArchivedBoardResponse::from(&archived);
+        // Reference-marker model: the archived wire shape is the live board
+        // projection stamped with `archived_at` (no separate nested DTO).
+        let resp = BoardResponse::archived(&board, at);
 
-        assert_eq!(resp.board.id, board_id);
-        assert_eq!(resp.board.name, "Archived");
-        assert_eq!(resp.archived_at, at);
+        assert_eq!(resp.id, board_id);
+        assert_eq!(resp.name, "Archived");
+        assert_eq!(resp.archived_at, Some(at));
 
-        // Round-trips through the wire format.
         let json = serde_json::to_string(&resp).unwrap();
-        let back: ArchivedBoardResponse = serde_json::from_str(&json).unwrap();
+        let back: BoardResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(back, resp);
     }
 }

--- a/crates/kanban-service/src/api/v1/cards/mod.rs
+++ b/crates/kanban-service/src/api/v1/cards/mod.rs
@@ -2,4 +2,4 @@ mod conversions;
 mod requests;
 mod response;
 pub use requests::{CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
-pub use response::{ArchivedCardResponse, CardResponse};
+pub use response::CardResponse;

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -1,6 +1,6 @@
 use super::super::enums::{CardPriorityDto, CardStatusDto};
 use chrono::{DateTime, Utc};
-use kanban_domain::{Archived, ArchivedCard, Card, CardRestoreContext};
+use kanban_domain::Card;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -81,47 +81,6 @@ impl From<&Card> for CardResponse {
             updated_at: *updated_at,
             completed_at: *completed_at,
             archived_at: None,
-        }
-    }
-}
-
-/// Response body for an archived card. Nests the rich [`CardResponse`] (not the
-/// lean domain summary) and surfaces the first-class `board_id` plus the archival
-/// metadata as a stable v1 contract.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ArchivedCardResponse {
-    pub card: CardResponse,
-    /// The board the card belonged to. `None` when unknown — the domain uses a
-    /// nil UUID sentinel for an archived card whose original column was already
-    /// gone at backfill time; surfacing that zero-UUID would read as a real
-    /// board, so it maps to `null` here.
-    pub board_id: Option<Uuid>,
-    pub archived_at: DateTime<Utc>,
-    pub original_column_id: Uuid,
-    pub original_position: i32,
-}
-
-impl From<&ArchivedCard> for ArchivedCardResponse {
-    fn from(archived: &ArchivedCard) -> Self {
-        // Exhaustive destructure: a future archived-card field (entity, metadata,
-        // or restore-context) fails to compile here until it is deliberately
-        // mapped (or omitted) in the DTO.
-        let Archived {
-            entity,
-            metadata,
-            context:
-                CardRestoreContext {
-                    board_id,
-                    original_column_id,
-                    original_position,
-                },
-        } = archived;
-        Self {
-            card: CardResponse::from(entity),
-            board_id: (!board_id.is_nil()).then_some(*board_id),
-            archived_at: metadata.archived_at,
-            original_column_id: *original_column_id,
-            original_position: *original_position,
         }
     }
 }
@@ -209,39 +168,5 @@ mod tests {
             value.get("archived_at").is_none(),
             "a live card payload must not carry an archived_at key"
         );
-    }
-
-    #[test]
-    fn test_archived_card_response_carries_board_id_and_archived_meta() {
-        use kanban_domain::ArchivedCard;
-        let card = sample_card();
-        let board_id = Uuid::new_v4();
-        let original_column_id = Uuid::new_v4();
-        let ac = ArchivedCard::new(card, board_id, original_column_id, 7);
-
-        let resp = ArchivedCardResponse::from(&ac);
-
-        // First-class board_id (B1) + the archival metadata are surfaced, and the
-        // nested card is the rich CardResponse projection (not the lean summary).
-        assert_eq!(resp.board_id, Some(board_id));
-        assert_eq!(resp.archived_at, ac.metadata.archived_at);
-        assert_eq!(resp.original_column_id, original_column_id);
-        assert_eq!(resp.original_position, 7);
-        assert_eq!(resp.card, CardResponse::from(&ac.entity));
-        // The rich card projection carries `description` (the lean summary did not).
-        let json = serde_json::to_value(&resp).unwrap();
-        assert!(json["card"].get("description").is_some());
-    }
-
-    #[test]
-    fn test_archived_card_response_maps_nil_board_id_to_null() {
-        // A nil board_id (unknown board — original column gone at backfill time)
-        // must NOT surface as a zero-UUID a client would misread as a real board;
-        // it maps to `None` -> serialized `null`.
-        use kanban_domain::ArchivedCard;
-        let ac = ArchivedCard::new(sample_card(), Uuid::nil(), Uuid::new_v4(), 0);
-        let resp = ArchivedCardResponse::from(&ac);
-        assert_eq!(resp.board_id, None);
-        assert!(serde_json::to_value(&resp).unwrap()["board_id"].is_null());
     }
 }

--- a/crates/kanban-service/src/api/v1/mod.rs
+++ b/crates/kanban-service/src/api/v1/mod.rs
@@ -8,13 +8,8 @@ mod events;
 mod pagination;
 mod patch;
 mod sprints;
-pub use boards::{
-    ArchivedBoardResponse, BoardResponse, CreateBoardRequest, ReplaceBoardRequest,
-    UpdateBoardRequest,
-};
-pub use cards::{
-    ArchivedCardResponse, CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest,
-};
+pub use boards::{BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
+pub use cards::{CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
 pub use columns::{
     ColumnResponse, CreateColumnRequest, ReorderColumnRequest, ReplaceColumnRequest,
     UpdateColumnRequest,

--- a/crates/kanban-service/src/cascade.rs
+++ b/crates/kanban-service/src/cascade.rs
@@ -23,7 +23,7 @@ pub(crate) fn delete_board(store: &dyn DataStore, board_id: Uuid) -> KanbanResul
     let archived_card_ids: Vec<Uuid> = store
         .list_archived_cards_by_board(board_id)?
         .into_iter()
-        .map(|ac| ac.entity.id)
+        .map(|ac| ac.entity_id)
         .collect();
 
     // Widened early-return guard: the only remaining board may hold nothing but

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -196,7 +196,7 @@ impl KanbanContext {
             .backend
             .list_archived_boards()?
             .iter()
-            .map(|ab| ab.entity.id)
+            .map(|ab| ab.entity_id)
             .collect())
     }
     pub(super) fn list_live_columns_impl(&self) -> KanbanResult<Vec<Column>> {
@@ -301,27 +301,27 @@ impl KanbanContext {
         column_id: Option<Uuid>,
     ) -> KanbanResult<Card> {
         use kanban_domain::commands::RestoreCard;
-        let archived = self
+        if self.backend.get_archived_card(id)?.is_none() {
+            return Err(KanbanError::not_found("archived card", id));
+        }
+        // Reference-marker model: the card stayed LIVE in place while archived, so
+        // there is no "original column/position" to reconstruct. Restore leaves it
+        // where it is unless the caller redirects it to another column.
+        let card = self
             .backend
-            .get_archived_card(id)?
-            .ok_or_else(|| KanbanError::not_found("archived card", id))?;
+            .get_card(id)?
+            .ok_or_else(|| KanbanError::not_found("Card", id))?;
 
         let target_column = if let Some(col_id) = column_id {
             if self.backend.get_column(col_id)?.is_none() {
                 return Err(KanbanError::not_found("Column", col_id));
             }
             col_id
-        } else if self
-            .backend
-            .get_column(archived.context.original_column_id)?
-            .is_some()
-        {
-            archived.context.original_column_id
         } else {
-            return Err(KanbanError::validation("Original column no longer exists. Specify --column-id to restore to a different column"));
+            card.column_id
         };
 
-        let position = archived.context.original_position;
+        let position = card.position;
         let cmd = Command::Card(CardCommand::Restore(RestoreCard {
             card_id: id,
             column_id: target_column,

--- a/crates/kanban-service/src/context/filters.rs
+++ b/crates/kanban-service/src/context/filters.rs
@@ -12,10 +12,9 @@ impl KanbanContext {
                 let columns = self.backend.list_columns_by_board(bid)?;
                 let col_ids: Vec<Uuid> = columns.iter().map(|c| c.id).collect();
                 let cards = self.backend.list_cards_by_columns(&col_ids)?;
-                let board = match self.backend.get_board(bid)? {
-                    Some(b) => Some(b),
-                    None => self.backend.get_archived_board(bid)?.map(|ab| ab.entity),
-                };
+                // `get_board` is unfiltered (reference-marker model): it resolves
+                // the head whether the board is live or archived.
+                let board = self.backend.get_board(bid)?;
                 (cards, columns, board)
             }
             None => (self.list_live_cards_impl()?, Vec::new(), None),

--- a/crates/kanban-service/src/context/graph.rs
+++ b/crates/kanban-service/src/context/graph.rs
@@ -64,7 +64,7 @@ impl KanbanContext {
             self.backend
                 .list_archived_cards_by_board(board_id)?
                 .iter()
-                .map(|ac| ac.entity.id),
+                .map(|ac| ac.entity_id),
         );
 
         let graph = self.backend.get_graph()?;

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -287,21 +287,32 @@ impl KanbanContext {
         let imported_column_ids: HashSet<Uuid> = imported.columns.iter().map(|c| c.id).collect();
         let existing_column_ids: HashSet<Uuid> = existing_columns.iter().map(|c| c.id).collect();
 
-        // Backfill board_id on archived cards that predate the first-class field
-        // (they deserialize to nil when the `board_id` key is absent). Reconstruct
-        // from original_column_id -> column.board_id using the imported columns
-        // unioned with the existing store columns; leave nil only when the original
-        // column resolves nowhere (mirrors the V8 / schema-3 migration rule).
+        // Backfill board_id on archived-card markers that predate the first-class
+        // field (they deserialize to nil when the `board_id` key is absent).
+        // Reference-marker model: the marker references the live card by
+        // `entity_id`; reconstruct board_id via that card's column -> board using
+        // the imported cards + columns unioned with the existing store. Leave nil
+        // only when it resolves nowhere.
         let col_to_board: std::collections::HashMap<Uuid, Uuid> = imported
             .columns
             .iter()
             .chain(existing_columns.iter())
             .map(|c| (c.id, c.board_id))
             .collect();
+        let existing_cards = self.backend.list_all_cards()?;
+        let card_to_column: std::collections::HashMap<Uuid, Uuid> = imported
+            .cards
+            .iter()
+            .chain(existing_cards.iter())
+            .map(|c| (c.id, c.column_id))
+            .collect();
         for ac in &mut imported.archived_cards {
             if ac.context.board_id.is_nil() {
-                if let Some(&board_id) = col_to_board.get(&ac.context.original_column_id) {
-                    ac.context.board_id = board_id;
+                if let Some(board_id) = card_to_column
+                    .get(&ac.entity_id)
+                    .and_then(|col_id| col_to_board.get(col_id))
+                {
+                    ac.context.board_id = *board_id;
                 }
             }
         }

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -626,10 +626,11 @@ mod tests {
     // correct through the F3b `Archived<T>` collapse.
 
     /// Seed one live card and one archived card, flush, and inspect the raw
-    /// on-disk JSON: the archived card's id lives under `archived_cards.entity`
-    /// and MUST NOT also appear under `cards`.
+    /// on-disk JSON. Reference-marker model (F3b): EVERY card is the source of
+    /// truth under `cards` (live AND archived), and `archived_cards` carries a
+    /// pure marker (`entity_id`, no embedded `entity`).
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_archived_card_not_duplicated_in_ondisk_cards() {
+    async fn test_archived_card_stored_as_live_plus_marker_ondisk() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("arch_dedup.json");
         let jds = make_store(&path);
@@ -641,7 +642,7 @@ mod tests {
         let archived_id = archived.id;
         jds.upsert_card(live).unwrap();
         jds.upsert_card(archived.clone()).unwrap();
-        jds.insert_archived_card(ArchivedCard::new(archived, board.id, col_id, 1))
+        jds.insert_archived_card(ArchivedCard::new(archived.id, board.id))
             .unwrap();
         jds.flush().await.unwrap();
 
@@ -651,22 +652,26 @@ mod tests {
         let archived_cards = on_disk["data"]["archived_cards"].as_array().unwrap();
         let id_str = archived_id.to_string();
 
-        assert!(
-            archived_cards
-                .iter()
-                .any(|a| a["entity"]["id"].as_str() == Some(id_str.as_str())),
-            "archived card entity must be serialized under archived_cards"
+        assert_eq!(
+            cards.len(),
+            2,
+            "both the live and archived card rows are under on-disk cards"
         );
         assert!(
             cards
                 .iter()
-                .all(|c| c["id"].as_str() != Some(id_str.as_str())),
-            "archived card id must NOT be duplicated under on-disk cards"
+                .any(|c| c["id"].as_str() == Some(id_str.as_str())),
+            "the archived card's row is present under cards (source of truth)"
         );
-        assert_eq!(
-            cards.len(),
-            1,
-            "only the live card stays under on-disk cards"
+        assert!(
+            archived_cards
+                .iter()
+                .any(|a| a["entity_id"].as_str() == Some(id_str.as_str())),
+            "the marker references the card by entity_id under archived_cards"
+        );
+        assert!(
+            archived_cards.iter().all(|a| a.get("entity").is_none()),
+            "the marker embeds no entity"
         );
     }
 
@@ -684,7 +689,7 @@ mod tests {
         let card = Card::new(&mut board, col_id, "ToArchive", 0);
         let card_id = card.id;
         jds.upsert_card(card.clone()).unwrap();
-        jds.insert_archived_card(ArchivedCard::new(card, board.id, col_id, 0))
+        jds.insert_archived_card(ArchivedCard::new(card.id, board.id))
             .unwrap();
         jds.flush().await.unwrap();
 
@@ -725,7 +730,7 @@ mod tests {
         card.sprint_id = Some(Uuid::new_v4());
         let original = card.clone();
         jds.upsert_card(card.clone()).unwrap();
-        jds.insert_archived_card(ArchivedCard::new(card, board.id, col_id, 3))
+        jds.insert_archived_card(ArchivedCard::new(card.id, board.id))
             .unwrap();
         jds.flush().await.unwrap();
 

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -53,12 +53,14 @@ pub async fn test_archive_card_roundtrip(factory: &BackendFactory) {
     assert_eq!(archived.len(), 1);
 
     let ac = &archived[0];
-    assert_eq!(ac.entity.id, card.id);
-    assert_eq!(ac.entity.title, "To Archive");
-    assert_eq!(ac.entity.description.as_deref(), Some("archived desc"));
-    assert_eq!(ac.entity.priority, CardPriority::High);
-    assert_eq!(ac.entity.points, Some(3));
-    assert_eq!(ac.context.original_column_id, col.id);
+    assert_eq!(ac.entity_id, card.id);
+    assert_eq!(ac.context.board_id, board.id);
+    let live = ctx.get_card(ac.entity_id).unwrap().unwrap();
+    assert_eq!(live.title, "To Archive");
+    assert_eq!(live.description.as_deref(), Some("archived desc"));
+    assert_eq!(live.priority, CardPriority::High);
+    assert_eq!(live.points, Some(3));
+    assert_eq!(live.column_id, col.id);
 }
 
 pub async fn test_archive_card_with_sprint_logs_roundtrip(factory: &BackendFactory) {
@@ -89,7 +91,8 @@ pub async fn test_archive_card_with_sprint_logs_roundtrip(factory: &BackendFacto
 
     let archived = ctx.list_archived_cards().unwrap();
     assert_eq!(archived.len(), 1);
-    assert!(!archived[0].entity.sprint_logs.is_empty());
+    let live = ctx.get_card(archived[0].entity_id).unwrap().unwrap();
+    assert!(!live.sprint_logs.is_empty());
 }
 
 pub async fn test_restore_archived_card_roundtrip(factory: &BackendFactory) {

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -360,11 +360,13 @@ pub async fn test_full_populated_context_roundtrip(factory: &BackendFactory) -> 
 
     let archived = loaded.list_archived_cards().unwrap();
     assert_eq!(archived.len(), 1);
-    assert_eq!(archived[0].entity.id, card4.id);
-    assert_eq!(archived[0].entity.title, "Archived Card");
-    assert_eq!(archived[0].entity.priority, CardPriority::High);
-    assert_eq!(archived[0].entity.points, Some(5));
-    assert_eq!(archived[0].context.original_column_id, col_todo.id);
+    assert_eq!(archived[0].entity_id, card4.id);
+    assert_eq!(archived[0].context.board_id, board.id);
+    let c4 = loaded.get_card(archived[0].entity_id).unwrap().unwrap();
+    assert_eq!(c4.title, "Archived Card");
+    assert_eq!(c4.priority, CardPriority::High);
+    assert_eq!(c4.points, Some(5));
+    assert_eq!(c4.column_id, col_todo.id);
 
     let graph = loaded.graph()?;
     assert_eq!(graph.len(), 3, "expected 3 edges total");

--- a/crates/kanban-service/tests/archived_card_sprint_reattach_sqlite.rs
+++ b/crates/kanban-service/tests/archived_card_sprint_reattach_sqlite.rs
@@ -51,13 +51,9 @@ async fn test_set_archived_cards_sprint_edits_live_card_and_preserves_edges() ->
         "edge A->B seeded"
     );
 
-    // Archive card A (marker over the still-live card).
-    ds.insert_archived_card(ArchivedCard::new(
-        card_a.clone(),
-        board.id,
-        col.id,
-        card_a.position,
-    ))?;
+    // Archive card A (marker over the still-live card). card_a was created via
+    // `create_card`, so its live row already exists for the marker's FK.
+    ds.insert_archived_card(ArchivedCard::new(card_a.id, board.id))?;
 
     // Re-attach the sprint (the synthetic inverse command under test).
     let cmd = SetArchivedCardsSprint {
@@ -115,7 +111,7 @@ async fn test_clear_sprint_from_archived_cards_edits_live_card() -> KanbanResult
     let mut bound = card_a.clone();
     bound.sprint_id = Some(sprint.id);
     ds.upsert_card(bound.clone())?;
-    ds.insert_archived_card(ArchivedCard::new(bound, board.id, col.id, card_a.position))?;
+    ds.insert_archived_card(ArchivedCard::new(bound.id, board.id))?;
 
     ds.clear_sprint_from_archived_cards(sprint.id, chrono::Utc::now())?;
 

--- a/crates/kanban-service/tests/board_archive.rs
+++ b/crates/kanban-service/tests/board_archive.rs
@@ -36,7 +36,7 @@ async fn test_archive_board_hides_from_boards_and_lists_in_archived() -> KanbanR
     );
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1);
-    assert_eq!(archived[0].entity.id, board_id);
+    assert_eq!(archived[0].entity_id, board_id);
     // Subtree stays in place — hidden from live cross-board views (C3b) but
     // preserved in the snapshot (fidelity).
     assert!(
@@ -104,7 +104,7 @@ async fn test_delete_archived_board_undo_restores_as_archived() -> KanbanResult<
     assert!(ctx.boards()?.is_empty(), "not restored to the live set");
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1);
-    assert_eq!(archived[0].entity.id, board_id);
+    assert_eq!(archived[0].entity_id, board_id);
     assert!(
         ctx.list_all_columns()?.is_empty(),
         "still archived: subtree hidden from live view"

--- a/crates/kanban-service/tests/board_archive_json.rs
+++ b/crates/kanban-service/tests/board_archive_json.rs
@@ -49,7 +49,7 @@ async fn test_archived_board_survives_json_file_roundtrip() -> KanbanResult<()> 
         1,
         "archived board must survive the JSON file round-trip"
     );
-    assert_eq!(archived[0].entity.id, board_id);
+    assert_eq!(archived[0].entity_id, board_id);
     assert_eq!(jds.list_all_columns()?.len(), 1, "subtree column survived");
     Ok(())
 }

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -35,7 +35,7 @@ async fn test_archive_hides_from_live_lists_and_persists_across_reload() -> Kanb
         assert!(ctx.boards()?.is_empty(), "archived board left the live set");
         let archived = ctx.list_archived_boards()?;
         assert_eq!(archived.len(), 1);
-        assert_eq!(archived[0].entity.id, board_id);
+        assert_eq!(archived[0].entity_id, board_id);
         assert!(
             ctx.list_all_columns()?.is_empty(),
             "subtree hidden from live view (C3b)"
@@ -50,7 +50,7 @@ async fn test_archive_hides_from_live_lists_and_persists_across_reload() -> Kanb
     assert!(ctx.boards()?.is_empty(), "live boards empty after reload");
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1, "archived board persisted");
-    assert_eq!(archived[0].entity.id, board_id);
+    assert_eq!(archived[0].entity_id, board_id);
     assert!(
         ctx.list_all_columns()?.is_empty(),
         "subtree hidden from live view"
@@ -144,7 +144,7 @@ async fn test_delete_works_on_archived_board_and_undo_restores_as_archived() -> 
     assert!(ctx.boards()?.is_empty(), "not restored to the live set");
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1, "restored as archived");
-    assert_eq!(archived[0].entity.id, board_id);
+    assert_eq!(archived[0].entity_id, board_id);
     assert!(
         ctx.list_all_columns()?.is_empty(),
         "still archived: hidden from live"

--- a/crates/kanban-service/tests/data_integrity_tests.rs
+++ b/crates/kanban-service/tests/data_integrity_tests.rs
@@ -218,15 +218,17 @@ async fn test_import_backfills_board_id_on_legacy_archived_card() -> KanbanResul
     let column_id = column.id;
     let card = kanban_domain::Card::new(&mut board, column_id, "Archived", 0);
     let card_id = card.id;
-    // Archived card constructed with nil board_id, then its `board_id` key is
-    // stripped from the serialized JSON to emulate a pre-field export.
-    let archived = kanban_domain::ArchivedCard::new(card, Uuid::nil(), column_id, 0);
+    // Reference-marker model: the archived record is a pure marker over a LIVE
+    // card (referenced by `entity_id`). Constructed with nil board_id, then its
+    // `board_id` key is stripped from the serialized JSON to emulate a pre-field
+    // export. Backfill reconstructs board_id via the live card's column -> board.
+    let archived = kanban_domain::ArchivedCard::new(card_id, Uuid::nil());
 
     let snapshot = kanban_domain::Snapshot {
         archived_boards: Vec::new(),
         boards: vec![board],
         columns: vec![column],
-        cards: vec![],
+        cards: vec![card],
         archived_cards: vec![archived],
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::default(),
@@ -255,7 +257,7 @@ async fn test_import_backfills_board_id_on_legacy_archived_card() -> KanbanResul
         1,
         "board-scoped archived listing must return the backfilled card"
     );
-    assert_eq!(scoped[0].entity.id, card_id);
+    assert_eq!(scoped[0].entity_id, card_id);
     assert_eq!(
         scoped[0].context.board_id, board_id,
         "board_id must be backfilled from the imported column"

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -111,9 +111,14 @@ macro_rules! cascade_tests {
                 let col = Column::new(board_id, "Col", 0);
                 let col_id = col.id;
                 let card = Card::new(&mut board, col_id, "C", 0);
-                let archived = ArchivedCard::new(card, board_id, col_id, 0);
+                let card_id = card.id;
+                // Reference-marker model: the marker references a LIVE card by id
+                // (FK `archived_cards.card_id -> cards.id`), so the card row must
+                // exist before the marker is inserted.
+                let archived = ArchivedCard::new(card_id, board_id);
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col).unwrap();
+                backend.upsert_card(card).unwrap();
                 backend.insert_archived_card(archived).unwrap();
 
                 ctx.delete_board(board_id).unwrap();
@@ -149,10 +154,11 @@ macro_rules! cascade_tests {
                 let mut arch_board = board.clone();
                 let arch_card = Card::new(&mut arch_board, column.id, "C", 2);
                 let arch_card_id = arch_card.id;
+                // The marker references the live card by id, so seed the live row
+                // first, then the marker over it.
+                backend.upsert_card(arch_card).unwrap();
                 backend
-                    .insert_archived_card(ArchivedCard::new(
-                        arch_card, board_id, column.id, 2,
-                    ))
+                    .insert_archived_card(ArchivedCard::new(arch_card_id, board_id))
                     .unwrap();
 
                 assert_eq!(backend.list_boards().unwrap().len(), 1);
@@ -212,7 +218,7 @@ macro_rules! cascade_tests {
 
                 let archived = backend.list_archived_cards().unwrap();
                 assert!(
-                    archived.iter().any(|ac| ac.entity.id == arch_card_id),
+                    archived.iter().any(|ac| ac.entity_id == arch_card_id),
                     "the deleted board's archived card is restored by id"
                 );
 
@@ -377,7 +383,7 @@ macro_rules! cascade_tests {
                     1,
                     "board-scoped listing must keep the archived card despite its dangling original_column_id"
                 );
-                assert_eq!(archived[0].entity.id, card_id);
+                assert_eq!(archived[0].0.id, card_id);
             }
 
             /// KAN-833 (B5 review fix): a board with sprints but NO columns and

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -1404,7 +1404,7 @@ async fn test_inverse_delete_board_restores_full_cascade() -> KanbanResult<()> {
     let baseline_archived_ids: std::collections::HashSet<_> = baseline
         .archived_cards
         .iter()
-        .map(|ac| ac.entity.id)
+        .map(|ac| ac.entity_id)
         .collect();
     let baseline_sprint_ids: std::collections::HashSet<_> =
         baseline.sprints.iter().map(|s| s.id).collect();
@@ -1432,7 +1432,7 @@ async fn test_inverse_delete_board_restores_full_cascade() -> KanbanResult<()> {
     let restored_archived_ids: std::collections::HashSet<_> = restored
         .archived_cards
         .iter()
-        .map(|ac| ac.entity.id)
+        .map(|ac| ac.entity_id)
         .collect();
     let restored_sprint_ids: std::collections::HashSet<_> =
         restored.sprints.iter().map(|s| s.id).collect();

--- a/crates/kanban-service/tests/json_v7_migration.rs
+++ b/crates/kanban-service/tests/json_v7_migration.rs
@@ -18,21 +18,73 @@ fn make_json_backend(path: &std::path::Path) -> Arc<dyn KanbanBackend> {
     Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))))
 }
 
-/// Rewrite a current (V8) file to look like a legacy V7 file: bump the version
-/// down, drop `board_id` from every archived card, and remove the whole
-/// `archived_boards` key. Returns the board_id the archived card belonged to.
+/// Rewrite a current (marker-shape) file to a GENUINE legacy V7 file so the full
+/// V7 -> V8 -> V9 chain plus the F3b read-shim are exercised end-to-end. A V7
+/// archived card EMBEDS its entity (under the legacy `card` key — what V7 -> V8
+/// reads), is NOT present in the live `cards` array, and carries
+/// `original_column_id` / `original_position` (from which V7 -> V8 backfills
+/// `board_id`) but no `board_id` and no `entity_id`. Also bumps the version down
+/// and removes the `archived_boards` key (V7 predates that collection).
 fn downgrade_to_v7(path: &std::path::Path) {
     let raw = std::fs::read_to_string(path).unwrap();
     let mut env: serde_json::Value = serde_json::from_str(&raw).unwrap();
     env["version"] = serde_json::json!(7);
     let data = env["data"].as_object_mut().unwrap();
     data.remove("archived_boards");
+
+    // The marker-shape file keeps every card (live + archived) in `cards` and a
+    // pure marker under `archived_cards`. Reconstruct the V7 embed shape: MOVE
+    // each archived marker's live card row out of `cards` and embed it.
+    let archived_entity_ids: Vec<String> = data
+        .get("archived_cards")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|ac| {
+            ac.get("entity_id")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        })
+        .collect();
+
+    let mut embedded: std::collections::HashMap<String, serde_json::Value> =
+        std::collections::HashMap::new();
+    if let Some(cards) = data.get_mut("cards").and_then(|v| v.as_array_mut()) {
+        cards.retain(|c| match c.get("id").and_then(|v| v.as_str()) {
+            Some(id) if archived_entity_ids.iter().any(|a| a == id) => {
+                embedded.insert(id.to_string(), c.clone());
+                false // V7 did NOT carry the archived card in the live array
+            }
+            _ => true,
+        });
+    }
+
     if let Some(acs) = data
         .get_mut("archived_cards")
         .and_then(|v| v.as_array_mut())
     {
         for ac in acs {
-            ac.as_object_mut().unwrap().remove("board_id");
+            let obj = ac.as_object_mut().unwrap();
+            let entity_id = obj
+                .get("entity_id")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            if let Some(card) = entity_id.as_deref().and_then(|id| embedded.get(id)) {
+                let column_id = card
+                    .get("column_id")
+                    .cloned()
+                    .unwrap_or(serde_json::json!(null));
+                let position = card
+                    .get("position")
+                    .cloned()
+                    .unwrap_or(serde_json::json!(0));
+                obj.insert("card".to_string(), card.clone());
+                obj.insert("original_column_id".to_string(), column_id);
+                obj.insert("original_position".to_string(), position);
+            }
+            // V7 carried neither of these on an archived card.
+            obj.remove("board_id");
+            obj.remove("entity_id");
         }
     }
     std::fs::write(path, serde_json::to_string(&env).unwrap()).unwrap();
@@ -83,7 +135,7 @@ async fn test_v7_json_migrates_and_preserves_cards_and_boards() -> KanbanResult<
     // Archived card survived AND its board_id was backfilled by V7->V8.
     let archived = ctx.list_archived_cards()?;
     assert_eq!(archived.len(), 1, "archived card survived migration");
-    assert_eq!(archived[0].entity.id, archived_card);
+    assert_eq!(archived[0].entity_id, archived_card);
     assert_eq!(
         archived[0].context.board_id, board_a,
         "V7->V8 backfilled archived_cards.board_id"
@@ -109,7 +161,7 @@ async fn test_v7_json_migrates_and_preserves_cards_and_boards() -> KanbanResult<
         1,
         "archived board persisted after migrating a V7 file"
     );
-    assert_eq!(ab[0].entity.id, board_a);
+    assert_eq!(ab[0].entity_id, board_a);
     // The originally-archived card is still archived on the reloaded store.
     assert_eq!(reloaded.list_archived_cards()?.len(), 1);
     Ok(())

--- a/crates/kanban-service/tests/list_archived_cards_sort.rs
+++ b/crates/kanban-service/tests/list_archived_cards_sort.rs
@@ -101,7 +101,7 @@ async fn test_list_archived_cards_sorted_uses_board_default() -> KanbanResult<()
         ..Default::default()
     })?;
 
-    let ids: Vec<Uuid> = archived.iter().map(|a| a.entity.id).collect();
+    let ids: Vec<Uuid> = archived.iter().map(|(card, _)| card.id).collect();
     assert_eq!(ids, vec![earliest, middle, latest]);
     Ok(())
 }
@@ -118,7 +118,7 @@ async fn test_list_archived_cards_sorted_explicit_override_wins() -> KanbanResul
         sort_order: Some(SortOrder::Descending),
     })?;
 
-    let ids: Vec<Uuid> = archived.iter().map(|a| a.entity.id).collect();
+    let ids: Vec<Uuid> = archived.iter().map(|(card, _)| card.id).collect();
     assert_eq!(ids, vec![latest, middle, earliest]);
     Ok(())
 }

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -97,7 +97,7 @@ impl App {
             .model
             .archived_cards()
             .iter()
-            .find(|dc| dc.entity.id == card_id)
+            .find(|dc| dc.entity_id == card_id)
             .cloned()
         {
             self.restore_card(archived_card);

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -55,20 +55,44 @@ impl Model {
     }
 
     pub fn load_from_snapshot(&mut self, snapshot: Snapshot) {
+        // Reference-marker model: `snapshot.cards` carries EVERY card — live AND
+        // archived — with archival recorded by markers in `snapshot.archived_cards`
+        // (keyed by `entity_id`). Split them: the live board views see only live
+        // cards; the archived view sees the archived ones, reconstructed from the
+        // same live rows (no stale copy).
+        let archived_ids: std::collections::HashSet<Uuid> = snapshot
+            .archived_cards
+            .iter()
+            .map(|ac| ac.entity_id)
+            .collect();
+
+        let card_by_id: std::collections::HashMap<Uuid, Card> =
+            snapshot.cards.iter().map(|c| (c.id, c.clone())).collect();
+
+        let live_cards: Vec<Card> = snapshot
+            .cards
+            .into_iter()
+            .filter(|c| !archived_ids.contains(&c.id))
+            .collect();
+
         self.card_index.clear();
-        for (i, card) in snapshot.cards.iter().enumerate() {
+        for (i, card) in live_cards.iter().enumerate() {
             self.card_index.insert(card.id, i);
         }
-        self.boards = Some(snapshot.boards);
-        self.columns = Some(snapshot.columns);
-        self.cards = Some(snapshot.cards);
-        self.sprints = Some(snapshot.sprints);
+
         self.archived_card_index.clear();
         let mut flat = Vec::with_capacity(snapshot.archived_cards.len());
-        for (i, ac) in snapshot.archived_cards.iter().enumerate() {
-            self.archived_card_index.insert(ac.entity.id, i);
-            flat.push(ac.entity.clone());
+        for ac in snapshot.archived_cards.iter() {
+            if let Some(card) = card_by_id.get(&ac.entity_id) {
+                self.archived_card_index.insert(ac.entity_id, flat.len());
+                flat.push(card.clone());
+            }
         }
+
+        self.boards = Some(snapshot.boards);
+        self.columns = Some(snapshot.columns);
+        self.sprints = Some(snapshot.sprints);
+        self.cards = Some(live_cards);
         self.archived_cards = Some(snapshot.archived_cards);
         self.archived_cards_flat = Some(flat);
         self.graph = snapshot.graph;
@@ -142,9 +166,12 @@ mod tests {
         let col_id = Uuid::new_v4();
         let card = make_card(&mut board, col_id);
         let card_id = card.id;
-        let archived = ArchivedCard::new(card, uuid::Uuid::nil(), col_id, 0);
+        // Reference-marker model: the card stays live in `cards`; the marker
+        // references it by id.
+        let archived = ArchivedCard::new(card_id, uuid::Uuid::nil());
         m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
+            cards: vec![card],
             archived_cards: vec![archived],
             ..Default::default()
         });
@@ -167,7 +194,8 @@ mod tests {
         let card_id = card.id;
         m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
-            archived_cards: vec![ArchivedCard::new(card, uuid::Uuid::nil(), col_id, 0)],
+            cards: vec![card],
+            archived_cards: vec![ArchivedCard::new(card_id, uuid::Uuid::nil())],
             ..Default::default()
         });
         assert_eq!(m.archived_cards_flat().len(), 1);

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -174,8 +174,8 @@ impl App {
     }
 
     /// Entity counts owned by `board_id` (columns, live cards, archived cards,
-    /// sprints). Archived cards are scoped via `original_column_id` -> column
-    /// -> board (pre-SE-B `ArchivedCard` carries no `board_id`).
+    /// sprints). Archived cards are scoped via the first-class `board_id` on the
+    /// marker (survives a column deleted after archival).
     pub(crate) fn board_delete_counts(&self, board_id: uuid::Uuid) -> BoardDeleteCounts {
         let col_ids: std::collections::HashSet<uuid::Uuid> = self
             .model
@@ -195,7 +195,7 @@ impl App {
             .model
             .archived_cards()
             .iter()
-            .filter(|a| col_ids.contains(&a.context.original_column_id))
+            .filter(|a| a.context.board_id == board_id)
             .count();
         let sprints = self
             .model

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -712,7 +712,7 @@ impl App {
             .model
             .archived_cards()
             .iter()
-            .any(|dc| dc.entity.id == card_id)
+            .any(|dc| dc.entity_id == card_id)
         {
             self.animation.animating.insert(
                 card_id,
@@ -725,10 +725,16 @@ impl App {
     }
 
     pub fn restore_card(&mut self, archived_card: ArchivedCard) {
-        let card_id = archived_card.entity.id;
-        let original_column_id = archived_card.context.original_column_id;
-        let original_position = archived_card.context.original_position;
-        let card_title = archived_card.entity.title.clone();
+        let card_id = archived_card.entity_id;
+        // Reference-marker model: the card stayed LIVE in place while archived, so
+        // it keeps its current column/position on restore; there is no "original"
+        // location to reconstruct. Read the live card for its column/position and
+        // to resolve the restore target if its column was removed.
+        let (current_column_id, current_position, card_title) =
+            match self.model.archived_card(card_id) {
+                Some(card) => (card.column_id, card.position, card.title.clone()),
+                None => return,
+            };
 
         let boards = self.model.boards();
         let board_id = self
@@ -741,17 +747,17 @@ impl App {
         let target_column_id = board_id
             .and_then(|bid| {
                 kanban_domain::card_lifecycle::resolve_restore_column(
-                    original_column_id,
+                    current_column_id,
                     bid,
                     columns,
                 )
             })
-            .unwrap_or(original_column_id);
+            .unwrap_or(current_column_id);
 
         let cmd = Command::Card(CardCommand::Restore(RestoreCard {
             card_id,
             column_id: target_column_id,
-            position: original_position,
+            position: current_position,
             timestamp: chrono::Utc::now(),
         }));
 
@@ -794,7 +800,7 @@ impl App {
             .model
             .archived_cards()
             .iter()
-            .any(|dc| dc.entity.id == card_id)
+            .any(|dc| dc.entity_id == card_id)
         {
             self.animation.animating.insert(
                 card_id,

--- a/crates/kanban-tui/tests/data_integrity_tests.rs
+++ b/crates/kanban-tui/tests/data_integrity_tests.rs
@@ -121,7 +121,7 @@ fn test_delete_column_with_archived_cards_succeeds() {
     assert_eq!(
         store.list_archived_cards().unwrap().len(),
         1,
-        "the archived record survives the column deletion (dangling original_column_id)"
+        "the archived record survives the column deletion (scoped by first-class board_id, not column)"
     );
 }
 

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -120,11 +120,12 @@ fn test_archived_cards_flat_returns_card_data() {
     let column_id = Uuid::new_v4();
     let card1 = make_card(&mut board, column_id, "Archived1", 0);
     let card2 = make_card(&mut board, column_id, "Archived2", 1);
-    let ac1 = ArchivedCard::new(card1.clone(), uuid::Uuid::nil(), column_id, 0);
-    let ac2 = ArchivedCard::new(card2.clone(), uuid::Uuid::nil(), column_id, 1);
+    let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
+    let ac2 = ArchivedCard::new(card2.id, uuid::Uuid::nil());
 
     model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
+        cards: vec![card1, card2],
         archived_cards: vec![ac1, ac2],
         ..Default::default()
     });
@@ -143,9 +144,10 @@ fn test_archived_cards_flat_rebuilds_on_reload() {
     let column_id = Uuid::new_v4();
 
     let card1 = make_card(&mut board, column_id, "First", 0);
-    let ac1 = ArchivedCard::new(card1.clone(), uuid::Uuid::nil(), column_id, 0);
+    let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
     model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
+        cards: vec![card1],
         archived_cards: vec![ac1],
         ..Default::default()
     });
@@ -154,10 +156,11 @@ fn test_archived_cards_flat_rebuilds_on_reload() {
 
     let card2 = make_card(&mut board, column_id, "Second", 0);
     let card3 = make_card(&mut board, column_id, "Third", 1);
-    let ac2 = ArchivedCard::new(card2.clone(), uuid::Uuid::nil(), column_id, 0);
-    let ac3 = ArchivedCard::new(card3.clone(), uuid::Uuid::nil(), column_id, 1);
+    let ac2 = ArchivedCard::new(card2.id, uuid::Uuid::nil());
+    let ac3 = ArchivedCard::new(card3.id, uuid::Uuid::nil());
     model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
+        cards: vec![card2, card3],
         archived_cards: vec![ac2, ac3],
         ..Default::default()
     });
@@ -178,11 +181,12 @@ fn test_archived_card_lookup_by_id() {
     let card2 = make_card(&mut board, column_id, "Archived2", 1);
     let id1 = card1.id;
     let id2 = card2.id;
-    let ac1 = ArchivedCard::new(card1, uuid::Uuid::nil(), column_id, 0);
-    let ac2 = ArchivedCard::new(card2, uuid::Uuid::nil(), column_id, 1);
+    let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
+    let ac2 = ArchivedCard::new(card2.id, uuid::Uuid::nil());
 
     model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
+        cards: vec![card1, card2],
         archived_cards: vec![ac1, ac2],
         ..Default::default()
     });
@@ -198,10 +202,11 @@ fn test_archived_card_lookup_missing_returns_none() {
     let mut board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
     let card = make_card(&mut board, column_id, "Archived", 0);
-    let ac = ArchivedCard::new(card, uuid::Uuid::nil(), column_id, 0);
+    let ac = ArchivedCard::new(card.id, uuid::Uuid::nil());
 
     model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
+        cards: vec![card],
         archived_cards: vec![ac],
         ..Default::default()
     });


### PR DESCRIPTION
## What

FOUND-F3b (KAN-884), the atomic keystone of the archival unification (root KAN-864). Retires the embedded entity from the archival wrapper so an archived record is a PURE MARKER and the live card/board is the single source of truth. This is the one PR where the whole workspace flips; every `.entity` consumer migrates together so it compiles at the boundary.

## The collapse

`Archived<T, C>` (which embedded a full copy of the entity) becomes `Archived<C> { entity_id: Uuid, metadata, context }` (derives `Copy`).

- `ArchivedCard = Archived<CardRestoreContext { board_id }>` — dropped `original_column_id`/`original_position`; nothing moves on archive, so there is no position to remember.
- `ArchivedBoard = Archived<NoContext>`.
- Deleted the `entity_serde` bridge, the `ArchivableEntity` trait + its `Card`/`Board` impls, and `card_ref`/`card_mut`/`into_card`/`into_entity`/`From`/`Borrow`. `entity_id()` now returns the field.

## Consumers (all migrated in this PR)

- Reads that need entity fields fetch the live entity by id (`get_card`/`get_board` are unfiltered). `Snapshot.cards`/`.boards` carry every entity (live and archived); `archived_cards`/`archived_boards` are pure markers keyed by `entity_id` — no duplication.
- Board archival is unified onto the same marker model as cards: the board head stays live, a marker hides it from live lists, `list_boards` is live-scoped on both backends.

## Three resistant seams

- `list_archived_cards_sorted` now returns `Vec<(Card, DateTime<Utc>)>`: it joins each marker to its live card, sorts the cards, and re-pairs `archived_at`. CLI and MCP map the pairs to `CardResponse::archived(&card, at)`.
- `DeleteBoard::capture_inverse` discriminates archived-ness via the marker (`get_archived_board`), since `get_board` is now unfiltered; undo re-imports the board head and its marker.
- `DeleteArchivedCards` deletes the underlying live card too (else it orphans), and its inverse re-imports both the card and the marker.

## DTO retirement

`ArchivedCardResponse`/`ArchivedBoardResponse` and their `From<&Archived*>` impls are removed; CLI/MCP archived-list handlers emit the unified `CardResponse` with `archived_at` set (D1/D2 landed the additive field). The two integration tests that asserted the old nested shape now assert the flat shape.

## Reversibility

`archive`↔`restore` and `delete`↔`undo` hold over the full entity graph on in-memory AND SQLite, verified by the contract, inverse-command, delete_board_cascade, and board_archive_sqlite suites. This work exposed and fixed a latent reversibility bug: in-memory `delete_cards_by_columns` dropped archived-but-live card rows whose inverse could not restore them (SQLite already guarded this via `NOT EXISTS`).

## Old-file compatibility

A temporary read-shim (`normalize_embedded_archived_to_references`) lifts old embed-shape archived entries into the live `cards`/`boards` arrays as markers at JSON load time, so existing files still load. No `FormatVersion` bump. MIGRATION-M1 (KAN-874) replaces it with a formal, version-bumped V9→V10 step and lands immediately after this, per the F3b→M1 back-to-back decision recorded on KAN-864.

## Verification

Whole workspace green: kanban-domain (614), kanban-service (608), kanban-persistence-json (160, incl. 5 new shim tests), plus core/persistence/persistence-sqlite/cli/tui/mcp. `clippy -D warnings` clean, `fmt` clean. Net 70 files, +1307/−1038 (the collapse removes the embed machinery).

## SQLite note

`archived_cards.original_column_id`/`original_position` columns remain in `schema.sql` (untouched); inserts write inert placeholders and reads never consult them. Dropping them is deferred to the migration area.
