### PR TITLE
KAN-927 refactor(cli): board list uses BoardListFilter, drop build_board_list

### DIFF
--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -2,7 +2,7 @@ use crate::cli::{BoardAction, BoardUpdateArgs};
 use crate::context::CliContext;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
-use kanban_domain::{BoardUpdate, FieldUpdate, KanbanOperations};
+use kanban_domain::{ArchivedFilter, BoardListFilter, BoardUpdate, FieldUpdate, KanbanOperations};
 use kanban_service::api::BoardResponse;
 
 pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result<()> {
@@ -20,11 +20,22 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             page,
             page_size,
         } => {
-            // I4 (KAN-886): ONE list command, three states. Boards have no domain
-            // filter struct, so the selector is composed here from the service ops.
-            // Live board payloads stay byte-identical (BoardResponse omits
+            // B4a (KAN-927): ONE list command, three states, routed through the
+            // service filter (B2). The archival selector is built from the flags
+            // exactly as cards do (handlers/card.rs); `archived_at` is stamped
+            // per board from its archive marker (the filtered `Board`s carry no
+            // timestamp). Live payloads stay byte-identical (BoardResponse omits
             // archived_at when None — D2 skip_serializing_if).
-            let responses = match build_board_list(ctx, archived, include_archived) {
+            let filter = BoardListFilter {
+                archived: if archived {
+                    ArchivedFilter::ArchivedOnly
+                } else if include_archived {
+                    ArchivedFilter::Include
+                } else {
+                    ArchivedFilter::LiveOnly
+                },
+            };
+            let responses = match project_board_list(ctx, filter) {
                 Ok(r) => r,
                 Err(e) => return output::output_error(&e),
             };
@@ -91,37 +102,28 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
     Ok(())
 }
 
-/// Compose the three-state board list from the service ops.
-/// - default: live boards (`archived_at` None).
-/// - `--archived`: only archived boards, each stamped `archived_at` (the live
-///   head resolved by the marker's `entity_id`).
-/// - `--include-archived`: live boards followed by the archived ones.
-fn build_board_list(
+/// Project a service-filtered board list, stamping `archived_at` per board from
+/// its archive marker. The filtered `Board`s carry no timestamp (an archived
+/// head is a still-live board plus a marker), so the marker's `archived_at` is
+/// looked up by board id; a board with no marker is live and stamps `None`
+/// (BoardResponse then omits the wire key).
+fn project_board_list(
     ctx: &CliContext,
-    archived: bool,
-    include_archived: bool,
+    filter: BoardListFilter,
 ) -> Result<Vec<BoardResponse>, String> {
-    let mut out: Vec<BoardResponse> = Vec::new();
+    let archived_at: std::collections::HashMap<uuid::Uuid, chrono::DateTime<chrono::Utc>> = ctx
+        .list_archived_boards()
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .map(|m| (m.entity_id, m.metadata.archived_at))
+        .collect();
 
-    if !archived {
-        out.extend(
-            ctx.list_boards()
-                .map_err(|e| e.to_string())?
-                .iter()
-                .map(BoardResponse::from),
-        );
-    }
-
-    if archived || include_archived {
-        for marker in ctx.list_archived_boards().map_err(|e| e.to_string())? {
-            // `get_board` is unfiltered: it resolves the still-live head.
-            if let Some(board) = ctx.get_board(marker.entity_id).map_err(|e| e.to_string())? {
-                out.push(BoardResponse::archived(&board, marker.metadata.archived_at));
-            }
-        }
-    }
-
-    Ok(out)
+    Ok(ctx
+        .list_boards_filtered(filter)
+        .map_err(|e| e.to_string())?
+        .iter()
+        .map(|board| BoardResponse::with_archived_at(board, archived_at.get(&board.id).copied()))
+        .collect())
 }
 
 /// Resolve a board id from EITHER the live or the archived view. UUIDs resolve

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -534,6 +534,87 @@ mod board_tests {
             .failure();
     }
 
+    // B4a (KAN-927): `board list` builds a `BoardListFilter` from the flags and
+    // routes through `list_boards_filtered`, dropping the hand-rolled builder.
+    // These three pin the per-flag contract so the refactor is behavior-safe.
+
+    /// Default (no flag): only live boards, and their payload carries no
+    /// `archived_at` key (live wire shape is byte-identical to before).
+    #[test]
+    fn test_board_list_default_is_live_only() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let _live = mk_board(&file, "Live Board");
+        let archived = mk_board(&file, "Archived Board");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &archived])
+            .assert()
+            .success();
+
+        let live = board_list(&file, &[]);
+        assert_eq!(live["data"]["total"], 1);
+        assert_eq!(live["data"]["items"][0]["name"], "Live Board");
+        assert!(
+            live["data"]["items"][0].get("archived_at").is_none(),
+            "a live board list item must not carry an archived_at key"
+        );
+    }
+
+    /// `--archived`: only archived boards, each stamped with `archived_at` from
+    /// its marker.
+    #[test]
+    fn test_board_list_archived_flag_only_archived() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let _live = mk_board(&file, "Live Board");
+        let archived = mk_board(&file, "Archived Board");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &archived])
+            .assert()
+            .success();
+
+        let arch = board_list(&file, &["--archived"]);
+        assert_eq!(arch["data"]["total"], 1);
+        assert_eq!(arch["data"]["items"][0]["name"], "Archived Board");
+        assert!(
+            arch["data"]["items"][0]["archived_at"].is_string(),
+            "an archived board list item must carry the marker's archived_at"
+        );
+    }
+
+    /// `--include-archived`: both live and archived, each stamped appropriately
+    /// (live unstamped, archived stamped).
+    #[test]
+    fn test_board_list_include_both() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let _live = mk_board(&file, "Live Board");
+        let archived = mk_board(&file, "Archived Board");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &archived])
+            .assert()
+            .success();
+
+        let both = board_list(&file, &["--include-archived"]);
+        assert_eq!(both["data"]["total"], 2);
+        let stamped: Vec<bool> = both["data"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i.get("archived_at").is_some())
+            .collect();
+        assert!(
+            stamped.contains(&true) && stamped.contains(&false),
+            "include mixes one stamped (archived) and one unstamped (live)"
+        );
+    }
+
     // REGR-4 (KAN-894): `-archived` commands must resolve ONLY archived boards,
     // never a same-named live board (delete_board cascades → data loss).
     #[test]


