### PR TITLE
KAN-926 feat(domain): 3-state archived predicate on in-memory filtered card reads + delegator forwarding

### DIFF
--- a/crates/kanban-domain/src/in_memory_store/cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/cards.rs
@@ -157,6 +157,118 @@ mod tests {
     use super::*;
     use crate::data_store::DataStore;
     use crate::in_memory_store::test_support::{make_board, make_card, make_column};
+    use crate::{ArchivedCard, ArchivedFilter};
+
+    /// Seed one column with 2 live + 2 archived cards. Returns the store, the
+    /// column id, the 2 live ids, and the 2 archived ids.
+    fn seed_two_live_two_archived() -> (InMemoryStore, Uuid, Vec<Uuid>, Vec<Uuid>) {
+        let store = InMemoryStore::new();
+        let mut board = make_board("B");
+        let col = make_column(board.id, "Todo", 0);
+        store.upsert_board(board.clone()).unwrap();
+        store.upsert_column(col.clone()).unwrap();
+
+        let mut live = Vec::new();
+        let mut archived = Vec::new();
+        for i in 0..2 {
+            let c = make_card(&mut board, col.id, &format!("live{i}"), i);
+            live.push(c.id);
+            store.upsert_card(c).unwrap();
+        }
+        for i in 0..2 {
+            let c = make_card(&mut board, col.id, &format!("arch{i}"), 2 + i);
+            archived.push(c.id);
+            store.upsert_card(c.clone()).unwrap();
+            // Archive the ArchiveCards way: marker + guarded delete_card no-op.
+            store
+                .insert_archived_card(ArchivedCard::new(c.id, board.id))
+                .unwrap();
+            store.delete_card(c.id).unwrap();
+        }
+        (store, col.id, live, archived)
+    }
+
+    #[test]
+    fn test_inmem_count_filtered_liveonly_is_2() {
+        let (store, col_id, _live, _archived) = seed_two_live_two_archived();
+        assert_eq!(
+            store
+                .count_cards_in_column_filtered(col_id, ArchivedFilter::LiveOnly)
+                .unwrap(),
+            2,
+            "LiveOnly counts only the 2 live cards"
+        );
+    }
+
+    #[test]
+    fn test_inmem_count_filtered_archivedonly_is_2() {
+        let (store, col_id, _live, _archived) = seed_two_live_two_archived();
+        assert_eq!(
+            store
+                .count_cards_in_column_filtered(col_id, ArchivedFilter::ArchivedOnly)
+                .unwrap(),
+            2,
+            "ArchivedOnly counts only the 2 archived cards"
+        );
+    }
+
+    #[test]
+    fn test_inmem_count_filtered_include_is_4() {
+        let (store, col_id, _live, _archived) = seed_two_live_two_archived();
+        assert_eq!(
+            store
+                .count_cards_in_column_filtered(col_id, ArchivedFilter::Include)
+                .unwrap(),
+            4,
+            "Include counts all 4 cards"
+        );
+    }
+
+    #[test]
+    fn test_inmem_list_filtered_liveonly_returns_live_ids() {
+        let (store, col_id, mut live, _archived) = seed_two_live_two_archived();
+        let mut got: Vec<Uuid> = store
+            .list_cards_by_column_filtered(col_id, ArchivedFilter::LiveOnly)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        got.sort();
+        live.sort();
+        assert_eq!(got, live, "LiveOnly lists only the 2 live cards");
+    }
+
+    #[test]
+    fn test_inmem_list_filtered_archivedonly_returns_archived_ids() {
+        let (store, col_id, _live, mut archived) = seed_two_live_two_archived();
+        let mut got: Vec<Uuid> = store
+            .list_cards_by_column_filtered(col_id, ArchivedFilter::ArchivedOnly)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        got.sort();
+        archived.sort();
+        assert_eq!(
+            got, archived,
+            "ArchivedOnly lists only the 2 archived cards"
+        );
+    }
+
+    #[test]
+    fn test_inmem_list_filtered_include_returns_all_ids() {
+        let (store, col_id, live, archived) = seed_two_live_two_archived();
+        let mut want: Vec<Uuid> = live.into_iter().chain(archived).collect();
+        let mut got: Vec<Uuid> = store
+            .list_cards_by_column_filtered(col_id, ArchivedFilter::Include)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        got.sort();
+        want.sort();
+        assert_eq!(got, want, "Include lists all 4 cards");
+    }
 
     #[test]
     fn test_list_cards_by_column_orders_equal_position_by_created_at() {

--- a/crates/kanban-domain/src/in_memory_store/cards.rs
+++ b/crates/kanban-domain/src/in_memory_store/cards.rs
@@ -1,8 +1,20 @@
 use uuid::Uuid;
 
 use super::ordering::sort_by_position;
+use super::state::StoreState;
 use super::InMemoryStore;
-use crate::{Card, KanbanResult};
+use crate::{ArchivedFilter, Card, KanbanResult};
+
+/// 3-state archived predicate shared by the in-memory `*_filtered` reads. Hoisted
+/// to a free function so both `list`/`count` overrides use one spec and neither
+/// captures `state` in a closure across the borrow.
+fn keep_by_filter(state: &StoreState, id: &Uuid, archived: ArchivedFilter) -> bool {
+    match archived {
+        ArchivedFilter::LiveOnly => !state.is_card_archived(id),
+        ArchivedFilter::ArchivedOnly => state.is_card_archived(id),
+        ArchivedFilter::Include => true,
+    }
+}
 
 impl InMemoryStore {
     pub(super) fn get_card_impl(&self, id: Uuid) -> KanbanResult<Option<Card>> {
@@ -77,6 +89,46 @@ impl InMemoryStore {
             })
             .unwrap_or(0);
         Ok(count)
+    }
+
+    // F1c (KAN-926): 3-state archived-aware column reads. Overrides the loud-floor
+    // trait default so in-memory (and thus JSON) honour ArchivedOnly/Include;
+    // LiveOnly stays identical to `list_cards_by_column`/`count_cards_in_column`.
+    pub(super) fn list_cards_by_column_filtered_impl(
+        &self,
+        column_id: Uuid,
+        archived: ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        let state = self.read_state()?;
+        let mut cards: Vec<Card> = state
+            .cards_by_column
+            .get(&column_id)
+            .map(|ids| {
+                ids.iter()
+                    .filter(|id| keep_by_filter(&state, id, archived))
+                    .filter_map(|id| state.cards.get(id).cloned())
+                    .collect()
+            })
+            .unwrap_or_default();
+        sort_by_position(&mut cards);
+        Ok(cards)
+    }
+
+    pub(super) fn count_cards_in_column_filtered_impl(
+        &self,
+        column_id: Uuid,
+        archived: ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        let state = self.read_state()?;
+        Ok(state
+            .cards_by_column
+            .get(&column_id)
+            .map(|ids| {
+                ids.iter()
+                    .filter(|id| keep_by_filter(&state, id, archived))
+                    .count()
+            })
+            .unwrap_or(0))
     }
 
     pub(super) fn upsert_card_impl(&self, card: Card) -> KanbanResult<()> {

--- a/crates/kanban-domain/src/in_memory_store/mod.rs
+++ b/crates/kanban-domain/src/in_memory_store/mod.rs
@@ -162,6 +162,22 @@ impl DataStore for InMemoryStore {
         self.count_cards_in_column_excluding_impl(column_id, exclude)
     }
 
+    fn list_cards_by_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: crate::ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        self.list_cards_by_column_filtered_impl(column_id, archived)
+    }
+
+    fn count_cards_in_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: crate::ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        self.count_cards_in_column_filtered_impl(column_id, archived)
+    }
+
     fn upsert_card(&self, card: Card) -> KanbanResult<()> {
         self.upsert_card_impl(card)
     }

--- a/crates/kanban-service/src/json_backend.rs
+++ b/crates/kanban-service/src/json_backend.rs
@@ -218,6 +218,20 @@ impl DataStore for JsonDataStore {
     ) -> KanbanResult<usize> {
         self.with_read(|s| s.count_cards_in_column_excluding(column_id, exclude))
     }
+    fn list_cards_by_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        self.with_read(|s| s.list_cards_by_column_filtered(column_id, archived))
+    }
+    fn count_cards_in_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        self.with_read(|s| s.count_cards_in_column_filtered(column_id, archived))
+    }
     fn upsert_card(&self, card: Card) -> KanbanResult<()> {
         self.with_mutate(|s| s.upsert_card(card))
     }

