### PR TITLE
KAN-873 test(service): cross-backend archival contract + edit-archived roundtrip (F4)

### DIFF
--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
@@ -123,12 +123,33 @@ impl SqliteStore {
         where_clause: &str,
         binds: &[String],
     ) -> KanbanResult<Vec<Card>> {
+        // LIVE-scoped reads exclude archived cards (they stay live behind a marker
+        // but are hidden from the live list). Snapshot/export fidelity uses
+        // `fetch_all_cards_unfiltered` instead.
+        let filter = "WHERE NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)";
+        self.fetch_cards_query(filter, where_clause, binds).await
+    }
+
+    /// ALL card rows, live AND archived (unfiltered). Reference-marker model
+    /// (F3b): `snapshot.cards` is the single source of truth for every card, so a
+    /// snapshot must carry the archived cards' live rows too (their archival is
+    /// recorded separately by the `archived_cards` markers).
+    pub(crate) async fn fetch_all_cards_unfiltered(&self) -> KanbanResult<Vec<Card>> {
+        self.fetch_cards_query("", "", &[]).await
+    }
+
+    async fn fetch_cards_query(
+        &self,
+        base_filter: &str,
+        where_clause: &str,
+        binds: &[String],
+    ) -> KanbanResult<Vec<Card>> {
         let sql = format!(
             "SELECT id, column_id, title, description, priority, status, position,
                     due_date, points, card_number, sprint_id, created_at, updated_at, completed_at
-             FROM cards WHERE NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id) {}
+             FROM cards {} {}
              ORDER BY position ASC, created_at ASC",
-            where_clause
+            base_filter, where_clause
         );
         let mut query = sqlx::query(&sql);
         for b in binds {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
@@ -29,7 +29,9 @@ impl SqliteStore {
         // separate `archived_boards` markers.
         let boards = self.all_boards_async().await?;
         let columns = self.list_all_columns_async().await?;
-        let cards = self.fetch_cards_with_filter("", &[]).await?;
+        // Carry ALL card rows (live + archived) — the archived card's live row must
+        // survive the round-trip; its archival rides on the `archived_cards` markers.
+        let cards = self.fetch_all_cards_unfiltered().await?;
         let archived_cards = self.list_archived_cards_async().await?;
         let sprints = self.list_all_sprints_async().await?;
         let graph = self.get_graph_async().await?;

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -1,6 +1,8 @@
 use super::super::BackendFactory;
+use super::assert_card_eq;
 use crate::KanbanContext;
 use kanban_core::AppConfig;
+use kanban_domain::archival::ArchivedEntity;
 use kanban_domain::card::CardPriority;
 use kanban_domain::{CreateCardOptions, KanbanOperations};
 use tempfile::TempDir;
@@ -28,6 +30,8 @@ pub async fn test_archive_card_roundtrip(factory: &BackendFactory) {
             },
         )
         .unwrap();
+    // The full pre-archive entity — every field must survive the round-trip.
+    let pre_archive = ctx.get_card(card.id).unwrap().unwrap();
 
     ctx.archive_card(card.id).unwrap();
 
@@ -52,15 +56,15 @@ pub async fn test_archive_card_roundtrip(factory: &BackendFactory) {
     let archived = ctx.list_archived_cards().unwrap();
     assert_eq!(archived.len(), 1);
 
+    // F3b marker: only `entity_id` (== card.id) and `context.board_id` are on the
+    // marker. The whole entity is asserted via the still-live card fetched by id.
     let ac = &archived[0];
+    assert_eq!(ac.entity_id(), card.id);
     assert_eq!(ac.entity_id, card.id);
     assert_eq!(ac.context.board_id, board.id);
+
     let live = ctx.get_card(ac.entity_id).unwrap().unwrap();
-    assert_eq!(live.title, "To Archive");
-    assert_eq!(live.description.as_deref(), Some("archived desc"));
-    assert_eq!(live.priority, CardPriority::High);
-    assert_eq!(live.points, Some(3));
-    assert_eq!(live.column_id, col.id);
+    assert_card_eq(&live, &pre_archive);
 }
 
 pub async fn test_archive_card_with_sprint_logs_roundtrip(factory: &BackendFactory) {
@@ -113,6 +117,7 @@ pub async fn test_restore_archived_card_roundtrip(factory: &BackendFactory) {
             CreateCardOptions::default(),
         )
         .unwrap();
+    let pre_archive = ctx.get_card(card.id).unwrap().unwrap();
 
     ctx.archive_card(card.id).unwrap();
     ctx.restore_card(card.id, None).unwrap();
@@ -120,7 +125,82 @@ pub async fn test_restore_archived_card_roundtrip(factory: &BackendFactory) {
     ctx.save().await.unwrap();
     let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
 
+    // The card stays live in place across archive→restore; every field survives
+    // EXCEPT `updated_at`, which `RestoreCard` re-stamps to the restore time.
     let c = ctx.get_card(card.id).unwrap().unwrap();
-    assert_eq!(c.title, "Will Restore");
+    let expected = kanban_domain::Card {
+        updated_at: c.updated_at,
+        ..pre_archive
+    };
+    assert_card_eq(&c, &expected);
     assert!(ctx.list_archived_cards().unwrap().is_empty());
+}
+
+/// An archived card is an ordinary LIVE card behind a marker; editing it (here:
+/// clearing its sprint by deleting the sprint, which drives
+/// `clear_sprint_from_archived_cards`) must reach the live card AND survive a
+/// save/reload — on every backend. Every OTHER field must be untouched.
+pub async fn test_edit_archived_card_roundtrip(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    let card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Edited While Archived".into(),
+            CreateCardOptions {
+                description: Some("body".into()),
+                priority: Some(CardPriority::High),
+                points: Some(2),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    ctx.assign_card_to_sprint(card.id, sprint.id).unwrap();
+    ctx.archive_card(card.id).unwrap();
+
+    // Snapshot the archived-but-live card BEFORE the edit (it carries the sprint).
+    let pre_edit = ctx.get_card(card.id).unwrap().unwrap();
+    assert_eq!(
+        pre_edit.sprint_id,
+        Some(sprint.id),
+        "sprint assigned pre-edit"
+    );
+
+    // Edit the archived card in place: deleting its sprint clears sprint_id on the
+    // LIVE archived card via `clear_sprint_from_archived_cards`.
+    ctx.delete_sprint(sprint.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    // Still archived (hidden from live, present as a marker).
+    let archived = ctx.list_archived_cards().unwrap();
+    assert_eq!(archived.len(), 1);
+    assert_eq!(archived[0].entity_id, card.id);
+
+    // The edit reached the live card and survived the round-trip.
+    let live = ctx.get_card(card.id).unwrap().unwrap();
+    assert_eq!(
+        live.sprint_id, None,
+        "the sprint clear reached the live archived card and persisted"
+    );
+
+    // Every OTHER field is unchanged from the pre-edit snapshot (only sprint_id
+    // and updated_at may move; build the expectation by clearing the sprint on the
+    // pre-edit copy and letting updated_at be the observed value).
+    let expected = kanban_domain::Card {
+        sprint_id: None,
+        updated_at: live.updated_at,
+        ..pre_edit
+    };
+    assert_card_eq(&live, &expected);
 }

--- a/crates/kanban-service/src/test_helpers/contract/mod.rs
+++ b/crates/kanban-service/src/test_helpers/contract/mod.rs
@@ -7,3 +7,24 @@ pub mod lifecycle;
 pub mod movement;
 pub mod sprint;
 pub mod sprint_log;
+
+/// Assert two `Card`s are equal field-by-field (including `sprint_logs`), so a
+/// round-trip mismatch names the exact field that drifted rather than dumping
+/// the whole struct. Shared by the archive/edit/restore contract round-trips.
+pub fn assert_card_eq(a: &kanban_domain::Card, b: &kanban_domain::Card) {
+    assert_eq!(a.id, b.id, "card id");
+    assert_eq!(a.column_id, b.column_id, "card column_id");
+    assert_eq!(a.title, b.title, "card title");
+    assert_eq!(a.description, b.description, "card description");
+    assert_eq!(a.priority, b.priority, "card priority");
+    assert_eq!(a.status, b.status, "card status");
+    assert_eq!(a.position, b.position, "card position");
+    assert_eq!(a.due_date, b.due_date, "card due_date");
+    assert_eq!(a.points, b.points, "card points");
+    assert_eq!(a.card_number, b.card_number, "card card_number");
+    assert_eq!(a.sprint_id, b.sprint_id, "card sprint_id");
+    assert_eq!(a.created_at, b.created_at, "card created_at");
+    assert_eq!(a.updated_at, b.updated_at, "card updated_at");
+    assert_eq!(a.completed_at, b.completed_at, "card completed_at");
+    assert_eq!(a.sprint_logs, b.sprint_logs, "card sprint_logs");
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -122,6 +122,10 @@ macro_rules! context_contract_tests {
         async fn test_restore_archived_card_roundtrip() {
             $crate::test_helpers::contract::archive::test_restore_archived_card_roundtrip(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_edit_archived_card_roundtrip() {
+            $crate::test_helpers::contract::archive::test_edit_archived_card_roundtrip(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]
@@ -196,9 +200,11 @@ macro_rules! context_contract_tests {
         async fn test_reload_picks_up_external_changes() {
             $crate::test_helpers::contract::lifecycle::test_reload_picks_up_external_changes(&$factory_fn()).await;
         }
-        #[tokio::test(flavor = "multi_thread")]
-        async fn test_save_with_stale_metadata_returns_conflict() {
-            $crate::test_helpers::contract::lifecycle::test_save_with_stale_metadata_returns_conflict(&$factory_fn()).await;
-        }
+        // NOTE: `test_save_with_stale_metadata_returns_conflict` is intentionally
+        // NOT in this shared macro. Optimistic-concurrency conflict detection is a
+        // FILE-store feature (it versions on-disk metadata): the in-memory backend
+        // has no persistence layer to conflict on, and the SQLite backend shares a
+        // live DB connection rather than snapshot-versioning. It is invoked
+        // directly for the JSON backend by the F4 registration test instead.
     };
 }

--- a/crates/kanban-service/tests/archival_contract.rs
+++ b/crates/kanban-service/tests/archival_contract.rs
@@ -1,0 +1,98 @@
+//! FOUND-F4 (KAN-873): run the shared `KanbanContext` contract suite on ALL
+//! THREE backends — in-memory, JSON, and SQLite — so board/column/card/sprint/
+//! archive/edge/lifecycle round-trips (incl. the F3b reference-marker archival
+//! model and an edit-while-archived round-trip) are held to ONE spec everywhere.
+//!
+//! The `context_contract_tests!` macro generates a `#[tokio::test]` per contract
+//! function; invoking it inside three modules gives 3× the coverage.
+//!
+//! Requires the `test-helpers` feature (which exposes `test_helpers` and the
+//! contract macro). CI runs `cargo test --all-features`, so this is active there;
+//! run locally with `cargo test -p kanban-service --features test-helpers`.
+#![cfg(feature = "test-helpers")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use kanban_domain::InMemoryStore;
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::sqlite_backend::SqliteBackend;
+use kanban_service::test_helpers::BackendFactory;
+use kanban_service::{json_backend::JsonDataStore, KanbanBackend};
+
+/// JSON backend: a `JsonDataStore` over a `JsonFileStore` at the given path.
+/// Reopening the same path reads the persisted file, so `factory(&path)` twice
+/// returns two stores sharing on-disk state — exactly what the reload
+/// assertions need.
+fn json_backend_factory() -> BackendFactory {
+    Box::new(|path: &Path| {
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path)))) as Arc<dyn KanbanBackend>
+    })
+}
+
+/// SQLite backend: `SqliteBackend::open` is async, but the factory is sync AND
+/// is called from within the test's tokio runtime. Blocking on a nested runtime
+/// on the current thread panics ("cannot start a runtime from within a
+/// runtime"), so open on a fresh OS thread with its own runtime and join it.
+/// Reopening the same file path shares the on-disk database.
+fn sqlite_backend_factory() -> BackendFactory {
+    Box::new(|path: &Path| {
+        let path = path.to_path_buf();
+        std::thread::spawn(move || {
+            // Multi-threaded: `SqliteStore` rejects a current_thread runtime, and
+            // opening does async SQLite I/O. The pool it builds is runtime-agnostic;
+            // the backend's later sync `DataStore` calls run on the test's own
+            // multi-thread runtime via `Handle::current()` + `block_in_place`.
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .expect("multi-thread runtime");
+            let backend = rt
+                .block_on(SqliteBackend::open(path.to_str().unwrap()))
+                .expect("open sqlite backend");
+            Arc::new(backend) as Arc<dyn KanbanBackend>
+        })
+        .join()
+        .expect("sqlite open thread")
+    })
+}
+
+/// In-memory backend: the contract fns reopen by calling `factory(&path)` a
+/// SECOND time and expect the SAME persisted state. In-memory has no disk, so a
+/// naive fresh `InMemoryStore::new()` per call would drop the data. Key a shared
+/// registry on the path so the same path always returns the same store.
+fn in_memory_backend_factory() -> BackendFactory {
+    let registry: Arc<Mutex<HashMap<PathBuf, Arc<dyn KanbanBackend>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    Box::new(move |path: &Path| {
+        let mut map = registry.lock().unwrap();
+        map.entry(path.to_path_buf())
+            .or_insert_with(|| Arc::new(InMemoryStore::new()) as Arc<dyn KanbanBackend>)
+            .clone()
+    })
+}
+
+mod in_memory {
+    kanban_service::context_contract_tests!(super::in_memory_backend_factory);
+}
+
+mod json {
+    kanban_service::context_contract_tests!(super::json_backend_factory);
+}
+
+mod sqlite {
+    kanban_service::context_contract_tests!(super::sqlite_backend_factory);
+}
+
+/// Optimistic-concurrency conflict detection is a FILE-store feature (it versions
+/// on-disk metadata), so it is not part of the shared cross-backend macro. Run it
+/// against the JSON backend, which is the one that implements it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_save_with_stale_metadata_returns_conflict() {
+    kanban_service::test_helpers::contract::lifecycle::test_save_with_stale_metadata_returns_conflict(
+        &json_backend_factory(),
+    )
+    .await;
+}


### PR DESCRIPTION
## What

FOUND-F4 (KAN-873), the final Foundation card of the archival unification (root KAN-864). Realizes the CLAUDE.md all-backend rule for archival: the shared context contract (board/column/card/sprint/archive/edge round-trips) was defined but invoked on no backend; this registers it for in-memory, JSON, and SQLite so every round-trip runs on all three, and adds an edit-archived round-trip.

## Backend registration

New `crates/kanban-service/tests/archival_contract.rs` invokes `context_contract_tests!` in per-backend submodules (133 tests total = 3 × 44 + 1 JSON-only conflict test):

- Keyed in-memory factory (`Arc<Mutex<HashMap<PathBuf, Arc<dyn KanbanBackend>>>>`) so a second `factory(&path)` returns the same store — the contract fns reopen-and-reload, which a fresh in-memory store per call would defeat.
- JSON reopens from the file; SQLite opens on a worker-thread runtime (`SqliteStore` rejects a `current_thread` runtime, and a nested `block_on` on the test runtime would panic).

## Strengthened assertions

- `test_archive_card_roundtrip` now asserts the WHOLE entity graph: after archive + save + reload, the live entity fetched by id equals the pre-archive card on every field including `sprint_logs` (new `assert_card_eq` helper), plus the card is hidden from live reads and the marker exposes the right `entity_id`/`board_id`.
- New `test_edit_archived_card_roundtrip`: an edit made while archived (sprint cleared via delete-sprint, which drives `clear_sprint_from_archived_cards` on the live card) reaches the live card and survives save→reload on every backend; all other fields unchanged.
- Conflict-detection is a file-store feature (in-memory has no version layer; SQLite shares a live connection), so it is invoked directly for JSON rather than forced onto the shared macro.

## Real bug this surfaced (separate `fix` commit)

Running the contract on SQLite exposed a production bug: `SqliteStore::snapshot_async` built `.cards` from the live-scoped query (`WHERE NOT EXISTS in archived_cards`), so an archived card's row was dropped from the snapshot. Under F3b, `snapshot.cards` must carry every card (the marker only references it). Fixed by adding `fetch_all_cards_unfiltered` and using it in the snapshot path. This is exactly the class of silent backend-divergence data-loss bug the all-backend rule exists to catch.

## Verification

`cargo test -p kanban-service --features test-helpers`: 741 passed, 0 failed. `kanban-persistence-sqlite`: 95 passed. `clippy -D warnings --all-features` clean, `fmt` clean. CI runs `--all-features --workspace`, so the feature-gated contract suite executes there.
