### PR TITLE
KAN-898/899/908 fix(domain): align clear_sprint_from_cards + guard delete_board across backends (regression)

### DIFF
--- a/crates/kanban-domain/src/in_memory_store/archived_boards.rs
+++ b/crates/kanban-domain/src/in_memory_store/archived_boards.rs
@@ -30,6 +30,21 @@ impl InMemoryStore {
 
     pub(super) fn delete_archived_board_impl(&self, board_id: Uuid) -> KanbanResult<()> {
         let mut state = self.write_state()?;
+        // Permanent delete: remove the marker AND the board head (matching SQLite's
+        // `DELETE FROM boards WHERE EXISTS board_archival` + FK CASCADE). Only acts on
+        // boards with an archived marker; no-op on live boards.
+        if state.archived_boards.remove(&board_id).is_some() {
+            state.boards.remove(&board_id);
+        }
+        Ok(())
+    }
+
+    pub(super) fn unarchive_board_impl(&self, board_id: Uuid) -> KanbanResult<()> {
+        let mut state = self.write_state()?;
+        // Restore path: drop the marker only, never the head or subtree.
+        // Splitting from `delete_archived_board` is required because that method now
+        // removes the board head (for permanent delete). The default `DataStore::unarchive_board`
+        // delegates to `delete_archived_board`, so we must override it via `mod.rs`.
         state.archived_boards.remove(&board_id);
         Ok(())
     }

--- a/crates/kanban-domain/src/in_memory_store/boards.rs
+++ b/crates/kanban-domain/src/in_memory_store/boards.rs
@@ -34,6 +34,14 @@ impl InMemoryStore {
 
     pub(super) fn delete_board_impl(&self, id: Uuid) -> KanbanResult<()> {
         let mut state = self.write_state()?;
+        // Parity with SQLite (`AND NOT EXISTS board_archival`): the bare `delete_board`
+        // removes a LIVE board head only. An archived board's head stays put behind its
+        // marker; permanent-delete of an archived board is owned by `delete_archived_board`
+        // (marker + row). Guarding here prevents a bare delete from orphaning an archived
+        // board's still-present subtree and marker.
+        if state.archived_boards.contains_key(&id) {
+            return Ok(());
+        }
         state.boards.remove(&id);
         Ok(())
     }

--- a/crates/kanban-domain/src/in_memory_store/cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/cards.rs
@@ -136,8 +136,14 @@ impl InMemoryStore {
         timestamp: chrono::DateTime<chrono::Utc>,
     ) -> KanbanResult<()> {
         let mut state = self.write_state()?;
+        // Live-only, matching SQLite (`AND NOT EXISTS archived_cards`): the archived
+        // subset is owned by `clear_sprint_from_archived_cards`. Mirrors the same
+        // HashSet snapshot pattern used by `delete_cards_by_columns_impl` (line 117)
+        // to avoid a borrow conflict between `values_mut()` and `archived_cards`.
+        let archived: std::collections::HashSet<Uuid> =
+            state.archived_cards.keys().copied().collect();
         for card in state.cards.values_mut() {
-            if card.sprint_id == Some(sprint_id) {
+            if card.sprint_id == Some(sprint_id) && !archived.contains(&card.id) {
                 card.sprint_id = None;
                 card.updated_at = timestamp;
             }

--- a/crates/kanban-domain/src/in_memory_store/mod.rs
+++ b/crates/kanban-domain/src/in_memory_store/mod.rs
@@ -230,6 +230,10 @@ impl DataStore for InMemoryStore {
         self.delete_archived_board_impl(board_id)
     }
 
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.unarchive_board_impl(board_id)
+    }
+
     // Sprint
 
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -119,6 +119,45 @@ fn test_open_migrates_old_db_to_v4_with_board_archival_and_backup() {
 }
 
 #[test]
+fn test_delete_board_noop_on_archived_keeps_head_and_marker() {
+    // KAN-899: pins the SQLite `AND NOT EXISTS board_archival` guard as the canonical
+    // spec. A bare `delete_board` on an archived board must be a no-op — head and
+    // marker both survive.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("noop.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let board = Board::new("Archived", None::<String>);
+        let id = board.id;
+        store.upsert_board(board).unwrap();
+        let col = Column::new(id, "Col", 0);
+        let col_id = col.id;
+        store.upsert_column(col).unwrap();
+        store.insert_archived_board(Archived::now(id)).unwrap();
+
+        // Bare delete_board must be a no-op on an archived board.
+        store.delete_board(id).unwrap();
+
+        assert!(
+            store.get_board(id).unwrap().is_some(),
+            "board head must survive bare delete_board on archived board"
+        );
+        assert!(
+            store.get_archived_board(id).unwrap().is_some(),
+            "archived marker must survive bare delete_board"
+        );
+        let cols = store.list_columns_by_board(id).unwrap();
+        assert_eq!(
+            cols.len(),
+            1,
+            "subtree must survive bare delete_board on archived board"
+        );
+        assert_eq!(cols[0].id, col_id);
+    });
+}
+
+#[test]
 fn test_delete_archived_board_is_noop_on_a_live_board() {
     // Parity with the in-memory store: delete_archived_board must only remove an
     // ARCHIVED board, never a live one.

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -4,8 +4,9 @@ use crate::KanbanContext;
 use kanban_core::AppConfig;
 use kanban_domain::archival::ArchivedEntity;
 use kanban_domain::card::CardPriority;
-use kanban_domain::{CardListFilter, CreateCardOptions, KanbanOperations};
+use kanban_domain::{CardListFilter, CreateCardOptions, GraphOperations, KanbanOperations, Severity};
 use tempfile::TempDir;
+use uuid::Uuid;
 
 pub async fn test_archive_card_roundtrip(factory: &BackendFactory) {
     let dir = TempDir::new().unwrap();
@@ -375,4 +376,317 @@ pub async fn test_list_cards_archived_selector_board_scoped(factory: &BackendFac
     assert!(!include
         .iter()
         .any(|s| s.id == other_live.id || s.id == other_arch.id));
+}
+
+/// KAN-898: `clear_sprint_from_cards` must skip archived cards on every backend
+/// (live-only semantics), matching SQLite's `AND NOT EXISTS archived_cards` guard.
+/// Calling it on a sprint that is assigned to both a live and an archived card must
+/// clear the live card's `sprint_id` but leave the archived card's `sprint_id`
+/// (and `updated_at`) untouched. Save + reload verifies the split holds through
+/// persistence.
+pub async fn test_clear_sprint_from_cards_leaves_archived_untouched(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    let live_card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived_card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    ctx.assign_card_to_sprint(live_card.id, sprint.id).unwrap();
+    ctx.assign_card_to_sprint(archived_card.id, sprint.id)
+        .unwrap();
+
+    // Capture archived card's sprint_id and updated_at BEFORE archiving
+    // (archiving may bump updated_at, but clear_sprint_from_cards must not touch it).
+    ctx.archive_card(archived_card.id).unwrap();
+    let archived_before = ctx.get_card(archived_card.id).unwrap().unwrap();
+    assert_eq!(
+        archived_before.sprint_id,
+        Some(sprint.id),
+        "archived card has sprint pre-clear"
+    );
+
+    let ts = chrono::Utc::now();
+    ctx.data_store()
+        .clear_sprint_from_cards(sprint.id, ts)
+        .unwrap();
+
+    // Live card: sprint_id must be cleared.
+    let live_after = ctx.get_card(live_card.id).unwrap().unwrap();
+    assert_eq!(
+        live_after.sprint_id, None,
+        "live card sprint cleared by clear_sprint_from_cards"
+    );
+
+    // Archived card: sprint_id must NOT be touched.
+    let archived_after = ctx.get_card(archived_card.id).unwrap().unwrap();
+    assert_eq!(
+        archived_after.sprint_id,
+        Some(sprint.id),
+        "archived card sprint_id must be untouched by clear_sprint_from_cards"
+    );
+    assert_eq!(
+        archived_after.updated_at, archived_before.updated_at,
+        "archived card updated_at must not be bumped"
+    );
+
+    // Save + reload: the split must survive persistence.
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let live_reloaded = ctx.get_card(live_card.id).unwrap().unwrap();
+    assert_eq!(
+        live_reloaded.sprint_id, None,
+        "live card sprint_id still None after reload"
+    );
+    let archived_reloaded = ctx.get_card(archived_card.id).unwrap().unwrap();
+    assert_eq!(
+        archived_reloaded.sprint_id,
+        Some(sprint.id),
+        "archived card sprint_id still Some after reload"
+    );
+}
+
+/// KAN-899: `delete_board` (the bare primitive) must be a no-op on an archived
+/// board on every backend, matching SQLite's `AND NOT EXISTS board_archival` guard.
+/// Calling it on an archived board must leave the head and its subtree intact.
+pub async fn test_delete_board_is_noop_on_archived_board(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let _ = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Task".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    ctx.archive_board(board.id).unwrap();
+
+    // Call the raw DataStore primitive directly.
+    ctx.data_store().delete_board(board.id).unwrap();
+
+    // Board head must still be fetchable (get_board is unfiltered).
+    assert!(
+        ctx.data_store()
+            .get_board(board.id)
+            .unwrap()
+            .is_some(),
+        "archived board head must survive bare delete_board"
+    );
+    // Archived marker must still be present.
+    assert!(
+        ctx.data_store()
+            .get_archived_board(board.id)
+            .unwrap()
+            .is_some(),
+        "archived marker must still be present after bare delete_board"
+    );
+    // Subtree must be intact.
+    let snap = ctx.data_store().snapshot().unwrap();
+    assert_eq!(
+        snap.columns.len(),
+        1,
+        "column must survive bare delete_board on archived board"
+    );
+    assert_eq!(
+        snap.cards.len(),
+        1,
+        "card must survive bare delete_board on archived board"
+    );
+}
+
+/// KAN-908: rich-seed struct for board delete/undo and archive/restore full-graph
+/// round-trip tests.
+struct RichSeed {
+    board: Uuid,
+    live: Uuid,
+    arch: Uuid,
+    sprint: Uuid,
+}
+
+fn seed_rich(ctx: &mut KanbanContext) -> kanban_domain::KanbanResult<RichSeed> {
+    let b = ctx.create_board("Proj".into(), None)?;
+    let col = ctx.create_column(b.id, "Todo".into(), None)?;
+    let sprint = ctx.create_sprint(b.id, None, None)?;
+    let live = ctx.create_card(
+        b.id,
+        col.id,
+        "Live".into(),
+        CreateCardOptions::default(),
+    )?;
+    let arch = ctx.create_card(
+        b.id,
+        col.id,
+        "Arch".into(),
+        CreateCardOptions::default(),
+    )?;
+    ctx.assign_card_to_sprint(live.id, sprint.id)?;
+    ctx.block(live.id, arch.id, Severity::High)?;
+    ctx.archive_card(arch.id)?;
+    Ok(RichSeed {
+        board: b.id,
+        live: live.id,
+        arch: arch.id,
+        sprint: sprint.id,
+    })
+}
+
+/// KAN-908: board delete+undo must be the identity over the FULL entity graph.
+/// Seeds ≥1 column + live card + inner individually-archived card + sprint +
+/// dependency edge, archives + permanently deletes the board, asserts the whole
+/// graph is gone, undoes, then asserts EVERY owned/referenced entity type is back.
+/// Save+reload before the final asserts on persistent backends.
+pub async fn test_board_delete_undo_full_graph_roundtrip(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let s = seed_rich(&mut ctx).unwrap();
+
+    ctx.archive_board(s.board).unwrap();
+    ctx.delete_board(s.board).unwrap();
+
+    // Everything gone after permanent delete.
+    let empty = ctx.data_store().snapshot().unwrap();
+    assert!(empty.cards.is_empty(), "all card rows gone after delete");
+    assert!(empty.columns.is_empty(), "columns gone after delete");
+    assert!(empty.sprints.is_empty(), "sprints gone after delete");
+    assert!(
+        empty.archived_cards.is_empty(),
+        "inner archived-card marker gone after delete"
+    );
+    assert_eq!(
+        empty.graph.len(),
+        0,
+        "dependency edge gone after delete"
+    );
+
+    assert!(ctx.undo().unwrap(), "undo returned true");
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let snap = ctx.data_store().snapshot().unwrap();
+    assert_eq!(snap.archived_boards.len(), 1, "board restored as archived");
+    assert_eq!(snap.columns.len(), 1, "column restored after undo");
+    assert_eq!(snap.cards.len(), 2, "both card rows restored after undo");
+    assert_eq!(snap.sprints.len(), 1, "sprint restored after undo");
+    assert_eq!(
+        snap.archived_cards.len(),
+        1,
+        "inner archived-card marker restored after undo"
+    );
+    assert_eq!(
+        snap.graph.len(),
+        1,
+        "dependency edge restored after undo"
+    );
+    assert!(
+        ctx.get_card(s.live).unwrap().is_some(),
+        "live card reachable after undo"
+    );
+    assert!(
+        ctx.get_card(s.arch).unwrap().is_some(),
+        "archived card reachable after undo"
+    );
+    assert_eq!(
+        ctx.get_card(s.live).unwrap().unwrap().sprint_id,
+        Some(s.sprint),
+        "sprint binding restored after undo"
+    );
+    assert!(
+        !ctx.get_card(s.live)
+            .unwrap()
+            .unwrap()
+            .sprint_logs
+            .is_empty(),
+        "sprint_logs survived undo"
+    );
+}
+
+/// KAN-908: board archive+restore must be the identity over the FULL entity
+/// graph. Seeds the same rich graph, archives, restores, save+reload, then
+/// asserts every entity type survived unchanged.
+pub async fn test_board_archive_restore_full_graph_roundtrip(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let s = seed_rich(&mut ctx).unwrap();
+
+    ctx.archive_board(s.board).unwrap();
+    ctx.restore_board(s.board).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let snap = ctx.data_store().snapshot().unwrap();
+    assert_eq!(snap.boards.len(), 1, "board is live after restore");
+    assert!(snap.archived_boards.is_empty(), "no archived-board marker");
+    assert_eq!(snap.columns.len(), 1, "column survived archive/restore");
+    assert_eq!(snap.cards.len(), 2, "both card rows survived archive/restore");
+    assert_eq!(snap.sprints.len(), 1, "sprint survived archive/restore");
+    assert_eq!(
+        snap.archived_cards.len(),
+        1,
+        "inner archived-card marker survived archive/restore"
+    );
+    assert_eq!(
+        snap.graph.len(),
+        1,
+        "dependency edge survived archive/restore"
+    );
+    assert!(
+        ctx.get_card(s.live).unwrap().is_some(),
+        "live card reachable after restore"
+    );
+    assert!(
+        ctx.get_card(s.arch).unwrap().is_some(),
+        "archived card reachable after restore"
+    );
+    assert_eq!(
+        ctx.get_card(s.live).unwrap().unwrap().sprint_id,
+        Some(s.sprint),
+        "sprint binding survived archive/restore"
+    );
+    assert!(
+        !ctx.get_card(s.live)
+            .unwrap()
+            .unwrap()
+            .sprint_logs
+            .is_empty(),
+        "sprint_logs survived archive/restore"
+    );
 }

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -4,7 +4,9 @@ use crate::KanbanContext;
 use kanban_core::AppConfig;
 use kanban_domain::archival::ArchivedEntity;
 use kanban_domain::card::CardPriority;
-use kanban_domain::{CardListFilter, CreateCardOptions, GraphOperations, KanbanOperations, Severity};
+use kanban_domain::{
+    CardListFilter, CreateCardOptions, GraphOperations, KanbanOperations, Severity,
+};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -495,10 +497,7 @@ pub async fn test_delete_board_is_noop_on_archived_board(factory: &BackendFactor
 
     // Board head must still be fetchable (get_board is unfiltered).
     assert!(
-        ctx.data_store()
-            .get_board(board.id)
-            .unwrap()
-            .is_some(),
+        ctx.data_store().get_board(board.id).unwrap().is_some(),
         "archived board head must survive bare delete_board"
     );
     // Archived marker must still be present.
@@ -536,18 +535,8 @@ fn seed_rich(ctx: &mut KanbanContext) -> kanban_domain::KanbanResult<RichSeed> {
     let b = ctx.create_board("Proj".into(), None)?;
     let col = ctx.create_column(b.id, "Todo".into(), None)?;
     let sprint = ctx.create_sprint(b.id, None, None)?;
-    let live = ctx.create_card(
-        b.id,
-        col.id,
-        "Live".into(),
-        CreateCardOptions::default(),
-    )?;
-    let arch = ctx.create_card(
-        b.id,
-        col.id,
-        "Arch".into(),
-        CreateCardOptions::default(),
-    )?;
+    let live = ctx.create_card(b.id, col.id, "Live".into(), CreateCardOptions::default())?;
+    let arch = ctx.create_card(b.id, col.id, "Arch".into(), CreateCardOptions::default())?;
     ctx.assign_card_to_sprint(live.id, sprint.id)?;
     ctx.block(live.id, arch.id, Severity::High)?;
     ctx.archive_card(arch.id)?;
@@ -585,11 +574,7 @@ pub async fn test_board_delete_undo_full_graph_roundtrip(factory: &BackendFactor
         empty.archived_cards.is_empty(),
         "inner archived-card marker gone after delete"
     );
-    assert_eq!(
-        empty.graph.len(),
-        0,
-        "dependency edge gone after delete"
-    );
+    assert_eq!(empty.graph.len(), 0, "dependency edge gone after delete");
 
     assert!(ctx.undo().unwrap(), "undo returned true");
 
@@ -606,11 +591,7 @@ pub async fn test_board_delete_undo_full_graph_roundtrip(factory: &BackendFactor
         1,
         "inner archived-card marker restored after undo"
     );
-    assert_eq!(
-        snap.graph.len(),
-        1,
-        "dependency edge restored after undo"
-    );
+    assert_eq!(snap.graph.len(), 1, "dependency edge restored after undo");
     assert!(
         ctx.get_card(s.live).unwrap().is_some(),
         "live card reachable after undo"
@@ -656,7 +637,11 @@ pub async fn test_board_archive_restore_full_graph_roundtrip(factory: &BackendFa
     assert_eq!(snap.boards.len(), 1, "board is live after restore");
     assert!(snap.archived_boards.is_empty(), "no archived-board marker");
     assert_eq!(snap.columns.len(), 1, "column survived archive/restore");
-    assert_eq!(snap.cards.len(), 2, "both card rows survived archive/restore");
+    assert_eq!(
+        snap.cards.len(),
+        2,
+        "both card rows survived archive/restore"
+    );
     assert_eq!(snap.sprints.len(), 1, "sprint survived archive/restore");
     assert_eq!(
         snap.archived_cards.len(),

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -134,6 +134,22 @@ macro_rules! context_contract_tests {
         async fn test_list_cards_archived_selector_board_scoped() {
             $crate::test_helpers::contract::archive::test_list_cards_archived_selector_board_scoped(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_clear_sprint_from_cards_leaves_archived_untouched() {
+            $crate::test_helpers::contract::archive::test_clear_sprint_from_cards_leaves_archived_untouched(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_delete_board_is_noop_on_archived_board() {
+            $crate::test_helpers::contract::archive::test_delete_board_is_noop_on_archived_board(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_board_delete_undo_full_graph_roundtrip() {
+            $crate::test_helpers::contract::archive::test_board_delete_undo_full_graph_roundtrip(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_board_archive_restore_full_graph_roundtrip() {
+            $crate::test_helpers::contract::archive::test_board_archive_restore_full_graph_roundtrip(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- **KAN-898**: `InMemoryStore::clear_sprint_from_cards` was clearing archived cards' `sprint_id`, while SQLite scopes the primitive to live cards only (`AND NOT EXISTS archived_cards`). Fixed by snapshotting the archived key set into a `HashSet` and gating the clear on `!archived.contains(&card.id)` -- the same pattern used by `delete_cards_by_columns_impl` in the same file.

- **KAN-899**: `InMemoryStore::delete_board` removed the board head unconditionally, while SQLite guards the delete with `AND NOT EXISTS board_archival` (no-op on archived boards). Three-part fix: (1) guard `delete_board_impl`; (2) update `delete_archived_board_impl` to also remove the board head (permanent delete must own the head removal now); (3) add `unarchive_board_impl` + `DataStore` override to drop only the marker on the restore path.

- **KAN-908**: Enriched the board delete/undo and archive/restore contract tests with a non-trivial rich seed (column, live card, inner individually-archived card, sprint with binding+log, dependency edge) and full-graph assertions on every entity type across all three backends. Guards the KAN-863 failure class.

## Test plan

- All three contract tests registered in `context_contract_tests!`, running on in-memory, JSON, and SQLite via `archival_contract.rs`
- `test_clear_sprint_from_cards_leaves_archived_untouched`: was Red on in-memory+JSON pre-fix; Green on all 3 post-fix
- `test_delete_board_is_noop_on_archived_board`: was Red on in-memory+JSON pre-fix; Green on all 3 post-fix
- `test_board_delete_undo_full_graph_roundtrip` + `test_board_archive_restore_full_graph_roundtrip`: Green on all 3 backends (hardening tests, no production code change)
- New SQLite unit test `test_delete_board_noop_on_archived_keeps_head_and_marker` pins the canonical guard
- `cargo test -p kanban-domain`: 619 passed
- `cargo test -p kanban-service --features test-helpers`: 151 passed (contract suite, feature-gated)
- `cargo test -p kanban-persistence-sqlite`: 75 + 21 passed
- `cargo clippy --all-targets --features test-helpers -D warnings`: clean on all touched crates
- `cargo fmt --check`: clean