### PR TITLE
KAN-928 refactor(cli): resolve archived board via ArchivedOnly filter, drop resolve_archived_board_id

### DIFF
--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -76,7 +76,9 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             output::output_success(serde_json::json!({"archived": uuid.to_string()}));
         }
         BoardAction::Restore { board } => {
-            let uuid = match resolve_archived_board_id(ctx, &board) {
+            // Resolve against the ARCHIVED collection only (ArchivedOnly filter):
+            // a same-named live board must never be hit (KAN-894).
+            let uuid = match resolve_archived_board(ctx, &board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
@@ -90,7 +92,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
         BoardAction::DeleteArchived { board } => {
             // Resolve against the ARCHIVED collection only: a same-named live
             // board must never be hit by `delete-archived` (delete_board cascades).
-            let uuid = match resolve_archived_board_id(ctx, &board) {
+            let uuid = match resolve_archived_board(ctx, &board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
@@ -126,25 +128,21 @@ fn project_board_list(
         .collect())
 }
 
-/// Resolve a board id from EITHER the live or the archived view. UUIDs resolve
-/// immediately; a live-board name resolves via the standard resolver; otherwise
-/// fall back to matching an archived board by name (its head is unfiltered via
-/// `get_board`). Keeps the domain resolver (live-only) unchanged.
-/// Resolve a board id from the ARCHIVED collection ONLY. A UUID passes through
-/// (the caller's op validates existence); a name matches an archived board's
-/// head exactly. This never matches a LIVE board, so an `-archived` command can
-/// never accidentally hit a same-named live board (REGR-4 / KAN-894 data-loss).
-fn resolve_archived_board_id(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, String> {
+/// Resolve a board id from the ARCHIVED collection ONLY, for `-archived`
+/// commands. A UUID passes straight through (the caller's op validates
+/// existence); a name is matched against the `ArchivedOnly` service filter.
+/// Because the candidate set is archived boards only, an `-archived` command can
+/// never match a same-named LIVE board (REGR-4 / KAN-894 data-loss guard).
+fn resolve_archived_board(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, String> {
     if let Ok(uuid) = uuid::Uuid::parse_str(raw) {
         return Ok(uuid);
     }
-    let mut heads: Vec<kanban_domain::Board> = Vec::new();
-    for marker in ctx.list_archived_boards().map_err(|e| e.to_string())? {
-        if let Some(board) = ctx.get_board(marker.entity_id).map_err(|e| e.to_string())? {
-            heads.push(board);
-        }
-    }
-    let matches: Vec<uuid::Uuid> = kanban_domain::find_boards_by_name(raw, &heads)
+    let archived = ctx
+        .list_boards_filtered(BoardListFilter {
+            archived: ArchivedFilter::ArchivedOnly,
+        })
+        .map_err(|e| e.to_string())?;
+    let matches: Vec<uuid::Uuid> = kanban_domain::find_boards_by_name(raw, &archived)
         .iter()
         .map(|b| b.id)
         .collect();

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -709,6 +709,86 @@ mod board_tests {
         );
     }
 
+    // KAN-928 (B4b): the archived-only resolver is collapsed onto the
+    // ArchivedOnly filter path; these pin the KAN-894 invariant across the swap.
+
+    /// KAN-894 data-loss guard: with a live and an archived board of the SAME
+    /// name, `delete-archived <name>` must target the ARCHIVED one and leave the
+    /// live board untouched. ArchivedOnly guarantees a name never hits a live board.
+    #[test]
+    fn test_delete_archived_by_name_never_matches_live_board() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let live = mk_board(&file, "Roadmap");
+        let arch = mk_board(&file, "Roadmap");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &arch])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "delete-archived",
+                "Roadmap",
+            ])
+            .assert()
+            .success();
+        // The live Roadmap survives; the archived one is permanently gone.
+        let live_list = board_list(&file, &[]);
+        assert_eq!(live_list["data"]["total"], 1);
+        assert_eq!(live_list["data"]["items"][0]["id"].as_str().unwrap(), live);
+        assert_eq!(board_list(&file, &["--archived"])["data"]["total"], 0);
+    }
+
+    /// A name that matches only an archived board resolves via the ArchivedOnly
+    /// filter and restores it to the live list.
+    #[test]
+    fn test_restore_by_name_resolves_archived() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let arch = mk_board(&file, "Roadmap");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &arch])
+            .assert()
+            .success();
+        let out = kanban()
+            .args([file.to_str().unwrap(), "board", "restore", "Roadmap"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let restored = parse_json_output(&String::from_utf8_lossy(&out));
+        assert_eq!(restored["data"]["id"].as_str().unwrap(), arch);
+        assert_eq!(board_list(&file, &["--archived"])["data"]["total"], 0);
+        assert_eq!(board_list(&file, &[])["data"]["total"], 1);
+    }
+
+    /// A UUID passes straight through the resolver (no name lookup); the op
+    /// validates existence. Works for both restore and delete-archived.
+    #[test]
+    fn test_archived_resolver_uuid_passthrough() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+        let arch = mk_board(&file, "Solo");
+        kanban()
+            .args([file.to_str().unwrap(), "board", "archive", &arch])
+            .assert()
+            .success();
+        kanban()
+            .args([file.to_str().unwrap(), "board", "delete-archived", &arch])
+            .assert()
+            .success();
+        assert_eq!(
+            board_list(&file, &["--include-archived"])["data"]["total"],
+            0
+        );
+    }
+
     #[test]
     fn test_board_archive_and_restore() {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
## What

B4b (ARCH-DECOR). Collapse the archived-only board resolver in `kanban-cli` onto the B2 service filter path.

The old `resolve_archived_board_id` (`handlers/board.rs`) iterated archive markers and re-fetched each head via `get_board` to build a candidate list. It is replaced by `resolve_archived_board`, which resolves a name against `ctx.list_boards_filtered(BoardListFilter { archived: ArchivedFilter::ArchivedOnly })` + `kanban_domain::find_boards_by_name`. UUIDs still pass straight through; ambiguous / not-found error messages are unchanged.

`resolve_archived_board_id` is deleted.

## KAN-894 data-loss guard preserved

`restore` / `delete-archived` by name must never match a same-named LIVE board (`delete_board` cascades the whole subtree away). With `ArchivedOnly`, the candidate set is archived boards only, so the guard holds by construction. Verified by temporarily swapping the filter to `Include`, which makes the guard tests fail (a same-named live board then becomes a candidate); reverted.

## Tests (TDD)

Named tests pinning the invariant across the swap:
- `test_delete_archived_by_name_never_matches_live_board` — a live + archived board of the same name; `delete-archived <name>` targets the archived one, the live board survives.
- `test_restore_by_name_resolves_archived`.
- `test_archived_resolver_uuid_passthrough`.

## Verification

- `cargo test -p kanban-cli` — green (137 integration + unit tests pass).
- `cargo clippy -p kanban-cli --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.

Commits split test / impl. Sibling of B4a (shares `board.rs`); sequenced after it.