### PR TITLE
KAN-934 feat(tui): archived card view via shared panel + extension (LSP), closes #414 findings

### DIFF
--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -85,223 +85,21 @@ impl App {
             return false;
         }
 
+        // Edit (`e`) on the cards panel launches the external editor, which needs
+        // the terminal — pre-intercepted here (where the terminal is in scope) for
+        // BOTH the live Normal view and the archived-cards view, so edit works
+        // identically on a live or archived card and the shared Normal/archived
+        // dispatch below stays terminal-free (and unit-testable).
+        if matches!(key.code, KeyCode::Char('e'))
+            && self.focus.active == Focus::Cards
+            && matches!(self.mode, AppMode::Normal | AppMode::ArchivedCardsView)
+        {
+            self.pending_key = None;
+            return self.handle_edit_card_key(terminal, event_handler);
+        }
+
         match self.mode {
-            AppMode::Normal => match key.code {
-                KeyCode::Char('/') => {
-                    self.pending_key = None;
-                    if self.focus.active == Focus::Cards {
-                        self.filter.search.activate();
-                        self.mode = AppMode::Search;
-                    }
-                }
-                KeyCode::Char('g') => {
-                    if self.pending_key == Some('g') {
-                        self.pending_key = None;
-                        self.handle_jump_to_top();
-                    } else {
-                        self.pending_key = Some('g');
-                    }
-                }
-                KeyCode::Char('G') => {
-                    self.pending_key = None;
-                    self.handle_jump_to_bottom();
-                }
-                KeyCode::Char('{') => {
-                    self.pending_key = None;
-                    self.handle_jump_half_viewport_up();
-                }
-                KeyCode::Char('}') => {
-                    self.pending_key = None;
-                    self.handle_jump_half_viewport_down();
-                }
-                KeyCode::Char('n') => {
-                    self.pending_key = None;
-                    match self.focus.active {
-                        Focus::Boards => self.handle_create_board_key(),
-                        Focus::Cards => self.handle_create_card_key(),
-                    }
-                }
-                KeyCode::Char('r') => {
-                    self.pending_key = None;
-                    self.handle_rename_board_key();
-                }
-                KeyCode::Char('e') => {
-                    self.pending_key = None;
-                    match self.focus.active {
-                        Focus::Boards => self.handle_edit_board_key(),
-                        Focus::Cards => {
-                            should_restart_events =
-                                self.handle_edit_card_key(terminal, event_handler);
-                        }
-                    }
-                }
-                KeyCode::Char('x') => {
-                    self.pending_key = None;
-                    self.handle_export_board_key();
-                }
-                KeyCode::Char('X') => {
-                    self.pending_key = None;
-                    self.handle_export_all_key();
-                }
-                KeyCode::Char('d') => {
-                    self.pending_key = None;
-                    // Mirror the card removal flow: `d` is the primary removal
-                    // action on both panels (delete a board / archive a card).
-                    match self.focus.active {
-                        Focus::Boards => self.handle_delete_board_key(),
-                        Focus::Cards => self.handle_archive_card(),
-                    }
-                }
-                KeyCode::Char('D') => {
-                    self.pending_key = None;
-                    // `D` toggles the archived view of the focused panel: the
-                    // archived-cards view on the cards panel, the archived-boards
-                    // view on the boards panel.
-                    match self.focus.active {
-                        Focus::Cards => self.handle_toggle_archived_cards_view(),
-                        Focus::Boards => self.handle_toggle_archived_boards_view(),
-                    }
-                }
-                KeyCode::Char('i') => {
-                    self.pending_key = None;
-                    self.handle_import_board_key();
-                }
-                KeyCode::Char('a') => {
-                    self.pending_key = None;
-                    self.handle_assign_to_sprint_key();
-                }
-                KeyCode::Char('c') => {
-                    self.pending_key = None;
-                    self.handle_toggle_card_completion();
-                }
-                KeyCode::Char('s') => {
-                    self.pending_key = None;
-                    if self.focus.active == Focus::Cards {
-                        self.handle_manage_children_from_list();
-                    }
-                }
-                KeyCode::Char('o') => {
-                    self.pending_key = None;
-                    self.handle_order_cards_key();
-                }
-                KeyCode::Char('O') => {
-                    self.pending_key = None;
-                    self.handle_toggle_sort_order_key();
-                }
-                KeyCode::Char('T') => {
-                    self.pending_key = None;
-                    self.handle_open_filter_dialog();
-                }
-                KeyCode::Char('t') => {
-                    self.pending_key = None;
-                    self.handle_toggle_sprint_filter();
-                }
-                KeyCode::Char('v') => {
-                    self.pending_key = None;
-                    self.handle_card_selection_toggle();
-                }
-                KeyCode::Char('V') => {
-                    self.pending_key = None;
-                    self.handle_toggle_task_list_view();
-                }
-                KeyCode::Char('p') => {
-                    self.pending_key = None;
-                    if self.focus.active == Focus::Cards {
-                        self.handle_set_card_priority_key();
-                    }
-                }
-                KeyCode::Char('P') => {
-                    self.pending_key = None;
-                    self.handle_set_selected_cards_priority();
-                }
-                KeyCode::Char('H') => {
-                    self.pending_key = None;
-                    self.handle_move_card_left();
-                }
-                KeyCode::Char('L') => {
-                    self.pending_key = None;
-                    self.handle_move_card_right();
-                }
-                KeyCode::Char('h') => {
-                    self.pending_key = None;
-                    self.handle_kanban_column_left();
-                }
-                KeyCode::Char('l') => {
-                    self.pending_key = None;
-                    self.handle_kanban_column_right();
-                }
-                KeyCode::Char('1') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(0);
-                }
-                KeyCode::Char('2') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(1);
-                }
-                KeyCode::Char('3') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(2);
-                }
-                KeyCode::Char('4') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(3);
-                }
-                KeyCode::Char('5') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(4);
-                }
-                KeyCode::Char('6') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(5);
-                }
-                KeyCode::Char('7') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(6);
-                }
-                KeyCode::Char('8') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(7);
-                }
-                KeyCode::Char('9') => {
-                    self.pending_key = None;
-                    self.handle_column_or_focus_switch(8);
-                }
-                KeyCode::Esc => {
-                    self.pending_key = None;
-                    self.handle_escape_key();
-                }
-                KeyCode::Char('j') | KeyCode::Down => {
-                    self.pending_key = None;
-                    self.handle_navigation_down();
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    self.pending_key = None;
-                    self.handle_navigation_up();
-                }
-                KeyCode::Enter | KeyCode::Char(' ') => {
-                    self.pending_key = None;
-                    self.handle_selection_activate();
-                }
-                KeyCode::Char('u') => {
-                    self.pending_key = None;
-                    if let Err(e) = self.undo() {
-                        self.set_error(format!("Undo failed: {}", e));
-                    }
-                }
-                KeyCode::Char('U') => {
-                    self.pending_key = None;
-                    if let Err(e) = self.redo() {
-                        self.set_error(format!("Redo failed: {}", e));
-                    }
-                }
-                KeyCode::Char('S') => {
-                    self.pending_key = None;
-                    self.handle_open_settings();
-                }
-                _ => {
-                    self.pending_key = None;
-                }
-            },
+            AppMode::Normal => self.handle_normal_key(key.code),
             AppMode::CardDetail => {
                 should_restart_events =
                     self.handle_card_detail_key(key.code, terminal, event_handler);
@@ -374,6 +172,231 @@ impl App {
         should_restart_events
     }
 
+    /// Shared Normal-mode key dispatch for the cards/boards panels. Extracted so
+    /// the archived-cards view can delegate every non-extension key to the SAME
+    /// handlers a live card uses (LSP): an archived card is substitutable for a
+    /// live one in detail/priority/move/sprint-assign. Terminal-free — edit
+    /// (`e`), the only key that launches the external editor, is pre-intercepted
+    /// in `handle_key_event` where the terminal is in scope.
+    fn handle_normal_key(&mut self, key_code: crossterm::event::KeyCode) {
+        use crossterm::event::KeyCode;
+        match key_code {
+            KeyCode::Char('/') => {
+                self.pending_key = None;
+                if self.focus.active == Focus::Cards {
+                    self.filter.search.activate();
+                    self.mode = AppMode::Search;
+                }
+            }
+            KeyCode::Char('g') => {
+                if self.pending_key == Some('g') {
+                    self.pending_key = None;
+                    self.handle_jump_to_top();
+                } else {
+                    self.pending_key = Some('g');
+                }
+            }
+            KeyCode::Char('G') => {
+                self.pending_key = None;
+                self.handle_jump_to_bottom();
+            }
+            KeyCode::Char('{') => {
+                self.pending_key = None;
+                self.handle_jump_half_viewport_up();
+            }
+            KeyCode::Char('}') => {
+                self.pending_key = None;
+                self.handle_jump_half_viewport_down();
+            }
+            KeyCode::Char('n') => {
+                self.pending_key = None;
+                match self.focus.active {
+                    Focus::Boards => self.handle_create_board_key(),
+                    Focus::Cards => self.handle_create_card_key(),
+                }
+            }
+            KeyCode::Char('r') => {
+                self.pending_key = None;
+                self.handle_rename_board_key();
+            }
+            KeyCode::Char('e') => {
+                self.pending_key = None;
+                // Cards-panel edit launches the external editor and is
+                // pre-intercepted in `handle_key_event` (terminal in scope);
+                // only the boards-panel edit reaches this shared dispatch.
+                if self.focus.active == Focus::Boards {
+                    self.handle_edit_board_key();
+                }
+            }
+            KeyCode::Char('x') => {
+                self.pending_key = None;
+                self.handle_export_board_key();
+            }
+            KeyCode::Char('X') => {
+                self.pending_key = None;
+                self.handle_export_all_key();
+            }
+            KeyCode::Char('d') => {
+                self.pending_key = None;
+                // Mirror the card removal flow: `d` is the primary removal
+                // action on both panels (delete a board / archive a card).
+                match self.focus.active {
+                    Focus::Boards => self.handle_delete_board_key(),
+                    Focus::Cards => self.handle_archive_card(),
+                }
+            }
+            KeyCode::Char('D') => {
+                self.pending_key = None;
+                // `D` toggles the archived view of the focused panel: the
+                // archived-cards view on the cards panel, the archived-boards
+                // view on the boards panel.
+                match self.focus.active {
+                    Focus::Cards => self.handle_toggle_archived_cards_view(),
+                    Focus::Boards => self.handle_toggle_archived_boards_view(),
+                }
+            }
+            KeyCode::Char('i') => {
+                self.pending_key = None;
+                self.handle_import_board_key();
+            }
+            KeyCode::Char('a') => {
+                self.pending_key = None;
+                self.handle_assign_to_sprint_key();
+            }
+            KeyCode::Char('c') => {
+                self.pending_key = None;
+                self.handle_toggle_card_completion();
+            }
+            KeyCode::Char('s') => {
+                self.pending_key = None;
+                if self.focus.active == Focus::Cards {
+                    self.handle_manage_children_from_list();
+                }
+            }
+            KeyCode::Char('o') => {
+                self.pending_key = None;
+                self.handle_order_cards_key();
+            }
+            KeyCode::Char('O') => {
+                self.pending_key = None;
+                self.handle_toggle_sort_order_key();
+            }
+            KeyCode::Char('T') => {
+                self.pending_key = None;
+                self.handle_open_filter_dialog();
+            }
+            KeyCode::Char('t') => {
+                self.pending_key = None;
+                self.handle_toggle_sprint_filter();
+            }
+            KeyCode::Char('v') => {
+                self.pending_key = None;
+                self.handle_card_selection_toggle();
+            }
+            KeyCode::Char('V') => {
+                self.pending_key = None;
+                self.handle_toggle_task_list_view();
+            }
+            KeyCode::Char('p') => {
+                self.pending_key = None;
+                if self.focus.active == Focus::Cards {
+                    self.handle_set_card_priority_key();
+                }
+            }
+            KeyCode::Char('P') => {
+                self.pending_key = None;
+                self.handle_set_selected_cards_priority();
+            }
+            KeyCode::Char('H') => {
+                self.pending_key = None;
+                self.handle_move_card_left();
+            }
+            KeyCode::Char('L') => {
+                self.pending_key = None;
+                self.handle_move_card_right();
+            }
+            KeyCode::Char('h') => {
+                self.pending_key = None;
+                self.handle_kanban_column_left();
+            }
+            KeyCode::Char('l') => {
+                self.pending_key = None;
+                self.handle_kanban_column_right();
+            }
+            KeyCode::Char('1') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(0);
+            }
+            KeyCode::Char('2') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(1);
+            }
+            KeyCode::Char('3') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(2);
+            }
+            KeyCode::Char('4') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(3);
+            }
+            KeyCode::Char('5') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(4);
+            }
+            KeyCode::Char('6') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(5);
+            }
+            KeyCode::Char('7') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(6);
+            }
+            KeyCode::Char('8') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(7);
+            }
+            KeyCode::Char('9') => {
+                self.pending_key = None;
+                self.handle_column_or_focus_switch(8);
+            }
+            KeyCode::Esc => {
+                self.pending_key = None;
+                self.handle_escape_key();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.pending_key = None;
+                self.handle_navigation_down();
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.pending_key = None;
+                self.handle_navigation_up();
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                self.pending_key = None;
+                self.handle_selection_activate();
+            }
+            KeyCode::Char('u') => {
+                self.pending_key = None;
+                if let Err(e) = self.undo() {
+                    self.set_error(format!("Undo failed: {}", e));
+                }
+            }
+            KeyCode::Char('U') => {
+                self.pending_key = None;
+                if let Err(e) = self.redo() {
+                    self.set_error(format!("Redo failed: {}", e));
+                }
+            }
+            KeyCode::Char('S') => {
+                self.pending_key = None;
+                self.handle_open_settings();
+            }
+            _ => {
+                self.pending_key = None;
+            }
+        }
+    }
+
     fn handle_search_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
         match key_code {
@@ -394,6 +417,14 @@ impl App {
         }
     }
 
