### PR TITLE
KAN-881 feat(cli): unify card list with a three-state archived filter (I1)

### DIFF
--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -434,8 +434,12 @@ pub struct CardListArgs {
     pub sprint: Option<String>,
     #[arg(long)]
     pub status: Option<String>,
-    #[arg(long)]
+    /// Show only archived cards (mutually exclusive with --include-archived).
+    #[arg(long, conflicts_with = "include_archived")]
     pub archived: bool,
+    /// Include archived cards alongside live ones.
+    #[arg(long)]
+    pub include_archived: bool,
     /// Sort key. When omitted, falls back to the board's `task_sort_field`
     /// (requires --board).
     #[arg(long, value_enum)]

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -3,8 +3,8 @@ use crate::context::CliContext;
 use crate::output;
 use kanban_core::{parse_datetime_input, resolve_page_params, PaginatedList};
 use kanban_domain::{
-    CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions, FieldUpdate,
-    KanbanOperations, SprintStatus,
+    ArchivedFilter, CardListFilter, CardPriority, CardStatus, CardUpdate, CreateCardOptions,
+    FieldUpdate, KanbanOperations, SprintStatus,
 };
 use kanban_service::api::CardResponse;
 
@@ -38,33 +38,15 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
         }
         CardAction::List(args) => {
             let (page, page_size) = resolve_page_params(args.page, args.page_size)?;
-            if args.archived {
-                let board_id = match &args.board {
-                    Some(raw) => match ctx.resolve_board_id(raw) {
-                        Ok(u) => Some(u),
-                        Err(e) => return output::output_error(&e.to_string()),
-                    },
-                    None => None,
-                };
-                let archived =
-                    ctx.list_archived_cards_sorted(kanban_domain::ArchivedCardListFilter {
-                        board_id,
-                        sort: args.sort.map(|s| s.to_sort_field()),
-                        sort_order: args.order.map(|o| o.to_sort_order()),
-                    })?;
-                let responses: Vec<CardResponse> = archived
-                    .iter()
-                    .map(|(card, at)| CardResponse::archived(card, *at))
-                    .collect();
-                output::output_success(PaginatedList::paginate(responses, page, page_size)?);
-            } else {
-                let filter = match build_filter(ctx, &args) {
-                    Ok(f) => f,
-                    Err(e) => return output::output_error(&e),
-                };
-                let summaries = ctx.list_cards(filter)?;
-                output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
-            }
+            // I1 (KAN-881): ONE path. The `--archived`/`--include-archived` flags
+            // map to the domain archived selector; `list_cards` returns the unified
+            // `CardSummary` set (each carrying `archived_at`), live or archived.
+            let filter = match build_filter(ctx, &args) {
+                Ok(f) => f,
+                Err(e) => return output::output_error(&e),
+            };
+            let summaries = ctx.list_cards(filter)?;
+            output::output_success(PaginatedList::paginate(summaries, page, page_size)?);
         }
         CardAction::Get { card } => {
             if let Ok(uuid) = Uuid::parse_str(&card) {
@@ -311,6 +293,13 @@ fn build_filter(ctx: &CliContext, args: &CardListArgs) -> Result<CardListFilter,
         }),
         None => None,
     };
+    let archived = if args.archived {
+        ArchivedFilter::ArchivedOnly
+    } else if args.include_archived {
+        ArchivedFilter::Include
+    } else {
+        ArchivedFilter::LiveOnly
+    };
     Ok(CardListFilter {
         board_id,
         column_id,
@@ -318,6 +307,7 @@ fn build_filter(ctx: &CliContext, args: &CardListArgs) -> Result<CardListFilter,
         status,
         sort: args.sort.map(|s| s.to_sort_field()),
         sort_order: args.order.map(|o| o.to_sort_order()),
+        archived,
         ..Default::default()
     })
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1227,6 +1227,92 @@ mod card_tests {
     }
 
     #[test]
