### PR TITLE
KAN-933 refactor(tui): single cached displayed_cards/displayed_boards accessor (borrow, base-mode-aware)

### DIFF
--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -16,6 +16,15 @@ pub struct Model {
     archived_card_ids: HashSet<Uuid>,
     archived_boards: Option<Vec<ArchivedBoard>>,
     archived_board_ids: HashSet<Uuid>,
+    // Live/archived partitions of the unified `cards`/`boards` collections,
+    // computed ONCE in `load_from_snapshot` (snapshot-on-open) and served as a
+    // borrow by `displayed_cards`/`displayed_boards`. This is the concrete
+    // no-per-frame-recompute fix (KAN-933): the projects/tasks panels borrow
+    // the cached subset every redraw instead of re-filtering+cloning per frame.
+    displayed_cards_live: Vec<Card>,
+    displayed_cards_archived: Vec<Card>,
+    displayed_boards_live: Vec<Board>,
+    displayed_boards_archived: Vec<Board>,
     graph: DependencyGraph,
 }
 
@@ -95,6 +104,30 @@ impl Model {
         &self.archived_board_ids
     }
 
+    /// The cards the tasks panel should display, selected by `want_archived`:
+    /// the archived subset when a confirm dialog / the archived-cards view is
+    /// active, the live subset otherwise. Returns a BORROW of the partition
+    /// cached on the last `load_from_snapshot` — no per-frame filter or clone.
+    pub fn displayed_cards(&self, want_archived: bool) -> &[Card] {
+        if want_archived {
+            &self.displayed_cards_archived
+        } else {
+            &self.displayed_cards_live
+        }
+    }
+
+    /// The boards the projects panel should display, selected by `want_archived`.
+    /// Borrow of the partition cached on `load_from_snapshot`; the mode decision
+    /// (live vs archived) lives at the `App` accessor, which passes the
+    /// stack-aware base mode in.
+    pub fn displayed_boards(&self, want_archived: bool) -> &[Board] {
+        if want_archived {
+            &self.displayed_boards_archived
+        } else {
+            &self.displayed_boards_live
+        }
+    }
+
     /// Resolve a board by id from the single unified collection (live AND
     /// archived heads). One index lookup — no live/archived re-join. It is
     /// deliberately archival-agnostic: a board is a board regardless of whether
@@ -153,6 +186,30 @@ impl Model {
         self.archived_cards = Some(snapshot.archived_cards);
         self.archived_boards = Some(snapshot.archived_boards);
         self.graph = snapshot.graph;
+
+        // Partition the unified collections into live/archived subsets ONCE, here
+        // on load (snapshot-on-open), so `displayed_cards`/`displayed_boards` can
+        // serve a borrow every redraw instead of re-filtering per frame. Order is
+        // preserved so index-based selection into the displayed set is stable.
+        self.rebuild_displayed_partitions();
+    }
+
+    fn rebuild_displayed_partitions(&mut self) {
+        let (archived_cards, live_cards): (Vec<Card>, Vec<Card>) = self
+            .cards()
+            .iter()
+            .cloned()
+            .partition(|c| self.archived_card_ids.contains(&c.id));
+        self.displayed_cards_live = live_cards;
+        self.displayed_cards_archived = archived_cards;
+
+        let (archived_boards, live_boards): (Vec<Board>, Vec<Board>) = self
+            .boards()
+            .iter()
+            .cloned()
+            .partition(|b| self.archived_board_ids.contains(&b.id));
+        self.displayed_boards_live = live_boards;
+        self.displayed_boards_archived = archived_boards;
     }
 }
 

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -275,6 +275,51 @@ mod tests {
     }
 
     #[test]
