### PR TITLE
chore(changeset): unified reference-marker archival for v0.8.0 release

### DIFF
--- a/.changeset/kan-864-unified-reference-marker-archival.md
+++ b/.changeset/kan-864-unified-reference-marker-archival.md
@@ -1,0 +1,27 @@
+---
+bump: minor
+---
+
+Archived cards and boards are now fully functional everywhere. An archived
+entity is just its ordinary card or board plus a marker, so you can view,
+browse, edit, and restore archived items exactly like live ones. The
+live/archived distinction is now a filter at each surface rather than a
+separate, limited mode.
+
+- CLI: `card list` and `board list` gain `--archived` (archived only) and
+  `--include-archived` (live and archived together), plus `board archive`,
+  `board restore`, and `board delete-archived` commands.
+- MCP: `list_cards` and `list_boards` take an `archived` filter (`exclude`,
+  `only`, `include`), and there are board archive, restore, and delete-archived
+  tools. The separate `list_archived_cards` tool remains as a thin deprecated
+  wrapper over the unified list.
+- TUI: an archived boards view you can open into and browse like any live board,
+  drilling into its columns and cards, with archive, restore, and
+  permanent-delete affordances.
+
+Under the hood the archival model was unified onto a single reference marker
+(the entity stays live and a marker records that it is archived), which removes
+the old separate archived collections and their drift. JSON files upgrade
+automatically from format V9 to V10 on first open, lifting embedded archived
+entities into references and writing a `.v9.backup` first; SQLite needs no
+migration. The change is backward compatible.


### PR DESCRIPTION
Adds the missing changeset for the KAN-864 reference-marker archival unification + all CLI/MCP/TUI archived surfaces (KAN-870-889) and its regression hardening (KAN-890-910), landed on develop this cycle. Without it the v0.8.0 release would ship this whole user-facing feature with no changelog entry or version bump. Bump: minor.