### PR TITLE
KAN-916 fix(service): coherent move_card for archived cards via ArchivedFilter

### DIFF
--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -65,7 +65,12 @@ impl KanbanContext {
             .get_board(board_id)?
             .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
         let card_number = board.card_counter;
-        let position = self.backend.list_cards_by_column(spec.column_id)?.len() as i32;
+        // Append past the FULL (live + archived) set so a new card shares one
+        // coherent ordinal space with any archived siblings (KAN-916 / O1-A).
+        let position = self.backend.count_cards_in_column_filtered(
+            spec.column_id,
+            kanban_domain::ArchivedFilter::Include,
+        )? as i32;
 
         // Keep construction inside the frozen `CreateCard` command (it owns the
         // WIP check, board-counter bump, sprint-log seeding and upserts); the
@@ -272,7 +277,14 @@ impl KanbanContext {
         use kanban_domain::commands::{MoveCard, UpdateCard};
         let position = match position {
             Some(p) => p,
-            None => self.backend.list_cards_by_column(column_id)?.len() as i32,
+            // Append past the FULL (live + archived) set so a moved card — live
+            // or archived — lands at a coherent ordinal that never collides with
+            // an existing archived sibling (KAN-916 / O1-A). For a destination
+            // holding no archived cards this equals the former live-only count.
+            None => self
+                .backend
+                .count_cards_in_column_filtered(column_id, kanban_domain::ArchivedFilter::Include)?
+                as i32,
         };
         let mut batch = vec![Command::Card(CardCommand::Move(MoveCard {
             card_id: id,

--- a/crates/kanban-service/tests/move_cards.rs
+++ b/crates/kanban-service/tests/move_cards.rs
@@ -356,6 +356,111 @@ macro_rules! move_cards_tests {
                 assert_eq!(result.failed.len(), 1);
                 assert_eq!(result.failed[0].id, bogus);
             }
+
+            // KAN-916 (O1-A): a `None`-position move appends past the FULL
+            // (live + archived) set, so a card moved into a column that already
+            // holds an archived sibling never collides with the archived
+            // ordinal. Before the fix the append used the live-only count and
+            // handed out a position that an archived card already occupied.
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_move_archived_card_positions_coherently() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                // Destination column holds a live card at 0 and an archived
+                // card at 1 (the marker model keeps the archived card live in
+                // place, so it still occupies ordinal 1).
+                let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();
+                let src = ctx.create_column(board.id, "Src".into(), None).unwrap();
+                let dst = ctx.create_column(board.id, "Dst".into(), None).unwrap();
+
+                let live_in_dst = ctx
+                    .create_card(board.id, dst.id, "LiveDst".into(), Default::default())
+                    .unwrap();
+                let archived_in_dst = ctx
+                    .create_card(board.id, dst.id, "ArchDst".into(), Default::default())
+                    .unwrap();
+                ctx.archive_card(archived_in_dst.id).unwrap();
+
+                assert_eq!(live_in_dst.position, 0);
+                let archived_row = backend.get_card(archived_in_dst.id).unwrap().unwrap();
+                assert_eq!(
+                    archived_row.position, 1,
+                    "archived card keeps its live ordinal (marker model)"
+                );
+
+                // Move a live card from Src into Dst with position None.
+                let mover = ctx
+                    .create_card(board.id, src.id, "Mover".into(), Default::default())
+                    .unwrap();
+                let moved = ctx.move_card(mover.id, dst.id, None).unwrap();
+
+                // Coherent append: past BOTH the live (0) AND the archived (1)
+                // ordinal → position 2, not the live-only-count 1 that would
+                // collide with the archived card.
+                assert_eq!(
+                    moved.position, 2,
+                    "moved card must append past live+archived, not collide at 1"
+                );
+                assert_eq!(moved.column_id, dst.id);
+                assert_ne!(
+                    moved.position, archived_row.position,
+                    "moved card must not share the archived card's ordinal"
+                );
+            }
+
+            // KAN-916 / D4: archive is a pure marker flip that leaves the live
+            // card's column/position untouched, so archive → (move a sibling)
+            // → restore is the identity over the archived card's column and
+            // position. Reload from the backend so a persisted incoherent row
+            // would be caught.
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_archive_then_move_sibling_then_restore_round_trips() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();
+                let src = ctx.create_column(board.id, "Src".into(), None).unwrap();
+                let dst = ctx.create_column(board.id, "Dst".into(), None).unwrap();
+
+                // Column holds two live cards; card_a (ordinal 0) will be
+                // archived, sibling card_b (ordinal 1) will be moved.
+                let card_a = ctx
+                    .create_card(board.id, dst.id, "A".into(), Default::default())
+                    .unwrap();
+                let card_b = ctx
+                    .create_card(board.id, dst.id, "B".into(), Default::default())
+                    .unwrap();
+                let a_col_before = card_a.column_id;
+                let a_pos_before = card_a.position;
+
+                ctx.archive_card(card_a.id).unwrap();
+
+                // Move the sibling out and back with None positions; each append
+                // is now Include-aware so it accounts for the archived card_a.
+                ctx.move_card(card_b.id, src.id, None).unwrap();
+                ctx.move_card(card_b.id, dst.id, None).unwrap();
+
+                // Restore card_a to its original (still-present) column.
+                let restored = ctx.restore_card(card_a.id, None).unwrap();
+                assert_eq!(
+                    restored.column_id, a_col_before,
+                    "restore is identity on column"
+                );
+                assert_eq!(
+                    restored.position, a_pos_before,
+                    "restore is identity on position"
+                );
+
+                // The persisted row agrees (reload from backend).
+                let reloaded = backend.get_card(card_a.id).unwrap().unwrap();
+                assert_eq!(reloaded.column_id, a_col_before);
+                assert_eq!(reloaded.position, a_pos_before);
+                assert!(
+                    backend.get_archived_card(card_a.id).unwrap().is_none(),
+                    "restore clears the archive marker"
+                );
+            }
         }
     };
 }


### PR DESCRIPTION
## KAN-916 (ARCH-DECOR C1) — coherent `move_card` for archived cards

Resolves O1 as **Option A (coherent shared ordering)**, per the validated spike on the card. Depends on F1 (`list_cards_by_column_filtered` / `count_cards_in_column_filtered(col, ArchivedFilter)`), which is fully merged across all backends.

### Problem
A `None`-position move (and card create) computed its append ordinal from the live-only `list_cards_by_column().len()`. When the destination column held an archived sibling (the marker model keeps that card live in place at its original ordinal), the append handed out a position the archived card already occupied — an incoherent collision, and archived cards themselves could persist a wrong position.

### Fix (kanban-service only)
Switch both append sites to `count_cards_in_column_filtered(col, ArchivedFilter::Include)` so live + archived share one coherent ordinal space:

- `move_card_impl` (`context/cards.rs`) — the `None`-position append.
- `create_card_from_spec` (`context/cards.rs`) — swept to the filtered count for consistency.

**No migration.** Archiving does not compact live positions (marker model, `commands/card/lifecycle.rs`), so existing ordinals remain coherent. For a destination holding no archived cards, `Include == LiveOnly`, so live-move behavior is unchanged.

### Tests (multi-backend: JSON + SQLite via the existing macro)
- `test_move_archived_card_positions_coherently` — a card moved into a column with a live card (0) and an archived card (1) appends to **2**, never colliding at 1. Red on the live-only `.len()`; green with the filtered count.
- `test_archive_then_move_sibling_then_restore_round_trips` — archive → move a sibling out and back → restore; the archived card's column/position are the identity (D4). Regression guard on the marker model.

Full `kanban-service` suite green (test/clippy `-D warnings`/fmt). Split test/impl commits.

### Follow-up
This fixes the service-level move/create append. Full coherence through the TUI archive+compact path is completed by **KAN-936 (C2)**, which makes `CompactColumnPositions` (`positioning.rs`) `Include`-aware; that path is intentionally **not** touched here.