+    /// Key handling for the archived-cards view. The archived list is an ordinary
+    /// cards panel showing a different SET; navigation, detail, edit, priority,
+    /// move and sprint-assign all reuse the SAME shared handlers as the live cards
+    /// panel via `handle_normal_key` (LSP: an archived card is substitutable for a
+    /// live one). Only the consumption-site keys differ: `r` restores and `x`
+    /// permanently deletes the highlighted archived card(s), and `Esc`/`q` toggles
+    /// back to the live set. Create (`n`) is intercepted and dropped — an archived
+    /// list is not where new cards are created (would make an invisible live card).
     pub fn handle_archived_cards_view_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
         if self.focus.active != Focus::Cards {
@@ -401,18 +432,23 @@ impl App {
         }
 
         match key_code {
+            // Archived extension keys.
             KeyCode::Char('r') => self.handle_restore_card(),
             KeyCode::Char('x') => self.handle_delete_card_permanent(),
+            // Toggle back to the live set.
             KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {
                 self.handle_toggle_archived_cards_view();
             }
-            KeyCode::Char('v') => self.handle_card_selection_toggle(),
-            KeyCode::Char('V') => self.handle_toggle_task_list_view(),
-            KeyCode::Char('h') => self.handle_kanban_column_left(),
-            KeyCode::Char('l') => self.handle_kanban_column_right(),
-            KeyCode::Char('j') | KeyCode::Down => self.handle_navigation_down(),
-            KeyCode::Char('k') | KeyCode::Up => self.handle_navigation_up(),
-            _ => {}
+            // Create makes no sense from an archived list — drop it so it never
+            // creates an invisible live card (#414 finding 1).
+            KeyCode::Char('n') => {}
+            // Everything else reuses the shared Normal-mode card dispatch:
+            // navigation, detail, priority, move, sprint-assign — proving an
+            // archived card is operated exactly like a live one. (Edit `e` is
+            // pre-intercepted in `handle_key_event` for both views.)
+            other => {
+                self.handle_normal_key(other);
+            }
         }
     }
 

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -1,3 +1,4 @@
+use super::card_list::CardListProvider;
 use super::{Keybinding, KeybindingAction, KeybindingContext, KeybindingProvider};
 
 pub struct NormalModeBoardsProvider;
