### PR TITLE
KAN-889 feat(domain/service): three-state archived selector on the card list (F7)

### DIFF
--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -92,6 +92,12 @@ pub struct CardSummary {
     pub updated_at: DateTime<Utc>,
     #[serde(default)]
     pub completed_at: Option<DateTime<Utc>>,
+    /// `Some` iff this card is archived (the marker's `archived_at`); `None` for
+    /// a live card. Stamped by the service when the unified card list includes
+    /// archived cards. Skipped on the wire when `None` so live summaries are
+    /// byte-identical to before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
 }
 
 impl From<&Card> for CardSummary {
@@ -110,6 +116,7 @@ impl From<&Card> for CardSummary {
             created_at: card.created_at,
             updated_at: card.updated_at,
             completed_at: card.completed_at,
+            archived_at: None,
         }
     }
 }
@@ -339,6 +346,39 @@ mod tests {
         let mut board = Board::new("board", None::<String>);
         let card = Card::new(&mut board, column_id, "my card", 0);
         assert_eq!(card.title, "my card");
+    }
+
+    #[test]
+    fn test_card_summary_from_card_has_none_archived_at() {
+        let mut board = Board::new("board", None::<String>);
+        let card = Card::new(&mut board, uuid::Uuid::new_v4(), "c", 0);
+        let summary = CardSummary::from(&card);
+        assert_eq!(summary.archived_at, None);
+    }
+
+    #[test]
+    fn test_card_summary_serializes_without_archived_at_when_none() {
+        let mut board = Board::new("board", None::<String>);
+        let card = Card::new(&mut board, uuid::Uuid::new_v4(), "c", 0);
+        let summary = CardSummary::from(&card);
+        let value = serde_json::to_value(&summary).unwrap();
+        assert!(
+            value.get("archived_at").is_none(),
+            "a live summary must not carry an archived_at key"
+        );
+    }
+
+    #[test]
+    fn test_card_summary_serializes_archived_at_when_some() {
+        let mut board = Board::new("board", None::<String>);
+        let card = Card::new(&mut board, uuid::Uuid::new_v4(), "c", 0);
+        let at = Utc::now();
+        let summary = CardSummary {
+            archived_at: Some(at),
+            ..CardSummary::from(&card)
+        };
+        let value = serde_json::to_value(&summary).unwrap();
+        assert!(value.get("archived_at").is_some());
     }
 
     #[test]

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -62,7 +62,7 @@ pub use query::{
         calculate_points, calculate_points_by_ids, get_sprint_cards, get_sprint_completed_cards,
         get_sprint_uncompleted_cards, partition_sprint_cards, sort_card_ids,
     },
-    ArchivedCardListFilter, CardListFilter, CardQueryBuilder,
+    ArchivedCardListFilter, ArchivedFilter, CardListFilter, CardQueryBuilder,
 };
 pub use search::{
     find_boards_by_name, find_cards_by_identifier, find_columns_by_name,

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -19,6 +19,21 @@ use std::borrow::Borrow;
 use std::collections::HashSet;
 use uuid::Uuid;
 
+/// Three-state selector over a card's archival status for the unified card list.
+/// The default is [`LiveOnly`](ArchivedFilter::LiveOnly), so an existing
+/// `CardListFilter::default()` caller sees exactly the pre-selector behavior.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ArchivedFilter {
+    /// Only live (non-archived) cards. The default — byte-identical to the
+    /// behavior before the selector existed.
+    #[default]
+    LiveOnly,
+    /// Only individually-archived cards.
+    ArchivedOnly,
+    /// Both live and archived cards (the union).
+    Include,
+}
+
 #[derive(Default, Clone)]
 pub struct CardListFilter {
     pub board_id: Option<Uuid>,
@@ -32,6 +47,9 @@ pub struct CardListFilter {
     pub search: Option<String>,
     pub sort: Option<SortField>,
     pub sort_order: Option<SortOrder>,
+    /// Three-state archival selector. Defaults to `LiveOnly`, so callers that
+    /// build the filter with `..Default::default()` are unaffected.
+    pub archived: ArchivedFilter,
 }
 
 #[derive(Default, Clone)]
@@ -158,4 +176,19 @@ pub fn count_filtered_cards<T: Borrow<Card>>(
             )
         })
         .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_archived_filter_default_is_live_only() {
+        assert_eq!(ArchivedFilter::default(), ArchivedFilter::LiveOnly);
+    }
+
+    #[test]
+    fn test_card_list_filter_default_archived_is_live_only() {
+        assert_eq!(CardListFilter::default().archived, ArchivedFilter::LiveOnly);
+    }
 }

