### PR TITLE
KAN-886 feat(cli): board archive/restore/delete + unified list with archived filter (I4)

### DIFF
--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -62,8 +62,14 @@ pub enum BoardAction {
         #[arg(long)]
         card_prefix: Option<String>,
     },
-    /// List all boards
+    /// List boards (live by default; use --archived / --include-archived).
     List {
+        /// Show only archived boards (mutually exclusive with --include-archived).
+        #[arg(long, conflicts_with = "include_archived")]
+        archived: bool,
+        /// Include archived boards alongside live ones.
+        #[arg(long)]
+        include_archived: bool,
         #[arg(long)]
         page: Option<u32>,
         #[arg(long)]
@@ -78,6 +84,21 @@ pub enum BoardAction {
     Update(BoardUpdateArgs),
     /// Delete a board by UUID or name
     Delete {
+        /// Board UUID or name
+        board: String,
+    },
+    /// Archive a board by UUID or name
+    Archive {
+        /// Board UUID or name
+        board: String,
+    },
+    /// Restore an archived board by UUID or name
+    Restore {
+        /// Board UUID or name
+        board: String,
+    },
+    /// Permanently delete an archived board by UUID or name
+    DeleteArchived {
         /// Board UUID or name
         board: String,
     },

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -14,9 +14,20 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             ctx.save().await?;
             output::output_success(BoardResponse::from(&board));
         }
-        BoardAction::List { page, page_size } => {
-            let boards = ctx.list_boards()?;
-            let responses: Vec<BoardResponse> = boards.iter().map(BoardResponse::from).collect();
+        BoardAction::List {
+            archived,
+            include_archived,
+            page,
+            page_size,
+        } => {
+            // I4 (KAN-886): ONE list command, three states. Boards have no domain
+            // filter struct, so the selector is composed here from the service ops.
+            // Live board payloads stay byte-identical (BoardResponse omits
+            // archived_at when None — D2 skip_serializing_if).
+            let responses = match build_board_list(ctx, archived, include_archived) {
+                Ok(r) => r,
+                Err(e) => return output::output_error(&e),
+            };
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(responses, page, page_size)?);
         }
@@ -43,8 +54,101 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
+        BoardAction::Archive { board } => {
+            // Live board (still in the live list) — the standard resolver suffices.
+            let uuid = match ctx.resolve_board_id(&board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e.to_string()),
+            };
+            ctx.archive_board(uuid)?;
+            ctx.save().await?;
+            output::output_success(serde_json::json!({"archived": uuid.to_string()}));
+        }
+        BoardAction::Restore { board } => {
+            let uuid = match resolve_board_id_any(ctx, &board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e),
+            };
+            ctx.restore_board(uuid)?;
+            ctx.save().await?;
+            match ctx.get_board(uuid)? {
+                Some(b) => output::output_success(BoardResponse::from(&b)),
+                None => return output::output_error(&format!("Board not found: {}", board)),
+            }
+        }
+        BoardAction::DeleteArchived { board } => {
+            // A board is just a board: delete works on an archived one because
+            // `get_board` is unfiltered. Resolve from either view.
+            let uuid = match resolve_board_id_any(ctx, &board) {
+                Ok(u) => u,
+                Err(e) => return output::output_error(&e),
+            };
+            ctx.delete_board(uuid)?;
+            ctx.save().await?;
+            output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
+        }
     }
     Ok(())
