### PR TITLE
KAN-935 feat(tui): archived board view via shared panel + extension (LSP)

### DIFF
--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -466,6 +466,7 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => self.handle_navigation_down(),
             KeyCode::Char('k') | KeyCode::Up => self.handle_navigation_up(),
             KeyCode::Char('G') => self.handle_jump_to_bottom(),
+            KeyCode::Char('S') => self.handle_open_settings(),
             KeyCode::Char('u') => {
                 if let Err(e) = self.undo() {
                     self.set_error(format!("Undo failed: {e}"));

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1104,4 +1104,153 @@ mod tests {
 
         assert_eq!(app.selection.active_board_id, None);
     }
+
+    // KAN-935: extension keys + underlay-mode correctness
+
+    /// Permanent-delete keeps a confirm dialog. Pressing `x` in the archived view
+    /// opens `DeletePermanentBoardConfirm` (pushed over the archived view, so the
+    /// base mode stays `ArchivedBoardsView` and the underlay still shows the
+    /// archived set); confirming actually removes the board and its subtree.
+    #[test]
+    fn test_permanent_delete_confirm_in_archived_view() {
+        let mut app = App::test_default();
+        let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "Arch");
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        // `x` opens the confirm dialog rather than deleting immediately.
+        app.handle_archived_boards_view_mode(KeyCode::Char('x'));
+        assert_eq!(
+            app.mode,
+            AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm),
+            "x opens the permanent-delete confirm dialog"
+        );
+        // Underlay fix: base mode (what the projects panel renders) is still the
+        // archived set while the modal is open, not the live set.
+        assert_eq!(
+            *app.get_base_mode(),
+            AppMode::ArchivedBoardsView,
+            "confirm dialog is pushed over the archived view (base mode preserved)"
+        );
+        assert!(
+            app.ctx
+                .list_archived_boards()
+                .unwrap()
+                .iter()
+                .any(|ab| ab.entity_id == arch_board_id),
+            "board still present until the confirm is accepted"
+        );
+
+        // Confirm removes the board entirely.
+        app.handle_delete_permanent_board_confirm_popup(KeyCode::Enter);
+        assert_eq!(app.mode, AppMode::ArchivedBoardsView, "dialog closed");
+        assert!(
+            app.ctx
+                .list_archived_boards()
+                .unwrap()
+                .iter()
+                .all(|ab| ab.entity_id != arch_board_id),
+            "board permanently deleted after confirm"
+        );
+        assert!(
+            app.ctx
+                .data_store()
+                .list_all_columns()
+                .unwrap()
+                .iter()
+                .all(|c| c.board_id != arch_board_id),
+            "board's subtree deleted with it"
+        );
+    }
+
+    /// Cancelling the permanent-delete confirm keeps the archived board.
+    #[test]
+    fn test_permanent_delete_confirm_cancel_keeps_board() {
+        let mut app = App::test_default();
+        let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "Arch");
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        app.handle_archived_boards_view_mode(KeyCode::Char('x'));
+        app.handle_delete_permanent_board_confirm_popup(KeyCode::Esc);
+
+        assert_eq!(
+            app.mode,
+            AppMode::ArchivedBoardsView,
+            "back to archived view"
+        );
+        assert!(
+            app.ctx
+                .list_archived_boards()
+                .unwrap()
+                .iter()
+                .any(|ab| ab.entity_id == arch_board_id),
+            "board intact after cancel"
+        );
+    }
+
+    /// The LIVE projects panel excludes archived boards. `displayed_boards()` in
+    /// Normal mode returns only the live set, so an archived board never leaks into
+    /// the live list (the sole data-source distinction).
+    #[test]
+    fn test_live_projects_panel_excludes_archived_boards() {
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Live");
+        let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "Arch");
+
+        app.mode = AppMode::Normal;
+        app.focus.active = Focus::Boards;
+        app.prepare_frame();
+
+        let displayed: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
+        assert!(
+            displayed.iter().all(|id| *id != arch_board_id),
+            "archived board must not appear in the live projects panel"
+        );
+        assert!(
+            app.displayed_boards().iter().any(|b| b.name == "Live"),
+            "live board is still shown"
+        );
+
+        // Toggling to the archived view flips the set (and only the set).
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        assert!(
+            app.displayed_boards().iter().any(|b| b.id == arch_board_id),
+            "archived board appears once the panel is toggled to the archived set"
+        );
+    }
+
+    /// Drilling into an archived board reuses the SAME activation handler a live
+    /// board uses (Enter/Space → `handle_selection_activate`) and, from the
+    /// archived boards LIST, `S` opens settings through the SAME shared handler as
+    /// the live list — proving no archival branching in the operation handlers.
+    #[test]
+    fn test_archived_board_drill_in_and_settings_use_shared_handlers() {
+        let mut app = App::test_default();
+        let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "Arch");
+
+        // Drill-in: the archived board becomes THE active board via the shared
+        // activation handler (no archival-specific entry point).
+        open_archived_board(&mut app);
+        assert_eq!(app.focus.active, Focus::Cards, "drilled into the board");
+        assert_eq!(app.selection.active_board_id, Some(arch_board_id));
+
+        // Back to the archived boards list; `S` dispatched through the archived
+        // view's key handler opens settings via the SHARED handler, board-set-
+        // agnostic (same as from the live projects panel) — proving the dispatch
+        // delegates rather than intercepting.
+        app.handle_escape_key();
+        assert_eq!(app.focus.active, Focus::Boards);
+        app.handle_archived_boards_view_mode(KeyCode::Char('S'));
+        assert_eq!(
+            app.mode,
+            AppMode::Settings,
+            "settings opens from the archived boards list like the live one"
+        );
+    }
 }

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -185,53 +185,67 @@ impl KeybindingProvider for ArchivedCardsViewProvider {
 
 pub struct ArchivedBoardsViewProvider;
 
+impl ArchivedBoardsViewProvider {
+    /// The live-panel actions the archived view REUSES verbatim (same key, same
+    /// handler, delegated through `handle_shared_boards_key`). The archived
+    /// provider is derived from `NormalModeBoardsProvider` by keeping exactly
+    /// these bindings and appending the extension/toggle keys, so navigation,
+    /// drill-in, settings and undo/redo can never drift from the live panel.
+    /// Live-only operations (create/rename/edit/export/import, the `d` archive,
+    /// the `D` toggle) are intentionally NOT reused: they are no-ops or
+    /// misbehave against the archived set, so they are curated out here.
+    const REUSED_ACTIONS: &'static [KeybindingAction] = &[
+        KeybindingAction::ShowHelp,
+        KeybindingAction::NavigateDown,
+        KeybindingAction::NavigateUp,
+        KeybindingAction::JumpToTop,
+        KeybindingAction::JumpToBottom,
+        KeybindingAction::SelectItem,
+        KeybindingAction::Undo,
+        KeybindingAction::Redo,
+        KeybindingAction::OpenSettings,
+    ];
+}
+
 impl KeybindingProvider for ArchivedBoardsViewProvider {
     fn get_context(&self) -> KeybindingContext {
-        KeybindingContext::new(
-            "Archived Projects View",
-            vec![
-                Keybinding::new("?", "help", "Show help", KeybindingAction::ShowHelp),
-                Keybinding::new(
-                    "j/↓",
-                    "down",
-                    "Navigate down",
-                    KeybindingAction::NavigateDown,
-                ),
-                Keybinding::new("k/↑", "up", "Navigate up", KeybindingAction::NavigateUp),
-                Keybinding::new("gg", "top", "Jump to top", KeybindingAction::JumpToTop),
-                Keybinding::new(
-                    "G",
-                    "bottom",
-                    "Jump to bottom",
-                    KeybindingAction::JumpToBottom,
-                ),
-                Keybinding::new(
-                    "r",
-                    "restore",
-                    "Restore selected project",
-                    KeybindingAction::RestoreBoard,
-                ),
-                Keybinding::new(
-                    "x",
-                    "delete",
-                    "Permanently delete selected project",
-                    KeybindingAction::DeleteArchivedBoard,
-                ),
-                Keybinding::new(
-                    "q/Esc",
-                    "back",
-                    "Back to projects view",
-                    KeybindingAction::Escape,
-                ),
-                Keybinding::new("u", "undo", "Undo last action", KeybindingAction::Undo),
-                Keybinding::new(
-                    "U",
-                    "redo",
-                    "Redo last undone action",
-                    KeybindingAction::Redo,
-                ),
-            ],
-        )
+        // Delegate to the live projects provider and keep only the shared
+        // bindings, then append the archived-view extension (restore /
+        // permanent-delete) and the toggle-back binding. This mirrors the card
+        // side: the archived view IS the ordinary panel on a different set plus a
+        // small extension, not a hand-maintained parallel list.
+        let live = NormalModeBoardsProvider.get_context();
+        let mut bindings: Vec<Keybinding> = live
+            .bindings
+            .into_iter()
+            .filter(|b| Self::REUSED_ACTIONS.contains(&b.action))
+            .collect();
+
+        bindings.extend([
+            Keybinding::new(
+                "r",
+                "restore",
+                "Restore selected project",
+                KeybindingAction::RestoreBoard,
+            ),
+            Keybinding::new(
+                "x",
+                "delete",
+                "Permanently delete selected project",
+                KeybindingAction::DeleteArchivedBoard,
+            ),
+            // Reused binding whose archived-view behavior DIFFERS from the live
+            // panel's `q` (quit): here it toggles back to the live projects list.
+            // The help text describes the actual behavior.
+            Keybinding::new(
+                "q/Esc",
+                "back",
+                "Back to projects view",
+                KeybindingAction::Escape,
+            ),
+        ]);
+
+        KeybindingContext::new("Archived Projects View", bindings)
     }
 }
 

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -277,6 +277,80 @@ mod tests {
             .any(|b| b.key == "x" && b.action == KeybindingAction::DeleteArchivedBoard));
     }
 
