### PR TITLE
KAN-882 feat(mcp): merge card list tools into one list_cards with archived filter (I2)

### DIFF
--- a/crates/kanban-mcp/src/helpers/mod.rs
+++ b/crates/kanban-mcp/src/helpers/mod.rs
@@ -9,7 +9,8 @@ pub(crate) use error_mapping::{
 };
 pub(crate) use macros::{locked_read, locked_write, mutating_op, read_op};
 pub(crate) use parsers::{
-    parse_datetime, parse_priority, parse_sort_field, parse_sort_order, parse_status,
+    parse_archived_selector, parse_datetime, parse_priority, parse_sort_field, parse_sort_order,
+    parse_status,
 };
 pub(crate) use resolvers::{card_board, project_sprint, resolve_summaries, McpResolve};
 pub(crate) use serialization::{to_call_tool_result, to_call_tool_result_json};

--- a/crates/kanban-mcp/src/helpers/parsers.rs
+++ b/crates/kanban-mcp/src/helpers/parsers.rs
@@ -1,6 +1,21 @@
 use kanban_core::parse_datetime_input;
-use kanban_domain::{CardPriority, CardStatus, SortField, SortOrder};
+use kanban_domain::{ArchivedFilter, CardPriority, CardStatus, SortField, SortOrder};
 use rmcp::model::ErrorData as McpError;