+}
+
+/// Compose the three-state board list from the service ops.
+/// - default: live boards (`archived_at` None).
+/// - `--archived`: only archived boards, each stamped `archived_at` (the live
+///   head resolved by the marker's `entity_id`).
+/// - `--include-archived`: live boards followed by the archived ones.
+fn build_board_list(
+    ctx: &CliContext,
+    archived: bool,
+    include_archived: bool,
+) -> Result<Vec<BoardResponse>, String> {
+    let mut out: Vec<BoardResponse> = Vec::new();
+
+    if !archived {
+        out.extend(
+            ctx.list_boards()
+                .map_err(|e| e.to_string())?
+                .iter()
+                .map(BoardResponse::from),
+        );
+    }
+
+    if archived || include_archived {
+        for marker in ctx.list_archived_boards().map_err(|e| e.to_string())? {
+            // `get_board` is unfiltered: it resolves the still-live head.
+            if let Some(board) = ctx.get_board(marker.entity_id).map_err(|e| e.to_string())? {
+                out.push(BoardResponse::archived(&board, marker.metadata.archived_at));
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Resolve a board id from EITHER the live or the archived view. UUIDs resolve
+/// immediately; a live-board name resolves via the standard resolver; otherwise
+/// fall back to matching an archived board by name (its head is unfiltered via
+/// `get_board`). Keeps the domain resolver (live-only) unchanged.
+fn resolve_board_id_any(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, String> {
+    if let Ok(uuid) = uuid::Uuid::parse_str(raw) {
+        return Ok(uuid);
+    }
+    if let Ok(uuid) = ctx.resolve_board_id(raw) {
+        return Ok(uuid);
+    }
+    // Fall back to archived boards: resolve each marker's live head and match by name.
+    let mut matches: Vec<uuid::Uuid> = Vec::new();
+    for marker in ctx.list_archived_boards().map_err(|e| e.to_string())? {
+        if let Some(board) = ctx.get_board(marker.entity_id).map_err(|e| e.to_string())? {
+            if board.name == raw {
+                matches.push(board.id);
+            }
+        }
+    }
+    match matches.as_slice() {
+        [id] => Ok(*id),
+        [] => Err(format!("Board not found: {}", raw)),
+        _ => Err(format!("Ambiguous archived board name: {}", raw)),
+    }
 }
 
 async fn handle_update(

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -454,6 +454,174 @@ mod board_tests {
         let json = parse_json_output(&String::from_utf8_lossy(&list_output));
         assert_eq!(json["data"]["total"], 0);
     }
+
+    // ---- I4 (KAN-886): the CLI board surface — archived selector + subcommands ----
+
+    /// Create a board and return its id.
+    fn mk_board(file: &std::path::Path, name: &str) -> String {
+        let out = kanban()
+            .args([file.to_str().unwrap(), "board", "create", "--name", name])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        extract_id(&parse_json_output(&String::from_utf8_lossy(&out)))
+    }
+
+    fn board_list(file: &std::path::Path, extra: &[&str]) -> Value {
+        let mut a = vec![file.to_str().unwrap(), "board", "list"];
+        a.extend_from_slice(extra);
+        let out = kanban()
+            .args(a)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        parse_json_output(&String::from_utf8_lossy(&out))
+    }
+
+    #[test]
+    fn test_board_list_archived_selector_states() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let _live = mk_board(&file, "Live Board");
+        let archived = mk_board(&file, "Archived Board");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &archived])
+            .assert()
+            .success();
+
+        // Default: live only, no archived_at.
+        let live = board_list(&file, &[]);
+        assert_eq!(live["data"]["total"], 1);
+        assert_eq!(live["data"]["items"][0]["name"], "Live Board");
+        assert!(live["data"]["items"][0].get("archived_at").is_none());
+
+        // --archived: archived only, stamped with archived_at.
+        let arch = board_list(&file, &["--archived"]);
+        assert_eq!(arch["data"]["total"], 1);
+        assert_eq!(arch["data"]["items"][0]["name"], "Archived Board");
+        assert!(arch["data"]["items"][0]["archived_at"].is_string());
+
+        // --include-archived: both, each stamped appropriately.
+        let both = board_list(&file, &["--include-archived"]);
+        assert_eq!(both["data"]["total"], 2);
+        let stamped: Vec<bool> = both["data"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i.get("archived_at").is_some())
+            .collect();
+        assert!(
+            stamped.contains(&true) && stamped.contains(&false),
+            "include mixes one stamped (archived) and one unstamped (live)"
+        );
+
+        // Mutually exclusive flags are rejected by clap.
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "list",
+                "--archived",
+                "--include-archived",
+            ])
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn test_board_archive_and_restore() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let id = mk_board(&file, "Round Trip");
+
+        // Archive: leaves the live list.
+        let out = kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &id])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let archived = parse_json_output(&String::from_utf8_lossy(&out));
+        assert_eq!(archived["data"]["archived"].as_str().unwrap(), id);
+        assert_eq!(board_list(&file, &[])["data"]["total"], 0);
+        assert_eq!(board_list(&file, &["--archived"])["data"]["total"], 1);
+
+        // Restore (by UUID): returns to the live list, projected via BoardResponse.
+        let out = kanban()
+            .args([file.to_str().unwrap(), "board", "restore", &id])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let restored = parse_json_output(&String::from_utf8_lossy(&out));
+        assert_eq!(restored["data"]["id"].as_str().unwrap(), id);
+        assert!(
+            restored["data"].get("archived_at").is_none(),
+            "restored board is live: no archived_at"
+        );
+        assert_eq!(board_list(&file, &[])["data"]["total"], 1);
+        assert_eq!(board_list(&file, &["--archived"])["data"]["total"], 0);
+    }
+
+    #[test]
+    fn test_board_restore_by_archived_name() {
+        // An archived board is not in the live list, so name resolution must fall
+        // back to the archived view.
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let id = mk_board(&file, "By Name");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &id])
+            .assert()
+            .success();
+
+        kanban()
+            .args([file.to_str().unwrap(), "board", "restore", "By Name"])
+            .assert()
+            .success();
+        assert_eq!(board_list(&file, &[])["data"]["total"], 1);
+    }
+
+    #[test]
+    fn test_board_delete_archived_removes_permanently() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let id = mk_board(&file, "Doomed");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &id])
+            .assert()
+            .success();
+        assert_eq!(board_list(&file, &["--archived"])["data"]["total"], 1);
+
+        let out = kanban()
+            .args([file.to_str().unwrap(), "board", "delete-archived", &id])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let deleted = parse_json_output(&String::from_utf8_lossy(&out));
+        assert_eq!(deleted["data"]["deleted"].as_str().unwrap(), id);
+
+        // Absent from BOTH the live and archived lists afterward.
+        assert_eq!(board_list(&file, &[])["data"]["total"], 0);
+        assert_eq!(board_list(&file, &["--archived"])["data"]["total"], 0);
+        assert_eq!(
+            board_list(&file, &["--include-archived"])["data"]["total"],
+            0
+        );
+    }
 }
 
 mod column_tests {


### PR DESCRIPTION
## What

INTERFACES-I4 (KAN-886). The CLI board surface, mirroring I1 for boards: one `board list` with a three-state archived filter, plus archive/restore/delete-archived subcommands. A board is just a board — the same command surface works whether it's live or archived.

## Unified list

`board list` gains `--archived` (archived only; `conflicts_with = "include_archived"`) and `--include-archived` (both). Boards have no list-filter struct, so the three states are composed at the CLI (no domain change):
- default → `boards()` via `BoardResponse::from` (live).
- `--archived` → `list_archived_boards()`, each marker's live head resolved via the unfiltered `get_board` and mapped to `BoardResponse::archived(&board, archived_at)`.
- `--include-archived` → live then archived.

Live payloads stay byte-identical (D2's `skip_serializing_if` on `archived_at`).

## Subcommands

- `board archive <board>` → `archive_board` (marker set), `{ "archived": id }`.
- `board restore <board>` → `restore_board` (marker clear), restored `BoardResponse`.
- `board delete-archived <board>` → `delete_board` (permanent; works on an archived board because `get_board` is unfiltered), `{ "deleted": id }`.

`resolve_board_id_any` adds an archived-by-name fallback (UUID → live resolver → archived-by-name, with ambiguity handling) since the live resolver only sees live boards; the domain resolver is unchanged.

## Tests

assert_cmd: list default/`--archived`/`--include-archived` + flag conflict; archive→restore round-trip; restore-by-archived-name; delete-archived permanent removal (absent from all three views).

`cargo test -p kanban-cli` 148 passed, clippy `-D warnings` + fmt clean.
