### PR TITLE
chore: remove superseded archival dead code (deprecated tool, unused DTO ctors, stale comments)

### DIFF
--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -1,6 +1,6 @@
 # kanban-mcp
 
-Model Context Protocol (MCP) server for kanban project management. Provides 44 tools covering boards, columns, cards, card relations (parent/child), sprints, bulk operations, import/export, and undo/redo.
+Model Context Protocol (MCP) server for kanban project management. Provides 46 tools covering boards, columns, cards, card relations (parent/child), sprints, bulk operations, import/export, and undo/redo.
 
 ## Architecture
 
@@ -104,7 +104,7 @@ Most tool inputs accept either an opaque UUID or a friendlier reference, resolve
 | `tool_delete_column` | Delete column and all its cards | `column: String` | — |
 | `tool_reorder_column` | Move column to a new position | `column: String`, `position: i32` | — |
 
-### Cards (10 tools)
+### Cards (9 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
@@ -116,7 +116,6 @@ Most tool inputs accept either an opaque UUID or a friendlier reference, resolve
 | `tool_archive_card` | Archive a card (restorable) | `card: String` | — |
 | `tool_restore_card` | Restore an archived card | `card: String` | `column: String` |
 | `tool_delete_card` | Delete a card permanently | `card: String` | — |
-| `tool_list_archived_cards` | Returns ArchivedCardSummary (title, archived_at, original column — use tool_get_card for full detail) | — | `page: u32`, `page_size: u32` |
 
 ### Card–Sprint (2 tools)
 

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -16,9 +16,9 @@ pub use requests::board::{
 pub use requests::card::{
     ArchiveCardRequest, ArchiveCardsRequest, AssignCardToSprintRequest, AssignCardsToSprintRequest,
     CreateCardParams, DeleteCardRequest, GetCardBranchNameRequest, GetCardGitCheckoutRequest,
-    GetCardRequest, ListArchivedCardsRequest, ListCardChildrenRequest, ListCardParentsRequest,
-    ListCardsRequest, MoveCardRequest, MoveCardsRequest, RemoveCardParentRequest,
-    RestoreCardRequest, SetCardParentRequest, UnassignCardFromSprintRequest, UpdateCardRequest,
+    GetCardRequest, ListCardChildrenRequest, ListCardParentsRequest, ListCardsRequest,
+    MoveCardRequest, MoveCardsRequest, RemoveCardParentRequest, RestoreCardRequest,
+    SetCardParentRequest, UnassignCardFromSprintRequest, UpdateCardRequest,
 };
 pub use requests::column::{
     CreateColumnParams, DeleteColumnRequest, GetColumnRequest, ListColumnsRequest,

--- a/crates/kanban-mcp/src/requests/card.rs
+++ b/crates/kanban-mcp/src/requests/card.rs
@@ -59,26 +59,6 @@ pub struct ListCardsRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-pub struct ListArchivedCardsRequest {
-    #[schemars(
-        description = "Filter archives by board UUID or name (also drives the default sort field)"
-    )]
-    pub board: Option<String>,
-    #[schemars(
-        description = "Sort field. Valid: points, priority, created_at, updated_at, due_date, status, position, default. 'default' orders by card number; date fields and points place None values last in ascending order. Falls back to the board's task_sort_field when omitted."
-    )]
-    pub sort: Option<String>,
-    #[schemars(
-        description = "Sort direction: 'asc' or 'desc'. Defaults to the board's task_sort_order."
-    )]
-    pub order: Option<String>,
-    #[schemars(description = "Page number, 1-based (default: 1)")]
-    pub page: Option<u32>,
-    #[schemars(description = "Items per page (default: 50)")]
-    pub page_size: Option<u32>,
-}
-
-#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetCardRequest {
     #[schemars(description = "UUID or identifier of the card to retrieve (e.g. 'KAN-5' or '5')")]
     pub card: String,
@@ -249,17 +229,6 @@ mod tests {
             "order": "asc",
         });
         let req: ListCardsRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(req.sort.as_deref(), Some("due-date"));
-        assert_eq!(req.order.as_deref(), Some("asc"));
-    }
-
-    #[test]
-    fn list_archived_cards_request_accepts_sort_and_order() {
-        let json = serde_json::json!({
-            "sort": "due-date",
-            "order": "asc",
-        });
-        let req: ListArchivedCardsRequest = serde_json::from_value(json).unwrap();
         assert_eq!(req.sort.as_deref(), Some("due-date"));
         assert_eq!(req.order.as_deref(), Some("asc"));
     }