+    fn test_card_list_archived_selector_states() {
+        // I1 (KAN-881): one `card list` path, archival as a three-state filter.
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+
+        let mk = |title: &str| -> String {
+            let out = kanban()
+                .args([
+                    file.to_str().unwrap(),
+                    "card",
+                    "create",
+                    "--board",
+                    &board_id,
+                    "--column",
+                    &column_id,
+                    "--title",
+                    title,
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout
+                .clone();
+            extract_id(&parse_json_output(&String::from_utf8_lossy(&out)))
+        };
+        let _live = mk("Live");
+        let archived = mk("Archived");
+        kanban()
+            .args([file.to_str().unwrap(), "card", "archive", &archived])
+            .assert()
+            .success();
+
+        let list = |extra: &[&str]| -> serde_json::Value {
+            let mut a = vec![file.to_str().unwrap(), "card", "list"];
+            a.extend_from_slice(extra);
+            let out = kanban()
+                .args(a)
+                .assert()
+                .success()
+                .get_output()
+                .stdout
+                .clone();
+            parse_json_output(&String::from_utf8_lossy(&out))
+        };
+
+        // Default: live only, no archived_at.
+        let live = list(&[]);
+        assert_eq!(live["data"]["total"], 1);
+        assert_eq!(live["data"]["items"][0]["title"], "Live");
+        assert!(live["data"]["items"][0].get("archived_at").is_none());
+
+        // --archived: archived only, stamped.
+        let arch = list(&["--archived"]);
+        assert_eq!(arch["data"]["total"], 1);
+        assert_eq!(arch["data"]["items"][0]["title"], "Archived");
+        assert!(arch["data"]["items"][0]["archived_at"].is_string());
+
+        // --include-archived: both, each stamped appropriately.
+        let both = list(&["--include-archived"]);
+        assert_eq!(both["data"]["total"], 2);
+        let stamped: Vec<bool> = both["data"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i.get("archived_at").is_some())
+            .collect();
+        assert!(
+            stamped.contains(&true) && stamped.contains(&false),
+            "include mixes one stamped (archived) and one unstamped (live)"
+        );
+
+        // Mutually exclusive flags are rejected by clap.
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "list",
+                "--archived",
+                "--include-archived",
+            ])
+            .assert()
+            .failure();
+    }
+
+    #[test]
     fn test_card_archive_and_restore() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
@@ -1270,12 +1356,12 @@ mod card_tests {
         let archived_json = parse_json_output(&String::from_utf8_lossy(&archived_output));
         assert_eq!(archived_json["data"]["total"], 1);
         let item = &archived_json["data"]["items"][0];
-        // Under DTO retirement the archived list item is the flat CardResponse
-        // shape: a top-level `archived_at` plus the normal card fields, with no
-        // nested `card`, no `original_column_id`, and no first-class `board_id`.
+        // I1 (KAN-881): `card list --archived` now flows through the ONE unified
+        // path and emits the same lean `CardSummary` as the live list, plus a
+        // top-level `archived_at`. No nested `card`, no restore-context; and
+        // (like the live list) no `description` — that lives on `card get`.
         assert!(item["archived_at"].is_string());
         assert!(item.get("title").is_some());
-        assert!(item.get("description").is_some());
         assert!(item.get("card").is_none(), "no nested card object");
         assert!(
             item.get("original_column_id").is_none(),


### PR DESCRIPTION
## What

INTERFACES-I1 (KAN-881). Realizes the "live/archived distinction lives only at the consumption site, as a filter" invariant for the CLI. `card list` no longer forks into two code paths; archival is a three-state filter over the one unified card set (built on the F7 selector).

## Changes

- `--archived` (archived only) keeps its name/meaning; new `--include-archived` (live + archived); the two are mutually exclusive (clap `conflicts_with`). Default (no flag) is live-only, unchanged.
- The handler collapses to a single `ctx.list_cards(filter)` call; `build_filter` maps the flags to `CardListFilter.archived` (`LiveOnly`/`ArchivedOnly`/`Include`). The `list_archived_cards_sorted` / `ArchivedCardListFilter` branch is gone from the CLI.
- The archived list now emits the same lean `CardSummary` as the live list, plus a top-level `archived_at`, instead of the retired rich `ArchivedCardResponse`. `description` stays on `card get` (as it already did for the live list) — this is the intentional unification.

## Tests

- New `test_card_list_archived_selector_states`: default lists live only (no `archived_at`); `--archived` lists only the archived card (stamped); `--include-archived` lists both (one stamped, one not); `--archived --include-archived` is rejected by clap.
- Updated the existing archive/restore test to the unified `CardSummary` shape.

`cargo test -p kanban-cli` green, clippy `-D warnings` + fmt clean.