@@ -110,76 +111,45 @@ impl KeybindingProvider for NormalModeBoardsProvider {
 pub struct ArchivedCardsViewProvider;
 
 impl KeybindingProvider for ArchivedCardsViewProvider {
+    /// The archived-cards view is the ordinary card panel showing a different
+    /// SET, so it DELEGATES to `CardListProvider` and inherits the full card-list
+    /// bindings (LSP) — an archived card is operated exactly like a live one. It
+    /// then adjusts only where behaviour differs:
+    /// - drops create (`n`): an archived list is not where new cards are created
+    ///   (would make an invisible live card — #414 finding 1);
+    /// - drops the live `q` (quit) and `Esc` (clear selection) bindings, whose
+    ///   keys instead toggle back to the live set here, and re-advertises them as
+    ///   the toggle (#414 finding 3);
+    /// - appends the archived extension: `r` restore, `x` permanent-delete.
     fn get_context(&self) -> KeybindingContext {
-        KeybindingContext::new(
-            "Archived Cards View",
-            vec![
-                Keybinding::new("?", "help", "Show help", KeybindingAction::ShowHelp),
-                Keybinding::new(
-                    "j/↓",
-                    "down",
-                    "Navigate down",
-                    KeybindingAction::NavigateDown,
-                ),
-                Keybinding::new("k/↑", "up", "Navigate up", KeybindingAction::NavigateUp),
-                Keybinding::new("gg", "top", "Jump to top", KeybindingAction::JumpToTop),
-                Keybinding::new(
-                    "G",
-                    "bottom",
-                    "Jump to bottom",
-                    KeybindingAction::JumpToBottom,
-                ),
-                Keybinding::new(
-                    "{",
-                    "half up",
-                    "Jump half viewport up",
-                    KeybindingAction::JumpHalfViewportUp,
-                ),
-                Keybinding::new(
-                    "}",
-                    "half down",
-                    "Jump half viewport down",
-                    KeybindingAction::JumpHalfViewportDown,
-                ),
-                Keybinding::new(
-                    "r",
-                    "restore",
-                    "Restore selected task(s)",
-                    KeybindingAction::RestoreCard,
-                ),
-                Keybinding::new(
-                    "x",
-                    "delete",
-                    "Delete selected task(s)",
-                    KeybindingAction::DeleteCard,
-                ),
-                Keybinding::new(
-                    "v",
-                    "select",
-                    "Select task for bulk operation",
-                    KeybindingAction::ToggleCardSelection,
-                ),
-                Keybinding::new(
-                    "V",
-                    "view",
-                    "Toggle task list view",
-                    KeybindingAction::ToggleTaskListView,
-                ),
-                Keybinding::new(
-                    "q/Esc",
-                    "back",
-                    "Back to normal view",
-                    KeybindingAction::Escape,
-                ),
-                Keybinding::new("u", "undo", "Undo last action", KeybindingAction::Undo),
-                Keybinding::new(
-                    "U",
-                    "redo",
-                    "Redo last undone action",
-                    KeybindingAction::Redo,
-                ),
-            ],
-        )
+        let mut bindings = CardListProvider.get_context().bindings;
+
+        // Reused keys whose behaviour differs in the archived view: create is not
+        // offered; `q`/`Esc` toggle back rather than quit/clear.
+        bindings.retain(|b| b.key != "n" && b.key != "q" && b.key != "Esc");
+
+        // Archived extension keys.
+        bindings.push(Keybinding::new(
+            "r",
+            "restore",
+            "Restore selected task(s)",
+            KeybindingAction::RestoreCard,
+        ));
+        bindings.push(Keybinding::new(
+            "x",
+            "delete",
+            "Permanently delete selected task(s)",
+            KeybindingAction::DeleteCard,
+        ));
+        // Reconciled toggle-back text (not "Quit" / "clear selection").
+        bindings.push(Keybinding::new(
+            "q/Esc",
+            "back",
+            "Back to live tasks view",
+            KeybindingAction::Escape,
+        ));
+
+        KeybindingContext::new("Archived Cards View", bindings)
     }
 }
 

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -318,7 +318,7 @@ impl RenderStrategy for SinglePanelRenderer {
             .with_focus_indicator(&title)
             .focused(app.focus.active == crate::app::Focus::Cards);
 
-        if app.mode == crate::app::AppMode::ArchivedCardsView
+        if *app.get_base_mode() == crate::app::AppMode::ArchivedCardsView
             && app.focus.active == crate::app::Focus::Cards
         {
             panel_config = panel_config.with_custom_border_style(deleted_view_focused_border());
@@ -477,7 +477,9 @@ impl RenderStrategy for MultiPanelRenderer {
                         .with_focus_indicator(&title)
                         .focused(app.focus.active == crate::app::Focus::Cards && is_focused_column);
 
-                    if app.mode == crate::app::AppMode::ArchivedCardsView && is_focused_column {
+                    if *app.get_base_mode() == crate::app::AppMode::ArchivedCardsView
+                        && is_focused_column
+                    {
                         panel_config =
                             panel_config.with_custom_border_style(deleted_view_focused_border());
                     }

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -111,7 +111,12 @@ pub fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
         .selection
         .active_board_id
         .is_some_and(|id| app.model.archived_board_ids().contains(&id));
-    let mut title = if app.mode == AppMode::ArchivedCardsView {
+    // Stack-aware: key off the base mode so a confirm dialog opened OVER the
+    // archived-cards view keeps the "Archive" title as the underlay, rather than
+    // flipping to the live "Tasks" title while the modal is open (#428 / #414
+    // finding 4). Matches `displayed_cards()`, which selects the set the same way.
+    let viewing_archived_cards = *app.get_base_mode() == AppMode::ArchivedCardsView;
+    let mut title = if viewing_archived_cards {
         format!("Archive [{}]", count)
     } else if viewing_archived_board {
         format!("[ARCHIVED] Tasks [2] ({})", count)
@@ -121,7 +126,7 @@ pub fn build_tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
         "Tasks".to_string()
     };
 
-    if with_filter_suffix && app.mode != AppMode::ArchivedCardsView {
+    if with_filter_suffix && !viewing_archived_cards {
         if let Some(suffix) = build_filter_title_suffix(app) {
             title.push_str(&suffix);
         }

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -1,0 +1,374 @@
+//! KAN-934: the archived-CARD view is the ordinary card panel fed the archived
+//! SET + archived decoration + the restore/delete extension, through the SAME
+//! shared handlers a live card uses.
+//!
+//! These tests drive an ARCHIVED card, from the archived-cards view, through the
+//! exact shared card handlers/dispatch a live card uses — detail, priority,
+//! sprint-assign, move — and assert the behaviour is identical, plus the archived
+//! extension (restore / permanent-delete). They also close the #414 review
+//! findings: `n` (create) is not offered from the archived view, the help text
+//! describes the toggle-back for `q`/`Esc`, and the tasks-panel title keys off
+//! the stack-aware base mode (correct under a modal underlay).
+
+use crossterm::event::KeyCode;
+use kanban_domain::{CardPriority, CreateCardOptions, KanbanOperations};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::keybindings::card_list::CardListProvider;
+use kanban_tui::keybindings::normal_mode::ArchivedCardsViewProvider;
+use kanban_tui::keybindings::KeybindingProvider;
+use kanban_tui::App;
+
+/// Seed a board with two columns and a card, archive the card, then enter the
+/// archived-cards view with that card selected. Returns (board_id, col1, col2,
+/// card_id).
+fn seed_archived_card(app: &mut App) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid, uuid::Uuid) {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col1 = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let col2 = app
+        .ctx
+        .create_column(board.id, "Doing".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            col1.id,
+            "ArchiveMe".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::ArchivedCardsView;
+    app.focus.active = Focus::Cards;
+    app.prepare_frame();
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+    (board.id, col1.id, col2.id, card.id)
+}
+
+/// Enter (detail) from the archived list must open CardDetail on the archived
+/// card via the SHARED activation handler — not be swallowed by the archived
+/// dispatch.
+#[test]
+fn test_archived_card_detail_via_shared_handler_opens_detail() {
+    let mut app = App::test_default();
+    let (_, _, _, card_id) = seed_archived_card(&mut app);
+
+    app.handle_archived_cards_view_mode(KeyCode::Enter);
+
+    assert_eq!(
+        app.mode,
+        AppMode::CardDetail,
+        "Enter from the archived list opens card detail via the shared handler"
+    );
+    assert_eq!(
+        app.selection.active_card_id,
+        Some(card_id),
+        "detail resolves the archived card by id"
+    );
+}
+
+/// `p` (set priority) from the archived list opens the priority dialog on the
+/// archived card and, driven to Enter, changes the card's real state.
+#[test]
+fn test_archived_card_priority_via_shared_handler_changes_state() {
+    let mut app = App::test_default();
+    let (_, _, _, card_id) = seed_archived_card(&mut app);
+
+    // Baseline priority.
+    let before = app.model.card_by_id(card_id).unwrap().priority;
+    assert_ne!(before, CardPriority::Critical, "precondition: not Critical");
+
+    // `p` opens the priority dialog targeting the archived card.
+    app.handle_archived_cards_view_mode(KeyCode::Char('p'));
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(kanban_tui::app::DialogMode::SetCardPriority),
+        "`p` opens the shared priority dialog from the archived view"
+    );
+
+    // Select "Critical" (index 3) and apply.
+    app.dialog_input.priority_selection.set(Some(3));
+    app.handle_set_card_priority_popup(KeyCode::Enter);
+    app.prepare_frame();
+
+    assert_eq!(
+        app.model.card_by_id(card_id).unwrap().priority,
+        CardPriority::Critical,
+        "priority change on an archived card takes real effect via the shared handler"
+    );
+}
+
+/// `a` (assign-to-sprint) from the archived list opens the shared sprint-assign
+/// dialog targeting the archived card.
+#[test]
+fn test_archived_card_sprint_assign_via_shared_handler_opens_dialog() {
+    let mut app = App::test_default();
+    let (board_id, _, _, card_id) = seed_archived_card(&mut app);
+    // A sprint must exist for the assign dialog to open.
+    app.ctx.create_sprint(board_id, None, None).unwrap();
+    app.prepare_frame();
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('a'));
+
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(kanban_tui::app::DialogMode::AssignCardToSprint),
+        "`a` opens the shared sprint-assign dialog from the archived view"
+    );
+    assert_eq!(
+        app.selection.active_card_id,
+        Some(card_id),
+        "sprint-assign targets the archived card"
+    );
+}
+
+/// Edit/detail resolve the archived card via the shared active-card resolver —
+/// proving those operations are archival-agnostic. Enter activates the archived
+/// card, then the shared detail-view resolver returns it (the same resolver the
+/// edit handler reads).
+#[test]
+fn test_archived_card_detail_resolver_finds_archived_card() {
+    let mut app = App::test_default();
+    let (_, _, _, card_id) = seed_archived_card(&mut app);
+
+    app.handle_archived_cards_view_mode(KeyCode::Enter);
+
+    assert_eq!(
+        app.selection.active_card_id,
+        Some(card_id),
+        "the shared active-card resolver finds the archived card"
+    );
+    let card = app
+        .get_card_for_detail_view()
+        .expect("archived card resolves for detail/edit");
+    assert_eq!(card.title, "ArchiveMe");
+}
+
+/// Move (`L`) from the archived list moves the archived card to the next column
+/// coherently (C1's coherent service semantics), via the shared move handler.
+#[test]
+fn test_move_in_archived_view_matches_c1() {
+    let mut app = App::test_default();
+    let (_, col1, col2, card_id) = seed_archived_card(&mut app);
+
+    assert_eq!(
+        app.model.card_by_id(card_id).unwrap().column_id,
+        col1,
+        "precondition: archived card starts in col1"
+    );
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('L'));
+    app.prepare_frame();
+
+    assert_eq!(
+        app.model.card_by_id(card_id).unwrap().column_id,
+        col2,
+        "moving right from the archived view lands the card in col2 (coherent), \
+         not a wrong/live-only-computed column"
+    );
+}
+
+/// #414 finding 1: `n` (create card) must NOT create an invisible live card
+/// from the archived view. It is excluded — no dialog opens, no card is created.
+#[test]
+fn test_create_not_offered_in_archived_view() {
+    let mut app = App::test_default();
+    let (_, _, _, _) = seed_archived_card(&mut app);
+    let live_before = app.model.cards().len();
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('n'));
+
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedCardsView,
+        "`n` must not open the create-card dialog from the archived view"
+    );
+    app.prepare_frame();
+    assert_eq!(
+        app.model.cards().len(),
+        live_before,
+        "`n` must not create an invisible live card from the archived view"
+    );
+}
+
+/// `r` (restore) extension: restores the archived card.
+#[test]
+fn test_restore_extension_in_archived_view() {
+    let mut app = App::test_default();
+    let (_, _, _, card_id) = seed_archived_card(&mut app);
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('r'));
+    assert!(
+        app.animation.animating.contains_key(&card_id),
+        "`r` starts the restore animation for the archived card"
+    );
+}
+
+/// `x` (permanent-delete) extension: deletes the archived card.
+#[test]
+fn test_delete_extension_in_archived_view() {
+    let mut app = App::test_default();
+    let (_, _, _, card_id) = seed_archived_card(&mut app);
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('x'));
+    assert!(
+        app.animation.animating.contains_key(&card_id),
+        "`x` starts the permanent-delete animation for the archived card"
+    );
+}
+
+/// The archived-cards provider DELEGATES to the card-list provider (inherits the
+/// full live card bindings) and appends ONLY the restore/delete extension — but
+/// EXCLUDES create (`n`), which makes no sense from an archived list.
+#[test]
+fn test_archived_provider_delegates_and_excludes_create() {
+    let card_ctx = CardListProvider.get_context();
+    let arch_ctx = ArchivedCardsViewProvider.get_context();
+
+    // Inherits shared card-list bindings (e.g. edit, priority, move).
+    for key in ["e", "p", "a", "L", "H"] {
+        assert!(
+            arch_ctx.bindings.iter().any(|b| b.key == key),
+            "archived provider inherits shared card binding `{key}`"
+        );
+    }
+    // Appends the extension keys.
+    assert!(arch_ctx
+        .bindings
+        .iter()
+        .any(|b| b.key == "r" && b.description.to_lowercase().contains("restore")));
+    assert!(arch_ctx
+        .bindings
+        .iter()
+        .any(|b| b.key == "x" && b.description.to_lowercase().contains("delete")));
+
+    // #414 finding 1: create (`n`) is NOT offered from the archived view even
+    // though the shared card provider offers it.
+    assert!(
+        card_ctx.bindings.iter().any(|b| b.key == "n"),
+        "sanity: the live card provider does offer create"
+    );
+    assert!(
+        !arch_ctx.bindings.iter().any(|b| b.key == "n"),
+        "create `n` is excluded from the archived-cards provider"
+    );
+}
+
+/// #414 finding 3: reused bindings whose behaviour differs must describe the
+/// actual behaviour. `q`/`Esc` in the archived view toggle back to the live
+/// set — the help must say so, NOT "Quit"/"clear selection".
+#[test]
+fn test_archived_help_describes_toggle_for_q_and_esc() {
+    let ctx = ArchivedCardsViewProvider.get_context();
+
+    let back = ctx
+        .bindings
+        .iter()
+        .find(|b| b.key.contains("Esc") || b.key.contains('q'))
+        .expect("archived view advertises a q/Esc binding");
+
+    let desc = back.description.to_lowercase();
+    assert!(
+        desc.contains("back") || desc.contains("normal") || desc.contains("live"),
+        "q/Esc must describe the toggle-back, got: {:?}",
+        back.description
+    );
+    assert!(
+        !desc.contains("quit") && !desc.contains("clear"),
+        "q/Esc must not still advertise Quit/clear, got: {:?}",
+        back.description
+    );
+}
+
+/// #414 finding 4 / #428 review: the tasks-panel title keys off the stack-aware
+/// base mode, so a confirm dialog opened OVER the archived view keeps the
+/// "Archive" title rather than flipping to the live "Tasks" title.
+#[test]
+fn test_archived_tasks_panel_title_uses_base_mode_under_dialog() {
+    let mut app = App::test_default();
+    let (_, _, _, _) = seed_archived_card(&mut app);
+
+    let title_plain = kanban_tui::ui::build_tasks_panel_title(&app, false);
+    assert!(
+        title_plain.starts_with("Archive"),
+        "archived view shows the Archive title, got: {title_plain}"
+    );
+
+    // Push a dialog over the archived view: raw `mode` becomes Dialog(..) but the
+    // base mode is still ArchivedCardsView.
+    app.push_mode(AppMode::Dialog(
+        kanban_tui::app::DialogMode::SetCardPriority,
+    ));
+    let title_under_dialog = kanban_tui::ui::build_tasks_panel_title(&app, false);
+    assert!(
+        title_under_dialog.starts_with("Archive"),
+        "the tasks-panel title under a modal must stay Archive (base-mode-aware), \
+         got: {title_under_dialog}"
+    );
+}
+
+/// Guard: the LIVE card list excludes archived cards; they appear only when the
+/// panel is toggled to the archived set.
+#[test]
+fn test_live_card_list_excludes_archived() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let live = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let arch = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Arch".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(arch.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+
+    // Live view: only the live card.
+    app.mode = AppMode::Normal;
+    app.prepare_frame();
+    let live_ids: Vec<_> = app.displayed_cards().iter().map(|c| c.id).collect();
+    assert!(live_ids.contains(&live.id), "live card is shown");
+    assert!(
+        !live_ids.contains(&arch.id),
+        "archived card hidden from the live set"
+    );
+
+    // Archived view: only the archived card.
+    app.mode = AppMode::ArchivedCardsView;
+    app.prepare_frame();
+    let arch_ids: Vec<_> = app.displayed_cards().iter().map(|c| c.id).collect();
+    assert!(
+        arch_ids.contains(&arch.id),
+        "archived card shown in archived set"
+    );
+    assert!(
+        !arch_ids.contains(&live.id),
+        "live card hidden from the archived set"
+    );
+}


