### PR TITLE
KAN-929 refactor(mcp): board list tool uses BoardListFilter

### DIFF
--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -8,14 +8,17 @@ use crate::requests::board::{
     GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, UpdateBoardRequest,
 };
 use crate::KanbanMcpServer;
+use chrono::{DateTime, Utc};
 use kanban_core::{resolve_page_params, PaginatedList};
-use kanban_domain::{ArchivedFilter, BoardUpdate, FieldUpdate, KanbanOperations};
+use kanban_domain::{BoardListFilter, BoardUpdate, FieldUpdate, KanbanOperations};
 use kanban_service::api::BoardResponse;
 use rmcp::{
     handler::server::wrapper::Parameters,
     model::{CallToolResult, ErrorData as McpError},
     tool, tool_router,
 };
+use std::collections::HashMap;
+use uuid::Uuid;
 
 #[tool_router(router = board_router, vis = "pub(crate)")]
 impl KanbanMcpServer {
@@ -45,29 +48,27 @@ impl KanbanMcpServer {
             .map(parse_archived_selector)
             .transpose()?
             .unwrap_or_default();
-        // Boards have no domain list-filter, so the three states are composed here
-        // from the service ops (mirroring the CLI's I4 `build_board_list`).
+        // One gather path: the service filter yields the live/archived/both head
+        // set (mirroring `filter_cards`). The archive markers only supply the
+        // per-board `archived_at`, so we decorate the filtered heads by looking
+        // each up in a marker map — a live head stays `None` (key skipped on the
+        // wire), an archived head is stamped `Some`.
         let responses = locked_read(&self.ctx, |ctx| -> Result<Vec<BoardResponse>, McpError> {
-            let mut out: Vec<BoardResponse> = Vec::new();
-            if archived != ArchivedFilter::ArchivedOnly {
-                out.extend(
-                    ctx.list_boards()
-                        .map_err(kanban_err_to_mcp)?
-                        .iter()
-                        .map(BoardResponse::from),
-                );
-            }
-            if archived != ArchivedFilter::LiveOnly {
-                for marker in ctx.list_archived_boards().map_err(kanban_err_to_mcp)? {
-                    // `get_board` is unfiltered: it resolves the still-live head.
-                    if let Some(board) =
-                        ctx.get_board(marker.entity_id).map_err(kanban_err_to_mcp)?
-                    {
-                        out.push(BoardResponse::archived(&board, marker.metadata.archived_at));
-                    }
-                }
-            }
-            Ok(out)
+            let archived_at: HashMap<Uuid, DateTime<Utc>> = ctx
+                .list_archived_boards()
+                .map_err(kanban_err_to_mcp)?
+                .into_iter()
+                .map(|m| (m.entity_id, m.metadata.archived_at))
+                .collect();
+            let filter = BoardListFilter { archived };
+            Ok(ctx
+                .list_boards_filtered(filter)
+                .map_err(kanban_err_to_mcp)?
+                .iter()
+                .map(|board| {
+                    BoardResponse::with_archived_at(board, archived_at.get(&board.id).copied())
+                })
+                .collect())
         })
         .await?;
         match (req.page, req.page_size) {

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -2121,6 +2121,96 @@ async fn test_mcp_list_boards_archived_selector() {
         .is_err());
 }
 
+// B5a (KAN-929): the board list tool consumes the service filter
+// (`list_boards_filtered`) as the single gather path, projecting via
+// `BoardResponse`. These pin the three selector states plus the live-shape
+// guard directly on the tool.
+
+#[tokio::test]
+async fn test_mcp_list_boards_default_live() {
+    let (server, _tmp) = setup_server().await;
+    let _live = mcp_create_board(&server, "Live Board").await;
+    let archived = mcp_create_board(&server, "Archived Board").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest {
+            board: archived.clone(),
+        }))
+        .await
+        .unwrap();
+
+    // Default (no selector): live boards only, and the live shape carries no
+    // archived_at key.
+    let live = mcp_list_boards(&server, None).await;
+    assert_eq!(mcp_list_boards_count(&live), 1);
+    let arr = live.as_array().unwrap();
+    assert_eq!(arr[0]["name"], "Live Board");
+    assert!(
+        arr[0].get("archived_at").is_none(),
+        "a live board must not carry an archived_at key: {live}"
+    );
+
+    // Explicit `exclude` matches the default.
+    let excluded = mcp_list_boards(&server, Some("exclude")).await;
+    assert_eq!(mcp_list_boards_count(&excluded), 1);
+    assert!(excluded.as_array().unwrap()[0].get("archived_at").is_none());
+}
+
+#[tokio::test]
+async fn test_mcp_list_boards_archived_only() {
+    let (server, _tmp) = setup_server().await;
+    let _live = mcp_create_board(&server, "Live Board").await;
+    let archived = mcp_create_board(&server, "Archived Board").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest {
+            board: archived.clone(),
+        }))
+        .await
+        .unwrap();
+
+    let only = mcp_list_boards(&server, Some("only")).await;
+    assert_eq!(mcp_list_boards_count(&only), 1);
+    let arr = only.as_array().unwrap();
+    assert_eq!(arr[0]["name"], "Archived Board");
+    assert!(
+        arr[0]["archived_at"].is_string(),
+        "an archived board must be stamped with archived_at: {only}"
+    );
+}
+
+#[tokio::test]
+async fn test_mcp_list_boards_include_both() {
+    let (server, _tmp) = setup_server().await;
+    let _live = mcp_create_board(&server, "Live Board").await;
+    let archived = mcp_create_board(&server, "Archived Board").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest {
+            board: archived.clone(),
+        }))
+        .await
+        .unwrap();
+
+    let both = mcp_list_boards(&server, Some("include")).await;
+    assert_eq!(mcp_list_boards_count(&both), 2);
+    let arr = both.as_array().unwrap();
+    // Exactly one live (no archived_at) and one archived (stamped).
+    let live = arr
+        .iter()
+        .find(|b| b["name"] == "Live Board")
+        .expect("live board present");
+    let arch = arr
+        .iter()
+        .find(|b| b["name"] == "Archived Board")
+        .expect("archived board present");
+    assert!(
+        live.get("archived_at").is_none(),
+        "the live board in the combined list must not carry archived_at: {both}"
+    );
+    assert!(
+        arch["archived_at"].is_string(),
+        "the archived board in the combined list must be stamped: {both}"
+    );
+}
+
 #[tokio::test]
 async fn test_mcp_archive_and_restore_board() {
     let (server, _tmp) = setup_server().await;


### PR DESCRIPTION
## What

B5a (ARCH-DECOR). Makes the MCP board list tool (`tool_list_boards`) consume the service filter `list_boards_filtered` as its single gather path, mirroring the card list tool (`tools/card_crud.rs` builds a `CardListFilter` from the `archived` selector). Removes the three-branch hand build.

Parent KAN-921 (B5). Depends on B2 (KAN-918, `list_boards_filtered` wired through the MCP context) and B3 (KAN-919, one-shape `BoardResponse` + `archived_at`).

## How

- Parse the `archived` param (exclude/only/include) into a `BoardListFilter { archived }`.
- Call `ctx.list_boards_filtered(filter)` for the live/archived/both head set.
- The archive markers only supply per-board `archived_at`, so build an `entity_id -> archived_at` map from `list_archived_boards()` and stamp each filtered head via `BoardResponse::with_archived_at`: a live head looks up as `None` (wire key skipped), an archived head as `Some`.

The pagination branch is unchanged. `tool_restore_board` / `tool_delete_archived_board` / `mcp_resolve_archived_board` are untouched (that is B5b, KAN-930).

## Tests

New integration tests against a real `KanbanContext` pinning the three selector states plus the live-shape guard directly on the tool:
- `test_mcp_list_boards_default_live` (also asserts explicit `exclude`; no `archived_at` key on live)
- `test_mcp_list_boards_archived_only`
- `test_mcp_list_boards_include_both`

`cargo test -p kanban-mcp` (73 integration tests), `cargo clippy -p kanban-mcp --all-targets -D warnings`, and `cargo fmt` all green.