### PR TITLE
KAN-932 refactor(tui): unify board collection + archived-id set, drop archived_boards_flat

### DIFF
--- a/crates/kanban-tui/src/app/export_import.rs
+++ b/crates/kanban-tui/src/app/export_import.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 impl App {
     pub fn export_board_with_filename(&self) -> io::Result<()> {
         if let Some(board_idx) = self.selection.board.get() {
-            let board_id = self.model.boards().get(board_idx).map(|b| b.id);
+            let board_id = self.displayed_boards().get(board_idx).map(|b| b.id);
             if let Some(board_id) = board_id {
                 let export = self.build_boards_export(&[board_id])?;
                 BoardExporter::export_to_file(&export, self.input.as_str())?;
@@ -62,7 +62,7 @@ impl App {
     pub fn import_board_from_file(&mut self, filename: &str) -> io::Result<()> {
         let content = std::fs::read_to_string(filename)?;
 
-        let first_new_index = self.model.boards().len();
+        let first_new_index = self.model.live_boards().count();
 
         // Try V2 format first (preserves graph)
         if let Some(snapshot) = BoardImporter::try_load_snapshot(&content) {

--- a/crates/kanban-tui/src/app/file_io.rs
+++ b/crates/kanban-tui/src/app/file_io.rs
@@ -13,8 +13,8 @@ impl App {
         field: BoardField,
     ) -> io::Result<()> {
         if let Some(board_idx) = self.selection.board.get() {
-            let boards = self.model.boards();
-            if let Some(board) = boards.get(board_idx) {
+            let board = self.displayed_boards().get(board_idx).cloned();
+            if let Some(board) = board {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {
                     BoardField::Name => {

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -28,7 +28,7 @@ impl App {
         self.ctx.mark_clean();
         self.prepare_frame();
         self.check_ended_sprints();
-        if self.selection.board.get().is_none() && !self.model.boards().is_empty() {
+        if self.selection.board.get().is_none() && self.model.live_boards().next().is_some() {
             self.selection.board.set(Some(0));
         }
     }

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -10,19 +10,44 @@ pub struct Model {
     columns: Option<Vec<Column>>,
     cards: Option<Vec<Card>>,
     card_index: HashMap<Uuid, usize>,
+    board_index: HashMap<Uuid, usize>,
     sprints: Option<Vec<Sprint>>,
     archived_cards: Option<Vec<ArchivedCard>>,
     archived_card_ids: HashSet<Uuid>,
     archived_boards: Option<Vec<ArchivedBoard>>,
-    archived_boards_flat: Option<Vec<Board>>,
-    archived_board_index: HashMap<Uuid, usize>,
+    archived_board_ids: HashSet<Uuid>,
     graph: DependencyGraph,
 }
 
 impl Model {
-    /// LIVE boards only (archived heads are split out into `archived_boards_flat`).
+    /// The single unified board collection (live AND archived heads). Which of
+    /// these are archived is recorded in `archived_board_ids`; consumers that
+    /// want only one subset filter this collection by that set (the projects
+    /// panel does so via `displayed_boards`). Mirrors the unified `cards()`.
     pub fn boards(&self) -> &[Board] {
         self.boards.as_deref().unwrap_or(&[])
+    }
+
+    /// The LIVE boards (unified collection minus the archived heads), in board
+    /// order. The live projects panel and every live-only quantity (first-board
+    /// default selection, new-board position, live counts) resolve through this,
+    /// so broadening `boards()` to the unified collection cannot leak archived
+    /// heads into live semantics.
+    pub fn live_boards(&self) -> impl Iterator<Item = &Board> {
+        self.boards()
+            .iter()
+            .filter(|b| !self.archived_board_ids.contains(&b.id))
+    }
+
+    /// The ARCHIVED heads (unified collection filtered to the archived-id set),
+    /// in board order. This is what the ArchivedBoardsView renders and what its
+    /// restore / permanent-delete affordances index into — resolved directly
+    /// from the id set so it is independent of the transient `AppMode` (a confirm
+    /// dialog opened over the archived view must still resolve the archived head).
+    pub fn archived_boards_view(&self) -> impl Iterator<Item = &Board> {
+        self.boards()
+            .iter()
+            .filter(|b| self.archived_board_ids.contains(&b.id))
     }
 
     pub fn columns(&self) -> &[Column] {
@@ -61,28 +86,22 @@ impl Model {
         self.archived_boards.as_deref().unwrap_or(&[])
     }
 
-    /// The resolved live board heads for the archived boards, in marker order —
-    /// what the ArchivedBoardsView renders. Built once on load, so rendering is
-    /// zero-cost (no per-frame resolution).
-    pub fn archived_boards_flat(&self) -> &[Board] {
-        self.archived_boards_flat.as_deref().unwrap_or(&[])
+    /// Ids of the archived boards. The heads themselves live in the unified
+    /// `boards()` collection; this set records which of them are archived (built
+    /// from the markers). Consumers that need the archived subset filter
+    /// `boards()` by this set. (T1c introduces a single `displayed_boards()`
+    /// accessor that subsumes the inline filter.)
+    pub fn archived_board_ids(&self) -> &HashSet<Uuid> {
+        &self.archived_board_ids
     }
 
-    pub fn archived_board(&self, id: Uuid) -> Option<&Board> {
-        let &idx = self.archived_board_index.get(&id)?;
-        self.archived_boards_flat.as_ref()?.get(idx)
-    }
-
-    /// Resolve a board by id across BOTH the live set and the archived heads.
-    /// This is the single uniform resolver for "the board with this id" — it is
+    /// Resolve a board by id from the single unified collection (live AND
+    /// archived heads). One index lookup — no live/archived re-join. It is
     /// deliberately archival-agnostic: a board is a board regardless of whether
-    /// its head is archived. Live boards take precedence (an id is only ever in
-    /// one set, but the ordering makes the common case a direct hit).
+    /// its head is archived.
     pub fn board_by_id(&self, id: Uuid) -> Option<&Board> {
-        self.boards()
-            .iter()
-            .find(|b| b.id == id)
-            .or_else(|| self.archived_board(id))
+        let &idx = self.board_index.get(&id)?;
+        self.boards.as_ref()?.get(idx)
     }
 
     pub fn graph(&self) -> &DependencyGraph {
@@ -108,42 +127,31 @@ impl Model {
         }
         self.archived_card_ids = archived_card_ids;
 
-        // Boards split exactly like cards: `snapshot.boards` carries EVERY board
-        // head (live + archived); `snapshot.archived_boards` are markers keyed by
-        // `entity_id`. The live board views see only live boards; the archived
-        // view sees the archived heads resolved from the same rows.
-        let archived_board_ids: std::collections::HashSet<Uuid> = snapshot
+        // Boards unify exactly like cards: `snapshot.boards` carries EVERY board
+        // head (live + archived) in one collection; `snapshot.archived_boards`
+        // are markers keyed by `entity_id`, and the id set records which heads
+        // are archived. The live/archived distinction is a consumption decision
+        // applied by filtering `boards()` on this set (the projects panel does so
+        // via `displayed_boards`).
+        let archived_board_ids: HashSet<Uuid> = snapshot
             .archived_boards
             .iter()
             .map(|ab| ab.entity_id)
             .collect();
 
-        let board_by_id: std::collections::HashMap<Uuid, Board> =
-            snapshot.boards.iter().map(|b| (b.id, b.clone())).collect();
-
-        let live_boards: Vec<Board> = snapshot
-            .boards
-            .into_iter()
-            .filter(|b| !archived_board_ids.contains(&b.id))
-            .collect();
-
-        self.archived_board_index.clear();
-        let mut board_flat = Vec::with_capacity(snapshot.archived_boards.len());
-        for ab in snapshot.archived_boards.iter() {
-            if let Some(board) = board_by_id.get(&ab.entity_id) {
-                self.archived_board_index
-                    .insert(ab.entity_id, board_flat.len());
-                board_flat.push(board.clone());
-            }
+        let boards = snapshot.boards;
+        self.board_index.clear();
+        for (i, board) in boards.iter().enumerate() {
+            self.board_index.insert(board.id, i);
         }
+        self.archived_board_ids = archived_board_ids;
 
-        self.boards = Some(live_boards);
+        self.boards = Some(boards);
         self.columns = Some(snapshot.columns);
         self.sprints = Some(snapshot.sprints);
         self.cards = Some(cards);
         self.archived_cards = Some(snapshot.archived_cards);
         self.archived_boards = Some(snapshot.archived_boards);
-        self.archived_boards_flat = Some(board_flat);
         self.graph = snapshot.graph;
     }
 }

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -270,16 +270,20 @@ mod tests {
     fn test_default_model_returns_empty_archived_board_slices() {
         let m = Model::default();
         assert!(m.archived_boards().is_empty());
-        assert!(m.archived_boards_flat().is_empty());
-        assert!(m.archived_board(Uuid::new_v4()).is_none());
+        assert!(m.archived_board_ids().is_empty());
+        assert!(m.board_by_id(Uuid::new_v4()).is_none());
     }
 
     #[test]
-    fn test_load_from_snapshot_splits_live_and_archived_boards() {
+    fn test_board_by_id_resolves_live_and_archived_from_one_collection() {
+        // After unification `boards()` holds live AND archived heads, and
+        // `board_by_id` resolves either from the single collection — no
+        // `or_else(archived_board())` re-join.
         use kanban_domain::Archived;
         let mut m = Model::default();
         let live = Board::new("Live", None::<String>);
         let archived = Board::new("Archived", None::<String>);
+        let live_id = live.id;
         let archived_id = archived.id;
         m.load_from_snapshot(Snapshot {
             // snapshot.boards carries BOTH heads; the marker names the archived one.
@@ -288,24 +292,79 @@ mod tests {
             ..Default::default()
         });
 
-        // Live board view excludes the archived head.
-        assert_eq!(m.boards().len(), 1);
-        assert_eq!(m.boards()[0].id, live.id);
+        // Both live and archived heads live in the single unified collection.
+        assert_eq!(m.boards().len(), 2);
 
-        // The archived view resolves the archived head.
-        assert_eq!(m.archived_boards().len(), 1);
-        assert_eq!(m.archived_boards()[0].entity_id, archived_id);
-        assert_eq!(m.archived_boards_flat().len(), 1);
-        assert_eq!(m.archived_boards_flat()[0].id, archived_id);
-        let found = m.archived_board(archived_id).unwrap();
-        assert_eq!(found.name, "Archived");
+        // The single index resolves both.
+        assert_eq!(m.board_by_id(live_id).map(|b| b.id), Some(live_id));
+        assert_eq!(
+            m.board_by_id(archived_id).map(|b| b.name.clone()),
+            Some("Archived".to_string())
+        );
+
+        // The archived-id set records which heads are archived.
+        assert!(!m.archived_board_ids().contains(&live_id));
+        assert!(m.archived_board_ids().contains(&archived_id));
     }
 
     #[test]
-    fn test_archived_board_lookup_missing_id_returns_none() {
+    fn test_archived_boards_view_filter_shows_archived_board_from_unified_collection() {
+        // The archived-boards view filters the unified collection by
+        // `archived_board_ids`. Assert an archived board is present through that
+        // path, and a live board is not.
+        use kanban_domain::Archived;
+        let mut m = Model::default();
+        let live = Board::new("Live", None::<String>);
+        let archived = Board::new("Archived", None::<String>);
+        let live_id = live.id;
+        let archived_id = archived.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![live.clone(), archived.clone()],
+            archived_boards: vec![Archived::now(archived_id)],
+            ..Default::default()
+        });
+
+        let displayed: Vec<Uuid> = m
+            .boards()
+            .iter()
+            .filter(|b| m.archived_board_ids().contains(&b.id))
+            .map(|b| b.id)
+            .collect();
+        assert_eq!(displayed, vec![archived_id]);
+        assert!(!displayed.contains(&live_id));
+    }
+
+    #[test]
+    fn test_live_board_filter_excludes_archived_board_from_unified_collection() {
+        // Guard: the LIVE projects panel filters archived heads OUT of the
+        // unified collection (analogue of T1a's live-branch card fix).
+        use kanban_domain::Archived;
+        let mut m = Model::default();
+        let live = Board::new("Live", None::<String>);
+        let archived = Board::new("Archived", None::<String>);
+        let live_id = live.id;
+        let archived_id = archived.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![live.clone(), archived.clone()],
+            archived_boards: vec![Archived::now(archived_id)],
+            ..Default::default()
+        });
+
+        let live_only: Vec<Uuid> = m
+            .boards()
+            .iter()
+            .filter(|b| !m.archived_board_ids().contains(&b.id))
+            .map(|b| b.id)
+            .collect();
+        assert_eq!(live_only, vec![live_id]);
+        assert!(!live_only.contains(&archived_id));
+    }
+
+    #[test]
+    fn test_board_by_id_missing_id_returns_none() {
         let mut m = Model::default();
         m.load_from_snapshot(Snapshot::default());
-        assert!(m.archived_board(Uuid::new_v4()).is_none());
+        assert!(m.board_by_id(Uuid::new_v4()).is_none());
     }
 
     #[test]

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -1,6 +1,7 @@
 use super::{App, AppMode};
 use crate::view_strategy::{UnifiedViewStrategy, ViewRefreshContext, ViewStrategy};
 use kanban_domain::{Board, Card, KanbanResult};
+use uuid::Uuid;
 
 impl App {
     /// Resolve the board the user is currently acting on / viewing, by identity.
@@ -24,14 +25,15 @@ impl App {
     /// projects set. Board-agnostic — resolves live OR archived boards uniformly,
     /// so board detail, sprints, and columns work identically for either.
     pub fn board_in_context(&self) -> Option<&Board> {
-        match self.selection.active_board_id {
-            Some(id) => self.model.board_by_id(id),
+        let id = match self.selection.active_board_id {
+            Some(id) => Some(id),
             None => self
                 .selection
                 .board
                 .get()
-                .and_then(|idx| self.displayed_boards().get(idx)),
-        }
+                .and_then(|idx| self.displayed_boards().get(idx).map(|b| b.id)),
+        }?;
+        self.model.board_by_id(id)
     }
 
     /// The board set the projects panel currently displays: the archived heads
@@ -40,12 +42,21 @@ impl App {
     /// the projects panel choosing which set to render and index selection into.
     /// Everything downstream (operations, navigation, resolution) is board-
     /// agnostic and resolves the active board by id via `active_board`.
-    pub fn displayed_boards(&self) -> &[Board] {
-        if self.mode == AppMode::ArchivedBoardsView {
-            self.model.archived_boards_flat()
-        } else {
-            self.model.boards()
-        }
+    ///
+    /// Boards are now one unified collection (live + archived); the view mode
+    /// selects which subset to display by filtering on `archived_board_ids`.
+    /// This inline filter is temporary: T1c introduces a single cached
+    /// `displayed_boards()` accessor that subsumes it (see KAN-914 D3 / KAN-933),
+    /// replacing both this and the card-side inline filter.
+    pub fn displayed_boards(&self) -> Vec<Board> {
+        let archived_ids = self.model.archived_board_ids();
+        let want_archived = self.mode == AppMode::ArchivedBoardsView;
+        self.model
+            .boards()
+            .iter()
+            .filter(|b| archived_ids.contains(&b.id) == want_archived)
+            .cloned()
+            .collect()
     }
 
     pub fn prepare_frame(&mut self) {
@@ -76,19 +87,26 @@ impl App {
         // `self.model`/`self.selection`/`self.mode`. When no board is active
         // (browsing the projects list), fall back to the highlighted board in the
         // currently displayed set so the tasks preview tracks the cursor.
-        let displayed: &[Board] = if self.mode == AppMode::ArchivedBoardsView {
-            self.model.archived_boards_flat()
-        } else {
-            self.model.boards()
-        };
-        let board: Option<&Board> = match self.selection.active_board_id {
-            Some(id) => self.model.board_by_id(id),
-            None => self
-                .selection
-                .board
-                .get()
-                .and_then(|idx| displayed.get(idx)),
-        };
+        // Boards are one unified collection (live + archived); the view mode
+        // selects which subset the projects panel shows by filtering on
+        // `archived_board_ids`. This inline filter mirrors the card-side one and
+        // is temporary: T1c introduces a single `displayed_boards()` accessor
+        // (see KAN-914 D3 / KAN-933). The highlighted board's id is extracted
+        // here and re-resolved by id so the borrow is tied to `self.model`, not a
+        // temporary — keeping it splittable from the `&mut self.view.strategy`
+        // borrow `refresh_task_lists` needs.
+        let archived_ids = self.model.archived_board_ids();
+        let want_archived = self.mode == AppMode::ArchivedBoardsView;
+        let highlighted_id: Option<Uuid> = self.selection.board.get().and_then(|idx| {
+            self.model
+                .boards()
+                .iter()
+                .filter(|b| archived_ids.contains(&b.id) == want_archived)
+                .nth(idx)
+                .map(|b| b.id)
+        });
+        let board_id: Option<Uuid> = self.selection.active_board_id.or(highlighted_id);
+        let board: Option<&Board> = board_id.and_then(|id| self.model.board_by_id(id));
 
         if let Some(board) = board {
             let search_query = if self.filter.search.is_active {

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -36,8 +36,7 @@ impl App {
                 .selection
                 .board
                 .get()
-                .and_then(|idx| self.displayed_boards().get(idx))
-                .map(|b| b.name.clone())
+                .and_then(|idx| self.displayed_boards().get(idx).map(|b| b.name.clone()))
             {
                 self.input.set(name);
                 self.open_dialog(DialogMode::RenameBoard);
@@ -54,8 +53,7 @@ impl App {
                 .selection
                 .board
                 .get()
-                .and_then(|idx| self.displayed_boards().get(idx))
-                .map(|b| b.id)
+                .and_then(|idx| self.displayed_boards().get(idx).map(|b| b.id))
             {
                 self.selection.active_board_id = Some(board_id);
                 self.push_mode(AppMode::BoardDetail);
@@ -67,10 +65,14 @@ impl App {
     pub fn handle_export_board_key(&mut self) {
         if self.focus.active == Focus::Boards && self.selection.board.get().is_some() {
             if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board) = self.model.boards().get(board_idx) {
+                if let Some(board_name) = self
+                    .displayed_boards()
+                    .get(board_idx)
+                    .map(|b| b.name.clone())
+                {
                     let filename = format!(
                         "{}-{}.json",
-                        board.name.replace(" ", "-").to_lowercase(),
+                        board_name.replace(" ", "-").to_lowercase(),
                         chrono::Utc::now().format("%Y%m%d-%H%M%S")
                     );
                     self.input.set(filename);
@@ -81,7 +83,7 @@ impl App {
     }
 
     pub fn handle_export_all_key(&mut self) {
-        if self.focus.active == Focus::Boards && !self.model.boards().is_empty() {
+        if self.focus.active == Focus::Boards && self.model.live_boards().next().is_some() {
             let filename = format!(
                 "kanban-all-{}.json",
                 chrono::Utc::now().format("%Y%m%d-%H%M%S")
@@ -104,7 +106,7 @@ impl App {
     pub fn handle_delete_board_key(&mut self) {
         if self.focus.active == Focus::Boards {
             if let Some(idx) = self.selection.board.get() {
-                if let Some(board_id) = self.model.boards().get(idx).map(|b| b.id) {
+                if let Some(board_id) = self.displayed_boards().get(idx).map(|b| b.id) {
                     // Snapshot the counts once, here, rather than re-scanning the
                     // model on every frame the modal is open.
                     self.dialog_input.board_delete_counts =
@@ -176,10 +178,10 @@ impl App {
         let Some(idx) = self.selection.board.get() else {
             return;
         };
-        let Some(board_id) = self.model.boards().get(idx).map(|b| b.id) else {
+        let Some(board_id) = self.displayed_boards().get(idx).map(|b| b.id) else {
             return;
         };
-        let remaining_after = self.model.boards().len().saturating_sub(1);
+        let remaining_after = self.model.live_boards().count().saturating_sub(1);
 
         if let Err(e) = self.ctx.archive_board(board_id) {
             tracing::error!("Failed to archive board: {}", e);
@@ -262,8 +264,10 @@ impl App {
                 // board that was open is no longer active.
                 self.selection.active_board_id = None;
                 self.prepare_frame();
-                // Select the first archived board (if any).
-                let has_any = !self.model.archived_boards_flat().is_empty();
+                // Select the first archived board (if any). In ArchivedBoardsView
+                // `displayed_boards()` is the archived subset of the unified
+                // collection.
+                let has_any = !self.displayed_boards().is_empty();
                 self.selection.board.set(has_any.then_some(0));
                 self.needs_redraw = true;
             }
@@ -271,7 +275,7 @@ impl App {
                 self.mode = AppMode::Normal;
                 self.selection.active_board_id = None;
                 self.prepare_frame();
-                let has_any = !self.model.boards().is_empty();
+                let has_any = self.model.live_boards().next().is_some();
                 self.selection.board.set(has_any.then_some(0));
                 self.needs_redraw = true;
             }
@@ -280,9 +284,12 @@ impl App {
     }
 
     /// The archived board currently highlighted in the ArchivedBoardsView.
+    /// Resolves against the archived subset of the unified collection directly
+    /// (not `displayed_boards`, which is transiently the LIVE set while a confirm
+    /// dialog is open on top of the archived view).
     fn selected_archived_board_id(&self) -> Option<uuid::Uuid> {
         let idx = self.selection.board.get()?;
-        self.model.archived_boards_flat().get(idx).map(|b| b.id)
+        self.model.archived_boards_view().nth(idx).map(|b| b.id)
     }
 
     /// Restore the highlighted archived board back into the live set (direct,
@@ -309,7 +316,7 @@ impl App {
         }
         self.prepare_frame();
         // Clamp the highlight to the shrunken archived list.
-        let remaining = self.model.archived_boards_flat().len();
+        let remaining = self.model.archived_boards_view().count();
         self.selection.board.set(
             (remaining > 0).then(|| self.selection.board.get().unwrap_or(0).min(remaining - 1)),
         );
@@ -329,7 +336,7 @@ impl App {
         }
         tracing::info!("Permanently deleted archived board {}", board_id);
         self.prepare_frame();
-        let remaining = self.model.archived_boards_flat().len();
+        let remaining = self.model.archived_boards_view().count();
         self.selection.board.set(
             (remaining > 0).then(|| self.selection.board.get().unwrap_or(0).min(remaining - 1)),
         );
@@ -340,7 +347,7 @@ impl App {
         let board_name = self.input.as_str().to_string();
 
         let board_id = uuid::Uuid::new_v4();
-        let position = self.model.boards().len() as i32;
+        let position = self.model.live_boards().count() as i32;
         let new_index = position as usize;
 
         let mut commands: Vec<Command> = vec![Command::Board(BoardCommand::Create(CreateBoard {
@@ -375,8 +382,7 @@ impl App {
 
     pub fn rename_board(&mut self) {
         if let Some(idx) = self.selection.board.get() {
-            if let Some(board) = self.model.boards().get(idx) {
-                let board_id = board.id;
+            if let Some(board_id) = self.displayed_boards().get(idx).map(|b| b.id) {
                 let new_name = self.input.as_str().to_string();
 
                 // Execute UpdateBoard command

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -547,8 +547,7 @@ impl App {
                             .board
                             .get()
                             .and_then(|idx| {
-                                let boards = self.model.boards();
-                                boards.get(idx).map(|board| {
+                                self.displayed_boards().get(idx).map(|board| {
                                     self.model
                                         .sprints()
                                         .iter()

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -452,12 +452,11 @@ impl App {
                 // panel currently displays (live OR archived) — a board is a
                 // board. From here on it is THE active board, tracked by id, and
                 // every view/operation resolves it archival-agnostically.
-                let activated = self
-                    .selection
-                    .board
-                    .get()
-                    .and_then(|idx| self.displayed_boards().get(idx))
-                    .map(|b| (b.id, b.task_list_view, b.task_sort_field, b.task_sort_order));
+                let activated = self.selection.board.get().and_then(|idx| {
+                    self.displayed_boards()
+                        .get(idx)
+                        .map(|b| (b.id, b.task_list_view, b.task_sort_field, b.task_sort_order))
+                });
 
                 if let Some((board_id, task_list_view, task_sort_field, task_sort_order)) =
                     activated

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -267,12 +267,14 @@ impl App {
             tracing::error!("Failed to clear history: {}", e);
         }
 
-        self.selection.active_board_id = self.model.boards().first().map(|b| b.id);
-        self.selection.board.set(if self.model.boards().is_empty() {
-            None
-        } else {
-            Some(0)
-        });
+        self.selection.active_board_id = self.model.live_boards().next().map(|b| b.id);
+        self.selection
+            .board
+            .set(if self.model.live_boards().next().is_none() {
+                None
+            } else {
+                Some(0)
+            });
         self.selection.active_card_id = None;
         self.selection.card_navigation_history.clear();
 
@@ -372,7 +374,7 @@ impl App {
             | KeyCode::Enter => self.handle_settings_key_nav(key),
             KeyCode::Char('e') => self.open_config_editor(terminal, event_handler),
             KeyCode::Char('x') => {
-                let board_count = self.model.boards().len();
+                let board_count = self.model.live_boards().count();
                 if board_count == 0 {
                     self.set_error("No boards to export".to_string());
                     return false;
@@ -523,7 +525,7 @@ impl App {
     }
 
     fn trigger_export(&mut self) -> bool {
-        let board_count = self.model.boards().len();
+        let board_count = self.model.live_boards().count();
         if board_count == 0 {
             self.set_error("No boards to export".to_string());
             return false;
@@ -627,10 +629,10 @@ impl App {
             return;
         }
 
-        let boards = self.model.boards();
+        let live_board_ids: Vec<_> = self.model.live_boards().map(|b| b.id).collect();
         let selected_board_ids: Vec<_> = selected_indices
             .iter()
-            .filter_map(|&i| boards.get(i).map(|b| b.id))
+            .filter_map(|&i| live_board_ids.get(i).copied())
             .collect();
 
         // Route through the snapshot so each selected board's archived-card live

--- a/crates/kanban-tui/src/ui/dialogs/boards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/boards.rs
@@ -28,8 +28,7 @@ pub(crate) fn render_export_boards_popup(app: &App, frame: &mut Frame) {
 
             let items: Vec<Line> = app
                 .model
-                .boards()
-                .iter()
+                .live_boards()
                 .enumerate()
                 .map(|(i, board)| {
                     let checkbox = if dialog.board_selections.get(i).copied().unwrap_or(false) {

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -107,7 +107,7 @@ pub fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
     let viewing_archived_board = app
         .selection
         .active_board_id
-        .is_some_and(|id| app.model.archived_board(id).is_some());
+        .is_some_and(|id| app.model.archived_board_ids().contains(&id));
     let mut title = if app.mode == AppMode::ArchivedCardsView {
         format!("Archive [{}]", count)
     } else if viewing_archived_board {

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -26,19 +26,21 @@ fn test_toggle_into_archived_boards_view_and_back() {
     app.focus.active = Focus::Boards;
     app.mode = AppMode::Normal;
     app.prepare_frame();
-    // The live boards view excludes the archived head.
-    assert!(app.model.boards().iter().all(|b| b.id != archived_id));
+    // The live boards view (unified collection filtered by the archived-id set)
+    // excludes the archived head, even though `boards()` now carries it.
+    assert!(app.model.boards().iter().any(|b| b.id == archived_id));
+    assert!(app.displayed_boards().iter().all(|b| b.id != archived_id));
 
     app.handle_toggle_archived_boards_view();
     assert_eq!(app.mode, AppMode::ArchivedBoardsView);
     // The archived view shows the archived board head.
-    assert_eq!(app.model.archived_boards_flat().len(), 1);
-    assert_eq!(app.model.archived_boards_flat()[0].id, archived_id);
+    assert_eq!(app.displayed_boards().len(), 1);
+    assert_eq!(app.displayed_boards()[0].id, archived_id);
 
     // Toggling again returns to the live boards view.
     app.handle_toggle_archived_boards_view();
     assert_eq!(app.mode, AppMode::Normal);
-    assert!(app.model.boards().iter().any(|b| b.name == "Live"));
+    assert!(app.displayed_boards().iter().any(|b| b.name == "Live"));
 }
 
 #[test]
@@ -151,8 +153,7 @@ fn test_x_in_archived_view_opens_confirm_not_immediate_delete() {
     app.prepare_frame();
     assert!(
         app.model
-            .archived_boards_flat()
-            .iter()
+            .archived_boards_view()
             .any(|b| b.id == archived_id),
         "board must not be deleted until user confirms"
     );
@@ -180,8 +181,7 @@ fn test_confirm_permanent_delete_removes_board() {
 
     assert!(
         app.model
-            .archived_boards_flat()
-            .iter()
+            .archived_boards_view()
             .all(|b| b.id != archived_id),
         "confirmed delete should permanently remove the board"
     );
@@ -220,8 +220,7 @@ fn test_cancel_permanent_delete_keeps_board() {
     );
     assert!(
         app.model
-            .archived_boards_flat()
-            .iter()
+            .archived_boards_view()
             .any(|b| b.id == archived_id),
         "cancelled delete must keep the board archived"
     );
@@ -293,7 +292,7 @@ fn test_archived_view_u_undoes_permanent_delete() {
     app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Enter);
     app.prepare_frame();
     assert!(
-        app.model.archived_boards_flat().is_empty(),
+        app.model.archived_boards_view().next().is_none(),
         "board must be gone after confirming permanent delete"
     );
 
@@ -302,8 +301,7 @@ fn test_archived_view_u_undoes_permanent_delete() {
     app.prepare_frame();
     assert!(
         app.model
-            .archived_boards_flat()
-            .iter()
+            .archived_boards_view()
             .any(|b| b.id == archived_id),
         "undo should restore the permanently deleted archived board"
     );

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -68,15 +68,12 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
     // Sanity: the archived board head is hidden from the live list, present in
     // the archived-boards view.
     assert!(
-        app.model.boards().iter().all(|b| b.id != arch_board.id),
+        app.model.live_boards().all(|b| b.id != arch_board.id),
         "archived board must be hidden from live list before export"
     );
     assert!(
-        app.model
-            .archived_boards_flat()
-            .iter()
-            .any(|b| b.id == arch_board.id),
-        "archived board head must be in the archived view before export"
+        app.model.archived_board_ids().contains(&arch_board.id),
+        "archived board head must be in the archived set before export"
     );
 
     // Drive the ACTUAL TUI File→Export-All entry point.
@@ -99,12 +96,12 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
     // Archived board head is back AND still archived (hidden from live list,
     // present in the archived view with its marker).
     assert!(
-        app2.model.boards().iter().all(|b| b.id != arch_board.id),
+        app2.model.live_boards().all(|b| b.id != arch_board.id),
         "archived board must remain hidden from live list after re-import"
     );
-    let archived_flat = app2.model.archived_boards_flat();
     assert!(
-        archived_flat.iter().any(|b| b.id == arch_board.id),
+        app2.model.boards().iter().any(|b| b.id == arch_board.id)
+            && app2.model.archived_board_ids().contains(&arch_board.id),
         "archived board head must round-trip and remain archived"
     );
     assert_eq!(


### PR DESCRIPTION
## What

T1b of ARCH-DECOR (KAN-914), mirroring T1a (KAN-931, card unification) for BOARDS. Collapses the board partition in the TUI `Model` into one unified collection plus an archived-id set, resolved through a single `board_by_id` lookup.

- `Model` now holds one `boards: Vec<Board>` (live + archived heads) + `archived_board_ids: HashSet<Uuid>` built from the markers, and a `board_index` for O(1) id resolution. `board_by_id()` is a single index lookup, no `boards().find().or_else(archived_board())` re-join.
- Deleted `archived_boards_flat` (field + accessor) and `archived_board()`; `load_from_snapshot` builds the unified collection + id set (mirrors the card path).
- Added `live_boards()` and `archived_boards_view()` iterators over the unified collection filtered by the id set.

## Consumption seam (temporary inline filter)

`displayed_boards()` and the `prepare_frame` board branch now filter the unified `boards()` by `archived_board_ids` per mode (live-only in Normal, archived-only in `ArchivedBoardsView`), the same TEMPORARY inline pattern T1a used for cards. **T1c (KAN-933) replaces both the card and board inline filters with a single cached accessor.**

## Repointed call sites

`archived_boards_flat()` / `archived_board()` callers:
- `view_management.rs`: `displayed_boards()` and the `prepare_frame` board branch now filter the unified collection; `board_in_context` resolves the highlighted id then re-looks-up by id.
- `board_handlers.rs`: projects-panel index sites (`handle_export_board_key`, `handle_delete_board_key`, `delete_board`, `rename_board`) use `displayed_boards()`; live-only quantities (`create_board` position, toggle-back first-live selection, `handle_export_all_key` gate) use `live_boards()`; the archived-view restore/permanent-delete affordances (`selected_archived_board_id`, remaining-count clamps) use the mode-independent `archived_boards_view()`.
- `main_view.rs`: the "viewing archived board" indicator uses `archived_board_ids().contains()`.
- Live-only callers broadened-safe via `live_boards()`: `settings_handlers.rs` (default selection + export dialog count/render/finalize cluster), `export_import.rs` (import insert index), `main_loop.rs` (startup default selection), `dialogs/boards.rs` (export checkbox list). Panel-index callers in `file_io.rs`, `detail_view_handlers.rs`, `navigation_handlers.rs`, `input_router.rs` use `displayed_boards()`.

Because broadening `boards()` from live-only to unified changes semantics for ~15 positional callers, live-only sites were repointed to `live_boards()` and panel-index sites to `displayed_boards()` so no archived head can leak into live semantics.

## Live projects panel excludes archived boards

Confirmed: the live projects panel (`displayed_boards()` in Normal mode, and `render_projects_panel`) filters archived heads out of the unified collection. Guarded by `test_live_board_filter_excludes_archived_board_from_unified_collection` and `test_toggle_into_archived_boards_view_and_back` (live view asserts the archived head is present in `boards()` but excluded from `displayed_boards()`).

## Tests (Red → Green)

- `test_board_by_id_resolves_live_and_archived_from_one_collection`
- `test_archived_boards_view_filter_shows_archived_board_from_unified_collection`
- `test_live_board_filter_excludes_archived_board_from_unified_collection`
- Existing board render/selection/`archive_board_view_tests`/export-import parity stay green.

`cargo test -p kanban-tui` green (all suites, 0 failed), `cargo clippy -p kanban-tui --all-targets -D warnings` clean, `cargo fmt` applied.

## Card note

The card body specified a `test_archived_boards_flat_field_removed` test; since the field is deleted (a compile-time guarantee, not a runtime assertion), that is covered by the field/accessor removal itself plus the resolution tests, and superseded by the more meaningful unified-collection + live-exclusion guards the task prompt asked for.

Part of KAN-932 (T1b), child of KAN-922 (T1) / KAN-914 (ARCH-DECOR).