### PR TITLE
KAN-891 feat(tui): archived-board full interaction parity + view fixes (regression cluster)

### DIFF
--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -435,6 +435,37 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => self.handle_navigation_down(),
             KeyCode::Char('k') | KeyCode::Up => self.handle_navigation_up(),
+            KeyCode::Char('g') => {
+                if self.pending_key == Some('g') {
+                    self.pending_key = None;
+                    self.selection.board.jump_to_first();
+                } else {
+                    self.pending_key = Some('g');
+                }
+            }
+            KeyCode::Char('G') => {
+                self.pending_key = None;
+                let len = self.model.archived_boards_flat().len();
+                self.selection.board.jump_to_last(len);
+            }
+            KeyCode::Char('u') => {
+                self.pending_key = None;
+                if let Err(e) = self.undo() {
+                    self.set_error(format!("Undo failed: {e}"));
+                }
+                self.prepare_frame();
+                let remaining = self.model.archived_boards_flat().len();
+                self.selection.board.clamp(remaining);
+            }
+            KeyCode::Char('U') => {
+                self.pending_key = None;
+                if let Err(e) = self.redo() {
+                    self.set_error(format!("Redo failed: {e}"));
+                }
+                self.prepare_frame();
+                let remaining = self.model.archived_boards_flat().len();
+                self.selection.board.clamp(remaining);
+            }
             _ => {}
         }
     }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -46,6 +46,7 @@ impl App {
                     | AppMode::ArchivedBoardsView
                     | AppMode::Dialog(DialogMode::DeleteBoardConfirm)
                     | AppMode::Dialog(DialogMode::DeleteColumnConfirm)
+                    | AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)
             )
         {
             self.handle_quit_key();
@@ -365,6 +366,9 @@ impl App {
                 DialogMode::CarryOverSprint => self.handle_carry_over_sprint_popup(key.code),
                 DialogMode::ExportBoards => self.handle_export_boards_dialog(key.code),
                 DialogMode::ChooseStorageFile => self.handle_choose_storage_file_dialog(key.code),
+                DialogMode::DeletePermanentBoardConfirm => {
+                    self.handle_delete_permanent_board_confirm_popup(key.code)
+                }
             },
         }
         should_restart_events

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -433,7 +433,7 @@ impl App {
         match key_code {
             KeyCode::Enter => self.handle_open_archived_board(),
             KeyCode::Char('r') => self.handle_restore_board(),
-            KeyCode::Char('x') => self.handle_delete_archived_board(),
+            KeyCode::Char('x') => self.handle_delete_archived_board_key(),
             KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {
                 self.handle_toggle_archived_boards_view();
             }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -417,11 +417,17 @@ impl App {
     /// boards view, `j`/`k` navigate. The Boards panel is the context here.
     pub fn handle_archived_boards_view_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
-        if self.focus.active != Focus::Boards {
+        // When drilled into an archived board the focus moves to Cards; don't
+        // force it back to Boards — the escape arm in handle_escape returns focus
+        // to Boards when the user presses Esc.
+        if self.focus.active != Focus::Boards
+            && self.selection.active_archived_board_index.is_none()
+        {
             self.focus.active = Focus::Boards;
         }
 
         match key_code {
+            KeyCode::Enter => self.handle_open_archived_board(),
             KeyCode::Char('r') => self.handle_restore_board(),
             KeyCode::Char('x') => self.handle_delete_archived_board(),
             KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {

--- a/crates/kanban-tui/src/app/mode.rs
+++ b/crates/kanban-tui/src/app/mode.rs
@@ -30,6 +30,7 @@ pub enum DialogMode {
     CarryOverSprint,
     ExportBoards,
     ChooseStorageFile,
+    DeletePermanentBoardConfirm,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -5,6 +5,10 @@ use std::cell::Cell;
 pub struct SelectionHub {
     pub board: SelectionState,
     pub active_board_index: Option<usize>,
+    /// When `Some`, the user has drilled into the archived board at this index
+    /// in `model.archived_boards_flat()`. Exactly one of `active_board_index`
+    /// and `active_archived_board_index` is `Some` at a time.
+    pub active_archived_board_index: Option<usize>,
     pub active_card_id: Option<uuid::Uuid>,
     pub sprint: SelectionState,
     pub sprint_scroll: Cell<usize>,

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -1,8 +1,28 @@
 use super::{App, AppMode};
 use crate::view_strategy::{UnifiedViewStrategy, ViewRefreshContext, ViewStrategy};
-use kanban_domain::{Card, KanbanResult};
+use kanban_domain::{Board, Card, KanbanResult};
 
 impl App {
+    /// Resolve the board currently being viewed (drilled into) — either a live
+    /// board (when `active_board_index` is set) or an archived board head (when
+    /// `active_archived_board_index` is set). Returns `None` when no board is
+    /// active (e.g. the user is browsing the boards list without opening one).
+    ///
+    /// Note: `prepare_frame` inlines the equivalent resolution instead of calling
+    /// this helper because it also needs a mutable borrow of `self.view.strategy`
+    /// in the same scope, which Rust's NLL cannot split through a method boundary.
+    /// All other call sites use this helper directly.
+    pub fn viewed_board(&self) -> Option<&Board> {
+        if let Some(ai) = self.selection.active_archived_board_index {
+            self.model.archived_boards_flat().get(ai)
+        } else {
+            self.selection
+                .active_board_index
+                .or(self.selection.board.get())
+                .and_then(|idx| self.model.boards().get(idx))
+        }
+    }
+
     pub fn prepare_frame(&mut self) {
         match self.ctx.snapshot() {
             Ok(snapshot) => self.model.load_from_snapshot(snapshot),
@@ -15,28 +35,36 @@ impl App {
             self.model.cards()
         };
 
-        let board_idx = self
-            .selection
-            .active_board_index
-            .or(self.selection.board.get());
-        if let Some(idx) = board_idx {
-            if let Some(board) = self.model.boards().get(idx) {
-                let search_query = if self.filter.search.is_active {
-                    Some(self.filter.search.query())
-                } else {
-                    None
-                };
-                let ctx = ViewRefreshContext {
-                    board,
-                    all_cards: cards_for_display,
-                    all_columns: self.model.columns(),
-                    all_sprints: self.model.sprints(),
-                    active_sprint_filters: self.filter.active_sprint_filters.clone(),
-                    hide_assigned_cards: self.filter.hide_assigned_cards,
-                    search_query,
-                };
-                self.view.strategy.refresh_task_lists(&ctx);
-            }
+        // Board resolution: inlined here because a call to `self.viewed_board()`
+        // (returning `Option<&Board>`) would borrow `self` immutably while
+        // `self.view.strategy.refresh_task_lists` below needs a mutable borrow
+        // of `self.view.strategy`. Rust NLL cannot split these through a method
+        // call boundary, so we inline the same logic.
+        let board: Option<&Board> = if let Some(ai) = self.selection.active_archived_board_index {
+            self.model.archived_boards_flat().get(ai)
+        } else {
+            self.selection
+                .active_board_index
+                .or(self.selection.board.get())
+                .and_then(|idx| self.model.boards().get(idx))
+        };
+
+        if let Some(board) = board {
+            let search_query = if self.filter.search.is_active {
+                Some(self.filter.search.query())
+            } else {
+                None
+            };
+            let ctx = ViewRefreshContext {
+                board,
+                all_cards: cards_for_display,
+                all_columns: self.model.columns(),
+                all_sprints: self.model.sprints(),
+                active_sprint_filters: self.filter.active_sprint_filters.clone(),
+                hide_assigned_cards: self.filter.hide_assigned_cards,
+                search_query,
+            };
+            self.view.strategy.refresh_task_lists(&ctx);
         }
         self.sync_card_list_component();
     }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -118,6 +118,13 @@ impl App {
         }
     }
 
+    /// Open the `DeletePermanentBoardConfirm` dialog for the highlighted archived
+    /// board. Called when `x` is pressed in ArchivedBoardsView.
+    pub fn handle_delete_archived_board_key(&mut self) {}
+
+    /// Handle a key press inside the `DeletePermanentBoardConfirm` dialog.
+    pub fn handle_delete_permanent_board_confirm_popup(&mut self, _key_code: KeyCode) {}
+
     /// Drill into the highlighted archived board: populate the tasks panel from
     /// its (still-live) subtree and focus Cards, exactly like a live board — but
     /// keyed on the archived flat list. The board head stays archived.

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -118,6 +118,9 @@ impl App {
         }
     }
 
+    /// Drill into the highlighted archived board (stub; full impl in KAN-891 feat).
+    pub fn handle_open_archived_board(&mut self) {}
+
     /// ARCHIVE the highlighted board (the primary "remove from live" action,
     /// mirroring the card panel's `d`). Its subtree stays in place; the board head
     /// moves to the archived-boards view where it can be restored or permanently
@@ -904,5 +907,144 @@ mod tests {
             app.dialog_input.board_delete_counts, None,
             "stash cleared on close"
         );
+    }
+
+    // KAN-891: archived-board drill-down tests
+
+    fn seed_archived_board_with_cards(app: &mut App, name: &str) -> (uuid::Uuid, uuid::Uuid) {
+        create_named_board(app, name);
+        let board_id = app
+            .ctx
+            .data_store()
+            .list_boards()
+            .unwrap()
+            .into_iter()
+            .find(|b| b.name == name)
+            .unwrap()
+            .id;
+        let col_id = first_column_id(app, board_id);
+        app.ctx
+            .create_card(board_id, col_id, "Card1".into(), CreateCardOptions::default())
+            .unwrap();
+        app.ctx
+            .create_card(board_id, col_id, "Card2".into(), CreateCardOptions::default())
+            .unwrap();
+        app.ctx.archive_board(board_id).unwrap();
+        refresh(app);
+        (board_id, col_id)
+    }
+
+    #[test]
+    fn test_open_archived_board_populates_its_own_tasks() {
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Live");
+        let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "Arch");
+
+        app.focus.active = Focus::Boards;
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.selection.board.set(Some(0));
+
+        app.handle_open_archived_board();
+
+        assert_eq!(app.selection.active_archived_board_index, Some(0));
+        assert_eq!(app.selection.active_board_index, None);
+        assert_eq!(app.focus.active, Focus::Cards);
+        let task_count = app
+            .view
+            .strategy
+            .get_active_task_list()
+            .map(|l| l.len())
+            .unwrap_or(0);
+        assert_eq!(task_count, 2, "task list must show archived board's 2 cards");
+        assert!(
+            app.ctx
+                .list_archived_boards()
+                .unwrap()
+                .iter()
+                .any(|ab| ab.entity_id == arch_board_id),
+            "board remains archived after drill-down"
+        );
+    }
+
+    #[test]
+    fn test_open_archived_board_with_zero_live_boards_still_opens() {
+        let mut app = App::test_default();
+        let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "OnlyBoard");
+
+        app.focus.active = Focus::Boards;
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.selection.board.set(Some(0));
+
+        app.handle_open_archived_board();
+
+        assert_eq!(app.selection.active_archived_board_index, Some(0));
+        assert_eq!(app.selection.active_board_index, None);
+        assert_eq!(app.focus.active, Focus::Cards);
+        assert!(
+            app.ctx
+                .list_archived_boards()
+                .unwrap()
+                .iter()
+                .any(|ab| ab.entity_id == arch_board_id),
+            "board still archived"
+        );
+    }
+
+    #[test]
+    fn test_enter_card_in_archived_board_opens_detail() {
+        let mut app = App::test_default();
+        let (_, _) = seed_archived_board_with_cards(&mut app, "Arch");
+        app.focus.active = Focus::Boards;
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.selection.board.set(Some(0));
+
+        app.handle_open_archived_board();
+
+        assert_eq!(app.focus.active, Focus::Cards);
+        if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+            list.set_selected_index(Some(0));
+        }
+
+        app.handle_selection_activate();
+
+        assert_eq!(app.mode, AppMode::CardDetail);
+        assert!(app.selection.active_card_id.is_some());
+    }
+
+    #[test]
+    fn test_escape_from_archived_board_drilldown_returns_to_archived_list() {
+        let mut app = App::test_default();
+        let (_, _) = seed_archived_board_with_cards(&mut app, "Arch");
+        app.focus.active = Focus::Boards;
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.selection.board.set(Some(0));
+        app.handle_open_archived_board();
+
+        app.handle_escape_key();
+
+        assert_eq!(app.selection.active_archived_board_index, None);
+        assert_eq!(app.focus.active, Focus::Boards);
+        assert_eq!(app.mode, AppMode::ArchivedBoardsView);
+    }
+
+    #[test]
+    fn test_restore_clears_active_archived_board_index() {
+        let mut app = App::test_default();
+        let (_, _) = seed_archived_board_with_cards(&mut app, "Arch");
+        app.focus.active = Focus::Boards;
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.selection.board.set(Some(0));
+        app.handle_open_archived_board();
+        assert_eq!(app.selection.active_archived_board_index, Some(0));
+
+        app.focus.active = Focus::Boards;
+        app.handle_restore_board();
+
+        assert_eq!(app.selection.active_archived_board_index, None);
     }
 }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -120,10 +120,36 @@ impl App {
 
     /// Open the `DeletePermanentBoardConfirm` dialog for the highlighted archived
     /// board. Called when `x` is pressed in ArchivedBoardsView.
-    pub fn handle_delete_archived_board_key(&mut self) {}
+    pub fn handle_delete_archived_board_key(&mut self) {
+        if self.mode != AppMode::ArchivedBoardsView {
+            return;
+        }
+        let Some(board_id) = self.selected_archived_board_id() else {
+            return;
+        };
+        self.dialog_input.board_delete_counts = Some(self.board_delete_counts(board_id));
+        self.open_dialog(DialogMode::DeletePermanentBoardConfirm);
+    }
 
     /// Handle a key press inside the `DeletePermanentBoardConfirm` dialog.
-    pub fn handle_delete_permanent_board_confirm_popup(&mut self, _key_code: KeyCode) {}
+    pub fn handle_delete_permanent_board_confirm_popup(&mut self, key_code: KeyCode) {
+        match key_code {
+            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+                self.handle_delete_archived_board();
+                self.pop_mode();
+                self.dialog_input.board_delete_counts = None;
+            }
+            KeyCode::Char('n')
+            | KeyCode::Char('N')
+            | KeyCode::Char('q')
+            | KeyCode::Char('Q')
+            | KeyCode::Esc => {
+                self.pop_mode();
+                self.dialog_input.board_delete_counts = None;
+            }
+            _ => {}
+        }
+    }
 
     /// Drill into the highlighted archived board: populate the tasks panel from
     /// its (still-live) subtree and focus Cards, exactly like a live board — but
@@ -312,11 +338,8 @@ impl App {
     }
 
     /// Permanently delete the highlighted archived board and its subtree (direct,
-    /// mirroring the archived-cards permanent delete).
+    /// called after the `DeletePermanentBoardConfirm` dialog confirms).
     pub fn handle_delete_archived_board(&mut self) {
-        if self.mode != AppMode::ArchivedBoardsView {
-            return;
-        }
         let Some(board_id) = self.selected_archived_board_id() else {
             return;
         };

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -118,8 +118,36 @@ impl App {
         }
     }
 
-    /// Drill into the highlighted archived board (stub; full impl in KAN-891 feat).
-    pub fn handle_open_archived_board(&mut self) {}
+    /// Drill into the highlighted archived board: populate the tasks panel from
+    /// its (still-live) subtree and focus Cards, exactly like a live board — but
+    /// keyed on the archived flat list. The board head stays archived.
+    pub fn handle_open_archived_board(&mut self) {
+        let Some(idx) = self.selection.board.get() else {
+            return;
+        };
+        let Some(board) = self.model.archived_boards_flat().get(idx) else {
+            return;
+        };
+        let (view, sort_field, sort_order) = (
+            board.task_list_view,
+            board.task_sort_field,
+            board.task_sort_order,
+        );
+        self.selection.active_archived_board_index = Some(idx);
+        self.selection.active_board_index = None;
+        self.filter.current_sort_field = Some(sort_field);
+        self.filter.current_sort_order = Some(sort_order);
+        self.switch_view_strategy(view);
+        self.prepare_frame();
+        if let Some(list) = self.view.strategy.get_active_task_list_mut() {
+            if !list.is_empty() {
+                list.set_selected_index(Some(0));
+                list.ensure_selected_visible(self.view.viewport_height);
+            }
+        }
+        self.focus.active = Focus::Cards;
+        self.needs_redraw = true;
+    }
 
     /// ARCHIVE the highlighted board (the primary "remove from live" action,
     /// mirroring the card panel's `d`). Its subtree stays in place; the board head
@@ -226,6 +254,7 @@ impl App {
         match self.mode {
             AppMode::Normal if self.focus.active == Focus::Boards => {
                 self.mode = AppMode::ArchivedBoardsView;
+                self.selection.active_archived_board_index = None;
                 self.prepare_frame();
                 // Select the first archived board (if any).
                 let has_any = !self.model.archived_boards_flat().is_empty();
@@ -234,6 +263,7 @@ impl App {
             }
             AppMode::ArchivedBoardsView => {
                 self.mode = AppMode::Normal;
+                self.selection.active_archived_board_index = None;
                 self.prepare_frame();
                 let has_any = !self.model.boards().is_empty();
                 self.selection.board.set(has_any.then_some(0));
@@ -264,6 +294,7 @@ impl App {
             return;
         }
         tracing::info!("Restored board {}", board_id);
+        self.selection.active_archived_board_index = None;
         self.prepare_frame();
         // Clamp the highlight to the shrunken archived list.
         let remaining = self.model.archived_boards_flat().len();

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -985,10 +985,20 @@ mod tests {
             .id;
         let col_id = first_column_id(app, board_id);
         app.ctx
-            .create_card(board_id, col_id, "Card1".into(), CreateCardOptions::default())
+            .create_card(
+                board_id,
+                col_id,
+                "Card1".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         app.ctx
-            .create_card(board_id, col_id, "Card2".into(), CreateCardOptions::default())
+            .create_card(
+                board_id,
+                col_id,
+                "Card2".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         app.ctx.archive_board(board_id).unwrap();
         refresh(app);
@@ -1017,7 +1027,10 @@ mod tests {
             .get_active_task_list()
             .map(|l| l.len())
             .unwrap_or(0);
-        assert_eq!(task_count, 2, "task list must show archived board's 2 cards");
+        assert_eq!(
+            task_count, 2,
+            "task list must show archived board's 2 cards"
+        );
         assert!(
             app.ctx
                 .list_archived_boards()

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -1018,6 +1018,196 @@ mod tests {
         assert_eq!(find_current_page(&pages, 22), None);
     }
 
+    // KAN-892: ArchivedBoardsView navigation bounded by archived list length
+
+    fn seed_two_archived_boards(app: &mut crate::App) {
+        use kanban_domain::KanbanOperations;
+        let b1 = app
+            .ctx
+            .inner_mut()
+            .create_board("Arch1".to_string(), None)
+            .unwrap();
+        let b2 = app
+            .ctx
+            .inner_mut()
+            .create_board("Arch2".to_string(), None)
+            .unwrap();
+        app.ctx.inner_mut().archive_board(b1.id).unwrap();
+        app.ctx.inner_mut().archive_board(b2.id).unwrap();
+        let snap = app.ctx.snapshot().unwrap();
+        app.model.load_from_snapshot(snap);
+    }
+
+    #[test]
+    fn test_archived_view_j_moves_when_no_live_boards() {
+        let mut app = crate::App::test_default();
+        seed_two_archived_boards(&mut app);
+        app.mode = AppMode::ArchivedBoardsView;
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        app.handle_navigation_down();
+
+        assert_eq!(
+            app.selection.board.get(),
+            Some(1),
+            "j must move to index 1 in archived view even with no live boards"
+        );
+    }
+
+    #[test]
+    fn test_archived_view_j_clamps_to_archived_len_not_live_len() {
+        use kanban_domain::KanbanOperations;
+        let mut app = crate::App::test_default();
+        app.ctx
+            .inner_mut()
+            .create_board("Live".to_string(), None)
+            .unwrap();
+        let b1 = app
+            .ctx
+            .inner_mut()
+            .create_board("Arch1".to_string(), None)
+            .unwrap();
+        let b2 = app
+            .ctx
+            .inner_mut()
+            .create_board("Arch2".to_string(), None)
+            .unwrap();
+        let b3 = app
+            .ctx
+            .inner_mut()
+            .create_board("Arch3".to_string(), None)
+            .unwrap();
+        app.ctx.inner_mut().archive_board(b1.id).unwrap();
+        app.ctx.inner_mut().archive_board(b2.id).unwrap();
+        app.ctx.inner_mut().archive_board(b3.id).unwrap();
+        let snap = app.ctx.snapshot().unwrap();
+        app.model.load_from_snapshot(snap);
+        app.mode = AppMode::ArchivedBoardsView;
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        app.handle_navigation_down();
+        app.handle_navigation_down();
+        app.handle_navigation_down();
+
+        assert_eq!(
+            app.selection.board.get(),
+            Some(2),
+            "after 3 j presses, should clamp at archived_len-1=2, not live_len-1=0"
+        );
+    }
+
+    #[test]
+    fn test_archived_view_g_jumps_to_last_archived() {
+        use kanban_domain::KanbanOperations;
+        let mut app = crate::App::test_default();
+        app.ctx
+            .inner_mut()
+            .create_board("Live".to_string(), None)
+            .unwrap();
+        let b1 = app
+            .ctx
+            .inner_mut()
+            .create_board("Arch1".to_string(), None)
+            .unwrap();
+        let b2 = app
+            .ctx
+            .inner_mut()
+            .create_board("Arch2".to_string(), None)
+            .unwrap();
+        let b3 = app
+            .ctx
+            .inner_mut()
+            .create_board("Arch3".to_string(), None)
+            .unwrap();
+        app.ctx.inner_mut().archive_board(b1.id).unwrap();
+        app.ctx.inner_mut().archive_board(b2.id).unwrap();
+        app.ctx.inner_mut().archive_board(b3.id).unwrap();
+        let snap = app.ctx.snapshot().unwrap();
+        app.model.load_from_snapshot(snap);
+        app.mode = AppMode::ArchivedBoardsView;
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        app.handle_jump_to_bottom();
+
+        assert_eq!(
+            app.selection.board.get(),
+            Some(2),
+            "G should jump to archived_len-1=2"
+        );
+    }
+
+    #[test]
+    fn test_archived_view_navigation_does_not_switch_view_strategy() {
+        use crate::layout_strategy::SingleListLayout;
+        use crate::view_strategy::UnifiedViewStrategy;
+        let mut app = crate::App::test_default();
+        seed_two_archived_boards(&mut app);
+        app.mode = AppMode::ArchivedBoardsView;
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        app.switch_view_strategy(kanban_domain::TaskListView::Flat);
+
+        app.handle_navigation_down();
+
+        let is_flat = app
+            .view
+            .strategy
+            .as_any()
+            .downcast_ref::<UnifiedViewStrategy>()
+            .map(|s| {
+                s.get_layout_strategy()
+                    .as_any()
+                    .downcast_ref::<SingleListLayout>()
+                    .is_some()
+            })
+            .unwrap_or(false);
+        assert!(
+            is_flat,
+            "navigation in ArchivedBoardsView must not switch view strategy"
+        );
+    }
+
+    #[test]
+    fn test_live_view_navigation_still_bounded_by_live_count() {
+        use kanban_domain::KanbanOperations;
+        let mut app = crate::App::test_default();
+        app.ctx
+            .inner_mut()
+            .create_board("Live1".to_string(), None)
+            .unwrap();
+        app.ctx
+            .inner_mut()
+            .create_board("Live2".to_string(), None)
+            .unwrap();
+        for i in 0..5 {
+            let b = app
+                .ctx
+                .inner_mut()
+                .create_board(format!("Arch{i}"), None)
+                .unwrap();
+            app.ctx.inner_mut().archive_board(b.id).unwrap();
+        }
+        let snap = app.ctx.snapshot().unwrap();
+        app.model.load_from_snapshot(snap);
+        app.mode = AppMode::Normal;
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        for _ in 0..10 {
+            app.handle_navigation_down();
+        }
+
+        assert_eq!(
+            app.selection.board.get(),
+            Some(1),
+            "live view navigation must clamp at live_count-1=1"
+        );
+    }
+
     // KAN-893: is_kanban_view must return false in ArchivedBoardsView
 
     fn make_app_with_columnview_active_board() -> crate::App {

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -301,39 +301,33 @@ impl App {
     /// Compute page boundaries appropriate for the current view mode
     fn compute_pages_for_current_view(&self, total_items: usize) -> Vec<PageBoundary> {
         // For GroupedByColumn view, use header-aware pagination
-        if let Some(board_idx) = self
-            .selection
-            .active_board_index
-            .or(self.selection.board.get())
-        {
-            if let Some(board) = self.model.boards().get(board_idx) {
-                if board.task_list_view == TaskListView::GroupedByColumn {
-                    // Try to get column boundaries for header-aware pagination
-                    if let Some(unified) = self
-                        .view
-                        .strategy
+        if let Some(board) = self.viewed_board() {
+            if board.task_list_view == TaskListView::GroupedByColumn {
+                // Try to get column boundaries for header-aware pagination
+                if let Some(unified) = self
+                    .view
+                    .strategy
+                    .as_any()
+                    .downcast_ref::<UnifiedViewStrategy>()
+                {
+                    use crate::layout_strategy::VirtualUnifiedLayout;
+
+                    if let Some(layout) = unified
+                        .get_layout_strategy()
                         .as_any()
-                        .downcast_ref::<UnifiedViewStrategy>()
+                        .downcast_ref::<VirtualUnifiedLayout>()
                     {
-                        use crate::layout_strategy::VirtualUnifiedLayout;
+                        let boundaries = layout.get_column_boundaries();
+                        let column_boundaries: Vec<(usize, usize)> = boundaries
+                            .iter()
+                            .map(|b| (b.start_index, b.card_count))
+                            .collect();
 
-                        if let Some(layout) = unified
-                            .get_layout_strategy()
-                            .as_any()
-                            .downcast_ref::<VirtualUnifiedLayout>()
-                        {
-                            let boundaries = layout.get_column_boundaries();
-                            let column_boundaries: Vec<(usize, usize)> = boundaries
-                                .iter()
-                                .map(|b| (b.start_index, b.card_count))
-                                .collect();
-
-                            return compute_page_boundaries_with_headers(
-                                total_items,
-                                self.view.viewport_height,
-                                &column_boundaries,
-                            );
-                        }
+                        return compute_page_boundaries_with_headers(
+                            total_items,
+                            self.view.viewport_height,
+                            &column_boundaries,
+                        );
                     }
                 }
             }
@@ -521,6 +515,15 @@ impl App {
             return;
         }
 
+        // When drilled into an archived board, escape returns to the archived
+        // boards list (not the live boards Normal mode).
+        if self.selection.active_archived_board_index.is_some() {
+            self.selection.active_archived_board_index = None;
+            self.focus.active = Focus::Boards;
+            self.switch_view_strategy(TaskListView::GroupedByColumn);
+            return;
+        }
+
         if self.selection.active_board_index.is_some() {
             self.selection.active_board_index = None;
             self.focus.active = Focus::Boards;
@@ -532,18 +535,15 @@ impl App {
     pub fn is_kanban_view(&self) -> bool {
         // ArchivedBoardsView always uses the split projects+tasks layout so the
         // archived projects list is visible regardless of any live board's view
-        // mode (KAN-893).
-        if self.mode == AppMode::ArchivedBoardsView {
+        // mode (KAN-893). When drilled into an archived board, resolve that
+        // board's view from the archived flat list instead.
+        if self.mode == AppMode::ArchivedBoardsView
+            && self.selection.active_archived_board_index.is_none()
+        {
             return false;
         }
-        if let Some(board_idx) = self
-            .selection
-            .active_board_index
-            .or(self.selection.board.get())
-        {
-            if let Some(board) = self.model.boards().get(board_idx) {
-                return board.task_list_view == TaskListView::ColumnView;
-            }
+        if let Some(board) = self.viewed_board() {
+            return board.task_list_view == TaskListView::ColumnView;
         }
         false
     }

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -1011,4 +1011,50 @@ mod tests {
         assert_eq!(find_current_page(&pages, 21), Some(2));
         assert_eq!(find_current_page(&pages, 22), None);
     }
+
+    // KAN-893: is_kanban_view must return false in ArchivedBoardsView
+
+    fn make_app_with_columnview_active_board() -> crate::App {
+        use kanban_domain::{BoardUpdate, KanbanOperations};
+        let mut app = crate::App::test_default();
+        let board = app
+            .ctx
+            .inner_mut()
+            .create_board("ColView".to_string(), None)
+            .unwrap();
+        app.ctx
+            .inner_mut()
+            .update_board(
+                board.id,
+                BoardUpdate {
+                    task_list_view: Some(kanban_domain::TaskListView::ColumnView),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let snap = app.ctx.snapshot().unwrap();
+        app.model.load_from_snapshot(snap);
+        app.selection.active_board_index = Some(0);
+        app
+    }
+
+    #[test]
+    fn test_is_kanban_view_false_in_archived_boards_view() {
+        let mut app = make_app_with_columnview_active_board();
+        app.mode = AppMode::ArchivedBoardsView;
+        assert!(
+            !app.is_kanban_view(),
+            "ArchivedBoardsView must never be treated as kanban view"
+        );
+    }
+
+    #[test]
+    fn test_is_kanban_view_true_for_columnview_active_board_in_normal_mode() {
+        let app = make_app_with_columnview_active_board();
+        assert_eq!(app.mode, AppMode::Normal);
+        assert!(
+            app.is_kanban_view(),
+            "Normal mode with ColumnView active board must be kanban view"
+        );
+    }
 }

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -359,8 +359,10 @@ impl App {
     pub fn handle_navigation_down(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                self.selection.board.next(self.model.boards().len());
-                self.switch_view_strategy(TaskListView::GroupedByColumn);
+                self.selection.board.next(self.displayed_board_count());
+                if self.mode != AppMode::ArchivedBoardsView {
+                    self.switch_view_strategy(TaskListView::GroupedByColumn);
+                }
             }
             Focus::Cards => {
                 // Get initial adjusted viewport before mutable borrow
@@ -406,7 +408,9 @@ impl App {
         match self.focus.active {
             Focus::Boards => {
                 self.selection.board.prev();
-                self.switch_view_strategy(TaskListView::GroupedByColumn);
+                if self.mode != AppMode::ArchivedBoardsView {
+                    self.switch_view_strategy(TaskListView::GroupedByColumn);
+                }
             }
             Focus::Cards => {
                 // Get initial adjusted viewport before mutable borrow
@@ -544,6 +548,16 @@ impl App {
         false
     }
 
+    /// Number of boards currently shown in the projects panel: archived heads in
+    /// ArchivedBoardsView, live boards otherwise. Used to bound j/k/G navigation.
+    fn displayed_board_count(&self) -> usize {
+        if self.mode == AppMode::ArchivedBoardsView {
+            self.model.archived_boards_flat().len()
+        } else {
+            self.model.boards().len()
+        }
+    }
+
     pub fn handle_kanban_column_left(&mut self) {
         if !self.is_kanban_view() || self.focus.active != Focus::Cards {
             return;
@@ -609,8 +623,12 @@ impl App {
     pub fn handle_jump_to_bottom(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                self.selection.board.jump_to_last(self.model.boards().len());
-                self.switch_view_strategy(TaskListView::GroupedByColumn);
+                self.selection
+                    .board
+                    .jump_to_last(self.displayed_board_count());
+                if self.mode != AppMode::ArchivedBoardsView {
+                    self.switch_view_strategy(TaskListView::GroupedByColumn);
+                }
             }
             Focus::Cards => {
                 // Get adjusted viewport first (immutable borrow), then do all mutable work

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -526,6 +526,12 @@ impl App {
     }
 
     pub fn is_kanban_view(&self) -> bool {
+        // ArchivedBoardsView always uses the split projects+tasks layout so the
+        // archived projects list is visible regardless of any live board's view
+        // mode (KAN-893).
+        if self.mode == AppMode::ArchivedBoardsView {
+            return false;
+        }
         if let Some(board_idx) = self
             .selection
             .active_board_index

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -113,6 +113,9 @@ impl KeybindingRegistry {
                 DialogMode::ChooseStorageFile => {
                     Box::new(DialogInputProvider::new("Choose Storage File"))
                 }
+                DialogMode::DeletePermanentBoardConfirm => {
+                    Box::new(DeleteConfirmProvider::new("Project (Permanent)"))
+                }
             },
             AppMode::ErrorLog => Box::new(ErrorLogProvider),
         }

--- a/crates/kanban-tui/src/ui/dialogs/boards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/boards.rs
@@ -139,6 +139,19 @@ pub(crate) fn render_delete_board_confirm_popup(app: &App, frame: &mut Frame) {
     super::render_confirm_popup(frame, "Archive Project", body);
 }
 
+pub(crate) fn render_delete_permanent_board_confirm_popup(app: &App, frame: &mut Frame) {
+    let body = match app.dialog_input.board_delete_counts {
+        Some(counts) if !counts.is_empty() => format!(
+            "Permanently delete this project and everything in it?\n\
+             {} column(s), {} task(s), {} archived task(s), {} sprint(s)\n\
+             This CANNOT be undone from here.",
+            counts.columns, counts.cards, counts.archived, counts.sprints,
+        ),
+        _ => "This project is empty.\nPermanently delete it?".to_string(),
+    };
+    super::render_confirm_popup(frame, "Permanently Delete Project", body);
+}
+
 pub(crate) fn render_create_board_popup(app: &App, frame: &mut Frame) {
     render_input_popup(
         frame,

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -10,15 +10,7 @@ use ratatui::{
 };
 
 pub(super) fn render_main(app: &mut App, frame: &mut Frame, area: Rect) {
-    let is_kanban_view = if let Some(idx) = app.selection.active_board_index {
-        if let Some(board) = app.model.boards().get(idx) {
-            board.task_list_view == kanban_domain::TaskListView::ColumnView
-        } else {
-            false
-        }
-    } else {
-        false
-    };
+    let is_kanban_view = app.is_kanban_view();
 
     if is_kanban_view {
         app.view.viewport_height = area.height.saturating_sub(2) as usize;

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -79,22 +79,16 @@ pub fn build_filter_title_suffix(app: &App) -> Option<String> {
     }
 
     if !app.filter.active_sprint_filters.is_empty() {
-        if let Some(board_idx) = app
-            .selection
-            .active_board_index
-            .or(app.selection.board.get())
-        {
-            if let Some(board) = app.model.boards().get(board_idx) {
-                let mut sprint_names: Vec<String> = app
-                    .model
-                    .sprints()
-                    .iter()
-                    .filter(|s| app.filter.active_sprint_filters.contains(&s.id))
-                    .map(|s| s.formatted_name(board, "sprint"))
-                    .collect();
-                sprint_names.sort();
-                filters.extend(sprint_names);
-            }
+        if let Some(board) = app.viewed_board() {
+            let mut sprint_names: Vec<String> = app
+                .model
+                .sprints()
+                .iter()
+                .filter(|s| app.filter.active_sprint_filters.contains(&s.id))
+                .map(|s| s.formatted_name(board, "sprint"))
+                .collect();
+            sprint_names.sort();
+            filters.extend(sprint_names);
         }
     }
 
@@ -112,8 +106,11 @@ pub fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
         .get_active_task_list()
         .map(|l| l.len())
         .unwrap_or(0);
+    let archived_drill_down = app.selection.active_archived_board_index.is_some();
     let mut title = if app.mode == AppMode::ArchivedCardsView {
         format!("Archive [{}]", count)
+    } else if archived_drill_down {
+        format!("[ARCHIVED] Tasks [2] ({})", count)
     } else if app.focus.active == Focus::Cards {
         format!("Tasks [2] ({})", count)
     } else {

--- a/crates/kanban-tui/src/ui/mod.rs
+++ b/crates/kanban-tui/src/ui/mod.rs
@@ -140,6 +140,9 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                 DialogMode::ChooseStorageFile => {
                     dialogs::render_choose_storage_file_popup(app, frame)
                 }
+                DialogMode::DeletePermanentBoardConfirm => {
+                    dialogs::render_delete_permanent_board_confirm_popup(app, frame)
+                }
             }
         }
     } else {

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -100,8 +100,10 @@ fn test_permanent_delete_from_archived_boards_view_removes_board() {
     app.prepare_frame();
     app.selection.board.set(Some(0));
 
-    // `x` permanently deletes the highlighted archived board.
+    // `x` opens the confirm dialog; confirming with Enter permanently deletes.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+    app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Enter);
 
     // Absent from BOTH the live and the archived collections.
     assert!(
@@ -270,11 +272,14 @@ fn test_archived_view_u_undoes_permanent_delete() {
     app.prepare_frame();
     app.selection.board.set(Some(0));
 
-    // Delete the archived board permanently.
+    // Delete the archived board permanently via the confirm dialog.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+    app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Enter);
+    app.prepare_frame();
     assert!(
         app.model.archived_boards_flat().is_empty(),
-        "board must be gone after x"
+        "board must be gone after confirming permanent delete"
     );
 
     // `u` should undo the delete, bringing the board back.

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -121,3 +121,79 @@ fn test_permanent_delete_from_archived_boards_view_removes_board() {
         "permanently deleted board is not archived"
     );
 }
+
+// KAN-903: key wiring for gg / G / u / U in ArchivedBoardsView
+
+#[test]
+fn test_archived_view_g_then_g_jumps_to_first() {
+    let mut app = App::test_default();
+    seed_archived_board(&mut app, "A");
+    seed_archived_board(&mut app, "B");
+    seed_archived_board(&mut app, "C");
+
+    app.focus.active = Focus::Boards;
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    // Start at the bottom.
+    app.selection.board.set(Some(2));
+
+    // `g` → pending, second `g` → jump to first.
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('g'));
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('g'));
+
+    assert_eq!(
+        app.selection.board.get(),
+        Some(0),
+        "gg should jump to the first item in the archived list"
+    );
+}
+
+#[test]
+fn test_archived_view_shift_g_jumps_to_last() {
+    let mut app = App::test_default();
+    seed_archived_board(&mut app, "A");
+    seed_archived_board(&mut app, "B");
+    seed_archived_board(&mut app, "C");
+
+    app.focus.active = Focus::Boards;
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('G'));
+
+    assert_eq!(
+        app.selection.board.get(),
+        Some(2),
+        "G should jump to the last item in the archived list"
+    );
+}
+
+#[test]
+fn test_archived_view_u_undoes_permanent_delete() {
+    let mut app = App::test_default();
+    let archived_id = seed_archived_board(&mut app, "Undo Me");
+
+    app.focus.active = Focus::Boards;
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+
+    // Delete the archived board permanently.
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
+    assert!(
+        app.model.archived_boards_flat().is_empty(),
+        "board must be gone after x"
+    );
+
+    // `u` should undo the delete, bringing the board back.
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('u'));
+    app.prepare_frame();
+    assert!(
+        app.model
+            .archived_boards_flat()
+            .iter()
+            .any(|b| b.id == archived_id),
+        "undo should restore the permanently deleted archived board"
+    );
+}

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -102,7 +102,10 @@ fn test_permanent_delete_from_archived_boards_view_removes_board() {
 
     // `x` opens the confirm dialog; confirming with Enter permanently deletes.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
-    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)
+    );
     app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Enter);
 
     // Absent from BOTH the live and the archived collections.
@@ -166,7 +169,10 @@ fn test_confirm_permanent_delete_removes_board() {
     app.selection.board.set(Some(0));
 
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
-    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)
+    );
 
     // Confirming with 'y' should delete the board.
     app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Char('y'));
@@ -180,7 +186,10 @@ fn test_confirm_permanent_delete_removes_board() {
         "confirmed delete should permanently remove the board"
     );
     assert!(
-        !matches!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)),
+        !matches!(
+            app.mode,
+            AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)
+        ),
         "dialog should be dismissed after confirm"
     );
 }
@@ -196,7 +205,10 @@ fn test_cancel_permanent_delete_keeps_board() {
     app.selection.board.set(Some(0));
 
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
-    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)
+    );
 
     // Cancelling with 'n' must keep the board and dismiss dialog.
     app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Char('n'));
@@ -274,7 +286,10 @@ fn test_archived_view_u_undoes_permanent_delete() {
 
     // Delete the archived board permanently via the confirm dialog.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
-    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)
+    );
     app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Enter);
     app.prepare_frame();
     assert!(

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -5,7 +5,7 @@
 
 use kanban_domain::KanbanOperations;
 use kanban_tui::app::focus::Focus;
-use kanban_tui::app::mode::AppMode;
+use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::App;
 
 /// Create a board via the ctx, archive it, refresh the model. Returns its id.
@@ -119,6 +119,97 @@ fn test_permanent_delete_from_archived_boards_view_removes_board() {
             .iter()
             .all(|ab| ab.entity_id != archived_id),
         "permanently deleted board is not archived"
+    );
+}
+
+// KAN-906: confirm dialog before permanent delete
+
+#[test]
+fn test_x_in_archived_view_opens_confirm_not_immediate_delete() {
+    let mut app = App::test_default();
+    let archived_id = seed_archived_board(&mut app, "Delete Me");
+
+    app.focus.active = Focus::Boards;
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+
+    // `x` must open the confirm dialog, NOT delete immediately.
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
+
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm),
+        "x must open DeletePermanentBoardConfirm dialog"
+    );
+    // Board must still be in the archived list — not yet deleted.
+    app.prepare_frame();
+    assert!(
+        app.model
+            .archived_boards_flat()
+            .iter()
+            .any(|b| b.id == archived_id),
+        "board must not be deleted until user confirms"
+    );
+}
+
+#[test]
+fn test_confirm_permanent_delete_removes_board() {
+    let mut app = App::test_default();
+    let archived_id = seed_archived_board(&mut app, "Delete Me");
+
+    app.focus.active = Focus::Boards;
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+
+    // Confirming with 'y' should delete the board.
+    app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Char('y'));
+    app.prepare_frame();
+
+    assert!(
+        app.model
+            .archived_boards_flat()
+            .iter()
+            .all(|b| b.id != archived_id),
+        "confirmed delete should permanently remove the board"
+    );
+    assert!(
+        !matches!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)),
+        "dialog should be dismissed after confirm"
+    );
+}
+
+#[test]
+fn test_cancel_permanent_delete_keeps_board() {
+    let mut app = App::test_default();
+    let archived_id = seed_archived_board(&mut app, "Keep Me");
+
+    app.focus.active = Focus::Boards;
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+
+    // Cancelling with 'n' must keep the board and dismiss dialog.
+    app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Char('n'));
+    app.prepare_frame();
+
+    assert!(
+        app.mode == AppMode::ArchivedBoardsView,
+        "cancelling confirm must return to ArchivedBoardsView"
+    );
+    assert!(
+        app.model
+            .archived_boards_flat()
+            .iter()
+            .any(|b| b.id == archived_id),
+        "cancelled delete must keep the board archived"
     );
 }
 


### PR DESCRIPTION
## Summary

Five spike-validated TUI regression fixes for the ArchivedBoardsView, applied cumulatively in dependency order:

- **KAN-893**: Force split layout in ArchivedBoardsView regardless of the active live board's view mode (was hidden when a ColumnView board was active)
- **KAN-892**: Bound j/k/G navigation by the archived list length, not the live board count (was navigating out of range)
- **KAN-891**: Full archived-board drill-down parity: Enter drills into an archived board's tasks/columns, Esc returns to the archived list, tasks panel shows `[ARCHIVED]` prefix, `viewed_board()` helper resolves the correct board for filter/page computation
- **KAN-903**: Wire the inert keys advertised by ArchivedBoardsView: gg, G, u (undo), U (redo) now work correctly using the archived list bounds instead of the live list
- **KAN-906**: Confirm dialog (`DeletePermanentBoardConfirm`) before permanent board delete; `x` opens the dialog, Enter/y confirms, n/Esc/q cancels

## Test plan

- All 628 kanban-tui tests pass (0 failures)
- `cargo clippy -p kanban-tui --all-targets -- -D warnings` clean
- `cargo check -p kanban-cli -p kanban-mcp` clean (no downstream breakage)
- `cargo fmt --all` applied