### PR TITLE
KAN-887 feat(mcp): board archive/restore + unified list_boards with archived filter (I5)

### DIFF
--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -35,6 +35,11 @@ pub(crate) fn resolve_summaries(ctx: &McpContext, ids: Vec<Uuid>) -> Vec<CardSum
 /// `locked_write` stay readable.
 pub(crate) trait McpResolve {
     fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError>;
+    /// Resolve a board id from EITHER the live or the archived view. UUIDs
+    /// resolve immediately; a live-board name resolves via the standard resolver;
+    /// otherwise fall back to matching an archived board by name (its head is
+    /// unfiltered via `get_board`). Mirrors the CLI's `resolve_board_id_any` (I4).
+    fn mcp_resolve_board_any(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
     fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
@@ -47,6 +52,39 @@ pub(crate) trait McpResolve {
 impl McpResolve for McpContext {
     fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError> {
         self.resolve_board_id(raw).map_err(kanban_err_to_mcp)
+    }
+    fn mcp_resolve_board_any(&self, raw: &str) -> Result<Uuid, McpError> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        // Live boards first (the domain resolver is live-only).
+        if let Ok(id) = self.resolve_board_id(raw) {
+            return Ok(id);
+        }
+        // Fall back to archived boards: resolve each marker's live head (get_board
+        // is unfiltered) and match by name.
+        let mut matches: Vec<Uuid> = Vec::new();
+        for marker in self.list_archived_boards().map_err(kanban_err_to_mcp)? {
+            if let Some(board) = self
+                .get_board(marker.entity_id)
+                .map_err(kanban_err_to_mcp)?
+            {
+                if board.name == raw {
+                    matches.push(board.id);
+                }
+            }
+        }
+        match matches.as_slice() {
+            [id] => Ok(*id),
+            [] => Err(McpError::invalid_params(
+                format!("Board not found: '{raw}'"),
+                None,
+            )),
+            _ => Err(McpError::invalid_params(
+                format!("Ambiguous archived board name: '{raw}'"),
+                None,
+            )),
+        }
     }
     fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError> {
         self.resolve_column_id(raw, board_id)

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -10,7 +10,8 @@ pub use error::{KanbanMcpError, KanbanMcpResult};
 pub use server::McpServer;
 
 pub use requests::board::{
-    CreateBoardRequest, DeleteBoardRequest, GetBoardRequest, UpdateBoardRequest,
+    ArchiveBoardRequest, CreateBoardRequest, DeleteArchivedBoardRequest, DeleteBoardRequest,
+    GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, UpdateBoardRequest,
 };
 pub use requests::card::{
     ArchiveCardRequest, ArchiveCardsRequest, AssignCardToSprintRequest, AssignCardsToSprintRequest,

--- a/crates/kanban-mcp/src/requests/board.rs
+++ b/crates/kanban-mcp/src/requests/board.rs
@@ -34,8 +34,38 @@ pub struct UpdateBoardRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListBoardsRequest {
+    #[schemars(
+        description = "Archived filter: 'exclude' (default, live only), 'only' (archived only), or 'include' (both live and archived). Archived boards carry an archived_at timestamp."
+    )]
+    pub archived: Option<String>,
+    #[schemars(description = "Page number, 1-based (default: 1)")]
+    pub page: Option<u32>,
+    #[schemars(description = "Items per page (default: 50)")]
+    pub page_size: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteBoardRequest {
     #[schemars(description = "UUID or name of the board to delete")]
+    pub board: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ArchiveBoardRequest {
+    #[schemars(description = "UUID or name of the board to archive")]
+    pub board: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct RestoreBoardRequest {
+    #[schemars(description = "UUID or name of the archived board to restore")]
+    pub board: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DeleteArchivedBoardRequest {
+    #[schemars(description = "UUID or name of the archived board to permanently delete")]
     pub board: String,
 }
 

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -1,12 +1,15 @@
 use crate::helpers::{
-    kanban_err_to_mcp, locked_read, locked_write, mutating_op, parse_sort_field, parse_sort_order,
-    read_op, to_call_tool_result, to_call_tool_result_json, McpResolve,
+    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, mutating_op,
+    parse_archived_selector, parse_sort_field, parse_sort_order, to_call_tool_result,
+    to_call_tool_result_json, McpResolve,
 };
 use crate::requests::board::{
-    CreateBoardRequest, DeleteBoardRequest, GetBoardRequest, UpdateBoardRequest,
+    ArchiveBoardRequest, CreateBoardRequest, DeleteArchivedBoardRequest, DeleteBoardRequest,
+    GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, UpdateBoardRequest,
 };
 use crate::KanbanMcpServer;
-use kanban_domain::{BoardUpdate, FieldUpdate, KanbanOperations};
+use kanban_core::{resolve_page_params, PaginatedList};
+use kanban_domain::{ArchivedFilter, BoardUpdate, FieldUpdate, KanbanOperations};
 use kanban_service::api::BoardResponse;
 use rmcp::{
     handler::server::wrapper::Parameters,
@@ -29,11 +32,48 @@ impl KanbanMcpServer {
         to_call_tool_result(&BoardResponse::from(&board))
     }
 
-    #[tool(description = "List all kanban boards")]
-    pub async fn tool_list_boards(&self) -> Result<CallToolResult, McpError> {
-        let boards = read_op!(self.ctx, list_boards)?;
-        let responses: Vec<BoardResponse> = boards.iter().map(BoardResponse::from).collect();
-        to_call_tool_result(&responses)
+    #[tool(
+        description = "List kanban boards with an `archived` selector: 'exclude' (default, live only), 'only' (archived only), or 'include' (both). Archived boards carry an archived_at timestamp. Use page/page_size for pagination (default: page=1, page_size=50)."
+    )]
+    pub async fn tool_list_boards(
+        &self,
+        Parameters(req): Parameters<ListBoardsRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let archived = req
+            .archived
+            .as_deref()
+            .map(parse_archived_selector)
+            .transpose()?
+            .unwrap_or_default();
+        let (page, page_size) =
+            resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
+        // Boards have no domain list-filter, so the three states are composed here
+        // from the service ops (mirroring the CLI's I4 `build_board_list`).
+        let responses = locked_read(&self.ctx, |ctx| -> Result<Vec<BoardResponse>, McpError> {
+            let mut out: Vec<BoardResponse> = Vec::new();
+            if archived != ArchivedFilter::ArchivedOnly {
+                out.extend(
+                    ctx.list_boards()
+                        .map_err(kanban_err_to_mcp)?
+                        .iter()
+                        .map(BoardResponse::from),
+                );
+            }
+            if archived != ArchivedFilter::LiveOnly {
+                for marker in ctx.list_archived_boards().map_err(kanban_err_to_mcp)? {
+                    // `get_board` is unfiltered: it resolves the still-live head.
+                    if let Some(board) =
+                        ctx.get_board(marker.entity_id).map_err(kanban_err_to_mcp)?
+                    {
+                        out.push(BoardResponse::archived(&board, marker.metadata.archived_at));
+                    }
+                }
+            }
+            Ok(out)
+        })
+        .await?;
+        let paged = PaginatedList::paginate(responses, page, page_size).map_err(core_err_to_mcp)?;
+        to_call_tool_result(&paged)
     }
 
     #[tool(description = "Get a specific board by UUID or name")]
@@ -100,6 +140,54 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
+        to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
+    }
+
+    #[tool(description = "Archive a board by UUID or name (hides it from the live list)")]
+    pub async fn tool_archive_board(
+        &self,
+        Parameters(req): Parameters<ArchiveBoardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
+            // Live board (still in the live list) — the standard resolver suffices.
+            let id = ctx.mcp_resolve_board(&req.board)?;
+            ctx.archive_board(id).map_err(kanban_err_to_mcp)?;
+            Ok(id)
+        })
+        .await?;
+        to_call_tool_result_json(serde_json::json!({"archived": id.to_string()}))
+    }
+
+    #[tool(description = "Restore an archived board by UUID or name (returns it to the live list)")]
+    pub async fn tool_restore_board(
+        &self,
+        Parameters(req): Parameters<RestoreBoardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let board = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
+            // Resolve from either view: an archived board is not in the live list.
+            let id = ctx.mcp_resolve_board_any(&req.board)?;
+            ctx.restore_board(id).map_err(kanban_err_to_mcp)?;
+            ctx.get_board(id).map_err(kanban_err_to_mcp)
+        })
+        .await?;
+        to_call_tool_result(&board.as_ref().map(BoardResponse::from))
+    }
+
+    #[tool(
+        description = "Permanently delete an archived board by UUID or name, along with its columns, cards, and sprints"
+    )]
+    pub async fn tool_delete_archived_board(
+        &self,
+        Parameters(req): Parameters<DeleteArchivedBoardRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        // A board is just a board: delete works on an archived one because
+        // `get_board` is unfiltered. Resolve from either view.
+        let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
+            let id = ctx.mcp_resolve_board_any(&req.board)?;
             ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
         })

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -732,10 +732,11 @@ async fn require_same_board_rejects_cross_board_on_mcp() {
 // ============================================================================
 
 use kanban_mcp::{
-    AssignCardToSprintRequest, CarryOverSprintCardsRequest, CreateBoardRequest, CreateCardParams,
-    CreateColumnParams, CreateSprintParams, GetBoardRequest, GetCardRequest, GetColumnRequest,
-    GetSprintRequest, KanbanMcpServer, ListColumnsRequest, ListSprintsRequest, MoveCardRequest,
-    MoveCardsRequest,
+    ArchiveBoardRequest, AssignCardToSprintRequest, CarryOverSprintCardsRequest,
+    CreateBoardRequest, CreateCardParams, CreateColumnParams, CreateSprintParams,
+    DeleteArchivedBoardRequest, GetBoardRequest, GetCardRequest, GetColumnRequest,
+    GetSprintRequest, KanbanMcpServer, ListBoardsRequest, ListColumnsRequest, ListSprintsRequest,
+    MoveCardRequest, MoveCardsRequest, RestoreBoardRequest,
 };
 use rmcp::handler::server::wrapper::Parameters;
 use serde_json::Value;
@@ -1769,9 +1770,20 @@ async fn read_tools_project_through_v1_response_dtos_hiding_internal_state() {
     let board_hidden = ["card_counter", "next_sprint_number", "sprint_counters"];
     let card_hidden = ["sprint_logs"];
 
-    // list_boards: array of BoardResponse — no internal counters.
-    let boards = text_payload(&server.tool_list_boards().await.unwrap());
-    let board0 = &boards.as_array().expect("list_boards is an array")[0];
+    // list_boards: paginated BoardResponse items — no internal counters.
+    let boards = text_payload(
+        &server
+            .tool_list_boards(Parameters(ListBoardsRequest {
+                archived: None,
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    let board0 = &boards["items"]
+        .as_array()
+        .expect("list_boards items is an array")[0];
     assert_eq!(board0["name"], "Roadmap");
     for f in board_hidden {
         assert!(board0.get(f).is_none(), "list_boards leaked {f}: {boards}");
@@ -2017,4 +2029,159 @@ async fn test_mcp_list_cards_archived_selector() {
         .tool_list_cards(Parameters(req(Some("bogus"))))
         .await
         .is_err());
+}
+
+// ---- I5 (KAN-887): the MCP board surface — archived selector + subcommands ----
+
+fn list_boards_req(archived: Option<&str>) -> ListBoardsRequest {
+    ListBoardsRequest {
+        archived: archived.map(|s| s.to_string()),
+        page: None,
+        page_size: None,
+    }
+}
+
+async fn mcp_list_boards(server: &KanbanMcpServer, archived: Option<&str>) -> Value {
+    text_payload(
+        &server
+            .tool_list_boards(Parameters(list_boards_req(archived)))
+            .await
+            .unwrap(),
+    )
+}
+
+/// Create a board via the tool and return its id.
+async fn mcp_create_board(server: &KanbanMcpServer, name: &str) -> String {
+    text_payload(
+        &server
+            .tool_create_board(Parameters(board_req(name, Some("B".into()))))
+            .await
+            .unwrap(),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+#[tokio::test]
+async fn test_mcp_list_boards_archived_selector() {
+    let (server, _tmp) = setup_server().await;
+    let _live = mcp_create_board(&server, "Live Board").await;
+    let archived = mcp_create_board(&server, "Archived Board").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest {
+            board: archived.clone(),
+        }))
+        .await
+        .unwrap();
+
+    // default / exclude: live only, no archived_at.
+    let live = mcp_list_boards(&server, None).await;
+    assert_eq!(live["total"], 1);
+    assert_eq!(live["items"][0]["name"], "Live Board");
+    assert!(live["items"][0].get("archived_at").is_none());
+
+    let excluded = mcp_list_boards(&server, Some("exclude")).await;
+    assert_eq!(excluded["total"], 1);
+
+    // only: archived, stamped with archived_at.
+    let only = mcp_list_boards(&server, Some("only")).await;
+    assert_eq!(only["total"], 1);
+    assert_eq!(only["items"][0]["name"], "Archived Board");
+    assert!(only["items"][0]["archived_at"].is_string());
+
+    // include: both, one stamped and one not.
+    let both = mcp_list_boards(&server, Some("include")).await;
+    assert_eq!(both["total"], 2);
+    let stamped: Vec<bool> = both["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i.get("archived_at").is_some())
+        .collect();
+    assert!(stamped.contains(&true) && stamped.contains(&false));
+
+    // invalid selector is rejected.
+    assert!(server
+        .tool_list_boards(Parameters(list_boards_req(Some("bogus"))))
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn test_mcp_archive_and_restore_board() {
+    let (server, _tmp) = setup_server().await;
+    let id = mcp_create_board(&server, "Round Trip").await;
+
+    // Archive: leaves the live list.
+    let archived = text_payload(
+        &server
+            .tool_archive_board(Parameters(ArchiveBoardRequest { board: id.clone() }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(archived["archived"].as_str().unwrap(), id);
+    assert_eq!(mcp_list_boards(&server, None).await["total"], 0);
+    assert_eq!(mcp_list_boards(&server, Some("only")).await["total"], 1);
+
+    // Restore (by UUID): returns to the live list, projected via BoardResponse.
+    let restored = text_payload(
+        &server
+            .tool_restore_board(Parameters(RestoreBoardRequest { board: id.clone() }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(restored["id"].as_str().unwrap(), id);
+    assert!(
+        restored.get("archived_at").is_none(),
+        "restored board is live: no archived_at"
+    );
+    assert_eq!(mcp_list_boards(&server, None).await["total"], 1);
+    assert_eq!(mcp_list_boards(&server, Some("only")).await["total"], 0);
+}
+
+#[tokio::test]
+async fn test_mcp_restore_board_by_archived_name() {
+    // An archived board is not in the live list, so name resolution must fall
+    // back to the archived view.
+    let (server, _tmp) = setup_server().await;
+    let id = mcp_create_board(&server, "By Name").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest { board: id }))
+        .await
+        .unwrap();
+
+    server
+        .tool_restore_board(Parameters(RestoreBoardRequest {
+            board: "By Name".into(),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(mcp_list_boards(&server, None).await["total"], 1);
+}
+
+#[tokio::test]
+async fn test_mcp_delete_archived_board_permanent() {
+    let (server, _tmp) = setup_server().await;
+    let id = mcp_create_board(&server, "Doomed").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest { board: id.clone() }))
+        .await
+        .unwrap();
+    assert_eq!(mcp_list_boards(&server, Some("only")).await["total"], 1);
+
+    let deleted = text_payload(
+        &server
+            .tool_delete_archived_board(Parameters(DeleteArchivedBoardRequest {
+                board: id.clone(),
+            }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(deleted["deleted"].as_str().unwrap(), id);
+
+    // Absent from BOTH the live and archived lists afterward.
+    assert_eq!(mcp_list_boards(&server, None).await["total"], 0);
+    assert_eq!(mcp_list_boards(&server, Some("only")).await["total"], 0);
+    assert_eq!(mcp_list_boards(&server, Some("include")).await["total"], 0);
 }


### PR DESCRIPTION
## What

INTERFACES-I5 (KAN-887). The MCP board surface, mirroring I2 (archived filter on the list) + I4 (archive/restore/delete-archived), for boards.

## Changes

- `tool_list_boards` now takes `ListBoardsRequest` with an `archived` selector (`exclude`/`only`/`include`, parsed by the shared `parse_archived_selector`). Boards have no domain list-filter, so the three states are composed as in I4: live via `BoardResponse::from`; archived via `list_archived_boards` with each marker's head resolved through the unfiltered `get_board` → `BoardResponse::archived`; include is both. Unified `Vec<BoardResponse>` is paginated; live payloads stay byte-identical (`archived_at` skipped when None).
- New tools `tool_archive_board` / `tool_restore_board` / `tool_delete_archived_board` (auto-registered by the tool_router). archive/restore set/clear the marker; delete-archived routes to `delete_board` (permanent; works on an archived board via the unfiltered `get_board`).
- `mcp_resolve_board_any` adds an archived-by-name fallback (UUID → live → archived-by-name, with ambiguity errors) for restore/delete-archived, since an archived board isn't in the live view.

## Tests

`test_mcp_list_boards_archived_selector` (default/only/include + invalid), archive→restore round-trip, restore-by-archived-name, delete-archived permanent removal. Updated the v1-DTO projection test for the now-paginated `list_boards`.

`cargo test -p kanban-mcp` 110 passed, clippy `-D warnings` + fmt clean.
