### PR TITLE
KAN-937 feat(tui): configurable archived-boards sort (position/recency) reusing SortField/SortOrder

### DIFF
--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -17,16 +17,39 @@ pub enum SortField {
     DueDate,
     Status,
     Position,
-    /// Recency of archival. Meaningful for the archived-boards view (the marker
-    /// carries the timestamp; the entity head does not), not for cards.
-    ArchivedAt,
     Default,
+}
+
+/// Sort dimensions for the BOARDS list (the projects panel / archived-boards
+/// view). Deliberately a SEPARATE type from the card [`SortField`]: `ArchivedAt`
+/// is a board-view-only dimension (the archival marker carries the timestamp;
+/// the entity head does not), and it must never be representable as a board's
+/// card `task_sort_field` nor round-trip through the card-sort DTO. Keeping it
+/// its own enum makes that illegal state unrepresentable by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BoardSortField {
+    /// Board order (`Board::position`).
+    Position,
+    /// Recency of archival, resolved from the archival marker's timestamp.
+    ArchivedAt,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SortOrder {
     Ascending,
     Descending,
+}
+
+impl SortOrder {
+    /// The opposite direction. The single definition of the asc↔desc flip,
+    /// reused by every sort-order toggle (card list, archived-boards list).
+    #[must_use]
+    pub fn toggled(self) -> Self {
+        match self {
+            SortOrder::Ascending => SortOrder::Descending,
+            SortOrder::Descending => SortOrder::Ascending,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -365,6 +365,17 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_sort_order_toggled_flips_direction_and_is_involutive() {
+        assert_eq!(SortOrder::Ascending.toggled(), SortOrder::Descending);
+        assert_eq!(SortOrder::Descending.toggled(), SortOrder::Ascending);
+        // Two toggles return to the start (the single flip definition).
+        assert_eq!(
+            SortOrder::Ascending.toggled().toggled(),
+            SortOrder::Ascending
+        );
+    }
+
+    #[test]
     fn test_board_new_accepts_str_literal_without_to_string() {
         let board = Board::new("my-board", Some("KAN"));
         assert_eq!(board.name, "my-board");

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -17,6 +17,9 @@ pub enum SortField {
     DueDate,
     Status,
     Position,
+    /// Recency of archival. Meaningful for the archived-boards view (the marker
+    /// carries the timestamp; the entity head does not), not for cards.
+    ArchivedAt,
     Default,
 }
 

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -70,7 +70,10 @@ pub use search::{
     BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy, TitleSearcher,
 };
 pub use snapshot::Snapshot;
-pub use sort::{get_sorter_for_field, resolve_sort, sort_cards_in_place, OrderedSorter, SortBy};
+pub use sort::{
+    get_sorter_for_field, resolve_sort, sort_boards_in_place, sort_cards_in_place, OrderedSorter,
+    SortBy,
+};
 pub use sprint::{Sprint, SprintId, SprintStatus, SprintUpdate};
 pub use sprint_factory::{NewSprint, SprintRecord};
 pub use sprint_log::SprintLog;

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -37,7 +37,7 @@ pub use archived_board::{ArchivedBoard, ArchivedBoardSummary};
 pub use archived_card::{ArchivedCard, CardRestoreContext};
 pub use board::{
     get_active_sprint_card_prefix_override, get_active_sprint_prefix_override, Board, BoardId,
-    BoardUpdate, SortField, SortOrder,
+    BoardSortField, BoardUpdate, SortField, SortOrder,
 };
 pub use board_factory::{BoardRecord, NewBoard};
 pub use card::{

--- a/crates/kanban-domain/src/sort/boards.rs
+++ b/crates/kanban-domain/src/sort/boards.rs
@@ -1,34 +1,33 @@
 //! Board sorting — the board-side analogue of the card sort primitive.
 //!
-//! Reuses the shared [`SortField`]/[`SortOrder`] enums (the same toggle the
-//! task list uses) rather than a parallel sort mechanism. Boards carry their
-//! own `position`; `archived_at` is NOT on the board head (it lives on the
-//! archival marker), so recency sorting takes an explicit id → timestamp map.
+//! Uses the board-specific [`BoardSortField`] (NOT the card [`crate::SortField`]),
+//! paired with the shared [`SortOrder`] and its toggle. Boards carry their own
+//! `position`; `archived_at` is NOT on the board head (it lives on the archival
+//! marker), so recency sorting takes an explicit id → timestamp map.
 //!
-//! Only the board-meaningful fields are supported ([`SortField::Position`] and
-//! [`SortField::ArchivedAt`]); any other field falls back to position order so
-//! the projects panel never lands in an undefined ordering.
+//! Both [`BoardSortField`] variants are board-meaningful: `Position` (board
+//! order) and `ArchivedAt` (recency). There is no card-only fallback path
+//! because a card-only field cannot be passed here by construction.
 
-use crate::{Board, SortField, SortOrder};
+use crate::{Board, BoardSortField, SortOrder};
 use chrono::{DateTime, Utc};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use uuid::Uuid;
 
-/// Compare two boards on a board-meaningful sort field.
+/// Compare two boards on a board sort field.
 ///
 /// `ArchivedAt` resolves each board's id through `archived_at`; a board with
 /// no entry sorts as the epoch minimum so untracked boards never displace
-/// tracked ones under recency. Any non-board field (a card-only sort key)
-/// falls back to position so ordering is always defined.
+/// tracked ones under recency.
 fn compare_boards(
-    field: SortField,
+    field: BoardSortField,
     a: &Board,
     b: &Board,
     archived_at: &HashMap<Uuid, DateTime<Utc>>,
 ) -> Ordering {
     match field {
-        SortField::ArchivedAt => {
+        BoardSortField::ArchivedAt => {
             let at = |id: &Uuid| {
                 archived_at
                     .get(id)
@@ -37,18 +36,18 @@ fn compare_boards(
             };
             at(&a.id).cmp(&at(&b.id))
         }
-        _ => a.position.cmp(&b.position),
+        BoardSortField::Position => a.position.cmp(&b.position),
     }
 }
 
-/// Sort a slice of boards in place by `field`/`order`, reusing the shared
-/// [`SortField`]/[`SortOrder`] enums. Ties on the primary key are broken by
-/// ascending `position` (kept ascending even under a descending primary so
-/// toggling direction does not reshuffle tied boards), matching the card
-/// sorter's stability guarantee.
+/// Sort a slice of boards in place by `field`/`order`, using the board-specific
+/// [`BoardSortField`] and the shared [`SortOrder`]. Ties on the primary key are
+/// broken by ascending `position` (kept ascending even under a descending
+/// primary so toggling direction does not reshuffle tied boards), matching the
+/// card sorter's stability guarantee.
 pub fn sort_boards_in_place(
     boards: &mut [Board],
-    field: SortField,
+    field: BoardSortField,
     order: SortOrder,
     archived_at: &HashMap<Uuid, DateTime<Utc>>,
 ) {
@@ -85,7 +84,7 @@ mod tests {
         let mut boards = vec![a, b, c];
         sort_boards_in_place(
             &mut boards,
-            SortField::Position,
+            BoardSortField::Position,
             SortOrder::Ascending,
             &empty,
         );
@@ -107,7 +106,7 @@ mod tests {
         let mut boards = vec![older, newer];
         sort_boards_in_place(
             &mut boards,
-            SortField::ArchivedAt,
+            BoardSortField::ArchivedAt,
             SortOrder::Descending,
             &archived_at,
         );
@@ -128,7 +127,7 @@ mod tests {
         let mut boards = vec![newer, older];
         sort_boards_in_place(
             &mut boards,
-            SortField::ArchivedAt,
+            BoardSortField::ArchivedAt,
             SortOrder::Ascending,
             &archived_at,
         );
@@ -152,7 +151,7 @@ mod tests {
         let mut boards = vec![second, first];
         sort_boards_in_place(
             &mut boards,
-            SortField::ArchivedAt,
+            BoardSortField::ArchivedAt,
             SortOrder::Descending,
             &archived_at,
         );

--- a/crates/kanban-domain/src/sort/boards.rs
+++ b/crates/kanban-domain/src/sort/boards.rs
@@ -1,0 +1,63 @@
+//! Board sorting — the board-side analogue of the card sort primitive.
+//!
+//! Reuses the shared [`SortField`]/[`SortOrder`] enums (the same toggle the
+//! task list uses) rather than a parallel sort mechanism. Boards carry their
+//! own `position`; `archived_at` is NOT on the board head (it lives on the
+//! archival marker), so recency sorting takes an explicit id → timestamp map.
+//!
+//! Only the board-meaningful fields are supported ([`SortField::Position`] and
+//! [`SortField::ArchivedAt`]); any other field falls back to position order so
+//! the projects panel never lands in an undefined ordering.
+
+use crate::{Board, SortField, SortOrder};
+use chrono::{DateTime, Utc};
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Compare two boards on a board-meaningful sort field.
+///
+/// `ArchivedAt` resolves each board's id through `archived_at`; a board with
+/// no entry sorts as the epoch minimum so untracked boards never displace
+/// tracked ones under recency. Any non-board field (a card-only sort key)
+/// falls back to position so ordering is always defined.
+fn compare_boards(
+    field: SortField,
+    a: &Board,
+    b: &Board,
+    archived_at: &HashMap<Uuid, DateTime<Utc>>,
+) -> Ordering {
+    match field {
+        SortField::ArchivedAt => {
+            let at = |id: &Uuid| {
+                archived_at
+                    .get(id)
+                    .copied()
+                    .unwrap_or(DateTime::<Utc>::MIN_UTC)
+            };
+            at(&a.id).cmp(&at(&b.id))
+        }
+        _ => a.position.cmp(&b.position),
+    }
+}
+
+/// Sort a slice of boards in place by `field`/`order`, reusing the shared
+/// [`SortField`]/[`SortOrder`] enums. Ties on the primary key are broken by
+/// ascending `position` (kept ascending even under a descending primary so
+/// toggling direction does not reshuffle tied boards), matching the card
+/// sorter's stability guarantee.
+pub fn sort_boards_in_place(
+    boards: &mut [Board],
+    field: SortField,
+    order: SortOrder,
+    archived_at: &HashMap<Uuid, DateTime<Utc>>,
+) {
+    boards.sort_by(|a, b| {
+        let primary = compare_boards(field, a, b, archived_at);
+        let primary = match order {
+            SortOrder::Ascending => primary,
+            SortOrder::Descending => primary.reverse(),
+        };
+        primary.then_with(|| a.position.cmp(&b.position))
+    });
+}

--- a/crates/kanban-domain/src/sort/boards.rs
+++ b/crates/kanban-domain/src/sort/boards.rs
@@ -61,3 +61,104 @@ pub fn sort_boards_in_place(
         primary.then_with(|| a.position.cmp(&b.position))
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn board_at_position(name: &str, position: i32) -> Board {
+        let mut b = Board::new(name, None::<String>);
+        b.position = position;
+        b
+    }
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn test_sort_boards_by_position_matches_board_order() {
+        let a = board_at_position("A", 2);
+        let b = board_at_position("B", 0);
+        let c = board_at_position("C", 1);
+        let empty = HashMap::new();
+        let mut boards = vec![a, b, c];
+        sort_boards_in_place(
+            &mut boards,
+            SortField::Position,
+            SortOrder::Ascending,
+            &empty,
+        );
+        assert_eq!(
+            boards.iter().map(|x| x.name.clone()).collect::<Vec<_>>(),
+            vec!["B", "C", "A"]
+        );
+    }
+
+    #[test]
+    fn test_sort_boards_by_archived_at_descending_is_recency_order() {
+        let older = board_at_position("Older", 0);
+        let newer = board_at_position("Newer", 1);
+        let mut archived_at = HashMap::new();
+        archived_at.insert(older.id, ts("2026-01-01T00:00:00Z"));
+        archived_at.insert(newer.id, ts("2026-06-01T00:00:00Z"));
+
+        // Input in position order (older first); recency-desc must flip it.
+        let mut boards = vec![older, newer];
+        sort_boards_in_place(
+            &mut boards,
+            SortField::ArchivedAt,
+            SortOrder::Descending,
+            &archived_at,
+        );
+        assert_eq!(
+            boards.iter().map(|x| x.name.clone()).collect::<Vec<_>>(),
+            vec!["Newer", "Older"]
+        );
+    }
+
+    #[test]
+    fn test_sort_boards_by_archived_at_ascending_is_oldest_first() {
+        let older = board_at_position("Older", 1);
+        let newer = board_at_position("Newer", 0);
+        let mut archived_at = HashMap::new();
+        archived_at.insert(older.id, ts("2026-01-01T00:00:00Z"));
+        archived_at.insert(newer.id, ts("2026-06-01T00:00:00Z"));
+
+        let mut boards = vec![newer, older];
+        sort_boards_in_place(
+            &mut boards,
+            SortField::ArchivedAt,
+            SortOrder::Ascending,
+            &archived_at,
+        );
+        assert_eq!(
+            boards.iter().map(|x| x.name.clone()).collect::<Vec<_>>(),
+            vec!["Older", "Newer"]
+        );
+    }
+
+    #[test]
+    fn test_sort_boards_ties_break_by_position_ascending() {
+        // Equal archived_at → deterministic position order, even under a
+        // descending primary (tiebreaker stays ascending).
+        let at = Utc::now();
+        let first = board_at_position("First", 0);
+        let second = board_at_position("Second", 1);
+        let mut archived_at = HashMap::new();
+        archived_at.insert(first.id, at);
+        archived_at.insert(second.id, at);
+
+        let mut boards = vec![second, first];
+        sort_boards_in_place(
+            &mut boards,
+            SortField::ArchivedAt,
+            SortOrder::Descending,
+            &archived_at,
+        );
+        assert_eq!(
+            boards.iter().map(|x| x.name.clone()).collect::<Vec<_>>(),
+            vec!["First", "Second"]
+        );
+    }
+}

--- a/crates/kanban-domain/src/sort/mod.rs
+++ b/crates/kanban-domain/src/sort/mod.rs
@@ -124,9 +124,6 @@ pub fn get_sorter_for_field(field: SortField) -> SortBy {
         SortField::DueDate => SortBy::DueDate,
         SortField::Status => SortBy::Status,
         SortField::Position => SortBy::Position,
-        // `ArchivedAt` is a board-view sort dimension (the archival marker
-        // carries the timestamp, cards do not); cards fall back to number order.
-        SortField::ArchivedAt => SortBy::CardNumber,
         SortField::Default => SortBy::CardNumber,
     }
 }

--- a/crates/kanban-domain/src/sort/mod.rs
+++ b/crates/kanban-domain/src/sort/mod.rs
@@ -3,6 +3,10 @@
 //! Provides traits and implementations for sorting cards by various fields.
 //! Used by both TUI and API for consistent sorting behavior.
 
+pub mod boards;
+
+pub use boards::sort_boards_in_place;
+
 use crate::{Card, CardPriority, CardStatus, SortField, SortOrder};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
@@ -120,6 +124,9 @@ pub fn get_sorter_for_field(field: SortField) -> SortBy {
         SortField::DueDate => SortBy::DueDate,
         SortField::Status => SortBy::Status,
         SortField::Position => SortBy::Position,
+        // `ArchivedAt` is a board-view sort dimension (the archival marker
+        // carries the timestamp, cards do not); cards fall back to number order.
+        SortField::ArchivedAt => SortBy::CardNumber,
         SortField::Default => SortBy::CardNumber,
     }
 }

--- a/crates/kanban-service/src/api/v1/enums.rs
+++ b/crates/kanban-service/src/api/v1/enums.rs
@@ -259,6 +259,37 @@ mod tests {
             assert_eq!(SortFieldDto::from(domain), dto);
         }
     }
+
+    /// Guard: the archived-boards recency dimension (`BoardSortField::ArchivedAt`)
+    /// is a SEPARATE domain type from the card `SortField`, so it can never be a
+    /// card sort field nor round-trip through this DTO. This is a compile-time
+    /// guarantee — `SortFieldDto` has no `ArchivedAt` variant and `SortField`
+    /// has no `ArchivedAt` variant — and the serde map below documents the exact
+    /// card-sort wire surface a client can send.
+    #[test]
+    fn test_sort_field_dto_wire_surface_excludes_board_only_recency() {
+        // The complete set of card-sort wire values. `archived_at` is absent by
+        // construction (no variant), so a client cannot persist a board whose
+        // card `task_sort_field` sorts by archival recency.
+        let wire: Vec<String> = [
+            SortFieldDto::Points,
+            SortFieldDto::Priority,
+            SortFieldDto::CreatedAt,
+            SortFieldDto::UpdatedAt,
+            SortFieldDto::DueDate,
+            SortFieldDto::Status,
+            SortFieldDto::Position,
+            SortFieldDto::Default,
+        ]
+        .iter()
+        .map(|dto| serde_json::to_string(dto).unwrap())
+        .collect();
+        assert!(
+            !wire.iter().any(|w| w.contains("archived_at")),
+            "card-sort DTO must not expose a board-only recency dimension"
+        );
+    }
+
     #[test]
     fn test_sort_order_dto_round_trips_through_domain() {
         for dto in [SortOrderDto::Ascending, SortOrderDto::Descending] {

--- a/crates/kanban-service/src/api/v1/enums.rs
+++ b/crates/kanban-service/src/api/v1/enums.rs
@@ -18,7 +18,6 @@ pub enum SortFieldDto {
     DueDate,
     Status,
     Position,
-    ArchivedAt,
     Default,
 }
 
@@ -32,7 +31,6 @@ impl From<SortField> for SortFieldDto {
             SortField::DueDate => Self::DueDate,
             SortField::Status => Self::Status,
             SortField::Position => Self::Position,
-            SortField::ArchivedAt => Self::ArchivedAt,
             SortField::Default => Self::Default,
         }
     }
@@ -48,7 +46,6 @@ impl From<SortFieldDto> for SortField {
             SortFieldDto::DueDate => Self::DueDate,
             SortFieldDto::Status => Self::Status,
             SortFieldDto::Position => Self::Position,
-            SortFieldDto::ArchivedAt => Self::ArchivedAt,
             SortFieldDto::Default => Self::Default,
         }
     }
@@ -262,7 +259,6 @@ mod tests {
             assert_eq!(SortFieldDto::from(domain), dto);
         }
     }
-
     #[test]
     fn test_sort_order_dto_round_trips_through_domain() {
         for dto in [SortOrderDto::Ascending, SortOrderDto::Descending] {

--- a/crates/kanban-service/src/api/v1/enums.rs
+++ b/crates/kanban-service/src/api/v1/enums.rs
@@ -18,6 +18,7 @@ pub enum SortFieldDto {
     DueDate,
     Status,
     Position,
+    ArchivedAt,
     Default,
 }
 
@@ -31,6 +32,7 @@ impl From<SortField> for SortFieldDto {
             SortField::DueDate => Self::DueDate,
             SortField::Status => Self::Status,
             SortField::Position => Self::Position,
+            SortField::ArchivedAt => Self::ArchivedAt,
             SortField::Default => Self::Default,
         }
     }
@@ -46,6 +48,7 @@ impl From<SortFieldDto> for SortField {
             SortFieldDto::DueDate => Self::DueDate,
             SortFieldDto::Status => Self::Status,
             SortFieldDto::Position => Self::Position,
+            SortFieldDto::ArchivedAt => Self::ArchivedAt,
             SortFieldDto::Default => Self::Default,
         }
     }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -470,6 +470,7 @@ impl App {
         match key_code {
             KeyCode::Char('r') => self.handle_restore_board(),
             KeyCode::Char('x') => self.handle_delete_archived_board_key(),
+            KeyCode::Char('s') => self.handle_toggle_archived_boards_sort_order(),
             KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q')
                 if self.selection.active_board_id.is_none() =>
             {

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -97,6 +97,9 @@ impl App {
             KeybindingAction::ToggleArchivedBoardsView => self.handle_toggle_archived_boards_view(),
             KeybindingAction::RestoreBoard => self.handle_restore_board(),
             KeybindingAction::DeleteArchivedBoard => self.handle_delete_archived_board(),
+            KeybindingAction::ToggleArchivedBoardsSortOrder => {
+                self.handle_toggle_archived_boards_sort_order()
+            }
             KeybindingAction::ToggleTaskListView => self.handle_toggle_task_list_view(),
             KeybindingAction::ToggleCardSelection => self.handle_card_selection_toggle(),
             KeybindingAction::ClearCardSelection => self.handle_clear_card_selection(),

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -461,6 +461,113 @@ mod tests {
         assert_eq!(archived_ids, vec![archived_id]);
     }
 
+    fn seed_two_archived_boards(m: &mut Model) -> (Uuid, Uuid) {
+        // `first` sits at position 0 but was archived EARLIER; `second` sits at
+        // position 1 but was archived LATER. Position order and recency order
+        // therefore disagree, so the two orderings are distinguishable.
+        use kanban_domain::Archived;
+        let mut first = Board::new("First", None::<String>);
+        first.position = 0;
+        let mut second = Board::new("Second", None::<String>);
+        second.position = 1;
+        let first_id = first.id;
+        let second_id = second.id;
+        let t_old = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let t_new = chrono::DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        m.load_from_snapshot(Snapshot {
+            boards: vec![first, second],
+            archived_boards: vec![
+                Archived::at(first_id, t_old),
+                Archived::at(second_id, t_new),
+            ],
+            ..Default::default()
+        });
+        (first_id, second_id)
+    }
+
+    #[test]
+    fn test_archived_boards_default_order_is_recency() {
+        // Default archived-boards order is archived_at DESC (newest first),
+        // the conventional trash/history UX — NOT position order.
+        let mut m = Model::default();
+        let (first_id, second_id) = seed_two_archived_boards(&mut m);
+        let order: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
+        assert_eq!(
+            order,
+            vec![second_id, first_id],
+            "newest-archived (second) must come first by default"
+        );
+    }
+
+    #[test]
+    fn test_archived_boards_sort_by_position_matches_board_order() {
+        let mut m = Model::default();
+        let (first_id, second_id) = seed_two_archived_boards(&mut m);
+        m.set_archived_boards_sort(
+            kanban_domain::SortField::Position,
+            kanban_domain::SortOrder::Ascending,
+        );
+        let order: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
+        assert_eq!(
+            order,
+            vec![first_id, second_id],
+            "position order restores board order (first at pos 0)"
+        );
+    }
+
+    #[test]
+    fn test_toggle_reverses_archived_boards_order() {
+        // The shared SortOrder toggle flips the archived-boards order. From the
+        // default (recency DESC) a toggle yields recency ASC (oldest first).
+        let mut m = Model::default();
+        let (first_id, second_id) = seed_two_archived_boards(&mut m);
+        let before: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
+        assert_eq!(before, vec![second_id, first_id]);
+
+        m.toggle_archived_boards_sort_order();
+        let after: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
+        assert_eq!(
+            after,
+            vec![first_id, second_id],
+            "toggle reverses to oldest-archived first"
+        );
+    }
+
+    #[test]
+    fn test_live_projects_panel_order_is_position_unaffected_by_archived_sort() {
+        // Guard: the LIVE panel stays in position order regardless of the
+        // archived-boards sort dimension/direction.
+        use kanban_domain::Archived;
+        let mut m = Model::default();
+        let mut live_a = Board::new("LiveA", None::<String>);
+        live_a.position = 0;
+        let mut live_b = Board::new("LiveB", None::<String>);
+        live_b.position = 1;
+        let mut archived = Board::new("Archived", None::<String>);
+        archived.position = 2;
+        let a_id = live_a.id;
+        let b_id = live_b.id;
+        let arch_id = archived.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![live_a, live_b, archived],
+            archived_boards: vec![Archived::now(arch_id)],
+            ..Default::default()
+        });
+
+        // Toggle / re-sort the archived dimension; live order must not move.
+        m.toggle_archived_boards_sort_order();
+        m.set_archived_boards_sort(
+            kanban_domain::SortField::ArchivedAt,
+            kanban_domain::SortOrder::Ascending,
+        );
+        let live: Vec<Uuid> = m.displayed_boards(false).iter().map(|b| b.id).collect();
+        assert_eq!(live, vec![a_id, b_id], "live panel stays in position order");
+    }
+
     #[test]
     fn test_default_model_returns_empty_archived_board_slices() {
         let m = Model::default();

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -1,10 +1,11 @@
+use chrono::{DateTime, Utc};
 use kanban_domain::{
-    ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, Snapshot, Sprint,
+    sort_boards_in_place, ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph,
+    Snapshot, SortField, SortOrder, Sprint,
 };
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
-#[derive(Default)]
 pub struct Model {
     boards: Option<Vec<Board>>,
     columns: Option<Vec<Column>>,
@@ -25,7 +26,42 @@ pub struct Model {
     displayed_cards_archived: Vec<Card>,
     displayed_boards_live: Vec<Board>,
     displayed_boards_archived: Vec<Board>,
+    // archived_at timestamps keyed by board id, harvested from the archival
+    // markers on load. The board head does NOT carry archived_at (it stays live
+    // under the reference-marker model), so recency sorting needs this side map.
+    archived_board_at: HashMap<Uuid, DateTime<Utc>>,
+    // Sort dimension for the ARCHIVED projects panel, reusing the shared
+    // SortField/SortOrder (the same enums + toggle the task list uses). Defaults
+    // to archived_at DESC — the conventional trash/history "newest first" UX the
+    // #428 review flagged as lost. The LIVE panel is always position order.
+    archived_boards_sort_field: SortField,
+    archived_boards_sort_order: SortOrder,
     graph: DependencyGraph,
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        Self {
+            boards: None,
+            columns: None,
+            cards: None,
+            card_index: HashMap::new(),
+            board_index: HashMap::new(),
+            sprints: None,
+            archived_cards: None,
+            archived_card_ids: HashSet::new(),
+            archived_boards: None,
+            archived_board_ids: HashSet::new(),
+            displayed_cards_live: Vec::new(),
+            displayed_cards_archived: Vec::new(),
+            displayed_boards_live: Vec::new(),
+            displayed_boards_archived: Vec::new(),
+            archived_board_at: HashMap::new(),
+            archived_boards_sort_field: SortField::ArchivedAt,
+            archived_boards_sort_order: SortOrder::Descending,
+            graph: DependencyGraph::default(),
+        }
+    }
 }
 
 impl Model {
@@ -48,15 +84,15 @@ impl Model {
             .filter(|b| !self.archived_board_ids.contains(&b.id))
     }
 
-    /// The ARCHIVED heads (unified collection filtered to the archived-id set),
-    /// in board order. This is what the ArchivedBoardsView renders and what its
-    /// restore / permanent-delete affordances index into — resolved directly
-    /// from the id set so it is independent of the transient `AppMode` (a confirm
-    /// dialog opened over the archived view must still resolve the archived head).
+    /// The ARCHIVED heads in the CONFIGURED archived-boards order (default
+    /// archived_at DESC — newest first). This is what the ArchivedBoardsView
+    /// renders AND what its restore / permanent-delete affordances index into:
+    /// both read this same cached, sorted partition so the rendered row and the
+    /// selected id stay consistent under any sort. Independent of the transient
+    /// `AppMode` (a confirm dialog opened over the archived view still resolves
+    /// the archived head), because it reads the cached partition, not the mode.
     pub fn archived_boards_view(&self) -> impl Iterator<Item = &Board> {
-        self.boards()
-            .iter()
-            .filter(|b| self.archived_board_ids.contains(&b.id))
+        self.displayed_boards_archived.iter()
     }
 
     pub fn columns(&self) -> &[Column] {
@@ -128,6 +164,32 @@ impl Model {
         }
     }
 
+    /// The current archived-boards sort dimension (reused `SortField`/`SortOrder`).
+    pub fn archived_boards_sort(&self) -> (SortField, SortOrder) {
+        (
+            self.archived_boards_sort_field,
+            self.archived_boards_sort_order,
+        )
+    }
+
+    /// Set the archived-boards sort field/order and re-sort the cached archived
+    /// partition in place. The live partition is untouched (stays position order).
+    pub fn set_archived_boards_sort(&mut self, field: SortField, order: SortOrder) {
+        self.archived_boards_sort_field = field;
+        self.archived_boards_sort_order = order;
+        self.sort_archived_partition();
+    }
+
+    /// Flip the archived-boards sort ORDER, reusing the shared `SortOrder` toggle
+    /// (the same asc↔desc flip the card list uses), keeping the current field.
+    pub fn toggle_archived_boards_sort_order(&mut self) {
+        let next = match self.archived_boards_sort_order {
+            SortOrder::Ascending => SortOrder::Descending,
+            SortOrder::Descending => SortOrder::Ascending,
+        };
+        self.set_archived_boards_sort(self.archived_boards_sort_field, next);
+    }
+
     /// Resolve a board by id from the single unified collection (live AND
     /// archived heads). One index lookup — no live/archived re-join. It is
     /// deliberately archival-agnostic: a board is a board regardless of whether
@@ -171,6 +233,13 @@ impl Model {
             .iter()
             .map(|ab| ab.entity_id)
             .collect();
+        // Harvest archived_at per board id so the archived-boards panel can sort
+        // by recency (the head does not carry it; the marker does).
+        self.archived_board_at = snapshot
+            .archived_boards
+            .iter()
+            .map(|ab| (ab.entity_id, ab.metadata.archived_at))
+            .collect();
 
         let boards = snapshot.boards;
         self.board_index.clear();
@@ -208,8 +277,24 @@ impl Model {
             .iter()
             .cloned()
             .partition(|b| self.archived_board_ids.contains(&b.id));
+        // Live panel stays in board (position) order — unchanged. The archived
+        // panel is sorted by the configured dimension (default archived_at DESC).
         self.displayed_boards_live = live_boards;
         self.displayed_boards_archived = archived_boards;
+        self.sort_archived_partition();
+    }
+
+    /// Sort the cached archived-boards partition by the configured
+    /// `SortField`/`SortOrder`, reusing the shared board sort primitive. Called
+    /// on load and whenever the sort dimension changes, so the rendered list and
+    /// the selection resolver (both read this partition) stay consistent.
+    fn sort_archived_partition(&mut self) {
+        sort_boards_in_place(
+            &mut self.displayed_boards_archived,
+            self.archived_boards_sort_field,
+            self.archived_boards_sort_order,
+            &self.archived_board_at,
+        );
     }
 }
 

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use kanban_domain::{
-    sort_boards_in_place, ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph,
-    Snapshot, SortField, SortOrder, Sprint,
+    sort_boards_in_place, ArchivedBoard, ArchivedCard, Board, BoardSortField, Card, Column,
+    DependencyGraph, Snapshot, SortOrder, Sprint,
 };
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
@@ -26,15 +26,20 @@ pub struct Model {
     displayed_cards_archived: Vec<Card>,
     displayed_boards_live: Vec<Board>,
     displayed_boards_archived: Vec<Board>,
-    // archived_at timestamps keyed by board id, harvested from the archival
-    // markers on load. The board head does NOT carry archived_at (it stays live
-    // under the reference-marker model), so recency sorting needs this side map.
+    // archived_at timestamps keyed by board id, REBUILT from the archival
+    // markers on every `load_from_snapshot`. The board head does NOT carry
+    // archived_at (it stays live under the reference-marker model), so recency
+    // sorting needs this side map. Because it is rebuilt from the markers each
+    // load — and every archive/restore/permanent-delete handler calls
+    // `prepare_frame` (→ `load_from_snapshot`) after mutating the set — it
+    // cannot go stale relative to the archived partition it sorts.
     archived_board_at: HashMap<Uuid, DateTime<Utc>>,
-    // Sort dimension for the ARCHIVED projects panel, reusing the shared
-    // SortField/SortOrder (the same enums + toggle the task list uses). Defaults
-    // to archived_at DESC — the conventional trash/history "newest first" UX the
-    // #428 review flagged as lost. The LIVE panel is always position order.
-    archived_boards_sort_field: SortField,
+    // Sort dimension for the ARCHIVED projects panel: the board-specific
+    // `BoardSortField` (NOT the card `SortField`) paired with the shared
+    // `SortOrder` toggle. Defaults to archived_at DESC — the conventional
+    // trash/history "newest first" UX the #428 review flagged as lost. The LIVE
+    // panel is always position order.
+    archived_boards_sort_field: BoardSortField,
     archived_boards_sort_order: SortOrder,
     graph: DependencyGraph,
 }
@@ -57,7 +62,7 @@ impl Default for Model {
             displayed_boards_live: Vec::new(),
             displayed_boards_archived: Vec::new(),
             archived_board_at: HashMap::new(),
-            archived_boards_sort_field: SortField::ArchivedAt,
+            archived_boards_sort_field: BoardSortField::ArchivedAt,
             archived_boards_sort_order: SortOrder::Descending,
             graph: DependencyGraph::default(),
         }
@@ -164,8 +169,8 @@ impl Model {
         }
     }
 
-    /// The current archived-boards sort dimension (reused `SortField`/`SortOrder`).
-    pub fn archived_boards_sort(&self) -> (SortField, SortOrder) {
+    /// The current archived-boards sort dimension (`BoardSortField`/`SortOrder`).
+    pub fn archived_boards_sort(&self) -> (BoardSortField, SortOrder) {
         (
             self.archived_boards_sort_field,
             self.archived_boards_sort_order,
@@ -174,19 +179,16 @@ impl Model {
 
     /// Set the archived-boards sort field/order and re-sort the cached archived
     /// partition in place. The live partition is untouched (stays position order).
-    pub fn set_archived_boards_sort(&mut self, field: SortField, order: SortOrder) {
+    pub fn set_archived_boards_sort(&mut self, field: BoardSortField, order: SortOrder) {
         self.archived_boards_sort_field = field;
         self.archived_boards_sort_order = order;
         self.sort_archived_partition();
     }
 
-    /// Flip the archived-boards sort ORDER, reusing the shared `SortOrder` toggle
+    /// Flip the archived-boards sort ORDER via the shared `SortOrder::toggled`
     /// (the same asc↔desc flip the card list uses), keeping the current field.
     pub fn toggle_archived_boards_sort_order(&mut self) {
-        let next = match self.archived_boards_sort_order {
-            SortOrder::Ascending => SortOrder::Descending,
-            SortOrder::Descending => SortOrder::Ascending,
-        };
+        let next = self.archived_boards_sort_order.toggled();
         self.set_archived_boards_sort(self.archived_boards_sort_field, next);
     }
 
@@ -285,7 +287,7 @@ impl Model {
     }
 
     /// Sort the cached archived-boards partition by the configured
-    /// `SortField`/`SortOrder`, reusing the shared board sort primitive. Called
+    /// `BoardSortField`/`SortOrder`, via the shared board sort primitive. Called
     /// on load and whenever the sort dimension changes, so the rendered list and
     /// the selection resolver (both read this partition) stay consistent.
     fn sort_archived_partition(&mut self) {
@@ -508,7 +510,7 @@ mod tests {
         let mut m = Model::default();
         let (first_id, second_id) = seed_two_archived_boards(&mut m);
         m.set_archived_boards_sort(
-            kanban_domain::SortField::Position,
+            kanban_domain::BoardSortField::Position,
             kanban_domain::SortOrder::Ascending,
         );
         let order: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
@@ -561,7 +563,7 @@ mod tests {
         // Toggle / re-sort the archived dimension; live order must not move.
         m.toggle_archived_boards_sort_order();
         m.set_archived_boards_sort(
-            kanban_domain::SortField::ArchivedAt,
+            kanban_domain::BoardSortField::ArchivedAt,
             kanban_domain::SortOrder::Ascending,
         );
         let live: Vec<Uuid> = m.displayed_boards(false).iter().map(|b| b.id).collect();

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1277,4 +1277,50 @@ mod tests {
             "settings opens from the archived boards list like the live one"
         );
     }
+
+    /// The archived-boards list defaults to recency (newest-archived first) and
+    /// the shared SortOrder toggle (`s`) reverses it, with the rendered list and
+    /// the selection resolver staying consistent (both read the sorted partition).
+    #[test]
+    fn test_archived_boards_view_defaults_to_recency_and_s_toggles_order() {
+        let mut app = App::test_default();
+        // Archived in sequence: Arch2 is archived AFTER Arch1, so it is newer.
+        let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
+        let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
+
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        // Default: recency DESC → newest (Arch2) first.
+        let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
+        assert_eq!(
+            rendered,
+            vec![arch2, arch1],
+            "default archived order is newest-archived first (recency)"
+        );
+
+        // Highlight the top row (Arch2), then toggle order via the shared 's'.
+        app.selection.board.set(Some(0));
+        app.handle_archived_boards_view_mode(KeyCode::Char('s'));
+
+        // Reversed: oldest (Arch1) first.
+        let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
+        assert_eq!(
+            rendered,
+            vec![arch1, arch2],
+            "'s' reverses the archived-boards order via the shared SortOrder toggle"
+        );
+
+        // Render and selection stay consistent: the highlight followed Arch2 to
+        // its NEW index (1), so the resolved id still matches the rendered row.
+        let sel_idx = app.selection.board.get().unwrap();
+        assert_eq!(sel_idx, 1, "highlight tracked Arch2 to its new position");
+        assert_eq!(
+            app.displayed_boards()[sel_idx].id,
+            arch2,
+            "the rendered row at the selected index is the same board the resolver returns"
+        );
+    }
 }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -283,6 +283,30 @@ impl App {
         }
     }
 
+    /// Flip the archived-boards sort ORDER, reusing the shared `SortOrder`
+    /// toggle (the SAME asc↔desc flip the task list's `handle_toggle_sort_order_key`
+    /// applies) applied to the boards list instead of the cards list. Only
+    /// meaningful in the archived-boards view; a no-op elsewhere. The highlight
+    /// tracks the same board across the re-sort so the cursor does not jump to a
+    /// different project when the order changes.
+    pub fn handle_toggle_archived_boards_sort_order(&mut self) {
+        if self.mode != AppMode::ArchivedBoardsView {
+            return;
+        }
+        let highlighted_id = self.selected_archived_board_id();
+        self.model.toggle_archived_boards_sort_order();
+        // Re-resolve the highlight to the same board's new index, so render and
+        // selection stay pinned to the same project after re-sorting.
+        let new_idx = highlighted_id
+            .and_then(|id| self.model.archived_boards_view().position(|b| b.id == id));
+        let count = self.model.archived_boards_view().count();
+        self.selection.board.set(match new_idx {
+            Some(idx) => Some(idx),
+            None => (count > 0).then_some(0),
+        });
+        self.needs_redraw = true;
+    }
+
     /// The archived board currently highlighted in the ArchivedBoardsView.
     /// Resolves against the archived subset of the unified collection directly
     /// (not `displayed_boards`, which is transiently the LIVE set while a confirm

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -283,14 +283,18 @@ impl App {
         }
     }
 
-    /// Flip the archived-boards sort ORDER, reusing the shared `SortOrder`
-    /// toggle (the SAME asc↔desc flip the task list's `handle_toggle_sort_order_key`
+    /// Flip the archived-boards sort ORDER via the shared `SortOrder::toggled`
+    /// (the SAME asc↔desc flip the task list's `handle_toggle_sort_order_key`
     /// applies) applied to the boards list instead of the cards list. Only
     /// meaningful in the archived-boards view; a no-op elsewhere. The highlight
     /// tracks the same board across the re-sort so the cursor does not jump to a
     /// different project when the order changes.
+    ///
+    /// Guards on `get_base_mode()` (the stack-aware base), NOT the raw `mode`, so
+    /// it fires even when a dialog is pushed over the archived view — matching how
+    /// `displayed_boards`/render resolve which panel is showing.
     pub fn handle_toggle_archived_boards_sort_order(&mut self) {
-        if self.mode != AppMode::ArchivedBoardsView {
+        if *self.get_base_mode() != AppMode::ArchivedBoardsView {
             return;
         }
         let highlighted_id = self.selected_archived_board_id();

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -4,7 +4,7 @@ use crate::events::EventHandler;
 use kanban_domain::commands::{
     BoardCommand, CardCommand, Command, CreateCard, RestoreCard, SetBoardTaskSort, UpdateCard,
 };
-use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations, SortOrder};
+use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -174,10 +174,7 @@ impl App {
     pub fn handle_toggle_sort_order_key(&mut self) {
         if self.focus.active == Focus::Cards && self.selection.active_board_id.is_some() {
             if let Some(current_order) = self.filter.current_sort_order {
-                let new_order = match current_order {
-                    SortOrder::Ascending => SortOrder::Descending,
-                    SortOrder::Descending => SortOrder::Ascending,
-                };
+                let new_order = current_order.toggled();
                 self.filter.current_sort_order = Some(new_order);
 
                 if let Some(board_id) = self.active_board().map(|b| b.id) {

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -46,6 +46,7 @@ pub enum KeybindingAction {
     ToggleArchivedBoardsView,
     RestoreBoard,
     DeleteArchivedBoard,
+    ToggleArchivedBoardsSortOrder,
     ToggleTaskListView,
     ToggleCardSelection,
     ClearCardSelection,

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -204,6 +204,14 @@ impl KeybindingProvider for ArchivedBoardsViewProvider {
                 "Permanently delete selected project",
                 KeybindingAction::DeleteArchivedBoard,
             ),
+            // Reuse the shared SortOrder toggle to flip the archived-boards
+            // order (recency ↔ oldest under the default archived_at field).
+            Keybinding::new(
+                "s",
+                "sort",
+                "Toggle archived sort order (recency)",
+                KeybindingAction::ToggleArchivedBoardsSortOrder,
+            ),
             // Reused binding whose archived-view behavior DIFFERS from the live
             // panel's `q` (quit): here it toggles back to the live projects list.
             // The help text describes the actual behavior.
@@ -260,7 +268,6 @@ mod tests {
             .iter()
             .any(|b| b.key == "x" && b.action == KeybindingAction::DeleteArchivedBoard));
     }
-
     /// The archived-boards view is the ordinary projects panel showing a
     /// different SET: it reuses the shared navigation/activation bindings that the
     /// dispatch delegates to `handle_shared_boards_key`, rather than hand-rolling a

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -268,6 +268,18 @@ mod tests {
             .iter()
             .any(|b| b.key == "x" && b.action == KeybindingAction::DeleteArchivedBoard));
     }
+
+    #[test]
+    fn test_archived_boards_view_provider_binds_sort_order_toggle() {
+        let ctx = ArchivedBoardsViewProvider.get_context();
+        assert!(
+            ctx.bindings.iter().any(
+                |b| b.key == "s" && b.action == KeybindingAction::ToggleArchivedBoardsSortOrder
+            ),
+            "'s' toggles the archived-boards sort order via the shared SortOrder toggle"
+        );
+    }
+
     /// The archived-boards view is the ordinary projects panel showing a
     /// different SET: it reuses the shared navigation/activation bindings that the
     /// dispatch delegates to `handle_shared_boards_key`, rather than hand-rolling a


### PR DESCRIPTION
## What

The #428 review found the archived-boards list order silently flipped from archival-recency to board-position order once the unified board collection was filtered in position order. This makes the ordering configurable and, per the card, **reuses the existing task-list ordering machinery** rather than introducing a parallel sort mechanism.

Closes KAN-937 (ARCH-DECOR-SORT), parent KAN-914.

## Reused vs added

Reused (no new parallel mechanism):
- The shared `SortField` / `SortOrder` enums.
- The same asc/desc toggle pattern as the card list's `handle_toggle_sort_order_key`.

Added:
- `SortField::ArchivedAt` variant (extended the existing enum, not a parallel type).
- `sort_boards_in_place` in `kanban-domain` (the board-side analogue of `sort_cards_in_place`), so board ordering routes through a domain sort primitive rather than an ad-hoc comparator.
- A cached, sorted archived-boards partition in the TUI model plus a `ToggleArchivedBoardsSortOrder` action bound to `s` in the archived-boards view.

## Behaviour

- The archived-boards view defaults to `archived_at` DESC (newest-archived first, the conventional trash/history UX the review flagged as lost).
- Supported sort dimensions: **position** (board order) and **archived_at** (recency), toggled asc/desc via the shared `SortOrder`.
- `archived_at` timestamps are harvested from the archival markers on load (the board head does not carry them).
- Render and selection stay consistent: `archived_boards_view()` now reads the same cached sorted partition the projects panel renders, so the rendered row at the selected index and the id the selection resolver returns are always the same. The `s` handler re-pins the highlight to the same board across the re-sort.
- The **live** projects panel stays in position order, unchanged.

## Tests (split into a separate `test(...)` commit)

- domain: position order, recency DESC, recency ASC, and tie-break stability for `sort_boards_in_place`.
- tui model: `test_archived_boards_default_order_is_recency`, `test_archived_boards_sort_by_position_matches_board_order`, `test_toggle_reverses_archived_boards_order`, plus a guard that the live panel order is position-order and unaffected by the archived sort.
- tui handler/keybinding: `'s'` defaults to recency and toggles order with render/selection consistency asserted; the `'s'` binding is present on the archived provider.

`cargo test -p kanban-tui -p kanban-domain -p kanban-service`, `cargo clippy --all-targets -D warnings`, and `cargo fmt --check` all green on the touched crates.