+    /// The archived-boards view is the ordinary projects panel showing a
+    /// different SET: it reuses the shared navigation/activation bindings that the
+    /// dispatch delegates to `handle_shared_boards_key`, rather than hand-rolling a
+    /// divergent list that can drift from the live panel.
+    #[test]
+    fn test_archived_boards_provider_reuses_shared_navigation_bindings() {
+        let ctx = ArchivedBoardsViewProvider.get_context();
+        let has = |action: KeybindingAction| ctx.bindings.iter().any(|b| b.action == action);
+        assert!(has(KeybindingAction::NavigateDown), "j/↓ navigate down");
+        assert!(has(KeybindingAction::NavigateUp), "k/↑ navigate up");
+        assert!(has(KeybindingAction::JumpToTop), "gg jump to top");
+        assert!(has(KeybindingAction::JumpToBottom), "G jump to bottom");
+        assert!(has(KeybindingAction::Undo), "u undo");
+        assert!(has(KeybindingAction::Redo), "U redo");
+    }
+
+    /// Drilling into an archived board is the SAME activation the live panel uses
+    /// (Enter/Space → `handle_selection_activate`). It must be advertised so help
+    /// describes the real behavior, not a truncated one.
+    #[test]
+    fn test_archived_boards_provider_advertises_drill_in_activation() {
+        let ctx = ArchivedBoardsViewProvider.get_context();
+        assert!(
+            ctx.bindings
+                .iter()
+                .any(|b| b.key == "Enter/Space" && b.action == KeybindingAction::SelectItem),
+            "archived view must advertise Enter/Space drill-in (shared activation)"
+        );
+    }
+
+    /// Live-only board operations that the archived dispatch does NOT handle must
+    /// be EXCLUDED from the provider, so help never advertises a binding that is a
+    /// no-op (or misbehaves) in the archived view. This is the curation half of
+    /// the LSP contract: the archived view substitutes for the live panel only on
+    /// the bindings that actually apply.
+    #[test]
+    fn test_archived_boards_provider_excludes_live_only_operations() {
+        let ctx = ArchivedBoardsViewProvider.get_context();
+        for action in [
+            KeybindingAction::CreateBoard,
+            KeybindingAction::DeleteBoard,
+            KeybindingAction::EditBoard,
+            KeybindingAction::ExportBoard,
+            KeybindingAction::ExportAll,
+            KeybindingAction::ImportBoard,
+            KeybindingAction::ToggleArchivedBoardsView,
+        ] {
+            assert!(
+                !ctx.bindings.iter().any(|b| b.action == action),
+                "live-only action {action:?} must not be advertised in the archived view"
+            );
+        }
+    }
+
+    /// In the archived view `q`/`Esc` do NOT quit the app: they toggle back to the
+    /// live projects list. The help text for the reused binding must describe that
+    /// actual behavior, not the live panel's "quit".
+    #[test]
+    fn test_archived_board_help_describes_toggle() {
+        let ctx = ArchivedBoardsViewProvider.get_context();
+        let back = ctx
+            .bindings
+            .iter()
+            .find(|b| b.key == "q/Esc")
+            .expect("archived view binds q/Esc");
+        assert_eq!(back.action, KeybindingAction::Escape);
+        let desc = back.description.to_lowercase();
+        assert!(
+            desc.contains("projects") && !desc.contains("quit"),
+            "q/Esc help must describe toggling back to projects, not quitting; got {:?}",
+            back.description
+        );
+    }
+
     #[test]
     fn test_delete_board_action_is_distinct_from_delete_column() {
         assert_ne!(


### PR DESCRIPTION
## What

Completes ARCH-DECOR **T2b** (KAN-935): audit and finish the archived-BOARD view to the same LSP bar as the card side (T2a). The archived-boards view is now the ordinary projects panel fed the archived set (via the base-mode-aware `displayed_boards()` from T1c) plus decoration and the restore / permanent-delete extension, driven through the shared board handlers. No operation or render handler branches on archival except the data source, styling, and the `r`/`x` extension.

## Context

KAN-911 (merged) already unified active-board resolution and made archived boards drillable, and T1c made `displayed_boards()` / `prepare_frame` / `render_projects_panel` key off `get_base_mode()`. This card closes the remaining board-side fork: the keybinding provider.

## What was already LSP-clean (from KAN-911 / T1)

- `handle_archived_boards_view_mode` already intercepts only the extension/toggle keys and delegates the rest to `handle_shared_boards_key` (shared navigation / activation / undo-redo).
- Drill-in, edit, rename, delete-board all resolve through `displayed_boards()` and the shared handlers already.
- The panel-under-dialog underlay already keys off `get_base_mode()` (the T1c REVIEW FINDING was already fixed): `displayed_boards()`, `prepare_frame`, and `render_projects_panel` all use the stack-aware base mode. This PR adds a test proving it holds for the `DeletePermanentBoardConfirm` dialog pushed over the archived view.

## What this PR changes

- **`ArchivedBoardsViewProvider` now delegates** to `NormalModeBoardsProvider` and keeps only the reusable shared bindings (help, navigation, `Enter/Space` drill-in, `S` settings, undo/redo), then appends the `r` restore / `x` permanent-delete extension and the toggle-back `q/Esc`. It was previously a hand-rolled, divergent list that under-advertised the real behavior (no drill-in, no settings) and could drift from the live panel. Live-only ops (create / rename / edit / export / import, the `d` archive, the `D` toggle) are curated out so help never advertises a binding that is a no-op against the archived set.
- **`S` (settings) routed through `handle_shared_boards_key`** so the archived list reaches the same board-agnostic settings handler as the live panel.

## Curation (closed by construction)

- Live-only board ops are excluded from the provider rather than allowed to leak and misbehave.
- `q`/`Esc` help now describes the actual archived-view behavior (toggle back to projects), not the live panel's "quit".

## Tests (Red → Green)

- `test_archived_boards_provider_advertises_drill_in_activation` (was red)
- `test_archived_board_drill_in_and_settings_use_shared_handlers` (was red)
- `test_archived_boards_provider_reuses_shared_navigation_bindings`
- `test_archived_boards_provider_excludes_live_only_operations`
- `test_archived_board_help_describes_toggle`
- `test_permanent_delete_confirm_in_archived_view` (opens confirm dialog; base mode stays `ArchivedBoardsView`; confirm deletes board + subtree)
- `test_permanent_delete_confirm_cancel_keeps_board`
- `test_live_projects_panel_excludes_archived_boards`

## Gates

`cargo test -p kanban-tui` green (299 lib + all integration suites), `cargo clippy -p kanban-tui --all-targets -D warnings` clean, `cargo fmt --check` clean.