### PR TITLE
KAN-944 feat(core): persist board-list sort default in AppConfig

### DIFF
--- a/crates/kanban-core/src/config.rs
+++ b/crates/kanban-core/src/config.rs
@@ -45,6 +45,10 @@ pub struct AppConfig {
     pub storage_backend: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_location: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub board_sort_field: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub board_sort_order: Option<String>,
 }
 
 impl AppConfig {

--- a/crates/kanban-core/src/config.rs
+++ b/crates/kanban-core/src/config.rs
@@ -134,6 +134,28 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_appconfig_omits_board_sort_when_none() {
+        let config = AppConfig::default();
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(!serialized.contains("board_sort_field"));
+        assert!(!serialized.contains("board_sort_order"));
+    }
+
+    #[test]
+    fn test_appconfig_serializes_board_sort_when_set() {
+        let config = AppConfig {
+            board_sort_field: Some("Name".into()),
+            board_sort_order: Some("Descending".into()),
+            ..Default::default()
+        };
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(serialized.contains("board_sort_field"));
+        assert!(serialized.contains("Name"));
+        assert!(serialized.contains("board_sort_order"));
+        assert!(serialized.contains("Descending"));
+    }
+
+    #[test]
     fn test_effective_storage_backend() {
         let config = AppConfig::default();
         assert_eq!(config.effective_storage_backend(), "json");

--- a/crates/kanban-service/src/config.rs
+++ b/crates/kanban-service/src/config.rs
@@ -831,6 +831,7 @@ mod tests {
             configuration_format: Some("toml".into()),
             configuration_location: config_path().map(|p| p.display().to_string()),
             storage_location: Some("boards.json".into()),
+            ..Default::default()
         };
         assert!(has_non_default_values(&config));
     }
@@ -1077,6 +1078,49 @@ mod tests {
             "should not contain fragment from old 'fix' value"
         );
         assert!(result.contains("feat"), "should contain new value");
+    }
+
+    #[test]
+    fn test_appconfig_roundtrips_board_sort_fields() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let config = AppConfig {
+            board_sort_field: Some("Name".into()),
+            board_sort_order: Some("Descending".into()),
+            ..Default::default()
+        };
+        save_to(&config, &path).unwrap();
+
+        let loaded = load_from(&path);
+        assert_eq!(loaded.board_sort_field.as_deref(), Some("Name"));
+        assert_eq!(loaded.board_sort_order.as_deref(), Some("Descending"));
+    }
+
+    #[test]
+    fn test_appconfig_omits_board_sort_when_none() {
+        let config = AppConfig::default();
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(
+            !serialized.contains("board_sort_field"),
+            "default config should not serialize board_sort_field, got: {serialized:?}"
+        );
+        assert!(
+            !serialized.contains("board_sort_order"),
+            "default config should not serialize board_sort_order, got: {serialized:?}"
+        );
+    }
+
+    #[test]
+    fn test_appconfig_legacy_without_board_sort_loads_as_none() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "default_card_prefix = \"feat\"\n").unwrap();
+
+        let config = load_from(&path);
+        assert_eq!(config.default_card_prefix.as_deref(), Some("feat"));
+        assert!(config.board_sort_field.is_none());
+        assert!(config.board_sort_order.is_none());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## What

BOARD-SORT S3 (child of KAN-941). Adds a persisted, global board-list sort default to `AppConfig` so the board-list sort choice survives restart and CLI/MCP can fall back to it (D1).

Two new fields on `AppConfig` (`crates/kanban-core/src/config.rs`):

```rust
#[serde(default, skip_serializing_if = "Option::is_none")]
pub board_sort_field: Option<String>,   // "Position" | "Name" | "CreatedAt" | "ArchivedAt"
#[serde(default, skip_serializing_if = "Option::is_none")]
pub board_sort_order: Option<String>,   // "Ascending" | "Descending"
```

They are kept as `Option<String>` so `kanban-core` stays free of a `kanban-domain` dependency; parsing to `BoardSortField`/`SortOrder` happens at the service edge in a later card (S4). `#[serde(default)]` makes legacy configs load cleanly; `skip_serializing_if = "Option::is_none"` omits them from the serialized file when unset, keeping back-compat and a minimal on-disk config.

## Design notes

These fields have no compile-time non-`None` default (they are pure optional preferences), so no changes were needed to the `strip_defaults`/`is_all_defaults` machinery in `kanban-service/src/config.rs` — `skip_serializing_if` alone omits them when `None`. The default-stripping logic only concerns fields with meaningful compile-time defaults (prefixes, backend, formats); the new fields correctly fall outside it.

## Tests (TDD, red first)

Service load/save layer (`kanban-service/src/config.rs`):
- `test_appconfig_roundtrips_board_sort_fields` — set both, save to temp path, load, assert equal.
- `test_appconfig_omits_board_sort_when_none` — default `AppConfig` serializes with no `board_sort_field`/`board_sort_order` keys.
- `test_appconfig_legacy_without_board_sort_loads_as_none` — a config lacking the fields loads them as `None`.

Core type (`kanban-core/src/config.rs`):
- `test_appconfig_omits_board_sort_when_none` / `test_appconfig_serializes_board_sort_when_set` — serde omit/serialize behavior on the type itself.

Also added `..Default::default()` to one pre-existing exhaustive-struct-literal test so it stays forward-compatible.

## Verification

`cargo test -p kanban-core -p kanban-service`, `cargo clippy -p kanban-core -p kanban-service --all-targets -D warnings`, and `cargo fmt --check` all green.

Parent: KAN-941. Consumed by S4 (fallback), S5/S6 (set + read), S7 (load/save).