--- a/crates/kanban-domain/src/query/mod.rs
+++ b/crates/kanban-domain/src/query/mod.rs
@@ -12,7 +12,8 @@ pub mod filter_sort;
 pub mod sprint;
 
 pub use filter_sort::{
-    count_filtered_cards, filter_and_sort_cards, ArchivedCardListFilter, CardListFilter,
+    count_filtered_cards, filter_and_sort_cards, ArchivedCardListFilter, ArchivedFilter,
+    CardListFilter,
 };
 
 use crate::{Board, Card, Column, Sprint};

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -150,8 +150,18 @@ impl KanbanContext {
     }
 
     pub(super) fn list_cards_impl(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
+        let (_ids, at_by_id) = self.archived_card_index()?;
         let cards = self.filter_cards(&filter)?;
-        Ok(cards.iter().map(CardSummary::from).collect())
+        Ok(cards
+            .iter()
+            .map(|c| {
+                // Stamp `archived_at` from the marker map; `None` for a live card.
+                CardSummary {
+                    archived_at: at_by_id.get(&c.id).copied(),
+                    ..CardSummary::from(c)
+                }
+            })
+            .collect())
     }
 
     pub(super) fn get_card_impl(&self, id: Uuid) -> KanbanResult<Option<Card>> {
@@ -191,7 +201,7 @@ impl KanbanContext {
     // ARCHIVED boards (whose subtree stays in the flat collections). Fidelity
     // paths (snapshot/import/export/migrate) keep reading `self.backend.list_all_*`
     // raw. This is a service-tier filter, uniform across all backends.
-    fn archived_board_id_set(&self) -> KanbanResult<std::collections::HashSet<Uuid>> {
+    pub(super) fn archived_board_id_set(&self) -> KanbanResult<std::collections::HashSet<Uuid>> {
         Ok(self
             .backend
             .list_archived_boards()?

--- a/crates/kanban-service/src/context/filters.rs
+++ b/crates/kanban-service/src/context/filters.rs
@@ -1,9 +1,31 @@
 use super::KanbanContext;
-use kanban_domain::{Card, CardListFilter, KanbanResult};
+use chrono::{DateTime, Utc};
+use kanban_domain::{ArchivedFilter, Card, CardListFilter, KanbanResult};
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
+/// The set of individually-archived card ids plus an `entity_id -> archived_at`
+/// map (read from the archived-card markers).
+pub(super) type ArchivedCardIndex = (HashSet<Uuid>, HashMap<Uuid, DateTime<Utc>>);
+
 impl KanbanContext {
+    /// The set of individually-archived card ids plus an `entity_id -> archived_at`
+    /// map, read once from the archived-card markers. Shared by the selector-aware
+    /// gather and by `list_cards_impl`'s `archived_at` stamping.
+    pub(super) fn archived_card_index(&self) -> KanbanResult<ArchivedCardIndex> {
+        let markers = self.backend.list_archived_cards()?;
+        let mut ids = HashSet::with_capacity(markers.len());
+        let mut at_by_id = HashMap::with_capacity(markers.len());
+        for m in &markers {
+            ids.insert(m.entity_id);
+            at_by_id.insert(m.entity_id, m.metadata.archived_at);
+        }
+        Ok((ids, at_by_id))
+    }
+
     pub(super) fn filter_cards(&self, filter: &CardListFilter) -> KanbanResult<Vec<Card>> {
+        let (archived_ids, _at) = self.archived_card_index()?;
+
         // C10a: an explicit `board_id` is a deliberate scoped request, so base the
         // card set on THAT board's own cards (raw) — honoring the board whether it
         // is live or archived. Only the UNSCOPED read stays live-scoped (C3b).
@@ -11,13 +33,22 @@ impl KanbanContext {
             Some(bid) => {
                 let columns = self.backend.list_columns_by_board(bid)?;
                 let col_ids: Vec<Uuid> = columns.iter().map(|c| c.id).collect();
-                let cards = self.backend.list_cards_by_columns(&col_ids)?;
+                // `list_cards_by_columns` is LIVE-scoped (excludes individually
+                // archived cards on both backends), so gather RAW: live cards in
+                // the board's columns UNION the board's archived cards (fetched by
+                // marker id), then apply the selector.
+                let cards =
+                    self.gather_board_cards_for_selector(&col_ids, &archived_ids, filter.archived)?;
                 // `get_board` is unfiltered (reference-marker model): it resolves
                 // the head whether the board is live or archived.
                 let board = self.backend.get_board(bid)?;
                 (cards, columns, board)
             }
-            None => (self.list_live_cards_impl()?, Vec::new(), None),
+            None => (
+                self.gather_unscoped_cards_for_selector(&archived_ids, filter.archived)?,
+                Vec::new(),
+                None,
+            ),
         };
         let sprints = match (board.as_ref(), filter.search.as_deref()) {
             (Some(b), Some(q)) if !q.is_empty() => self.backend.list_sprints_by_board(b.id)?,
@@ -30,5 +61,89 @@ impl KanbanContext {
             board.as_ref(),
             filter,
         ))
+    }
+
+    /// Board-scoped raw gather + selector. LiveOnly keeps the pre-selector set
+    /// (live cards in the board's columns). ArchivedOnly/Include add the board's
+    /// individually-archived cards (their column is in `col_ids`).
+    fn gather_board_cards_for_selector(
+        &self,
+        col_ids: &[Uuid],
+        archived_ids: &HashSet<Uuid>,
+        selector: ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        let live: Vec<Card> = self.backend.list_cards_by_columns(col_ids)?;
+        match selector {
+            ArchivedFilter::LiveOnly => Ok(live),
+            ArchivedFilter::ArchivedOnly | ArchivedFilter::Include => {
+                let col_set: HashSet<Uuid> = col_ids.iter().copied().collect();
+                let mut archived: Vec<Card> = Vec::new();
+                for id in archived_ids {
+                    if let Some(card) = self.backend.get_card(*id)? {
+                        if col_set.contains(&card.column_id) {
+                            archived.push(card);
+                        }
+                    }
+                }
+                if selector == ArchivedFilter::ArchivedOnly {
+                    Ok(archived)
+                } else {
+                    let mut all = live;
+                    all.extend(archived);
+                    Ok(all)
+                }
+            }
+        }
+    }
+
+    /// Unscoped gather + selector, preserving C3b (archived-BOARD descendants stay
+    /// excluded regardless of the selector — the selector is about individually
+    /// archived CARDS). LiveOnly is byte-identical to the pre-selector base.
+    fn gather_unscoped_cards_for_selector(
+        &self,
+        archived_ids: &HashSet<Uuid>,
+        selector: ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        let live = self.list_live_cards_impl()?;
+        match selector {
+            ArchivedFilter::LiveOnly => Ok(live),
+            ArchivedFilter::ArchivedOnly | ArchivedFilter::Include => {
+                // Individually-archived cards on LIVE boards only: fetch each by
+                // marker id and drop those whose column belongs to an archived
+                // board (same exclusion `list_live_cards_impl` applies).
+                let archived_board_cols = self.archived_board_column_set()?;
+                let mut archived: Vec<Card> = Vec::new();
+                for id in archived_ids {
+                    if let Some(card) = self.backend.get_card(*id)? {
+                        if !archived_board_cols.contains(&card.column_id) {
+                            archived.push(card);
+                        }
+                    }
+                }
+                if selector == ArchivedFilter::ArchivedOnly {
+                    Ok(archived)
+                } else {
+                    let mut all = live;
+                    all.extend(archived);
+                    Ok(all)
+                }
+            }
+        }
+    }
+
+    /// The set of column ids that belong to an ARCHIVED board (used to exclude
+    /// archived-board descendants from unscoped reads — C3b).
+    fn archived_board_column_set(&self) -> KanbanResult<HashSet<Uuid>> {
+        let archived_boards = self.archived_board_id_set()?;
+        if archived_boards.is_empty() {
+            return Ok(HashSet::new());
+        }
+        Ok(self
+            .backend
+            .list_all_columns()?
+            .into_iter()
+            .filter(|c| archived_boards.contains(&c.board_id))
+            .map(|c| c.id)
+            .collect())
     }
 }

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -4,7 +4,7 @@ use crate::KanbanContext;
 use kanban_core::AppConfig;
 use kanban_domain::archival::ArchivedEntity;
 use kanban_domain::card::CardPriority;
-use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_domain::{CardListFilter, CreateCardOptions, KanbanOperations};
 use tempfile::TempDir;
 
 pub async fn test_archive_card_roundtrip(factory: &BackendFactory) {
@@ -203,4 +203,176 @@ pub async fn test_edit_archived_card_roundtrip(factory: &BackendFactory) {
         ..pre_edit
     };
     assert_card_eq(&live, &expected);
+}
+
+/// F7 (KAN-889): the unified `list_cards` is the ONE path for live/archived/both
+/// via `CardListFilter::archived`. Seed one live + one archived card and assert
+/// each selector state returns exactly the right set, each `CardSummary` stamped
+/// with the correct `archived_at`. Also guards that the DEFAULT filter (LiveOnly)
+/// is unchanged.
+pub async fn test_list_cards_archived_selector_roundtrip(factory: &BackendFactory) {
+    use kanban_domain::ArchivedFilter;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let live = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(archived.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    // The DEFAULT filter is LiveOnly and MUST be unchanged: only the live card,
+    // with no archived_at.
+    let default_ids: Vec<_> = ctx
+        .list_cards(CardListFilter::default())
+        .unwrap()
+        .into_iter()
+        .map(|s| (s.id, s.archived_at))
+        .collect();
+    assert_eq!(default_ids, vec![(live.id, None)], "default == LiveOnly");
+
+    // LiveOnly (explicit): same as default.
+    let live_only = ctx
+        .list_cards(CardListFilter {
+            archived: ArchivedFilter::LiveOnly,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(live_only.len(), 1);
+    assert_eq!(live_only[0].id, live.id);
+    assert_eq!(live_only[0].archived_at, None);
+
+    // ArchivedOnly: exactly the archived card, stamped with archived_at.
+    let archived_only = ctx
+        .list_cards(CardListFilter {
+            archived: ArchivedFilter::ArchivedOnly,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(archived_only.len(), 1);
+    assert_eq!(archived_only[0].id, archived.id);
+    assert!(
+        archived_only[0].archived_at.is_some(),
+        "archived summary carries archived_at"
+    );
+
+    // Include: both, no duplicates, each stamped correctly.
+    let include = ctx
+        .list_cards(CardListFilter {
+            archived: ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(include.len(), 2, "union of live + archived, no duplicates");
+    let live_summary = include.iter().find(|s| s.id == live.id).unwrap();
+    let arch_summary = include.iter().find(|s| s.id == archived.id).unwrap();
+    assert_eq!(live_summary.archived_at, None, "live stays None");
+    assert!(arch_summary.archived_at.is_some(), "archived stays Some");
+}
+
+/// The same three-state selector, but board-scoped (an explicit `board_id`).
+pub async fn test_list_cards_archived_selector_board_scoped(factory: &BackendFactory) {
+    use kanban_domain::ArchivedFilter;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    // A second board with its own cards, to prove board scoping holds across the
+    // selector (its cards never leak into the target board's results).
+    let other = ctx.create_board("Other".into(), Some("O".into())).unwrap();
+    let other_col = ctx.create_column(other.id, "OC".into(), None).unwrap();
+    let other_live = ctx
+        .create_card(
+            other.id,
+            other_col.id,
+            "OL".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let other_arch = ctx
+        .create_card(
+            other.id,
+            other_col.id,
+            "OA".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(other_arch.id).unwrap();
+
+    let live = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(archived.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let scoped = |archived: ArchivedFilter| CardListFilter {
+        board_id: Some(board.id),
+        archived,
+        ..Default::default()
+    };
+
+    // LiveOnly: only the target board's live card.
+    let live_only = ctx.list_cards(scoped(ArchivedFilter::LiveOnly)).unwrap();
+    assert_eq!(live_only.len(), 1);
+    assert_eq!(live_only[0].id, live.id);
+    assert!(!live_only.iter().any(|s| s.id == other_live.id));
+
+    // ArchivedOnly: only the target board's archived card, stamped.
+    let archived_only = ctx
+        .list_cards(scoped(ArchivedFilter::ArchivedOnly))
+        .unwrap();
+    assert_eq!(archived_only.len(), 1);
+    assert_eq!(archived_only[0].id, archived.id);
+    assert!(archived_only[0].archived_at.is_some());
+    assert!(!archived_only.iter().any(|s| s.id == other_arch.id));
+
+    // Include: both of the target board's cards; nothing from the other board.
+    let include = ctx.list_cards(scoped(ArchivedFilter::Include)).unwrap();
+    assert_eq!(include.len(), 2);
+    assert!(include.iter().any(|s| s.id == live.id));
+    assert!(include.iter().any(|s| s.id == archived.id));
+    assert!(!include
+        .iter()
+        .any(|s| s.id == other_live.id || s.id == other_arch.id));
 }

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -126,6 +126,14 @@ macro_rules! context_contract_tests {
         async fn test_edit_archived_card_roundtrip() {
             $crate::test_helpers::contract::archive::test_edit_archived_card_roundtrip(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_cards_archived_selector_roundtrip() {
+            $crate::test_helpers::contract::archive::test_list_cards_archived_selector_roundtrip(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_cards_archived_selector_board_scoped() {
+            $crate::test_helpers::contract::archive::test_list_cards_archived_selector_board_scoped(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What

FOUND-F7 (KAN-889), a prerequisite discovered while executing the interface cards: they assume a unified archived selector on the card list, but the tree folded that into abstract "Foundation" and never built it. Today `CardListFilter` has no archived selector (a separate `ArchivedCardListFilter` + `list_archived_cards_sorted` still exist) and `CardSummary` carries no `archived_at`. This adds the shared domain primitive I1-I3 map their flags onto.

## Domain

- `ArchivedFilter { LiveOnly (default), ArchivedOnly, Include }` on `CardListFilter` (Default derive keeps it `LiveOnly`).
- `CardSummary.archived_at: Option<DateTime<Utc>>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` — a live summary stays byte-identical on the wire. `From<&Card>` sets it `None`.

## Service

`list_cards_impl`/`filter_cards` are selector-aware. `list_cards_by_columns` is live-scoped on both backends, so:
- Board-scoped path unions the board's live cards with its archived cards (fetched by marker id), then applies the selector.
- Unscoped path adds individually-archived cards on LIVE boards only, dropping archived-board descendants so C3b (archived-board subtree hiding) still holds regardless of the selector.
- Both feed the same `filter_and_sort_cards`, so sort is uniform across modes. Summaries are stamped `archived_at` from the marker map (`None` for live).

## Invariant

**LiveOnly is the default and byte-identical to prior behavior.** Every existing `CardListFilter` caller across CLI/MCP/TUI/service uses `..Default::default()`, so no surface changes and the whole workspace compiles unchanged. Guarded by a test asserting `list_cards(Default)` returns exactly the live set with `archived_at == None`.

The old `ArchivedCardListFilter` / `list_archived_cards_sorted` are left intact; the surface cards (I1-I3) retire them.

## Tests

All-backend contract fns wired into `context_contract_tests!` (in-memory + JSON + SQLite): selector roundtrip (default==LiveOnly; the three states return the right sets with correct `archived_at`; Include is a no-duplicate union) and a board-scoped variant proving a second board's cards never leak across any selector state. Domain units for the default + `CardSummary` serde.

`kanban-domain` 621 tests, `kanban-service --features test-helpers` 747, clippy `-D warnings` + fmt clean.