### PR DESCRIPTION
## What

`BoardAction::List` (kanban-cli) now consumes the service-tier board filter instead of the hand-rolled `build_board_list` composition.

- Builds a `BoardListFilter` from the `--archived`/`--include-archived` flags (three-state `ArchivedFilter`), mirroring the card handler pattern in `handlers/card.rs`.
- Routes through `ctx.list_boards_filtered(filter)` (B2, KAN-918).
- Projects each board via B3's single `BoardResponse` (KAN-919), stamping `archived_at` from a marker lookup (`entity_id -> archived_at`) keyed on board id. Filtered `Board` heads carry no timestamp (an archived board is a still-live head plus a marker), so the marker map supplies it; a board with no marker stamps `None` and `BoardResponse` omits the wire key.
- `build_board_list` is deleted; there is now one filter path.

Live board payloads stay byte-identical (the `archived_at` key is skipped when `None`). `--include-archived` ordering (live-first, then archived) is preserved by `list_boards_filtered`.

Out of scope: the `Restore`/`DeleteArchived` resolver (`resolve_archived_board_id`) is untouched (that is B4b, KAN-928).

## Tests (TDD)

Added three named assert_cmd tests pinning the per-flag contract before the refactor, plus a guard that a live board's list item has no `archived_at` key (folded into the default test):

- `test_board_list_default_is_live_only`
- `test_board_list_archived_flag_only_archived`
- `test_board_list_include_both`

As a behavior-preserving refactor, these codify the contract as a safety net; the pre-existing `test_board_list_archived_selector_states` (KAN-886) also continues to pass, confirming parity across the swap.

## Verification

- `cargo test -p kanban-cli`: green (134 lib + full integration + migrate suites pass)
- `cargo clippy -p kanban-cli --all-targets -D warnings`: clean
- `cargo fmt`: clean

## Note

KAN-880 already added the `BoardResponse.archived_at` field, so the DTO work the card implies was already in place. The scope here is purely the CLI handler swap, as the card's Target states.