### PR TITLE
KAN-931 refactor(tui): unify card collection + archived-id set, drop get_card_by_id re-join

### DIFF
--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -40,7 +40,7 @@ impl App {
     pub fn get_selected_card_in_context(&self) -> Option<Card> {
         if let Some(task_list) = self.view.strategy.get_active_task_list() {
             if let Some(card_id) = task_list.get_selected_card_id() {
-                return self.get_card_by_id(card_id);
+                return self.model.card_by_id(card_id).cloned();
             }
         }
         None
@@ -79,17 +79,10 @@ impl App {
         }
     }
 
-    pub fn get_card_by_id(&self, card_id: uuid::Uuid) -> Option<Card> {
-        self.model
-            .card(card_id)
-            .or_else(|| self.model.archived_card(card_id))
-            .cloned()
-    }
-
     pub fn get_card_for_detail_view(&self) -> Option<Card> {
         self.selection
             .active_card_id
-            .and_then(|id| self.model.card(id).cloned())
+            .and_then(|id| self.model.card_by_id(id).cloned())
     }
 
     /// Sets `active_card_id` to `id` if a card with that id exists in the
@@ -98,7 +91,7 @@ impl App {
     /// On miss the previously-active card is left untouched; sites that
     /// require clear-on-miss semantics must use [`Self::set_active_card_or_clear`].
     pub(crate) fn activate_card(&mut self, id: uuid::Uuid) -> bool {
-        if self.model.card(id).is_some() {
+        if self.model.card_by_id(id).is_some() {
             self.selection.active_card_id = Some(id);
             true
         } else {
@@ -112,7 +105,7 @@ impl App {
     /// reload race), so downstream code that gates on
     /// `active_card_id.is_some()` does not act on a stale previous card.
     pub(crate) fn set_active_card_or_clear(&mut self, id: uuid::Uuid) {
-        self.selection.active_card_id = self.model.card(id).map(|c| c.id);
+        self.selection.active_card_id = self.model.card_by_id(id).map(|c| c.id);
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {

--- a/crates/kanban-tui/src/app/clipboard.rs
+++ b/crates/kanban-tui/src/app/clipboard.rs
@@ -10,7 +10,7 @@ impl App {
     {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(board) = self.active_board() {
-                if let Some(card) = self.model.card(active_id) {
+                if let Some(card) = self.model.card_by_id(active_id) {
                     let sprints = self.model.sprints();
                     let output = get_output(
                         card,

--- a/crates/kanban-tui/src/app/file_io.rs
+++ b/crates/kanban-tui/src/app/file_io.rs
@@ -79,7 +79,7 @@ impl App {
         field: CardField,
     ) -> io::Result<()> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {
                     CardField::Title => {

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -1,7 +1,7 @@
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, Snapshot, Sprint,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 #[derive(Default)]
@@ -12,8 +12,7 @@ pub struct Model {
     card_index: HashMap<Uuid, usize>,
     sprints: Option<Vec<Sprint>>,
     archived_cards: Option<Vec<ArchivedCard>>,
-    archived_cards_flat: Option<Vec<Card>>,
-    archived_card_index: HashMap<Uuid, usize>,
+    archived_card_ids: HashSet<Uuid>,
     archived_boards: Option<Vec<ArchivedBoard>>,
     archived_boards_flat: Option<Vec<Board>>,
     archived_board_index: HashMap<Uuid, usize>,
@@ -34,7 +33,10 @@ impl Model {
         self.cards.as_deref().unwrap_or(&[])
     }
 
-    pub fn card(&self, id: Uuid) -> Option<&Card> {
+    /// Resolve a card by id from the single unified collection (live AND
+    /// archived rows). One index lookup — no live/archived re-join. A card is
+    /// a card regardless of whether its head is archived.
+    pub fn card_by_id(&self, id: Uuid) -> Option<&Card> {
         let &idx = self.card_index.get(&id)?;
         self.cards.as_ref()?.get(idx)
     }
@@ -47,13 +49,12 @@ impl Model {
         self.archived_cards.as_deref().unwrap_or(&[])
     }
 
-    pub fn archived_cards_flat(&self) -> &[Card] {
-        self.archived_cards_flat.as_deref().unwrap_or(&[])
-    }
-
-    pub fn archived_card(&self, id: Uuid) -> Option<&Card> {
-        let &idx = self.archived_card_index.get(&id)?;
-        self.archived_cards_flat.as_ref()?.get(idx)
+    /// Ids of the archived cards. Rows themselves live in the unified `cards()`
+    /// collection; this set records which of them are archived (built from the
+    /// markers). Consumers that need the archived subset filter `cards()` by
+    /// this set. (T1c introduces a single `displayed_cards()` accessor.)
+    pub fn archived_card_ids(&self) -> &std::collections::HashSet<Uuid> {
+        &self.archived_card_ids
     }
 
     pub fn archived_boards(&self) -> &[ArchivedBoard] {
@@ -91,37 +92,21 @@ impl Model {
     pub fn load_from_snapshot(&mut self, snapshot: Snapshot) {
         // Reference-marker model: `snapshot.cards` carries EVERY card — live AND
         // archived — with archival recorded by markers in `snapshot.archived_cards`
-        // (keyed by `entity_id`). Split them: the live board views see only live
-        // cards; the archived view sees the archived ones, reconstructed from the
-        // same live rows (no stale copy).
-        let archived_ids: std::collections::HashSet<Uuid> = snapshot
+        // (keyed by `entity_id`). Unify: one collection holds all rows, and an
+        // id set records which are archived. The live/archived distinction is a
+        // consumption decision applied by filtering `cards()` on this set.
+        let archived_card_ids: HashSet<Uuid> = snapshot
             .archived_cards
             .iter()
             .map(|ac| ac.entity_id)
             .collect();
 
-        let card_by_id: std::collections::HashMap<Uuid, Card> =
-            snapshot.cards.iter().map(|c| (c.id, c.clone())).collect();
-
-        let live_cards: Vec<Card> = snapshot
-            .cards
-            .into_iter()
-            .filter(|c| !archived_ids.contains(&c.id))
-            .collect();
-
+        let cards = snapshot.cards;
         self.card_index.clear();
-        for (i, card) in live_cards.iter().enumerate() {
+        for (i, card) in cards.iter().enumerate() {
             self.card_index.insert(card.id, i);
         }
-
-        self.archived_card_index.clear();
-        let mut flat = Vec::with_capacity(snapshot.archived_cards.len());
-        for ac in snapshot.archived_cards.iter() {
-            if let Some(card) = card_by_id.get(&ac.entity_id) {
-                self.archived_card_index.insert(ac.entity_id, flat.len());
-                flat.push(card.clone());
-            }
-        }
+        self.archived_card_ids = archived_card_ids;
 
         // Boards split exactly like cards: `snapshot.boards` carries EVERY board
         // head (live + archived); `snapshot.archived_boards` are markers keyed by
@@ -155,9 +140,8 @@ impl Model {
         self.boards = Some(live_boards);
         self.columns = Some(snapshot.columns);
         self.sprints = Some(snapshot.sprints);
-        self.cards = Some(live_cards);
+        self.cards = Some(cards);
         self.archived_cards = Some(snapshot.archived_cards);
-        self.archived_cards_flat = Some(flat);
         self.archived_boards = Some(snapshot.archived_boards);
         self.archived_boards_flat = Some(board_flat);
         self.graph = snapshot.graph;
@@ -181,7 +165,7 @@ mod tests {
         assert!(m.cards().is_empty());
         assert!(m.sprints().is_empty());
         assert!(m.archived_cards().is_empty());
-        assert!(m.archived_cards_flat().is_empty());
+        assert!(m.archived_card_ids().is_empty());
     }
 
     #[test]
@@ -214,57 +198,72 @@ mod tests {
             cards: vec![card_a, card_b],
             ..Default::default()
         });
-        let found = m.card(card_b_id).unwrap();
+        let found = m.card_by_id(card_b_id).unwrap();
         assert_eq!(found.id, card_b_id);
     }
 
     #[test]
-    fn test_card_lookup_missing_id_returns_none() {
-        let m = Model::default();
-        assert!(m.card(Uuid::new_v4()).is_none());
-    }
-
-    #[test]
-    fn test_archived_card_lookup_by_id() {
+    fn test_card_by_id_resolves_live_and_archived_from_one_collection() {
+        // After unification `cards()` holds live AND archived rows, and
+        // `card_by_id` resolves either from the single collection — no
+        // `or_else(archived_card())` re-join.
         let mut m = Model::default();
         let mut board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let card = make_card(&mut board, col_id);
-        let card_id = card.id;
-        // Reference-marker model: the card stays live in `cards`; the marker
-        // references it by id.
-        let archived = ArchivedCard::new(card_id, uuid::Uuid::nil());
+        let live = make_card(&mut board, col_id);
+        let archived = make_card(&mut board, col_id);
+        let live_id = live.id;
+        let archived_id = archived.id;
         m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
-            cards: vec![card],
-            archived_cards: vec![archived],
+            cards: vec![live, archived],
+            archived_cards: vec![ArchivedCard::new(archived_id, uuid::Uuid::nil())],
             ..Default::default()
         });
-        let found = m.archived_card(card_id).unwrap();
-        assert_eq!(found.id, card_id);
+
+        // Both live and archived rows live in the single unified collection.
+        assert_eq!(m.cards().len(), 2);
+
+        // The single index resolves both.
+        assert_eq!(m.card_by_id(live_id).map(|c| c.id), Some(live_id));
+        assert_eq!(m.card_by_id(archived_id).map(|c| c.id), Some(archived_id));
+
+        // The archived-id set records which rows are archived.
+        assert!(!m.archived_card_ids().contains(&live_id));
+        assert!(m.archived_card_ids().contains(&archived_id));
     }
 
     #[test]
-    fn test_archived_card_lookup_missing_id_returns_none() {
-        let m = Model::default();
-        assert!(m.archived_card(Uuid::new_v4()).is_none());
-    }
-
-    #[test]
-    fn test_archived_cards_flat_matches_archived_cards() {
+    fn test_archived_view_filter_shows_archived_card_from_unified_collection() {
+        // The archived-cards view (pending T1c's `displayed_cards()`) filters
+        // the unified collection by `archived_card_ids`. Assert an archived
+        // card is present through that path.
         let mut m = Model::default();
         let mut board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let card = make_card(&mut board, col_id);
-        let card_id = card.id;
+        let live = make_card(&mut board, col_id);
+        let archived = make_card(&mut board, col_id);
+        let archived_id = archived.id;
         m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
-            cards: vec![card],
-            archived_cards: vec![ArchivedCard::new(card_id, uuid::Uuid::nil())],
+            cards: vec![live, archived],
+            archived_cards: vec![ArchivedCard::new(archived_id, uuid::Uuid::nil())],
             ..Default::default()
         });
-        assert_eq!(m.archived_cards_flat().len(), 1);
-        assert_eq!(m.archived_cards_flat()[0].id, card_id);
+
+        let displayed: Vec<Uuid> = m
+            .cards()
+            .iter()
+            .filter(|c| m.archived_card_ids().contains(&c.id))
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(displayed, vec![archived_id]);
+    }
+
+    #[test]
+    fn test_card_by_id_missing_id_returns_none() {
+        let m = Model::default();
+        assert!(m.card_by_id(Uuid::new_v4()).is_none());
     }
 
     #[test]
@@ -343,10 +342,10 @@ mod tests {
             cards: vec![card],
             ..Default::default()
         });
-        assert!(m.card(old_id).is_some());
+        assert!(m.card_by_id(old_id).is_some());
 
         // Reload with no cards — stale index entry must be gone
         m.load_from_snapshot(Snapshot::default());
-        assert!(m.card(old_id).is_none());
+        assert!(m.card_by_id(old_id).is_none());
     }
 }

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -3,7 +3,7 @@ use super::App;
 impl App {
     pub fn get_current_priority_selection_index(&self) -> usize {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 use kanban_domain::CardPriority;
                 return match card.priority {
                     CardPriority::Low => 0,
@@ -20,7 +20,7 @@ impl App {
         use crate::components::sprint_assign_list::{build_entries, sprint_id_of};
 
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 if let Some(card_sprint_id) = card.sprint_id {
                     if let Some(board) = self.active_board() {
                         let sprints = self.model.sprints();

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -54,11 +54,20 @@ impl App {
             Err(e) => tracing::warn!("Failed to load snapshot for frame: {e}"),
         }
 
-        let cards_for_display: &[Card] = if self.mode == AppMode::ArchivedCardsView {
-            self.model.archived_cards_flat()
-        } else {
-            self.model.cards()
-        };
+        // Cards are now one unified collection (live + archived); the view mode
+        // selects which subset to display by filtering on `archived_card_ids`.
+        // This inline filter is temporary: T1c introduces a single
+        // `displayed_cards()` accessor that subsumes it (see KAN-914 D3 / KAN-931).
+        let archived_ids = self.model.archived_card_ids();
+        let want_archived = self.mode == AppMode::ArchivedCardsView;
+        let cards_for_display: Vec<Card> = self
+            .model
+            .cards()
+            .iter()
+            .filter(|c| archived_ids.contains(&c.id) == want_archived)
+            .cloned()
+            .collect();
+        let cards_for_display: &[Card] = &cards_for_display;
 
         // Board resolution: inlined (rather than calling `active_board` /
         // `displayed_boards`) because those return borrows tied to all of `self`,

--- a/crates/kanban-tui/src/components/relationship_popup.rs
+++ b/crates/kanban-tui/src/components/relationship_popup.rs
@@ -84,7 +84,8 @@ fn render_relationship_card_list(app: &App, frame: &mut Frame, area: ratatui::la
             .card_ids
             .iter()
             .filter(|card_id| {
-                app.get_card_by_id(**card_id)
+                app.model
+                    .card_by_id(**card_id)
                     .map(|c| c.title.to_lowercase().contains(&search_lower))
                     .unwrap_or(false)
             })
@@ -94,7 +95,7 @@ fn render_relationship_card_list(app: &App, frame: &mut Frame, area: ratatui::la
 
     let mut lines = vec![];
     for (idx, card_id) in filtered_cards.iter().enumerate() {
-        if let Some(card) = app.get_card_by_id(*card_id) {
+        if let Some(card) = app.model.card_by_id(*card_id) {
             let is_selected = app.relationship.selection.get() == Some(idx);
             let is_checked = app.relationship.selected.contains(card_id);
 

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -146,7 +146,7 @@ impl App {
             let current_sprint_id = self
                 .selection
                 .active_card_id
-                .and_then(|id| self.model.card(id))
+                .and_then(|id| self.model.card_by_id(id))
                 .and_then(|c| c.sprint_id);
             // Re-borrow board after the &mut self call above.
             if let Some(board) = self.active_board().cloned() {
@@ -710,11 +710,11 @@ impl App {
         // it keeps its current column/position on restore; there is no "original"
         // location to reconstruct. Read the live card for its column/position and
         // to resolve the restore target if its column was removed.
-        let (current_column_id, current_position, card_title) =
-            match self.model.archived_card(card_id) {
-                Some(card) => (card.column_id, card.position, card.title.clone()),
-                None => return,
-            };
+        let (current_column_id, current_position, card_title) = match self.model.card_by_id(card_id)
+        {
+            Some(card) => (card.column_id, card.position, card.title.clone()),
+            None => return,
+        };
 
         let board_id = self.active_board().map(|b| b.id);
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -303,7 +303,7 @@ impl App {
                         let current_sprint_id = self
                             .selection
                             .active_card_id
-                            .and_then(|id| self.model.card(id))
+                            .and_then(|id| self.model.card_by_id(id))
                             .and_then(|c| c.sprint_id);
                         self.dialog_input
                             .assign_sprint_picker
@@ -810,8 +810,10 @@ impl App {
                                         .filter(|s| s.board_id == board.id)
                                         .count();
                                     if sprint_count > 0 {
-                                        let current_sprint_id =
-                                            self.model.card(card_id).and_then(|c| c.sprint_id);
+                                        let current_sprint_id = self
+                                            .model
+                                            .card_by_id(card_id)
+                                            .and_then(|c| c.sprint_id);
                                         self.dialog_input
                                             .assign_sprint_picker
                                             .reset_for_card_assignment(
@@ -937,7 +939,7 @@ impl App {
 
     pub(crate) fn handle_manage_parents(&mut self) {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
@@ -990,7 +992,7 @@ impl App {
 
     pub(crate) fn handle_manage_children(&mut self) {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
@@ -1043,7 +1045,7 @@ impl App {
 
     pub fn get_current_card_parents(&self) -> Vec<uuid::Uuid> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 return self.model.graph().parents(card.id);
             }
         }
@@ -1052,7 +1054,7 @@ impl App {
 
     pub fn get_current_card_children(&self) -> Vec<uuid::Uuid> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card(active_id) {
+            if let Some(card) = self.model.card_by_id(active_id) {
                 return self.model.graph().children(card.id);
             }
         }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -181,7 +181,7 @@ impl App {
                 let card_id = self
                     .selection
                     .active_card_id
-                    .and_then(|id| self.model.card(id))
+                    .and_then(|id| self.model.card_by_id(id))
                     .map(|c| c.id)
                     .or_else(|| self.get_selected_card_in_context().map(|c| c.id));
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -49,7 +49,7 @@ impl App {
             KeyCode::Enter => {
                 if let Some(priority_idx) = self.dialog_input.priority_selection.get() {
                     if let Some(active_id) = self.selection.active_card_id {
-                        if let Some(card) = self.model.card(active_id) {
+                        if let Some(card) = self.model.card_by_id(active_id) {
                             use kanban_domain::{CardPriority, CardUpdate};
                             let priority = match priority_idx {
                                 0 => CardPriority::Low,
@@ -239,7 +239,7 @@ impl App {
                         return;
                     }
                 };
-                let card_id = match self.model.card(active_card_id) {
+                let card_id = match self.model.card_by_id(active_card_id) {
                     Some(card) => card.id,
                     None => return,
                 };
@@ -548,7 +548,7 @@ impl App {
                 if let Some(idx) = self.relationship.selection.get() {
                     if let Some(selected_card_id) = filtered_cards.get(idx).copied() {
                         if let Some(active_id) = self.selection.active_card_id {
-                            if let Some(current_card) = self.model.card(active_id) {
+                            if let Some(current_card) = self.model.card_by_id(active_id) {
                                 let current_card_id = current_card.id;
 
                                 let (child_id, parent_id) = if is_parent_mode {

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -634,7 +634,7 @@ impl App {
             .collect();
 
         // Route through the snapshot so each selected board's archived-card live
-        // rows and markers round-trip (the live-scoped model.cards() omits them).
+        // rows and markers round-trip.
         let export = match self.build_boards_export(&selected_board_ids) {
             Ok(export) => export,
             Err(e) => {

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -171,7 +171,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                 }
 
                                 if let Some(card_id) = task_list.cards.get(*card_idx) {
-                                    if let Some(card) = app.get_card_by_id(*card_id) {
+                                    if let Some(card) = app.model.card_by_id(*card_id) {
                                         let is_selected =
                                             task_list.get_selected_index() == Some(*card_idx);
                                         let animation_type = app
@@ -180,7 +180,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                             .get(&card.id)
                                             .map(|a| a.animation_type);
                                         let line = render_card_list_item(CardListItemConfig {
-                                            card: &card,
+                                            card,
                                             board,
                                             sprints,
                                             is_selected,
@@ -268,14 +268,14 @@ impl RenderStrategy for SinglePanelRenderer {
 
                         for card_idx in &render_info.visible_card_indices {
                             if let Some(card_id) = task_list.cards.get(*card_idx) {
-                                if let Some(card) = app.get_card_by_id(*card_id) {
+                                if let Some(card) = app.model.card_by_id(*card_id) {
                                     let animation_type = app
                                         .animation
                                         .animating
                                         .get(&card.id)
                                         .map(|a| a.animation_type);
                                     let line = render_card_list_item(CardListItemConfig {
-                                        card: &card,
+                                        card,
                                         board,
                                         sprints,
                                         is_selected: task_list.get_selected_index()
@@ -407,7 +407,7 @@ impl RenderStrategy for MultiPanelRenderer {
 
                         for card_idx in &render_info.visible_card_indices {
                             if let Some(card_id) = task_list.cards.get(*card_idx) {
-                                if let Some(card) = app.get_card_by_id(*card_id) {
+                                if let Some(card) = app.model.card_by_id(*card_id) {
                                     let is_selected = if is_focused_column {
                                         task_list.get_selected_index() == Some(*card_idx)
                                     } else {
@@ -420,7 +420,7 @@ impl RenderStrategy for MultiPanelRenderer {
                                         .get(&card.id)
                                         .map(|a| a.animation_type);
                                     let line = render_card_list_item(CardListItemConfig {
-                                        card: &card,
+                                        card,
                                         board,
                                         sprints,
                                         is_selected,

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -208,7 +208,7 @@ fn calculate_task_panel_points(
     let filtered: Vec<&kanban_domain::Card> = task_list
         .cards
         .iter()
-        .filter_map(|card_id| model.card(*card_id))
+        .filter_map(|card_id| model.card_by_id(*card_id))
         .collect();
     kanban_domain::calculate_points(&filtered)
 }
@@ -243,7 +243,7 @@ pub(super) fn render_sprint_task_panel_with_selection(
 
         for card_idx in &render_info.visible_card_indices {
             if let Some(card_id) = task_list.cards.get(*card_idx) {
-                if let Some(card) = app.get_card_by_id(*card_id) {
+                if let Some(card) = app.model.card_by_id(*card_id) {
                     let is_selected = selected_idx == Some(*card_idx) && is_focused;
                     let animation_type = app
                         .animation
@@ -251,7 +251,7 @@ pub(super) fn render_sprint_task_panel_with_selection(
                         .get(&card.id)
                         .map(|a| a.animation_type);
                     let line = render_card_list_item(CardListItemConfig {
-                        card: &card,
+                        card,
                         board,
                         sprints,
                         is_selected,

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -13,7 +13,7 @@ fn force_animation_complete(app: &mut App, card_id: uuid::Uuid) {
 }
 
 #[test]
-fn test_archived_card_visible_via_get_card_by_id() {
+fn test_archived_card_visible_via_card_by_id() {
     let mut app = App::test_default();
 
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();
@@ -44,10 +44,10 @@ fn test_archived_card_visible_via_get_card_by_id() {
     app.mode = AppMode::ArchivedCardsView;
     app.prepare_frame();
 
-    let found = app.get_card_by_id(card_id);
+    let found = app.model.card_by_id(card_id);
     assert!(
         found.is_some(),
-        "get_card_by_id should return archived card, got None"
+        "card_by_id should return archived card, got None"
     );
     assert_eq!(found.unwrap().title, "ArchiveMe");
 }
@@ -151,8 +151,8 @@ fn test_permanent_delete_removes_archived_card() {
         "card should not be restored to active cards"
     );
     assert!(
-        app.get_card_by_id(card_id).is_none(),
-        "get_card_by_id should return None for permanently deleted card"
+        app.model.card_by_id(card_id).is_none(),
+        "card_by_id should return None for permanently deleted card"
     );
 }
 
@@ -194,17 +194,21 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
     app.handle_animation_tick();
     app.prepare_frame();
 
+    // Unified model: the row stays in `cards()`; archival is recorded by the
+    // id set. "Archived" means present in `archived_card_ids`, not removed.
     assert!(
-        app.model.cards().iter().all(|c| c.id != card_id),
-        "card must be archived after animation completion"
+        app.model.cards().iter().any(|c| c.id == card_id)
+            && app.model.archived_card_ids().contains(&card_id),
+        "card must be archived (marked) after animation completion"
     );
 
     assert!(app.ctx.undo().unwrap(), "first undo must succeed");
     app.prepare_frame();
 
     assert!(
-        app.model.cards().iter().any(|c| c.id == card_id),
-        "card must be back after one undo press — archive + compact must \
+        app.model.cards().iter().any(|c| c.id == card_id)
+            && !app.model.archived_card_ids().contains(&card_id),
+        "card must be live again after one undo press — archive + compact must \
          live in a single undo batch"
     );
 }

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -188,7 +188,7 @@ fn test_archived_board_card_action_works() {
     let snap = app.ctx.snapshot().unwrap();
     app.model.load_from_snapshot(snap);
 
-    let card = app.model.card(card_id).expect("card still live");
+    let card = app.model.card_by_id(card_id).expect("card still live");
     assert!(
         card.is_completed(),
         "card action on an archived board's card takes effect"

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -33,7 +33,7 @@ fn test_prepare_frame_populates_model_from_snapshot() {
     assert_eq!(app.model.boards()[0].name, "Board");
     assert_eq!(app.model.columns().len(), 1);
     assert_eq!(app.model.cards().len(), 1);
-    assert_eq!(app.model.card(card.id).unwrap().title, "Task");
+    assert_eq!(app.model.card_by_id(card.id).unwrap().title, "Task");
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn test_model_reflects_mutation_after_prepare_frame() {
         .map(|b| b.id);
     app.prepare_frame();
 
-    assert_eq!(app.model.card(card.id).unwrap().title, "Original");
+    assert_eq!(app.model.card_by_id(card.id).unwrap().title, "Original");
 
     let cmd = kanban_domain::commands::Command::Card(kanban_domain::commands::CardCommand::Update(
         kanban_domain::commands::UpdateCard {
@@ -79,7 +79,7 @@ fn test_model_reflects_mutation_after_prepare_frame() {
     app.prepare_frame();
 
     assert_eq!(
-        app.model.card(card.id).unwrap().title,
+        app.model.card_by_id(card.id).unwrap().title,
         "Updated",
         "model must reflect the mutated title after prepare_frame"
     );
@@ -117,7 +117,7 @@ fn test_model_description_reflects_mutation() {
     app.prepare_frame();
 
     assert_eq!(
-        app.model.card(card.id).unwrap().description,
+        app.model.card_by_id(card.id).unwrap().description,
         Some("Initial desc".to_string())
     );
 
@@ -134,7 +134,7 @@ fn test_model_description_reflects_mutation() {
     app.prepare_frame();
 
     assert_eq!(
-        app.model.card(card.id).unwrap().description,
+        app.model.card_by_id(card.id).unwrap().description,
         Some("Updated desc".to_string()),
         "model must reflect the updated description after prepare_frame"
     );

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -65,8 +65,8 @@ fn test_card_lookup_by_id() {
         ..Default::default()
     });
 
-    assert_eq!(model.card(id1).unwrap().title, "First");
-    assert_eq!(model.card(id2).unwrap().title, "Second");
+    assert_eq!(model.card_by_id(id1).unwrap().title, "First");
+    assert_eq!(model.card_by_id(id2).unwrap().title, "Second");
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn test_card_lookup_missing_id_returns_none() {
         ..Default::default()
     });
 
-    assert!(model.card(Uuid::new_v4()).is_none());
+    assert!(model.card_by_id(Uuid::new_v4()).is_none());
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
         cards: vec![card_a],
         ..Default::default()
     });
-    assert!(model.card(id_a).is_some());
+    assert!(model.card_by_id(id_a).is_some());
 
     let card_b = make_card(&mut board, column_id, "B", 0);
     let id_b = card_b.id;
@@ -108,12 +108,28 @@ fn test_load_from_snapshot_rebuilds_card_index() {
         ..Default::default()
     });
 
-    assert!(model.card(id_a).is_none(), "old card should not be found");
-    assert_eq!(model.card(id_b).unwrap().title, "B");
+    assert!(
+        model.card_by_id(id_a).is_none(),
+        "old card should not be found"
+    );
+    assert_eq!(model.card_by_id(id_b).unwrap().title, "B");
+}
+
+// Helper mirroring the archived-cards view: the archived subset of the unified
+// collection, filtered by `archived_card_ids` (temporary until T1c's
+// `displayed_cards()`).
+fn archived_titles(model: &Model) -> Vec<String> {
+    let ids = model.archived_card_ids();
+    model
+        .cards()
+        .iter()
+        .filter(|c| ids.contains(&c.id))
+        .map(|c| c.title.clone())
+        .collect()
 }
 
 #[test]
-fn test_archived_cards_flat_returns_card_data() {
+fn test_archived_cards_resolve_from_unified_collection() {
     let mut model = Model::default();
 
     let mut board = Board::new("B", None::<String>);
@@ -130,14 +146,11 @@ fn test_archived_cards_flat_returns_card_data() {
         ..Default::default()
     });
 
-    let flat = model.archived_cards_flat();
-    assert_eq!(flat.len(), 2);
-    assert_eq!(flat[0].title, "Archived1");
-    assert_eq!(flat[1].title, "Archived2");
+    assert_eq!(archived_titles(&model), vec!["Archived1", "Archived2"]);
 }
 
 #[test]
-fn test_archived_cards_flat_rebuilds_on_reload() {
+fn test_archived_id_set_rebuilds_on_reload() {
     let mut model = Model::default();
 
     let mut board = Board::new("B", None::<String>);
@@ -151,8 +164,7 @@ fn test_archived_cards_flat_rebuilds_on_reload() {
         archived_cards: vec![ac1],
         ..Default::default()
     });
-    assert_eq!(model.archived_cards_flat().len(), 1);
-    assert_eq!(model.archived_cards_flat()[0].title, "First");
+    assert_eq!(archived_titles(&model), vec!["First"]);
 
     let card2 = make_card(&mut board, column_id, "Second", 0);
     let card3 = make_card(&mut board, column_id, "Third", 1);
@@ -165,14 +177,15 @@ fn test_archived_cards_flat_rebuilds_on_reload() {
         ..Default::default()
     });
 
-    let flat = model.archived_cards_flat();
-    assert_eq!(flat.len(), 2, "should reflect second snapshot");
-    assert_eq!(flat[0].title, "Second");
-    assert_eq!(flat[1].title, "Third");
+    assert_eq!(
+        archived_titles(&model),
+        vec!["Second", "Third"],
+        "should reflect second snapshot"
+    );
 }
 
 #[test]
-fn test_archived_card_lookup_by_id() {
+fn test_card_by_id_resolves_archived_card() {
     let mut model = Model::default();
 
     let mut board = Board::new("B", None::<String>);
@@ -191,12 +204,14 @@ fn test_archived_card_lookup_by_id() {
         ..Default::default()
     });
 
-    assert_eq!(model.archived_card(id1).unwrap().title, "Archived1");
-    assert_eq!(model.archived_card(id2).unwrap().title, "Archived2");
+    assert_eq!(model.card_by_id(id1).unwrap().title, "Archived1");
+    assert_eq!(model.card_by_id(id2).unwrap().title, "Archived2");
+    assert!(model.archived_card_ids().contains(&id1));
+    assert!(model.archived_card_ids().contains(&id2));
 }
 
 #[test]
-fn test_archived_card_lookup_missing_returns_none() {
+fn test_card_by_id_missing_returns_none() {
     let mut model = Model::default();
 
     let mut board = Board::new("B", None::<String>);
@@ -211,5 +226,5 @@ fn test_archived_card_lookup_missing_returns_none() {
         ..Default::default()
     });
 
-    assert!(model.archived_card(Uuid::new_v4()).is_none());
+    assert!(model.card_by_id(Uuid::new_v4()).is_none());
 }

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -81,7 +81,7 @@ fn open_assign_dialog(app: &mut App) {
     let current_sprint_id = app
         .selection
         .active_card_id
-        .and_then(|id| app.model.card(id))
+        .and_then(|id| app.model.card_by_id(id))
         .and_then(|c| c.sprint_id);
     let sprints = app.model.sprints().to_vec();
     let board = app


### PR DESCRIPTION
## What

Collapse the CARD partition in the TUI `Model` (KAN-931 / ARCH-DECOR T1a, child of KAN-914). An archived card is now resolved from ONE collection, killing the hand re-join.

Before: the model split snapshot cards into a live `cards()` collection and a separate `archived_cards_flat()` copy, and `App::get_card_by_id` hand re-joined them (`card().or_else(archived_card())`) at every render/selection site.

After:
- The model holds one unified `cards: Vec<Card>` (live + archived) plus `archived_card_ids: HashSet<Uuid>` built from the markers (the marker vec is kept for `archived_at`).
- `Model::card()` becomes `card_by_id()`: a single index lookup over the unified collection, dropping the `or_else(archived_card())` re-join.
- `App::get_card_by_id` (the re-join) is deleted; its callers point at `model.card_by_id`.
- `archived_cards_flat` field + accessor removed.

## Call sites repointed off `get_card_by_id`

- `src/app/card_selection.rs:43` — `get_selected_card_in_context` (clones at the call site, since it returns an owned `Card`)
- `src/render_strategy.rs:174, 271, 410` — card list rendering (borrow `&Card`; `card: &card` became field-shorthand `card`)
- `src/components/relationship_popup.rs:87, 97` — relationship card list filter + render
- `src/ui/sprint_detail.rs:246` — sprint detail card list
- `src/handlers/card_handlers.rs` restore path (`archived_card(id)` → `card_by_id(id)`, same live row)

All other `model.card(id)` callers were renamed to `card_by_id(id)`.

## Keeping the archived view working (pending T1c)

The archived-cards view previously read `archived_cards_flat()`. Since that display path is reworked in T1c/T2, `prepare_frame` now selects the displayed subset by filtering the unified collection on `archived_card_ids` by mode: the live board view stays live-only, the `ArchivedCardsView` shows the archived subset. This inline filter is temporary — T1c introduces the single `displayed_cards()` accessor that subsumes it.

## Tests (TDD)

Red first, then impl:
- `test_card_by_id_resolves_live_and_archived_from_one_collection` (model.rs) — seeds a live + archived card; both resolve via `card_by_id`; `archived_card_ids` records membership.
- `test_archived_view_filter_shows_archived_card_from_unified_collection` (model.rs) — the archived subset is recovered by filtering `cards()` on `archived_card_ids`.
- `test_archived_cards_resolve_from_unified_collection`, `test_archived_id_set_rebuilds_on_reload`, `test_card_by_id_resolves_archived_card` (tests/model_tests.rs).
- `archive_delete_tests`: "archived" now means present-and-marked (in `cards()` + in `archived_card_ids`), not removed; resolver assertions repointed at `card_by_id`.

`cargo test -p kanban-tui`, `cargo clippy -p kanban-tui --all-targets -D warnings`, `cargo fmt --check` all green.

## Notes / follow-ups (T2)

- `App::get_board_card_count` / `get_sorted_board_cards` pass `model.cards()` (now unified) to archival-agnostic domain filters. They currently have no callers or tests, so no live-count regression is reachable; parameterizing them with `ArchivedFilter` is T2 work per KAN-914.
- Removed a now-stale comment in `settings_handlers.rs` that described `model.cards()` as live-scoped.

Part of KAN-931 (T1a). Child of KAN-914 (ARCH-DECOR).