### PR TITLE
KAN-942 refactor(domain): generalize sort reverse+tiebreak core (cards & boards)

### DIFF
--- a/crates/kanban-domain/src/sort/boards.rs
+++ b/crates/kanban-domain/src/sort/boards.rs
@@ -9,6 +9,7 @@
 //! order) and `ArchivedAt` (recency). There is no card-only fallback path
 //! because a card-only field cannot be passed here by construction.
 
+use crate::sort::sort_by_with_order;
 use crate::{Board, BoardSortField, SortOrder};
 use chrono::{DateTime, Utc};
 use std::cmp::Ordering;
@@ -51,14 +52,12 @@ pub fn sort_boards_in_place(
     order: SortOrder,
     archived_at: &HashMap<Uuid, DateTime<Utc>>,
 ) {
-    boards.sort_by(|a, b| {
-        let primary = compare_boards(field, a, b, archived_at);
-        let primary = match order {
-            SortOrder::Ascending => primary,
-            SortOrder::Descending => primary.reverse(),
-        };
-        primary.then_with(|| a.position.cmp(&b.position))
-    });
+    sort_by_with_order(
+        boards,
+        order,
+        |a, b| compare_boards(field, a, b, archived_at),
+        |a, b| a.position.cmp(&b.position),
+    );
 }
 
 #[cfg(test)]

--- a/crates/kanban-domain/src/sort/mod.rs
+++ b/crates/kanban-domain/src/sort/mod.rs
@@ -51,6 +51,30 @@ impl SortBy {
     }
 }
 
+/// Sort a slice in place applying `order` to a `primary` comparator, then
+/// breaking ties with a `tiebreak` comparator that stays ascending regardless
+/// of `order`.
+///
+/// This is the shared reverse+tiebreak core behind both the card sorter
+/// ([`OrderedSorter::sort_by`], tiebreak = `card_number`) and the board sorter
+/// ([`sort_boards_in_place`], tiebreak = `position`). Keeping the tiebreak
+/// direction fixed means toggling the primary direction never reshuffles tied
+/// elements.
+pub fn sort_by_with_order<T>(
+    items: &mut [T],
+    order: SortOrder,
+    mut primary: impl FnMut(&T, &T) -> Ordering,
+    mut tiebreak: impl FnMut(&T, &T) -> Ordering,
+) {
+    items.sort_by(|a, b| {
+        let p = match order {
+            SortOrder::Ascending => primary(a, b),
+            SortOrder::Descending => primary(a, b).reverse(),
+        };
+        p.then_with(|| tiebreak(a, b))
+    });
+}
+
 /// Wrapper that applies sort order (ascending/descending) to a sort field.
 pub struct OrderedSorter {
     sorter: SortBy,
@@ -78,14 +102,12 @@ impl OrderedSorter {
     /// view would need a different tiebreaker (e.g. `(board_id, card_number)`
     /// or `card.id`).
     pub fn sort_by<T: Borrow<Card>>(&self, cards: &mut [T]) {
-        cards.sort_by(|a, b| {
-            let primary = self.sorter.compare(a.borrow(), b.borrow());
-            let primary = match self.order {
-                SortOrder::Ascending => primary,
-                SortOrder::Descending => primary.reverse(),
-            };
-            primary.then_with(|| a.borrow().card_number.cmp(&b.borrow().card_number))
-        });
+        sort_by_with_order(
+            cards,
+            self.order,
+            |a, b| self.sorter.compare(a.borrow(), b.borrow()),
+            |a, b| a.borrow().card_number.cmp(&b.borrow().card_number),
+        );
     }
 }
 

--- a/crates/kanban-domain/src/sort/mod.rs
+++ b/crates/kanban-domain/src/sort/mod.rs
@@ -439,6 +439,28 @@ mod tests {
         assert_eq!(cards[1].due_date, Some(later));
     }
 
+    /// The generic reverse+tiebreak core must apply `order` to the primary
+    /// comparator (reversing it under `Descending`) while keeping the tiebreak
+    /// comparator ascending regardless of `order`. Toggling direction flips the
+    /// primary ranking but leaves tied elements in the same (ascending) order.
+    #[test]
+    fn test_sort_by_with_order_reverses_primary_but_keeps_tiebreak_ascending() {
+        // Elements: (primary_key, tiebreak_key). Two share primary=0 to exercise
+        // the tiebreak; one has primary=1 to exercise the reversal.
+        let primary = |a: &(i32, i32), b: &(i32, i32)| a.0.cmp(&b.0);
+        let tiebreak = |a: &(i32, i32), b: &(i32, i32)| a.1.cmp(&b.1);
+
+        // Ascending: primary ascends (0s before 1), ties break ascending (10, 20).
+        let mut asc = vec![(1, 5), (0, 20), (0, 10)];
+        sort_by_with_order(&mut asc, SortOrder::Ascending, primary, tiebreak);
+        assert_eq!(asc, vec![(0, 10), (0, 20), (1, 5)]);
+
+        // Descending: primary reverses (1 before 0s), ties STAY ascending (10, 20).
+        let mut desc = vec![(0, 20), (1, 5), (0, 10)];
+        sort_by_with_order(&mut desc, SortOrder::Descending, primary, tiebreak);
+        assert_eq!(desc, vec![(1, 5), (0, 10), (0, 20)]);
+    }
+
     /// `CardNumber` and `Position` are excluded because their primaries
     /// are themselves unique per slice — there's nothing to tiebreak.
     #[test]


### PR DESCRIPTION
## What

Foundation slice **S1** of KAN-941 (BOARD-SORT). A behavior-preserving domain refactor that extracts the shared reverse+tiebreak sort core so cards and boards stop duplicating the same "apply `SortOrder` to a primary comparator, then a fixed ascending tiebreak" logic.

## Changes

- New `sort_by_with_order<T>(items, order, primary, tiebreak)` in `crates/kanban-domain/src/sort/mod.rs`: applies `SortOrder` to the `primary` comparator (`.reverse()` under `Descending`), then `.then_with(tiebreak)` where the tiebreak stays ascending regardless of order.
- `OrderedSorter::sort_by` (cards) now delegates to it with `primary = self.sorter.compare`, `tiebreak = card_number` ascending.
- `sort_boards_in_place` (boards) now delegates to it with `primary = compare_boards`, `tiebreak = position` ascending.
- Removes the two hand-rolled `match order { .. }` + `.then_with(..)` blocks.

## Behavior

No behavior change. All existing card and board sort tests are the behavior-preservation guard and stay green unchanged. Resolves the KAN-937 nit that `sort_boards_in_place` duplicated `OrderedSorter`'s reverse/tiebreak.

## Tests

- Added `test_sort_by_with_order_reverses_primary_but_keeps_tiebreak_ascending` exercising the generic helper directly: ascending vs descending flips the primary ranking while the tiebreak stays ascending. Committed red-first (helper absent → compile error), then green.
- `cargo test -p kanban-domain`: 641 passed.
- `cargo clippy -p kanban-domain --all-targets -D warnings`: clean.
- `cargo fmt --check`: clean.

Unblocks S2.