### PR TITLE
KAN-943 feat(domain): board sort dimensions + BoardListFilter.sort + filter_and_sort_boards

### DIFF
--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -34,6 +34,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                 } else {
                     ArchivedFilter::LiveOnly
                 },
+                ..Default::default()
             };
             let responses = match project_board_list(ctx, filter) {
                 Ok(r) => r,
@@ -140,6 +141,7 @@ fn resolve_archived_board(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, Str
     let archived = ctx
         .list_boards_filtered(BoardListFilter {
             archived: ArchivedFilter::ArchivedOnly,
+            ..Default::default()
         })
         .map_err(|e| e.to_string())?;
     let matches: Vec<uuid::Uuid> = kanban_domain::find_boards_by_name(raw, &archived)

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -30,6 +30,10 @@ pub enum SortField {
 pub enum BoardSortField {
     /// Board order (`Board::position`).
     Position,
+    /// Board name, compared case-insensitively.
+    Name,
+    /// Board creation time (`Board::created_at`).
+    CreatedAt,
     /// Recency of archival, resolved from the archival marker's timestamp.
     ArchivedAt,
 }

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -57,7 +57,7 @@ pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use operations::KanbanOperations;
 pub use query::{
-    count_filtered_cards, filter_and_sort_cards,
+    count_filtered_cards, filter_and_sort_boards, filter_and_sort_cards, resolve_board_sort,
     sprint::{
         calculate_points, calculate_points_by_ids, get_sprint_cards, get_sprint_completed_cards,
         get_sprint_uncompleted_cards, partition_sprint_cards, sort_card_ids,

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -206,4 +206,176 @@ mod tests {
             ArchivedFilter::LiveOnly
         );
     }
+
+    #[test]
+    fn test_board_list_filter_default_sort_is_none() {
+        let f = BoardListFilter::default();
+        assert_eq!(f.sort, None);
+        assert_eq!(f.sort_order, None);
+    }
+
+    fn board_named(name: &str, position: i32) -> Board {
+        let mut b = Board::new(name, None::<String>);
+        b.position = position;
+        b
+    }
+
+    fn ts(s: &str) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339(s)
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+    }
+
+    fn names(boards: &[Board]) -> Vec<String> {
+        boards.iter().map(|b| b.name.clone()).collect()
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_by_name_asc() {
+        let boards = vec![
+            board_named("Charlie", 0),
+            board_named("alpha", 1),
+            board_named("Bravo", 2),
+        ];
+        let filter = BoardListFilter {
+            sort: Some(BoardSortField::Name),
+            sort_order: Some(SortOrder::Ascending),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
+        assert_eq!(names(&out), vec!["alpha", "Bravo", "Charlie"]);
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_by_name_desc() {
+        let boards = vec![
+            board_named("Charlie", 0),
+            board_named("alpha", 1),
+            board_named("Bravo", 2),
+        ];
+        let filter = BoardListFilter {
+            sort: Some(BoardSortField::Name),
+            sort_order: Some(SortOrder::Descending),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
+        assert_eq!(names(&out), vec!["Charlie", "Bravo", "alpha"]);
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_by_created_at() {
+        let mut older = board_named("Older", 0);
+        let mut newer = board_named("Newer", 1);
+        older.created_at = ts("2026-01-01T00:00:00Z");
+        newer.created_at = ts("2026-06-01T00:00:00Z");
+        let boards = vec![newer, older];
+        let filter = BoardListFilter {
+            sort: Some(BoardSortField::CreatedAt),
+            sort_order: Some(SortOrder::Ascending),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
+        assert_eq!(names(&out), vec!["Older", "Newer"]);
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_by_archived_at() {
+        let older = board_named("Older", 0);
+        let newer = board_named("Newer", 1);
+        let mut archived_at = HashMap::new();
+        archived_at.insert(older.id, ts("2026-01-01T00:00:00Z"));
+        archived_at.insert(newer.id, ts("2026-06-01T00:00:00Z"));
+        let boards = vec![older, newer];
+        let filter = BoardListFilter {
+            sort: Some(BoardSortField::ArchivedAt),
+            sort_order: Some(SortOrder::Descending),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &archived_at, None);
+        assert_eq!(names(&out), vec!["Newer", "Older"]);
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_by_position() {
+        let boards = vec![
+            board_named("A", 2),
+            board_named("B", 0),
+            board_named("C", 1),
+        ];
+        let filter = BoardListFilter {
+            sort: Some(BoardSortField::Position),
+            sort_order: Some(SortOrder::Ascending),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
+        assert_eq!(names(&out), vec!["B", "C", "A"]);
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_uses_default_when_filter_has_no_sort() {
+        let boards = vec![
+            board_named("A", 2),
+            board_named("B", 0),
+            board_named("C", 1),
+        ];
+        let filter = BoardListFilter::default();
+        let out = filter_and_sort_boards(
+            &boards,
+            &filter,
+            &HashMap::new(),
+            Some((BoardSortField::Position, SortOrder::Ascending)),
+        );
+        assert_eq!(names(&out), vec!["B", "C", "A"]);
+    }
+
+    #[test]
+    fn test_resolve_board_sort_override_beats_default() {
+        let got = resolve_board_sort(
+            Some(BoardSortField::Name),
+            Some(SortOrder::Descending),
+            Some((BoardSortField::Position, SortOrder::Ascending)),
+        );
+        assert_eq!(got, Some((BoardSortField::Name, SortOrder::Descending)));
+    }
+
+    #[test]
+    fn test_resolve_board_sort_falls_back_to_default() {
+        let got = resolve_board_sort(
+            None,
+            None,
+            Some((BoardSortField::CreatedAt, SortOrder::Descending)),
+        );
+        assert_eq!(got, Some((BoardSortField::CreatedAt, SortOrder::Descending)));
+    }
+
+    #[test]
+    fn test_resolve_board_sort_none_when_neither() {
+        assert_eq!(resolve_board_sort(None, None, None), None);
+    }
+
+    #[test]
+    fn test_resolve_board_sort_field_override_takes_default_order() {
+        let got = resolve_board_sort(
+            Some(BoardSortField::Name),
+            None,
+            Some((BoardSortField::Position, SortOrder::Descending)),
+        );
+        assert_eq!(got, Some((BoardSortField::Name, SortOrder::Descending)));
+    }
+
+    #[test]
+    fn test_resolve_board_sort_field_override_without_default_is_ascending() {
+        let got = resolve_board_sort(Some(BoardSortField::Name), None, None);
+        assert_eq!(got, Some((BoardSortField::Name, SortOrder::Ascending)));
+    }
+
+    #[test]
+    fn test_resolve_board_sort_order_override_layers_on_default_field() {
+        let got = resolve_board_sort(
+            None,
+            Some(SortOrder::Descending),
+            Some((BoardSortField::Position, SortOrder::Ascending)),
+        );
+        assert_eq!(got, Some((BoardSortField::Position, SortOrder::Descending)));
+    }
 }

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -12,10 +12,11 @@
 //! three frontends (CLI, MCP, TUI) inherit one filter+sort path.
 
 use crate::search::{CardSearcher, CompositeSearcher};
-use crate::sort::{resolve_sort, sort_cards_in_place};
-use crate::{Board, Card, CardStatus, Column, SortField, SortOrder, Sprint};
+use crate::sort::{resolve_sort, sort_boards_in_place, sort_cards_in_place};
+use crate::{Board, BoardSortField, Card, CardStatus, Column, SortField, SortOrder, Sprint};
+use chrono::{DateTime, Utc};
 use std::borrow::Borrow;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 /// Three-state selector over a card's archival status for the unified card list.
@@ -58,12 +59,19 @@ pub struct CardListFilter {
 /// Board list request shape, mirroring [`CardListFilter`]. Carries the
 /// three-state [`ArchivedFilter`] so board listing takes the same selector
 /// cards do; the service tier (B2) gathers the live-vs-archived board set,
-/// exactly as it does for cards. Kept minimal (no search/sort yet).
+/// exactly as it does for cards. Also carries the optional sort override
+/// (field + order) the picker sets; when absent, the service supplies the
+/// AppConfig default to [`filter_and_sort_boards`].
 #[derive(Default, Clone)]
 pub struct BoardListFilter {
     /// Three-state archival selector. Defaults to `LiveOnly`, so callers that
     /// build the filter with `..Default::default()` see the pre-selector set.
     pub archived: ArchivedFilter,
+    /// Optional board sort dimension override. `None` falls back to the
+    /// `default` passed to [`filter_and_sort_boards`] (the AppConfig value).
+    pub sort: Option<BoardSortField>,
+    /// Optional sort direction override, resolved alongside `sort`.
+    pub sort_order: Option<SortOrder>,
 }
 
 fn allowed_column_ids(columns: &[Column], board_id: Option<Uuid>) -> Option<HashSet<Uuid>> {
@@ -185,9 +193,50 @@ pub fn count_filtered_cards<T: Borrow<Card>>(
         .count()
 }
 
+/// Resolve `(field, order)` for the board list from a caller override and an
+/// optional default. Mirrors [`resolve_sort`], but the fallback is the passed
+/// `default` (the AppConfig board-list value threaded by the service) rather
+/// than a `Board` entity: override wins; else `default`; else `None`.
+///
+/// A field override with no explicit order borrows the default's order (or
+/// ascending when there is no default); an order override with no field layers
+/// onto the default's field.
+pub fn resolve_board_sort(
+    sort: Option<BoardSortField>,
+    order: Option<SortOrder>,
+    default: Option<(BoardSortField, SortOrder)>,
+) -> Option<(BoardSortField, SortOrder)> {
+    match (sort, order, default) {
+        (Some(f), Some(o), _) => Some((f, o)),
+        (Some(f), None, Some((_, o))) => Some((f, o)),
+        (Some(f), None, None) => Some((f, SortOrder::Ascending)),
+        (None, override_order, Some((f, o))) => Some((f, override_order.unwrap_or(o))),
+        (None, _, None) => None,
+    }
+}
+
+/// Single filter + sort entry point for in-memory board slices, mirroring
+/// [`filter_and_sort_cards`]. Boards have no column/sprint predicates (their
+/// archival split is handled upstream at the service tier), so this is
+/// predominantly the sort: it resolves `(field, order)` via
+/// [`resolve_board_sort`] and applies the shared board sort primitive.
+pub fn filter_and_sort_boards(
+    boards: &[Board],
+    filter: &BoardListFilter,
+    archived_at: &HashMap<Uuid, DateTime<Utc>>,
+    default: Option<(BoardSortField, SortOrder)>,
+) -> Vec<Board> {
+    let mut result: Vec<Board> = boards.to_vec();
+    if let Some((field, order)) = resolve_board_sort(filter.sort, filter.sort_order, default) {
+        sort_boards_in_place(&mut result, field, order, archived_at);
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_archived_filter_default_is_live_only() {
@@ -345,7 +394,10 @@ mod tests {
             None,
             Some((BoardSortField::CreatedAt, SortOrder::Descending)),
         );
-        assert_eq!(got, Some((BoardSortField::CreatedAt, SortOrder::Descending)));
+        assert_eq!(
+            got,
+            Some((BoardSortField::CreatedAt, SortOrder::Descending))
+        );
     }
 
     #[test]

--- a/crates/kanban-domain/src/query/mod.rs
+++ b/crates/kanban-domain/src/query/mod.rs
@@ -11,7 +11,8 @@ pub mod filter_sort;
 pub mod sprint;
 
 pub use filter_sort::{
-    count_filtered_cards, filter_and_sort_cards, ArchivedFilter, BoardListFilter, CardListFilter,
+    count_filtered_cards, filter_and_sort_boards, filter_and_sort_cards, resolve_board_sort,
+    ArchivedFilter, BoardListFilter, CardListFilter,
 };
 
 use crate::{Board, Card, Column, Sprint};

--- a/crates/kanban-domain/src/sort/boards.rs
+++ b/crates/kanban-domain/src/sort/boards.rs
@@ -137,6 +137,59 @@ mod tests {
     }
 
     #[test]
+    fn test_sort_boards_by_name_ascending_is_case_insensitive() {
+        let a = board_at_position("Charlie", 0);
+        let b = board_at_position("alpha", 1);
+        let c = board_at_position("Bravo", 2);
+        let empty = HashMap::new();
+        let mut boards = vec![a, b, c];
+        sort_boards_in_place(&mut boards, BoardSortField::Name, SortOrder::Ascending, &empty);
+        assert_eq!(
+            boards.iter().map(|x| x.name.clone()).collect::<Vec<_>>(),
+            vec!["alpha", "Bravo", "Charlie"]
+        );
+    }
+
+    #[test]
+    fn test_sort_boards_by_name_descending_reverses_case_insensitive_order() {
+        let a = board_at_position("Charlie", 0);
+        let b = board_at_position("alpha", 1);
+        let c = board_at_position("Bravo", 2);
+        let empty = HashMap::new();
+        let mut boards = vec![a, b, c];
+        sort_boards_in_place(
+            &mut boards,
+            BoardSortField::Name,
+            SortOrder::Descending,
+            &empty,
+        );
+        assert_eq!(
+            boards.iter().map(|x| x.name.clone()).collect::<Vec<_>>(),
+            vec!["Charlie", "Bravo", "alpha"]
+        );
+    }
+
+    #[test]
+    fn test_sort_boards_by_created_at_ascending_is_oldest_first() {
+        let mut older = board_at_position("Older", 0);
+        let mut newer = board_at_position("Newer", 1);
+        older.created_at = ts("2026-01-01T00:00:00Z");
+        newer.created_at = ts("2026-06-01T00:00:00Z");
+        let empty = HashMap::new();
+        let mut boards = vec![newer, older];
+        sort_boards_in_place(
+            &mut boards,
+            BoardSortField::CreatedAt,
+            SortOrder::Ascending,
+            &empty,
+        );
+        assert_eq!(
+            boards.iter().map(|x| x.name.clone()).collect::<Vec<_>>(),
+            vec!["Older", "Newer"]
+        );
+    }
+
+    #[test]
     fn test_sort_boards_ties_break_by_position_ascending() {
         // Equal archived_at → deterministic position order, even under a
         // descending primary (tiebreaker stays ascending).

--- a/crates/kanban-domain/src/sort/boards.rs
+++ b/crates/kanban-domain/src/sort/boards.rs
@@ -5,9 +5,10 @@
 //! `position`; `archived_at` is NOT on the board head (it lives on the archival
 //! marker), so recency sorting takes an explicit id → timestamp map.
 //!
-//! Both [`BoardSortField`] variants are board-meaningful: `Position` (board
-//! order) and `ArchivedAt` (recency). There is no card-only fallback path
-//! because a card-only field cannot be passed here by construction.
+//! Every [`BoardSortField`] variant is board-meaningful: `Position` (board
+//! order), `Name` (case-insensitive), `CreatedAt`, and `ArchivedAt` (recency).
+//! There is no card-only fallback path because a card-only field cannot be
+//! passed here by construction.
 
 use crate::sort::sort_by_with_order;
 use crate::{Board, BoardSortField, SortOrder};
@@ -37,6 +38,8 @@ fn compare_boards(
             };
             at(&a.id).cmp(&at(&b.id))
         }
+        BoardSortField::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+        BoardSortField::CreatedAt => a.created_at.cmp(&b.created_at),
         BoardSortField::Position => a.position.cmp(&b.position),
     }
 }
@@ -143,7 +146,12 @@ mod tests {
         let c = board_at_position("Bravo", 2);
         let empty = HashMap::new();
         let mut boards = vec![a, b, c];
-        sort_boards_in_place(&mut boards, BoardSortField::Name, SortOrder::Ascending, &empty);
+        sort_boards_in_place(
+            &mut boards,
+            BoardSortField::Name,
+            SortOrder::Ascending,
+            &empty,
+        );
         assert_eq!(
             boards.iter().map(|x| x.name.clone()).collect::<Vec<_>>(),
             vec!["alpha", "Bravo", "Charlie"]

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -60,7 +60,10 @@ impl KanbanMcpServer {
                 .into_iter()
                 .map(|m| (m.entity_id, m.metadata.archived_at))
                 .collect();
-            let filter = BoardListFilter { archived };
+            let filter = BoardListFilter {
+                archived,
+                ..Default::default()
+            };
             Ok(ctx
                 .list_boards_filtered(filter)
                 .map_err(kanban_err_to_mcp)?
@@ -217,6 +220,7 @@ fn resolve_archived_board(ctx: &crate::context::McpContext, raw: &str) -> Result
     let heads = ctx
         .list_boards_filtered(BoardListFilter {
             archived: kanban_domain::ArchivedFilter::ArchivedOnly,
+            ..Default::default()
         })
         .map_err(kanban_err_to_mcp)?;
     let matches: Vec<Uuid> = kanban_domain::find_boards_by_name(raw, &heads)

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -873,6 +873,7 @@ pub async fn test_list_boards_archived_selector_roundtrip(factory: &BackendFacto
     let live_only = ctx
         .list_boards_filtered(BoardListFilter {
             archived: ArchivedFilter::LiveOnly,
+            ..Default::default()
         })
         .unwrap();
     let live_only_ids: Vec<_> = live_only.iter().map(|b| b.id).collect();
@@ -891,6 +892,7 @@ pub async fn test_list_boards_archived_selector_roundtrip(factory: &BackendFacto
     let archived_only = ctx
         .list_boards_filtered(BoardListFilter {
             archived: ArchivedFilter::ArchivedOnly,
+            ..Default::default()
         })
         .unwrap();
     let archived_only_ids: Vec<_> = archived_only.iter().map(|b| b.id).collect();
@@ -904,6 +906,7 @@ pub async fn test_list_boards_archived_selector_roundtrip(factory: &BackendFacto
     let include = ctx
         .list_boards_filtered(BoardListFilter {
             archived: ArchivedFilter::Include,
+            ..Default::default()
         })
         .unwrap();
     let include_ids: HashSet<_> = include.iter().map(|b| b.id).collect();


### PR DESCRIPTION
Parent: KAN-941 (BOARD-SORT). Layer S2 (domain: filter + dimensions). Depends on S1 (merged).

## What

Gives the board list the same filter-carries-sort shape as the card list, plus enough sort dimensions for the picker.

- `BoardSortField` expanded from `{Position, ArchivedAt}` to `{Position, Name, CreatedAt, ArchivedAt}`. `compare_boards` extended: `Name` is case-insensitive (`to_lowercase` compare), `CreatedAt` compares `created_at`; `ArchivedAt` (marker map) and `Position` unchanged. `sort_boards_in_place` still calls the S1 core.
- `BoardListFilter` now carries `sort: Option<BoardSortField>` and `sort_order: Option<SortOrder>`.
- `filter_and_sort_boards(boards, filter, archived_at, default)` mirrors `filter_and_sort_cards`. Boards have no column/sprint predicates (archival split is handled upstream), so this is predominantly the sort.
- `resolve_board_sort(sort, order, default)` mirrors `resolve_sort`: override wins, else the passed `default`, else `None`. Unlike cards (default from a Board entity), the board-list default is the AppConfig value threaded in by the service (S4).

Both new functions are re-exported from `query` and the crate root.

## Tests (Red first, split commit)

New: `test_filter_and_sort_boards_by_name_asc`/`_desc`, `_by_created_at`, `_by_archived_at`, `_by_position`, `_uses_default_when_filter_has_no_sort`; `test_resolve_board_sort_override_beats_default`, `_falls_back_to_default`, `_none_when_neither`, plus `_field_override_takes_default_order`, `_field_override_without_default_is_ascending`, `_order_override_layers_on_default_field`. Board-sort-primitive tests added for the new dimensions (`_by_name_ascending_is_case_insensitive`, `_descending`, `_by_created_at_ascending_is_oldest_first`); existing board sort tests migrated over the 4-variant enum, not deleted.

`cargo test -p kanban-domain` (657 passed), `cargo clippy -p kanban-domain --all-targets -D warnings` clean, `cargo fmt` applied.

Unblocks S4, S5, S6, S7.