--- a/crates/kanban-service/src/sqlite_backend.rs
+++ b/crates/kanban-service/src/sqlite_backend.rs
@@ -96,6 +96,20 @@ impl DataStore for SqliteBackend {
     ) -> KanbanResult<usize> {
         self.db.count_cards_in_column_excluding(column_id, exclude)
     }
+    fn list_cards_by_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        self.db.list_cards_by_column_filtered(column_id, archived)
+    }
+    fn count_cards_in_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        self.db.count_cards_in_column_filtered(column_id, archived)
+    }
     fn upsert_card(&self, card: Card) -> KanbanResult<()> {
         self.db.upsert_card(card)
     }

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -180,6 +180,102 @@ pub async fn test_card_all_status_variants_roundtrip(factory: &BackendFactory) {
     }
 }
 
+/// F1c (KAN-926): the 3-state archived-aware primitives
+/// `list_cards_by_column_filtered` / `count_cards_in_column_filtered` must agree
+/// on ONE spec across every backend (in-memory, JSON, SQLite) — reached through
+/// `ctx.data_store()`. Seeds 2 live + 2 archived cards in one column and pins
+/// LiveOnly=2, ArchivedOnly=2, Include=4 for both list (by id) and count.
+pub async fn test_column_filtered_reads_three_state(factory: &BackendFactory) {
+    use kanban_domain::ArchivedFilter;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+
+    let mut live = Vec::new();
+    for i in 0..2 {
+        let c = ctx
+            .create_card(
+                board.id,
+                col.id,
+                format!("live{i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        live.push(c.id);
+    }
+    let mut archived = Vec::new();
+    for i in 0..2 {
+        let c = ctx
+            .create_card(
+                board.id,
+                col.id,
+                format!("arch{i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        ctx.archive_card(c.id).unwrap();
+        archived.push(c.id);
+    }
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+    let ds = ctx.data_store();
+
+    // Counts.
+    assert_eq!(
+        ds.count_cards_in_column_filtered(col.id, ArchivedFilter::LiveOnly)
+            .unwrap(),
+        2,
+        "LiveOnly count == 2"
+    );
+    assert_eq!(
+        ds.count_cards_in_column_filtered(col.id, ArchivedFilter::ArchivedOnly)
+            .unwrap(),
+        2,
+        "ArchivedOnly count == 2"
+    );
+    assert_eq!(
+        ds.count_cards_in_column_filtered(col.id, ArchivedFilter::Include)
+            .unwrap(),
+        4,
+        "Include count == 4"
+    );
+
+    // Lists (compare id sets).
+    let ids = |archived_filter| -> Vec<uuid::Uuid> {
+        let mut v: Vec<uuid::Uuid> = ds
+            .list_cards_by_column_filtered(col.id, archived_filter)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        v.sort();
+        v
+    };
+
+    let mut want_live = live.clone();
+    want_live.sort();
+    assert_eq!(ids(ArchivedFilter::LiveOnly), want_live, "LiveOnly list");
+
+    let mut want_archived = archived.clone();
+    want_archived.sort();
+    assert_eq!(
+        ids(ArchivedFilter::ArchivedOnly),
+        want_archived,
+        "ArchivedOnly list"
+    );
+
+    let mut want_all: Vec<uuid::Uuid> = live.into_iter().chain(archived).collect();
+    want_all.sort();
+    assert_eq!(ids(ArchivedFilter::Include), want_all, "Include list");
+}
+
 pub async fn test_card_completed_at_set_on_done_status(factory: &BackendFactory) {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.store");

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -98,6 +98,10 @@ macro_rules! context_contract_tests {
         async fn test_card_completed_at_set_on_done_status() {
             $crate::test_helpers::contract::card::test_card_completed_at_set_on_done_status(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_column_filtered_reads_three_state() {
+            $crate::test_helpers::contract::card::test_column_filtered_reads_three_state(&$factory_fn()).await;
+        }
 
         // Sprint log tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What

Implements KAN-926 (ARCH-DECOR F1c). Overrides the two `*_filtered` archived-aware card reads on `InMemoryStore` (which JSON inherits) and forwards them through the two hand-written `DataStore` delegators in `kanban-service`.

Builds on F1a (trait default methods, loud floor) and is the in-memory sibling of F1b (the merged SQLite override).

## Changes

- `InMemoryStore` overrides `list_cards_by_column_filtered` and `count_cards_in_column_filtered` with a hoisted `keep_by_filter(&StoreState, id, ArchivedFilter)` predicate: `LiveOnly` keeps `!is_archived`, `ArchivedOnly` keeps `is_archived`, `Include` keeps all. This replaces the hard `!is_card_archived` clause and lifts the loud-floor `Unsupported` for the in-memory/JSON path.
- Forwards both new methods in the two hand-written `DataStore` delegators, `JsonDataStore` (`json_backend.rs`) and `SqliteBackend` (`sqlite_backend.rs`). This was the critical, easily-missed step: the overrides do not auto-reach JSON or service-wrapped SQLite, so without the forwarding non-live reads through the service return the `Unsupported` loud floor. Confirmed by watching the JSON and SQLite contract cases fail with `Unsupported` before the forwarding was added.

## Tests (TDD, split from impl)

- In-memory unit tests seed a column with 2 live + 2 archived cards and pin `LiveOnly=2`, `ArchivedOnly=2`, `Include=4` for both count and list (by id): `test_inmem_count_filtered_liveonly_is_2` / `_archivedonly_is_2` / `_include_is_4` and the three matching `test_inmem_list_filtered_*` cases.
- Extends the shared backend contract (`test_column_filtered_reads_three_state`) so all three backends (in-memory, JSON, SQLite) are held to one spec for the filtered reads, reached via `ctx.data_store()`. Runs under `--features test-helpers`.

## Verification

- `cargo test -p kanban-domain` green
- `cargo test -p kanban-service --features test-helpers` green (in-memory, JSON, SQLite contract all pass)
- `cargo clippy -p kanban-domain -p kanban-service --all-targets --features test-helpers -- -D warnings` clean
- `cargo fmt` clean