### PR TITLE
KAN-939 chore(choco): point projectUrl at kanban.rs

### DIFF
--- a/.changeset/kan-939-point-chocolatey-projecturl-at-kanban-rs.md
+++ b/.changeset/kan-939-point-chocolatey-projecturl-at-kanban-rs.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Repository housekeeping with no user-visible behaviour change. The Chocolatey package's "Software Site" link on chocolatey.org now points at the project's dedicated website, https://kanban.rs, instead of the GitHub repo. The "Source" link is unaffected and still points at GitHub.

--- a/packaging/chocolatey/kanban.nuspec
+++ b/packaging/chocolatey/kanban.nuspec
@@ -7,7 +7,7 @@
     <authors>Max Emil Yoon Blomstervall</authors>
     <owners>fulsomenko</owners>
     <licenseUrl>https://github.com/fulsomenko/kanban/blob/master/LICENSE.md</licenseUrl>
-    <projectUrl>https://github.com/fulsomenko/kanban</projectUrl>
+    <projectUrl>https://kanban.rs</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/fulsomenko/kanban/master/assets/icon-bold-transparent-black.png</iconUrl>
     <copyright>2025 Max Emil Yoon Blomstervall</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Points the Chocolatey package's projectUrl at the project's dedicated website:

- Changes `<projectUrl>` in `packaging/chocolatey/kanban.nuspec` from the GitHub repo to `https://kanban.rs`
- Leaves `<projectSourceUrl>` on GitHub, since that field specifically means "where the source lives"
- Adds a changeset

**What**: The Chocolatey package's "Software Site" link (rendered from `projectUrl` on chocolatey.org) now points at `https://kanban.rs` instead of `https://github.com/fulsomenko/kanban`.

**Why**: `kanban.rs` is now the project's dedicated website, and the nuspec's `projectUrl` hadn't been updated since the package predates the site. `projectUrl` is the field chocolatey.org renders as the homepage link, so leaving it on GitHub left the new site with no visibility from the Chocolatey listing.

**How**: Single-field change in `packaging/chocolatey/kanban.nuspec`. `projectSourceUrl` is untouched and still points at GitHub, where the source actually lives — that distinction (homepage vs. source location) is exactly what the two fields are for. `licenseUrl`, `iconUrl`, `packageSourceUrl`, `docsUrl`, and `bugTrackerUrl` are all unaffected. Takes effect on chocolatey.org starting with the next published version; the already-approved 0.7.2 listing isn't retroactively changed.

**Testing**: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace` — all clean. No Rust code touched; this is packaging-only.