### PR TITLE
KAN-919 refactor(service): consolidate BoardResponse to one shape + archived_at

### DIFF
--- a/crates/kanban-service/src/api/v1/boards/response.rs
+++ b/crates/kanban-service/src/api/v1/boards/response.rs
@@ -34,14 +34,24 @@ pub struct BoardResponse {
 }
 
 impl BoardResponse {
+    /// Project a board and stamp its optional `archived_at`. A board is one
+    /// shape: `None` yields the live projection (the wire key is skipped), `Some`
+    /// stamps the marker's timestamp. This is the single constructor callers
+    /// build a board through; `from(&Board)` is `with_archived_at(board, None)`.
+    pub fn with_archived_at(board: &Board, archived_at: Option<DateTime<Utc>>) -> Self {
+        Self {
+            archived_at,
+            ..Self::from(board)
+        }
+    }
+
     /// Project a live board and stamp it as archived at `archived_at`. Under the
     /// reference-marker model an archived board IS a live board plus a marker, so
     /// the archived wire shape is the live projection with `archived_at` set.
+    /// Thin wrapper over [`with_archived_at`]; retained for existing CLI/MCP
+    /// callers (B4/B5 migrate them to `with_archived_at` directly).
     pub fn archived(board: &Board, archived_at: DateTime<Utc>) -> Self {
-        Self {
-            archived_at: Some(archived_at),
-            ..Self::from(board)
-        }
+        Self::with_archived_at(board, Some(archived_at))
     }
 }
 

--- a/crates/kanban-service/src/api/v1/boards/response.rs
+++ b/crates/kanban-service/src/api/v1/boards/response.rs
@@ -137,6 +137,33 @@ mod tests {
         );
     }
 
+    // B3 (KAN-919): `with_archived_at` is the single constructor a board is
+    // built through — it carries the optional marker timestamp, so both live
+    // (`None`) and archived (`Some`) boards share one shape and one code path.
+    #[test]
+    fn test_board_response_omits_archived_at_when_live() {
+        let live = BoardResponse::with_archived_at(&Board::new("B", Some("KAN")), None);
+        assert_eq!(live.archived_at, None);
+        let value = serde_json::to_value(&live).unwrap();
+        assert!(
+            value.get("archived_at").is_none(),
+            "a live board built via with_archived_at must not carry an archived_at key"
+        );
+    }
+
+    #[test]
+    fn test_board_response_includes_archived_at_when_archived() {
+        use chrono::{TimeZone, Utc};
+        let at = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        let resp = BoardResponse::with_archived_at(&Board::new("B", Some("KAN")), Some(at));
+        assert_eq!(resp.archived_at, Some(at));
+        let value = serde_json::to_value(&resp).unwrap();
+        assert!(
+            value.get("archived_at").is_some(),
+            "an archived board must carry the archived_at key with its timestamp"
+        );
+    }
+
     #[test]
     fn test_board_response_archived_projects_board_and_archived_at() {
         use chrono::{TimeZone, Utc};


### PR DESCRIPTION
## KAN-919 (ARCH-DECOR B3): consolidate BoardResponse to one shape

Under the decorator model a board is a board: one wire shape carrying an optional `archived_at` (omitted when `None`), exactly like `CardSummary`. This slice consolidates the constructor surface so callers build a board through a single entry point.

### What changed
- Added `BoardResponse::with_archived_at(&Board, Option<DateTime<Utc>>)` as the single constructor a board is built through: `None` yields the live projection (the `archived_at` key is skipped on the wire), `Some` stamps the marker timestamp.
- Reworked the existing `archived(&Board, DateTime<Utc>)` into a thin wrapper delegating to `with_archived_at(board, Some(at))`.

### Deliberately out of scope (B4/B5)
The `archived(...)` signature and its CLI (`handlers/board.rs:119`) and MCP (`tools/board.rs:66`) callers are left untouched, so this slice is purely additive and the live-board payload is byte-identical.

### Note on prior work
The `archived_at` field itself (with `#[serde(default, skip_serializing_if = "Option::is_none")]`), `from(&Board)` setting `archived_at: None`, and the omit/include serde guards already landed in KAN-880 (D2). The card was written against the pre-D2 state; the genuinely remaining B3 work was the `with_archived_at` constructor and delegation, which this PR delivers.

### TDD (Red -> Green)
Red tests (committed first, failed to compile without the constructor):
- `test_board_response_omits_archived_at_when_live` — a live board built via `with_archived_at(.., None)` serializes with no `archived_at` key (byte-identical guard).
- `test_board_response_includes_archived_at_when_archived` — `with_archived_at(.., Some(at))` carries the key with the timestamp.

### Verification
- `cargo test -p kanban-service` green (all suites).
- `cargo clippy -p kanban-service --all-targets -- -D warnings` clean.
- `cargo fmt` clean.
- Live-board JSON unchanged: no `archived_at` key present on live payloads.