### PR DESCRIPTION
## What

Re-lands the card-side archived-view parity (KAN-913, held PR #414) cleanly on the unified card model (T1a/b/c). The archived-CARD view is now the ordinary card panel fed the archived SET + archived decoration + the restore/delete extension, operated through the SAME shared handlers a live card uses. An archived card is substitutable for a live one (LSP): detail, edit, priority, move and sprint-assign all flow through the shared Normal-mode dispatch; only the data source, styling and the `r`/`x` extension key off archival.

Under root KAN-923 (T2). Supersedes and closes KAN-913.

## How

- **One shared dispatch.** Extracted the Normal-mode card/board key dispatch into `handle_normal_key`. `handle_archived_cards_view_mode` intercepts only the extension/toggle keys (`r` restore, `x` permanent-delete, `Esc`/`q` toggle back) and delegates everything else to it. Edit (`e`) launches the external editor and needs the terminal, so it is pre-intercepted in `handle_key_event` for BOTH the live and archived views, keeping the shared dispatch terminal-free and unit-testable.
- **One provider.** `ArchivedCardsViewProvider` delegates to `CardListProvider` (inheriting the full card-list bindings) and appends only the `r`/`x` extension.
- **Data source + styling** flow through the existing base-mode-aware `displayed_cards()` accessor; the tasks-panel title and archived border now key off `get_base_mode()` too.

## Closes #414 review findings (by construction)

1. **Create (`n`) no longer makes an invisible live card.** `n` is dropped from both the archived handler and the archived provider — an archived list is not where new cards are created.
2. **Move (H/L) is coherent.** It goes through the shared move handler, which positions against the correct set (C1's coherent service semantics).
3. **Help text reconciled.** Reused bindings whose behaviour differs are re-advertised: `q`/`Esc` describe the toggle-back to the live set, not "Quit"/"clear selection".
4. **Base-mode under a modal.** `build_tasks_panel_title` and the archived border styling now key off the stack-aware `get_base_mode()`, so a confirm dialog opened over the archived view keeps the "Archive" title/decoration as the underlay instead of flipping to the live set (also closes the #428 pre-existing latent pattern on the card side).

Result: no operation/render handler branches on archival except the data source, styling, and the `r`/`x` extension.

## Tests

New `archived_card_parity_tests.rs` (12 tests) drives an archived card through the shared handlers from the archived view and asserts real state changes (priority applied end-to-end, move lands in the correct column, detail/sprint-assign resolve the archived card), plus the restore/delete extension, the `n`-not-offered and `q`/`Esc`-describes-toggle findings, the base-mode-aware title under a modal, and a guard that the live card list excludes archived cards. Full `kanban-tui` suite green; `clippy -D warnings` and `fmt --check` clean; `kanban-cli` checks clean.
