### PR TITLE
KAN-911 feat(tui): archived boards reuse the full live-board UI 1:1

### DIFF
--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -117,10 +117,9 @@ impl App {
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
         let cards = self.model.cards();
-        let board_opt = self
-            .selection
-            .active_board_index
-            .and_then(|i| self.model.boards().get(i));
+        // Archival-agnostic: resolve the viewed board (live or drilled-in
+        // archived) so an archived board's sprint task lists populate 1:1.
+        let board_opt = self.viewed_board();
 
         let (uncompleted_ids, completed_ids) = if let Some(board) = board_opt {
             let columns = self.model.columns();

--- a/crates/kanban-tui/src/app/clipboard.rs
+++ b/crates/kanban-tui/src/app/clipboard.rs
@@ -9,22 +9,19 @@ impl App {
         F: Fn(&Card, &Board, &[Sprint], &str) -> String,
     {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(board_idx) = self.selection.active_board_index {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
-                    if let Some(card) = self.model.card(active_id) {
-                        let sprints = self.model.sprints();
-                        let output = get_output(
-                            card,
-                            board,
-                            sprints,
-                            self.app_config.effective_default_card_prefix(),
-                        );
-                        if let Err(e) = clipboard::copy_to_clipboard(&output) {
-                            self.set_error(format!("Failed to copy: {}", e));
-                        } else {
-                            self.set_success(format!("Copied {}", output_type));
-                        }
+            if let Some(board) = self.viewed_board() {
+                if let Some(card) = self.model.card(active_id) {
+                    let sprints = self.model.sprints();
+                    let output = get_output(
+                        card,
+                        board,
+                        sprints,
+                        self.app_config.effective_default_card_prefix(),
+                    );
+                    if let Err(e) = clipboard::copy_to_clipboard(&output) {
+                        self.set_error(format!("Failed to copy: {}", e));
+                    } else {
+                        self.set_success(format!("Copied {}", output_type));
                     }
                 }
             }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -73,8 +73,9 @@ impl App {
             return false;
         }
 
-        // Handle Ctrl+a for select all cards
-        if matches!(self.mode, AppMode::Normal)
+        // Handle Ctrl+a for select all cards (also when drilled into an archived
+        // board, which reuses the Normal card UI 1:1 — KAN-911).
+        if (matches!(self.mode, AppMode::Normal) || self.is_archived_board_drilldown())
             && key
                 .modifiers
                 .contains(crossterm::event::KeyModifiers::CONTROL)
@@ -85,7 +86,21 @@ impl App {
             return false;
         }
 
-        match self.mode {
+        // KAN-911: when the user has drilled into an archived board, its live
+        // subtree is viewed through the FULL board UI. Route keys through the
+        // Normal handler (card detail, board settings, sprints, card ops) so an
+        // archived board behaves 1:1 with a live board. `self.mode` itself stays
+        // `ArchivedBoardsView` (so the projects panel and its navigation bounds
+        // stay archived-scoped per KAN-893); only the key DISPATCH is Normal.
+        let dispatch_mode = if matches!(self.mode, AppMode::ArchivedBoardsView)
+            && self.is_archived_board_drilldown()
+        {
+            AppMode::Normal
+        } else {
+            self.mode.clone()
+        };
+
+        match dispatch_mode {
             AppMode::Normal => match key.code {
                 KeyCode::Char('/') => {
                     self.pending_key = None;

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -26,6 +26,17 @@ impl Model {
         self.boards.as_deref().unwrap_or(&[])
     }
 
+    /// Resolve a board by id across BOTH the live and archived flat lists, so a
+    /// drilled-in archived board resolves through the same accessor as a live
+    /// one (KAN-911). Live-list consumers (projects panel, selection bounds)
+    /// must keep using `boards()` so archived heads never leak into them.
+    pub fn board_by_id(&self, id: Uuid) -> Option<&Board> {
+        self.boards()
+            .iter()
+            .find(|b| b.id == id)
+            .or_else(|| self.archived_board(id))
+    }
+
     pub fn columns(&self) -> &[Column] {
         self.columns.as_deref().unwrap_or(&[])
     }

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -22,15 +22,12 @@ impl App {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card(active_id) {
                 if let Some(card_sprint_id) = card.sprint_id {
-                    if let Some(board_idx) = self.selection.active_board_index {
-                        let boards = self.model.boards();
-                        if let Some(board) = boards.get(board_idx) {
-                            let sprints = self.model.sprints();
-                            let entries = build_entries(sprints, board.id, chrono::Utc::now());
-                            for (idx, entry) in entries.iter().enumerate() {
-                                if sprint_id_of(entry) == Some(card_sprint_id) {
-                                    return idx;
-                                }
+                    if let Some(board_id) = self.viewed_board_id() {
+                        let sprints = self.model.sprints();
+                        let entries = build_entries(sprints, board_id, chrono::Utc::now());
+                        for (idx, entry) in entries.iter().enumerate() {
+                            if sprint_id_of(entry) == Some(card_sprint_id) {
+                                return idx;
                             }
                         }
                     }

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -23,6 +23,30 @@ impl App {
         }
     }
 
+    /// The id of the board currently being viewed/acted on — live OR archived.
+    /// This is the archival-agnostic key every board-action / detail / settings
+    /// / sprint / card-op consumer should resolve through, so an archived board
+    /// exposes the full board UI 1:1 (KAN-911). Consumers that mean "the LIVE
+    /// board list" (projects panel, list-selection bounds) must stay on
+    /// `model.boards()` instead.
+    pub fn viewed_board_id(&self) -> Option<uuid::Uuid> {
+        self.viewed_board().map(|b| b.id)
+    }
+
+    /// True when the user has drilled into an archived board (its head is
+    /// archived but its live subtree is being viewed via the full board UI).
+    pub fn is_archived_board_drilldown(&self) -> bool {
+        self.selection.active_archived_board_index.is_some()
+    }
+
+    /// True when a board has been ACTIVATED (drilled into) — live or archived —
+    /// as opposed to merely highlighted in the projects list. Distinguishes the
+    /// "No tasks yet, press n" state (a board is being acted on) from the
+    /// "Enter/Space to add tasks" hint (a board is only highlighted).
+    pub fn is_board_active(&self) -> bool {
+        self.selection.active_board_index.is_some() || self.is_archived_board_drilldown()
+    }
+
     pub fn prepare_frame(&mut self) {
         match self.ctx.snapshot() {
             Ok(snapshot) => self.model.load_from_snapshot(snapshot),

--- a/crates/kanban-tui/src/components/filter_popup.rs
+++ b/crates/kanban-tui/src/components/filter_popup.rs
@@ -82,9 +82,8 @@ fn render_filter_sprints_section(
         label_text(),
     )));
 
-    if let Some(board_idx) = app.selection.active_board_index {
-        let boards = app.model.boards();
-        if let Some(board) = boards.get(board_idx) {
+    if let Some(board) = app.viewed_board() {
+        {
             let sprints = app.model.sprints();
             let board_sprints: Vec<_> = sprints.iter().filter(|s| s.board_id == board.id).collect();
 

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -194,16 +194,12 @@ impl SelectionDialog for CarryOverSprintDialog {
     }
 
     fn options_count(&self, app: &App) -> usize {
-        if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.model.boards().get(board_idx) {
-                app.model
-                    .sprints()
-                    .iter()
-                    .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
-                    .count()
-            } else {
-                0
-            }
+        if let Some(board) = app.viewed_board() {
+            app.model
+                .sprints()
+                .iter()
+                .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
+                .count()
         } else {
             0
         }
@@ -242,9 +238,8 @@ impl SelectionDialog for CarryOverSprintDialog {
 
         let mut lines = vec![];
 
-        if let Some(board_idx) = app.selection.active_board_index {
-            let boards = app.model.boards();
-            if let Some(board) = boards.get(board_idx) {
+        if let Some(board) = app.viewed_board() {
+            {
                 let sprints = app.model.sprints();
                 let planning_sprints: Vec<_> = sprints
                     .iter()
@@ -289,12 +284,9 @@ impl SelectionDialog for SprintAssignDialog {
     }
 
     fn options_count(&self, app: &App) -> usize {
-        if let Some(board_idx) = app.selection.active_board_index {
-            let boards = app.model.boards();
-            if let Some(board) = boards.get(board_idx) {
-                let sprints = app.model.sprints();
-                return build_entries(sprints, board.id, chrono::Utc::now()).len();
-            }
+        if let Some(board) = app.viewed_board() {
+            let sprints = app.model.sprints();
+            return build_entries(sprints, board.id, chrono::Utc::now()).len();
         }
         1
     }
@@ -329,10 +321,7 @@ impl SelectionDialog for SprintAssignDialog {
             chunks[0],
         );
 
-        let Some(board_idx) = app.selection.active_board_index else {
-            return;
-        };
-        let Some(board) = app.model.boards().get(board_idx) else {
+        let Some(board) = app.viewed_board() else {
             return;
         };
         app.dialog_input.assign_sprint_picker.render(

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -42,7 +42,12 @@ impl App {
     }
 
     pub fn handle_edit_board_key(&mut self) {
-        if self.focus.active == Focus::Boards && self.selection.board.get().is_some() {
+        // A live board opens its detail/settings view from the Boards panel; a
+        // drilled-in archived board (focus is Cards) reuses the same view via
+        // the archival-agnostic viewed board (KAN-911).
+        let from_live_list =
+            self.focus.active == Focus::Boards && self.selection.board.get().is_some();
+        if from_live_list || self.is_archived_board_drilldown() {
             self.push_mode(AppMode::BoardDetail);
             self.focus.board_focus = BoardFocus::Name;
         }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -447,7 +447,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::BoardDeleteCounts;
-    use crate::app::{AppMode, DialogMode, Focus};
+    use crate::app::{AppMode, BoardFocus, DialogMode, Focus};
     use crate::App;
     use crossterm::event::KeyCode;
     use kanban_domain::{BoardUpdate, CreateCardOptions, KanbanOperations, TaskListView};
@@ -1125,5 +1125,190 @@ mod tests {
         app.handle_restore_board();
 
         assert_eq!(app.selection.active_archived_board_index, None);
+    }
+
+    // KAN-911: archived boards must reuse the FULL live-board UI 1:1. The
+    // helpers below seed a non-trivial archived subtree (>=1 column, card,
+    // sprint) and drill into it via the exact same handlers a live board uses.
+
+    /// Seed a board with a column, two cards and a sprint, then archive the
+    /// board head (its subtree stays live in place under the reference-marker
+    /// model). Returns (board_id, column_id, sprint_id, first_card_id).
+    fn seed_archived_board_full(
+        app: &mut App,
+        name: &str,
+    ) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid, uuid::Uuid) {
+        create_named_board(app, name);
+        let board_id = app
+            .ctx
+            .data_store()
+            .list_boards()
+            .unwrap()
+            .into_iter()
+            .find(|b| b.name == name)
+            .unwrap()
+            .id;
+        let col_id = first_column_id(app, board_id);
+        let c1 = app
+            .ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Card1".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        app.ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Card2".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        let sprint = app.ctx.create_sprint(board_id, None, None).unwrap();
+        app.ctx.archive_board(board_id).unwrap();
+        refresh(app);
+        (board_id, col_id, sprint.id, c1.id)
+    }
+
+    /// Drive the drill-down entry exactly like the UI: enter the archived
+    /// boards view, highlight the first archived board, press Enter.
+    fn drill_into_archived_board(app: &mut App) {
+        app.focus.active = Focus::Boards;
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.selection.board.set(Some(0));
+        app.handle_open_archived_board();
+    }
+
+    #[test]
+    fn test_archived_board_card_detail_matches_live() {
+        let mut app = App::test_default();
+        let (_, _, _, _) = seed_archived_board_full(&mut app, "Arch");
+        drill_into_archived_board(&mut app);
+
+        assert_eq!(app.focus.active, Focus::Cards);
+        if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+            list.set_selected_index(Some(0));
+        }
+
+        // Same handler a live board uses to open card detail.
+        app.handle_selection_activate();
+
+        assert_eq!(
+            app.mode,
+            AppMode::CardDetail,
+            "opening a card in an archived board must enter CardDetail, exactly like a live board"
+        );
+        let card = app
+            .get_card_for_detail_view()
+            .expect("card detail must resolve the selected archived-board card");
+        assert_eq!(card.title, "Card1");
+    }
+
+    #[test]
+    fn test_archived_board_settings_view_reachable() {
+        let mut app = App::test_default();
+        let (arch_board_id, _, _, _) = seed_archived_board_full(&mut app, "Arch");
+        drill_into_archived_board(&mut app);
+
+        // Same handler a live board uses to open the board detail/settings view.
+        app.handle_edit_board_key();
+
+        assert_eq!(
+            app.mode,
+            AppMode::BoardDetail,
+            "the board detail/settings view must open for a drilled-in archived board"
+        );
+        assert_eq!(
+            app.viewed_board().map(|b| b.id),
+            Some(arch_board_id),
+            "board detail must resolve to the archived board, not a live-list board"
+        );
+    }
+
+    #[test]
+    fn test_archived_board_sprints_view_reachable() {
+        let mut app = App::test_default();
+        let (_, _, sprint_id, _) = seed_archived_board_full(&mut app, "Arch");
+        drill_into_archived_board(&mut app);
+
+        app.handle_edit_board_key();
+        assert_eq!(app.mode, AppMode::BoardDetail);
+
+        // Focus the Sprints section and activate the sprint, exactly like a live
+        // board (the Enter-on-Sprints path of handle_board_detail_key, extracted
+        // into a terminal-free handler so it is exercised identically here).
+        app.focus.board_focus = BoardFocus::Sprints;
+        app.selection.sprint.set(Some(0));
+        app.handle_open_selected_board_sprint();
+
+        assert_eq!(
+            app.mode,
+            AppMode::SprintDetail,
+            "the sprints view must be reachable for a drilled-in archived board"
+        );
+        assert_eq!(
+            app.model
+                .sprints()
+                .get(app.selection.active_sprint_index.unwrap())
+                .map(|s| s.id),
+            Some(sprint_id),
+            "the archived board's own sprint must be the one activated"
+        );
+    }
+
+    #[test]
+    fn test_archived_board_card_action_works() {
+        let mut app = App::test_default();
+        let (_, _, _, card1_id) = seed_archived_board_full(&mut app, "Arch");
+        drill_into_archived_board(&mut app);
+
+        assert_eq!(app.focus.active, Focus::Cards);
+        app.select_card_by_id(card1_id);
+        assert_eq!(
+            app.get_selected_card_id(),
+            Some(card1_id),
+            "precondition: the archived board's card must be selectable in its task list"
+        );
+
+        // Same handler a live board uses to toggle a card's completion — a
+        // representative card action routed through the service.
+        app.handle_toggle_card_completion();
+
+        let toggled = app
+            .ctx
+            .data_store()
+            .list_all_cards()
+            .unwrap()
+            .into_iter()
+            .find(|c| c.id == card1_id)
+            .unwrap();
+        assert_eq!(
+            toggled.status,
+            kanban_domain::CardStatus::Done,
+            "a card action (toggle completion) must apply on an archived board's card"
+        );
+    }
+
+    #[test]
+    fn test_projects_panel_still_lists_live_boards_only() {
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Live");
+        seed_archived_board_full(&mut app, "Arch");
+
+        // GUARD: the live projects list must exclude archived boards.
+        let live_names: Vec<&str> = app.model.boards().iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(
+            live_names,
+            vec!["Live"],
+            "the live projects panel must list only live boards, never archived ones"
+        );
+        assert_eq!(
+            app.model.archived_boards_flat().len(),
+            1,
+            "the archived board is only visible via the archived flat list"
+        );
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -10,15 +10,13 @@ use std::io;
 
 impl App {
     pub fn handle_create_card_key(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
-            if let Some(idx) = self.selection.active_board_index {
-                if let Some(board) = self.model.boards().get(idx) {
-                    self.dialog_input.create_card_sprint_picker.reset_for_board(
-                        self.model.sprints(),
-                        board,
-                        chrono::Utc::now(),
-                    );
-                }
+        if self.focus.active == Focus::Cards && self.viewed_board().is_some() {
+            if let Some(board) = self.viewed_board().cloned() {
+                self.dialog_input.create_card_sprint_picker.reset_for_board(
+                    self.model.sprints(),
+                    &board,
+                    chrono::Utc::now(),
+                );
             }
             self.open_dialog(DialogMode::CreateCard);
             self.input.clear();
@@ -109,25 +107,19 @@ impl App {
         }
 
         if !self.multi_select.selected_cards.is_empty() {
-            if let Some(board_idx) = self.selection.active_board_index {
-                if let Some(board) = self.model.boards().get(board_idx) {
-                    self.dialog_input
-                        .assign_sprint_picker
-                        .reset_for_bulk_card_assignment(
-                            self.model.sprints(),
-                            board,
-                            chrono::Utc::now(),
-                        );
-                }
+            if let Some(board) = self.viewed_board().cloned() {
+                self.dialog_input
+                    .assign_sprint_picker
+                    .reset_for_bulk_card_assignment(
+                        self.model.sprints(),
+                        &board,
+                        chrono::Utc::now(),
+                    );
             }
             self.open_dialog(DialogMode::AssignMultipleCardsToSprint);
         } else if self.get_selected_card_id().is_some() {
-            let Some(board_idx) = self.selection.active_board_index else {
+            let Some(board_id) = self.viewed_board_id() else {
                 return;
-            };
-            let board_id = match self.model.boards().get(board_idx) {
-                Some(b) => b.id,
-                None => return,
             };
             let now = chrono::Utc::now();
             let has_assignable = {
@@ -156,17 +148,22 @@ impl App {
                 .and_then(|id| self.model.card(id))
                 .and_then(|c| c.sprint_id);
             // Re-borrow board after the &mut self call above.
-            if let Some(board) = self.model.boards().get(board_idx) {
+            if let Some(board) = self.viewed_board().cloned() {
                 self.dialog_input
                     .assign_sprint_picker
-                    .reset_for_card_assignment(current_sprint_id, self.model.sprints(), board, now);
+                    .reset_for_card_assignment(
+                        current_sprint_id,
+                        self.model.sprints(),
+                        &board,
+                        now,
+                    );
             }
             self.open_dialog(DialogMode::AssignCardToSprint);
         }
     }
 
     pub fn handle_order_cards_key(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
+        if self.focus.active == Focus::Cards && self.viewed_board().is_some() {
             let sort_idx = self.get_current_sort_field_selection_index();
             self.filter.sort_field_selection.set(Some(sort_idx));
             self.open_dialog(DialogMode::OrderCards);
@@ -174,7 +171,7 @@ impl App {
     }
 
     pub fn handle_toggle_sort_order_key(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
+        if self.focus.active == Focus::Cards && self.viewed_board().is_some() {
             if let Some(current_order) = self.filter.current_sort_order {
                 let new_order = match current_order {
                     SortOrder::Ascending => SortOrder::Descending,
@@ -182,21 +179,18 @@ impl App {
                 };
                 self.filter.current_sort_order = Some(new_order);
 
-                if let Some(board_idx) = self.selection.active_board_index {
-                    let boards = self.model.boards();
-                    if let Some(board) = boards.get(board_idx) {
-                        if let Some(field) = self.filter.current_sort_field {
-                            let cmd = Command::Board(BoardCommand::SetTaskSort(SetBoardTaskSort {
-                                board_id: board.id,
-                                field,
-                                order: new_order,
-                            }));
+                if let Some(board_id) = self.viewed_board_id() {
+                    if let Some(field) = self.filter.current_sort_field {
+                        let cmd = Command::Board(BoardCommand::SetTaskSort(SetBoardTaskSort {
+                            board_id,
+                            field,
+                            order: new_order,
+                        }));
 
-                            if let Err(e) = self.execute_command(cmd) {
-                                tracing::error!("Failed to set board task sort: {}", e);
-                                self.set_error(format!("Failed to set board task sort: {}", e));
-                                return;
-                            }
+                        if let Err(e) = self.execute_command(cmd) {
+                            tracing::error!("Failed to set board task sort: {}", e);
+                            self.set_error(format!("Failed to set board task sort: {}", e));
+                            return;
                         }
                     }
                 }
@@ -207,7 +201,7 @@ impl App {
     }
 
     pub fn handle_toggle_hide_assigned(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
+        if self.focus.active == Focus::Cards && self.viewed_board().is_some() {
             self.filter.hide_assigned_cards = !self.filter.hide_assigned_cards;
             let status = if self.filter.hide_assigned_cards {
                 "enabled"
@@ -219,29 +213,24 @@ impl App {
     }
 
     pub fn handle_toggle_sprint_filter(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
-            if let Some(board_idx) = self.selection.active_board_index {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
-                    if let Some(active_sprint_id) = board.active_sprint_id {
-                        if self
-                            .filter
-                            .active_sprint_filters
-                            .contains(&active_sprint_id)
-                        {
-                            self.filter.active_sprint_filters.remove(&active_sprint_id);
-                            tracing::info!("Disabled sprint filter - showing all cards");
-                        } else {
-                            self.filter.active_sprint_filters.clear();
-                            self.filter.active_sprint_filters.insert(active_sprint_id);
-                            tracing::info!("Enabled sprint filter - showing active sprint only");
-                        }
-                    } else {
-                        let msg = "No active sprint set for filtering";
-                        tracing::warn!("{}", msg);
-                        self.set_error(msg);
-                    }
+        if self.focus.active == Focus::Cards {
+            if let Some(active_sprint_id) = self.viewed_board().and_then(|b| b.active_sprint_id) {
+                if self
+                    .filter
+                    .active_sprint_filters
+                    .contains(&active_sprint_id)
+                {
+                    self.filter.active_sprint_filters.remove(&active_sprint_id);
+                    tracing::info!("Disabled sprint filter - showing all cards");
+                } else {
+                    self.filter.active_sprint_filters.clear();
+                    self.filter.active_sprint_filters.insert(active_sprint_id);
+                    tracing::info!("Enabled sprint filter - showing active sprint only");
                 }
+            } else if self.viewed_board().is_some() {
+                let msg = "No active sprint set for filtering";
+                tracing::warn!("{}", msg);
+                self.set_error(msg);
             }
         }
     }
@@ -344,9 +333,9 @@ impl App {
     }
 
     pub fn create_card(&mut self) {
-        if let Some(idx) = self.selection.active_board_index {
+        if self.viewed_board().is_some() {
             let focused_col_id = self.get_focused_column_id();
-            let board_info = self.model.boards().get(idx).map(|b| (b.id, b.card_counter));
+            let board_info = self.viewed_board().map(|b| (b.id, b.card_counter));
 
             if let Some((bid, card_number)) = board_info {
                 let target_column_id = if let Some(focused_col_id) = focused_col_id {
@@ -385,10 +374,9 @@ impl App {
                 let position =
                     kanban_domain::card_lifecycle::next_position_in_column(cards, column.id);
 
-                let boards = self.model.boards();
                 let columns = self.model.columns();
-                let mark_as_complete = boards
-                    .get(idx)
+                let mark_as_complete = self
+                    .viewed_board()
                     .map(|board| {
                         kanban_domain::card_lifecycle::should_auto_complete_new_card(
                             column.id, board, columns,
@@ -462,12 +450,7 @@ impl App {
         }
 
         if let Some(card) = self.get_selected_card_in_context() {
-            let boards = self.model.boards();
-            let board = self
-                .selection
-                .active_board_index
-                .and_then(|idx| boards.get(idx));
-            let board = match board {
+            let board = match self.viewed_board() {
                 Some(b) => b,
                 None => return,
             };
@@ -517,12 +500,9 @@ impl App {
                             }
                         }
                         kanban_domain::card_lifecycle::MoveDirection::Right => {
-                            let boards = self.model.boards();
                             let columns = self.model.columns();
                             let num_cols = self
-                                .selection
-                                .active_board_index
-                                .and_then(|idx| boards.get(idx))
+                                .viewed_board()
                                 .map(|b| columns.iter().filter(|c| c.board_id == b.id).count())
                                 .unwrap_or(0);
                             if current_col_idx < num_cols - 1 {
@@ -541,12 +521,7 @@ impl App {
     }
 
     fn move_selected_cards(&mut self, direction: kanban_domain::card_lifecycle::MoveDirection) {
-        let boards = self.model.boards();
-        let board = self
-            .selection
-            .active_board_index
-            .and_then(|idx| boards.get(idx));
-        let board = match board {
+        let board = match self.viewed_board() {
             Some(b) => b,
             None => return,
         };
@@ -853,13 +828,9 @@ impl App {
 
         let card_id = card.id;
 
-        // Get the board ID for filtering
-        let boards = self.model.boards();
-        let board_id = match self.selection.active_board_index {
-            Some(idx) => match boards.get(idx) {
-                Some(board) => board.id,
-                None => return,
-            },
+        // Get the board ID for filtering (archival-agnostic viewed board).
+        let board_id = match self.viewed_board_id() {
+            Some(id) => id,
             None => return,
         };
 

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -8,13 +8,9 @@ use kanban_domain::{ColumnUpdate, TaskListView};
 
 impl App {
     pub fn handle_create_column_key(&mut self) {
-        if self.focus.board_focus == BoardFocus::Columns {
-            if let Some(board_idx) = self.selection.board.get() {
-                if self.model.boards().get(board_idx).is_some() {
-                    self.open_dialog(DialogMode::CreateColumn);
-                    self.input.clear();
-                }
-            }
+        if self.focus.board_focus == BoardFocus::Columns && self.viewed_board().is_some() {
+            self.open_dialog(DialogMode::CreateColumn);
+            self.input.clear();
         }
     }
 
@@ -22,20 +18,17 @@ impl App {
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_selection.get().is_some()
         {
-            if let Some(board_idx) = self.selection.board.get() {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
-                    let columns = self.model.columns();
-                    let board_columns: Vec<_> = columns
-                        .iter()
-                        .filter(|col| col.board_id == board.id)
-                        .collect();
+            if let Some(board_id) = self.viewed_board_id() {
+                let columns = self.model.columns();
+                let board_columns: Vec<_> = columns
+                    .iter()
+                    .filter(|col| col.board_id == board_id)
+                    .collect();
 
-                    if let Some(column_idx) = self.dialog_input.column_selection.get() {
-                        if let Some(column) = board_columns.get(column_idx) {
-                            self.input.set(column.name.clone());
-                            self.open_dialog(DialogMode::RenameColumn);
-                        }
+                if let Some(column_idx) = self.dialog_input.column_selection.get() {
+                    if let Some(column) = board_columns.get(column_idx) {
+                        self.input.set(column.name.clone());
+                        self.open_dialog(DialogMode::RenameColumn);
                     }
                 }
             }
@@ -46,20 +39,18 @@ impl App {
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_selection.get().is_some()
         {
-            if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.model.boards().get(board_idx) {
-                    let column_count = self
-                        .model
-                        .columns()
-                        .iter()
-                        .filter(|col| col.board_id == board.id)
-                        .count();
+            if let Some(board_id) = self.viewed_board_id() {
+                let column_count = self
+                    .model
+                    .columns()
+                    .iter()
+                    .filter(|col| col.board_id == board_id)
+                    .count();
 
-                    if column_count > 1 {
-                        self.open_dialog(DialogMode::DeleteColumnConfirm);
-                    } else {
-                        tracing::warn!("Cannot delete the last column");
-                    }
+                if column_count > 1 {
+                    self.open_dialog(DialogMode::DeleteColumnConfirm);
+                } else {
+                    tracing::warn!("Cannot delete the last column");
                 }
             }
         }
@@ -69,14 +60,14 @@ impl App {
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_selection.get().is_some()
         {
-            if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.model.boards().get(board_idx) {
+            if let Some(board_id) = self.viewed_board_id() {
+                {
                     // Collect and sort column data before mutating
                     let mut board_columns: Vec<_> = self
                         .model
                         .columns()
                         .iter()
-                        .filter(|col| col.board_id == board.id)
+                        .filter(|col| col.board_id == board_id)
                         .map(|col| (col.id, col.position))
                         .collect();
 
@@ -125,14 +116,14 @@ impl App {
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_selection.get().is_some()
         {
-            if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.model.boards().get(board_idx) {
+            if let Some(board_id) = self.viewed_board_id() {
+                {
                     // Collect and sort column data before mutating
                     let mut board_columns: Vec<_> = self
                         .model
                         .columns()
                         .iter()
-                        .filter(|col| col.board_id == board.id)
+                        .filter(|col| col.board_id == board_id)
                         .map(|col| (col.id, col.position))
                         .collect();
 
@@ -183,27 +174,22 @@ impl App {
             return;
         }
 
-        if let Some(board_idx) = self.selection.active_board_index {
-            if let Some(board) = self.model.boards().get(board_idx) {
-                let current_view_idx = match board.task_list_view {
-                    TaskListView::Flat => 0,
-                    TaskListView::GroupedByColumn => 1,
-                    TaskListView::ColumnView => 2,
-                };
-                self.dialog_input
-                    .task_list_view_selection
-                    .set(Some(current_view_idx));
-                self.open_dialog(DialogMode::SelectTaskListView);
-            }
+        if let Some(board) = self.viewed_board() {
+            let current_view_idx = match board.task_list_view {
+                TaskListView::Flat => 0,
+                TaskListView::GroupedByColumn => 1,
+                TaskListView::ColumnView => 2,
+            };
+            self.dialog_input
+                .task_list_view_selection
+                .set(Some(current_view_idx));
+            self.open_dialog(DialogMode::SelectTaskListView);
         }
     }
 
     pub fn create_column(&mut self) {
-        if let Some(board_idx) = self.selection.board.get() {
-            // Collect board_id before command execution
-            let board_id = self.model.boards().get(board_idx).map(|board| board.id);
-
-            if let Some(board_id) = board_id {
+        {
+            if let Some(board_id) = self.viewed_board_id() {
                 let column_name = self.input.as_str().trim().to_string();
 
                 if column_name.is_empty() {
@@ -251,22 +237,17 @@ impl App {
     }
 
     pub fn rename_column(&mut self) {
-        if let Some(board_idx) = self.selection.board.get() {
+        if let Some(board_id) = self.viewed_board_id() {
             // Collect column ID before mutable borrow
             let column_info = {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
-                    if let Some(column_idx) = self.dialog_input.column_selection.get() {
-                        let columns = self.model.columns();
-                        let board_columns: Vec<_> = columns
-                            .iter()
-                            .filter(|col| col.board_id == board.id)
-                            .collect();
+                if let Some(column_idx) = self.dialog_input.column_selection.get() {
+                    let columns = self.model.columns();
+                    let board_columns: Vec<_> = columns
+                        .iter()
+                        .filter(|col| col.board_id == board_id)
+                        .collect();
 
-                        board_columns.get(column_idx).map(|col| col.id)
-                    } else {
-                        None
-                    }
+                    board_columns.get(column_idx).map(|col| col.id)
                 } else {
                     None
                 }
@@ -300,16 +281,16 @@ impl App {
     }
 
     pub fn delete_column(&mut self) {
-        if let Some(board_idx) = self.selection.board.get() {
+        if let Some(board_id) = self.viewed_board_id() {
             // Collect all necessary data before mutating
             let delete_info = {
-                if let Some(board) = self.model.boards().get(board_idx) {
+                {
                     if let Some(column_idx) = self.dialog_input.column_selection.get() {
                         let board_columns: Vec<_> = self
                             .model
                             .columns()
                             .iter()
-                            .filter(|col| col.board_id == board.id)
+                            .filter(|col| col.board_id == board_id)
                             .map(|col| (col.id, col.name.clone()))
                             .collect();
 
@@ -342,26 +323,18 @@ impl App {
                     } else {
                         None
                     }
-                } else {
-                    None
                 }
             };
 
             if let Some((column_id, column_name, first_column_id, cards_to_move, column_idx)) =
                 delete_info
             {
-                let remaining_after_delete = {
-                    let columns = self.model.columns();
-                    let board = self.model.boards().get(board_idx);
-                    board
-                        .map(|b| {
-                            columns
-                                .iter()
-                                .filter(|c| c.board_id == b.id && c.id != column_id)
-                                .count()
-                        })
-                        .unwrap_or(0)
-                };
+                let remaining_after_delete = self
+                    .model
+                    .columns()
+                    .iter()
+                    .filter(|c| c.board_id == board_id && c.id != column_id)
+                    .count();
 
                 tracing::warn!("Cannot delete the last column");
 
@@ -507,31 +480,28 @@ impl App {
 
                     let selected_card_id = self.get_selected_card_id();
 
-                    if let Some(board_idx) = self.selection.active_board_index {
-                        if let Some(board) = self.model.boards().get(board_idx) {
-                            let cmd = Command::Board(BoardCommand::SetTaskListView(
-                                SetBoardTaskListView {
-                                    board_id: board.id,
-                                    view,
-                                },
-                            ));
+                    if let Some(board_id) = self.viewed_board_id() {
+                        let cmd =
+                            Command::Board(BoardCommand::SetTaskListView(SetBoardTaskListView {
+                                board_id,
+                                view,
+                            }));
 
-                            if let Err(e) = self.execute_command(cmd) {
-                                tracing::error!("Failed to set task list view: {}", e);
-                                self.set_error(format!("Failed to set task list view: {}", e));
-                                self.pop_mode();
-                                self.dialog_input.task_list_view_selection.clear();
-                                return;
-                            }
-
-                            self.switch_view_strategy(view);
-
-                            if let Some(card_id) = selected_card_id {
-                                self.select_card_by_id(card_id);
-                            }
-
-                            tracing::info!("Updated task list view to: {:?}", view);
+                        if let Err(e) = self.execute_command(cmd) {
+                            tracing::error!("Failed to set task list view: {}", e);
+                            self.set_error(format!("Failed to set task list view: {}", e));
+                            self.pop_mode();
+                            self.dialog_input.task_list_view_selection.clear();
+                            return;
                         }
+
+                        self.switch_view_strategy(view);
+
+                        if let Some(card_id) = selected_card_id {
+                            self.select_card_by_id(card_id);
+                        }
+
+                        tracing::info!("Updated task list view to: {:?}", view);
                     }
                 }
                 self.pop_mode();

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -292,30 +292,28 @@ impl App {
                 self.focus.card_focus = CardFocus::Title;
             }
             KeyCode::Char('a') => {
-                if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.model.boards().get(board_idx) {
-                        let sprint_count = self
-                            .model
-                            .sprints()
-                            .iter()
-                            .filter(|s| s.board_id == board.id)
-                            .count();
-                        if sprint_count > 0 {
-                            let current_sprint_id = self
-                                .selection
-                                .active_card_id
-                                .and_then(|id| self.model.card(id))
-                                .and_then(|c| c.sprint_id);
-                            self.dialog_input
-                                .assign_sprint_picker
-                                .reset_for_card_assignment(
-                                    current_sprint_id,
-                                    self.model.sprints(),
-                                    board,
-                                    chrono::Utc::now(),
-                                );
-                            self.open_dialog(DialogMode::AssignCardToSprint);
-                        }
+                if let Some(board) = self.viewed_board().cloned() {
+                    let sprint_count = self
+                        .model
+                        .sprints()
+                        .iter()
+                        .filter(|s| s.board_id == board.id)
+                        .count();
+                    if sprint_count > 0 {
+                        let current_sprint_id = self
+                            .selection
+                            .active_card_id
+                            .and_then(|id| self.model.card(id))
+                            .and_then(|c| c.sprint_id);
+                        self.dialog_input
+                            .assign_sprint_picker
+                            .reset_for_card_assignment(
+                                current_sprint_id,
+                                self.model.sprints(),
+                                &board,
+                                chrono::Utc::now(),
+                            );
+                        self.open_dialog(DialogMode::AssignCardToSprint);
                     }
                 }
             }
@@ -396,12 +394,18 @@ impl App {
                     should_restart = true;
                 }
                 BoardFocus::Settings => {
-                    if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.model.boards().get(board_idx) {
-                            let board_id = board.id;
-                            let dto = BoardSettingsDto::from_entity(board);
-                            let json = serde_json::to_string_pretty(&dto)
-                                .unwrap_or_else(|_| "{}".to_string());
+                    // Snapshot the viewed board's id + serialized settings before
+                    // the editor / command calls so no &Board borrow is held
+                    // across the &mut self operations below (NLL).
+                    let board_settings = self.viewed_board().map(|board| {
+                        (
+                            board.id,
+                            serde_json::to_string_pretty(&BoardSettingsDto::from_entity(board))
+                                .unwrap_or_else(|_| "{}".to_string()),
+                        )
+                    });
+                    if let Some((board_id, json)) = board_settings {
+                        {
                             let temp_file = std::env::temp_dir()
                                 .join(format!("kanban-board-{}-settings.json", board_id));
                             match edit_in_external_editor(terminal, event_handler, temp_file, &json)
@@ -480,40 +484,36 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => match self.focus.board_focus {
                 BoardFocus::Sprints => {
-                    if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.model.boards().get(board_idx) {
-                            let sprint_count = self
-                                .model
-                                .sprints()
-                                .iter()
-                                .filter(|s| s.board_id == board.id)
-                                .count();
-                            let current_idx = self.selection.sprint.get().unwrap_or(0);
-                            if sprint_count == 0 || current_idx >= sprint_count - 1 {
-                                self.focus.board_focus = BoardFocus::Columns;
-                                self.dialog_input.column_selection.set(Some(0));
-                            } else {
-                                self.selection.sprint.next(sprint_count);
-                            }
+                    if let Some(board_id) = self.viewed_board_id() {
+                        let sprint_count = self
+                            .model
+                            .sprints()
+                            .iter()
+                            .filter(|s| s.board_id == board_id)
+                            .count();
+                        let current_idx = self.selection.sprint.get().unwrap_or(0);
+                        if sprint_count == 0 || current_idx >= sprint_count - 1 {
+                            self.focus.board_focus = BoardFocus::Columns;
+                            self.dialog_input.column_selection.set(Some(0));
+                        } else {
+                            self.selection.sprint.next(sprint_count);
                         }
                     }
                 }
                 BoardFocus::Columns => {
-                    if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.model.boards().get(board_idx) {
-                            let column_count = self
-                                .model
-                                .columns()
-                                .iter()
-                                .filter(|col| col.board_id == board.id)
-                                .count();
-                            let current_idx = self.dialog_input.column_selection.get().unwrap_or(0);
-                            if column_count > 0 && current_idx >= column_count - 1 {
-                                self.focus.board_focus = BoardFocus::Name;
-                                self.selection.sprint.set(Some(0));
-                            } else {
-                                self.dialog_input.column_selection.next(column_count);
-                            }
+                    if let Some(board_id) = self.viewed_board_id() {
+                        let column_count = self
+                            .model
+                            .columns()
+                            .iter()
+                            .filter(|col| col.board_id == board_id)
+                            .count();
+                        let current_idx = self.dialog_input.column_selection.get().unwrap_or(0);
+                        if column_count > 0 && current_idx >= column_count - 1 {
+                            self.focus.board_focus = BoardFocus::Name;
+                            self.selection.sprint.set(Some(0));
+                        } else {
+                            self.dialog_input.column_selection.next(column_count);
                         }
                     }
                 }
@@ -545,18 +545,13 @@ impl App {
                     let current_idx = self.dialog_input.column_selection.get().unwrap_or(0);
                     if current_idx == 0 {
                         let sprint_count = self
-                            .selection
-                            .board
-                            .get()
-                            .and_then(|idx| {
-                                let boards = self.model.boards();
-                                boards.get(idx).map(|board| {
-                                    self.model
-                                        .sprints()
-                                        .iter()
-                                        .filter(|s| s.board_id == board.id)
-                                        .count()
-                                })
+                            .viewed_board_id()
+                            .map(|board_id| {
+                                self.model
+                                    .sprints()
+                                    .iter()
+                                    .filter(|s| s.board_id == board_id)
+                                    .count()
                             })
                             .unwrap_or(0);
                         if sprint_count == 0 {
@@ -584,38 +579,16 @@ impl App {
             },
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if self.focus.board_focus == BoardFocus::Sprints {
-                    if let Some(sprint_idx) = self.selection.sprint.get() {
-                        if let Some(board_idx) = self.selection.board.get() {
-                            let boards = self.model.boards();
-                            if let Some(board) = boards.get(board_idx) {
-                                let sprints = self.model.sprints();
-                                let board_sprints: Vec<_> = sprints
-                                    .iter()
-                                    .enumerate()
-                                    .filter(|(_, s)| s.board_id == board.id)
-                                    .collect();
-                                if let Some((actual_idx, _)) = board_sprints.get(sprint_idx) {
-                                    self.selection.active_sprint_index = Some(*actual_idx);
-                                    self.selection.active_board_index = Some(board_idx);
-                                    if let Some(sprint) = sprints.get(*actual_idx) {
-                                        self.populate_sprint_task_lists(sprint.id);
-                                    }
-                                    self.push_mode(AppMode::SprintDetail);
-                                }
-                            }
-                        }
-                    }
+                    self.handle_open_selected_board_sprint();
                 }
             }
             KeyCode::Char('p') => {
                 if self.focus.board_focus == BoardFocus::Settings {
-                    if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.model.boards().get(board_idx) {
-                            let current_prefix =
-                                board.sprint_prefix.clone().unwrap_or_else(String::new);
-                            self.input.set(current_prefix);
-                            self.open_dialog(DialogMode::SetBranchPrefix);
-                        }
+                    if let Some(board) = self.viewed_board() {
+                        let current_prefix =
+                            board.sprint_prefix.clone().unwrap_or_else(String::new);
+                        self.input.set(current_prefix);
+                        self.open_dialog(DialogMode::SetBranchPrefix);
                     }
                 }
             }
@@ -805,27 +778,25 @@ impl App {
                         CardListAction::AssignSprint(card_id)
                         | CardListAction::ReassignSprint(card_id) => {
                             if self.activate_card(card_id) {
-                                if let Some(board_idx) = self.selection.active_board_index {
-                                    if let Some(board) = self.model.boards().get(board_idx) {
-                                        let sprint_count = self
-                                            .model
-                                            .sprints()
-                                            .iter()
-                                            .filter(|s| s.board_id == board.id)
-                                            .count();
-                                        if sprint_count > 0 {
-                                            let current_sprint_id =
-                                                self.model.card(card_id).and_then(|c| c.sprint_id);
-                                            self.dialog_input
-                                                .assign_sprint_picker
-                                                .reset_for_card_assignment(
-                                                    current_sprint_id,
-                                                    self.model.sprints(),
-                                                    board,
-                                                    chrono::Utc::now(),
-                                                );
-                                            self.open_dialog(DialogMode::AssignCardToSprint);
-                                        }
+                                if let Some(board) = self.viewed_board().cloned() {
+                                    let sprint_count = self
+                                        .model
+                                        .sprints()
+                                        .iter()
+                                        .filter(|s| s.board_id == board.id)
+                                        .count();
+                                    if sprint_count > 0 {
+                                        let current_sprint_id =
+                                            self.model.card(card_id).and_then(|c| c.sprint_id);
+                                        self.dialog_input
+                                            .assign_sprint_picker
+                                            .reset_for_card_assignment(
+                                                current_sprint_id,
+                                                self.model.sprints(),
+                                                &board,
+                                                chrono::Utc::now(),
+                                            );
+                                        self.open_dialog(DialogMode::AssignCardToSprint);
                                     }
                                 }
                             }
@@ -863,17 +834,13 @@ impl App {
                                     kanban_domain::card_lifecycle::MoveDirection::Left
                                 };
 
-                                let boards = self.model.boards();
                                 let columns = self.model.columns();
                                 let cards = self.model.cards();
-                                let move_result =
-                                    self.selection.active_board_index.and_then(|idx| {
-                                        boards.get(idx).and_then(|board| {
-                                            kanban_domain::card_lifecycle::compute_card_column_move(
-                                                &card, board, columns, cards, direction,
-                                            )
-                                        })
-                                    });
+                                let move_result = self.viewed_board().and_then(|board| {
+                                    kanban_domain::card_lifecycle::compute_card_column_move(
+                                        &card, board, columns, cards, direction,
+                                    )
+                                });
 
                                 if let Some(result) = move_result {
                                     use kanban_domain::KanbanOperations;
@@ -941,6 +908,33 @@ impl App {
                 };
                 active_card_list.set_selected_index(active_component.get_selected_index());
             }
+        }
+    }
+
+    /// Activate the sprint highlighted in the board-detail Sprints section and
+    /// open its detail view. Archival-agnostic: resolves the sprint against the
+    /// VIEWED board (live or drilled-in archived) rather than a live-list index,
+    /// so an archived board's sprints view works 1:1 (KAN-911).
+    pub fn handle_open_selected_board_sprint(&mut self) {
+        let Some(sprint_idx) = self.selection.sprint.get() else {
+            return;
+        };
+        let Some(board_id) = self.viewed_board_id() else {
+            return;
+        };
+        let sprints = self.model.sprints();
+        let actual_idx = sprints
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.board_id == board_id)
+            .nth(sprint_idx)
+            .map(|(i, _)| i);
+        if let Some(actual_idx) = actual_idx {
+            self.selection.active_sprint_index = Some(actual_idx);
+            if let Some(sprint_id) = self.model.sprints().get(actual_idx).map(|s| s.id) {
+                self.populate_sprint_task_lists(sprint_id);
+            }
+            self.push_mode(AppMode::SprintDetail);
         }
     }
 

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -73,16 +73,14 @@ impl App {
             self.dialog_input.reset_create_card_focus();
             return;
         }
-        if let Some(idx) = self.selection.active_board_index {
-            if let Some(board) = self.model.boards().get(idx) {
-                let now = chrono::Utc::now();
-                self.dialog_input.create_card_sprint_picker.handle_key(
-                    key_code,
-                    self.model.sprints(),
-                    board,
-                    now,
-                );
-            }
+        if let Some(board) = self.viewed_board().cloned() {
+            let now = chrono::Utc::now();
+            self.dialog_input.create_card_sprint_picker.handle_key(
+                key_code,
+                self.model.sprints(),
+                &board,
+                now,
+            );
         }
     }
 

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -5,7 +5,7 @@ use kanban_domain::CardFilters;
 
 impl App {
     pub fn handle_open_filter_dialog(&mut self) {
-        if self.focus.active != Focus::Cards || self.selection.active_board_index.is_none() {
+        if self.focus.active != Focus::Cards || self.viewed_board().is_none() {
             return;
         }
 
@@ -24,6 +24,12 @@ impl App {
     pub fn handle_filter_options_popup(&mut self, key_code: KeyCode) {
         use crossterm::event::KeyCode;
 
+        // Resolve the viewed board (live OR drilled-in archived) up front so the
+        // sprint sections below don't need a &self reborrow while `dialog_state`
+        // holds a &mut borrow of `self.filter.dialog_state` (KAN-911, NLL).
+        let viewed_board_id = self.viewed_board_id();
+        let viewed_board = viewed_board_id.and_then(|id| self.model.board_by_id(id).cloned());
+
         if let Some(ref mut dialog_state) = self.filter.dialog_state {
             match key_code {
                 KeyCode::Esc => {
@@ -32,20 +38,18 @@ impl App {
                 }
                 KeyCode::Char('j') | KeyCode::Down => match dialog_state.current_section {
                     FilterDialogSection::Sprints => {
-                        if let Some(board_idx) = self.selection.active_board_index {
-                            if let Some(board) = self.model.boards().get(board_idx) {
-                                let sprint_count = self
-                                    .model
-                                    .sprints()
-                                    .iter()
-                                    .filter(|s| s.board_id == board.id)
-                                    .count();
-                                let total_items = 1 + sprint_count;
-                                if dialog_state.item_selection < total_items.saturating_sub(1) {
-                                    dialog_state.item_selection += 1;
-                                } else {
-                                    dialog_state.next_section();
-                                }
+                        if let Some(board_id) = viewed_board_id {
+                            let sprint_count = self
+                                .model
+                                .sprints()
+                                .iter()
+                                .filter(|s| s.board_id == board_id)
+                                .count();
+                            let total_items = 1 + sprint_count;
+                            if dialog_state.item_selection < total_items.saturating_sub(1) {
+                                dialog_state.item_selection += 1;
+                            } else {
+                                dialog_state.next_section();
                             }
                         }
                     }
@@ -75,9 +79,8 @@ impl App {
                                 dialog_state.filters.show_unassigned_sprints
                             );
                             self.apply_filters();
-                        } else if let Some(board_idx) = self.selection.active_board_index {
-                            let boards = self.model.boards();
-                            if let Some(board) = boards.get(board_idx) {
+                        } else if let Some(board) = viewed_board.as_ref() {
+                            {
                                 let sprints = self.model.sprints();
                                 let board_sprints: Vec<_> =
                                     sprints.iter().filter(|s| s.board_id == board.id).collect();

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -343,7 +343,7 @@ impl App {
                 self.focus.active = Focus::Boards;
             }
             Focus::Cards => {
-                if self.selection.active_board_index.is_some() {
+                if self.viewed_board().is_some() {
                     self.focus.active = Focus::Cards;
                 }
             }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -192,22 +192,19 @@ impl App {
                     self.filter.current_sort_field = Some(field);
                     self.filter.current_sort_order = Some(order);
 
-                    if let Some(board_idx) = self.selection.active_board_index {
-                        if let Some(board) = self.model.boards().get(board_idx) {
-                            let board_id = board.id;
-                            let cmd = kanban_domain::commands::Command::Board(
-                                kanban_domain::commands::BoardCommand::SetTaskSort(
-                                    kanban_domain::commands::SetBoardTaskSort {
-                                        board_id,
-                                        field,
-                                        order,
-                                    },
-                                ),
-                            );
-                            if let Err(e) = self.execute_command(cmd) {
-                                tracing::error!("Failed to set board task sort: {}", e);
-                                self.set_error(format!("Failed to set board task sort: {}", e));
-                            }
+                    if let Some(board_id) = self.viewed_board_id() {
+                        let cmd = kanban_domain::commands::Command::Board(
+                            kanban_domain::commands::BoardCommand::SetTaskSort(
+                                kanban_domain::commands::SetBoardTaskSort {
+                                    board_id,
+                                    field,
+                                    order,
+                                },
+                            ),
+                        );
+                        if let Err(e) = self.execute_command(cmd) {
+                            tracing::error!("Failed to set board task sort: {}", e);
+                            self.set_error(format!("Failed to set board task sort: {}", e));
                         }
                     }
 
@@ -246,11 +243,7 @@ impl App {
                     Some(card) => card.id,
                     None => return,
                 };
-                let active_board_id = self
-                    .selection
-                    .active_board_index
-                    .and_then(|idx| self.model.boards().get(idx))
-                    .map(|b| b.id);
+                let active_board_id = self.viewed_board_id();
                 let picker = &self.dialog_input.assign_sprint_picker;
                 let board_matches = active_board_id
                     .map(|bid| picker.bound_board_id() == Some(bid))
@@ -288,16 +281,14 @@ impl App {
                 self.dialog_input.assign_sprint_picker.clear();
             }
             _ => {
-                if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.model.boards().get(board_idx) {
-                        let now = chrono::Utc::now();
-                        self.dialog_input.assign_sprint_picker.handle_key(
-                            key_code,
-                            self.model.sprints(),
-                            board,
-                            now,
-                        );
-                    }
+                if let Some(board) = self.viewed_board().cloned() {
+                    let now = chrono::Utc::now();
+                    self.dialog_input.assign_sprint_picker.handle_key(
+                        key_code,
+                        self.model.sprints(),
+                        &board,
+                        now,
+                    );
                 }
             }
         }
@@ -314,11 +305,7 @@ impl App {
             KeyCode::Enter => {
                 let card_ids: Vec<uuid::Uuid> =
                     self.multi_select.selected_cards.iter().copied().collect();
-                let active_board_id = self
-                    .selection
-                    .active_board_index
-                    .and_then(|idx| self.model.boards().get(idx))
-                    .map(|b| b.id);
+                let active_board_id = self.viewed_board_id();
                 let picker = &self.dialog_input.assign_sprint_picker;
                 let board_matches = active_board_id
                     .map(|bid| picker.bound_board_id() == Some(bid))
@@ -363,16 +350,14 @@ impl App {
                 self.multi_select.selection_mode_active = false;
             }
             _ => {
-                if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.model.boards().get(board_idx) {
-                        let now = chrono::Utc::now();
-                        self.dialog_input.assign_sprint_picker.handle_key(
-                            key_code,
-                            self.model.sprints(),
-                            board,
-                            now,
-                        );
-                    }
+                if let Some(board) = self.viewed_board().cloned() {
+                    let now = chrono::Utc::now();
+                    self.dialog_input.assign_sprint_picker.handle_key(
+                        key_code,
+                        self.model.sprints(),
+                        &board,
+                        now,
+                    );
                 }
             }
         }

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 impl App {
     pub fn handle_create_sprint_key(&mut self) {
-        if self.focus.board_focus == BoardFocus::Sprints && self.selection.board.get().is_some() {
+        if self.focus.board_focus == BoardFocus::Sprints && self.viewed_board().is_some() {
             self.open_dialog(DialogMode::CreateSprint);
             self.input.clear();
         }
@@ -15,17 +15,15 @@ impl App {
 
     pub fn handle_activate_sprint_key(&mut self) {
         if let Some(sprint_idx) = self.selection.active_sprint_index {
-            // Collect sprint info before mutations
+            // Collect sprint info before mutations. Resolve the board through the
+            // archival-agnostic viewed board so an archived board's sprints work.
+            let viewed_board = self.viewed_board().cloned();
             let sprint_info = {
-                if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+                if let (Some(sprint), Some(board)) =
+                    (self.model.sprints().get(sprint_idx), viewed_board.as_ref())
+                {
                     if sprint.status == SprintStatus::Planning {
-                        Some((
-                            sprint.id,
-                            sprint.formatted_name(
-                                &self.model.boards()[self.selection.board.get().unwrap_or(0)],
-                                "sprint",
-                            ),
-                        ))
+                        Some((sprint.id, sprint.formatted_name(board, "sprint")))
                     } else {
                         None
                     }
@@ -35,12 +33,8 @@ impl App {
             };
 
             if let Some((sprint_id, sprint_name)) = sprint_info {
-                let board_idx = self
-                    .selection
-                    .active_board_index
-                    .or(self.selection.board.get());
-                if let Some(board_idx) = board_idx {
-                    if let Some(board) = self.model.boards().get(board_idx) {
+                if let Some(board) = viewed_board.as_ref() {
+                    {
                         let duration = board.sprint_duration_days.unwrap_or(14);
                         let board_id = board.id;
 
@@ -75,19 +69,14 @@ impl App {
     pub fn handle_complete_sprint_key(&mut self) {
         if let Some(sprint_idx) = self.selection.active_sprint_index {
             // Collect sprint and board info before mutations
+            let viewed_board = self.viewed_board().cloned();
             let sprint_info = {
                 if let Some(sprint) = self.model.sprints().get(sprint_idx) {
                     if sprint.status == SprintStatus::Active
                         || sprint.status == SprintStatus::Planning
                     {
-                        let board_idx = self
-                            .selection
-                            .active_board_index
-                            .or(self.selection.board.get());
-                        board_idx.and_then(|board_idx| {
-                            self.model.boards().get(board_idx).map(|board| {
-                                (sprint.id, board.id, sprint.formatted_name(board, "sprint"))
-                            })
+                        viewed_board.as_ref().map(|board| {
+                            (sprint.id, board.id, sprint.formatted_name(board, "sprint"))
                         })
                     } else {
                         None
@@ -166,13 +155,9 @@ impl App {
     }
 
     pub fn create_sprint(&mut self) {
-        let board_idx = self
-            .selection
-            .active_board_index
-            .or(self.selection.board.get());
-        if let Some(board_idx) = board_idx {
+        if self.viewed_board().is_some() {
             let (board_id, name) = {
-                if let Some(board) = self.model.boards().get(board_idx) {
+                if let Some(board) = self.viewed_board() {
                     let input_text = self.input.as_str().trim();
                     let name = if input_text.is_empty() {
                         None

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -59,15 +59,10 @@ impl SinglePanelRenderer {
 
 impl RenderStrategy for SinglePanelRenderer {
     fn render(&self, app: &App, frame: &mut Frame, area: Rect) {
-        let board_idx = app
-            .selection
-            .active_board_index
-            .or(app.selection.board.get());
-
         let mut lines = vec![];
 
-        if let Some(idx) = board_idx {
-            if let Some(board) = app.model.boards().get(idx) {
+        if let Some(board) = app.viewed_board() {
+            {
                 let active_task_list = app.view.strategy.get_active_task_list();
 
                 if self.show_column_headers {
@@ -89,7 +84,7 @@ impl RenderStrategy for SinglePanelRenderer {
                             .unwrap_or_default();
 
                         if column_boundaries.is_empty() && task_list.is_empty() {
-                            let message = if app.selection.active_board_index.is_some() {
+                            let message = if app.is_board_active() {
                                 "  No tasks yet. Press 'n' to create one!"
                             } else {
                                 "  (Enter/Space) to add tasks"
@@ -214,7 +209,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                 "Task",
                             ));
                         }
-                    } else if let Some(board) = app.model.boards().get(board_idx.unwrap()) {
+                    } else if let Some(board) = app.viewed_board() {
                         let mut board_columns: Vec<_> = app
                             .model
                             .columns()
@@ -229,7 +224,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                 label_text(),
                             )));
                         } else {
-                            let message = if app.selection.active_board_index.is_some() {
+                            let message = if app.is_board_active() {
                                 "  No tasks yet. Press 'n' to create one!"
                             } else {
                                 "  (Enter/Space) to add tasks"
@@ -239,7 +234,7 @@ impl RenderStrategy for SinglePanelRenderer {
                     }
                 } else if let Some(task_list) = app.view.strategy.get_active_task_list() {
                     if task_list.is_empty() {
-                        let message = if app.selection.active_board_index.is_some() {
+                        let message = if app.is_board_active() {
                             "  No tasks yet. Press 'n' to create one!"
                         } else {
                             "  (Enter/Space) to add tasks"
@@ -338,13 +333,8 @@ pub struct MultiPanelRenderer;
 
 impl RenderStrategy for MultiPanelRenderer {
     fn render(&self, app: &App, frame: &mut Frame, area: Rect) {
-        let board_idx = app
-            .selection
-            .active_board_index
-            .or(app.selection.board.get());
-
-        if let Some(idx) = board_idx {
-            if let Some(board) = app.model.boards().get(idx) {
+        if let Some(board) = app.viewed_board() {
+            {
                 let task_lists = app.view.strategy.get_all_task_lists();
 
                 if task_lists.is_empty() {

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -27,12 +27,23 @@ impl TuiSnapshot for Snapshot {
     fn apply_to_app(&self, app: &mut App) -> kanban_domain::KanbanResult<()> {
         app.ctx.apply_snapshot(self.clone())?;
 
-        // Sync sort field/order from active board to preserve user's selection after reload
-        if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = self.boards.get(board_idx) {
-                app.filter.current_sort_field = Some(board.task_sort_field);
-                app.filter.current_sort_order = Some(board.task_sort_order);
-            }
+        // Sync sort field/order from the viewed board (live OR drilled-in
+        // archived) to preserve the user's selection after reload. The snapshot's
+        // `boards` list carries every head (live + archived). Resolve the viewed
+        // board by id where the model is loaded (covers the archived drilldown),
+        // else fall back to the live `active_board_index` into the snapshot list
+        // (the model may not be reloaded yet at this call site) (KAN-911).
+        let board = app
+            .viewed_board_id()
+            .and_then(|id| self.boards.iter().find(|b| b.id == id))
+            .or_else(|| {
+                app.selection
+                    .active_board_index
+                    .and_then(|idx| self.boards.get(idx))
+            });
+        if let Some(board) = board {
+            app.filter.current_sort_field = Some(board.task_sort_field);
+            app.filter.current_sort_order = Some(board.task_sort_order);
         }
         Ok(())
     }

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -65,8 +65,8 @@ pub(super) fn render_relationship_boxes(
 pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
     if let Some(card) = app.get_card_for_detail_view() {
         let card = &card;
-        if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.model.boards().get(board_idx) {
+        {
+            if let Some(board) = app.viewed_board() {
                 let has_sprint_logs = !card.sprint_logs.is_empty();
                 let card_id = card.id;
 

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -10,7 +10,7 @@ use ratatui::{
 pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
     use crate::components::centered_rect;
 
-    let Some(board_idx) = app.selection.active_board_index else {
+    let Some(board) = app.viewed_board() else {
         render_input_popup(
             frame,
             "Create New Task",
@@ -18,9 +18,6 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
             app.input.as_str(),
             app.input.cursor_byte_offset(),
         );
-        return;
-    };
-    let Some(board) = app.model.boards().get(board_idx) else {
         return;
     };
 
@@ -157,10 +154,7 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
         chunks[0],
     );
 
-    let Some(board_idx) = app.selection.active_board_index else {
-        return;
-    };
-    let Some(board) = app.model.boards().get(board_idx) else {
+    let Some(board) = app.viewed_board() else {
         return;
     };
     app.dialog_input.assign_sprint_picker.render(

--- a/crates/kanban-tui/src/ui/dialogs/columns.rs
+++ b/crates/kanban-tui/src/ui/dialogs/columns.rs
@@ -43,12 +43,7 @@ pub(crate) fn render_select_task_list_view_popup(app: &App, frame: &mut Frame) {
 
     let selected = app.dialog_input.task_list_view_selection.get();
 
-    let current_view = app.selection.active_board_index.and_then(|idx| {
-        app.model
-            .boards()
-            .get(idx)
-            .map(|board| board.task_list_view)
-    });
+    let current_view = app.viewed_board().map(|board| board.task_list_view);
 
     let items: Vec<ListItem> = views
         .iter()

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -15,15 +15,13 @@ pub(super) fn render_sprint_detail_view(app: &mut App, frame: &mut Frame, area: 
         Some(i) => i,
         None => return,
     };
-    let board_idx = match app.selection.active_board_index {
-        Some(i) => i,
-        None => return,
-    };
     let sprint = match app.model.sprints().get(sprint_idx).cloned() {
         Some(s) => s,
         None => return,
     };
-    let board = match app.model.boards().get(board_idx).cloned() {
+    // Archival-agnostic: the sprint detail view resolves its board through the
+    // viewed board (live OR drilled-in archived) so it renders 1:1 (KAN-911).
+    let board = match app.viewed_board().cloned() {
         Some(b) => b,
         None => return,
     };


### PR DESCRIPTION
## Context

Follow-up to KAN-891 under root KAN-864 ("an archived board is just a board; the full existing board UI should work 1:1"). KAN-891 let you OPEN an archived board and see its tasks, but did so with a parallel `active_archived_board_index` and routed only ~5 of ~89 board-resolution sites through an archival-aware `viewed_board()`, setting `active_board_index = None` when an archived board is active. So card detail, board settings, sprints, columns and most card operations were dead for archived boards, and the input router dispatched a drilled-in archived board through a tiny archived-only keyset.

## The accessor

- `App::viewed_board_id()` (from the existing `viewed_board()`) and `Model::board_by_id()` — the archival-agnostic key that resolves a live OR drilled-in archived board (checks both `boards()` and the archived flat list).
- `App::is_board_active()` distinguishes an activated/viewed board from one merely highlighted in the projects list (used by the empty-state render messages).

## Consumer categories routed through the accessor

- **Card operations** (`card_handlers`): create/move/toggle/assign-sprint/order/sort/hide-assigned/sprint-filter/manage-children gates and board resolution.
- **Card detail & sprint-detail actions** (`detail_view_handlers`): `a` assign-sprint, sprint-detail Assign/MoveColumn, extracted `handle_open_selected_board_sprint()`.
- **Board detail / settings / sprints / columns** (`detail_view_handlers`, `column_handlers`, `sprint_handlers`): settings edit, branch-prefix, sprint nav counts, sprint activate/complete/create, column create/rename/delete/move — all now resolve the viewed board, not the live-list highlight.
- **Filters, popups, dialogs** (`filter_handlers`, `popup_handlers`, `dialog_handlers`, `selection_dialog`, `filter_popup`): sprint pickers and task-sort commands.
- **Render / UI** (`render_strategy`, `ui/card_detail`, `ui/sprint_detail`, `ui/dialogs/*`): task-list panels, card/sprint detail, create-card and view-select dialogs.
- **Input router**: when drilled into an archived board, keys dispatch through the full Normal handler while `mode` stays `ArchivedBoardsView` so the projects panel and its navigation bounds remain archived-scoped (KAN-893). `handle_edit_board_key` opens BoardDetail for a drilled-in archived board.

## Kept on the live list (not archival-agnostic)

Projects-panel selection bounds, activate/deactivate, delete-board index shifting, rename/export board — these legitimately mean "the live board LIST", so archived heads never leak into it.

## Tests

Parity tests drive the SAME handlers/key events a live board uses on a drilled-in archived board seeded with a column, cards and a sprint:
- `test_archived_board_card_detail_matches_live`
- `test_archived_board_settings_view_reachable`
- `test_archived_board_sprints_view_reachable`
- `test_archived_board_card_action_works` (toggle completion via the shared handler)
- `test_projects_panel_still_lists_live_boards_only` (GUARD: the live projects list excludes archived boards)

All kanban-tui tests green (293 lib + integration), `clippy -D warnings` clean, `fmt` applied; `kanban-cli`/`kanban-mcp` compile.

## Not 1:1 (minor)

`q` while drilled into an archived board is a no-op rather than quitting (Esc returns to the archived list, which is tested and the intended exit); the archived-view `q` on the list still toggles back to live.