+    fn test_displayed_cards_partition_cached_on_load() {
+        // Cache-on-load guard: `load_from_snapshot` partitions the unified card
+        // collection into live/archived subsets ONCE, and `displayed_cards`
+        // returns the cached slice by `want_archived` — no per-frame filter.
+        let mut m = Model::default();
+        let mut board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let live = make_card(&mut board, col_id);
+        let archived = make_card(&mut board, col_id);
+        let live_id = live.id;
+        let archived_id = archived.id;
+        m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
+            cards: vec![live, archived],
+            archived_cards: vec![ArchivedCard::new(archived_id, uuid::Uuid::nil())],
+            ..Default::default()
+        });
+
+        let live_ids: Vec<Uuid> = m.displayed_cards(false).iter().map(|c| c.id).collect();
+        let archived_ids: Vec<Uuid> = m.displayed_cards(true).iter().map(|c| c.id).collect();
+        assert_eq!(live_ids, vec![live_id]);
+        assert_eq!(archived_ids, vec![archived_id]);
+    }
+
+    #[test]
+    fn test_displayed_boards_partition_cached_on_load() {
+        use kanban_domain::Archived;
+        let mut m = Model::default();
+        let live = Board::new("Live", None::<String>);
+        let archived = Board::new("Archived", None::<String>);
+        let live_id = live.id;
+        let archived_id = archived.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![live, archived],
+            archived_boards: vec![Archived::now(archived_id)],
+            ..Default::default()
+        });
+
+        let live_ids: Vec<Uuid> = m.displayed_boards(false).iter().map(|b| b.id).collect();
+        let archived_ids: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
+        assert_eq!(live_ids, vec![live_id]);
+        assert_eq!(archived_ids, vec![archived_id]);
+    }
+
+    #[test]
     fn test_default_model_returns_empty_archived_board_slices() {
         let m = Model::default();
         assert!(m.archived_boards().is_empty());

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -36,6 +36,16 @@ impl App {
         self.model.board_by_id(id)
     }
 
+    /// The card subset the tasks panel currently displays: the archived cards
+    /// under the archived-cards view (stack-aware, so a confirm dialog opened
+    /// over it still resolves the archived set), the live cards otherwise. A
+    /// borrow of the partition cached on `load_from_snapshot` — no per-frame
+    /// filter or clone. The SOLE card-side live/archived selector.
+    pub fn displayed_cards(&self) -> &[Card] {
+        let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedCardsView);
+        self.model.displayed_cards(want_archived)
+    }
+
     /// The board set the projects panel currently displays: the archived heads
     /// when the panel is toggled to the archived set, the live boards otherwise.
     /// This is the SOLE place the live/archived distinction affects behavior —
