### PR TITLE
KAN-911 feat(tui): archived boards are ordinary boards — unify active board by id (LSP)

### DIFF
--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -119,8 +119,8 @@ impl App {
         let cards = self.model.cards();
         let board_opt = self
             .selection
-            .active_board_index
-            .and_then(|i| self.model.boards().get(i));
+            .active_board_id
+            .and_then(|id| self.model.board_by_id(id));
 
         let (uncompleted_ids, completed_ids) = if let Some(board) = board_opt {
             let columns = self.model.columns();

--- a/crates/kanban-tui/src/app/clipboard.rs
+++ b/crates/kanban-tui/src/app/clipboard.rs
@@ -9,22 +9,19 @@ impl App {
         F: Fn(&Card, &Board, &[Sprint], &str) -> String,
     {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(board_idx) = self.selection.active_board_index {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
-                    if let Some(card) = self.model.card(active_id) {
-                        let sprints = self.model.sprints();
-                        let output = get_output(
-                            card,
-                            board,
-                            sprints,
-                            self.app_config.effective_default_card_prefix(),
-                        );
-                        if let Err(e) = clipboard::copy_to_clipboard(&output) {
-                            self.set_error(format!("Failed to copy: {}", e));
-                        } else {
-                            self.set_success(format!("Copied {}", output_type));
-                        }
+            if let Some(board) = self.active_board() {
+                if let Some(card) = self.model.card(active_id) {
+                    let sprints = self.model.sprints();
+                    let output = get_output(
+                        card,
+                        board,
+                        sprints,
+                        self.app_config.effective_default_card_prefix(),
+                    );
+                    if let Err(e) = clipboard::copy_to_clipboard(&output) {
+                        self.set_error(format!("Failed to copy: {}", e));
+                    } else {
+                        self.set_success(format!("Copied {}", output_type));
                     }
                 }
             }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -416,59 +416,69 @@ impl App {
         }
     }
 
-    /// Key handling for the archived-boards view (mirrors the archived-cards
-    /// view): `r` restores, `x` permanently deletes, `Esc`/`q` returns to the live
-    /// boards view, `j`/`k` navigate. The Boards panel is the context here.
+    /// Key handling for the archived-boards view. The archived list is an
+    /// ordinary boards panel showing a different SET; navigation and activation
+    /// reuse the SAME shared handlers as the live projects panel (no separate
+    /// operation dispatch). Only the consumption-site keys differ: `r` restores
+    /// and `x` permanently deletes the highlighted archived board, and `Esc`/`q`
+    /// toggles back to the live set. Once a board is activated with `Enter` it is
+    /// THE active board and every view/operation is board-agnostic.
     pub fn handle_archived_boards_view_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
-        // When drilled into an archived board the focus moves to Cards; don't
-        // force it back to Boards — the escape arm in handle_escape returns focus
-        // to Boards when the user presses Esc.
-        if self.focus.active != Focus::Boards
-            && self.selection.active_archived_board_index.is_none()
-        {
+        // While browsing the list (no board activated) the Boards panel is the
+        // context. Once a board is active the focus is on Cards; leave it.
+        if self.focus.active != Focus::Boards && self.selection.active_board_id.is_none() {
             self.focus.active = Focus::Boards;
         }
 
         match key_code {
-            KeyCode::Enter => self.handle_open_archived_board(),
             KeyCode::Char('r') => self.handle_restore_board(),
             KeyCode::Char('x') => self.handle_delete_archived_board_key(),
-            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {
+            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q')
+                if self.selection.active_board_id.is_none() =>
+            {
                 self.handle_toggle_archived_boards_view();
             }
-            KeyCode::Char('j') | KeyCode::Down => self.handle_navigation_down(),
-            KeyCode::Char('k') | KeyCode::Up => self.handle_navigation_up(),
             KeyCode::Char('g') => {
                 if self.pending_key == Some('g') {
                     self.pending_key = None;
-                    self.selection.board.jump_to_first();
+                    self.handle_jump_to_top();
                 } else {
                     self.pending_key = Some('g');
                 }
             }
-            KeyCode::Char('G') => {
+            // Everything else reuses the shared Normal-mode boards handlers:
+            // activation, navigation, jumps, undo/redo — proving reuse.
+            other => {
                 self.pending_key = None;
-                let len = self.model.archived_boards_flat().len();
-                self.selection.board.jump_to_last(len);
+                self.handle_shared_boards_key(other);
             }
+        }
+    }
+
+    /// Dispatch the boards-panel keys shared between the live and archived
+    /// projects views. Board-set-agnostic: it drives the same navigation and
+    /// activation handlers regardless of which set the panel shows.
+    fn handle_shared_boards_key(&mut self, key_code: crossterm::event::KeyCode) {
+        use crossterm::event::KeyCode;
+        match key_code {
+            KeyCode::Enter | KeyCode::Char(' ') => self.handle_selection_activate(),
+            KeyCode::Char('j') | KeyCode::Down => self.handle_navigation_down(),
+            KeyCode::Char('k') | KeyCode::Up => self.handle_navigation_up(),
+            KeyCode::Char('G') => self.handle_jump_to_bottom(),
             KeyCode::Char('u') => {
-                self.pending_key = None;
                 if let Err(e) = self.undo() {
                     self.set_error(format!("Undo failed: {e}"));
                 }
                 self.prepare_frame();
-                let remaining = self.model.archived_boards_flat().len();
-                self.selection.board.clamp(remaining);
+                self.selection.board.clamp(self.displayed_boards().len());
             }
             KeyCode::Char('U') => {
-                self.pending_key = None;
                 if let Err(e) = self.redo() {
                     self.set_error(format!("Redo failed: {e}"));
                 }
                 self.prepare_frame();
-                let remaining = self.model.archived_boards_flat().len();
-                self.selection.board.clamp(remaining);
+                self.selection.board.clamp(self.displayed_boards().len());
             }
             _ => {}
         }

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -72,6 +72,18 @@ impl Model {
         self.archived_boards_flat.as_ref()?.get(idx)
     }
 
+    /// Resolve a board by id across BOTH the live set and the archived heads.
+    /// This is the single uniform resolver for "the board with this id" — it is
+    /// deliberately archival-agnostic: a board is a board regardless of whether
+    /// its head is archived. Live boards take precedence (an id is only ever in
+    /// one set, but the ordering makes the common case a direct hit).
+    pub fn board_by_id(&self, id: Uuid) -> Option<&Board> {
+        self.boards()
+            .iter()
+            .find(|b| b.id == id)
+            .or_else(|| self.archived_board(id))
+    }
+
     pub fn graph(&self) -> &DependencyGraph {
         &self.graph
     }

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -22,15 +22,12 @@ impl App {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card(active_id) {
                 if let Some(card_sprint_id) = card.sprint_id {
-                    if let Some(board_idx) = self.selection.active_board_index {
-                        let boards = self.model.boards();
-                        if let Some(board) = boards.get(board_idx) {
-                            let sprints = self.model.sprints();
-                            let entries = build_entries(sprints, board.id, chrono::Utc::now());
-                            for (idx, entry) in entries.iter().enumerate() {
-                                if sprint_id_of(entry) == Some(card_sprint_id) {
-                                    return idx;
-                                }
+                    if let Some(board) = self.active_board() {
+                        let sprints = self.model.sprints();
+                        let entries = build_entries(sprints, board.id, chrono::Utc::now());
+                        for (idx, entry) in entries.iter().enumerate() {
+                            if sprint_id_of(entry) == Some(card_sprint_id) {
+                                return idx;
                             }
                         }
                     }

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -4,11 +4,13 @@ use std::cell::Cell;
 #[derive(Default)]
 pub struct SelectionHub {
     pub board: SelectionState,
-    pub active_board_index: Option<usize>,
-    /// When `Some`, the user has drilled into the archived board at this index
-    /// in `model.archived_boards_flat()`. Exactly one of `active_board_index`
-    /// and `active_archived_board_index` is `Some` at a time.
-    pub active_archived_board_index: Option<usize>,
+    /// The board the user is currently viewing/acting on, tracked by IDENTITY so
+    /// it is archival-agnostic: it resolves through `Model::board_by_id`, which
+    /// finds the board whether its head is live or archived. `None` while
+    /// browsing the projects list without a board opened. An archived board is
+    /// substitutable for a live one everywhere — there is no separate archived
+    /// active-board state (Liskov).
+    pub active_board_id: Option<uuid::Uuid>,
     pub active_card_id: Option<uuid::Uuid>,
     pub sprint: SelectionState,
     pub sprint_scroll: Cell<usize>,

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -3,23 +3,48 @@ use crate::view_strategy::{UnifiedViewStrategy, ViewRefreshContext, ViewStrategy
 use kanban_domain::{Board, Card, KanbanResult};
 
 impl App {
-    /// Resolve the board currently being viewed (drilled into) — either a live
-    /// board (when `active_board_index` is set) or an archived board head (when
-    /// `active_archived_board_index` is set). Returns `None` when no board is
-    /// active (e.g. the user is browsing the boards list without opening one).
+    /// Resolve the board the user is currently acting on / viewing, by identity.
+    /// This is the single, archival-agnostic active-board accessor every
+    /// operation and view uses: a board is a board whether its head is live or
+    /// archived. Returns `None` when no board is active (browsing the projects
+    /// list without opening one).
     ///
     /// Note: `prepare_frame` inlines the equivalent resolution instead of calling
     /// this helper because it also needs a mutable borrow of `self.view.strategy`
     /// in the same scope, which Rust's NLL cannot split through a method boundary.
     /// All other call sites use this helper directly.
-    pub fn viewed_board(&self) -> Option<&Board> {
-        if let Some(ai) = self.selection.active_archived_board_index {
-            self.model.archived_boards_flat().get(ai)
+    pub fn active_board(&self) -> Option<&Board> {
+        self.selection
+            .active_board_id
+            .and_then(|id| self.model.board_by_id(id))
+    }
+
+    /// The board a board-scoped operation acts on: the active board (by id) if
+    /// one is open, otherwise the board highlighted in the currently displayed
+    /// projects set. Board-agnostic — resolves live OR archived boards uniformly,
+    /// so board detail, sprints, and columns work identically for either.
+    pub fn board_in_context(&self) -> Option<&Board> {
+        match self.selection.active_board_id {
+            Some(id) => self.model.board_by_id(id),
+            None => self
+                .selection
+                .board
+                .get()
+                .and_then(|idx| self.displayed_boards().get(idx)),
+        }
+    }
+
+    /// The board set the projects panel currently displays: the archived heads
+    /// when the panel is toggled to the archived set, the live boards otherwise.
+    /// This is the SOLE place the live/archived distinction affects behavior —
+    /// the projects panel choosing which set to render and index selection into.
+    /// Everything downstream (operations, navigation, resolution) is board-
+    /// agnostic and resolves the active board by id via `active_board`.
+    pub fn displayed_boards(&self) -> &[Board] {
+        if self.mode == AppMode::ArchivedBoardsView {
+            self.model.archived_boards_flat()
         } else {
-            self.selection
-                .active_board_index
-                .or(self.selection.board.get())
-                .and_then(|idx| self.model.boards().get(idx))
+            self.model.boards()
         }
     }
 
@@ -35,18 +60,25 @@ impl App {
             self.model.cards()
         };
 
-        // Board resolution: inlined here because a call to `self.viewed_board()`
-        // (returning `Option<&Board>`) would borrow `self` immutably while
-        // `self.view.strategy.refresh_task_lists` below needs a mutable borrow
-        // of `self.view.strategy`. Rust NLL cannot split these through a method
-        // call boundary, so we inline the same logic.
-        let board: Option<&Board> = if let Some(ai) = self.selection.active_archived_board_index {
-            self.model.archived_boards_flat().get(ai)
+        // Board resolution: inlined (rather than calling `active_board` /
+        // `displayed_boards`) because those return borrows tied to all of `self`,
+        // which Rust NLL cannot split from the `&mut self.view.strategy` borrow
+        // taken by `refresh_task_lists` below. Inlining keeps the borrow scoped to
+        // `self.model`/`self.selection`/`self.mode`. When no board is active
+        // (browsing the projects list), fall back to the highlighted board in the
+        // currently displayed set so the tasks preview tracks the cursor.
+        let displayed: &[Board] = if self.mode == AppMode::ArchivedBoardsView {
+            self.model.archived_boards_flat()
         } else {
-            self.selection
-                .active_board_index
-                .or(self.selection.board.get())
-                .and_then(|idx| self.model.boards().get(idx))
+            self.model.boards()
+        };
+        let board: Option<&Board> = match self.selection.active_board_id {
+            Some(id) => self.model.board_by_id(id),
+            None => self
+                .selection
+                .board
+                .get()
+                .and_then(|idx| displayed.get(idx)),
         };
 
         if let Some(board) = board {

--- a/crates/kanban-tui/src/components/filter_popup.rs
+++ b/crates/kanban-tui/src/components/filter_popup.rs
@@ -82,9 +82,8 @@ fn render_filter_sprints_section(
         label_text(),
     )));
 
-    if let Some(board_idx) = app.selection.active_board_index {
-        let boards = app.model.boards();
-        if let Some(board) = boards.get(board_idx) {
+    if let Some(board) = app.active_board() {
+        {
             let sprints = app.model.sprints();
             let board_sprints: Vec<_> = sprints.iter().filter(|s| s.board_id == board.id).collect();
 

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -194,16 +194,12 @@ impl SelectionDialog for CarryOverSprintDialog {
     }
 
     fn options_count(&self, app: &App) -> usize {
-        if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.model.boards().get(board_idx) {
-                app.model
-                    .sprints()
-                    .iter()
-                    .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
-                    .count()
-            } else {
-                0
-            }
+        if let Some(board) = app.active_board() {
+            app.model
+                .sprints()
+                .iter()
+                .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
+                .count()
         } else {
             0
         }
@@ -242,9 +238,8 @@ impl SelectionDialog for CarryOverSprintDialog {
 
         let mut lines = vec![];
 
-        if let Some(board_idx) = app.selection.active_board_index {
-            let boards = app.model.boards();
-            if let Some(board) = boards.get(board_idx) {
+        if let Some(board) = app.active_board() {
+            {
                 let sprints = app.model.sprints();
                 let planning_sprints: Vec<_> = sprints
                     .iter()
@@ -289,12 +284,9 @@ impl SelectionDialog for SprintAssignDialog {
     }
 
     fn options_count(&self, app: &App) -> usize {
-        if let Some(board_idx) = app.selection.active_board_index {
-            let boards = app.model.boards();
-            if let Some(board) = boards.get(board_idx) {
-                let sprints = app.model.sprints();
-                return build_entries(sprints, board.id, chrono::Utc::now()).len();
-            }
+        if let Some(board) = app.active_board() {
+            let sprints = app.model.sprints();
+            return build_entries(sprints, board.id, chrono::Utc::now()).len();
         }
         1
     }
@@ -329,10 +321,7 @@ impl SelectionDialog for SprintAssignDialog {
             chunks[0],
         );
 
-        let Some(board_idx) = app.selection.active_board_index else {
-            return;
-        };
-        let Some(board) = app.model.boards().get(board_idx) else {
+        let Some(board) = app.active_board() else {
             return;
         };
         app.dialog_input.assign_sprint_picker.render(

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -31,20 +31,36 @@ impl App {
     }
 
     pub fn handle_rename_board_key(&mut self) {
-        if self.focus.active == Focus::Boards && self.selection.board.get().is_some() {
-            if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.model.boards().get(board_idx) {
-                    self.input.set(board.name.clone());
-                    self.open_dialog(DialogMode::RenameBoard);
-                }
+        if self.focus.active == Focus::Boards {
+            if let Some(name) = self
+                .selection
+                .board
+                .get()
+                .and_then(|idx| self.displayed_boards().get(idx))
+                .map(|b| b.name.clone())
+            {
+                self.input.set(name);
+                self.open_dialog(DialogMode::RenameBoard);
             }
         }
     }
 
     pub fn handle_edit_board_key(&mut self) {
-        if self.focus.active == Focus::Boards && self.selection.board.get().is_some() {
-            self.push_mode(AppMode::BoardDetail);
-            self.focus.board_focus = BoardFocus::Name;
+        if self.focus.active == Focus::Boards {
+            // Opening a board's detail makes it THE active board (by id), from
+            // the currently displayed set — live or archived alike. Every detail
+            // view then resolves it archival-agnostically via `active_board`.
+            if let Some(board_id) = self
+                .selection
+                .board
+                .get()
+                .and_then(|idx| self.displayed_boards().get(idx))
+                .map(|b| b.id)
+            {
+                self.selection.active_board_id = Some(board_id);
+                self.push_mode(AppMode::BoardDetail);
+                self.focus.board_focus = BoardFocus::Name;
+            }
         }
     }
 
@@ -151,37 +167,6 @@ impl App {
         }
     }
 
-    /// Drill into the highlighted archived board: populate the tasks panel from
-    /// its (still-live) subtree and focus Cards, exactly like a live board — but
-    /// keyed on the archived flat list. The board head stays archived.
-    pub fn handle_open_archived_board(&mut self) {
-        let Some(idx) = self.selection.board.get() else {
-            return;
-        };
-        let Some(board) = self.model.archived_boards_flat().get(idx) else {
-            return;
-        };
-        let (view, sort_field, sort_order) = (
-            board.task_list_view,
-            board.task_sort_field,
-            board.task_sort_order,
-        );
-        self.selection.active_archived_board_index = Some(idx);
-        self.selection.active_board_index = None;
-        self.filter.current_sort_field = Some(sort_field);
-        self.filter.current_sort_order = Some(sort_order);
-        self.switch_view_strategy(view);
-        self.prepare_frame();
-        if let Some(list) = self.view.strategy.get_active_task_list_mut() {
-            if !list.is_empty() {
-                list.set_selected_index(Some(0));
-                list.ensure_selected_visible(self.view.viewport_height);
-            }
-        }
-        self.focus.active = Focus::Cards;
-        self.needs_redraw = true;
-    }
-
     /// ARCHIVE the highlighted board (the primary "remove from live" action,
     /// mirroring the card panel's `d`). Its subtree stays in place; the board head
     /// moves to the archived-boards view where it can be restored or permanently
@@ -195,18 +180,6 @@ impl App {
             return;
         };
         let remaining_after = self.model.boards().len().saturating_sub(1);
-
-        // Capture the viewed board's layout BEFORE removing, while the model and
-        // the active index are still valid. `None` when the viewed board is the
-        // one being removed, or nothing is active. (Reading it AFTER would use the
-        // stale model — `self.model` is only reloaded next frame — with the
-        // post-shift index, yielding the wrong board's layout.)
-        let surviving_view = match self.selection.active_board_index {
-            Some(active) if active != idx => {
-                self.model.boards().get(active).map(|b| b.task_list_view)
-            }
-            _ => None,
-        };
 
         if let Err(e) = self.ctx.archive_board(board_id) {
             tracing::error!("Failed to archive board: {}", e);
@@ -222,23 +195,21 @@ impl App {
             self.selection.board.set(Some(idx.min(remaining_after - 1)));
         }
 
-        // Active/viewed board: keep pointing at the SAME board across the shift
-        // caused by removing `idx`. The highlight and the active board are
-        // independent (activate with Enter, then move the highlight with j/k),
-        // so deriving `active` from the highlight would silently switch which
-        // board is being viewed.
-        self.selection.active_board_index = match self.selection.active_board_index {
-            Some(active) if active == idx => None, // the viewed board itself was deleted
-            Some(active) if active > idx => Some(active - 1), // elements after idx shift down
-            other => other,                        // active < idx (unchanged) or None (stay None)
-        };
+        // Active/viewed board: tracked by IDENTITY, so it is naturally stable
+        // across the list shift caused by removing a board — no index fixup. If
+        // the board being archived is the one currently viewed, stop viewing it
+        // (the projects list is the context now).
+        if self.selection.active_board_id == Some(board_id) {
+            self.selection.active_board_id = None;
+        }
 
-        // View: apply the surviving board's captured layout. When no board is
-        // viewed (deleted, or none active), reset to the default (Flat) strategy
-        // whose active task list is an empty list, so the next
+        // View: apply the still-active board's layout, or reset to the default
+        // (Flat) strategy when nothing is viewed, so the next
         // `sync_card_list_component` clears the cards panel rather than leaving
-        // stale cards (a grouped/kanban strategy would expose no active list
-        // and the sync would skip, leaving ghosts).
+        // stale cards (a grouped/kanban strategy would expose no active list and
+        // the sync would skip, leaving ghosts). The model still holds the
+        // archived head, so `active_board` resolves the surviving view.
+        let surviving_view = self.active_board().map(|b| b.task_list_view);
         self.switch_view_strategy(surviving_view.unwrap_or_default());
     }
 
@@ -287,7 +258,9 @@ impl App {
         match self.mode {
             AppMode::Normal if self.focus.active == Focus::Boards => {
                 self.mode = AppMode::ArchivedBoardsView;
-                self.selection.active_archived_board_index = None;
+                // Toggling the displayed set returns to the projects list; any
+                // board that was open is no longer active.
+                self.selection.active_board_id = None;
                 self.prepare_frame();
                 // Select the first archived board (if any).
                 let has_any = !self.model.archived_boards_flat().is_empty();
@@ -296,7 +269,7 @@ impl App {
             }
             AppMode::ArchivedBoardsView => {
                 self.mode = AppMode::Normal;
-                self.selection.active_archived_board_index = None;
+                self.selection.active_board_id = None;
                 self.prepare_frame();
                 let has_any = !self.model.boards().is_empty();
                 self.selection.board.set(has_any.then_some(0));
@@ -327,7 +300,13 @@ impl App {
             return;
         }
         tracing::info!("Restored board {}", board_id);
-        self.selection.active_archived_board_index = None;
+        // If the restored board was the active one, it remains active — its id is
+        // unchanged, `board_by_id` now finds it in the live set. Clear only if it
+        // was the board being viewed and we want to drop back to the list; here
+        // we keep the list context (restore is a list-view action).
+        if self.selection.active_board_id == Some(board_id) {
+            self.selection.active_board_id = None;
+        }
         self.prepare_frame();
         // Clamp the highlight to the shrunken archived list.
         let remaining = self.model.archived_boards_flat().len();
@@ -734,10 +713,7 @@ mod tests {
     // ---- review fixes: active-board fixup, view, q-cancel, counts snapshot ----
 
     fn active_board_id(app: &App) -> Option<uuid::Uuid> {
-        app.selection
-            .active_board_index
-            .and_then(|i| app.model.boards().get(i))
-            .map(|b| b.id)
+        app.active_board().map(|b| b.id)
     }
 
     fn is_kanban_strategy(app: &App) -> bool {
@@ -757,22 +733,22 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_non_active_board_keeps_viewed_board() {
+    fn test_delete_non_active_board_keeps_active_board() {
         let mut app = App::test_default();
         create_named_board(&mut app, "A");
         create_named_board(&mut app, "B");
         create_named_board(&mut app, "C");
         create_named_board(&mut app, "D");
         let a_id = app.model.boards()[0].id;
-        // Viewing A (index 0); highlight is on D (index 3).
-        app.selection.active_board_index = Some(0);
+        // Viewing A; highlight is on D (index 3).
+        app.selection.active_board_id = Some(a_id);
         app.focus.active = Focus::Boards;
         app.selection.board.set(Some(3));
 
         app.delete_board();
         refresh(&mut app);
 
-        assert_eq!(app.selection.active_board_index, Some(0));
+        assert_eq!(app.selection.active_board_id, Some(a_id));
         assert_eq!(
             active_board_id(&app),
             Some(a_id),
@@ -781,23 +757,25 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_board_before_active_shifts_active_index() {
+    fn test_delete_board_before_active_keeps_viewing_same_board() {
+        // Tracking the active board by id makes it shift-invariant: archiving a
+        // board earlier in the list does not disturb which board is viewed.
         let mut app = App::test_default();
         create_named_board(&mut app, "A");
         create_named_board(&mut app, "B");
         create_named_board(&mut app, "C");
         let c_id = app.model.boards()[2].id;
-        app.selection.active_board_index = Some(2); // viewing C
+        app.selection.active_board_id = Some(c_id); // viewing C
         app.focus.active = Focus::Boards;
         app.selection.board.set(Some(0)); // highlight A
 
-        app.delete_board(); // delete A (index 0, before the active one)
+        app.delete_board(); // archive A (before the active one)
         refresh(&mut app);
 
         assert_eq!(
-            app.selection.active_board_index,
-            Some(1),
-            "active index shifts down by one"
+            app.selection.active_board_id,
+            Some(c_id),
+            "active board id is stable across the list shift"
         );
         assert_eq!(active_board_id(&app), Some(c_id), "still viewing C");
     }
@@ -807,15 +785,16 @@ mod tests {
         let mut app = App::test_default();
         create_named_board(&mut app, "A");
         create_named_board(&mut app, "B");
-        app.selection.active_board_index = Some(1); // viewing B
+        let b_id = app.model.boards()[1].id;
+        app.selection.active_board_id = Some(b_id); // viewing B
         app.focus.active = Focus::Boards;
         app.selection.board.set(Some(1)); // highlight B (the active board)
 
         app.delete_board();
 
         assert_eq!(
-            app.selection.active_board_index, None,
-            "active cleared when the viewed board is deleted"
+            app.selection.active_board_id, None,
+            "active cleared when the viewed board is archived"
         );
     }
 
@@ -836,7 +815,7 @@ mod tests {
             )
             .unwrap();
         refresh(&mut app);
-        app.selection.active_board_index = Some(0); // viewing A
+        app.selection.active_board_id = Some(a_id); // viewing A
         app.focus.active = Focus::Boards;
         app.selection.board.set(Some(1)); // highlight B
 
@@ -850,10 +829,8 @@ mod tests {
 
     #[test]
     fn test_delete_board_before_active_preserves_viewed_view() {
-        // Regression: the viewed board sits AFTER the deleted one, so its index
-        // shifts. The view must reflect the VIEWED board's layout, captured
-        // before the delete, not a re-lookup by the shifted index into the
-        // (stale, pre-delete) model.
+        // The viewed board sits AFTER the archived one. With id-based tracking
+        // the active board is stable, and its ColumnView layout is preserved.
         let mut app = App::test_default();
         create_named_board(&mut app, "A");
         create_named_board(&mut app, "B");
@@ -870,16 +847,16 @@ mod tests {
             )
             .unwrap();
         refresh(&mut app);
-        app.selection.active_board_index = Some(2); // viewing C
+        app.selection.active_board_id = Some(c_id); // viewing C
         app.focus.active = Focus::Boards;
         app.selection.board.set(Some(0)); // highlight A (before C)
 
-        app.delete_board(); // delete A; C survives, its index shifts 2 -> 1
+        app.delete_board(); // archive A; C survives, unchanged id
 
-        assert_eq!(app.selection.active_board_index, Some(1));
+        assert_eq!(app.selection.active_board_id, Some(c_id));
         assert!(
             is_kanban_strategy(&app),
-            "still shows C's ColumnView layout, not B's/the deleted board's"
+            "still shows C's ColumnView layout, not B's/the archived board's"
         );
     }
 
@@ -887,7 +864,7 @@ mod tests {
     fn test_delete_last_board_leaves_no_cards() {
         let mut app = App::test_default();
         create_named_board(&mut app, "Solo");
-        app.selection.active_board_index = Some(0);
+        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
         app.focus.active = Focus::Boards;
         app.selection.board.set(Some(0));
         // Simulate a populated cards panel.
@@ -1005,21 +982,29 @@ mod tests {
         (board_id, col_id)
     }
 
+    /// Activate the highlighted archived board through the SAME handler a live
+    /// board uses. Proof of reuse: no archival-specific entry point.
+    fn open_archived_board(app: &mut App) {
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+        app.handle_selection_activate();
+    }
+
     #[test]
     fn test_open_archived_board_populates_its_own_tasks() {
         let mut app = App::test_default();
         create_named_board(&mut app, "Live");
         let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "Arch");
 
-        app.focus.active = Focus::Boards;
-        app.mode = AppMode::ArchivedBoardsView;
-        app.prepare_frame();
-        app.selection.board.set(Some(0));
+        open_archived_board(&mut app);
 
-        app.handle_open_archived_board();
-
-        assert_eq!(app.selection.active_archived_board_index, Some(0));
-        assert_eq!(app.selection.active_board_index, None);
+        assert_eq!(
+            app.selection.active_board_id,
+            Some(arch_board_id),
+            "archived board is the active board, tracked by id like a live one"
+        );
         assert_eq!(app.focus.active, Focus::Cards);
         let task_count = app
             .view
@@ -1037,7 +1022,7 @@ mod tests {
                 .unwrap()
                 .iter()
                 .any(|ab| ab.entity_id == arch_board_id),
-            "board remains archived after drill-down"
+            "board remains archived after being opened"
         );
     }
 
@@ -1046,15 +1031,9 @@ mod tests {
         let mut app = App::test_default();
         let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "OnlyBoard");
 
-        app.focus.active = Focus::Boards;
-        app.mode = AppMode::ArchivedBoardsView;
-        app.prepare_frame();
-        app.selection.board.set(Some(0));
+        open_archived_board(&mut app);
 
-        app.handle_open_archived_board();
-
-        assert_eq!(app.selection.active_archived_board_index, Some(0));
-        assert_eq!(app.selection.active_board_index, None);
+        assert_eq!(app.selection.active_board_id, Some(arch_board_id));
         assert_eq!(app.focus.active, Focus::Cards);
         assert!(
             app.ctx
@@ -1070,18 +1049,15 @@ mod tests {
     fn test_enter_card_in_archived_board_opens_detail() {
         let mut app = App::test_default();
         let (_, _) = seed_archived_board_with_cards(&mut app, "Arch");
-        app.focus.active = Focus::Boards;
-        app.mode = AppMode::ArchivedBoardsView;
-        app.prepare_frame();
-        app.selection.board.set(Some(0));
 
-        app.handle_open_archived_board();
+        open_archived_board(&mut app);
 
         assert_eq!(app.focus.active, Focus::Cards);
         if let Some(list) = app.view.strategy.get_active_task_list_mut() {
             list.set_selected_index(Some(0));
         }
 
+        // Same activation handler a live board's card uses — no archival branch.
         app.handle_selection_activate();
 
         assert_eq!(app.mode, AppMode::CardDetail);
@@ -1089,36 +1065,37 @@ mod tests {
     }
 
     #[test]
-    fn test_escape_from_archived_board_drilldown_returns_to_archived_list() {
+    fn test_escape_from_archived_board_returns_to_archived_list() {
         let mut app = App::test_default();
         let (_, _) = seed_archived_board_with_cards(&mut app, "Arch");
-        app.focus.active = Focus::Boards;
-        app.mode = AppMode::ArchivedBoardsView;
-        app.prepare_frame();
-        app.selection.board.set(Some(0));
-        app.handle_open_archived_board();
+
+        open_archived_board(&mut app);
 
         app.handle_escape_key();
 
-        assert_eq!(app.selection.active_archived_board_index, None);
+        assert_eq!(
+            app.selection.active_board_id, None,
+            "leaving the board drops back to the projects list"
+        );
         assert_eq!(app.focus.active, Focus::Boards);
-        assert_eq!(app.mode, AppMode::ArchivedBoardsView);
+        assert_eq!(
+            app.mode,
+            AppMode::ArchivedBoardsView,
+            "panel still shows the archived set"
+        );
     }
 
     #[test]
-    fn test_restore_clears_active_archived_board_index() {
+    fn test_restore_clears_active_board() {
         let mut app = App::test_default();
         let (_, _) = seed_archived_board_with_cards(&mut app, "Arch");
-        app.focus.active = Focus::Boards;
-        app.mode = AppMode::ArchivedBoardsView;
-        app.prepare_frame();
-        app.selection.board.set(Some(0));
-        app.handle_open_archived_board();
-        assert_eq!(app.selection.active_archived_board_index, Some(0));
+
+        open_archived_board(&mut app);
+        assert!(app.selection.active_board_id.is_some());
 
         app.focus.active = Focus::Boards;
         app.handle_restore_board();
 
-        assert_eq!(app.selection.active_archived_board_index, None);
+        assert_eq!(app.selection.active_board_id, None);
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -10,15 +10,13 @@ use std::io;
 
 impl App {
     pub fn handle_create_card_key(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
-            if let Some(idx) = self.selection.active_board_index {
-                if let Some(board) = self.model.boards().get(idx) {
-                    self.dialog_input.create_card_sprint_picker.reset_for_board(
-                        self.model.sprints(),
-                        board,
-                        chrono::Utc::now(),
-                    );
-                }
+        if self.focus.active == Focus::Cards && self.active_board().is_some() {
+            if let Some(board) = self.active_board().cloned() {
+                self.dialog_input.create_card_sprint_picker.reset_for_board(
+                    self.model.sprints(),
+                    &board,
+                    chrono::Utc::now(),
+                );
             }
             self.open_dialog(DialogMode::CreateCard);
             self.input.clear();
@@ -109,23 +107,18 @@ impl App {
         }
 
         if !self.multi_select.selected_cards.is_empty() {
-            if let Some(board_idx) = self.selection.active_board_index {
-                if let Some(board) = self.model.boards().get(board_idx) {
-                    self.dialog_input
-                        .assign_sprint_picker
-                        .reset_for_bulk_card_assignment(
-                            self.model.sprints(),
-                            board,
-                            chrono::Utc::now(),
-                        );
-                }
+            if let Some(board) = self.active_board().cloned() {
+                self.dialog_input
+                    .assign_sprint_picker
+                    .reset_for_bulk_card_assignment(
+                        self.model.sprints(),
+                        &board,
+                        chrono::Utc::now(),
+                    );
             }
             self.open_dialog(DialogMode::AssignMultipleCardsToSprint);
         } else if self.get_selected_card_id().is_some() {
-            let Some(board_idx) = self.selection.active_board_index else {
-                return;
-            };
-            let board_id = match self.model.boards().get(board_idx) {
+            let board_id = match self.active_board() {
                 Some(b) => b.id,
                 None => return,
             };
@@ -156,17 +149,22 @@ impl App {
                 .and_then(|id| self.model.card(id))
                 .and_then(|c| c.sprint_id);
             // Re-borrow board after the &mut self call above.
-            if let Some(board) = self.model.boards().get(board_idx) {
+            if let Some(board) = self.active_board().cloned() {
                 self.dialog_input
                     .assign_sprint_picker
-                    .reset_for_card_assignment(current_sprint_id, self.model.sprints(), board, now);
+                    .reset_for_card_assignment(
+                        current_sprint_id,
+                        self.model.sprints(),
+                        &board,
+                        now,
+                    );
             }
             self.open_dialog(DialogMode::AssignCardToSprint);
         }
     }
 
     pub fn handle_order_cards_key(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
+        if self.focus.active == Focus::Cards && self.selection.active_board_id.is_some() {
             let sort_idx = self.get_current_sort_field_selection_index();
             self.filter.sort_field_selection.set(Some(sort_idx));
             self.open_dialog(DialogMode::OrderCards);
@@ -174,7 +172,7 @@ impl App {
     }
 
     pub fn handle_toggle_sort_order_key(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
+        if self.focus.active == Focus::Cards && self.selection.active_board_id.is_some() {
             if let Some(current_order) = self.filter.current_sort_order {
                 let new_order = match current_order {
                     SortOrder::Ascending => SortOrder::Descending,
@@ -182,21 +180,18 @@ impl App {
                 };
                 self.filter.current_sort_order = Some(new_order);
 
-                if let Some(board_idx) = self.selection.active_board_index {
-                    let boards = self.model.boards();
-                    if let Some(board) = boards.get(board_idx) {
-                        if let Some(field) = self.filter.current_sort_field {
-                            let cmd = Command::Board(BoardCommand::SetTaskSort(SetBoardTaskSort {
-                                board_id: board.id,
-                                field,
-                                order: new_order,
-                            }));
+                if let Some(board_id) = self.active_board().map(|b| b.id) {
+                    if let Some(field) = self.filter.current_sort_field {
+                        let cmd = Command::Board(BoardCommand::SetTaskSort(SetBoardTaskSort {
+                            board_id,
+                            field,
+                            order: new_order,
+                        }));
 
-                            if let Err(e) = self.execute_command(cmd) {
-                                tracing::error!("Failed to set board task sort: {}", e);
-                                self.set_error(format!("Failed to set board task sort: {}", e));
-                                return;
-                            }
+                        if let Err(e) = self.execute_command(cmd) {
+                            tracing::error!("Failed to set board task sort: {}", e);
+                            self.set_error(format!("Failed to set board task sort: {}", e));
+                            return;
                         }
                     }
                 }
@@ -207,7 +202,7 @@ impl App {
     }
 
     pub fn handle_toggle_hide_assigned(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
+        if self.focus.active == Focus::Cards && self.selection.active_board_id.is_some() {
             self.filter.hide_assigned_cards = !self.filter.hide_assigned_cards;
             let status = if self.filter.hide_assigned_cards {
                 "enabled"
@@ -219,29 +214,24 @@ impl App {
     }
 
     pub fn handle_toggle_sprint_filter(&mut self) {
-        if self.focus.active == Focus::Cards && self.selection.active_board_index.is_some() {
-            if let Some(board_idx) = self.selection.active_board_index {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
-                    if let Some(active_sprint_id) = board.active_sprint_id {
-                        if self
-                            .filter
-                            .active_sprint_filters
-                            .contains(&active_sprint_id)
-                        {
-                            self.filter.active_sprint_filters.remove(&active_sprint_id);
-                            tracing::info!("Disabled sprint filter - showing all cards");
-                        } else {
-                            self.filter.active_sprint_filters.clear();
-                            self.filter.active_sprint_filters.insert(active_sprint_id);
-                            tracing::info!("Enabled sprint filter - showing active sprint only");
-                        }
-                    } else {
-                        let msg = "No active sprint set for filtering";
-                        tracing::warn!("{}", msg);
-                        self.set_error(msg);
-                    }
+        if self.focus.active == Focus::Cards && self.selection.active_board_id.is_some() {
+            if let Some(active_sprint_id) = self.active_board().and_then(|b| b.active_sprint_id) {
+                if self
+                    .filter
+                    .active_sprint_filters
+                    .contains(&active_sprint_id)
+                {
+                    self.filter.active_sprint_filters.remove(&active_sprint_id);
+                    tracing::info!("Disabled sprint filter - showing all cards");
+                } else {
+                    self.filter.active_sprint_filters.clear();
+                    self.filter.active_sprint_filters.insert(active_sprint_id);
+                    tracing::info!("Enabled sprint filter - showing active sprint only");
                 }
+            } else {
+                let msg = "No active sprint set for filtering";
+                tracing::warn!("{}", msg);
+                self.set_error(msg);
             }
         }
     }
@@ -344,9 +334,12 @@ impl App {
     }
 
     pub fn create_card(&mut self) {
-        if let Some(idx) = self.selection.active_board_index {
+        if let Some(board_id) = self.selection.active_board_id {
             let focused_col_id = self.get_focused_column_id();
-            let board_info = self.model.boards().get(idx).map(|b| (b.id, b.card_counter));
+            let board_info = self
+                .model
+                .board_by_id(board_id)
+                .map(|b| (b.id, b.card_counter));
 
             if let Some((bid, card_number)) = board_info {
                 let target_column_id = if let Some(focused_col_id) = focused_col_id {
@@ -385,10 +378,10 @@ impl App {
                 let position =
                     kanban_domain::card_lifecycle::next_position_in_column(cards, column.id);
 
-                let boards = self.model.boards();
                 let columns = self.model.columns();
-                let mark_as_complete = boards
-                    .get(idx)
+                let mark_as_complete = self
+                    .model
+                    .board_by_id(board_id)
                     .map(|board| {
                         kanban_domain::card_lifecycle::should_auto_complete_new_card(
                             column.id, board, columns,
@@ -462,12 +455,7 @@ impl App {
         }
 
         if let Some(card) = self.get_selected_card_in_context() {
-            let boards = self.model.boards();
-            let board = self
-                .selection
-                .active_board_index
-                .and_then(|idx| boards.get(idx));
-            let board = match board {
+            let board = match self.active_board() {
                 Some(b) => b,
                 None => return,
             };
@@ -517,12 +505,9 @@ impl App {
                             }
                         }
                         kanban_domain::card_lifecycle::MoveDirection::Right => {
-                            let boards = self.model.boards();
                             let columns = self.model.columns();
                             let num_cols = self
-                                .selection
-                                .active_board_index
-                                .and_then(|idx| boards.get(idx))
+                                .active_board()
                                 .map(|b| columns.iter().filter(|c| c.board_id == b.id).count())
                                 .unwrap_or(0);
                             if current_col_idx < num_cols - 1 {
@@ -541,12 +526,7 @@ impl App {
     }
 
     fn move_selected_cards(&mut self, direction: kanban_domain::card_lifecycle::MoveDirection) {
-        let boards = self.model.boards();
-        let board = self
-            .selection
-            .active_board_index
-            .and_then(|idx| boards.get(idx));
-        let board = match board {
+        let board = match self.active_board() {
             Some(b) => b,
             None => return,
         };
@@ -736,12 +716,7 @@ impl App {
                 None => return,
             };
 
-        let boards = self.model.boards();
-        let board_id = self
-            .selection
-            .active_board_index
-            .and_then(|idx| boards.get(idx))
-            .map(|b| b.id);
+        let board_id = self.active_board().map(|b| b.id);
 
         let columns = self.model.columns();
         let target_column_id = board_id
@@ -854,12 +829,8 @@ impl App {
         let card_id = card.id;
 
         // Get the board ID for filtering
-        let boards = self.model.boards();
-        let board_id = match self.selection.active_board_index {
-            Some(idx) => match boards.get(idx) {
-                Some(board) => board.id,
-                None => return,
-            },
+        let board_id = match self.active_board() {
+            Some(board) => board.id,
             None => return,
         };
 
@@ -926,7 +897,7 @@ mod create_card_factory_tests {
             .create_column(board.id, "TODO".into(), Some(0))
             .unwrap();
         refresh(app);
-        app.selection.active_board_index = Some(0);
+        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
     }
 
     /// KAN-796: the TUI card-create entry point funnels through the Card factory

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -9,8 +9,8 @@ use kanban_domain::{ColumnUpdate, TaskListView};
 impl App {
     pub fn handle_create_column_key(&mut self) {
         if self.focus.board_focus == BoardFocus::Columns {
-            if let Some(board_idx) = self.selection.board.get() {
-                if self.model.boards().get(board_idx).is_some() {
+            {
+                if self.active_board().is_some() {
                     self.open_dialog(DialogMode::CreateColumn);
                     self.input.clear();
                 }
@@ -22,9 +22,8 @@ impl App {
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_selection.get().is_some()
         {
-            if let Some(board_idx) = self.selection.board.get() {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
+            {
+                if let Some(board) = self.active_board() {
                     let columns = self.model.columns();
                     let board_columns: Vec<_> = columns
                         .iter()
@@ -46,8 +45,8 @@ impl App {
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_selection.get().is_some()
         {
-            if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.model.boards().get(board_idx) {
+            {
+                if let Some(board) = self.active_board() {
                     let column_count = self
                         .model
                         .columns()
@@ -69,8 +68,8 @@ impl App {
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_selection.get().is_some()
         {
-            if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.model.boards().get(board_idx) {
+            {
+                if let Some(board) = self.active_board() {
                     // Collect and sort column data before mutating
                     let mut board_columns: Vec<_> = self
                         .model
@@ -125,8 +124,8 @@ impl App {
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_selection.get().is_some()
         {
-            if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.model.boards().get(board_idx) {
+            {
+                if let Some(board) = self.active_board() {
                     // Collect and sort column data before mutating
                     let mut board_columns: Vec<_> = self
                         .model
@@ -183,25 +182,23 @@ impl App {
             return;
         }
 
-        if let Some(board_idx) = self.selection.active_board_index {
-            if let Some(board) = self.model.boards().get(board_idx) {
-                let current_view_idx = match board.task_list_view {
-                    TaskListView::Flat => 0,
-                    TaskListView::GroupedByColumn => 1,
-                    TaskListView::ColumnView => 2,
-                };
-                self.dialog_input
-                    .task_list_view_selection
-                    .set(Some(current_view_idx));
-                self.open_dialog(DialogMode::SelectTaskListView);
-            }
+        if let Some(board) = self.active_board() {
+            let current_view_idx = match board.task_list_view {
+                TaskListView::Flat => 0,
+                TaskListView::GroupedByColumn => 1,
+                TaskListView::ColumnView => 2,
+            };
+            self.dialog_input
+                .task_list_view_selection
+                .set(Some(current_view_idx));
+            self.open_dialog(DialogMode::SelectTaskListView);
         }
     }
 
     pub fn create_column(&mut self) {
-        if let Some(board_idx) = self.selection.board.get() {
+        {
             // Collect board_id before command execution
-            let board_id = self.model.boards().get(board_idx).map(|board| board.id);
+            let board_id = self.active_board().map(|board| board.id);
 
             if let Some(board_id) = board_id {
                 let column_name = self.input.as_str().trim().to_string();
@@ -251,11 +248,10 @@ impl App {
     }
 
     pub fn rename_column(&mut self) {
-        if let Some(board_idx) = self.selection.board.get() {
+        {
             // Collect column ID before mutable borrow
             let column_info = {
-                let boards = self.model.boards();
-                if let Some(board) = boards.get(board_idx) {
+                if let Some(board) = self.active_board() {
                     if let Some(column_idx) = self.dialog_input.column_selection.get() {
                         let columns = self.model.columns();
                         let board_columns: Vec<_> = columns
@@ -300,10 +296,10 @@ impl App {
     }
 
     pub fn delete_column(&mut self) {
-        if let Some(board_idx) = self.selection.board.get() {
+        {
             // Collect all necessary data before mutating
             let delete_info = {
-                if let Some(board) = self.model.boards().get(board_idx) {
+                if let Some(board) = self.active_board() {
                     if let Some(column_idx) = self.dialog_input.column_selection.get() {
                         let board_columns: Vec<_> = self
                             .model
@@ -352,8 +348,7 @@ impl App {
             {
                 let remaining_after_delete = {
                     let columns = self.model.columns();
-                    let board = self.model.boards().get(board_idx);
-                    board
+                    self.active_board()
                         .map(|b| {
                             columns
                                 .iter()
@@ -507,13 +502,10 @@ impl App {
 
                     let selected_card_id = self.get_selected_card_id();
 
-                    if let Some(board_idx) = self.selection.active_board_index {
-                        if let Some(board) = self.model.boards().get(board_idx) {
+                    if let Some(board_id) = self.active_board().map(|b| b.id) {
+                        {
                             let cmd = Command::Board(BoardCommand::SetTaskListView(
-                                SetBoardTaskListView {
-                                    board_id: board.id,
-                                    view,
-                                },
+                                SetBoardTaskListView { board_id, view },
                             ));
 
                             if let Err(e) = self.execute_command(cmd) {
@@ -559,6 +551,8 @@ mod tests {
         app.create_board();
         app.input.clear();
         refresh(app);
+        // Column operations act on the active board (as when editing its detail).
+        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
     }
 
     fn create_named_column(app: &mut App, name: &str) {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -292,30 +292,28 @@ impl App {
                 self.focus.card_focus = CardFocus::Title;
             }
             KeyCode::Char('a') => {
-                if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.model.boards().get(board_idx) {
-                        let sprint_count = self
-                            .model
-                            .sprints()
-                            .iter()
-                            .filter(|s| s.board_id == board.id)
-                            .count();
-                        if sprint_count > 0 {
-                            let current_sprint_id = self
-                                .selection
-                                .active_card_id
-                                .and_then(|id| self.model.card(id))
-                                .and_then(|c| c.sprint_id);
-                            self.dialog_input
-                                .assign_sprint_picker
-                                .reset_for_card_assignment(
-                                    current_sprint_id,
-                                    self.model.sprints(),
-                                    board,
-                                    chrono::Utc::now(),
-                                );
-                            self.open_dialog(DialogMode::AssignCardToSprint);
-                        }
+                if let Some(board) = self.active_board().cloned() {
+                    let sprint_count = self
+                        .model
+                        .sprints()
+                        .iter()
+                        .filter(|s| s.board_id == board.id)
+                        .count();
+                    if sprint_count > 0 {
+                        let current_sprint_id = self
+                            .selection
+                            .active_card_id
+                            .and_then(|id| self.model.card(id))
+                            .and_then(|c| c.sprint_id);
+                        self.dialog_input
+                            .assign_sprint_picker
+                            .reset_for_card_assignment(
+                                current_sprint_id,
+                                self.model.sprints(),
+                                &board,
+                                chrono::Utc::now(),
+                            );
+                        self.open_dialog(DialogMode::AssignCardToSprint);
                     }
                 }
             }
@@ -396,8 +394,8 @@ impl App {
                     should_restart = true;
                 }
                 BoardFocus::Settings => {
-                    if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.model.boards().get(board_idx) {
+                    if let Some(board) = self.active_board() {
+                        {
                             let board_id = board.id;
                             let dto = BoardSettingsDto::from_entity(board);
                             let json = serde_json::to_string_pretty(&dto)
@@ -480,8 +478,8 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => match self.focus.board_focus {
                 BoardFocus::Sprints => {
-                    if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.model.boards().get(board_idx) {
+                    if let Some(board) = self.active_board() {
+                        {
                             let sprint_count = self
                                 .model
                                 .sprints()
@@ -499,8 +497,8 @@ impl App {
                     }
                 }
                 BoardFocus::Columns => {
-                    if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.model.boards().get(board_idx) {
+                    if let Some(board) = self.active_board() {
+                        {
                             let column_count = self
                                 .model
                                 .columns()
@@ -585,23 +583,23 @@ impl App {
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if self.focus.board_focus == BoardFocus::Sprints {
                     if let Some(sprint_idx) = self.selection.sprint.get() {
-                        if let Some(board_idx) = self.selection.board.get() {
-                            let boards = self.model.boards();
-                            if let Some(board) = boards.get(board_idx) {
-                                let sprints = self.model.sprints();
-                                let board_sprints: Vec<_> = sprints
-                                    .iter()
-                                    .enumerate()
-                                    .filter(|(_, s)| s.board_id == board.id)
-                                    .collect();
-                                if let Some((actual_idx, _)) = board_sprints.get(sprint_idx) {
-                                    self.selection.active_sprint_index = Some(*actual_idx);
-                                    self.selection.active_board_index = Some(board_idx);
-                                    if let Some(sprint) = sprints.get(*actual_idx) {
-                                        self.populate_sprint_task_lists(sprint.id);
-                                    }
-                                    self.push_mode(AppMode::SprintDetail);
+                        let board_ctx = self.board_in_context().map(|b| b.id);
+                        if let Some(board_id) = board_ctx {
+                            let sprints = self.model.sprints();
+                            let board_sprints: Vec<_> = sprints
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, s)| s.board_id == board_id)
+                                .collect();
+                            if let Some((actual_idx, _)) = board_sprints.get(sprint_idx) {
+                                let actual_idx = *actual_idx;
+                                let sprint_id = sprints.get(actual_idx).map(|s| s.id);
+                                self.selection.active_sprint_index = Some(actual_idx);
+                                self.selection.active_board_id = Some(board_id);
+                                if let Some(sprint_id) = sprint_id {
+                                    self.populate_sprint_task_lists(sprint_id);
                                 }
+                                self.push_mode(AppMode::SprintDetail);
                             }
                         }
                     }
@@ -609,13 +607,12 @@ impl App {
             }
             KeyCode::Char('p') => {
                 if self.focus.board_focus == BoardFocus::Settings {
-                    if let Some(board_idx) = self.selection.board.get() {
-                        if let Some(board) = self.model.boards().get(board_idx) {
-                            let current_prefix =
-                                board.sprint_prefix.clone().unwrap_or_else(String::new);
-                            self.input.set(current_prefix);
-                            self.open_dialog(DialogMode::SetBranchPrefix);
-                        }
+                    if let Some(current_prefix) = self
+                        .active_board()
+                        .map(|b| b.sprint_prefix.clone().unwrap_or_default())
+                    {
+                        self.input.set(current_prefix);
+                        self.open_dialog(DialogMode::SetBranchPrefix);
                     }
                 }
             }
@@ -805,27 +802,25 @@ impl App {
                         CardListAction::AssignSprint(card_id)
                         | CardListAction::ReassignSprint(card_id) => {
                             if self.activate_card(card_id) {
-                                if let Some(board_idx) = self.selection.active_board_index {
-                                    if let Some(board) = self.model.boards().get(board_idx) {
-                                        let sprint_count = self
-                                            .model
-                                            .sprints()
-                                            .iter()
-                                            .filter(|s| s.board_id == board.id)
-                                            .count();
-                                        if sprint_count > 0 {
-                                            let current_sprint_id =
-                                                self.model.card(card_id).and_then(|c| c.sprint_id);
-                                            self.dialog_input
-                                                .assign_sprint_picker
-                                                .reset_for_card_assignment(
-                                                    current_sprint_id,
-                                                    self.model.sprints(),
-                                                    board,
-                                                    chrono::Utc::now(),
-                                                );
-                                            self.open_dialog(DialogMode::AssignCardToSprint);
-                                        }
+                                if let Some(board) = self.active_board().cloned() {
+                                    let sprint_count = self
+                                        .model
+                                        .sprints()
+                                        .iter()
+                                        .filter(|s| s.board_id == board.id)
+                                        .count();
+                                    if sprint_count > 0 {
+                                        let current_sprint_id =
+                                            self.model.card(card_id).and_then(|c| c.sprint_id);
+                                        self.dialog_input
+                                            .assign_sprint_picker
+                                            .reset_for_card_assignment(
+                                                current_sprint_id,
+                                                self.model.sprints(),
+                                                &board,
+                                                chrono::Utc::now(),
+                                            );
+                                        self.open_dialog(DialogMode::AssignCardToSprint);
                                     }
                                 }
                             }
@@ -863,17 +858,13 @@ impl App {
                                     kanban_domain::card_lifecycle::MoveDirection::Left
                                 };
 
-                                let boards = self.model.boards();
                                 let columns = self.model.columns();
                                 let cards = self.model.cards();
-                                let move_result =
-                                    self.selection.active_board_index.and_then(|idx| {
-                                        boards.get(idx).and_then(|board| {
-                                            kanban_domain::card_lifecycle::compute_card_column_move(
-                                                &card, board, columns, cards, direction,
-                                            )
-                                        })
-                                    });
+                                let move_result = self.active_board().and_then(|board| {
+                                    kanban_domain::card_lifecycle::compute_card_column_move(
+                                        &card, board, columns, cards, direction,
+                                    )
+                                });
 
                                 if let Some(result) = move_result {
                                     use kanban_domain::KanbanOperations;
@@ -1492,7 +1483,7 @@ mod tests {
 
         load_with_card_order(&mut app, &[a.id, p.id, b.id, c.id, d.id]);
         app.selection.active_card_id = Some(a.id);
-        app.selection.active_board_index = Some(0);
+        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
 
         app.focus.card_focus = CardFocus::Children;
         app.relationship.children_list.update_item_count(1);

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -73,16 +73,18 @@ impl App {
             self.dialog_input.reset_create_card_focus();
             return;
         }
-        if let Some(idx) = self.selection.active_board_index {
-            if let Some(board) = self.model.boards().get(idx) {
-                let now = chrono::Utc::now();
-                self.dialog_input.create_card_sprint_picker.handle_key(
-                    key_code,
-                    self.model.sprints(),
-                    board,
-                    now,
-                );
-            }
+        if let Some(board) = self
+            .selection
+            .active_board_id
+            .and_then(|id| self.model.board_by_id(id))
+        {
+            let now = chrono::Utc::now();
+            self.dialog_input.create_card_sprint_picker.handle_key(
+                key_code,
+                self.model.sprints(),
+                board,
+                now,
+            );
         }
     }
 
@@ -224,9 +226,7 @@ impl App {
                 if prefix_str.is_empty() {
                     match context {
                         PrefixDialogContext::BoardSprint => {
-                            if let Some(board_idx) = self.selection.board.get() {
-                                if let Some(board_id) =
-                                    self.model.boards().get(board_idx).map(|b| b.id)
+                            if let Some(board_id) = self.active_board().map(|b| b.id) {
                                 {
                                     let cmd = kanban_domain::commands::Command::Board(
                                         kanban_domain::commands::BoardCommand::Update(
@@ -314,9 +314,7 @@ impl App {
                 } else if kanban_core::validate_branch_prefix(&prefix_str) {
                     match context {
                         PrefixDialogContext::BoardSprint => {
-                            if let Some(board_idx) = self.selection.board.get() {
-                                if let Some(board_id) =
-                                    self.model.boards().get(board_idx).map(|b| b.id)
+                            if let Some(board_id) = self.active_board().map(|b| b.id) {
                                 {
                                     let cmd = kanban_domain::commands::Command::Board(
                                         kanban_domain::commands::BoardCommand::Update(

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -5,7 +5,7 @@ use kanban_domain::CardFilters;
 
 impl App {
     pub fn handle_open_filter_dialog(&mut self) {
-        if self.focus.active != Focus::Cards || self.selection.active_board_index.is_none() {
+        if self.focus.active != Focus::Cards || self.selection.active_board_id.is_none() {
             return;
         }
 
@@ -32,13 +32,17 @@ impl App {
                 }
                 KeyCode::Char('j') | KeyCode::Down => match dialog_state.current_section {
                     FilterDialogSection::Sprints => {
-                        if let Some(board_idx) = self.selection.active_board_index {
-                            if let Some(board) = self.model.boards().get(board_idx) {
+                        if let Some(board_id) = self
+                            .selection
+                            .active_board_id
+                            .and_then(|id| self.model.board_by_id(id).map(|b| b.id))
+                        {
+                            {
                                 let sprint_count = self
                                     .model
                                     .sprints()
                                     .iter()
-                                    .filter(|s| s.board_id == board.id)
+                                    .filter(|s| s.board_id == board_id)
                                     .count();
                                 let total_items = 1 + sprint_count;
                                 if dialog_state.item_selection < total_items.saturating_sub(1) {
@@ -75,9 +79,12 @@ impl App {
                                 dialog_state.filters.show_unassigned_sprints
                             );
                             self.apply_filters();
-                        } else if let Some(board_idx) = self.selection.active_board_index {
-                            let boards = self.model.boards();
-                            if let Some(board) = boards.get(board_idx) {
+                        } else if let Some(board) = self
+                            .selection
+                            .active_board_id
+                            .and_then(|id| self.model.board_by_id(id))
+                        {
+                            {
                                 let sprints = self.model.sprints();
                                 let board_sprints: Vec<_> =
                                     sprints.iter().filter(|s| s.board_id == board.id).collect();

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -301,7 +301,7 @@ impl App {
     /// Compute page boundaries appropriate for the current view mode
     fn compute_pages_for_current_view(&self, total_items: usize) -> Vec<PageBoundary> {
         // For GroupedByColumn view, use header-aware pagination
-        if let Some(board) = self.viewed_board() {
+        if let Some(board) = self.active_board() {
             if board.task_list_view == TaskListView::GroupedByColumn {
                 // Try to get column boundaries for header-aware pagination
                 if let Some(unified) = self
@@ -343,7 +343,7 @@ impl App {
                 self.focus.active = Focus::Boards;
             }
             Focus::Cards => {
-                if self.selection.active_board_index.is_some() {
+                if self.selection.active_board_id.is_some() {
                     self.focus.active = Focus::Cards;
                 }
             }
@@ -448,35 +448,32 @@ impl App {
     pub fn handle_selection_activate(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                if self.selection.board.get().is_some() {
-                    self.selection.active_board_index = self.selection.board.get();
+                // Activate the highlighted board from whichever set the projects
+                // panel currently displays (live OR archived) — a board is a
+                // board. From here on it is THE active board, tracked by id, and
+                // every view/operation resolves it archival-agnostically.
+                let activated = self
+                    .selection
+                    .board
+                    .get()
+                    .and_then(|idx| self.displayed_boards().get(idx))
+                    .map(|b| (b.id, b.task_list_view, b.task_sort_field, b.task_sort_order));
 
-                    if let Some(board_idx) = self.selection.active_board_index {
-                        let (task_list_view, task_sort_field, task_sort_order) = {
-                            if let Some(board) = self.model.boards().get(board_idx) {
-                                (
-                                    board.task_list_view,
-                                    board.task_sort_field,
-                                    board.task_sort_order,
-                                )
-                            } else {
-                                (
-                                    kanban_domain::TaskListView::Flat,
-                                    kanban_domain::SortField::Default,
-                                    kanban_domain::SortOrder::Ascending,
-                                )
-                            }
-                        };
+                if let Some((board_id, task_list_view, task_sort_field, task_sort_order)) =
+                    activated
+                {
+                    self.selection.active_board_id = Some(board_id);
+                    self.filter.current_sort_field = Some(task_sort_field);
+                    self.filter.current_sort_order = Some(task_sort_order);
+                    self.switch_view_strategy(task_list_view);
+                    // Populate the tasks panel from the now-active board's subtree
+                    // immediately, so the first item can be selected this tick.
+                    self.prepare_frame();
 
-                        self.filter.current_sort_field = Some(task_sort_field);
-                        self.filter.current_sort_order = Some(task_sort_order);
-                        self.switch_view_strategy(task_list_view);
-
-                        if let Some(list) = self.view.strategy.get_active_task_list_mut() {
-                            if !list.is_empty() {
-                                list.set_selected_index(Some(0));
-                                list.ensure_selected_visible(self.view.viewport_height);
-                            }
+                    if let Some(list) = self.view.strategy.get_active_task_list_mut() {
+                        if !list.is_empty() {
+                            list.set_selected_index(Some(0));
+                            list.ensure_selected_visible(self.view.viewport_height);
                         }
                     }
 
@@ -515,47 +512,33 @@ impl App {
             return;
         }
 
-        // When drilled into an archived board, escape returns to the archived
-        // boards list (not the live boards Normal mode).
-        if self.selection.active_archived_board_index.is_some() {
-            self.selection.active_archived_board_index = None;
+        // Leaving the active board returns focus to the projects panel. The
+        // panel keeps showing whichever set it was on (live or archived), so
+        // escaping an archived board lands back on the archived list — no
+        // archival-specific branch needed.
+        if self.selection.active_board_id.is_some() {
+            self.selection.active_board_id = None;
             self.focus.active = Focus::Boards;
-            self.switch_view_strategy(TaskListView::GroupedByColumn);
-            return;
-        }
-
-        if self.selection.active_board_index.is_some() {
-            self.selection.active_board_index = None;
-            self.focus.active = Focus::Boards;
-
             self.switch_view_strategy(TaskListView::GroupedByColumn);
         }
     }
 
     pub fn is_kanban_view(&self) -> bool {
-        // ArchivedBoardsView always uses the split projects+tasks layout so the
-        // archived projects list is visible regardless of any live board's view
-        // mode (KAN-893). When drilled into an archived board, resolve that
-        // board's view from the archived flat list instead.
-        if self.mode == AppMode::ArchivedBoardsView
-            && self.selection.active_archived_board_index.is_none()
-        {
-            return false;
-        }
-        if let Some(board) = self.viewed_board() {
+        // Kanban (column) layout only applies to the ACTIVE board. While browsing
+        // the projects list (no active board) the split projects+tasks layout is
+        // used so the list stays visible — this holds for the live and archived
+        // sets alike, with no archival-specific branch.
+        if let Some(board) = self.active_board() {
             return board.task_list_view == TaskListView::ColumnView;
         }
         false
     }
 
-    /// Number of boards currently shown in the projects panel: archived heads in
-    /// ArchivedBoardsView, live boards otherwise. Used to bound j/k/G navigation.
+    /// Number of boards currently shown in the projects panel. Used to bound
+    /// j/k/G navigation. Delegates to `displayed_boards` (the sole consumption
+    /// site that chooses which set the panel shows).
     fn displayed_board_count(&self) -> usize {
-        if self.mode == AppMode::ArchivedBoardsView {
-            self.model.archived_boards_flat().len()
-        } else {
-            self.model.boards().len()
-        }
+        self.displayed_boards().len()
     }
 
     pub fn handle_kanban_column_left(&mut self) {
@@ -1248,17 +1231,28 @@ mod tests {
             .unwrap();
         let snap = app.ctx.snapshot().unwrap();
         app.model.load_from_snapshot(snap);
-        app.selection.active_board_index = Some(0);
+        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
         app
     }
 
     #[test]
-    fn test_is_kanban_view_false_in_archived_boards_view() {
+    fn test_is_kanban_view_false_while_browsing_boards_list() {
+        // KAN-893: browsing a boards list (no active board) always uses the split
+        // projects+tasks layout so the list stays visible — even when a live
+        // ColumnView board exists in the model. Holds for the archived set too,
+        // with no archival-specific branch: toggling to it clears the active
+        // board, so `is_kanban_view` is false while browsing.
         let mut app = make_app_with_columnview_active_board();
-        app.mode = AppMode::ArchivedBoardsView;
+        app.focus.active = Focus::Boards;
+        app.handle_toggle_archived_boards_view();
+        assert_eq!(app.mode, AppMode::ArchivedBoardsView);
+        assert_eq!(
+            app.selection.active_board_id, None,
+            "no board active in list"
+        );
         assert!(
             !app.is_kanban_view(),
-            "ArchivedBoardsView must never be treated as kanban view"
+            "browsing the boards list must never be treated as kanban view"
         );
     }
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -192,22 +192,19 @@ impl App {
                     self.filter.current_sort_field = Some(field);
                     self.filter.current_sort_order = Some(order);
 
-                    if let Some(board_idx) = self.selection.active_board_index {
-                        if let Some(board) = self.model.boards().get(board_idx) {
-                            let board_id = board.id;
-                            let cmd = kanban_domain::commands::Command::Board(
-                                kanban_domain::commands::BoardCommand::SetTaskSort(
-                                    kanban_domain::commands::SetBoardTaskSort {
-                                        board_id,
-                                        field,
-                                        order,
-                                    },
-                                ),
-                            );
-                            if let Err(e) = self.execute_command(cmd) {
-                                tracing::error!("Failed to set board task sort: {}", e);
-                                self.set_error(format!("Failed to set board task sort: {}", e));
-                            }
+                    if let Some(board_id) = self.active_board().map(|b| b.id) {
+                        let cmd = kanban_domain::commands::Command::Board(
+                            kanban_domain::commands::BoardCommand::SetTaskSort(
+                                kanban_domain::commands::SetBoardTaskSort {
+                                    board_id,
+                                    field,
+                                    order,
+                                },
+                            ),
+                        );
+                        if let Err(e) = self.execute_command(cmd) {
+                            tracing::error!("Failed to set board task sort: {}", e);
+                            self.set_error(format!("Failed to set board task sort: {}", e));
                         }
                     }
 
@@ -248,8 +245,8 @@ impl App {
                 };
                 let active_board_id = self
                     .selection
-                    .active_board_index
-                    .and_then(|idx| self.model.boards().get(idx))
+                    .active_board_id
+                    .and_then(|id| self.model.board_by_id(id))
                     .map(|b| b.id);
                 let picker = &self.dialog_input.assign_sprint_picker;
                 let board_matches = active_board_id
@@ -288,16 +285,18 @@ impl App {
                 self.dialog_input.assign_sprint_picker.clear();
             }
             _ => {
-                if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.model.boards().get(board_idx) {
-                        let now = chrono::Utc::now();
-                        self.dialog_input.assign_sprint_picker.handle_key(
-                            key_code,
-                            self.model.sprints(),
-                            board,
-                            now,
-                        );
-                    }
+                if let Some(board) = self
+                    .selection
+                    .active_board_id
+                    .and_then(|id| self.model.board_by_id(id))
+                {
+                    let now = chrono::Utc::now();
+                    self.dialog_input.assign_sprint_picker.handle_key(
+                        key_code,
+                        self.model.sprints(),
+                        board,
+                        now,
+                    );
                 }
             }
         }
@@ -316,8 +315,8 @@ impl App {
                     self.multi_select.selected_cards.iter().copied().collect();
                 let active_board_id = self
                     .selection
-                    .active_board_index
-                    .and_then(|idx| self.model.boards().get(idx))
+                    .active_board_id
+                    .and_then(|id| self.model.board_by_id(id))
                     .map(|b| b.id);
                 let picker = &self.dialog_input.assign_sprint_picker;
                 let board_matches = active_board_id
@@ -363,16 +362,18 @@ impl App {
                 self.multi_select.selection_mode_active = false;
             }
             _ => {
-                if let Some(board_idx) = self.selection.active_board_index {
-                    if let Some(board) = self.model.boards().get(board_idx) {
-                        let now = chrono::Utc::now();
-                        self.dialog_input.assign_sprint_picker.handle_key(
-                            key_code,
-                            self.model.sprints(),
-                            board,
-                            now,
-                        );
-                    }
+                if let Some(board) = self
+                    .selection
+                    .active_board_id
+                    .and_then(|id| self.model.board_by_id(id))
+                {
+                    let now = chrono::Utc::now();
+                    self.dialog_input.assign_sprint_picker.handle_key(
+                        key_code,
+                        self.model.sprints(),
+                        board,
+                        now,
+                    );
                 }
             }
         }

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -267,11 +267,7 @@ impl App {
             tracing::error!("Failed to clear history: {}", e);
         }
 
-        self.selection.active_board_index = if self.model.boards().is_empty() {
-            None
-        } else {
-            Some(0)
-        };
+        self.selection.active_board_id = self.model.boards().first().map(|b| b.id);
         self.selection.board.set(if self.model.boards().is_empty() {
             None
         } else {

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 impl App {
     pub fn handle_create_sprint_key(&mut self) {
-        if self.focus.board_focus == BoardFocus::Sprints && self.selection.board.get().is_some() {
+        if self.focus.board_focus == BoardFocus::Sprints && self.active_board().is_some() {
             self.open_dialog(DialogMode::CreateSprint);
             self.input.clear();
         }
@@ -17,15 +17,12 @@ impl App {
         if let Some(sprint_idx) = self.selection.active_sprint_index {
             // Collect sprint info before mutations
             let sprint_info = {
-                if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+                let context_board = self.board_in_context();
+                if let (Some(sprint), Some(board)) =
+                    (self.model.sprints().get(sprint_idx), context_board)
+                {
                     if sprint.status == SprintStatus::Planning {
-                        Some((
-                            sprint.id,
-                            sprint.formatted_name(
-                                &self.model.boards()[self.selection.board.get().unwrap_or(0)],
-                                "sprint",
-                            ),
-                        ))
+                        Some((sprint.id, sprint.formatted_name(board, "sprint")))
                     } else {
                         None
                     }
@@ -35,12 +32,8 @@ impl App {
             };
 
             if let Some((sprint_id, sprint_name)) = sprint_info {
-                let board_idx = self
-                    .selection
-                    .active_board_index
-                    .or(self.selection.board.get());
-                if let Some(board_idx) = board_idx {
-                    if let Some(board) = self.model.boards().get(board_idx) {
+                {
+                    if let Some(board) = self.board_in_context() {
                         let duration = board.sprint_duration_days.unwrap_or(14);
                         let board_id = board.id;
 
@@ -76,19 +69,14 @@ impl App {
         if let Some(sprint_idx) = self.selection.active_sprint_index {
             // Collect sprint and board info before mutations
             let sprint_info = {
-                if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+                let context_board = self.board_in_context();
+                if let (Some(sprint), Some(board)) =
+                    (self.model.sprints().get(sprint_idx), context_board)
+                {
                     if sprint.status == SprintStatus::Active
                         || sprint.status == SprintStatus::Planning
                     {
-                        let board_idx = self
-                            .selection
-                            .active_board_index
-                            .or(self.selection.board.get());
-                        board_idx.and_then(|board_idx| {
-                            self.model.boards().get(board_idx).map(|board| {
-                                (sprint.id, board.id, sprint.formatted_name(board, "sprint"))
-                            })
-                        })
+                        Some((sprint.id, board.id, sprint.formatted_name(board, "sprint")))
                     } else {
                         None
                     }
@@ -166,13 +154,9 @@ impl App {
     }
 
     pub fn create_sprint(&mut self) {
-        let board_idx = self
-            .selection
-            .active_board_index
-            .or(self.selection.board.get());
-        if let Some(board_idx) = board_idx {
+        {
             let (board_id, name) = {
-                if let Some(board) = self.model.boards().get(board_idx) {
+                if let Some(board) = self.board_in_context() {
                     let input_text = self.input.as_str().trim();
                     let name = if input_text.is_empty() {
                         None
@@ -240,7 +224,7 @@ mod create_sprint_factory_tests {
             .create_board("Board".into(), Some("KAN".into()))
             .unwrap();
         refresh(app);
-        app.selection.active_board_index = Some(0);
+        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
     }
 
     /// KAN-798: the TUI sprint-create entry point funnels through the Sprint

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -59,15 +59,10 @@ impl SinglePanelRenderer {
 
 impl RenderStrategy for SinglePanelRenderer {
     fn render(&self, app: &App, frame: &mut Frame, area: Rect) {
-        let board_idx = app
-            .selection
-            .active_board_index
-            .or(app.selection.board.get());
-
         let mut lines = vec![];
 
-        if let Some(idx) = board_idx {
-            if let Some(board) = app.model.boards().get(idx) {
+        if let Some(board) = app.board_in_context() {
+            {
                 let active_task_list = app.view.strategy.get_active_task_list();
 
                 if self.show_column_headers {
@@ -89,7 +84,7 @@ impl RenderStrategy for SinglePanelRenderer {
                             .unwrap_or_default();
 
                         if column_boundaries.is_empty() && task_list.is_empty() {
-                            let message = if app.selection.active_board_index.is_some() {
+                            let message = if app.selection.active_board_id.is_some() {
                                 "  No tasks yet. Press 'n' to create one!"
                             } else {
                                 "  (Enter/Space) to add tasks"
@@ -214,7 +209,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                 "Task",
                             ));
                         }
-                    } else if let Some(board) = app.model.boards().get(board_idx.unwrap()) {
+                    } else {
                         let mut board_columns: Vec<_> = app
                             .model
                             .columns()
@@ -229,7 +224,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                 label_text(),
                             )));
                         } else {
-                            let message = if app.selection.active_board_index.is_some() {
+                            let message = if app.selection.active_board_id.is_some() {
                                 "  No tasks yet. Press 'n' to create one!"
                             } else {
                                 "  (Enter/Space) to add tasks"
@@ -239,7 +234,7 @@ impl RenderStrategy for SinglePanelRenderer {
                     }
                 } else if let Some(task_list) = app.view.strategy.get_active_task_list() {
                     if task_list.is_empty() {
-                        let message = if app.selection.active_board_index.is_some() {
+                        let message = if app.selection.active_board_id.is_some() {
                             "  No tasks yet. Press 'n' to create one!"
                         } else {
                             "  (Enter/Space) to add tasks"
@@ -338,13 +333,8 @@ pub struct MultiPanelRenderer;
 
 impl RenderStrategy for MultiPanelRenderer {
     fn render(&self, app: &App, frame: &mut Frame, area: Rect) {
-        let board_idx = app
-            .selection
-            .active_board_index
-            .or(app.selection.board.get());
-
-        if let Some(idx) = board_idx {
-            if let Some(board) = app.model.boards().get(idx) {
+        if let Some(board) = app.board_in_context() {
+            {
                 let task_lists = app.view.strategy.get_all_task_lists();
 
                 if task_lists.is_empty() {

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -27,9 +27,11 @@ impl TuiSnapshot for Snapshot {
     fn apply_to_app(&self, app: &mut App) -> kanban_domain::KanbanResult<()> {
         app.ctx.apply_snapshot(self.clone())?;
 
-        // Sync sort field/order from active board to preserve user's selection after reload
-        if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = self.boards.get(board_idx) {
+        // Sync sort field/order from active board to preserve user's selection
+        // after reload. The snapshot's `boards` carries every head (live and
+        // archived), so resolving by id works for either.
+        if let Some(board_id) = app.selection.active_board_id {
+            if let Some(board) = self.boards.iter().find(|b| b.id == board_id) {
                 app.filter.current_sort_field = Some(board.task_sort_field);
                 app.filter.current_sort_order = Some(board.task_sort_order);
             }
@@ -68,6 +70,7 @@ mod tests {
         // Create a board with Position sort field
         let mut board = Board::new("Test", None::<String>);
         board.update_task_sort(SortField::Position, kanban_domain::SortOrder::Ascending);
+        let board_id = board.id;
 
         let snapshot = Snapshot {
             archived_boards: Vec::new(),
@@ -79,9 +82,9 @@ mod tests {
             graph: DependencyGraph::new(),
         };
 
-        // Create a minimal app with active_board_index set
+        // Create a minimal app with the active board set by id.
         let mut app = App::test_default();
-        app.selection.active_board_index = Some(0);
+        app.selection.active_board_id = Some(board_id);
         app.filter.current_sort_field = Some(SortField::Default);
 
         // Apply snapshot - should sync sort field from board

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -101,7 +101,7 @@ pub fn setup_reload_resort_fixture(app: &mut App) -> ReloadResortFixture {
 
     load_with_card_order(app, &[p.id, a.id, b.id, c.id, d.id]);
     app.selection.active_card_id = Some(a.id);
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
 
     load_with_card_order(app, &[a.id, p.id, b.id, c.id, d.id]);
 

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -12,8 +12,10 @@ use ratatui::{
 };
 
 pub(super) fn render_board_detail_view(app: &App, frame: &mut Frame, area: Rect) {
-    if let Some(board_idx) = app.selection.board.get() {
-        if let Some(board) = app.model.boards().get(board_idx) {
+    // Resolve the board by identity so board detail works for a live OR archived
+    // board without branching — a board is a board.
+    if let Some(board) = app.board_in_context() {
+        {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -65,8 +65,8 @@ pub(super) fn render_relationship_boxes(
 pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) {
     if let Some(card) = app.get_card_for_detail_view() {
         let card = &card;
-        if let Some(board_idx) = app.selection.active_board_index {
-            if let Some(board) = app.model.boards().get(board_idx) {
+        if let Some(board) = app.active_board() {
+            {
                 let has_sprint_logs = !card.sprint_logs.is_empty();
                 let card_id = card.id;
 

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -10,7 +10,7 @@ use ratatui::{
 pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
     use crate::components::centered_rect;
 
-    let Some(board_idx) = app.selection.active_board_index else {
+    let Some(board) = app.active_board() else {
         render_input_popup(
             frame,
             "Create New Task",
@@ -18,9 +18,6 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
             app.input.as_str(),
             app.input.cursor_byte_offset(),
         );
-        return;
-    };
-    let Some(board) = app.model.boards().get(board_idx) else {
         return;
     };
 
@@ -157,10 +154,7 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
         chunks[0],
     );
 
-    let Some(board_idx) = app.selection.active_board_index else {
-        return;
-    };
-    let Some(board) = app.model.boards().get(board_idx) else {
+    let Some(board) = app.active_board() else {
         return;
     };
     app.dialog_input.assign_sprint_picker.render(

--- a/crates/kanban-tui/src/ui/dialogs/columns.rs
+++ b/crates/kanban-tui/src/ui/dialogs/columns.rs
@@ -43,12 +43,7 @@ pub(crate) fn render_select_task_list_view_popup(app: &App, frame: &mut Frame) {
 
     let selected = app.dialog_input.task_list_view_selection.get();
 
-    let current_view = app.selection.active_board_index.and_then(|idx| {
-        app.model
-            .boards()
-            .get(idx)
-            .map(|board| board.task_list_view)
-    });
+    let current_view = app.active_board().map(|board| board.task_list_view);
 
     let items: Vec<ListItem> = views
         .iter()

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -33,11 +33,7 @@ pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
     // panel (mirroring how ArchivedCardsView shows archived cards in the tasks
     // panel); everywhere else it shows the LIVE boards.
     let archived_view = app.mode == AppMode::ArchivedBoardsView;
-    let boards = if archived_view {
-        app.model.archived_boards_flat()
-    } else {
-        app.model.boards()
-    };
+    let boards = app.displayed_boards();
 
     if boards.is_empty() {
         let empty = if archived_view {
@@ -51,7 +47,7 @@ pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
             let config = ListItemConfig::new()
                 .selected(app.selection.board.get() == Some(idx))
                 .focused(app.focus.active == Focus::Boards)
-                .active(!archived_view && app.selection.active_board_index == Some(idx));
+                .active(app.selection.active_board_id == Some(board.id));
 
             lines.push(styled_list_item(&board.name, &config));
         }
@@ -79,7 +75,7 @@ pub fn build_filter_title_suffix(app: &App) -> Option<String> {
     }
 
     if !app.filter.active_sprint_filters.is_empty() {
-        if let Some(board) = app.viewed_board() {
+        if let Some(board) = app.active_board() {
             let mut sprint_names: Vec<String> = app
                 .model
                 .sprints()
@@ -106,10 +102,15 @@ pub fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
         .get_active_task_list()
         .map(|l| l.len())
         .unwrap_or(0);
-    let archived_drill_down = app.selection.active_archived_board_index.is_some();
+    // Display indicator: the active board's head is archived (a pure display
+    // concern — the tasks behave identically to a live board).
+    let viewing_archived_board = app
+        .selection
+        .active_board_id
+        .is_some_and(|id| app.model.archived_board(id).is_some());
     let mut title = if app.mode == AppMode::ArchivedCardsView {
         format!("Archive [{}]", count)
-    } else if archived_drill_down {
+    } else if viewing_archived_board {
         format!("[ARCHIVED] Tasks [2] ({})", count)
     } else if app.focus.active == Focus::Cards {
         format!("Tasks [2] ({})", count)
@@ -174,7 +175,7 @@ mod tests {
             .create_sprint(board.id, None, Some("Sprint".to_string()))
             .unwrap();
         let sprint_id = sprint.id;
-        app.selection.active_board_index = Some(0);
+        app.selection.active_board_id = Some(board.id);
         app.filter.active_sprint_filters.insert(sprint_id);
         app.prepare_frame();
         let suffix = build_filter_title_suffix(&app);

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -15,15 +15,11 @@ pub(super) fn render_sprint_detail_view(app: &mut App, frame: &mut Frame, area: 
         Some(i) => i,
         None => return,
     };
-    let board_idx = match app.selection.active_board_index {
-        Some(i) => i,
-        None => return,
-    };
     let sprint = match app.model.sprints().get(sprint_idx).cloned() {
         Some(s) => s,
         None => return,
     };
-    let board = match app.model.boards().get(board_idx).cloned() {
+    let board = match app.active_board().cloned() {
         Some(b) => b,
         None => return,
     };

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -34,7 +34,13 @@ fn test_archived_card_visible_via_get_card_by_id() {
 
     app.ctx.archive_card(card_id).unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
     app.prepare_frame();
 
@@ -67,7 +73,13 @@ fn test_archived_card_appears_in_task_list() {
 
     app.ctx.archive_card(card.id).unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
     app.prepare_frame();
 
@@ -102,7 +114,13 @@ fn test_permanent_delete_removes_archived_card() {
 
     app.ctx.archive_card(card_id).unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
     app.prepare_frame();
 
@@ -162,7 +180,13 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
         .unwrap();
     let card_id = card.id;
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.prepare_frame();
 
     app.start_delete_animation(card_id);
@@ -239,7 +263,13 @@ fn test_multi_column_archive_compacts_every_affected_column() {
         )
         .unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.prepare_frame();
 
     app.start_delete_animation(archive1.id);
@@ -315,7 +345,13 @@ fn test_archive_anchors_selection_to_focused_card_column() {
         )
         .unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.focus.active = Focus::Cards;
     app.prepare_frame();
 
@@ -349,7 +385,13 @@ fn test_q_in_archived_view_returns_to_normal() {
         .create_column(board.id, "Todo".to_string(), None)
         .unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -1,0 +1,259 @@
+//! KAN-911: an archived board is substitutable for a live one everywhere.
+//!
+//! These tests drive an ARCHIVED board through the exact same handlers a LIVE
+//! board uses — activation, card detail, board detail (settings/sprints/columns),
+//! and a card action — and assert the behaviour is identical. There is no
+//! archival-specific entry point: the only place the live/archived distinction
+//! appears is the projects panel choosing which board SET to display.
+
+use kanban_domain::{BoardUpdate, CreateCardOptions, KanbanOperations, TaskListView};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::App;
+
+/// Seed a board with two columns, two cards and a sprint, then archive the head.
+/// Returns (board_id, first_column_id, first_card_id, sprint_id).
+fn seed_and_archive_board(
+    app: &mut App,
+    name: &str,
+) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid, uuid::Uuid) {
+    let board = app.ctx.create_board(name.to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_column(board.id, "Doing".to_string(), None)
+        .unwrap();
+    let card1 = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card1".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card2".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx.archive_board(board.id).unwrap();
+    let snap = app.ctx.snapshot().unwrap();
+    app.model.load_from_snapshot(snap);
+    (board.id, col.id, card1.id, sprint.id)
+}
+
+/// Open the archived board through the SAME activation handler a live board
+/// uses. Proof of reuse: `handle_selection_activate`, not a bespoke drilldown.
+fn open_archived_board(app: &mut App) {
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.focus.active = Focus::Boards;
+    app.selection.board.set(Some(0));
+    app.handle_selection_activate();
+}
+
+#[test]
+fn test_archived_board_activates_by_id_like_live() {
+    let mut app = App::test_default();
+    let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+
+    open_archived_board(&mut app);
+
+    assert_eq!(
+        app.selection.active_board_id,
+        Some(board_id),
+        "archived board becomes the active board, tracked by id"
+    );
+    assert_eq!(app.focus.active, Focus::Cards);
+    // Its two live cards populate the tasks panel, exactly like a live board.
+    let count = app
+        .view
+        .strategy
+        .get_active_task_list()
+        .map(|l| l.len())
+        .unwrap_or(0);
+    assert_eq!(count, 2, "archived board's tasks are shown");
+    // The head stays archived — opening it does not restore it.
+    assert!(app
+        .ctx
+        .list_archived_boards()
+        .unwrap()
+        .iter()
+        .any(|ab| ab.entity_id == board_id));
+}
+
+#[test]
+fn test_archived_board_card_detail_matches_live() {
+    let mut app = App::test_default();
+    let (_, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+
+    open_archived_board(&mut app);
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+
+    // Same activation handler a live card uses — no archival branch.
+    app.handle_selection_activate();
+
+    assert_eq!(app.mode, AppMode::CardDetail);
+    assert!(app.selection.active_card_id.is_some());
+}
+
+#[test]
+fn test_archived_board_settings_view_reachable() {
+    let mut app = App::test_default();
+    let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.focus.active = Focus::Boards;
+    app.selection.board.set(Some(0));
+
+    // `e` opens board detail through the same handler as for a live board.
+    app.handle_edit_board_key();
+
+    assert_eq!(app.mode, AppMode::BoardDetail);
+    assert_eq!(
+        app.active_board().map(|b| b.id),
+        Some(board_id),
+        "board detail resolves the archived board by id"
+    );
+}
+
+#[test]
+fn test_archived_board_sprints_view_reachable() {
+    let mut app = App::test_default();
+    let (board_id, _, _, sprint_id) = seed_and_archive_board(&mut app, "Arch");
+
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.focus.active = Focus::Boards;
+    app.selection.board.set(Some(0));
+    app.handle_edit_board_key();
+
+    // The active board's sprints resolve archival-agnostically.
+    let board = app.active_board().expect("archived board resolves");
+    assert_eq!(board.id, board_id);
+    let sprint_count = app
+        .model
+        .sprints()
+        .iter()
+        .filter(|s| s.board_id == board_id)
+        .count();
+    assert_eq!(sprint_count, 1, "archived board's sprint is visible");
+    assert!(app.model.sprints().iter().any(|s| s.id == sprint_id));
+}
+
+#[test]
+fn test_archived_board_columns_resolve() {
+    let mut app = App::test_default();
+    let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    app.focus.active = Focus::Boards;
+    app.selection.board.set(Some(0));
+    app.handle_edit_board_key();
+
+    let board = app.active_board().expect("archived board resolves");
+    assert_eq!(board.id, board_id);
+    let column_count = app
+        .model
+        .columns()
+        .iter()
+        .filter(|c| c.board_id == board_id)
+        .count();
+    assert_eq!(column_count, 2, "archived board's columns are visible");
+}
+
+#[test]
+fn test_archived_board_card_action_works() {
+    let mut app = App::test_default();
+    let (_, _, card_id, _) = seed_and_archive_board(&mut app, "Arch");
+
+    open_archived_board(&mut app);
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+
+    // Toggle completion via the SAME handler a live board's card uses.
+    app.handle_toggle_card_completion();
+    let snap = app.ctx.snapshot().unwrap();
+    app.model.load_from_snapshot(snap);
+
+    let card = app.model.card(card_id).expect("card still live");
+    assert!(
+        card.is_completed(),
+        "card action on an archived board's card takes effect"
+    );
+}
+
+#[test]
+fn test_archived_board_kanban_view_honours_board_setting() {
+    // A ColumnView archived board renders in kanban layout once active, exactly
+    // like a live one — the layout follows the board, not its archival state.
+    let mut app = App::test_default();
+    let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+    app.ctx
+        .update_board(
+            board_id,
+            BoardUpdate {
+                task_list_view: Some(TaskListView::ColumnView),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let snap = app.ctx.snapshot().unwrap();
+    app.model.load_from_snapshot(snap);
+
+    // Browsing the archived LIST is never kanban (the list must stay visible)...
+    app.mode = AppMode::ArchivedBoardsView;
+    app.focus.active = Focus::Boards;
+    app.selection.board.set(Some(0));
+    assert!(
+        !app.is_kanban_view(),
+        "the boards list itself is not kanban"
+    );
+
+    // ...but once the ColumnView board is active it IS kanban.
+    open_archived_board(&mut app);
+    assert!(
+        app.is_kanban_view(),
+        "an active ColumnView board is kanban, archived or not"
+    );
+}
+
+#[test]
+fn test_live_projects_panel_lists_live_boards_only() {
+    // Guard: the live projects view excludes archived heads; they appear only
+    // when the panel is toggled to the archived set.
+    let mut app = App::test_default();
+    app.ctx.create_board("Live".to_string(), None).unwrap();
+    let (arch_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+    app.prepare_frame();
+
+    // Normal mode: only the live board.
+    app.mode = AppMode::Normal;
+    let live: Vec<_> = app.displayed_boards().iter().map(|b| b.id).collect();
+    assert!(
+        !live.contains(&arch_id),
+        "archived head hidden from live set"
+    );
+    assert_eq!(live.len(), 1, "only the live board is listed");
+
+    // Toggled to archived: only the archived head.
+    app.mode = AppMode::ArchivedBoardsView;
+    let archived: Vec<_> = app.displayed_boards().iter().map(|b| b.id).collect();
+    assert_eq!(
+        archived,
+        vec![arch_id],
+        "archived set shows the archived head"
+    );
+}

--- a/crates/kanban-tui/tests/batch_completion_sync_tests.rs
+++ b/crates/kanban-tui/tests/batch_completion_sync_tests.rs
@@ -54,7 +54,13 @@ fn test_multi_select_toggle_completion_batches_into_one_undo_unit_with_distinct_
         })
         .collect();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.focus.active = Focus::Cards;
     app.prepare_frame();
 
@@ -134,7 +140,13 @@ fn test_multi_select_move_right_to_completion_column_chains_status_per_card() {
         })
         .collect();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.focus.active = Focus::Cards;
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -31,7 +31,13 @@ fn test_card_description_appears_in_detail_view() {
         .unwrap();
 
     // Setup app state to show the card detail view
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
 
     // Verify the card has the description
@@ -182,7 +188,13 @@ fn test_card_with_empty_string_description_displays_placeholder() {
         .unwrap();
 
     // Setup app state
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
 
     // Verify the card has an empty string description (not None)

--- a/crates/kanban-tui/tests/card_priority_key_tests.rs
+++ b/crates/kanban-tui/tests/card_priority_key_tests.rs
@@ -30,7 +30,13 @@ fn test_p_on_cards_list_opens_single_card_priority_dialog() {
         )
         .unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.focus.active = Focus::Cards;
     app.prepare_frame();
     app.select_card_by_id(card.id);
@@ -74,7 +80,13 @@ fn test_p_on_boards_panel_does_not_open_priority_dialog() {
         )
         .unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.focus.active = Focus::Boards;
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -13,7 +13,13 @@ fn setup_app_with_board() -> App {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app
 }
 

--- a/crates/kanban-tui/tests/filter_popup_tests.rs
+++ b/crates/kanban-tui/tests/filter_popup_tests.rs
@@ -65,7 +65,13 @@ fn test_render_filter_popup_with_sprint_shows_sprint_name() {
     app.ctx
         .create_sprint(board.id, None, Some("Sprint".to_string()))
         .unwrap();
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
     app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));
     let output = helpers::render_widget_to_string(120, 40, |frame| {

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -20,7 +20,13 @@ fn test_prepare_frame_populates_model_from_snapshot() {
         )
         .unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.prepare_frame();
 
     assert_eq!(app.model.boards().len(), 1);
@@ -49,7 +55,13 @@ fn test_model_reflects_mutation_after_prepare_frame() {
         )
         .unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.prepare_frame();
 
     assert_eq!(app.model.card(card.id).unwrap().title, "Original");
@@ -95,7 +107,13 @@ fn test_model_description_reflects_mutation() {
         )
         .unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.prepare_frame();
 
     assert_eq!(

--- a/crates/kanban-tui/tests/panel_title_tests.rs
+++ b/crates/kanban-tui/tests/panel_title_tests.rs
@@ -22,7 +22,13 @@ fn test_build_tasks_panel_title_cards_focus_with_cards() {
             )
             .unwrap();
     }
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.focus.active = Focus::Cards;
     app.prepare_frame();
     assert_eq!(
@@ -52,7 +58,13 @@ fn test_build_tasks_panel_title_archived_view_with_cards() {
             .unwrap();
         app.ctx.archive_card(card.id).unwrap();
     }
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
     app.prepare_frame();
     assert_eq!(

--- a/crates/kanban-tui/tests/scroll_board_edit_lists.rs
+++ b/crates/kanban-tui/tests/scroll_board_edit_lists.rs
@@ -37,7 +37,13 @@ fn test_board_sprints_list_scrolls_to_keep_selection_visible() {
     }
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
     app.selection.sprint.set(Some(19));
@@ -67,7 +73,13 @@ fn test_board_columns_list_scrolls_to_keep_selection_visible() {
     }
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Columns;
     app.dialog_input.column_selection.set(Some(19));
@@ -100,7 +112,13 @@ fn test_board_sprints_scroll_offset_is_stable_when_selection_moves_within_viewpo
     }
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
 
@@ -136,7 +154,13 @@ fn test_filter_popup_sprints_scrolls_to_keep_selection_visible() {
     }
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
     let mut dialog = FilterDialogState::new(CardFilters::default());
     // item_selection 0 = "show unassigned" row, 1..=20 = sprints index-0..19

--- a/crates/kanban-tui/tests/scroll_preservation_tests.rs
+++ b/crates/kanban-tui/tests/scroll_preservation_tests.rs
@@ -24,7 +24,13 @@ fn test_column_view_scroll_offset_preserved_after_prepare_frame() {
     }
 
     app.view.strategy = Box::new(UnifiedViewStrategy::kanban());
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.prepare_frame();
 
     if let Some(list) = app.view.strategy.get_active_task_list_mut() {

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -121,7 +121,13 @@ fn test_render_export_boards_select_step_shows_board_names() {
 
     let mut app = App::test_default();
     app.ctx.create_board("MyTestBoard".into(), None).unwrap();
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.prepare_frame();
     app.export_dialog = Some(ExportDialogState::new(1));
     app.push_mode(AppMode::Settings);

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -59,7 +59,13 @@ fn setup_app_with_sprints() -> DialogFixture {
     app.ctx.activate_sprint(to_complete.id, Some(7)).unwrap();
     app.ctx.complete_sprint(to_complete.id).unwrap();
 
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
     app.prepare_frame();
 
@@ -448,7 +454,13 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
     for _ in 0..30 {
         app.ctx.create_sprint(board.id, None, None).unwrap();
     }
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
     app.prepare_frame();
 
@@ -506,7 +518,13 @@ fn test_sticky_header_appears_at_top_when_scrolled_past_active_planned_header() 
     for _ in 0..30 {
         app.ctx.create_sprint(board.id, None, None).unwrap();
     }
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
     app.prepare_frame();
 
@@ -570,7 +588,13 @@ fn test_sticky_header_switches_to_completed_ended_when_selecting_in_lower_sectio
         app.ctx.activate_sprint(s.id, Some(7)).unwrap();
         app.ctx.complete_sprint(s.id).unwrap();
     }
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
+++ b/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
@@ -111,7 +111,13 @@ fn test_sprint_detail_populate_applies_board_sort_order() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
 
     let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
     let low = app
@@ -204,7 +210,13 @@ fn test_sprint_detail_status_done_card_is_not_in_uncompleted_panel_after_populat
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
 
     let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
     let card = app

--- a/crates/kanban-tui/tests/sprint_filter_toggle_tests.rs
+++ b/crates/kanban-tui/tests/sprint_filter_toggle_tests.rs
@@ -10,7 +10,13 @@ fn test_toggle_sprint_filter_without_active_sprint_shows_error_banner() {
     app.ctx
         .create_column(board.id, "Todo".into(), None)
         .unwrap();
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.focus.active = Focus::Cards;
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -18,7 +18,13 @@ fn make_app_with_board() -> (App, Uuid, Uuid) {
         .ctx
         .create_column(board.id, "Todo".into(), None)
         .unwrap();
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.prepare_frame();
     (app, board.id, column.id)
 }

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -13,7 +13,13 @@ fn setup_app_with_board() -> App {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app
 }
 
@@ -135,7 +141,13 @@ fn test_create_card_auto_completes_in_done_column() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
 
     // Use ColumnView and navigate to the done column (index 2)
     app.focus.active = Focus::Cards;
@@ -217,7 +229,13 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
 
     // Create a single sprint (Planning status by default)
     app.push_mode(AppMode::BoardDetail);
@@ -268,7 +286,13 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
 
     // Create two sprints (both start as Planning)
     app.push_mode(AppMode::BoardDetail);
@@ -337,7 +361,13 @@ fn test_move_card_right_selects_moved_card_in_kanban_view() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
     app.prepare_frame();
     app.focus.active = Focus::Cards;
@@ -385,7 +415,13 @@ fn test_move_selected_cards_right_selects_first_moved_card() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
     app.prepare_frame();
     app.focus.active = Focus::Cards;
@@ -438,7 +474,13 @@ fn test_delete_column_adjusts_selection() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Columns;
 
@@ -481,7 +523,13 @@ fn test_toggle_card_completion_retains_selection() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
 
     // Switch to the kanban (column) view so each column has its own CardList.
     // This is the view where stale-model causes select_card_by_id to silently fail.
@@ -529,7 +577,13 @@ fn test_toggle_multi_card_completion_retains_selection() {
         .unwrap();
     app.prepare_frame();
     app.selection.board.set(Some(0));
-    app.selection.active_board_index = Some(0);
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
 
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
     app.prepare_frame();


### PR DESCRIPTION
## Summary

Reworks KAN-911 the LSP-clean way: an archived board is now substitutable for a live one **everywhere**. The prior attempt (#411, closed) ADDED archival special-casing; this PR does the opposite and REMOVES it.

The archival distinction now lives ONLY at the projects panel (which board SET it displays) plus a display indicator. No operation, view, navigation, or resolution handler branches on archival.

## The measurable bar (met)

Count of the archival-specific active-board markers in `crates/kanban-tui/src` (non-test):

| symbol | before (develop) | after |
|---|---|---|
| `active_archived_board_index` + `is_board_active` + `viewed_board` (archival dual-resolver) | 24 | **0** |
| `active_board_index` (live-list-coupled active board) | present throughout | **0** (replaced by id) |

No NEW archival branch was added to any operation/navigation/resolution handler — verified: 0 `is_archived`/`archived_board_index` refs in card/detail/sprint/column op handlers.

## Design

Track the active board by IDENTITY:

- Replace `active_board_index: Option<usize>` and the parallel `active_archived_board_index` with a single `active_board_id: Option<BoardId>`.
- Add `Model::board_by_id(id)` — the ONE resolver, finds a board across both the live set and the archived heads. Not archival-aware branching; just "find the board by id."
- Add `App::active_board` / `App::board_in_context` (id-based) and `App::displayed_boards` (the SOLE consumption site choosing live vs archived set).

Route every operation/view through the id resolvers. `handle_selection_activate` (activation) and `handle_edit_board_key` (board-detail entry) set `active_board_id` from the displayed set, so opening a board from the archived list behaves exactly like a live one.

Remove the special-casing:
- Delete `handle_open_archived_board` — `Enter` on the archived list uses the same `handle_selection_activate` a live board uses.
- Delete `viewed_board`'s archival dual-resolver and the `active_archived_board_index` / `is_board_active` machinery.
- Collapse the archived-boards key routing into shared boards handlers (`handle_shared_boards_key`); only the consumption-site keys (restore `r`, permanent-delete `x`, toggle `Esc`/`q`) remain distinct — mirroring the `ArchivedCardsView` sibling.
- `delete_board` no longer fixes up an index; an id is shift-invariant.

## Operations verified board-agnostic (same handler for live and archived)

- Card detail (enter/activate a card)
- Board detail: settings, description, sprints, columns
- Card actions: toggle completion, move column, assign/reassign sprint, set priority, order/sort
- Sprint: create, activate, complete, sprint detail
- Column: create, rename, delete, reorder
- Filters (open filter dialog, sprint filter, hide-assigned), clipboard (branch name / checkout)
- Navigation, kanban-vs-split layout, task preview, panel titles

## Tests

- New `archived_board_parity_tests` (8): open an archived board and assert card detail, board settings, sprints, columns, a card action, and kanban layout all work IDENTICALLY through the SAME handlers, with NO archival code path. Guard: live projects panel lists live boards only; archived appear only when toggled.
- Carried over the parity tests from #411 into the shared handlers (no archival branch).
- All existing board key-event tests pass unchanged (proof of reuse).

## Verification

- `cargo test -p kanban-tui`: 638 passed, 0 failed
- `cargo clippy -p kanban-tui --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `cargo check -p kanban-cli -p kanban-mcp`: clean