### PR TITLE
KAN-930 refactor(mcp): resolve archived board via ArchivedOnly filter, drop mcp_resolve_archived_board

### DIFF
--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -35,11 +35,6 @@ pub(crate) fn resolve_summaries(ctx: &McpContext, ids: Vec<Uuid>) -> Vec<CardSum
 /// `locked_write` stay readable.
 pub(crate) trait McpResolve {
     fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError>;
-    /// Resolve a board id from the ARCHIVED collection ONLY (for `-archived`
-    /// tools). UUIDs pass through; a name matches an archived board's head
-    /// exactly. Never matches a live board — so a same-named live board can never
-    /// be hit by an archived-scoped command (REGR-4 / KAN-894 data-loss).
-    fn mcp_resolve_archived_board(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
     fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
@@ -52,38 +47,6 @@ pub(crate) trait McpResolve {
 impl McpResolve for McpContext {
     fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError> {
         self.resolve_board_id(raw).map_err(kanban_err_to_mcp)
-    }
-    fn mcp_resolve_archived_board(&self, raw: &str) -> Result<Uuid, McpError> {
-        if let Ok(uuid) = Uuid::parse_str(raw) {
-            return Ok(uuid);
-        }
-        // ARCHIVED collection only: resolve each marker's live head (get_board is
-        // unfiltered) and match by name using the same case-insensitive search as
-        // the live resolver. Never matches a live board.
-        let mut heads: Vec<kanban_domain::Board> = Vec::new();
-        for marker in self.list_archived_boards().map_err(kanban_err_to_mcp)? {
-            if let Some(board) = self
-                .get_board(marker.entity_id)
-                .map_err(kanban_err_to_mcp)?
-            {
-                heads.push(board);
-            }
-        }
-        let matches: Vec<Uuid> = kanban_domain::find_boards_by_name(raw, &heads)
-            .iter()
-            .map(|b| b.id)
-            .collect();
-        match matches.as_slice() {
-            [id] => Ok(*id),
-            [] => Err(McpError::invalid_params(
-                format!("No archived board named: '{raw}'"),
-                None,
-            )),
-            _ => Err(McpError::invalid_params(
-                format!("Ambiguous archived board name: '{raw}'"),
-                None,
-            )),
-        }
     }
     fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError> {
         self.resolve_column_id(raw, board_id)

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -175,8 +175,10 @@ impl KanbanMcpServer {
         Parameters(req): Parameters<RestoreBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
         let board = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            // Resolve from either view: an archived board is not in the live list.
-            let id = ctx.mcp_resolve_archived_board(&req.board)?;
+            // Resolve against the ARCHIVED-only set: an archived board is not in
+            // the live list, and scoping to archived-only guarantees a same-named
+            // live board is never hit (KAN-894 data-loss guard).
+            let id = resolve_archived_board(ctx, &req.board)?;
             ctx.restore_board(id).map_err(kanban_err_to_mcp)?;
             ctx.get_board(id).map_err(kanban_err_to_mcp)
         })
@@ -194,11 +196,42 @@ impl KanbanMcpServer {
         // A board is just a board: delete works on an archived one because
         // `get_board` is unfiltered. Resolve from either view.
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let id = ctx.mcp_resolve_archived_board(&req.board)?;
+            let id = resolve_archived_board(ctx, &req.board)?;
             ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
         .await?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
+    }
+}
+
+/// Resolve a board id from the ARCHIVED collection ONLY (for the `-archived`
+/// tools). A UUID passes straight through; a name is matched against the
+/// archived-only head set via `find_boards_by_name`. Scoping the candidate set
+/// to `ArchivedFilter::ArchivedOnly` structurally guarantees a same-named live
+/// board can never be hit by an archived-scoped command (KAN-894 data-loss).
+fn resolve_archived_board(ctx: &crate::context::McpContext, raw: &str) -> Result<Uuid, McpError> {
+    if let Ok(uuid) = Uuid::parse_str(raw) {
+        return Ok(uuid);
+    }
+    let heads = ctx
+        .list_boards_filtered(BoardListFilter {
+            archived: kanban_domain::ArchivedFilter::ArchivedOnly,
+        })
+        .map_err(kanban_err_to_mcp)?;
+    let matches: Vec<Uuid> = kanban_domain::find_boards_by_name(raw, &heads)
+        .iter()
+        .map(|b| b.id)
+        .collect();
+    match matches.as_slice() {
+        [id] => Ok(*id),
+        [] => Err(McpError::invalid_params(
+            format!("No archived board named: '{raw}'"),
+            None,
+        )),
+        _ => Err(McpError::invalid_params(
+            format!("Ambiguous archived board name: '{raw}'"),
+            None,
+        )),
     }
 }

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -2368,6 +2368,125 @@ async fn test_mcp_restore_board_name_collision_targets_archived() {
     );
 }
 
+// B5b (KAN-930): archived-board name resolution runs through the
+// `list_boards_filtered(ArchivedOnly)` filter path (dropping the bespoke
+// `mcp_resolve_archived_board`). The candidate set is archived-only, so the
+// KAN-894 guard (never touch a live board) is structural, and a UUID still
+// passes straight through.
+
+#[tokio::test]
+async fn test_mcp_restore_board_by_name_targets_archived_not_live() {
+    // Two boards share the SAME name: one live, one archived. Restore-by-name
+    // must resolve the ARCHIVED one (KAN-894). If the resolver drew from the
+    // live/full set, it would either hit the live board or report ambiguity.
+    let (server, _tmp) = setup_server().await;
+    let live = mcp_create_board(&server, "Roadmap").await;
+    let arch = mcp_create_board(&server, "Roadmap").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest {
+            board: arch.clone(),
+        }))
+        .await
+        .unwrap();
+
+    let restored = text_payload(
+        &server
+            .tool_restore_board(Parameters(RestoreBoardRequest {
+                board: "Roadmap".into(),
+            }))
+            .await
+            .unwrap(),
+    );
+    // The archived board is the one returned to live, not the pre-existing live one.
+    assert_eq!(
+        restored["id"].as_str().unwrap(),
+        arch,
+        "restore-by-name must target the archived board, not the same-named live one"
+    );
+    // Both are now live; none remain archived.
+    assert_eq!(
+        mcp_list_boards_count(&mcp_list_boards(&server, None).await),
+        2
+    );
+    assert_eq!(
+        mcp_list_boards_count(&mcp_list_boards(&server, Some("only")).await),
+        0
+    );
+    // The live board was never disturbed.
+    assert!(mcp_list_boards(&server, None)
+        .await
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|b| b["id"].as_str().unwrap() == live));
+}
+
+#[tokio::test]
+async fn test_mcp_delete_archived_by_name_resolves_archived() {
+    // Same-named live + archived boards. Permanent delete-by-name must resolve
+    // and remove ONLY the archived board (KAN-894), leaving the live one intact.
+    let (server, _tmp) = setup_server().await;
+    let live = mcp_create_board(&server, "Roadmap").await;
+    let arch = mcp_create_board(&server, "Roadmap").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest {
+            board: arch.clone(),
+        }))
+        .await
+        .unwrap();
+
+    let deleted = text_payload(
+        &server
+            .tool_delete_archived_board(Parameters(DeleteArchivedBoardRequest {
+                board: "Roadmap".into(),
+            }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        deleted["deleted"].as_str().unwrap(),
+        arch,
+        "delete-by-name must target the archived board"
+    );
+    // The archived collection is now empty; the live board survives, untouched.
+    assert_eq!(
+        mcp_list_boards_count(&mcp_list_boards(&server, Some("only")).await),
+        0
+    );
+    let live_arr = mcp_list_boards(&server, None).await;
+    let live_arr = live_arr.as_array().unwrap();
+    assert_eq!(live_arr.len(), 1);
+    assert_eq!(live_arr[0]["id"].as_str().unwrap(), live);
+}
+
+#[tokio::test]
+async fn test_mcp_restore_board_by_uuid_still_resolves_archived() {
+    // UUID passthrough: an archived board restored by its raw UUID skips name
+    // resolution entirely.
+    let (server, _tmp) = setup_server().await;
+    let id = mcp_create_board(&server, "By UUID").await;
+    server
+        .tool_archive_board(Parameters(ArchiveBoardRequest { board: id.clone() }))
+        .await
+        .unwrap();
+
+    let restored = text_payload(
+        &server
+            .tool_restore_board(Parameters(RestoreBoardRequest { board: id.clone() }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(restored["id"].as_str().unwrap(), id);
+    assert_eq!(
+        mcp_list_boards_count(&mcp_list_boards(&server, None).await),
+        1
+    );
+    assert_eq!(
+        mcp_list_boards_count(&mcp_list_boards(&server, Some("only")).await),
+        0
+    );
+}
+
 // KAN-905: archived-board name resolution uses case-insensitive matching.
 
 #[tokio::test]


### PR DESCRIPTION
## What

B5b (KAN-930): collapse the archived-only board name resolver onto the shared filter path.

`tool_restore_board` and `tool_delete_archived_board` previously resolved a board name through the bespoke `mcp_resolve_archived_board`, which iterated the archive markers and re-resolved each head via `get_board`. They now resolve through a local `resolve_archived_board` helper that:

- passes a UUID straight through, and
- matches a name via `kanban_domain::find_boards_by_name` over `ctx.list_boards_filtered(BoardListFilter { archived: ArchivedOnly })`.

`mcp_resolve_archived_board` and its `McpResolve` trait method are deleted.

## KAN-894 guard (data-loss)

The invariant that an archived-scoped command never touches a same-named live board is now structural: the candidate set is `ArchivedOnly`, so live boards are never in it. There is no way for restore/delete-archived-by-name to reach a live board.

## Tests (TDD)

Red-first, integration, against a real `KanbanContext`:

- `test_mcp_restore_board_by_name_targets_archived_not_live` — a live and an archived board share the same name; restore-by-name returns the archived board's id to live and leaves the live one untouched.
- `test_mcp_delete_archived_by_name_resolves_archived` — same collision; permanent delete-by-name removes only the archived board.
- `test_mcp_restore_board_by_uuid_still_resolves_archived` — UUID passthrough.

Both guard tests were confirmed red by temporarily widening the candidate set to `Include` (they failed with an ambiguous-name error), then green once scoped to `ArchivedOnly`.

`cargo test -p kanban-mcp` (76 integration + 7 builder + doctest), `cargo clippy -p kanban-mcp --all-targets -D warnings`, and `cargo fmt` all clean.