--- a/crates/kanban-mcp/src/requests/mod.rs
+++ b/crates/kanban-mcp/src/requests/mod.rs
@@ -8,9 +8,9 @@ pub use board::{CreateBoardRequest, DeleteBoardRequest, GetBoardRequest, UpdateB
 pub use card::{
     ArchiveCardRequest, ArchiveCardsRequest, AssignCardToSprintRequest, AssignCardsToSprintRequest,
     CreateCardParams, DeleteCardRequest, GetCardBranchNameRequest, GetCardGitCheckoutRequest,
-    GetCardRequest, ListArchivedCardsRequest, ListCardChildrenRequest, ListCardParentsRequest,
-    ListCardsRequest, MoveCardRequest, MoveCardsRequest, RemoveCardParentRequest,
-    RestoreCardRequest, SetCardParentRequest, UnassignCardFromSprintRequest, UpdateCardRequest,
+    GetCardRequest, ListCardChildrenRequest, ListCardParentsRequest, ListCardsRequest,
+    MoveCardRequest, MoveCardsRequest, RemoveCardParentRequest, RestoreCardRequest,
+    SetCardParentRequest, UnassignCardFromSprintRequest, UpdateCardRequest,
 };
 pub use column::{
     CreateColumnParams, DeleteColumnRequest, GetColumnRequest, ListColumnsRequest,

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -5,12 +5,12 @@ use crate::helpers::{
 };
 use crate::requests::card::{
     ArchiveCardRequest, CreateCardParams, DeleteCardRequest, GetCardBranchNameRequest,
-    GetCardGitCheckoutRequest, GetCardRequest, ListArchivedCardsRequest, ListCardsRequest,
-    MoveCardRequest, RestoreCardRequest, UpdateCardRequest,
+    GetCardGitCheckoutRequest, GetCardRequest, ListCardsRequest, MoveCardRequest,
+    RestoreCardRequest, UpdateCardRequest,
 };
 use crate::KanbanMcpServer;
 use kanban_core::resolve_page_params;
-use kanban_domain::{ArchivedFilter, CardListFilter, CardUpdate, FieldUpdate, KanbanOperations};
+use kanban_domain::{CardListFilter, CardUpdate, FieldUpdate, KanbanOperations};
 use kanban_service::api::CardResponse;
 use rmcp::{
     handler::server::wrapper::Parameters,
@@ -237,39 +237,6 @@ impl KanbanMcpServer {
         })
         .await?;
         to_call_tool_result_json(serde_json::json!({"deleted": id.to_string()}))
-    }
-
-    #[tool(
-        description = "DEPRECATED: use list_cards with archived='only'. Output shape CHANGED: now returns the lean CardSummary (title/status/priority + archived_at) — no longer the old ArchivedCardResponse (which had the full card, description, board_id, original_column_id). Clients relying on those fields must call `card get` for full details or migrate to list_cards. Use page/page_size for pagination (default: page=1, page_size=50)."
-    )]
-    pub async fn tool_list_archived_cards(
-        &self,
-        Parameters(req): Parameters<ListArchivedCardsRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        // I2 (KAN-882): one code path. This deprecated tool routes to the unified
-        // list with the archived-only selector, so its output matches
-        // `list_cards` with archived='only'.
-        let sort = req.sort.as_deref().map(parse_sort_field).transpose()?;
-        let sort_order = req.order.as_deref().map(parse_sort_order).transpose()?;
-        let (page, page_size) =
-            resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
-        let result = locked_read(&self.ctx, |ctx| {
-            let board_id = match &req.board {
-                Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
-                None => None,
-            };
-            let filter = CardListFilter {
-                board_id,
-                sort,
-                sort_order,
-                archived: ArchivedFilter::ArchivedOnly,
-                ..Default::default()
-            };
-            ctx.list_cards_paged(filter, page, page_size)
-                .map_err(kanban_err_to_mcp)
-        })
-        .await?;
-        to_call_tool_result(&result)
     }
 
     // Card Utilities

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1913,8 +1913,12 @@ async fn test_mcp_list_archived_cards_includes_board_id() {
 
     let listed = text_payload(
         &server
-            .tool_list_archived_cards(Parameters(kanban_mcp::ListArchivedCardsRequest {
+            .tool_list_cards(Parameters(kanban_mcp::ListCardsRequest {
                 board: None,
+                column: None,
+                sprint: None,
+                status: None,
+                archived: Some("only".into()),
                 sort: None,
                 order: None,
                 page: None,
@@ -1924,9 +1928,9 @@ async fn test_mcp_list_archived_cards_includes_board_id() {
             .unwrap(),
     );
     let item = &listed["items"][0];
-    // I2 (KAN-882): the deprecated tool routes to the unified list, so an item is
-    // the lean CardSummary plus a top-level `archived_at` — no nested `card`, no
-    // restore-context, and (like the live list) no `description`.
+    // list_cards with archived='only' returns the lean CardSummary plus a
+    // top-level `archived_at` — no nested `card`, no restore-context, and (like
+    // the live list) no `description`.
     assert!(item["archived_at"].is_string());
     assert_eq!(item["title"], "the card");
     let obj = item.as_object().unwrap();
@@ -2597,7 +2601,8 @@ async fn test_list_boards_include_archived_not_truncated() {
     assert_eq!(arr.len(), 65, "55 live + 10 archived = 65 total");
 }
 
-// KAN-902: list_archived_cards returns lean CardSummary shape (not old ArchivedCardResponse).
+// KAN-902: list_cards with archived='only' returns the lean CardSummary shape
+// (not the old ArchivedCardResponse).
 
 #[tokio::test]
 async fn test_list_archived_cards_returns_card_summary_shape() {
@@ -2637,8 +2642,12 @@ async fn test_list_archived_cards_returns_card_summary_shape() {
 
     let listed = text_payload(
         &server
-            .tool_list_archived_cards(Parameters(kanban_mcp::ListArchivedCardsRequest {
+            .tool_list_cards(Parameters(kanban_mcp::ListCardsRequest {
                 board: None,
+                column: None,
+                sprint: None,
+                status: None,
+                archived: Some("only".into()),
                 sort: None,
                 order: None,
                 page: None,

--- a/crates/kanban-service/src/api/v1/boards/response.rs
+++ b/crates/kanban-service/src/api/v1/boards/response.rs
@@ -44,15 +44,6 @@ impl BoardResponse {
             ..Self::from(board)
         }
     }
-
-    /// Project a live board and stamp it as archived at `archived_at`. Under the
-    /// reference-marker model an archived board IS a live board plus a marker, so
-    /// the archived wire shape is the live projection with `archived_at` set.
-    /// Thin wrapper over [`with_archived_at`]; retained for existing CLI/MCP
-    /// callers (B4/B5 migrate them to `with_archived_at` directly).
-    pub fn archived(board: &Board, archived_at: DateTime<Utc>) -> Self {
-        Self::with_archived_at(board, Some(archived_at))
-    }
 }
 
 impl From<&Board> for BoardResponse {
@@ -117,7 +108,7 @@ mod tests {
     fn test_board_response_archived_stamps_archived_at() {
         let board = Board::new("B", Some("KAN"));
         let at = Utc::now();
-        let archived = BoardResponse::archived(&board, at);
+        let archived = BoardResponse::with_archived_at(&board, Some(at));
         assert_eq!(archived.archived_at, Some(at));
         assert_eq!(
             BoardResponse {
@@ -130,7 +121,8 @@ mod tests {
 
     #[test]
     fn test_board_response_archived_at_serde_round_trip() {
-        let archived = BoardResponse::archived(&Board::new("B", Some("KAN")), Utc::now());
+        let archived =
+            BoardResponse::with_archived_at(&Board::new("B", Some("KAN")), Some(Utc::now()));
         let json = serde_json::to_string(&archived).unwrap();
         assert!(json.contains("archived_at"));
         let back: BoardResponse = serde_json::from_str(&json).unwrap();
@@ -183,7 +175,7 @@ mod tests {
 
         // Reference-marker model: the archived wire shape is the live board
         // projection stamped with `archived_at` (no separate nested DTO).
-        let resp = BoardResponse::archived(&board, at);
+        let resp = BoardResponse::with_archived_at(&board, Some(at));
 
         assert_eq!(resp.id, board_id);
         assert_eq!(resp.name, "Archived");

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -34,18 +34,6 @@ pub struct CardResponse {
     pub archived_at: Option<DateTime<Utc>>,
 }
 
-impl CardResponse {
-    /// Project a live card and stamp it as archived at `archived_at`. Under the
-    /// reference-marker model an archived card IS a live card plus a marker, so
-    /// the archived wire shape is the live projection with `archived_at` set.
-    pub fn archived(card: &Card, archived_at: DateTime<Utc>) -> Self {
-        Self {
-            archived_at: Some(archived_at),
-            ..Self::from(card)
-        }
-    }
-}
-
 impl From<&Card> for CardResponse {
     fn from(card: &Card) -> Self {
         let Card {
@@ -139,7 +127,11 @@ mod tests {
     fn test_card_response_archived_stamps_archived_at() {
         let card = sample_card();
         let at = Utc::now();
-        let archived = CardResponse::archived(&card, at);
+        // Production stamps the marker's `archived_at` onto the live projection.
+        let archived = CardResponse {
+            archived_at: Some(at),
+            ..CardResponse::from(&card)
+        };
         assert_eq!(archived.archived_at, Some(at));
         // Every other field matches the live projection.
         assert_eq!(
@@ -153,7 +145,10 @@ mod tests {
 
     #[test]
     fn test_card_response_archived_at_serde_round_trip() {
-        let archived = CardResponse::archived(&sample_card(), Utc::now());
+        let archived = CardResponse {
+            archived_at: Some(Utc::now()),
+            ..CardResponse::from(&sample_card())
+        };
         let json = serde_json::to_string(&archived).unwrap();
         assert!(json.contains("archived_at"));
         let back: CardResponse = serde_json::from_str(&json).unwrap();

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -85,8 +85,8 @@ impl Model {
 
     /// Ids of the archived cards. Rows themselves live in the unified `cards()`
     /// collection; this set records which of them are archived (built from the
-    /// markers). Consumers that need the archived subset filter `cards()` by
-    /// this set. (T1c introduces a single `displayed_cards()` accessor.)
+    /// markers). The live/archived partition is precomputed on load and served by
+    /// [`displayed_cards`](Self::displayed_cards); this set backs that split.
     pub fn archived_card_ids(&self) -> &std::collections::HashSet<Uuid> {
         &self.archived_card_ids
     }
@@ -97,9 +97,9 @@ impl Model {
 
     /// Ids of the archived boards. The heads themselves live in the unified
     /// `boards()` collection; this set records which of them are archived (built
-    /// from the markers). Consumers that need the archived subset filter
-    /// `boards()` by this set. (T1c introduces a single `displayed_boards()`
-    /// accessor that subsumes the inline filter.)
+    /// from the markers). The live/archived partition is precomputed on load and
+    /// served by [`displayed_boards`](Self::displayed_boards); this set backs that
+    /// split.
     pub fn archived_board_ids(&self) -> &HashSet<Uuid> {
         &self.archived_board_ids
     }
@@ -300,9 +300,9 @@ mod tests {
 
     #[test]
     fn test_archived_view_filter_shows_archived_card_from_unified_collection() {
-        // The archived-cards view (pending T1c's `displayed_cards()`) filters
-        // the unified collection by `archived_card_ids`. Assert an archived
-        // card is present through that path.
+        // `archived_card_ids` records the archived subset of the unified `cards()`
+        // collection (the same set that backs `displayed_cards`). Assert an
+        // archived card is reachable by filtering `cards()` through that set.
         let mut m = Model::default();
         let mut board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -116,8 +116,8 @@ fn test_load_from_snapshot_rebuilds_card_index() {
 }
 
 // Helper mirroring the archived-cards view: the archived subset of the unified
-// collection, filtered by `archived_card_ids` (temporary until T1c's
-// `displayed_cards()`).
+// collection, filtered by `archived_card_ids` (the same set that backs
+// `displayed_cards`).
 fn archived_titles(model: &Model) -> Vec<String> {
     let ids = model.archived_card_ids();
     model


### PR DESCRIPTION
## Summary

Dead-code cleanup confirmed by the post-KAN-914 archival audit. Each item was verified to have zero production callers; test coverage is preserved by repointing tests at the surviving production paths.

## Changes

- **Deprecated MCP tool `tool_list_archived_cards`** removed (fn + auto-registration via `#[tool_router]`, its `ListArchivedCardsRequest` DTO, all re-exports, and the README row). It was a shim routing to `list_cards` with `archived='only'`; the two integration tests that exercised it now call `tool_list_cards` with `archived: Some("only")` so the archived-only path stays covered.
- **`BoardResponse::archived()`** and **`CardResponse::archived()`** removed. Production migrated to `BoardResponse::with_archived_at()` (boards) and `From<&Card>` + marker-stamped `archived_at` (cards). Their test-only callers were repointed to those production constructors; the stale B4/B5 migration note on `BoardResponse` was dropped.
- **README tool count** corrected from 44 to 46 (47 tool macros minus the removed one), and the Cards section count from 10 to 9.
- **Stale T1c comments** in `kanban-tui` rewritten to describe the landed `displayed_cards()`/`displayed_boards()` accessors instead of describing them as pending (model.rs doc/test comments plus a `model_tests.rs` helper note).

Out of scope (needs a migration): the inert `archived_cards.original_column_id/original_position` schema columns are left untouched.

## Verification

- `cargo test -p kanban-mcp -p kanban-service -p kanban-tui` green
- `cargo clippy -p kanban-mcp -p kanban-service -p kanban-tui --all-targets -- -D warnings` clean (no orphaned imports left behind)
- `cargo fmt` applied