### PR TITLE
KAN-895 feat(domain): export/import carries archived boards + orphan-safe archived cards (regression)

### DIFF
--- a/crates/kanban-domain/src/export/exporter.rs
+++ b/crates/kanban-domain/src/export/exporter.rs
@@ -3,7 +3,9 @@
 //! Converts domain entities into export format for serialization.
 
 use super::models::{AllBoardsExport, BoardExport};
-use crate::{ArchivedCard, Board, Card, Column, Sprint};
+use crate::archival::ArchivedEntity;
+use crate::{ArchivedBoard, ArchivedCard, Board, Card, Column, Sprint};
+use std::collections::HashSet;
 use std::io;
 use uuid::Uuid;
 
@@ -12,11 +14,17 @@ pub struct BoardExporter;
 
 impl BoardExporter {
     /// Export a single board with all its associated data.
+    ///
+    /// Archived cards are scoped by `board_id` (not column membership) so that
+    /// cards whose original column was deleted after archival still round-trip.
+    /// Their live card rows are included via a union of column-membership ids and
+    /// archived-card entity ids, preventing orphaned markers on import.
     pub fn export_board(
         board: &Board,
         all_columns: &[Column],
         all_cards: &[Card],
         all_archived_cards: &[ArchivedCard],
+        all_archived_boards: &[ArchivedBoard],
         all_sprints: &[Sprint],
     ) -> BoardExport {
         let board_columns: Vec<Column> = all_columns
@@ -25,20 +33,31 @@ impl BoardExporter {
             .cloned()
             .collect();
 
-        let column_ids: Vec<Uuid> = board_columns.iter().map(|c| c.id).collect();
+        let column_ids: HashSet<Uuid> = board_columns.iter().map(|c| c.id).collect();
 
-        let board_cards: Vec<Card> = all_cards
-            .iter()
-            .filter(|card| column_ids.contains(&card.column_id))
-            .cloned()
-            .collect();
-
-        // Scope archived cards by the first-class `board_id` (their historical
-        // column may have been deleted after archival, so column membership is
-        // not reliable).
+        // Scope archived cards by board_id (column may have been deleted post-archive).
         let board_archived_cards: Vec<ArchivedCard> = all_archived_cards
             .iter()
             .filter(|dc| dc.context.board_id == board.id)
+            .cloned()
+            .collect();
+
+        // Carry live card rows for all archived cards in this board, even those
+        // whose column_id dangles (column deleted after archival).
+        let archived_card_ids: HashSet<Uuid> =
+            board_archived_cards.iter().map(|a| a.entity_id()).collect();
+
+        let board_cards: Vec<Card> = all_cards
+            .iter()
+            .filter(|card| {
+                column_ids.contains(&card.column_id) || archived_card_ids.contains(&card.id)
+            })
+            .cloned()
+            .collect();
+
+        let board_archived_boards: Vec<ArchivedBoard> = all_archived_boards
+            .iter()
+            .filter(|ab| ab.entity_id() == board.id)
             .cloned()
             .collect();
 
@@ -53,6 +72,7 @@ impl BoardExporter {
             columns: board_columns,
             cards: board_cards,
             archived_cards: board_archived_cards,
+            archived_boards: board_archived_boards,
             sprints: board_sprints,
         }
     }
@@ -63,11 +83,21 @@ impl BoardExporter {
         columns: &[Column],
         cards: &[Card],
         archived_cards: &[ArchivedCard],
+        archived_boards: &[ArchivedBoard],
         sprints: &[Sprint],
     ) -> AllBoardsExport {
         let board_exports: Vec<BoardExport> = boards
             .iter()
-            .map(|board| Self::export_board(board, columns, cards, archived_cards, sprints))
+            .map(|board| {
+                Self::export_board(
+                    board,
+                    columns,
+                    cards,
+                    archived_cards,
+                    archived_boards,
+                    sprints,
+                )
+            })
             .collect();
 
         AllBoardsExport {
@@ -90,6 +120,7 @@ impl BoardExporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::archival::ArchivedEntity;
 
     #[test]
     fn test_export_single_board() {
@@ -102,15 +133,23 @@ mod tests {
         let cards = vec![card];
 
         let archived_cards = vec![];
+        let archived_boards = vec![];
         let sprints = vec![];
 
-        let export =
-            BoardExporter::export_board(&board, &columns, &cards, &archived_cards, &sprints);
+        let export = BoardExporter::export_board(
+            &board,
+            &columns,
+            &cards,
+            &archived_cards,
+            &archived_boards,
+            &sprints,
+        );
 
         assert_eq!(export.board.name, "Test");
         assert_eq!(export.columns.len(), 1);
         assert_eq!(export.cards.len(), 1);
         assert_eq!(export.archived_cards.len(), 0);
+        assert_eq!(export.archived_boards.len(), 0);
     }
 
     #[test]
@@ -125,10 +164,17 @@ mod tests {
 
         let cards = vec![];
         let archived_cards = vec![];
+        let archived_boards = vec![];
         let sprints = vec![];
 
-        let export =
-            BoardExporter::export_all_boards(&boards, &columns, &cards, &archived_cards, &sprints);
+        let export = BoardExporter::export_all_boards(
+            &boards,
+            &columns,
+            &cards,
+            &archived_cards,
+            &archived_boards,
+            &sprints,
+        );
 
         assert_eq!(export.boards.len(), 2);
         assert_eq!(export.boards[0].board.name, "Board 1");
@@ -144,11 +190,92 @@ mod tests {
                 columns: vec![],
                 cards: vec![],
                 archived_cards: vec![],
+                archived_boards: vec![],
                 sprints: vec![],
             }],
         };
 
         let json = BoardExporter::export_to_json(&export).unwrap();
         assert!(json.contains("Test"));
+    }
+
+    #[test]
+    fn test_export_board_carries_its_archived_board_marker() {
+        let board = Board::new("Archived Board", None::<String>);
+        let ab = ArchivedBoard::at(board.id, chrono::Utc::now());
+        let columns = vec![];
+        let cards = vec![];
+        let archived_cards = vec![];
+        let archived_boards = vec![ab];
+        let sprints = vec![];
+
+        let export = BoardExporter::export_board(
+            &board,
+            &columns,
+            &cards,
+            &archived_cards,
+            &archived_boards,
+            &sprints,
+        );
+
+        assert_eq!(export.archived_boards.len(), 1);
+        assert_eq!(export.archived_boards[0].entity_id(), board.id);
+    }
+
+    #[test]
+    fn test_export_board_omits_other_boards_archived_marker() {
+        let board_a = Board::new("Board A", None::<String>);
+        let board_b = Board::new("Board B", None::<String>);
+        let ab_b = ArchivedBoard::at(board_b.id, chrono::Utc::now());
+        let archived_boards = vec![ab_b];
+
+        let export = BoardExporter::export_board(&board_a, &[], &[], &[], &archived_boards, &[]);
+
+        assert_eq!(
+            export.archived_boards.len(),
+            0,
+            "board A export must not carry board B's archived marker"
+        );
+    }
+
+    #[test]
+    fn test_export_board_carries_archived_card_row_with_dangling_column() {
+        let board = Board::new("B", None::<String>);
+        let live_col = Column::new(board.id, "Todo", 0);
+
+        let mut board_mut = board.clone();
+        let live_card = Card::new(&mut board_mut, live_col.id, "Live", 0);
+
+        // Archived card pointing at a DELETED column (dangling).
+        let dangling_col_id = Uuid::new_v4();
+        let archived_card_row = Card::new(&mut board_mut, dangling_col_id, "Archived", 1);
+        let ac_marker = crate::ArchivedCard::new(archived_card_row.id, board.id);
+
+        let columns = vec![live_col.clone()];
+        let cards = vec![live_card.clone(), archived_card_row.clone()];
+        let archived_cards = vec![ac_marker];
+        let archived_boards = vec![];
+        let sprints = vec![];
+
+        let export = BoardExporter::export_board(
+            &board,
+            &columns,
+            &cards,
+            &archived_cards,
+            &archived_boards,
+            &sprints,
+        );
+
+        assert_eq!(
+            export.cards.len(),
+            2,
+            "live row of dangling-column archived card must be carried"
+        );
+        assert!(
+            export.cards.iter().any(|c| c.id == archived_card_row.id),
+            "dangling-column archived card live row must appear in export.cards"
+        );
+        assert_eq!(export.archived_cards.len(), 1);
+        assert_eq!(export.archived_cards[0].entity_id(), archived_card_row.id);
     }
 }

--- a/crates/kanban-domain/src/export/importer.rs
+++ b/crates/kanban-domain/src/export/importer.rs
@@ -3,8 +3,11 @@
 //! Supports both V1 (AllBoardsExport) and V2 (Snapshot with version envelope) formats.
 
 use super::models::{AllBoardsExport, BoardExport};
-use crate::{ArchivedCard, Board, Card, Column, Snapshot, Sprint};
+use crate::archival::ArchivedEntity;
+use crate::{ArchivedBoard, ArchivedCard, Board, Card, Column, Snapshot, Sprint};
+use std::collections::HashSet;
 use std::io;
+use uuid::Uuid;
 
 /// Extracted entities from an import.
 pub struct ImportedEntities {
@@ -12,6 +15,7 @@ pub struct ImportedEntities {
     pub columns: Vec<Column>,
     pub cards: Vec<Card>,
     pub archived_cards: Vec<ArchivedCard>,
+    pub archived_boards: Vec<ArchivedBoard>,
     pub sprints: Vec<Sprint>,
 }
 
@@ -73,10 +77,15 @@ impl BoardImporter {
     ///
     /// V2 has flat structure: boards[], columns[], cards[], sprints[]
     /// V1 has nested structure: boards[{board, columns[], cards[], sprints[]}]
+    ///
+    /// Archived cards are scoped by `board_id` (not column membership) so that
+    /// cards whose original column was deleted after archival still round-trip.
+    /// Their live rows are included via a union of column-membership ids and
+    /// archived-card entity ids.
     pub fn convert_snapshot_to_export(snapshot: Snapshot) -> AllBoardsExport {
         let mut board_exports = Vec::new();
 
-        for board in snapshot.boards {
+        for board in &snapshot.boards {
             let board_columns: Vec<_> = snapshot
                 .columns
                 .iter()
@@ -84,10 +93,22 @@ impl BoardImporter {
                 .cloned()
                 .collect();
 
+            let column_ids: HashSet<Uuid> = board_columns.iter().map(|c| c.id).collect();
+
+            let board_archived: Vec<_> = snapshot
+                .archived_cards
+                .iter()
+                .filter(|a| a.context.board_id == board.id)
+                .cloned()
+                .collect();
+
+            let archived_card_ids: HashSet<Uuid> =
+                board_archived.iter().map(|a| a.entity_id()).collect();
+
             let board_cards: Vec<_> = snapshot
                 .cards
                 .iter()
-                .filter(|c| board_columns.iter().any(|col| col.id == c.column_id))
+                .filter(|c| column_ids.contains(&c.column_id) || archived_card_ids.contains(&c.id))
                 .cloned()
                 .collect();
 
@@ -98,19 +119,20 @@ impl BoardImporter {
                 .cloned()
                 .collect();
 
-            let board_archived: Vec<_> = snapshot
-                .archived_cards
+            let board_archived_boards: Vec<_> = snapshot
+                .archived_boards
                 .iter()
-                .filter(|a| a.context.board_id == board.id)
+                .filter(|ab| ab.entity_id() == board.id)
                 .cloned()
                 .collect();
 
             board_exports.push(BoardExport {
-                board,
+                board: board.clone(),
                 columns: board_columns,
                 cards: board_cards,
                 sprints: board_sprints,
                 archived_cards: board_archived,
+                archived_boards: board_archived_boards,
             });
         }
 
@@ -131,6 +153,7 @@ impl BoardImporter {
         let mut columns = Vec::new();
         let mut cards = Vec::new();
         let mut archived_cards = Vec::new();
+        let mut archived_boards = Vec::new();
         let mut sprints = Vec::new();
 
         for board_data in import.boards {
@@ -138,6 +161,7 @@ impl BoardImporter {
             columns.extend(board_data.columns);
             cards.extend(board_data.cards);
             archived_cards.extend(board_data.archived_cards);
+            archived_boards.extend(board_data.archived_boards);
             sprints.extend(board_data.sprints);
         }
 
@@ -146,6 +170,7 @@ impl BoardImporter {
             columns,
             cards,
             archived_cards,
+            archived_boards,
             sprints,
         }
     }
@@ -154,6 +179,7 @@ impl BoardImporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::archival::ArchivedEntity;
 
     #[test]
     fn test_import_from_json_v1_valid() {
@@ -182,6 +208,7 @@ mod tests {
                     "columns": [],
                     "cards": [],
                     "archived_cards": [],
+                    "archived_boards": [],
                     "sprints": []
                 }
             ]
@@ -216,6 +243,7 @@ mod tests {
                 columns: vec![column.clone()],
                 cards: vec![card.clone()],
                 archived_cards: vec![],
+                archived_boards: vec![],
                 sprints: vec![],
             }],
         };
@@ -226,6 +254,7 @@ mod tests {
         assert_eq!(entities.columns.len(), 1);
         assert_eq!(entities.cards.len(), 1);
         assert_eq!(entities.archived_cards.len(), 0);
+        assert_eq!(entities.archived_boards.len(), 0);
         assert_eq!(entities.sprints.len(), 0);
     }
 
@@ -254,5 +283,144 @@ mod tests {
         assert_eq!(export.boards.len(), 1);
         assert_eq!(export.boards[0].board.name, "Test");
         assert_eq!(export.boards[0].columns.len(), 1);
+    }
+
+    #[test]
+    fn test_export_import_round_trip_preserves_archived_card_row_and_marker() {
+        let board = Board::new("B", None::<String>);
+        let col = Column::new(board.id, "Todo", 0);
+        let mut board_mut = board.clone();
+        let live_card = Card::new(&mut board_mut, col.id, "Live", 0);
+        let archived_card_row = Card::new(&mut board_mut, col.id, "Archived", 1);
+        let ac_marker = ArchivedCard::new(archived_card_row.id, board.id);
+
+        let snapshot = Snapshot {
+            archived_boards: vec![],
+            boards: vec![board.clone()],
+            columns: vec![col.clone()],
+            cards: vec![live_card.clone(), archived_card_row.clone()],
+            archived_cards: vec![ac_marker],
+            sprints: vec![],
+            graph: crate::DependencyGraph::new(),
+        };
+
+        let export = BoardImporter::convert_snapshot_to_export(snapshot);
+        let entities = BoardImporter::extract_entities(export);
+
+        assert!(
+            entities.cards.iter().any(|c| c.id == live_card.id),
+            "live card must be present"
+        );
+        assert!(
+            entities.cards.iter().any(|c| c.id == archived_card_row.id),
+            "archived card live row must be present"
+        );
+        assert_eq!(entities.archived_cards.len(), 1);
+        assert_eq!(entities.archived_cards[0].entity_id(), archived_card_row.id);
+        assert_eq!(entities.archived_cards[0].context.board_id, board.id);
+    }
+
+    #[test]
+    fn test_export_import_round_trip_preserves_archived_card_with_dangling_column() {
+        let board = Board::new("B", None::<String>);
+        let live_col = Column::new(board.id, "Todo", 0);
+        let mut board_mut = board.clone();
+        // Archived card points at a column NOT in snapshot.columns (deleted).
+        let dangling_col_id = Uuid::new_v4();
+        let archived_card_row = Card::new(&mut board_mut, dangling_col_id, "Archived", 0);
+        let ac_marker = ArchivedCard::new(archived_card_row.id, board.id);
+
+        let snapshot = Snapshot {
+            archived_boards: vec![],
+            boards: vec![board.clone()],
+            columns: vec![live_col.clone()],
+            cards: vec![archived_card_row.clone()],
+            archived_cards: vec![ac_marker],
+            sprints: vec![],
+            graph: crate::DependencyGraph::new(),
+        };
+
+        let export = BoardImporter::convert_snapshot_to_export(snapshot);
+        let entities = BoardImporter::extract_entities(export);
+
+        assert!(
+            entities.cards.iter().any(|c| c.id == archived_card_row.id),
+            "dangling-column archived card live row must be carried through export/import"
+        );
+        assert_eq!(entities.archived_cards.len(), 1);
+        assert_eq!(entities.archived_cards[0].entity_id(), archived_card_row.id);
+    }
+
+    #[test]
+    fn test_export_import_round_trip_preserves_archived_board() {
+        let board = Board::new("B", None::<String>);
+        let ab = ArchivedBoard::at(board.id, chrono::Utc::now());
+
+        let snapshot = Snapshot {
+            archived_boards: vec![ab],
+            boards: vec![board.clone()],
+            columns: vec![],
+            cards: vec![],
+            archived_cards: vec![],
+            sprints: vec![],
+            graph: crate::DependencyGraph::new(),
+        };
+
+        let export = BoardImporter::convert_snapshot_to_export(snapshot);
+        let entities = BoardImporter::extract_entities(export);
+
+        assert!(
+            entities.boards.iter().any(|b| b.id == board.id),
+            "board head must be present"
+        );
+        assert_eq!(entities.archived_boards.len(), 1);
+        assert_eq!(entities.archived_boards[0].entity_id(), board.id);
+    }
+
+    #[test]
+    fn test_snapshot_export_import_round_trip_preserves_full_archival_graph() {
+        let board_live = Board::new("Live Board", None::<String>);
+        let board_arch = Board::new("Archived Board", None::<String>);
+        let col = Column::new(board_live.id, "Todo", 0);
+        let mut bm = board_live.clone();
+        let live_card = Card::new(&mut bm, col.id, "Live Card", 0);
+        // Archived card with dangling column (column deleted after archival)
+        let dangling_col = Uuid::new_v4();
+        let archived_card_row = Card::new(&mut bm, dangling_col, "Archived Card", 1);
+        let ac_marker = ArchivedCard::new(archived_card_row.id, board_live.id);
+        let ab_marker = ArchivedBoard::at(board_arch.id, chrono::Utc::now());
+
+        let snapshot = Snapshot {
+            archived_boards: vec![ab_marker],
+            boards: vec![board_live.clone(), board_arch.clone()],
+            columns: vec![col.clone()],
+            cards: vec![live_card.clone(), archived_card_row.clone()],
+            archived_cards: vec![ac_marker],
+            sprints: vec![],
+            graph: crate::DependencyGraph::new(),
+        };
+
+        let export = BoardImporter::convert_snapshot_to_export(snapshot);
+        let entities = BoardImporter::extract_entities(export);
+
+        assert_eq!(entities.boards.len(), 2, "both board heads present");
+        assert!(entities.boards.iter().any(|b| b.id == board_live.id));
+        assert!(entities.boards.iter().any(|b| b.id == board_arch.id));
+        assert_eq!(
+            entities.archived_boards.len(),
+            1,
+            "archived board marker present"
+        );
+        assert_eq!(entities.archived_boards[0].entity_id(), board_arch.id);
+        assert_eq!(entities.columns.len(), 1);
+        assert_eq!(
+            entities.cards.len(),
+            2,
+            "both live and dangling-column archived card row present"
+        );
+        assert!(entities.cards.iter().any(|c| c.id == live_card.id));
+        assert!(entities.cards.iter().any(|c| c.id == archived_card_row.id));
+        assert_eq!(entities.archived_cards.len(), 1);
+        assert_eq!(entities.archived_cards[0].entity_id(), archived_card_row.id);
     }
 }

--- a/crates/kanban-domain/src/export/models.rs
+++ b/crates/kanban-domain/src/export/models.rs
@@ -2,7 +2,7 @@
 //!
 //! These DTOs represent the structure for import/export operations.
 
-use crate::{ArchivedCard, Board, Card, Column, Sprint};
+use crate::{ArchivedBoard, ArchivedCard, Board, Card, Column, Sprint};
 use serde::{Deserialize, Serialize};
 
 /// Export format for a single board with all its data.
@@ -18,6 +18,8 @@ pub struct BoardExport {
     pub sprints: Vec<Sprint>,
     #[serde(default)]
     pub archived_cards: Vec<ArchivedCard>,
+    #[serde(default)]
+    pub archived_boards: Vec<ArchivedBoard>,
 }
 
 /// Export format for all boards.

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -212,7 +212,7 @@ impl StoreManager {
 
             let entities = BoardImporter::extract_entities(export);
             let snapshot = Snapshot {
-                archived_boards: Vec::new(),
+                archived_boards: entities.archived_boards,
                 boards: entities.boards,
                 columns: entities.columns,
                 cards: entities.cards,
@@ -438,18 +438,9 @@ fn repair_snapshot_fks(snapshot: &mut StoreSnapshot) -> Result<(), KanbanError> 
         }
     }
 
-    if let Some(archived) = data["archived_cards"].as_array_mut() {
-        for entry in archived.iter_mut() {
-            if let Some(card) = entry.get_mut("card") {
-                fix_card_fks(
-                    card,
-                    &valid_columns,
-                    &valid_sprints,
-                    fallback_column.as_deref(),
-                );
-            }
-        }
-    }
+    // Archived cards are pure markers ({ entity_id, archived_at, board_id }); the
+    // archived card's live row is repaired by the `cards` loop above. There is no
+    // embedded `card` to fix here since the V10 migration ran before FK repair.
 
     snapshot.data = serde_json::to_vec(&data).map_err(|e| {
         KanbanError::validation(format!("Failed to serialize repaired snapshot: {e}"))
@@ -481,8 +472,107 @@ fn fix_card_fks(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kanban_persistence::StoreRegistry;
+    use kanban_persistence::{PersistenceMetadata, StoreRegistry};
     use tempfile::tempdir;
+    use uuid::Uuid;
+
+    fn make_snapshot_with_json(data: serde_json::Value) -> StoreSnapshot {
+        StoreSnapshot {
+            data: serde_json::to_vec(&data).unwrap(),
+            metadata: PersistenceMetadata::new(Uuid::new_v4()),
+        }
+    }
+
+    /// Drift guard: verifies that an archived card whose live row has a dangling
+    /// column_id gets the live row repaired (moved to fallback column) without
+    /// erroring, and the marker entry is left unchanged with no `card` key.
+    #[test]
+    fn test_repair_snapshot_fks_repairs_live_row_of_archived_card() {
+        let valid_col_id = Uuid::new_v4().to_string();
+        let dangling_col_id = Uuid::new_v4().to_string();
+        let card_id = Uuid::new_v4().to_string();
+        let board_id = Uuid::new_v4().to_string();
+
+        let data = serde_json::json!({
+            "boards": [{"id": board_id}],
+            "columns": [{"id": valid_col_id, "position": 0}],
+            "sprints": [],
+            "cards": [{
+                "id": card_id,
+                "column_id": dangling_col_id,
+                "sprint_id": null
+            }],
+            "archived_cards": [{
+                "entity_id": card_id,
+                "board_id": board_id,
+                "archived_at": "2024-01-01T00:00:00Z"
+            }]
+        });
+
+        let mut snapshot = make_snapshot_with_json(data);
+        repair_snapshot_fks(&mut snapshot)
+            .expect("repair must succeed for archived card with dangling column");
+
+        let repaired: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
+
+        assert_eq!(
+            repaired["cards"][0]["column_id"].as_str().unwrap(),
+            valid_col_id,
+            "live card row must be reassigned to fallback column"
+        );
+        let marker = &repaired["archived_cards"][0];
+        assert!(
+            marker.get("card").is_none(),
+            "marker must have no embedded `card` key (pure marker shape)"
+        );
+        assert_eq!(marker["entity_id"].as_str().unwrap(), card_id);
+        assert_eq!(marker["board_id"].as_str().unwrap(), board_id);
+    }
+
+    /// Drift guard: verifies that a marker-only archived_cards entry passes
+    /// through repair_snapshot_fks byte-identical. Pins the marker-shape contract
+    /// so a future reader cannot silently re-add an embed-handling branch.
+    #[test]
+    fn test_repair_snapshot_fks_marker_archived_cards_pass_through_unchanged() {
+        let col_id = Uuid::new_v4().to_string();
+        let card_id = Uuid::new_v4().to_string();
+        let board_id = Uuid::new_v4().to_string();
+
+        let archived_entry = serde_json::json!({
+            "entity_id": card_id,
+            "board_id": board_id,
+            "archived_at": "2024-01-01T00:00:00Z"
+        });
+
+        let data = serde_json::json!({
+            "boards": [],
+            "columns": [{"id": col_id, "position": 0}],
+            "sprints": [],
+            "cards": [{"id": card_id, "column_id": col_id, "sprint_id": null}],
+            "archived_cards": [archived_entry.clone()]
+        });
+
+        let mut snapshot = make_snapshot_with_json(data);
+        repair_snapshot_fks(&mut snapshot).expect("repair must succeed");
+
+        let repaired: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
+        let marker_after = &repaired["archived_cards"][0];
+
+        assert_eq!(
+            marker_after["entity_id"].as_str().unwrap(),
+            card_id,
+            "entity_id must be unchanged"
+        );
+        assert_eq!(
+            marker_after["board_id"].as_str().unwrap(),
+            board_id,
+            "board_id must be unchanged"
+        );
+        assert!(
+            marker_after.get("card").is_none(),
+            "no `card` embed must be present before or after repair"
+        );
+    }
 
     fn make_sm() -> StoreManager {
         let mut registry = StoreRegistry::new();

--- a/crates/kanban-service/tests/export_import_archived_roundtrip.rs
+++ b/crates/kanban-service/tests/export_import_archived_roundtrip.rs
@@ -1,0 +1,271 @@
+//! Export/import round-trip tests for archival data (KAN-909).
+//!
+//! Proves that `BoardImporter::convert_snapshot_to_export` correctly carries
+//! `archived_boards` markers and archived-card live rows (incl. dangling-column
+//! cards) through a real file round-trip on both JSON and SQLite backends.
+//!
+//! The dependency graph is NOT part of `AllBoardsExport`; tests assert edges
+//! are ABSENT after import to encode the known export limitation.
+
+use kanban_domain::{
+    archival::ArchivedEntity,
+    export::{BoardExporter, BoardImporter},
+    DependencyGraph, GraphOperations, KanbanOperations, KanbanResult, Severity, Snapshot,
+};
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{
+    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
+    KanbanContext,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+async fn open_json_ctx(path: &std::path::Path) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+async fn open_sqlite_ctx(path: &std::path::Path) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap());
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+#[derive(Clone, Copy)]
+struct SeedIds {
+    live_board_id: uuid::Uuid,
+    archived_board_id: uuid::Uuid,
+    col_id: uuid::Uuid,
+    live_card_id: uuid::Uuid,
+    archived_card_id: uuid::Uuid,
+    sprint_id: uuid::Uuid,
+}
+
+/// Seed a non-trivial archival graph. Returns ids for later assertions.
+/// Seeds:
+/// - board B1 (live) with 1 column, 1 live card, 1 archived card, 1 sprint
+/// - board B2 (archived) so `archived_boards` is non-empty
+/// - a `blocks` edge between two live cards on B1
+async fn seed_archival_graph(ctx: &mut KanbanContext) -> SeedIds {
+    let b1 = ctx.create_board("Live Board".into(), None).unwrap();
+    let col = ctx.create_column(b1.id, "Todo".into(), None).unwrap();
+    let live_card = ctx
+        .create_card(b1.id, col.id, "Live Card".into(), Default::default())
+        .unwrap();
+    let arch_card = ctx
+        .create_card(b1.id, col.id, "Archived Card".into(), Default::default())
+        .unwrap();
+    let sprint = ctx.create_sprint(b1.id, Some("S".into()), None).unwrap();
+    ctx.archive_card(arch_card.id).unwrap();
+    // blocks edge between live cards (one of which is now archived)
+    ctx.block(live_card.id, arch_card.id, Severity::default())
+        .unwrap();
+
+    let b2 = ctx.create_board("Archived Board".into(), None).unwrap();
+    ctx.archive_board(b2.id).unwrap();
+
+    SeedIds {
+        live_board_id: b1.id,
+        archived_board_id: b2.id,
+        col_id: col.id,
+        live_card_id: live_card.id,
+        archived_card_id: arch_card.id,
+        sprint_id: sprint.id,
+    }
+}
+
+/// Assert the full archival graph is present in `ctx` after import.
+fn assert_full_graph(ctx: &KanbanContext, ids: &SeedIds) -> KanbanResult<()> {
+    // Live board present in live list
+    let live_boards = ctx.boards()?;
+    assert!(
+        live_boards.iter().any(|b| b.id == ids.live_board_id),
+        "live board must appear in ctx.boards()"
+    );
+
+    // archived_boards marker present
+    let archived_boards = ctx.list_archived_boards()?;
+    assert_eq!(
+        archived_boards.len(),
+        1,
+        "exactly one archived_boards marker"
+    );
+    assert_eq!(
+        archived_boards[0].entity_id(),
+        ids.archived_board_id,
+        "archived_boards marker entity_id"
+    );
+
+    // Archived board HEAD reachable from raw snapshot (apply_snapshot stores it)
+    let snap = ctx.snapshot()?;
+    assert!(
+        snap.boards.iter().any(|b| b.id == ids.archived_board_id),
+        "archived board head must be in snapshot.boards"
+    );
+
+    // Column present in live view
+    let columns = ctx.list_all_columns()?;
+    assert!(
+        columns.iter().any(|c| c.id == ids.col_id),
+        "column must be present"
+    );
+
+    // Live card present
+    let live_cards = ctx.list_all_cards()?;
+    assert!(
+        live_cards.iter().any(|c| c.id == ids.live_card_id),
+        "live card must be present in list_all_cards"
+    );
+
+    // Archived card live row reachable by id
+    // (list_all_cards is live-scoped and excludes archived cards)
+    let arch_row = ctx.get_card(ids.archived_card_id)?;
+    assert!(
+        arch_row.is_some(),
+        "archived card live row must be reachable via get_card (unfiltered)"
+    );
+
+    // archived_cards marker present with correct board_id
+    let archived_cards = ctx.list_archived_cards_by_board(ids.live_board_id)?;
+    assert_eq!(archived_cards.len(), 1, "archived_cards marker count");
+    assert_eq!(
+        archived_cards[0].entity_id(),
+        ids.archived_card_id,
+        "archived_cards marker entity_id"
+    );
+    assert_eq!(
+        archived_cards[0].context.board_id, ids.live_board_id,
+        "archived_cards marker board_id"
+    );
+
+    // Sprint present
+    let sprints = ctx.list_all_sprints()?;
+    assert!(
+        sprints.iter().any(|s| s.id == ids.sprint_id),
+        "sprint must be present"
+    );
+
+    // Dependency graph NOT exported — blocks edge must be absent
+    let graph = ctx.graph()?;
+    assert!(
+        graph.blocks_edges().is_empty(),
+        "blocks edge must be absent after import (graph is not part of AllBoardsExport)"
+    );
+
+    Ok(())
+}
+
+/// Export the full snapshot via `convert_snapshot_to_export` + `export_to_file`.
+/// This includes archived board heads (snapshot.boards has all board heads) and
+/// archived_boards markers, and correctly handles dangling-column archived cards.
+fn export_snapshot_to_json(ctx: &KanbanContext, export_path: &str) -> KanbanResult<()> {
+    let snapshot = ctx.snapshot()?;
+    let export = BoardImporter::convert_snapshot_to_export(snapshot);
+    BoardExporter::export_to_file(&export, export_path)
+        .map_err(|e| kanban_domain::KanbanError::Internal(format!("export_to_file failed: {e}")))
+}
+
+/// Import from `export_path` and apply to `ctx` via `apply_snapshot`.
+fn import_into_context(ctx: &KanbanContext, export_path: &str) -> KanbanResult<()> {
+    let import = BoardImporter::import_from_file(export_path).map_err(|e| {
+        kanban_domain::KanbanError::Internal(format!("import_from_file failed: {e}"))
+    })?;
+    let entities = BoardImporter::extract_entities(import);
+    let snapshot = Snapshot {
+        archived_boards: entities.archived_boards,
+        boards: entities.boards,
+        columns: entities.columns,
+        cards: entities.cards,
+        archived_cards: entities.archived_cards,
+        sprints: entities.sprints,
+        graph: DependencyGraph::default(),
+    };
+    ctx.apply_snapshot(snapshot)
+}
+
+// ── JSON backend test ─────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_import_round_trip_full_archival_graph_json() -> KanbanResult<()> {
+    let dir = tempdir().unwrap();
+    let source_path = dir.path().join("source.json");
+    let export_path = dir.path().join("export.json").to_string_lossy().to_string();
+    let dest_path = dir.path().join("dest.json");
+
+    // Seed
+    let ids = {
+        let mut ctx = open_json_ctx(&source_path).await;
+        let ids = seed_archival_graph(&mut ctx).await;
+        ctx.save().await?;
+        ids
+    };
+
+    // Export from source (fresh context to test reload-from-disk)
+    {
+        let ctx = open_json_ctx(&source_path).await;
+        export_snapshot_to_json(&ctx, &export_path)?;
+    }
+
+    // Import into fresh destination and assert
+    {
+        let ctx = open_json_ctx(&dest_path).await;
+        import_into_context(&ctx, &export_path)?;
+        ctx.save().await?;
+        assert_full_graph(&ctx, &ids)?;
+    }
+
+    // Reload from disk and re-assert durability
+    {
+        let ctx = open_json_ctx(&dest_path).await;
+        assert_full_graph(&ctx, &ids)?;
+    }
+
+    Ok(())
+}
+
+// ── SQLite backend test ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_import_round_trip_full_archival_graph_sqlite() -> KanbanResult<()> {
+    let dir = tempdir().unwrap();
+    let source_path = dir.path().join("source.sqlite");
+    let export_path = dir.path().join("export.json").to_string_lossy().to_string();
+    let dest_path = dir.path().join("dest.sqlite");
+
+    // Seed
+    let ids = {
+        let mut ctx = open_sqlite_ctx(&source_path).await;
+        let ids = seed_archival_graph(&mut ctx).await;
+        ctx.save().await?;
+        ids
+    };
+
+    // Export from source (fresh context to test reload-from-disk)
+    {
+        let ctx = open_sqlite_ctx(&source_path).await;
+        export_snapshot_to_json(&ctx, &export_path)?;
+    }
+
+    // Import into fresh destination and assert
+    {
+        let ctx = open_sqlite_ctx(&dest_path).await;
+        import_into_context(&ctx, &export_path)?;
+        ctx.save().await?;
+        assert_full_graph(&ctx, &ids)?;
+    }
+
+    // Reload from disk and re-assert durability
+    {
+        let ctx = open_sqlite_ctx(&dest_path).await;
+        assert_full_graph(&ctx, &ids)?;
+    }
+
+    Ok(())
+}

--- a/crates/kanban-tui/src/app/export_import.rs
+++ b/crates/kanban-tui/src/app/export_import.rs
@@ -10,9 +10,16 @@ impl App {
                 let columns = self.model.columns();
                 let cards = self.model.cards();
                 let archived_cards = self.model.archived_cards();
+                let archived_boards = self.model.archived_boards();
                 let sprints = self.model.sprints();
-                let board_export =
-                    BoardExporter::export_board(board, columns, cards, archived_cards, sprints);
+                let board_export = BoardExporter::export_board(
+                    board,
+                    columns,
+                    cards,
+                    archived_cards,
+                    archived_boards,
+                    sprints,
+                );
 
                 let export = AllBoardsExport {
                     boards: vec![board_export],
@@ -29,9 +36,16 @@ impl App {
         let columns = self.model.columns();
         let cards = self.model.cards();
         let archived_cards = self.model.archived_cards();
+        let archived_boards = self.model.archived_boards();
         let sprints = self.model.sprints();
-        let export =
-            BoardExporter::export_all_boards(boards, columns, cards, archived_cards, sprints);
+        let export = BoardExporter::export_all_boards(
+            boards,
+            columns,
+            cards,
+            archived_cards,
+            archived_boards,
+            sprints,
+        );
         BoardExporter::export_to_file(&export, self.input.as_str())?;
         Ok(())
     }
@@ -42,9 +56,16 @@ impl App {
             let columns = self.model.columns();
             let cards = self.model.cards();
             let archived_cards = self.model.archived_cards();
+            let archived_boards = self.model.archived_boards();
             let sprints = self.model.sprints();
-            let export =
-                BoardExporter::export_all_boards(boards, columns, cards, archived_cards, sprints);
+            let export = BoardExporter::export_all_boards(
+                boards,
+                columns,
+                cards,
+                archived_cards,
+                archived_boards,
+                sprints,
+            );
             BoardExporter::export_to_file(&export, filename)?;
         }
         Ok(())
@@ -92,7 +113,7 @@ impl App {
                     columns: entities.columns,
                     cards: entities.cards,
                     archived_cards: entities.archived_cards,
-                    archived_boards: vec![],
+                    archived_boards: entities.archived_boards,
                     sprints: entities.sprints,
                     graph: None,
                 },

--- a/crates/kanban-tui/src/app/export_import.rs
+++ b/crates/kanban-tui/src/app/export_import.rs
@@ -1,74 +1,62 @@
 use super::App;
 use kanban_domain::export::{AllBoardsExport, BoardExporter, BoardImporter};
 use std::io;
+use uuid::Uuid;
 
 impl App {
     pub fn export_board_with_filename(&self) -> io::Result<()> {
         if let Some(board_idx) = self.selection.board.get() {
-            let boards = self.model.boards();
-            if let Some(board) = boards.get(board_idx) {
-                let columns = self.model.columns();
-                let cards = self.model.cards();
-                let archived_cards = self.model.archived_cards();
-                let archived_boards = self.model.archived_boards();
-                let sprints = self.model.sprints();
-                let board_export = BoardExporter::export_board(
-                    board,
-                    columns,
-                    cards,
-                    archived_cards,
-                    archived_boards,
-                    sprints,
-                );
-
-                let export = AllBoardsExport {
-                    boards: vec![board_export],
-                };
-
+            let board_id = self.model.boards().get(board_idx).map(|b| b.id);
+            if let Some(board_id) = board_id {
+                let export = self.build_boards_export(&[board_id])?;
                 BoardExporter::export_to_file(&export, self.input.as_str())?;
             }
         }
         Ok(())
     }
 
+    /// Export ALL boards (live + archived) with their full subtrees. Routes
+    /// through the backend snapshot so an archived board's HEAD, its columns/
+    /// cards/sprints (which live in the flat collections under the archived
+    /// board_id), AND its `archived_boards` marker all round-trip. The
+    /// live-scoped model accessors omit archived boards and their subtrees, so
+    /// they must NOT be used here (KAN-895 regression).
     pub fn export_all_boards_with_filename(&self) -> io::Result<()> {
-        let boards = self.model.boards();
-        let columns = self.model.columns();
-        let cards = self.model.cards();
-        let archived_cards = self.model.archived_cards();
-        let archived_boards = self.model.archived_boards();
-        let sprints = self.model.sprints();
-        let export = BoardExporter::export_all_boards(
-            boards,
-            columns,
-            cards,
-            archived_cards,
-            archived_boards,
-            sprints,
-        );
+        let export = self.build_all_boards_export()?;
         BoardExporter::export_to_file(&export, self.input.as_str())?;
         Ok(())
     }
 
     pub fn auto_save(&self) -> io::Result<()> {
         if let Some(ref filename) = self.persistence.save_file {
-            let boards = self.model.boards();
-            let columns = self.model.columns();
-            let cards = self.model.cards();
-            let archived_cards = self.model.archived_cards();
-            let archived_boards = self.model.archived_boards();
-            let sprints = self.model.sprints();
-            let export = BoardExporter::export_all_boards(
-                boards,
-                columns,
-                cards,
-                archived_cards,
-                archived_boards,
-                sprints,
-            );
+            let export = self.build_all_boards_export()?;
             BoardExporter::export_to_file(&export, filename)?;
         }
         Ok(())
+    }
+
+    /// Build a full-fidelity `AllBoardsExport` from the backend snapshot
+    /// (`convert_snapshot_to_export`), which includes archived board heads and
+    /// their subtrees plus `archived_boards` markers, and handles dangling-column
+    /// archived cards.
+    fn build_all_boards_export(&self) -> io::Result<AllBoardsExport> {
+        let snapshot = self
+            .ctx
+            .snapshot()
+            .map_err(|e| io::Error::other(e.to_string()))?;
+        Ok(BoardImporter::convert_snapshot_to_export(snapshot))
+    }
+
+    /// Build an `AllBoardsExport` from the backend snapshot, keeping only the
+    /// boards in `board_ids` (preserving their order). Uses the snapshot path so
+    /// each board's archived-card live rows and markers round-trip correctly.
+    pub(crate) fn build_boards_export(&self, board_ids: &[Uuid]) -> io::Result<AllBoardsExport> {
+        let full = self.build_all_boards_export()?;
+        let selected: Vec<_> = board_ids
+            .iter()
+            .filter_map(|id| full.boards.iter().find(|be| be.board.id == *id).cloned())
+            .collect();
+        Ok(AllBoardsExport::from_boards(selected))
     }
 
     pub fn import_board_from_file(&mut self, filename: &str) -> io::Result<()> {

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -635,11 +635,21 @@ impl App {
         let columns = self.model.columns();
         let cards = self.model.cards();
         let archived = self.model.archived_cards();
+        let archived_boards = self.model.archived_boards();
         let sprints = self.model.sprints();
         let board_exports: Vec<_> = selected_indices
             .iter()
             .filter_map(|&i| boards.get(i))
-            .map(|board| BoardExporter::export_board(board, columns, cards, archived, sprints))
+            .map(|board| {
+                BoardExporter::export_board(
+                    board,
+                    columns,
+                    cards,
+                    archived,
+                    archived_boards,
+                    sprints,
+                )
+            })
             .collect();
 
         let export = AllBoardsExport::from_boards(board_exports);

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -3,7 +3,7 @@ use crate::edit_format::EditFormat;
 use crate::editor::edit_in_external_editor;
 use crate::events::EventHandler;
 use crossterm::event::KeyCode;
-use kanban_domain::export::{AllBoardsExport, BoardExporter};
+use kanban_domain::export::BoardExporter;
 use kanban_service::AppConfigDto;
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
@@ -632,27 +632,20 @@ impl App {
         }
 
         let boards = self.model.boards();
-        let columns = self.model.columns();
-        let cards = self.model.cards();
-        let archived = self.model.archived_cards();
-        let archived_boards = self.model.archived_boards();
-        let sprints = self.model.sprints();
-        let board_exports: Vec<_> = selected_indices
+        let selected_board_ids: Vec<_> = selected_indices
             .iter()
-            .filter_map(|&i| boards.get(i))
-            .map(|board| {
-                BoardExporter::export_board(
-                    board,
-                    columns,
-                    cards,
-                    archived,
-                    archived_boards,
-                    sprints,
-                )
-            })
+            .filter_map(|&i| boards.get(i).map(|b| b.id))
             .collect();
 
-        let export = AllBoardsExport::from_boards(board_exports);
+        // Route through the snapshot so each selected board's archived-card live
+        // rows and markers round-trip (the live-scoped model.cards() omits them).
+        let export = match self.build_boards_export(&selected_board_ids) {
+            Ok(export) => export,
+            Err(e) => {
+                self.set_error(format!("Export failed: {}", e));
+                return;
+            }
+        };
 
         match dialog.format {
             crate::app::ExportFormat::Json => {

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -1,0 +1,204 @@
+//! KAN-895 regression: the TUI File→Export-All path must fully round-trip an
+//! archived board — its HEAD, its entire subtree (columns / cards / sprints,
+//! which live in the flat collections under the archived board_id), AND its
+//! `archived_boards` marker (so it re-imports still archived, hidden from the
+//! live list).
+//!
+//! Before the fix, `export_all_boards_with_filename` / `auto_save` read the
+//! live-scoped `model.boards()` / `model.cards()`, so an archived board's head
+//! and subtree were omitted and the exported `archived_boards` marker referenced
+//! a board absent from the file → orphan / silent data loss on re-import. These
+//! tests drive the ACTUAL TUI export entry point (not the snapshot path
+//! directly).
+
+use kanban_domain::KanbanOperations;
+use kanban_tui::App;
+use tempfile::tempdir;
+
+#[test]
+fn test_tui_export_all_round_trips_archived_board_with_subtree() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("export_all_archived.json");
+
+    let mut app = App::test_default();
+
+    // A live board so the export is non-trivial and mixed.
+    let live_board = app
+        .ctx
+        .create_board("Live Board".to_string(), None)
+        .unwrap();
+    let live_col = app
+        .ctx
+        .create_column(live_board.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            live_board.id,
+            live_col.id,
+            "Live Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+
+    // The archived board WITH a full subtree: column, card, sprint.
+    let arch_board = app
+        .ctx
+        .create_board("Archived Board".to_string(), None)
+        .unwrap();
+    let arch_col = app
+        .ctx
+        .create_column(arch_board.id, "Backlog".to_string(), None)
+        .unwrap();
+    let arch_card = app
+        .ctx
+        .create_card(
+            arch_board.id,
+            arch_col.id,
+            "Archived Board Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    let arch_sprint = app
+        .ctx
+        .create_sprint(arch_board.id, Some("S".to_string()), None)
+        .unwrap();
+    app.ctx.archive_board(arch_board.id).unwrap();
+    app.prepare_frame();
+
+    // Sanity: the archived board head is hidden from the live list, present in
+    // the archived-boards view.
+    assert!(
+        app.model.boards().iter().all(|b| b.id != arch_board.id),
+        "archived board must be hidden from live list before export"
+    );
+    assert!(
+        app.model
+            .archived_boards_flat()
+            .iter()
+            .any(|b| b.id == arch_board.id),
+        "archived board head must be in the archived view before export"
+    );
+
+    // Drive the ACTUAL TUI File→Export-All entry point.
+    app.input.set(file_path.to_str().unwrap().to_string());
+    app.prepare_frame();
+    app.export_all_boards_with_filename().unwrap();
+
+    // Re-import into a FRESH app and assert the whole archived-board graph is back.
+    let mut app2 = App::test_default();
+    app2.import_board_from_file(file_path.to_str().unwrap())
+        .unwrap();
+    app2.prepare_frame();
+
+    // Live board still live.
+    assert!(
+        app2.model.boards().iter().any(|b| b.id == live_board.id),
+        "live board must be present after re-import"
+    );
+
+    // Archived board head is back AND still archived (hidden from live list,
+    // present in the archived view with its marker).
+    assert!(
+        app2.model.boards().iter().all(|b| b.id != arch_board.id),
+        "archived board must remain hidden from live list after re-import"
+    );
+    let archived_flat = app2.model.archived_boards_flat();
+    assert!(
+        archived_flat.iter().any(|b| b.id == arch_board.id),
+        "archived board head must round-trip and remain archived"
+    );
+    assert_eq!(
+        app2.model.archived_boards().len(),
+        1,
+        "exactly one archived_boards marker must survive"
+    );
+
+    // The archived board's SUBTREE must round-trip. Assert against the raw
+    // backend snapshot (the model's live-scoped views exclude archived-board
+    // descendants).
+    let snap = app2.ctx.snapshot().unwrap();
+    assert!(
+        snap.boards.iter().any(|b| b.id == arch_board.id),
+        "archived board head must be in the re-imported snapshot.boards"
+    );
+    assert!(
+        snap.columns.iter().any(|c| c.id == arch_col.id),
+        "archived board's column must round-trip"
+    );
+    assert!(
+        snap.cards.iter().any(|c| c.id == arch_card.id),
+        "archived board's card must round-trip"
+    );
+    assert!(
+        snap.sprints.iter().any(|s| s.id == arch_sprint.id),
+        "archived board's sprint must round-trip"
+    );
+    assert!(
+        snap.archived_boards
+            .iter()
+            .any(|ab| ab.entity_id == arch_board.id),
+        "archived_boards marker must reference the re-imported board head (no orphan)"
+    );
+}
+
+#[test]
+fn test_tui_auto_save_round_trips_archived_board_with_subtree() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("autosave_archived.json");
+
+    let mut app = App::test_default();
+    app.persistence.save_file = Some(file_path.to_str().unwrap().to_string());
+
+    let arch_board = app
+        .ctx
+        .create_board("Archived Board".to_string(), None)
+        .unwrap();
+    let arch_col = app
+        .ctx
+        .create_column(arch_board.id, "Backlog".to_string(), None)
+        .unwrap();
+    let arch_card = app
+        .ctx
+        .create_card(
+            arch_board.id,
+            arch_col.id,
+            "Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    app.ctx.archive_board(arch_board.id).unwrap();
+    app.prepare_frame();
+
+    // Drive the ACTUAL auto-save entry point.
+    app.auto_save().unwrap();
+
+    let mut app2 = App::test_default();
+    app2.import_board_from_file(file_path.to_str().unwrap())
+        .unwrap();
+    app2.prepare_frame();
+
+    assert_eq!(
+        app2.model.archived_boards().len(),
+        1,
+        "archived_boards marker must survive auto_save round-trip"
+    );
+    let snap = app2.ctx.snapshot().unwrap();
+    assert!(
+        snap.boards.iter().any(|b| b.id == arch_board.id),
+        "archived board head must survive auto_save round-trip"
+    );
+    assert!(
+        snap.columns.iter().any(|c| c.id == arch_col.id),
+        "archived board column must survive auto_save round-trip"
+    );
+    assert!(
+        snap.cards.iter().any(|c| c.id == arch_card.id),
+        "archived board card must survive auto_save round-trip"
+    );
+    assert!(
+        snap.archived_boards
+            .iter()
+            .any(|ab| ab.entity_id == arch_board.id),
+        "archived_boards marker must not be orphaned after auto_save round-trip"
+    );
+}


### PR DESCRIPTION
## Summary

- **KAN-895 (HIGH, data loss):** `BoardExport` / `AllBoardsExport` now carry `archived_boards: Vec<ArchivedBoard>`. `export_board` / `export_all_boards` accept `all_archived_boards` and filter per-board. Archived cards are scoped by first-class `board_id` (not column membership), and their live rows are carried via a union of column-id membership and archived-card-id set so dangling-column archived cards no longer produce orphan markers on re-import. `convert_snapshot_to_export` and `extract_entities` carry the same fix through the V2 snapshot path. `export_to_sqlite` now passes `entities.archived_boards` instead of `Vec::new()`. The V1 import path passes `entities.archived_boards` instead of `vec![]`.

- **KAN-895 TUI path (the user-facing REGR-5 bug):** File→Export-All (`export_all_boards_with_filename`), `auto_save`, single-board export, and the multi-board export dialog previously read the live-scoped `model.boards()` / `model.cards()`, which OMIT archived board heads and their entire subtrees (columns/cards/sprints live in the flat collections under the archived board_id) and exclude archived-card live rows. The exported `archived_boards` markers then referenced boards absent from the file → orphan / silent data loss on re-import. All TUI export paths now route through `ctx.snapshot()` + `convert_snapshot_to_export`, which carries every board head, full subtrees, and markers. Single-board / dialog exports use a `build_boards_export(&[ids])` helper that filters the snapshot export to the selected boards.

- **KAN-909 (test):** Domain-level round-trip tests (archived card row + marker, dangling-column card, archived board), two service-level integration tests against real JSON and SQLite backends (full graph + reload-from-disk durability), and two TUI integration tests that drive the ACTUAL File→Export-All and auto_save entry points and assert an archived board round-trips head + subtree + still-archived status. The TUI export test was verified red against the pre-fix live-scoped export body.

- **KAN-897 (LOW, chore):** Removed the dead `entry.get_mut("card")` block in `repair_snapshot_fks` (store_manager.rs). After V10 migration, `archived_cards` entries are pure markers; the live row is already repaired by the `cards` loop. Replaced with a clarifying comment and added two drift-guard tests that pin the marker-shape contract.

## Test plan

- [x] `cargo test -p kanban-domain` green (628 passed)
- [x] `cargo test -p kanban-service --features sqlite` green (612 passed, incl. 2 new round-trip tests)
- [x] `cargo test -p kanban-tui` green (612 passed, incl. 2 new archived-board round-trip tests)
- [x] `cargo clippy -p {kanban-domain,kanban-service --features sqlite,kanban-tui} --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean