### PR TITLE
KAN-936 fix(domain): make CompactColumnPositions archival-aware (compact over Include)

### DIFF
--- a/crates/kanban-domain/src/commands/card/positioning.rs
+++ b/crates/kanban-domain/src/commands/card/positioning.rs
@@ -55,7 +55,13 @@ pub struct CompactColumnPositions {
 
 impl CompactColumnPositions {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
-        let cards = context.store.list_cards_by_column(self.column_id)?;
+        // KAN-936 (ARCH-DECOR C2): compact over the Include set (live +
+        // archived). Archived cards stay live in `cards` behind a marker and
+        // keep their coherently-placed ordinal (C1); renumbering the live-only
+        // set would re-collide a live card onto an archived ordinal.
+        let cards = context
+            .store
+            .list_cards_by_column_filtered(self.column_id, crate::ArchivedFilter::Include)?;
         for (i, mut card) in cards.into_iter().enumerate() {
             if card.position != i as i32 {
                 card.position = i as i32;
@@ -72,9 +78,11 @@ impl CompactColumnPositions {
     /// Inverse: for each card in the column, emit a MoveCard back to its
     /// original position. Compaction is lossy without pre-state capture
     /// (multiple gappy arrangements compact to the same result), so this
-    /// is the only way to reverse it.
+    /// is the only way to reverse it. Captured over the Include set (KAN-936)
+    /// to match `execute`, which now renumbers archived cards too.
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
-        let cards = store.list_cards_by_column(self.column_id)?;
+        let cards =
+            store.list_cards_by_column_filtered(self.column_id, crate::ArchivedFilter::Include)?;
         let mut commands: Vec<Command> = Vec::new();
         for card in cards {
             commands.push(Command::Card(CardCommand::Move(MoveCard {

--- a/crates/kanban-domain/src/commands/card/positioning.rs
+++ b/crates/kanban-domain/src/commands/card/positioning.rs
@@ -175,4 +175,113 @@ mod tests {
         assert_eq!(cards[0].position, 0);
         assert_eq!(cards[1].position, 1);
     }
+
+    // KAN-936 (ARCH-DECOR C2): compaction must operate over the Include set
+    // (live + archived) so no live card is renumbered onto an archived card's
+    // coherently-placed ordinal. The live-only compaction (reading
+    // `list_cards_by_column`) re-collides an archived ordinal.
+    #[test]
+    fn test_compact_preserves_distinct_ordinals_across_live_and_archived() {
+        let tc = TestContext::new();
+        let mut board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let column_id = col.id;
+        // Interleaved: live @0, archived @1, live @3 (gappy). After compaction
+        // over the Include set the three cards should hold {0,1,2} distinctly.
+        let mut live_a = crate::Card::new(&mut board, column_id, "LiveA", 0);
+        live_a.position = 0;
+        let live_a_id = live_a.id;
+        let mut archived = crate::Card::new(&mut board, column_id, "Archived", 1);
+        archived.position = 1;
+        let archived_id = archived.id;
+        let mut live_b = crate::Card::new(&mut board, column_id, "LiveB", 3);
+        live_b.position = 3;
+        let live_b_id = live_b.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+        tc.store.upsert_card(live_a).unwrap();
+        tc.store.upsert_card(archived.clone()).unwrap();
+        tc.store.upsert_card(live_b).unwrap();
+        tc.store
+            .insert_archived_card(crate::ArchivedCard::new(archived_id, Uuid::nil()))
+            .unwrap();
+
+        let context = tc.as_command_context();
+        CompactColumnPositions { column_id }
+            .execute(&context)
+            .unwrap();
+
+        let positions = |id: Uuid| tc.store.get_card(id).unwrap().unwrap().position;
+        let pa = positions(live_a_id);
+        let par = positions(archived_id);
+        let pb = positions(live_b_id);
+
+        // No two cards in the column share a position.
+        let mut all = [pa, par, pb];
+        all.sort_unstable();
+        assert_eq!(
+            all,
+            [0, 1, 2],
+            "column should be dense over the Include set"
+        );
+
+        // Relative order preserved for each subset (live: A before B; archived
+        // sits between them as seeded).
+        assert!(pa < pb, "live relative order preserved");
+        assert!(
+            pa < par && par < pb,
+            "archived ordinal stays coherent between live cards"
+        );
+    }
+
+    #[test]
+    fn test_archive_then_compact_keeps_archived_card_coherent() {
+        use crate::commands::card::ArchiveCards;
+
+        let tc = TestContext::new();
+        let mut board = crate::Board::new("B", Some("TST"));
+        let col = crate::Column::new(board.id, "Col", 0);
+        let column_id = col.id;
+        // Three live cards at 0,1,2. Archive the middle one, then run the TUI's
+        // compact path. The archived card keeps position 1; live cards must not
+        // be renumbered onto it.
+        let mut c0 = crate::Card::new(&mut board, column_id, "C0", 0);
+        c0.position = 0;
+        let c0_id = c0.id;
+        let mut c1 = crate::Card::new(&mut board, column_id, "C1", 1);
+        c1.position = 1;
+        let c1_id = c1.id;
+        let mut c2 = crate::Card::new(&mut board, column_id, "C2", 2);
+        c2.position = 2;
+        let c2_id = c2.id;
+        tc.store.upsert_board(board).unwrap();
+        tc.store.upsert_column(col).unwrap();
+        tc.store.upsert_card(c0).unwrap();
+        tc.store.upsert_card(c1).unwrap();
+        tc.store.upsert_card(c2).unwrap();
+
+        let context = tc.as_command_context();
+        ArchiveCards { ids: vec![c1_id] }.execute(&context).unwrap();
+        CompactColumnPositions { column_id }
+            .execute(&context)
+            .unwrap();
+
+        let get = |id: Uuid| tc.store.get_card(id).unwrap().unwrap().position;
+        let archived_pos = get(c1_id);
+        let live0 = get(c0_id);
+        let live2 = get(c2_id);
+
+        assert_ne!(
+            live0, archived_pos,
+            "live C0 must not collide with archived ordinal"
+        );
+        assert_ne!(
+            live2, archived_pos,
+            "live C2 must not collide with archived ordinal"
+        );
+        // Whole column dense and distinct over the Include set.
+        let mut all = [live0, archived_pos, live2];
+        all.sort_unstable();
+        assert_eq!(all, [0, 1, 2]);
+    }
 }

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -918,3 +918,77 @@ pub async fn test_list_boards_archived_selector_roundtrip(factory: &BackendFacto
         "Include returns both heads",
     );
 }
+
+/// KAN-936 (ARCH-DECOR C2): the TUI issues `CompactColumnPositions` right after
+/// `ArchiveCards` (`app/animation_tick.rs`). Compaction must renumber over the
+/// Include set (live + archived), NOT the live-only set — otherwise a live card
+/// is renumbered onto the coherently-placed ordinal of an archived card that
+/// stays live behind a marker. Held on every backend: seed 3 cards, archive the
+/// middle, compact, save+reload, and assert every ordinal in the column is
+/// distinct (no live/archived collision).
+pub async fn test_archive_then_compact_keeps_archived_ordinal_distinct(factory: &BackendFactory) {
+    use kanban_domain::commands::{ArchiveCards, CardCommand, Command, CompactColumnPositions};
+    use kanban_domain::ArchivedFilter;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+
+    let c0 = ctx
+        .create_card(board.id, col.id, "C0".into(), CreateCardOptions::default())
+        .unwrap();
+    let c1 = ctx
+        .create_card(board.id, col.id, "C1".into(), CreateCardOptions::default())
+        .unwrap();
+    let c2 = ctx
+        .create_card(board.id, col.id, "C2".into(), CreateCardOptions::default())
+        .unwrap();
+    // Fixture: dense 0,1,2 as created.
+    assert_eq!(ctx.get_card(c0.id).unwrap().unwrap().position, 0);
+    assert_eq!(ctx.get_card(c1.id).unwrap().unwrap().position, 1);
+    assert_eq!(ctx.get_card(c2.id).unwrap().unwrap().position, 2);
+
+    // The TUI's post-archive batch: archive the middle card, then compact the
+    // column. The archived card keeps position 1 (archive doesn't compact).
+    ctx.execute(vec![
+        Command::Card(CardCommand::Archive(ArchiveCards { ids: vec![c1.id] })),
+        Command::Card(CardCommand::CompactPositions(CompactColumnPositions {
+            column_id: col.id,
+        })),
+    ])
+    .unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    // `get_card` is unfiltered: read the exact ordinal of each of the three cards.
+    let p0 = ctx.get_card(c0.id).unwrap().unwrap().position;
+    let p1 = ctx.get_card(c1.id).unwrap().unwrap().position;
+    let p2 = ctx.get_card(c2.id).unwrap().unwrap().position;
+
+    assert_ne!(p0, p1, "live C0 must not collide with archived ordinal");
+    assert_ne!(p2, p1, "live C2 must not collide with archived ordinal");
+
+    // Whole column dense and distinct over the Include set.
+    let mut all = [p0, p1, p2];
+    all.sort_unstable();
+    assert_eq!(all, [0, 1, 2], "column dense and distinct over Include set");
+
+    // The Include view (live + archived) renders all three in position order.
+    let include = ctx
+        .list_cards(CardListFilter {
+            column_id: Some(col.id),
+            archived: ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(include.len(), 3, "Include lists all three cards");
+    let mut include_positions: Vec<i32> = include.iter().map(|s| s.position).collect();
+    include_positions.sort_unstable();
+    assert_eq!(include_positions, vec![0, 1, 2]);
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -170,6 +170,10 @@ macro_rules! context_contract_tests {
         async fn test_list_boards_archived_selector_roundtrip() {
             $crate::test_helpers::contract::archive::test_list_boards_archived_selector_roundtrip(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_archive_then_compact_keeps_archived_ordinal_distinct() {
+            $crate::test_helpers::contract::archive::test_archive_then_compact_keeps_archived_ordinal_distinct(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What

KAN-936 (ARCH-DECOR C2), the follow-up the F1/C1 spike surfaced.

C1 made `move_card` place an archived card at a coherent ordinal over the Include set. But `CompactColumnPositions::execute` still renumbered the **live-only** set (`list_cards_by_column`), and the TUI runs it right after `ArchiveCards` (`app/animation_tick.rs`). So a live card could be renumbered onto the coherently-placed ordinal of an archived card (which stays live behind a marker and is untouched by archive), re-colliding it.

This switches the compaction read to the F1 filtered path with `ArchivedFilter::Include`, so every card in the column gets a distinct dense ordinal and each subset (live view, archived view) renders in correct relative order. `capture_inverse` now captures over the Include set too, matching `execute` (which renumbers archived cards as well).

## How the command reaches archived cards

`CompactColumnPositions::execute` runs in-memory against `CommandContext.store` (a `&dyn DataStore` backed by `InMemoryStore`). Archived cards stay in the `cards` map behind a marker in `StoreState.archived_cards`; `InMemoryStore` overrides `list_cards_by_column_filtered` (F1c) to honour `Include`, returning live + archived for the column. Switching the read from `list_cards_by_column` to `list_cards_by_column_filtered(column_id, Include)` is the whole fix.

## Tests (Red → Green, per backend)

Domain unit (in-memory):
- `test_compact_preserves_distinct_ordinals_across_live_and_archived`
- `test_archive_then_compact_keeps_archived_card_coherent`

Service contract (in-memory, JSON, SQLite via `context_contract_tests!`):
- `test_archive_then_compact_keeps_archived_ordinal_distinct` — archive the middle of three cards, compact, save+reload, assert no live/archived ordinal collision and the Include view is dense.

All went **red** on the old live-only impl (verified: live card collided at the archived card's position 1) and green after the fix, on all three backends.

## Verification

- `cargo test -p kanban-domain` (637 pass) and `cargo test -p kanban-service --features test-helpers` green
- `cargo clippy --all-targets -D warnings` clean on both crates
- `cargo fmt --check` clean