### PR TITLE
KAN-917 feat(domain): BoardListFilter carrying ArchivedFilter

### DIFF
--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -62,7 +62,7 @@ pub use query::{
         calculate_points, calculate_points_by_ids, get_sprint_cards, get_sprint_completed_cards,
         get_sprint_uncompleted_cards, partition_sprint_cards, sort_card_ids,
     },
-    ArchivedFilter, CardListFilter, CardQueryBuilder,
+    ArchivedFilter, BoardListFilter, CardListFilter, CardQueryBuilder,
 };
 pub use search::{
     find_boards_by_name, find_cards_by_identifier, find_columns_by_name,

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -187,4 +187,9 @@ mod tests {
     fn test_card_list_filter_default_archived_is_live_only() {
         assert_eq!(CardListFilter::default().archived, ArchivedFilter::LiveOnly);
     }
+
+    #[test]
+    fn test_board_list_filter_defaults_to_liveonly() {
+        assert_eq!(BoardListFilter::default().archived, ArchivedFilter::LiveOnly);
+    }
 }

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -55,6 +55,17 @@ pub struct CardListFilter {
     pub archived: ArchivedFilter,
 }
 
+/// Board list request shape, mirroring [`CardListFilter`]. Carries the
+/// three-state [`ArchivedFilter`] so board listing takes the same selector
+/// cards do; the service tier (B2) gathers the live-vs-archived board set,
+/// exactly as it does for cards. Kept minimal (no search/sort yet).
+#[derive(Default, Clone)]
+pub struct BoardListFilter {
+    /// Three-state archival selector. Defaults to `LiveOnly`, so callers that
+    /// build the filter with `..Default::default()` see the pre-selector set.
+    pub archived: ArchivedFilter,
+}
+
 fn allowed_column_ids(columns: &[Column], board_id: Option<Uuid>) -> Option<HashSet<Uuid>> {
     board_id.map(|bid| {
         columns
@@ -190,6 +201,9 @@ mod tests {
 
     #[test]
     fn test_board_list_filter_defaults_to_liveonly() {
-        assert_eq!(BoardListFilter::default().archived, ArchivedFilter::LiveOnly);
+        assert_eq!(
+            BoardListFilter::default().archived,
+            ArchivedFilter::LiveOnly
+        );
     }
 }

--- a/crates/kanban-domain/src/query/mod.rs
+++ b/crates/kanban-domain/src/query/mod.rs
@@ -11,7 +11,7 @@ pub mod filter_sort;
 pub mod sprint;
 
 pub use filter_sort::{
-    count_filtered_cards, filter_and_sort_cards, ArchivedFilter, CardListFilter,
+    count_filtered_cards, filter_and_sort_cards, ArchivedFilter, BoardListFilter, CardListFilter,
 };
 
 use crate::{Board, Card, Column, Sprint};


### PR DESCRIPTION
## What

Introduces `BoardListFilter`, the board-side list selector, mirroring the existing `CardListFilter`. It carries the three-state `ArchivedFilter` (LiveOnly / ArchivedOnly / Include) so board listing takes the same selector cards do, letting CLI/MCP stop hand-rolling archived resolvers (KAN-914 gap #3, D1).

```rust
#[derive(Default, Clone)]
pub struct BoardListFilter {
    pub archived: ArchivedFilter,
}
```

- Reuses the existing `ArchivedFilter` enum (`filter_sort.rs`); no duplication.
- Placed next to `CardListFilter`, exported from the query module and crate root the same way.
- Minimal by design: no search/sort fields yet.

## No engine fn (deliberate)

The card engine `filter_and_sort_cards` never inspects `filter.archived`: the service tier gathers the correct live-vs-archived card set and hands the resulting slice to the domain. Boards are the same, and the `Board` domain type carries no archival field (board archival lives at the service/persistence tier via markers). A domain `filter_boards` would have nothing to filter on and would force the domain to know about archival state it does not own, so gathering is left to the service (B2). Minimal wins.

## TDD

- Red: `test_board_list_filter_defaults_to_liveonly` (asserts `BoardListFilter::default().archived == ArchivedFilter::LiveOnly`), committed failing to compile first.
- Green: struct + exports.

## Checks

- `cargo test -p kanban-domain`: 629 passed
- `cargo clippy -p kanban-domain --all-targets -D warnings`: clean
- `cargo fmt`: clean

Scope: kanban-domain only. Unblocks B2.