### PR TITLE
KAN-918 feat(service): list_boards(filter) gather mirroring filter_cards

### DIFF
--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -1,8 +1,9 @@
 use kanban_core::AppConfig;
 use kanban_domain::KanbanResult;
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
-    ColumnUpdate, CreateCardOptions, GraphOperations, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter, CardSummary,
+    CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations, KanbanOperations, Sprint,
+    SprintUpdate,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;
@@ -61,6 +62,10 @@ impl KanbanOperations for CliContext {
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
         self.inner.list_boards()
+    }
+
+    fn list_boards_filtered(&self, filter: BoardListFilter) -> KanbanResult<Vec<Board>> {
+        self.inner.list_boards_filtered(filter)
     }
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -1,4 +1,4 @@
-use crate::query::filter_sort::CardListFilter;
+use crate::query::filter_sort::{BoardListFilter, CardListFilter};
 use crate::KanbanResult;
 use crate::{
     AmbiguousMatch, ArchivedBoard, ArchivedCard, BatchResolutionCause, BatchResolutionFailure,
@@ -12,7 +12,13 @@ use uuid::Uuid;
 pub trait KanbanOperations {
     // Board operations
     fn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board>;
+    /// List live boards only. Back-compat sugar for `list_boards_filtered` with
+    /// the default (`LiveOnly`) selector; the live path is byte-identical.
     fn list_boards(&self) -> KanbanResult<Vec<Board>>;
+    /// List board heads per the [`BoardListFilter`] archival selector: live
+    /// and/or archived, mirroring [`list_cards`](Self::list_cards). Archived
+    /// heads are resolved by their archive marker (unfiltered `get_board`).
+    fn list_boards_filtered(&self, filter: BoardListFilter) -> KanbanResult<Vec<Board>>;
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>>;
     fn update_board(&mut self, id: Uuid, updates: BoardUpdate) -> KanbanResult<Board>;
     /// Permanently delete a board and its subtree. Collection-agnostic: works

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -1,8 +1,9 @@
 use kanban_core::{AppConfig, PaginatedList};
 use kanban_domain::KanbanResult;
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
-    ColumnUpdate, CreateCardOptions, GraphOperations, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter, CardSummary,
+    CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations, KanbanOperations, Sprint,
+    SprintUpdate,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;
@@ -136,6 +137,10 @@ impl KanbanOperations for McpContext {
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
         self.inner.list_boards()
+    }
+
+    fn list_boards_filtered(&self, filter: BoardListFilter) -> KanbanResult<Vec<Board>> {
+        self.inner.list_boards_filtered(filter)
     }
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -2,7 +2,8 @@ use super::KanbanContext;
 use chrono::Utc;
 use kanban_domain::commands::{ArchiveBoards, BoardCommand, Command, ImportEntities, RestoreBoard};
 use kanban_domain::{
-    ArchivedBoard, Board, BoardUpdate, FieldUpdate, KanbanError, KanbanResult, NewBoard,
+    ArchivedBoard, ArchivedFilter, Board, BoardListFilter, BoardUpdate, FieldUpdate, KanbanError,
+    KanbanResult, NewBoard,
 };
 use uuid::Uuid;
 
@@ -100,6 +101,28 @@ impl KanbanContext {
 
     pub(super) fn list_boards_impl(&self) -> KanbanResult<Vec<Board>> {
         self.backend.list_boards()
+    }
+
+    /// Selector-aware board gather, mirroring `filter_cards`: gathers live
+    /// heads via `list_boards` and/or archived heads via the archive markers
+    /// (`get_board` is unfiltered, so it resolves an archived head). The
+    /// `LiveOnly` path is byte-identical to `list_boards_impl`.
+    pub(super) fn list_boards_filtered_impl(
+        &self,
+        filter: BoardListFilter,
+    ) -> KanbanResult<Vec<Board>> {
+        let mut out = Vec::new();
+        if filter.archived != ArchivedFilter::ArchivedOnly {
+            out.extend(self.backend.list_boards()?);
+        }
+        if filter.archived != ArchivedFilter::LiveOnly {
+            for m in self.backend.list_archived_boards()? {
+                if let Some(b) = self.backend.get_board(m.entity_id)? {
+                    out.push(b);
+                }
+            }
+        }
+        Ok(out)
     }
 
     pub(super) fn get_board_impl(&self, id: Uuid) -> KanbanResult<Option<Board>> {

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -1,8 +1,9 @@
 use crate::backend::KanbanBackend;
 use kanban_core::{AppConfig, AppType};
 use kanban_domain::{
-    ArchivedBoard, ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate,
-    Column, ColumnUpdate, CreateCardOptions, KanbanOperations, KanbanResult, Sprint, SprintUpdate,
+    ArchivedBoard, ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter,
+    CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, KanbanOperations,
+    KanbanResult, Sprint, SprintUpdate,
 };
 use serde::Serialize;
 use std::sync::Arc;
@@ -77,6 +78,9 @@ impl KanbanOperations for KanbanContext {
     }
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
         KanbanContext::list_boards_impl(self)
+    }
+    fn list_boards_filtered(&self, filter: BoardListFilter) -> KanbanResult<Vec<Board>> {
+        KanbanContext::list_boards_filtered_impl(self, filter)
     }
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         KanbanContext::get_board_impl(self, id)

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -7,6 +7,7 @@ use kanban_domain::card::CardPriority;
 use kanban_domain::{
     CardListFilter, CreateCardOptions, GraphOperations, KanbanOperations, Severity,
 };
+use std::collections::HashSet;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -843,5 +844,77 @@ pub async fn test_board_archive_restore_full_graph_roundtrip(factory: &BackendFa
             .sprint_logs
             .is_empty(),
         "sprint_logs survived archive/restore"
+    );
+}
+
+/// B2 (KAN-918): `list_boards_filtered` is the ONE path for live/archived/both
+/// board heads via `BoardListFilter::archived`, mirroring `list_cards`. Seed one
+/// live + one archived board and assert each selector state returns exactly the
+/// right set. Held to one spec across all backends via the contract macro.
+pub async fn test_list_boards_archived_selector_roundtrip(factory: &BackendFactory) {
+    use kanban_domain::{ArchivedFilter, BoardListFilter};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let live = ctx.create_board("Live".into(), Some("L".into())).unwrap();
+    let archived = ctx
+        .create_board("Archived".into(), Some("A".into()))
+        .unwrap();
+    ctx.archive_board(archived.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    // LiveOnly: exactly the live board, byte-identical to the legacy list_boards.
+    let live_only = ctx
+        .list_boards_filtered(BoardListFilter {
+            archived: ArchivedFilter::LiveOnly,
+        })
+        .unwrap();
+    let live_only_ids: Vec<_> = live_only.iter().map(|b| b.id).collect();
+    assert_eq!(live_only_ids, vec![live.id], "LiveOnly excludes archived");
+    assert_eq!(
+        ctx.list_boards()
+            .unwrap()
+            .iter()
+            .map(|b| b.id)
+            .collect::<Vec<_>>(),
+        live_only_ids,
+        "list_boards() == LiveOnly sugar",
+    );
+
+    // ArchivedOnly: exactly the archived board head.
+    let archived_only = ctx
+        .list_boards_filtered(BoardListFilter {
+            archived: ArchivedFilter::ArchivedOnly,
+        })
+        .unwrap();
+    let archived_only_ids: Vec<_> = archived_only.iter().map(|b| b.id).collect();
+    assert_eq!(
+        archived_only_ids,
+        vec![archived.id],
+        "ArchivedOnly returns only archived",
+    );
+
+    // Include: both heads, no duplicates.
+    let include = ctx
+        .list_boards_filtered(BoardListFilter {
+            archived: ArchivedFilter::Include,
+        })
+        .unwrap();
+    let include_ids: HashSet<_> = include.iter().map(|b| b.id).collect();
+    assert_eq!(
+        include.len(),
+        2,
+        "Include unions live + archived, no duplicates"
+    );
+    assert_eq!(
+        include_ids,
+        HashSet::from([live.id, archived.id]),
+        "Include returns both heads",
     );
 }

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -162,6 +162,10 @@ macro_rules! context_contract_tests {
         async fn test_board_archive_restore_full_graph_roundtrip() {
             $crate::test_helpers::contract::archive::test_board_archive_restore_full_graph_roundtrip(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_boards_archived_selector_roundtrip() {
+            $crate::test_helpers::contract::archive::test_list_boards_archived_selector_roundtrip(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -2,8 +2,9 @@ use crate::state::SaveCoordinator;
 use kanban_domain::commands::Command;
 use kanban_domain::KanbanResult;
 use kanban_domain::{
-    ArchivedCard, Board, BoardUpdate, Card, CardListFilter, CardSummary, CardUpdate, Column,
-    ColumnUpdate, CreateCardOptions, GraphOperations, KanbanOperations, Sprint, SprintUpdate,
+    ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter, CardSummary,
+    CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations, KanbanOperations, Sprint,
+    SprintUpdate,
 };
 use kanban_service::backend::KanbanBackend;
 use kanban_service::KanbanContext;
@@ -159,6 +160,10 @@ impl KanbanOperations for TuiContext {
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
         self.inner.list_boards()
+    }
+
+    fn list_boards_filtered(&self, filter: BoardListFilter) -> KanbanResult<Vec<Board>> {
+        self.inner.list_boards_filtered(filter)
     }
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {


### PR DESCRIPTION
## What

Give boards the `filter_cards` treatment: a single `list_boards_filtered(BoardListFilter)` gather on `KanbanContext` that returns live and/or archived board heads per the three-state `ArchivedFilter`, so CLI/MCP can consume one path (KAN-914 ARCH-DECOR, B2). Depends on B1 (`BoardListFilter`, already merged).

## How

- `context/boards.rs`: `list_boards_filtered_impl` gathers live heads via `backend.list_boards()` (skipped for `ArchivedOnly`) and archived heads by resolving each archive marker's `entity_id` through the unfiltered `get_board` (skipped for `LiveOnly`), unioned per the selector. This mirrors `filter_cards` in `context/filters.rs`.
- `KanbanOperations` (kanban-domain): add `list_boards_filtered`; keep `list_boards()` as `LiveOnly` back-compat sugar with a byte-identical live path.
- Forward the new method through the CLI, MCP and TUI context wrappers (each delegates to the inner `KanbanContext`).

## Tests

New contract test `test_list_boards_archived_selector_roundtrip` seeds one live + one archived board and asserts each selector state returns exactly the right set of board heads. It runs across in-memory, JSON and SQLite via the `context_contract_tests!` macro, and also asserts `list_boards()` equals the `LiveOnly` result. Red first (missing method), then green.

- `cargo test -p kanban-service --features test-helpers`: green (in_memory/json/sqlite selector tests pass)
- `cargo clippy --all-targets -- -D warnings` on domain/service/cli/mcp/tui: clean
- `cargo fmt`: applied

## Notes

The `ArchivedBoard` marker's entity field is `entity_id` (`ArchivedBoard = Archived<NoContext>`, `Archived.entity_id: Uuid`), matching the card path. Card body target signature was accurate.