@@ -43,20 +53,14 @@ impl App {
     /// Everything downstream (operations, navigation, resolution) is board-
     /// agnostic and resolves the active board by id via `active_board`.
     ///
-    /// Boards are now one unified collection (live + archived); the view mode
-    /// selects which subset to display by filtering on `archived_board_ids`.
-    /// This inline filter is temporary: T1c introduces a single cached
-    /// `displayed_boards()` accessor that subsumes it (see KAN-914 D3 / KAN-933),
-    /// replacing both this and the card-side inline filter.
-    pub fn displayed_boards(&self) -> Vec<Board> {
-        let archived_ids = self.model.archived_board_ids();
-        let want_archived = self.mode == AppMode::ArchivedBoardsView;
-        self.model
-            .boards()
-            .iter()
-            .filter(|b| archived_ids.contains(&b.id) == want_archived)
-            .cloned()
-            .collect()
+    /// Stack-aware: the choice keys off `get_base_mode()`, not the raw `mode`, so
+    /// a confirm dialog opened over the archived view (mode == Dialog(..)) still
+    /// resolves the archived heads — the underlay-bug fix. Returns a BORROW of
+    /// the partition cached on `load_from_snapshot`, eliminating the per-redraw
+    /// clone the interim owned-Vec form carried.
+    pub fn displayed_boards(&self) -> &[Board] {
+        let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
+        self.model.displayed_boards(want_archived)
     }
 
     pub fn prepare_frame(&mut self) {
@@ -65,44 +69,28 @@ impl App {
             Err(e) => tracing::warn!("Failed to load snapshot for frame: {e}"),
         }
 
-        // Cards are now one unified collection (live + archived); the view mode
-        // selects which subset to display by filtering on `archived_card_ids`.
-        // This inline filter is temporary: T1c introduces a single
-        // `displayed_cards()` accessor that subsumes it (see KAN-914 D3 / KAN-931).
-        let archived_ids = self.model.archived_card_ids();
-        let want_archived = self.mode == AppMode::ArchivedCardsView;
-        let cards_for_display: Vec<Card> = self
-            .model
-            .cards()
-            .iter()
-            .filter(|c| archived_ids.contains(&c.id) == want_archived)
-            .cloned()
-            .collect();
-        let cards_for_display: &[Card] = &cards_for_display;
+        // Single card-side selector: borrow the cached displayed subset (stack-
+        // aware base mode). No per-frame filter/clone — the partition was built
+        // on load. Resolved via `self.model` directly (not `self.displayed_cards`)
+        // so the borrow is scoped to `self.model` and splits cleanly from the
+        // `&mut self.view.strategy` borrow `refresh_task_lists` takes below.
+        let want_archived_cards = matches!(self.get_base_mode(), AppMode::ArchivedCardsView);
+        let cards_for_display: &[Card] = self.model.displayed_cards(want_archived_cards);
 
-        // Board resolution: inlined (rather than calling `active_board` /
-        // `displayed_boards`) because those return borrows tied to all of `self`,
-        // which Rust NLL cannot split from the `&mut self.view.strategy` borrow
-        // taken by `refresh_task_lists` below. Inlining keeps the borrow scoped to
-        // `self.model`/`self.selection`/`self.mode`. When no board is active
-        // (browsing the projects list), fall back to the highlighted board in the
-        // currently displayed set so the tasks preview tracks the cursor.
-        // Boards are one unified collection (live + archived); the view mode
-        // selects which subset the projects panel shows by filtering on
-        // `archived_board_ids`. This inline filter mirrors the card-side one and
-        // is temporary: T1c introduces a single `displayed_boards()` accessor
-        // (see KAN-914 D3 / KAN-933). The highlighted board's id is extracted
-        // here and re-resolved by id so the borrow is tied to `self.model`, not a
-        // temporary — keeping it splittable from the `&mut self.view.strategy`
-        // borrow `refresh_task_lists` needs.
-        let archived_ids = self.model.archived_board_ids();
-        let want_archived = self.mode == AppMode::ArchivedBoardsView;
+        // Board resolution: resolved via `self.model` directly (rather than
+        // `active_board` / `displayed_boards`, which borrow all of `self`) so the
+        // borrow stays scoped to `self.model` and NLL can split it from the
+        // `&mut self.view.strategy` borrow `refresh_task_lists` needs. When no
+        // board is active (browsing the projects list), fall back to the
+        // highlighted board in the currently displayed set — the same cached,
+        // base-mode-selected subset the projects panel indexes into — so the
+        // tasks preview tracks the cursor. The id is extracted and re-resolved by
+        // id so the returned borrow is tied to `self.model`, not a temporary.
+        let want_archived_boards = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
         let highlighted_id: Option<Uuid> = self.selection.board.get().and_then(|idx| {
             self.model
-                .boards()
-                .iter()
-                .filter(|b| archived_ids.contains(&b.id) == want_archived)
-                .nth(idx)
+                .displayed_boards(want_archived_boards)
+                .get(idx)
                 .map(|b| b.id)
         });
         let board_id: Option<Uuid> = self.selection.active_board_id.or(highlighted_id);

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -31,8 +31,11 @@ pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
     let mut lines = vec![];
     // The archived-boards view shows the archived board heads in the projects
     // panel (mirroring how ArchivedCardsView shows archived cards in the tasks
-    // panel); everywhere else it shows the LIVE boards.
-    let archived_view = app.mode == AppMode::ArchivedBoardsView;
+    // panel); everywhere else it shows the LIVE boards. Keyed on the stack-aware
+    // base mode so a confirm dialog opened over the archived view keeps the
+    // archived heads + "Archived Projects" title as the underlay (matching
+    // `displayed_boards()`), rather than flipping to the live set under the modal.
+    let archived_view = matches!(app.get_base_mode(), AppMode::ArchivedBoardsView);
     let boards = app.displayed_boards();
 
     if boards.is_empty() {

--- a/crates/kanban-tui/tests/displayed_accessor_tests.rs
+++ b/crates/kanban-tui/tests/displayed_accessor_tests.rs
@@ -1,0 +1,185 @@
+//! KAN-933 (ARCH-DECOR T1c): the single consumption accessor pair
+//! `App::displayed_cards()` / `App::displayed_boards()` that selects the
+//! live-vs-archived subset of the unified collection, keyed on the STACK-AWARE
+//! base mode (so a confirm dialog opened over an archived view still resolves
+//! the archived set — the underlay-bug regression guard).
+
+use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+
+/// Seed a board with a live card and an archived card. Returns
+/// (live_card_id, archived_card_id).
+fn seed_live_and_archived_card(app: &mut App) -> (uuid::Uuid, uuid::Uuid) {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let live = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Archived".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.prepare_frame();
+    (live.id, archived.id)
+}
+
+/// Seed a live board and an archived board. Returns (live_id, archived_id).
+fn seed_live_and_archived_board(app: &mut App) -> (uuid::Uuid, uuid::Uuid) {
+    let live = app.ctx.create_board("Live".to_string(), None).unwrap();
+    let archived = app.ctx.create_board("Archived".to_string(), None).unwrap();
+    app.ctx.archive_board(archived.id).unwrap();
+    app.prepare_frame();
+    (live.id, archived.id)
+}
+
+#[test]
+fn test_displayed_cards_liveonly_excludes_archived() {
+    let mut app = App::test_default();
+    let (live_id, archived_id) = seed_live_and_archived_card(&mut app);
+
+    app.mode = AppMode::Normal;
+    app.prepare_frame();
+
+    let displayed: Vec<uuid::Uuid> = app.displayed_cards().iter().map(|c| c.id).collect();
+    assert!(
+        displayed.contains(&live_id),
+        "live view shows the live card"
+    );
+    assert!(
+        !displayed.contains(&archived_id),
+        "live view excludes the archived card"
+    );
+}
+
+#[test]
+fn test_displayed_cards_archived_view_only_archived() {
+    let mut app = App::test_default();
+    let (live_id, archived_id) = seed_live_and_archived_card(&mut app);
+
+    app.mode = AppMode::ArchivedCardsView;
+    app.prepare_frame();
+
+    let displayed: Vec<uuid::Uuid> = app.displayed_cards().iter().map(|c| c.id).collect();
+    assert_eq!(
+        displayed,
+        vec![archived_id],
+        "archived view shows only the archived card"
+    );
+    assert!(
+        !displayed.contains(&live_id),
+        "archived view excludes the live card"
+    );
+}
+
+#[test]
+fn test_displayed_boards_liveonly_excludes_archived() {
+    let mut app = App::test_default();
+    let (live_id, archived_id) = seed_live_and_archived_board(&mut app);
+
+    app.mode = AppMode::Normal;
+    app.prepare_frame();
+
+    let displayed: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
+    assert!(
+        displayed.contains(&live_id),
+        "live view shows the live board"
+    );
+    assert!(
+        !displayed.contains(&archived_id),
+        "live view excludes the archived board"
+    );
+}
+
+#[test]
+fn test_displayed_boards_archived_view_only_archived() {
+    let mut app = App::test_default();
+    let (live_id, archived_id) = seed_live_and_archived_board(&mut app);
+
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+
+    let displayed: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
+    assert_eq!(
+        displayed,
+        vec![archived_id],
+        "archived view shows only the archived board"
+    );
+    assert!(
+        !displayed.contains(&live_id),
+        "archived view excludes the live board"
+    );
+}
+
+#[test]
+fn test_displayed_boards_set_uses_base_mode_under_dialog() {
+    // Underlay-bug regression guard: with a confirm dialog open OVER the archived
+    // boards view (mode == Dialog(..), base == ArchivedBoardsView), the accessor
+    // must still resolve the ARCHIVED set — not the live set that raw `app.mode`
+    // would (wrongly) select while the modal is up.
+    let mut app = App::test_default();
+    let (live_id, archived_id) = seed_live_and_archived_board(&mut app);
+
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    // Open a confirm dialog over the archived view.
+    app.open_dialog(DialogMode::DeletePermanentBoardConfirm);
+    assert!(
+        matches!(app.mode, AppMode::Dialog(_)),
+        "dialog is the raw mode"
+    );
+    assert_eq!(
+        app.get_base_mode(),
+        &AppMode::ArchivedBoardsView,
+        "base mode is still the archived view under the dialog"
+    );
+
+    let displayed: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
+    assert_eq!(
+        displayed,
+        vec![archived_id],
+        "under a dialog, displayed_boards still yields the archived set (base mode)"
+    );
+    assert!(
+        !displayed.contains(&live_id),
+        "under a dialog, the live board must not leak into the archived view"
+    );
+}
+
+#[test]
+fn test_displayed_cards_set_uses_base_mode_under_dialog() {
+    // Same underlay-bug guard for the card side: a confirm dialog over the
+    // archived CARDS view keeps `displayed_cards()` on the archived subset.
+    let mut app = App::test_default();
+    let (live_id, archived_id) = seed_live_and_archived_card(&mut app);
+
+    app.mode = AppMode::ArchivedCardsView;
+    app.prepare_frame();
+    app.open_dialog(DialogMode::DeletePermanentBoardConfirm);
+    assert!(matches!(app.mode, AppMode::Dialog(_)));
+    assert_eq!(app.get_base_mode(), &AppMode::ArchivedCardsView);
+
+    let displayed: Vec<uuid::Uuid> = app.displayed_cards().iter().map(|c| c.id).collect();
+    assert_eq!(
+        displayed,
+        vec![archived_id],
+        "under a dialog, displayed_cards still yields the archived set (base mode)"
+    );
+    assert!(!displayed.contains(&live_id));
+}


### PR DESCRIPTION
## KAN-933 (ARCH-DECOR T1c)

Parent: KAN-922 (T1). Depends on T1a (KAN-931, cards) and T1b (KAN-932, boards), both merged. Layer: TUI consumption accessor.

Consolidates the live-vs-archived subset selection into **one consumption accessor per entity** — `App::displayed_cards()` / `App::displayed_boards()` — with the three properties folded in from the T1a/T1b reviews.

### 1. No per-frame recompute / clone
`load_from_snapshot` now partitions the unified `cards`/`boards` collections into live/archived subsets **once** (snapshot-on-open) into cached `Vec`s on the `Model`. `Model::displayed_{cards,boards}(want_archived)` serves the cached subset as a **borrow** (`&[Card]` / `&[Board]`).

This replaces:
- the two interim per-frame `.filter(...).cloned().collect()` inline selectors in `prepare_frame` (one for cards, one for the board fallback), and
- the owned-Vec `displayed_boards()` that cloned every board on each redraw plus at ~16 `.len()` / `.is_empty()` / `.get(idx)` call sites.

**Approach: cache-on-load** (not borrowing-iterator). The view-strategy consumer (`ViewRefreshContext.all_cards: &[Card]` → `CardQueryBuilder::new(cards: &[Card], ...)` in `kanban-domain`) requires a contiguous slice, so an iterator would have forced a cross-crate signature change; the cached `&[Card]` slice plugs into the existing borrow field with zero downstream change. This matches the card's EXECUTION NOTE ("computed ON SNAPSHOT-LOAD ... returned as a BORROW").

### 2. Stack-aware mode (underlay-bug fix)
`want_archived` derives from `get_base_mode()`, not raw `app.mode`. So while a confirm dialog is open over an archived view (`mode == Dialog(..)`, base `== Archived*View`), the accessor still resolves the **archived** set.

This fixes a real pre-existing bug: `render_projects_panel` keyed off raw `app.mode`, so it showed the LIVE set + "Projects" title as the underlay under a modal. It and the projects panel now route through `get_base_mode()` / the accessor, mirroring the outer render dispatch at `ui/mod.rs`.

### 3. Consolidate
Both inline `prepare_frame` filters and the owned-Vec `displayed_boards()` collapse into the single accessor pair. No duplicated live/archived predicate remains.

## Tests (Red → Green)
- `test_displayed_cards_liveonly_excludes_archived` / `_archived_view_only_archived`; same for boards.
- `test_displayed_boards_set_uses_base_mode_under_dialog` / `test_displayed_cards_set_uses_base_mode_under_dialog` — underlay-bug regression guards (dialog open over archived view still yields the archived set). Verified the board guard **fails** when the accessor is reverted to raw `app.mode`.
- `test_displayed_{cards,boards}_partition_cached_on_load` (Model unit) — the partition is built in `load_from_snapshot`, not per frame.

`cargo test -p kanban-tui` green (0 failed), `cargo clippy -p kanban-tui --all-targets -D warnings` clean, `cargo fmt --check` clean. Existing card/board render, `archive_delete_tests`, and `archive_board_view_tests` stay green.