### PR TITLE
KAN-913 feat(tui): archived card list reuses the card-list component (LSP)

### DIFF
--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -89,16 +89,18 @@ impl App {
     pub fn get_card_for_detail_view(&self) -> Option<Card> {
         self.selection
             .active_card_id
-            .and_then(|id| self.model.card(id).cloned())
+            .and_then(|id| self.model.card_by_id(id).cloned())
     }
 
     /// Sets `active_card_id` to `id` if a card with that id exists in the
-    /// model. Returns whether the activation took effect, so callers that
-    /// gate downstream work on the card existing can chain off the boolean.
-    /// On miss the previously-active card is left untouched; sites that
+    /// model (live OR archived). Returns whether the activation took effect, so
+    /// callers that gate downstream work on the card existing can chain off the
+    /// boolean. On miss the previously-active card is left untouched; sites that
     /// require clear-on-miss semantics must use [`Self::set_active_card_or_clear`].
+    /// Resolution is archival-agnostic (`card_by_id`): an archived card is a
+    /// valid active card, substitutable for a live one in every operation.
     pub(crate) fn activate_card(&mut self, id: uuid::Uuid) -> bool {
-        if self.model.card(id).is_some() {
+        if self.model.card_by_id(id).is_some() {
             self.selection.active_card_id = Some(id);
             true
         } else {
@@ -106,13 +108,14 @@ impl App {
         }
     }
 
-    /// Sets `active_card_id` to `id` if the card resolves in the model,
-    /// otherwise clears it. Use at sites where `id` was obtained from a
-    /// surface that may still reference an archived card (the file-watcher
-    /// reload race), so downstream code that gates on
-    /// `active_card_id.is_some()` does not act on a stale previous card.
+    /// Sets `active_card_id` to `id` if the card resolves in the model (live OR
+    /// archived), otherwise clears it. Resolution is archival-agnostic
+    /// (`card_by_id`) so an archived card is a valid active card; the clear-on-
+    /// miss path only fires when the id resolves to no card at all (e.g. a card
+    /// removed by an external write), preventing downstream handlers that gate
+    /// on `active_card_id.is_some()` from acting on a stale previous card.
     pub(crate) fn set_active_card_or_clear(&mut self, id: uuid::Uuid) {
-        self.selection.active_card_id = self.model.card(id).map(|c| c.id);
+        self.selection.active_card_id = self.model.card_by_id(id).map(|c| c.id);
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {

--- a/crates/kanban-tui/src/app/clipboard.rs
+++ b/crates/kanban-tui/src/app/clipboard.rs
@@ -10,7 +10,7 @@ impl App {
     {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(board) = self.active_board() {
-                if let Some(card) = self.model.card(active_id) {
+                if let Some(card) = self.model.card_by_id(active_id) {
                     let sprints = self.model.sprints();
                     let output = get_output(
                         card,

--- a/crates/kanban-tui/src/app/file_io.rs
+++ b/crates/kanban-tui/src/app/file_io.rs
@@ -79,7 +79,7 @@ impl App {
         field: CardField,
     ) -> io::Result<()> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {
                     CardField::Title => {

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -86,222 +86,9 @@ impl App {
         }
 
         match self.mode {
-            AppMode::Normal => match key.code {
-                KeyCode::Char('/') => {
-                    self.pending_key = None;
-                    if self.focus.active == Focus::Cards {
-                        self.filter.search.activate();
-                        self.mode = AppMode::Search;
-                    }
-                }
-                KeyCode::Char('g') => {
-                    if self.pending_key == Some('g') {
-                        self.pending_key = None;
-                        self.handle_jump_to_top();
-                    } else {
-                        self.pending_key = Some('g');
-                    }
-                }
-                KeyCode::Char('G') => {
-                    self.pending_key = None;
-                    self.handle_jump_to_bottom();
-                }
-                KeyCode::Char('{') => {
-                    self.pending_key = None;
-                    self.handle_jump_half_viewport_up();
-                }
-                KeyCode::Char('}') => {
-                    self.pending_key = None;
-                    self.handle_jump_half_viewport_down();
-                }
-                KeyCode::Char('n') => {
-                    self.pending_key = None;
-                    match self.focus.active {
-                        Focus::Boards => self.handle_create_board_key(),
-                        Focus::Cards => self.handle_create_card_key(),
-                    }
-                }
-                KeyCode::Char('r') => {
-                    self.pending_key = None;
-                    self.handle_rename_board_key();
-                }
-                KeyCode::Char('e') => {
-                    self.pending_key = None;
-                    match self.focus.active {
-                        Focus::Boards => self.handle_edit_board_key(),
-                        Focus::Cards => {
-                            should_restart_events =
-                                self.handle_edit_card_key(terminal, event_handler);
-                        }
-                    }
-                }
-                KeyCode::Char('x') => {
-                    self.pending_key = None;
-                    self.handle_export_board_key();
-                }
-                KeyCode::Char('X') => {
-                    self.pending_key = None;
-                    self.handle_export_all_key();
-                }
-                KeyCode::Char('d') => {
-                    self.pending_key = None;
-                    // Mirror the card removal flow: `d` is the primary removal
-                    // action on both panels (delete a board / archive a card).
-                    match self.focus.active {
-                        Focus::Boards => self.handle_delete_board_key(),
-                        Focus::Cards => self.handle_archive_card(),
-                    }
-                }
-                KeyCode::Char('D') => {
-                    self.pending_key = None;
-                    // `D` toggles the archived view of the focused panel: the
-                    // archived-cards view on the cards panel, the archived-boards
-                    // view on the boards panel.
-                    match self.focus.active {
-                        Focus::Cards => self.handle_toggle_archived_cards_view(),
-                        Focus::Boards => self.handle_toggle_archived_boards_view(),
-                    }
-                }
-                KeyCode::Char('i') => {
-                    self.pending_key = None;
-                    self.handle_import_board_key();
-                }
-                KeyCode::Char('a') => {
-                    self.pending_key = None;
-                    self.handle_assign_to_sprint_key();
-                }
-                KeyCode::Char('c') => {
-                    self.pending_key = None;
-                    self.handle_toggle_card_completion();
-                }
-                KeyCode::Char('s') => {
-                    self.pending_key = None;
-                    if self.focus.active == Focus::Cards {
-                        self.handle_manage_children_from_list();
-                    }
-                }
-                KeyCode::Char('o') => {
-                    self.pending_key = None;
-                    self.handle_order_cards_key();
-                }
-                KeyCode::Char('O') => {
-                    self.pending_key = None;
-                    self.handle_toggle_sort_order_key();
-                }
-                KeyCode::Char('T') => {
-                    self.pending_key = None;
-                    self.handle_open_filter_dialog();
-                }
-                KeyCode::Char('t') => {
-                    self.pending_key = None;
-                    self.handle_toggle_sprint_filter();
-                }
-                KeyCode::Char('v') => {
-                    self.pending_key = None;
-                    self.handle_card_selection_toggle();
-                }
-                KeyCode::Char('V') => {
-                    self.pending_key = None;
-                    self.handle_toggle_task_list_view();
-                }
-                KeyCode::Char('p') => {
-                    self.pending_key = None;
-                    if self.focus.active == Focus::Cards {
-                        self.handle_set_card_priority_key();
-                    }
-                }
-                KeyCode::Char('P') => {
-                    self.pending_key = None;
-                    self.handle_set_selected_cards_priority();
-                }
-                KeyCode::Char('H') => {
-                    self.pending_key = None;
-                    self.handle_move_card_left();
-                }
-                KeyCode::Char('L') => {
-                    self.pending_key = None;
-                    self.handle_move_card_right();
-                }
-                KeyCode::Char('h') => {
-                    self.pending_key = None;
-                    self.handle_kanban_column_left();
-                }
-                KeyCode::Char('l') => {
-                    self.pending_key = None;
-                    self.handle_kanban_column_right();
-                }
-                KeyCode::Char('1') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(0);
-                }
-                KeyCode::Char('2') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(1);
-                }
-                KeyCode::Char('3') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(2);
-                }
-                KeyCode::Char('4') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(3);
-                }
-                KeyCode::Char('5') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(4);
-                }
-                KeyCode::Char('6') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(5);
-                }
-                KeyCode::Char('7') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(6);
-                }
-                KeyCode::Char('8') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(7);
-                }
-                KeyCode::Char('9') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(8);
-                }
-                KeyCode::Esc => {
-                    self.pending_key = None;
-                    self.handle_escape_key();
-                }
-                KeyCode::Char('j') | KeyCode::Down => {
-                    self.pending_key = None;
-                    self.handle_navigation_down();
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    self.pending_key = None;
-                    self.handle_navigation_up();
-                }
-                KeyCode::Enter | KeyCode::Char(' ') => {
-                    self.pending_key = None;
-                    self.handle_selection_activate();
-                }
-                KeyCode::Char('u') => {
-                    self.pending_key = None;
-                    if let Err(e) = self.undo() {
-                        self.set_error(format!("Undo failed: {}", e));
-                    }
-                }
-                KeyCode::Char('U') => {
-                    self.pending_key = None;
-                    if let Err(e) = self.redo() {
-                        self.set_error(format!("Redo failed: {}", e));
-                    }
-                }
-                KeyCode::Char('S') => {
-                    self.pending_key = None;
-                    self.handle_open_settings();
-                }
-                _ => {
-                    self.pending_key = None;
-                }
-            },
+            AppMode::Normal => {
+                should_restart_events = self.handle_normal_key(key, terminal, event_handler);
+            }
             AppMode::CardDetail => {
                 should_restart_events =
                     self.handle_card_detail_key(key.code, terminal, event_handler);
@@ -312,7 +99,10 @@ impl App {
             }
             AppMode::SprintDetail => self.handle_sprint_detail_key(key.code),
             AppMode::Search => self.handle_search_mode(key.code),
-            AppMode::ArchivedCardsView => self.handle_archived_cards_view_mode(key.code),
+            AppMode::ArchivedCardsView => {
+                should_restart_events =
+                    self.handle_archived_cards_view_mode(key, terminal, event_handler);
+            }
             AppMode::ArchivedBoardsView => self.handle_archived_boards_view_mode(key.code),
             AppMode::Settings => {
                 should_restart_events = self.handle_settings_key(key.code, terminal, event_handler);
@@ -374,6 +164,237 @@ impl App {
         should_restart_events
     }
 
+    /// The shared Normal-mode key dispatch for both panels. The archived-cards
+    /// view delegates here too (after intercepting its restore/delete extension
+    /// keys), so an archived card is driven by the exact same card handlers a
+    /// live card is — the only archival distinction survives at the tasks-panel
+    /// data source and the display styling, never in an operation branch.
+    fn handle_normal_key(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
+        use crossterm::event::KeyCode;
+        let mut should_restart_events = false;
+        match key.code {
+            KeyCode::Char('/') => {
+                self.pending_key = None;
+                if self.focus.active == Focus::Cards {
+                    self.filter.search.activate();
+                    self.mode = AppMode::Search;
+                }
+            }
+            KeyCode::Char('g') => {
+                if self.pending_key == Some('g') {
+                    self.pending_key = None;
+                    self.handle_jump_to_top();
+                } else {
+                    self.pending_key = Some('g');
+                }
+            }
+            KeyCode::Char('G') => {
+                self.pending_key = None;
+                self.handle_jump_to_bottom();
+            }
+            KeyCode::Char('{') => {
+                self.pending_key = None;
+                self.handle_jump_half_viewport_up();
+            }
+            KeyCode::Char('}') => {
+                self.pending_key = None;
+                self.handle_jump_half_viewport_down();
+            }
+            KeyCode::Char('n') => {
+                self.pending_key = None;
+                match self.focus.active {
+                    Focus::Boards => self.handle_create_board_key(),
+                    Focus::Cards => self.handle_create_card_key(),
+                }
+            }
+            KeyCode::Char('r') => {
+                self.pending_key = None;
+                self.handle_rename_board_key();
+            }
+            KeyCode::Char('e') => {
+                self.pending_key = None;
+                match self.focus.active {
+                    Focus::Boards => self.handle_edit_board_key(),
+                    Focus::Cards => {
+                        should_restart_events = self.handle_edit_card_key(terminal, event_handler);
+                    }
+                }
+            }
+            KeyCode::Char('x') => {
+                self.pending_key = None;
+                self.handle_export_board_key();
+            }
+            KeyCode::Char('X') => {
+                self.pending_key = None;
+                self.handle_export_all_key();
+            }
+            KeyCode::Char('d') => {
+                self.pending_key = None;
+                // Mirror the card removal flow: `d` is the primary removal
+                // action on both panels (delete a board / archive a card).
+                match self.focus.active {
+                    Focus::Boards => self.handle_delete_board_key(),
+                    Focus::Cards => self.handle_archive_card(),
+                }
+            }
+            KeyCode::Char('D') => {
+                self.pending_key = None;
+                // `D` toggles the archived view of the focused panel: the
+                // archived-cards view on the cards panel, the archived-boards
+                // view on the boards panel.
+                match self.focus.active {
+                    Focus::Cards => self.handle_toggle_archived_cards_view(),
+                    Focus::Boards => self.handle_toggle_archived_boards_view(),
+                }
+            }
+            KeyCode::Char('i') => {
+                self.pending_key = None;
+                self.handle_import_board_key();
+            }
+            KeyCode::Char('a') => {
+                self.pending_key = None;
+                self.handle_assign_to_sprint_key();
+            }
+            KeyCode::Char('c') => {
+                self.pending_key = None;
+                self.handle_toggle_card_completion();
+            }
+            KeyCode::Char('s') => {
+                self.pending_key = None;
+                if self.focus.active == Focus::Cards {
+                    self.handle_manage_children_from_list();
+                }
+            }
+            KeyCode::Char('o') => {
+                self.pending_key = None;
+                self.handle_order_cards_key();
+            }
+            KeyCode::Char('O') => {
+                self.pending_key = None;
+                self.handle_toggle_sort_order_key();
+            }
+            KeyCode::Char('T') => {
+                self.pending_key = None;
+                self.handle_open_filter_dialog();
+            }
+            KeyCode::Char('t') => {
+                self.pending_key = None;
+                self.handle_toggle_sprint_filter();
+            }
+            KeyCode::Char('v') => {
+                self.pending_key = None;
+                self.handle_card_selection_toggle();
+            }
+            KeyCode::Char('V') => {
+                self.pending_key = None;
+                self.handle_toggle_task_list_view();
+            }
+            KeyCode::Char('p') => {
+                self.pending_key = None;
+                if self.focus.active == Focus::Cards {
+                    self.handle_set_card_priority_key();
+                }
+            }
+            KeyCode::Char('P') => {
+                self.pending_key = None;
+                self.handle_set_selected_cards_priority();
+            }
+            KeyCode::Char('H') => {
+                self.pending_key = None;
+                self.handle_move_card_left();
+            }
+            KeyCode::Char('L') => {
+                self.pending_key = None;
+                self.handle_move_card_right();
+            }
+            KeyCode::Char('h') => {
+                self.pending_key = None;
+                self.handle_kanban_column_left();
+            }
+            KeyCode::Char('l') => {
+                self.pending_key = None;
+                self.handle_kanban_column_right();
+            }
+            KeyCode::Char('1') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(0);
+            }
+            KeyCode::Char('2') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(1);
+            }
+            KeyCode::Char('3') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(2);
+            }
+            KeyCode::Char('4') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(3);
+            }
+            KeyCode::Char('5') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(4);
+            }
+            KeyCode::Char('6') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(5);
+            }
+            KeyCode::Char('7') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(6);
+            }
+            KeyCode::Char('8') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(7);
+            }
+            KeyCode::Char('9') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(8);
+            }
+            KeyCode::Esc => {
+                self.pending_key = None;
+                self.handle_escape_key();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.pending_key = None;
+                self.handle_navigation_down();
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.pending_key = None;
+                self.handle_navigation_up();
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                self.pending_key = None;
+                self.handle_selection_activate();
+            }
+            KeyCode::Char('u') => {
+                self.pending_key = None;
+                if let Err(e) = self.undo() {
+                    self.set_error(format!("Undo failed: {}", e));
+                }
+            }
+            KeyCode::Char('U') => {
+                self.pending_key = None;
+                if let Err(e) = self.redo() {
+                    self.set_error(format!("Redo failed: {}", e));
+                }
+            }
+            KeyCode::Char('S') => {
+                self.pending_key = None;
+                self.handle_open_settings();
+            }
+            _ => {
+                self.pending_key = None;
+            }
+        }
+        should_restart_events
+    }
+
     fn handle_search_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
         match key_code {
@@ -394,25 +415,43 @@ impl App {
         }
     }
 
