### PR TITLE
KAN-894 fix(cli,mcp): board delete-archived/restore resolves archived-only (data-loss fix)

### DIFF
--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -65,7 +65,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             output::output_success(serde_json::json!({"archived": uuid.to_string()}));
         }
         BoardAction::Restore { board } => {
-            let uuid = match resolve_board_id_any(ctx, &board) {
+            let uuid = match resolve_archived_board_id(ctx, &board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
@@ -77,9 +77,9 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             }
         }
         BoardAction::DeleteArchived { board } => {
-            // A board is just a board: delete works on an archived one because
-            // `get_board` is unfiltered. Resolve from either view.
-            let uuid = match resolve_board_id_any(ctx, &board) {
+            // Resolve against the ARCHIVED collection only: a same-named live
+            // board must never be hit by `delete-archived` (delete_board cascades).
+            let uuid = match resolve_archived_board_id(ctx, &board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
@@ -128,14 +128,14 @@ fn build_board_list(
 /// immediately; a live-board name resolves via the standard resolver; otherwise
 /// fall back to matching an archived board by name (its head is unfiltered via
 /// `get_board`). Keeps the domain resolver (live-only) unchanged.
-fn resolve_board_id_any(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, String> {
+/// Resolve a board id from the ARCHIVED collection ONLY. A UUID passes through
+/// (the caller's op validates existence); a name matches an archived board's
+/// head exactly. This never matches a LIVE board, so an `-archived` command can
+/// never accidentally hit a same-named live board (REGR-4 / KAN-894 data-loss).
+fn resolve_archived_board_id(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, String> {
     if let Ok(uuid) = uuid::Uuid::parse_str(raw) {
         return Ok(uuid);
     }
-    if let Ok(uuid) = ctx.resolve_board_id(raw) {
-        return Ok(uuid);
-    }
-    // Fall back to archived boards: resolve each marker's live head and match by name.
     let mut matches: Vec<uuid::Uuid> = Vec::new();
     for marker in ctx.list_archived_boards().map_err(|e| e.to_string())? {
         if let Some(board) = ctx.get_board(marker.entity_id).map_err(|e| e.to_string())? {
@@ -146,7 +146,7 @@ fn resolve_board_id_any(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, Strin
     }
     match matches.as_slice() {
         [id] => Ok(*id),
-        [] => Err(format!("Board not found: {}", raw)),
+        [] => Err(format!("No archived board named: {}", raw)),
         _ => Err(format!("Ambiguous archived board name: {}", raw)),
     }
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -534,6 +534,100 @@ mod board_tests {
             .failure();
     }
 
+    // REGR-4 (KAN-894): `-archived` commands must resolve ONLY archived boards,
+    // never a same-named live board (delete_board cascades → data loss).
+    #[test]
+    fn test_delete_archived_with_name_collision_deletes_archived_not_live() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let live = mk_board(&file, "Roadmap");
+        let arch = mk_board(&file, "Roadmap");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &arch])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "delete-archived",
+                "Roadmap",
+            ])
+            .assert()
+            .success();
+        // The LIVE Roadmap survives; the archived one is gone.
+        let live_list = board_list(&file, &[]);
+        assert_eq!(live_list["data"]["total"], 1);
+        assert_eq!(live_list["data"]["items"][0]["id"].as_str().unwrap(), live);
+        assert_eq!(board_list(&file, &["--archived"])["data"]["total"], 0);
+    }
+
+    #[test]
+    fn test_delete_archived_unknown_name_errors_without_touching_live() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let live = mk_board(&file, "Roadmap");
+        // No archived board named "Roadmap" → error, live board untouched.
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "delete-archived",
+                "Roadmap",
+            ])
+            .assert()
+            .failure();
+        let live_list = board_list(&file, &[]);
+        assert_eq!(live_list["data"]["total"], 1);
+        assert_eq!(live_list["data"]["items"][0]["id"].as_str().unwrap(), live);
+    }
+
+    #[test]
+    fn test_restore_with_name_collision_restores_archived() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let _live = mk_board(&file, "Roadmap");
+        let arch = mk_board(&file, "Roadmap");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &arch])
+            .assert()
+            .success();
+        let out = kanban()
+            .args([file.to_str().unwrap(), "board", "restore", "Roadmap"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let restored = parse_json_output(&String::from_utf8_lossy(&out));
+        assert_eq!(restored["data"]["id"].as_str().unwrap(), arch);
+        assert_eq!(board_list(&file, &["--archived"])["data"]["total"], 0);
+        assert_eq!(board_list(&file, &[])["data"]["total"], 2);
+    }
+
+    #[test]
+    fn test_delete_archived_by_uuid_still_works() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let arch = mk_board(&file, "Solo");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &arch])
+            .assert()
+            .success();
+        kanban()
+            .args([file.to_str().unwrap(), "board", "delete-archived", &arch])
+            .assert()
+            .success();
+        assert_eq!(
+            board_list(&file, &["--include-archived"])["data"]["total"],
+            0
+        );
+    }
+
     #[test]
     fn test_board_archive_and_restore() {
         let dir = tempdir().unwrap();

--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -35,11 +35,11 @@ pub(crate) fn resolve_summaries(ctx: &McpContext, ids: Vec<Uuid>) -> Vec<CardSum
 /// `locked_write` stay readable.
 pub(crate) trait McpResolve {
     fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError>;
-    /// Resolve a board id from EITHER the live or the archived view. UUIDs
-    /// resolve immediately; a live-board name resolves via the standard resolver;
-    /// otherwise fall back to matching an archived board by name (its head is
-    /// unfiltered via `get_board`). Mirrors the CLI's `resolve_board_id_any` (I4).
-    fn mcp_resolve_board_any(&self, raw: &str) -> Result<Uuid, McpError>;
+    /// Resolve a board id from the ARCHIVED collection ONLY (for `-archived`
+    /// tools). UUIDs pass through; a name matches an archived board's head
+    /// exactly. Never matches a live board — so a same-named live board can never
+    /// be hit by an archived-scoped command (REGR-4 / KAN-894 data-loss).
+    fn mcp_resolve_archived_board(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
     fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
@@ -53,16 +53,12 @@ impl McpResolve for McpContext {
     fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError> {
         self.resolve_board_id(raw).map_err(kanban_err_to_mcp)
     }
-    fn mcp_resolve_board_any(&self, raw: &str) -> Result<Uuid, McpError> {
+    fn mcp_resolve_archived_board(&self, raw: &str) -> Result<Uuid, McpError> {
         if let Ok(uuid) = Uuid::parse_str(raw) {
             return Ok(uuid);
         }
-        // Live boards first (the domain resolver is live-only).
-        if let Ok(id) = self.resolve_board_id(raw) {
-            return Ok(id);
-        }
-        // Fall back to archived boards: resolve each marker's live head (get_board
-        // is unfiltered) and match by name.
+        // ARCHIVED collection only: resolve each marker's live head (get_board is
+        // unfiltered) and match by name. Never matches a live board.
         let mut matches: Vec<Uuid> = Vec::new();
         for marker in self.list_archived_boards().map_err(kanban_err_to_mcp)? {
             if let Some(board) = self
@@ -77,7 +73,7 @@ impl McpResolve for McpContext {
         match matches.as_slice() {
             [id] => Ok(*id),
             [] => Err(McpError::invalid_params(
-                format!("Board not found: '{raw}'"),
+                format!("No archived board named: '{raw}'"),
                 None,
             )),
             _ => Err(McpError::invalid_params(

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -169,7 +169,7 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let board = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             // Resolve from either view: an archived board is not in the live list.
-            let id = ctx.mcp_resolve_board_any(&req.board)?;
+            let id = ctx.mcp_resolve_archived_board(&req.board)?;
             ctx.restore_board(id).map_err(kanban_err_to_mcp)?;
             ctx.get_board(id).map_err(kanban_err_to_mcp)
         })
@@ -187,7 +187,7 @@ impl KanbanMcpServer {
         // A board is just a board: delete works on an archived one because
         // `get_board` is unfiltered. Resolve from either view.
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let id = ctx.mcp_resolve_board_any(&req.board)?;
+            let id = ctx.mcp_resolve_archived_board(&req.board)?;
             ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
         })

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -2185,3 +2185,45 @@ async fn test_mcp_delete_archived_board_permanent() {
     assert_eq!(mcp_list_boards(&server, Some("only")).await["total"], 0);
     assert_eq!(mcp_list_boards(&server, Some("include")).await["total"], 0);
 }
+
+// REGR-4 (KAN-894): archived-scoped MCP tools resolve ONLY archived boards, so a
+// same-named live board can never be hit.
+#[tokio::test]
+async fn test_mcp_delete_archived_board_name_collision_targets_archived() {
+    let (server, _tmp) = setup_server().await;
+    let live = mcp_create_board(&server, "Roadmap").await;
+    let arch = mcp_create_board(&server, "Roadmap").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest { board: arch }))
+        .await
+        .unwrap();
+    server
+        .tool_delete_archived_board(Parameters(DeleteArchivedBoardRequest {
+            board: "Roadmap".into(),
+        }))
+        .await
+        .unwrap();
+    let live_list = mcp_list_boards(&server, None).await;
+    assert_eq!(live_list["total"], 1);
+    assert_eq!(live_list["items"][0]["id"].as_str().unwrap(), live);
+    assert_eq!(mcp_list_boards(&server, Some("only")).await["total"], 0);
+}
+
+#[tokio::test]
+async fn test_mcp_restore_board_name_collision_targets_archived() {
+    let (server, _tmp) = setup_server().await;
+    let _live = mcp_create_board(&server, "Roadmap").await;
+    let arch = mcp_create_board(&server, "Roadmap").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest { board: arch }))
+        .await
+        .unwrap();
+    server
+        .tool_restore_board(Parameters(RestoreBoardRequest {
+            board: "Roadmap".into(),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(mcp_list_boards(&server, Some("only")).await["total"], 0);
+    assert_eq!(mcp_list_boards(&server, None).await["total"], 2);
+}


### PR DESCRIPTION
## What

REGR-4 (KAN-894) — first fix from the KAN-864 archival regression review (root KAN-890). A **data-loss** bug: `board delete-archived <name>` / `board restore <name>` resolved the LIVE board collection first, so if a live and an archived board shared a name, an `-archived` command targeted the *live* board — and `delete_board` cascade-deletes its entire subtree (columns, cards, sprints).

## Fix

Replace the live-first resolver (`resolve_board_id_any` / `mcp_resolve_board_any`) with an **archived-only** resolver (`resolve_archived_board_id` / `mcp_resolve_archived_board`): a UUID passes through; a name matches only an archived board's head (resolved via the unfiltered `get_board` over `list_archived_boards`), never a live board. Both CLI and MCP restore + delete-archived use it. An unknown archived name errors (`No archived board named: ...`) without touching any live board.

## Tests

- CLI (assert_cmd): with a live + archived "Roadmap", `delete-archived Roadmap` removes the archived one and the live survives; restore restores the archived one; an unknown archived name errors without touching live; UUID delete-archived still works.
- MCP (end-to-end): the same two collision cases.

`cargo test -p kanban-cli -p kanban-mcp` green, clippy `-D warnings` + fmt clean.

Spike-validated (KAN-894 fold-back): this exact resolver + tests reached green in an isolated worktree.