+
+/// Parse the `archived` list selector: `exclude` (live only, the default),
+/// `only` (archived only), or `include` (both). Mirrors the three-state
+/// `ArchivedFilter` the unified card list applies.
+pub(crate) fn parse_archived_selector(s: &str) -> Result<ArchivedFilter, McpError> {
+    match s.to_lowercase().as_str() {
+        "exclude" | "live" => Ok(ArchivedFilter::LiveOnly),
+        "only" | "archived" => Ok(ArchivedFilter::ArchivedOnly),
+        "include" | "both" => Ok(ArchivedFilter::Include),
+        _ => Err(McpError::invalid_params(
+            format!("Invalid archived filter '{s}'. Valid: exclude, only, include"),
+            None,
+        )),
+    }
+}
 
 pub(crate) fn parse_priority(s: &str) -> Result<CardPriority, McpError> {
     match s.to_lowercase().as_str() {
@@ -109,6 +124,30 @@ mod tests {
     fn parse_priority_invalid() {
         let err = parse_priority("urgent").unwrap_err();
         assert!(err.message.contains("Invalid priority"));
+    }
+
+    // parse_archived_selector
+
+    #[test]
+    fn parse_archived_selector_maps_three_states() {
+        use kanban_domain::ArchivedFilter;
+        assert_eq!(
+            parse_archived_selector("exclude").unwrap(),
+            ArchivedFilter::LiveOnly
+        );
+        assert_eq!(
+            parse_archived_selector("ONLY").unwrap(),
+            ArchivedFilter::ArchivedOnly
+        );
+        assert_eq!(
+            parse_archived_selector("Include").unwrap(),
+            ArchivedFilter::Include
+        );
+    }
+
+    #[test]
+    fn parse_archived_selector_rejects_unknown() {
+        assert!(parse_archived_selector("nope").is_err());
     }
 
     // parse_status

--- a/crates/kanban-mcp/src/requests/card.rs
+++ b/crates/kanban-mcp/src/requests/card.rs
@@ -41,6 +41,10 @@ pub struct ListCardsRequest {
     #[schemars(description = "Filter by status: 'todo', 'in_progress', 'blocked', or 'done'")]
     pub status: Option<String>,
     #[schemars(
+        description = "Archived filter: 'exclude' (default, live only), 'only' (archived only), or 'include' (both live and archived). Archived items carry an archived_at timestamp."
+    )]
+    pub archived: Option<String>,
+    #[schemars(
         description = "Sort field. Valid: points, priority, created_at, updated_at, due_date, status, position, default. 'default' orders by card number; date fields and points place None values last in ascending order. When omitted, falls back to the board's task_sort_field (requires `board`)."
     )]
     pub sort: Option<String>,

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -1,7 +1,7 @@
 use crate::helpers::{
-    card_board, core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, parse_datetime,
-    parse_priority, parse_sort_field, parse_sort_order, parse_status, read_op, to_call_tool_result,
-    to_call_tool_result_json, McpResolve,
+    card_board, core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write,
+    parse_archived_selector, parse_datetime, parse_priority, parse_sort_field, parse_sort_order,
+    parse_status, read_op, to_call_tool_result, to_call_tool_result_json, McpResolve,
 };
 use crate::requests::card::{
     ArchiveCardRequest, CreateCardParams, DeleteCardRequest, GetCardBranchNameRequest,
@@ -9,10 +9,8 @@ use crate::requests::card::{
     MoveCardRequest, RestoreCardRequest, UpdateCardRequest,
 };
 use crate::KanbanMcpServer;
-use kanban_core::{resolve_page_params, PaginatedList};
-use kanban_domain::{
-    ArchivedCardListFilter, CardListFilter, CardUpdate, FieldUpdate, KanbanOperations,
-};
+use kanban_core::resolve_page_params;
+use kanban_domain::{ArchivedFilter, CardListFilter, CardUpdate, FieldUpdate, KanbanOperations};
 use kanban_service::api::CardResponse;
 use rmcp::{
     handler::server::wrapper::Parameters,
@@ -51,13 +49,19 @@ impl KanbanMcpServer {
     }
 
     #[tool(
-        description = "List cards with optional filters. Returns CardSummary (title, status, priority — no description). Use card get for full details. Use page/page_size for pagination (default: page=1, page_size=50)."
+        description = "List cards with optional filters, including an `archived` selector: 'exclude' (default, live only), 'only' (archived only), or 'include' (both). Returns CardSummary (title, status, priority — no description; archived items carry archived_at). Use card get for full details. Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
     pub async fn tool_list_cards(
         &self,
         Parameters(req): Parameters<ListCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
         let status = req.status.as_deref().map(parse_status).transpose()?;
+        let archived = req
+            .archived
+            .as_deref()
+            .map(parse_archived_selector)
+            .transpose()?
+            .unwrap_or_default();
         let sort = req.sort.as_deref().map(parse_sort_field).transpose()?;
         let sort_order = req.order.as_deref().map(parse_sort_order).transpose()?;
         let (page, page_size) =
@@ -88,6 +92,7 @@ impl KanbanMcpServer {
                 status,
                 sort,
                 sort_order,
+                archived,
                 ..Default::default()
             };
             ctx.list_cards_paged(filter, page, page_size)
@@ -235,36 +240,36 @@ impl KanbanMcpServer {
     }
 
     #[tool(
-        description = "List archived cards. Returns CardResponse items (the full card projection) each carrying an archived_at timestamp. Use page/page_size for pagination (default: page=1, page_size=50)."
+        description = "DEPRECATED: use list_cards with archived='only'. Lists archived cards as the unified CardSummary (each carrying archived_at). Kept as a thin wrapper for existing clients. Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
     pub async fn tool_list_archived_cards(
         &self,
         Parameters(req): Parameters<ListArchivedCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
+        // I2 (KAN-882): one code path. This deprecated tool routes to the unified
+        // list with the archived-only selector, so its output matches
+        // `list_cards` with archived='only'.
         let sort = req.sort.as_deref().map(parse_sort_field).transpose()?;
         let sort_order = req.order.as_deref().map(parse_sort_order).transpose()?;
         let (page, page_size) =
             resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
-        let cards = locked_read(&self.ctx, |ctx| {
+        let result = locked_read(&self.ctx, |ctx| {
             let board_id = match &req.board {
                 Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
                 None => None,
             };
-            ctx.list_archived_cards_sorted(ArchivedCardListFilter {
+            let filter = CardListFilter {
                 board_id,
                 sort,
                 sort_order,
-            })
-            .map_err(kanban_err_to_mcp)
+                archived: ArchivedFilter::ArchivedOnly,
+                ..Default::default()
+            };
+            ctx.list_cards_paged(filter, page, page_size)
+                .map_err(kanban_err_to_mcp)
         })
         .await?;
-        let responses: Vec<CardResponse> = cards
-            .iter()
-            .map(|(card, at)| CardResponse::archived(card, *at))
-            .collect();
-        to_call_tool_result(
-            &PaginatedList::paginate(responses, page, page_size).map_err(core_err_to_mcp)?,
-        )
+        to_call_tool_result(&result)
     }
 
     // Card Utilities

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1912,12 +1912,11 @@ async fn test_mcp_list_archived_cards_includes_board_id() {
             .unwrap(),
     );
     let item = &listed["items"][0];
-    // Under DTO retirement the archived list item is the flat CardResponse shape:
-    // a top-level `archived_at` timestamp plus the normal card fields, with no
-    // nested `card`, no `original_column_id`, and no first-class `board_id`.
+    // I2 (KAN-882): the deprecated tool routes to the unified list, so an item is
+    // the lean CardSummary plus a top-level `archived_at` — no nested `card`, no
+    // restore-context, and (like the live list) no `description`.
     assert!(item["archived_at"].is_string());
     assert_eq!(item["title"], "the card");
-    assert_eq!(item["description"], "desc");
     let obj = item.as_object().unwrap();
     assert!(obj.get("card").is_none(), "no nested card object");
     assert!(
@@ -1926,4 +1925,96 @@ async fn test_mcp_list_archived_cards_includes_board_id() {
     );
     assert!(obj.get("board_id").is_none(), "no first-class board_id");
     let _ = board_id;
+}
+
+#[tokio::test]
+async fn test_mcp_list_cards_archived_selector() {
+    // I2 (KAN-882): the unified list_cards tool with the three-state `archived`
+    // selector replaces the separate archived tool.
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(board_req("Alpha", Some("A".into()))))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(column_req("Alpha", "TODO")))
+        .await
+        .unwrap();
+    let mk_card = |title: &str| CreateCardParams {
+        board: "Alpha".into(),
+        column: "TODO".into(),
+        sprint: None,
+        content: kanban_service::api::CreateCardRequest {
+            id: None,
+            title: title.into(),
+            description: None,
+            priority: None,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+    };
+    server
+        .tool_create_card(Parameters(mk_card("Live")))
+        .await
+        .unwrap();
+    let archived_id = text_payload(
+        &server
+            .tool_create_card(Parameters(mk_card("Archived")))
+            .await
+            .unwrap(),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server
+        .tool_archive_card(Parameters(kanban_mcp::ArchiveCardRequest {
+            card: archived_id,
+        }))
+        .await
+        .unwrap();
+
+    let req = |archived: Option<&str>| kanban_mcp::ListCardsRequest {
+        board: None,
+        column: None,
+        sprint: None,
+        status: None,
+        archived: archived.map(|s| s.to_string()),
+        sort: None,
+        order: None,
+        page: None,
+        page_size: None,
+    };
+
+    // default / exclude: live only, no archived_at.
+    let live = text_payload(&server.tool_list_cards(Parameters(req(None))).await.unwrap());
+    assert_eq!(live["total"], 1);
+    assert_eq!(live["items"][0]["title"], "Live");
+    assert!(live["items"][0].get("archived_at").is_none());
+
+    // only: archived, stamped.
+    let only = text_payload(
+        &server
+            .tool_list_cards(Parameters(req(Some("only"))))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(only["total"], 1);
+    assert_eq!(only["items"][0]["title"], "Archived");
+    assert!(only["items"][0]["archived_at"].is_string());
+
+    // include: both.
+    let both = text_payload(
+        &server
+            .tool_list_cards(Parameters(req(Some("include"))))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(both["total"], 2);
+
+    // invalid selector is rejected.
+    assert!(server
+        .tool_list_cards(Parameters(req(Some("bogus"))))
+        .await
+        .is_err());
 }


### PR DESCRIPTION
## What

INTERFACES-I2 (KAN-882). The MCP card surface: merge the two list tools into one `list_cards` with an archived filter, per the "distinction is a filter, not a branch" invariant.

## Changes

- `ListCardsRequest` gains an `archived` string param; `parse_archived_selector` maps `exclude` (default, live only), `only` (archived only), `include` (both) to the F7 `ArchivedFilter`. `tool_list_cards` threads it into the unified `CardListFilter` and returns the unified `CardSummary` (archived items carry `archived_at`); an invalid value is an `invalid_params` error.
- `tool_list_archived_cards` becomes a thin DEPRECATED wrapper routing to the same unified path with archived-only, so its output now matches `list_cards` `archived='only'` (lean `CardSummary` + `archived_at`) instead of the retired `ArchivedCardResponse`. Existing clients keep working; the description points them at `list_cards`.

## Tests

- `test_mcp_list_cards_archived_selector`: default/exclude → live only (no `archived_at`); `only` → archived stamped; `include` → both; invalid selector errors.
- Updated the deprecated-tool test to the unified shape; parser unit tests for the three states + rejection.

`cargo test -p kanban-mcp` green, clippy `-D warnings` + fmt clean.