-    pub fn handle_archived_cards_view_mode(&mut self, key_code: crossterm::event::KeyCode) {
+    /// Key handling for the archived-cards view. The archived list is the
+    /// ordinary cards panel showing a different SET; every card operation
+    /// (detail, edit, move, priority, sprint-assign, navigation...) reuses the
+    /// SAME shared Normal-mode dispatch (`handle_normal_key`) so an archived card
+    /// is substitutable for a live one. Only the consumption-site extension keys
+    /// are intercepted here: `r` restores and `x` permanently deletes the
+    /// highlighted archived card, and `Esc`/`q` toggles back to the live set.
+    pub fn handle_archived_cards_view_mode(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
         use crossterm::event::KeyCode;
-        if self.focus.active != Focus::Cards {
-            self.focus.active = Focus::Cards;
-        }
+        // The archived list lives on the cards panel.
+        self.focus.active = Focus::Cards;
 
-        match key_code {
-            KeyCode::Char('r') => self.handle_restore_card(),
-            KeyCode::Char('x') => self.handle_delete_card_permanent(),
-            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {
-                self.handle_toggle_archived_cards_view();
+        match key.code {
+            KeyCode::Char('r') => {
+                self.pending_key = None;
+                self.handle_restore_card();
+                false
             }
-            KeyCode::Char('v') => self.handle_card_selection_toggle(),
-            KeyCode::Char('V') => self.handle_toggle_task_list_view(),
-            KeyCode::Char('h') => self.handle_kanban_column_left(),
-            KeyCode::Char('l') => self.handle_kanban_column_right(),
-            KeyCode::Char('j') | KeyCode::Down => self.handle_navigation_down(),
-            KeyCode::Char('k') | KeyCode::Up => self.handle_navigation_up(),
-            _ => {}
+            KeyCode::Char('x') => {
+                self.pending_key = None;
+                self.handle_delete_card_permanent();
+                false
+            }
+            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {
+                self.pending_key = None;
+                self.handle_toggle_archived_cards_view();
+                false
+            }
+            // Everything else reuses the shared Normal-mode card handlers,
+            // proving reuse: an archived card flows through the identical
+            // operation paths as a live one.
+            _ => self.handle_normal_key(key, terminal, event_handler),
         }
     }
 

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -428,6 +428,24 @@ impl App {
         terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
         event_handler: &EventHandler,
     ) -> bool {
+        // The archived-set extension keys (restore/delete/toggle) are handled
+        // terminal-free; everything else reuses the shared Normal-mode card
+        // handlers, proving reuse: an archived card flows through the identical
+        // operation paths as a live one.
+        if self.handle_archived_cards_extension_key(key) {
+            false
+        } else {
+            self.handle_normal_key(key, terminal, event_handler)
+        }
+    }
+
+    /// The archived-set consumption-site affordances layered on top of the
+    /// shared card list: `r` restores and `x` permanently deletes the
+    /// highlighted archived card(s), and `Esc`/`q` toggles back to the live set.
+    /// Returns `true` when the key was one of these extension keys (and was
+    /// consumed here), `false` when it should fall through to the shared
+    /// Normal-mode dispatch. Terminal-free, so it is unit-testable headlessly.
+    pub fn handle_archived_cards_extension_key(&mut self, key: crossterm::event::KeyEvent) -> bool {
         use crossterm::event::KeyCode;
         // The archived list lives on the cards panel.
         self.focus.active = Focus::Cards;
@@ -436,22 +454,19 @@ impl App {
             KeyCode::Char('r') => {
                 self.pending_key = None;
                 self.handle_restore_card();
-                false
+                true
             }
             KeyCode::Char('x') => {
                 self.pending_key = None;
                 self.handle_delete_card_permanent();
-                false
+                true
             }
             KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {
                 self.pending_key = None;
                 self.handle_toggle_archived_cards_view();
-                false
+                true
             }
-            // Everything else reuses the shared Normal-mode card handlers,
-            // proving reuse: an archived card flows through the identical
-            // operation paths as a live one.
-            _ => self.handle_normal_key(key, terminal, event_handler),
+            _ => false,
         }
     }
 

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -56,6 +56,17 @@ impl Model {
         self.archived_cards_flat.as_ref()?.get(idx)
     }
 
+    /// Resolve a card by id across BOTH the live set and the archived cards.
+    /// This is the single uniform resolver for "the card with this id" — it is
+    /// deliberately archival-agnostic: a card is a card regardless of whether it
+    /// is archived. Live cards take precedence (an id is only ever in one set,
+    /// but the ordering makes the common case a direct hit). Mirrors
+    /// `board_by_id`; it is what lets an archived card be the active card and
+    /// flow through every operation exactly like a live one.
+    pub fn card_by_id(&self, id: Uuid) -> Option<&Card> {
+        self.card(id).or_else(|| self.archived_card(id))
+    }
+
     pub fn archived_boards(&self) -> &[ArchivedBoard] {
         self.archived_boards.as_deref().unwrap_or(&[])
     }

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -3,7 +3,7 @@ use super::App;
 impl App {
     pub fn get_current_priority_selection_index(&self) -> usize {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 use kanban_domain::CardPriority;
                 return match card.priority {
                     CardPriority::Low => 0,
@@ -20,7 +20,7 @@ impl App {
         use crate::components::sprint_assign_list::{build_entries, sprint_id_of};
 
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 if let Some(card_sprint_id) = card.sprint_id {
                     if let Some(board) = self.active_board() {
                         let sprints = self.model.sprints();

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -48,13 +48,34 @@ impl App {
         }
     }
 
+    /// Whether the tasks panel is toggled to the archived-cards set. This is the
+    /// SOLE live/archived predicate on the cards side: it selects the tasks-panel
+    /// data source (`displayed_cards`) and drives the display-only styling (the
+    /// archived border / title indicator). No operation, navigation, or
+    /// resolution handler branches on it — an archived card is substitutable for
+    /// a live one everywhere else (mirrors `displayed_boards` on the board side).
+    pub fn viewing_archived_cards(&self) -> bool {
+        self.mode == AppMode::ArchivedCardsView
+    }
+
+    /// The card set the tasks panel currently displays: the archived cards when
+    /// toggled to the archived set, the live cards otherwise. The one consumption
+    /// site choosing which cards to show.
+    pub fn displayed_cards(&self) -> &[Card] {
+        if self.viewing_archived_cards() {
+            self.model.archived_cards_flat()
+        } else {
+            self.model.cards()
+        }
+    }
+
     pub fn prepare_frame(&mut self) {
         match self.ctx.snapshot() {
             Ok(snapshot) => self.model.load_from_snapshot(snapshot),
             Err(e) => tracing::warn!("Failed to load snapshot for frame: {e}"),
         }
 
-        let cards_for_display: &[Card] = if self.mode == AppMode::ArchivedCardsView {
+        let cards_for_display: &[Card] = if self.viewing_archived_cards() {
             self.model.archived_cards_flat()
         } else {
             self.model.cards()

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -146,7 +146,7 @@ impl App {
             let current_sprint_id = self
                 .selection
                 .active_card_id
-                .and_then(|id| self.model.card(id))
+                .and_then(|id| self.model.card_by_id(id))
                 .and_then(|c| c.sprint_id);
             // Re-borrow board after the &mut self call above.
             if let Some(board) = self.active_board().cloned() {
@@ -662,11 +662,11 @@ impl App {
         // Else: no selection (falls back to current behavior - no explicit selection)
     }
 
+    /// Restore the highlighted (or multi-selected) card(s). This is an archived-
+    /// set extension affordance; it is only reachable from the archived-cards
+    /// view's `r` key. The per-card animation start is guarded on archived
+    /// membership, so a non-archived card is a no-op regardless of caller.
     pub fn handle_restore_card(&mut self) {
-        if self.mode != AppMode::ArchivedCardsView {
-            return;
-        }
-
         if !self.multi_select.selected_cards.is_empty() {
             self.start_restore_animations_for_selected();
         } else if let Some(card_id) = self.get_selected_card_id() {
@@ -745,11 +745,11 @@ impl App {
         tracing::info!("Card '{}' restored to original position", card_title);
     }
 
+    /// Permanently delete the highlighted (or multi-selected) card(s). Archived-
+    /// set extension affordance, only reachable from the archived-cards view's
+    /// `x` key. The per-card animation start is guarded on archived membership,
+    /// so a non-archived card is a no-op regardless of caller.
     pub fn handle_delete_card_permanent(&mut self) {
-        if self.mode != AppMode::ArchivedCardsView {
-            return;
-        }
-
         if !self.multi_select.selected_cards.is_empty() {
             self.start_permanent_delete_animations_for_selected();
         } else if let Some(card_id) = self.get_selected_card_id() {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -303,7 +303,7 @@ impl App {
                         let current_sprint_id = self
                             .selection
                             .active_card_id
-                            .and_then(|id| self.model.card(id))
+                            .and_then(|id| self.model.card_by_id(id))
                             .and_then(|c| c.sprint_id);
                         self.dialog_input
                             .assign_sprint_picker
@@ -810,8 +810,10 @@ impl App {
                                         .filter(|s| s.board_id == board.id)
                                         .count();
                                     if sprint_count > 0 {
-                                        let current_sprint_id =
-                                            self.model.card(card_id).and_then(|c| c.sprint_id);
+                                        let current_sprint_id = self
+                                            .model
+                                            .card_by_id(card_id)
+                                            .and_then(|c| c.sprint_id);
                                         self.dialog_input
                                             .assign_sprint_picker
                                             .reset_for_card_assignment(
@@ -937,7 +939,7 @@ impl App {
 
     pub(crate) fn handle_manage_parents(&mut self) {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
@@ -990,7 +992,7 @@ impl App {
 
     pub(crate) fn handle_manage_children(&mut self) {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
@@ -1043,7 +1045,7 @@ impl App {
 
     pub fn get_current_card_parents(&self) -> Vec<uuid::Uuid> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 return self.model.graph().parents(card.id);
             }
         }
@@ -1052,7 +1054,7 @@ impl App {
 
     pub fn get_current_card_children(&self) -> Vec<uuid::Uuid> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 return self.model.graph().children(card.id);
             }
         }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -181,7 +181,7 @@ impl App {
                 let card_id = self
                     .selection
                     .active_card_id
-                    .and_then(|id| self.model.card(id))
+                    .and_then(|id| self.model.card_by_id(id))
                     .map(|c| c.id)
                     .or_else(|| self.get_selected_card_in_context().map(|c| c.id));
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -49,7 +49,7 @@ impl App {
             KeyCode::Enter => {
                 if let Some(priority_idx) = self.dialog_input.priority_selection.get() {
                     if let Some(active_id) = self.selection.active_card_id {
-                        if let Some(card) = self.model.card(active_id) {
+                        if let Some(card) = self.model.card_by_id(active_id) {
                             use kanban_domain::{CardPriority, CardUpdate};
                             let priority = match priority_idx {
                                 0 => CardPriority::Low,
@@ -239,7 +239,7 @@ impl App {
                         return;
                     }
                 };
-                let card_id = match self.model.card(active_card_id) {
+                let card_id = match self.model.card_by_id(active_card_id) {
                     Some(card) => card.id,
                     None => return,
                 };
@@ -548,7 +548,7 @@ impl App {
                 if let Some(idx) = self.relationship.selection.get() {
                     if let Some(selected_card_id) = filtered_cards.get(idx).copied() {
                         if let Some(active_id) = self.selection.active_card_id {
-                            if let Some(current_card) = self.model.card(active_id) {
+                            if let Some(current_card) = self.model.card_by_id(active_id) {
                                 let current_card_id = current_card.id;
 
                                 let (child_id, parent_id) = if is_parent_mode {

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -107,79 +107,33 @@ impl KeybindingProvider for NormalModeBoardsProvider {
     }
 }
 
+/// The archived-cards view is the ordinary cards panel showing a different SET
+/// (the archived cards). Its keybindings are the SHARED `CardListProvider`
+/// bindings EXTENDED with the two consumption-site affordances — restore (`r`)
+/// and permanent-delete (`x`) — so an archived card is operable exactly like a
+/// live one (detail, edit, move, priority, sprint-assign...) plus can be
+/// restored or purged. This is an extension of the live card list, not a forked
+/// limited view.
 pub struct ArchivedCardsViewProvider;
 
 impl KeybindingProvider for ArchivedCardsViewProvider {
     fn get_context(&self) -> KeybindingContext {
-        KeybindingContext::new(
-            "Archived Cards View",
-            vec![
-                Keybinding::new("?", "help", "Show help", KeybindingAction::ShowHelp),
-                Keybinding::new(
-                    "j/↓",
-                    "down",
-                    "Navigate down",
-                    KeybindingAction::NavigateDown,
-                ),
-                Keybinding::new("k/↑", "up", "Navigate up", KeybindingAction::NavigateUp),
-                Keybinding::new("gg", "top", "Jump to top", KeybindingAction::JumpToTop),
-                Keybinding::new(
-                    "G",
-                    "bottom",
-                    "Jump to bottom",
-                    KeybindingAction::JumpToBottom,
-                ),
-                Keybinding::new(
-                    "{",
-                    "half up",
-                    "Jump half viewport up",
-                    KeybindingAction::JumpHalfViewportUp,
-                ),
-                Keybinding::new(
-                    "}",
-                    "half down",
-                    "Jump half viewport down",
-                    KeybindingAction::JumpHalfViewportDown,
-                ),
-                Keybinding::new(
-                    "r",
-                    "restore",
-                    "Restore selected task(s)",
-                    KeybindingAction::RestoreCard,
-                ),
-                Keybinding::new(
-                    "x",
-                    "delete",
-                    "Delete selected task(s)",
-                    KeybindingAction::DeleteCard,
-                ),
-                Keybinding::new(
-                    "v",
-                    "select",
-                    "Select task for bulk operation",
-                    KeybindingAction::ToggleCardSelection,
-                ),
-                Keybinding::new(
-                    "V",
-                    "view",
-                    "Toggle task list view",
-                    KeybindingAction::ToggleTaskListView,
-                ),
-                Keybinding::new(
-                    "q/Esc",
-                    "back",
-                    "Back to normal view",
-                    KeybindingAction::Escape,
-                ),
-                Keybinding::new("u", "undo", "Undo last action", KeybindingAction::Undo),
-                Keybinding::new(
-                    "U",
-                    "redo",
-                    "Redo last undone action",
-                    KeybindingAction::Redo,
-                ),
-            ],
-        )
+        let mut ctx = super::card_list::CardListProvider.get_context();
+        ctx.name = "Archived Cards View".to_string();
+        // Archived extension: the two affordances unique to the archived set.
+        ctx.bindings.push(Keybinding::new(
+            "r",
+            "restore",
+            "Restore selected task(s)",
+            KeybindingAction::RestoreCard,
+        ));
+        ctx.bindings.push(Keybinding::new(
+            "x",
+            "delete",
+            "Permanently delete selected task(s)",
+            KeybindingAction::DeleteCard,
+        ));
+        ctx
     }
 }
 

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -318,9 +318,7 @@ impl RenderStrategy for SinglePanelRenderer {
             .with_focus_indicator(&title)
             .focused(app.focus.active == crate::app::Focus::Cards);
 
-        if app.mode == crate::app::AppMode::ArchivedCardsView
-            && app.focus.active == crate::app::Focus::Cards
-        {
+        if app.viewing_archived_cards() && app.focus.active == crate::app::Focus::Cards {
             panel_config = panel_config.with_custom_border_style(deleted_view_focused_border());
         }
 
@@ -477,7 +475,7 @@ impl RenderStrategy for MultiPanelRenderer {
                         .with_focus_indicator(&title)
                         .focused(app.focus.active == crate::app::Focus::Cards && is_focused_column);
 
-                    if app.mode == crate::app::AppMode::ArchivedCardsView && is_focused_column {
+                    if app.viewing_archived_cards() && is_focused_column {
                         panel_config =
                             panel_config.with_custom_border_style(deleted_view_focused_border());
                     }

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -30,8 +30,8 @@ pub(super) fn render_main(app: &mut App, frame: &mut Frame, area: Rect) {
 pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
     let mut lines = vec![];
     // The archived-boards view shows the archived board heads in the projects
-    // panel (mirroring how ArchivedCardsView shows archived cards in the tasks
-    // panel); everywhere else it shows the LIVE boards.
+    // panel (mirroring how the archived-cards view shows archived cards in the
+    // tasks panel); everywhere else it shows the LIVE boards.
     let archived_view = app.mode == AppMode::ArchivedBoardsView;
     let boards = app.displayed_boards();
 
@@ -108,7 +108,7 @@ pub fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
         .selection
         .active_board_id
         .is_some_and(|id| app.model.archived_board(id).is_some());
-    let mut title = if app.mode == AppMode::ArchivedCardsView {
+    let mut title = if app.viewing_archived_cards() {
         format!("Archive [{}]", count)
     } else if viewing_archived_board {
         format!("[ARCHIVED] Tasks [2] ({})", count)
@@ -118,7 +118,7 @@ pub fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
         "Tasks".to_string()
     };
 
-    if with_filter_suffix && app.mode != AppMode::ArchivedCardsView {
+    if with_filter_suffix && !app.viewing_archived_cards() {
         if let Some(suffix) = build_filter_title_suffix(app) {
             title.push_str(&suffix);
         }

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -376,12 +376,8 @@ fn test_archive_anchors_selection_to_focused_card_column() {
     );
 }
 
-#[tokio::test]
-async fn test_q_in_archived_view_returns_to_normal() {
-    use kanban_tui::events::EventHandler;
-    use ratatui::backend::CrosstermBackend;
-    use ratatui::Terminal;
-
+#[test]
+fn test_q_in_archived_view_returns_to_normal() {
     let mut app = App::test_default();
 
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();
@@ -399,14 +395,15 @@ async fn test_q_in_archived_view_returns_to_normal() {
     app.mode = AppMode::ArchivedCardsView;
     app.prepare_frame();
 
-    // `q` is intercepted terminal-free by the archived extension; the delegate
-    // path (which needs the terminal/event handler) is never reached for it.
-    let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout())).unwrap();
-    let event_handler = EventHandler::new();
-    app.handle_archived_cards_view_mode(
-        crossterm::event::KeyEvent::from(crossterm::event::KeyCode::Char('q')),
-        &mut terminal,
-        &event_handler,
+    // `q` is an archived-extension key, intercepted terminal-free; the delegate
+    // path (which needs the terminal/event handler) is never reached for it, so
+    // this asserts the toggle without a live TTY.
+    let consumed = app.handle_archived_cards_extension_key(crossterm::event::KeyEvent::from(
+        crossterm::event::KeyCode::Char('q'),
+    ));
+    assert!(
+        consumed,
+        "'q' is an archived-extension key and must be consumed"
     );
 
     assert_eq!(

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -376,8 +376,12 @@ fn test_archive_anchors_selection_to_focused_card_column() {
     );
 }
 
-#[test]
-fn test_q_in_archived_view_returns_to_normal() {
+#[tokio::test]
+async fn test_q_in_archived_view_returns_to_normal() {
+    use kanban_tui::events::EventHandler;
+    use ratatui::backend::CrosstermBackend;
+    use ratatui::Terminal;
+
     let mut app = App::test_default();
 
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();
@@ -395,7 +399,15 @@ fn test_q_in_archived_view_returns_to_normal() {
     app.mode = AppMode::ArchivedCardsView;
     app.prepare_frame();
 
-    app.handle_archived_cards_view_mode(crossterm::event::KeyCode::Char('q'));
+    // `q` is intercepted terminal-free by the archived extension; the delegate
+    // path (which needs the terminal/event handler) is never reached for it.
+    let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout())).unwrap();
+    let event_handler = EventHandler::new();
+    app.handle_archived_cards_view_mode(
+        crossterm::event::KeyEvent::from(crossterm::event::KeyCode::Char('q')),
+        &mut terminal,
+        &event_handler,
+    );
 
     assert_eq!(
         app.mode,

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -1,0 +1,301 @@
+//! KAN-913: an archived card is substitutable for a live one everywhere.
+//!
+//! These tests drive an ARCHIVED card, reached through the archived-cards list,
+//! through the exact same handlers a LIVE card uses — card detail, edit,
+//! move-column, set-priority and sprint-assign — and assert the behaviour is
+//! identical. The only place the live/archived distinction appears is the tasks
+//! panel choosing which card SET it displays plus a display indicator. The
+//! archived-only affordances (restore / permanent-delete) are an EXTENSION layered
+//! on the shared card keybindings, not a forked limited view.
+
+use kanban_domain::{CardPriority, CreateCardOptions, KanbanOperations};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::App;
+use std::time::{Duration, Instant};
+
+/// Seed a board with two columns and two cards, archive the first card, and load
+/// the snapshot. Returns (board_id, first_column_id, second_column_id,
+/// archived_card_id, live_card_id).
+fn seed_and_archive_card(
+    app: &mut App,
+) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid, uuid::Uuid, uuid::Uuid) {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col1 = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let col2 = app
+        .ctx
+        .create_column(board.id, "Doing".to_string(), None)
+        .unwrap();
+    let card1 = app
+        .ctx
+        .create_card(
+            board.id,
+            col1.id,
+            "ArchiveMe".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card2 = app
+        .ctx
+        .create_card(
+            board.id,
+            col1.id,
+            "StayLive".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx.archive_card(card1.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    let snap = app.ctx.snapshot().unwrap();
+    app.model.load_from_snapshot(snap);
+    (board.id, col1.id, col2.id, card1.id, card2.id)
+}
+
+/// Enter the archived-cards list the same way the user does: toggle to it and
+/// select the first (archived) card. Proof of reuse: the tasks panel is the same
+/// component, fed the archived set.
+fn open_archived_cards(app: &mut App) {
+    app.mode = AppMode::ArchivedCardsView;
+    app.prepare_frame();
+    app.focus.active = Focus::Cards;
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+}
+
+fn force_animation_complete(app: &mut App, card_id: uuid::Uuid) {
+    if let Some(anim) = app.animation.animating.get_mut(&card_id) {
+        anim.start_time = Instant::now() - Duration::from_millis(400);
+    }
+}
+
+#[test]
+fn test_archived_card_detail_opens_via_shared_handler() {
+    let mut app = App::test_default();
+    let (_, _, _, archived_id, _) = seed_and_archive_card(&mut app);
+
+    open_archived_cards(&mut app);
+
+    // The SAME activation handler a live card uses — no archival branch.
+    app.handle_selection_activate();
+
+    assert_eq!(
+        app.mode,
+        AppMode::CardDetail,
+        "opening an archived card enters card detail exactly like a live card"
+    );
+    assert_eq!(
+        app.selection.active_card_id,
+        Some(archived_id),
+        "the archived card resolves as the active card by id"
+    );
+}
+
+#[test]
+fn test_archived_card_set_priority_via_shared_handler() {
+    let mut app = App::test_default();
+    let (_, _, _, archived_id, _) = seed_and_archive_card(&mut app);
+
+    open_archived_cards(&mut app);
+
+    // `p` opens the priority dialog for the highlighted card, then Enter applies.
+    app.handle_set_card_priority_key();
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(kanban_tui::app::DialogMode::SetCardPriority),
+        "priority dialog opens for an archived card via the shared handler"
+    );
+    // Choose Critical (index 3) and confirm.
+    app.dialog_input.priority_selection.set(Some(3));
+    app.handle_set_card_priority_popup(crossterm::event::KeyCode::Enter);
+
+    let snap = app.ctx.snapshot().unwrap();
+    app.model.load_from_snapshot(snap);
+    let card = app
+        .get_card_by_id(archived_id)
+        .expect("archived card still resolves");
+    assert_eq!(
+        card.priority,
+        CardPriority::Critical,
+        "priority change on an archived card takes effect"
+    );
+}
+
+#[test]
+fn test_archived_card_move_column_via_shared_handler() {
+    let mut app = App::test_default();
+    let (_, _, col2, archived_id, _) = seed_and_archive_card(&mut app);
+
+    open_archived_cards(&mut app);
+
+    // Move the archived card right (Todo -> Doing) via the same handler.
+    app.handle_move_card_right();
+
+    let snap = app.ctx.snapshot().unwrap();
+    app.model.load_from_snapshot(snap);
+    let card = app
+        .get_card_by_id(archived_id)
+        .expect("archived card still resolves");
+    assert_eq!(
+        card.column_id, col2,
+        "move-column on an archived card takes effect"
+    );
+}
+
+#[test]
+fn test_archived_card_action_applies_via_shared_handler() {
+    // A mutating card action (toggle completion) drives through the same handler
+    // a live card uses and takes effect on the archived card — proving the edit /
+    // action path is not gated on liveness.
+    let mut app = App::test_default();
+    let (_, _, _, archived_id, _) = seed_and_archive_card(&mut app);
+
+    open_archived_cards(&mut app);
+
+    app.handle_toggle_card_completion();
+
+    let snap = app.ctx.snapshot().unwrap();
+    app.model.load_from_snapshot(snap);
+    let card = app
+        .get_card_by_id(archived_id)
+        .expect("archived card still resolves");
+    assert!(
+        card.is_completed(),
+        "a card action on an archived card takes effect via the shared handler"
+    );
+}
+
+#[test]
+fn test_archived_card_sprint_assign_via_shared_handler() {
+    let mut app = App::test_default();
+    let (_, _, _, archived_id, _) = seed_and_archive_card(&mut app);
+
+    open_archived_cards(&mut app);
+
+    app.handle_assign_to_sprint_key();
+
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(kanban_tui::app::DialogMode::AssignCardToSprint),
+        "sprint-assign dialog opens for an archived card via the shared handler"
+    );
+    assert_eq!(
+        app.selection.active_card_id,
+        Some(archived_id),
+        "the archived card is the assignment target"
+    );
+}
+
+#[test]
+fn test_archived_card_restore_extension_still_works() {
+    let mut app = App::test_default();
+    let (_, _, _, archived_id, _) = seed_and_archive_card(&mut app);
+
+    open_archived_cards(&mut app);
+
+    // The archived-only extension key: restore.
+    app.handle_restore_card();
+    assert!(
+        app.animation.animating.contains_key(&archived_id),
+        "restore starts a restore animation on the archived card"
+    );
+    force_animation_complete(&mut app, archived_id);
+    app.restore_card(
+        app.model
+            .archived_cards()
+            .iter()
+            .find(|ac| ac.entity_id == archived_id)
+            .cloned()
+            .unwrap(),
+    );
+
+    assert!(
+        !app.ctx
+            .list_archived_cards()
+            .unwrap()
+            .iter()
+            .any(|ac| ac.entity_id == archived_id),
+        "the card is no longer archived after restore"
+    );
+}
+
+#[test]
+fn test_archived_card_permanent_delete_extension_still_works() {
+    let mut app = App::test_default();
+    let (_, _, _, archived_id, _) = seed_and_archive_card(&mut app);
+
+    open_archived_cards(&mut app);
+
+    // The archived-only extension key: permanent delete.
+    app.handle_delete_card_permanent();
+    assert!(
+        app.animation.animating.contains_key(&archived_id),
+        "permanent delete starts a deleting animation on the archived card"
+    );
+}
+
+#[test]
+fn test_archived_cards_view_uses_shared_card_provider_extended() {
+    // The archived-cards view reuses the normal card provider EXTENDED with
+    // restore/delete — not a limited replacement. Detail, edit, priority and
+    // sprint-assign bindings must be present (they were absent in the old
+    // forked provider).
+    use kanban_tui::keybindings::{KeybindingAction, KeybindingRegistry};
+    let mut app = App::test_default();
+    seed_and_archive_card(&mut app);
+    open_archived_cards(&mut app);
+
+    let provider = KeybindingRegistry::get_provider(&app);
+    let ctx = provider.get_context();
+    let has = |a: KeybindingAction| ctx.bindings.iter().any(|b| b.action == a);
+
+    assert!(
+        has(KeybindingAction::SelectItem),
+        "archived view exposes card detail (Enter) like the live card list"
+    );
+    assert!(
+        has(KeybindingAction::EditCard),
+        "archived view exposes edit (e)"
+    );
+    assert!(
+        has(KeybindingAction::SetCardPriority),
+        "archived view exposes set-priority (p)"
+    );
+    assert!(
+        has(KeybindingAction::AssignToSprint),
+        "archived view exposes sprint-assign (a)"
+    );
+    assert!(
+        has(KeybindingAction::RestoreCard),
+        "archived view still exposes the restore extension"
+    );
+}
+
+#[test]
+fn test_live_card_list_excludes_archived_cards() {
+    // Guard: the live card list is unchanged and excludes archived cards.
+    let mut app = App::test_default();
+    let (_, _, _, archived_id, live_id) = seed_and_archive_card(&mut app);
+
+    app.mode = AppMode::Normal;
+    app.focus.active = Focus::Cards;
+    app.prepare_frame();
+
+    let list = app
+        .view
+        .strategy
+        .get_active_task_list()
+        .expect("active task list");
+    assert!(
+        list.cards.contains(&live_id),
+        "the live card is shown in the live list"
+    );
+    assert!(
+        !list.cards.contains(&archived_id),
+        "the archived card is excluded from the live list"
+    );
+}


### PR DESCRIPTION
## What

Card-side counterpart to KAN-911 (which did this for boards). An archived card is now substitutable for a live one in every operation and view: the archived-cards list is the SAME card-list keybinding provider and render path, EXTENDED with the archived affordances, rather than a forked, limited view.

Under root KAN-864 / regression root KAN-890.

## How

- **Resolve the active card by identity, archival-agnostically.** New `Model::card_by_id` (live then archived, mirroring `board_by_id`). The active-card resolvers (`get_card_for_detail_view`, `activate_card`, `set_active_card_or_clear`) and the active-card read sites (priority / sprint-assign dialogs, detail-view handlers, clipboard, query, file_io) route through it. This is what lets an archived card open detail and take a priority/sprint/edit/move exactly like a live one.
- **One keybinding provider.** `ArchivedCardsViewProvider` now delegates to `CardListProvider.get_context()` and only appends the two extension keys (`r` restore, `x` permanent-delete). Archived cards inherit the full card-list bindings for free.
- **One render path.** The archived styling (dimmed border, `Archive` title) flows through the single `App::viewing_archived_cards()` predicate plus a `displayed_cards()` data-source accessor, replacing the inline `if mode == ArchivedCardsView` render branches. `render_strategy.rs` has zero archival refs now.
- **Shared key dispatch.** Extracted the Normal-mode card dispatch into `handle_normal_key`; the archived-cards handler intercepts only its extension/toggle keys (`r`, `x`, `Esc`/`q`) and delegates everything else to that shared dispatch. Dropped the `if mode != ArchivedCardsView` gates from `handle_restore_card` / `handle_delete_card_permanent`.

## Measurable bar (archival-specific refs → ~0)

The bar grep `grep -rnE 'ArchivedCardsView|handle_archived_cards_view|archived_cards_flat' crates/kanban-tui/src | grep -viE 'test|cfg\(test'`:

- **Before: 29**
- **After: 24** (of which 5 are inside `#[cfg(test)]` modules the line-grep cannot detect, so **19 in production code**)

Every remaining production ref is in a permitted category — the mode enum, the data-source selection (`displayed_cards` / `archived_cards_flat` storage), the single `viewing_archived_cards()` styling/data predicate, the mode dispatch + toggle, and the delegating provider registration. **Zero** `if mode == ArchivedCardsView` (or `is_card_archived`) branches remain in any operation or render handler.

## Operations now working on an archived card from the archived list (via the same handlers a live card uses)

- Open card **detail** (Enter)
- **Set priority** (p) — applied end-to-end
- **Move column** (H/L) — applied end-to-end
- **Card action** (toggle completion) — applied end-to-end
- **Sprint-assign** (a) — dialog opens targeting the archived card
- Plus the archived **extension**: **restore** (r) and **permanent-delete** (x)
- Navigation / sort / select and the rest of the card-list bindings, inherited from the shared provider

## Tests

New `archived_card_parity_tests.rs` (9 tests) drives the above through the shared handlers and asserts real state changes, plus a guard that the live card list excludes archived cards. Full `kanban-tui` suite green; `clippy -D warnings` and `fmt --check` clean; `kanban-cli` / `kanban-mcp` check clean.


---

## Status: HELD (do not merge)

Review found that the UI-layer parity here sits on top of a data layer that still *partitions* archived entities rather than treating archival as a decorator flag: primitive queries (`count_cards_in_column`, `list_cards_by_column`, the move/position queries) hard-code `NOT EXISTS archived_cards`. That makes several delegated operations misbehave on archived cards (e.g. move computes position against the live-only set and persists a wrong column/position; create-from-archived-view makes an invisible live card). These are not UI bugs; they are the partition surfacing.

Held pending the archival-as-decorator refactor of the data/domain/service layer. The good structural parts of this PR (unforked view, delegating provider, single render predicate) will be re-landed on top of the corrected core.
