### PR TITLE
KAN-945 feat(service): apply board sort in list_boards_filtered (live+archived, config default)

### DIFF
--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -1,11 +1,41 @@
 use super::KanbanContext;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use kanban_domain::commands::{ArchiveBoards, BoardCommand, Command, ImportEntities, RestoreBoard};
 use kanban_domain::{
-    ArchivedBoard, ArchivedFilter, Board, BoardListFilter, BoardUpdate, FieldUpdate, KanbanError,
-    KanbanResult, NewBoard,
+    filter_and_sort_boards, ArchivedBoard, ArchivedFilter, Board, BoardListFilter, BoardSortField,
+    BoardUpdate, FieldUpdate, KanbanError, KanbanResult, NewBoard, SortOrder,
 };
+use std::collections::HashMap;
 use uuid::Uuid;
+
+/// The built-in board sort applied when the AppConfig sets no default: Position
+/// ascending, so the live board list stays in insertion/position order and is
+/// byte-identical to `list_boards()` when nothing is configured.
+const DEFAULT_BOARD_SORT: (BoardSortField, SortOrder) =
+    (BoardSortField::Position, SortOrder::Ascending);
+
+/// Parse an AppConfig `board_sort_field` string into a [`BoardSortField`].
+/// Case-insensitive and tolerant of `-`/`_` separators. Unknown strings fall
+/// back to `None` so the caller can apply the built-in default.
+fn parse_board_sort_field(s: &str) -> Option<BoardSortField> {
+    match s.to_lowercase().replace(['-', '_'], "").as_str() {
+        "position" => Some(BoardSortField::Position),
+        "name" => Some(BoardSortField::Name),
+        "createdat" => Some(BoardSortField::CreatedAt),
+        "archivedat" => Some(BoardSortField::ArchivedAt),
+        _ => None,
+    }
+}
+
+/// Parse an AppConfig `board_sort_order` string into a [`SortOrder`].
+/// Case-insensitive; unknown strings fall back to `None`.
+fn parse_sort_order(s: &str) -> Option<SortOrder> {
+    match s.to_lowercase().as_str() {
+        "asc" | "ascending" => Some(SortOrder::Ascending),
+        "desc" | "descending" => Some(SortOrder::Descending),
+        _ => None,
+    }
+}
 
 /// Result of an idempotent PUT-create ([`KanbanContext::create_or_replace_board`]):
 /// the resulting board plus whether this call created it (`true`, HTTP 201) or
@@ -115,14 +145,49 @@ impl KanbanContext {
         if filter.archived != ArchivedFilter::ArchivedOnly {
             out.extend(self.backend.list_boards()?);
         }
+        // Harvest archived_at per board id (needed both to resolve archived heads
+        // and to sort by the ArchivedAt dimension), mirroring how the TUI does it.
+        let markers = self.backend.list_archived_boards()?;
+        let archived_at: HashMap<Uuid, DateTime<Utc>> = markers
+            .iter()
+            .map(|m| (m.entity_id, m.metadata.archived_at))
+            .collect();
         if filter.archived != ArchivedFilter::LiveOnly {
-            for m in self.backend.list_archived_boards()? {
+            for m in &markers {
                 if let Some(b) = self.backend.get_board(m.entity_id)? {
                     out.push(b);
                 }
             }
         }
-        Ok(out)
+        // Request sort/sort_order override the AppConfig default via
+        // `resolve_board_sort` (inside `filter_and_sort_boards`).
+        let default = self.board_sort_default();
+        Ok(filter_and_sort_boards(
+            &out,
+            &filter,
+            &archived_at,
+            Some(default),
+        ))
+    }
+
+    /// Resolve the board sort default from the AppConfig `board_sort_field` /
+    /// `board_sort_order`, falling back to [`DEFAULT_BOARD_SORT`] (Position ASC)
+    /// for any unset or unrecognized value. An unset field with a set order (or
+    /// vice versa) layers onto the built-in default's other half.
+    fn board_sort_default(&self) -> (BoardSortField, SortOrder) {
+        let field = self
+            .app_config
+            .board_sort_field
+            .as_deref()
+            .and_then(parse_board_sort_field)
+            .unwrap_or(DEFAULT_BOARD_SORT.0);
+        let order = self
+            .app_config
+            .board_sort_order
+            .as_deref()
+            .and_then(parse_sort_order)
+            .unwrap_or(DEFAULT_BOARD_SORT.1);
+        (field, order)
     }
 
     pub(super) fn get_board_impl(&self, id: Uuid) -> KanbanResult<Option<Board>> {

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -921,3 +921,125 @@ pub async fn test_list_boards_archived_selector_roundtrip(factory: &BackendFacto
         "Include returns both heads",
     );
 }
+
+/// S4 (KAN-945): a request-level `sort` on `BoardListFilter` sorts the returned
+/// heads server-side. Seed boards out of alphabetical order and assert
+/// `sort = Name` (ascending default) returns them alphabetically, on every
+/// backend.
+pub async fn test_list_boards_filtered_sorts_by_request_sort(factory: &BackendFactory) {
+    use kanban_domain::{BoardListFilter, BoardSortField};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    ctx.create_board("Charlie".into(), None).unwrap();
+    ctx.create_board("Alpha".into(), None).unwrap();
+    ctx.create_board("Bravo".into(), None).unwrap();
+
+    let sorted = ctx
+        .list_boards_filtered(BoardListFilter {
+            sort: Some(BoardSortField::Name),
+            ..Default::default()
+        })
+        .unwrap();
+    let names: Vec<_> = sorted.iter().map(|b| b.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["Alpha", "Bravo", "Charlie"],
+        "request sort=Name orders boards alphabetically"
+    );
+}
+
+/// S4 (KAN-945): a request-level `sort_order = Descending` reverses the sort.
+pub async fn test_list_boards_filtered_order_desc_reverses(factory: &BackendFactory) {
+    use kanban_domain::{BoardListFilter, BoardSortField, SortOrder};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    ctx.create_board("Alpha".into(), None).unwrap();
+    ctx.create_board("Charlie".into(), None).unwrap();
+    ctx.create_board("Bravo".into(), None).unwrap();
+
+    let sorted = ctx
+        .list_boards_filtered(BoardListFilter {
+            sort: Some(BoardSortField::Name),
+            sort_order: Some(SortOrder::Descending),
+            ..Default::default()
+        })
+        .unwrap();
+    let names: Vec<_> = sorted.iter().map(|b| b.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["Charlie", "Bravo", "Alpha"],
+        "request sort_order=Descending reverses the board order"
+    );
+}
+
+/// S4 (KAN-945): with NO request sort, the service falls back to the AppConfig
+/// default (`board_sort_field`/`board_sort_order`). Configure `Name` and assert
+/// the boards come back alphabetically without any request-level sort.
+pub async fn test_list_boards_filtered_falls_back_to_config_default(factory: &BackendFactory) {
+    use kanban_domain::BoardListFilter;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let config = AppConfig {
+        board_sort_field: Some("Name".into()),
+        board_sort_order: Some("Ascending".into()),
+        ..Default::default()
+    };
+    let mut ctx = KanbanContext::open(factory(&path), config).await.unwrap();
+
+    ctx.create_board("Charlie".into(), None).unwrap();
+    ctx.create_board("Alpha".into(), None).unwrap();
+    ctx.create_board("Bravo".into(), None).unwrap();
+
+    // No request-level sort — the AppConfig default drives the order.
+    let sorted = ctx
+        .list_boards_filtered(BoardListFilter::default())
+        .unwrap();
+    let names: Vec<_> = sorted.iter().map(|b| b.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["Alpha", "Bravo", "Charlie"],
+        "AppConfig board_sort_field=Name drives the order when no request sort is set"
+    );
+}
+
+/// S4 (KAN-945): with NO config and NO request sort, the live board list stays
+/// in Position order — byte-identical to `list_boards()`. This is the guard that
+/// the default configuration does not perturb today's ordering.
+pub async fn test_list_boards_no_config_no_request_is_position_order(factory: &BackendFactory) {
+    use kanban_domain::BoardListFilter;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    // Created in this order → positions 0,1,2. Names are NOT alphabetical, so a
+    // stray Name sort would reorder them and fail this guard.
+    ctx.create_board("Charlie".into(), None).unwrap();
+    ctx.create_board("Alpha".into(), None).unwrap();
+    ctx.create_board("Bravo".into(), None).unwrap();
+
+    let filtered_ids: Vec<_> = ctx
+        .list_boards_filtered(BoardListFilter::default())
+        .unwrap()
+        .iter()
+        .map(|b| b.id)
+        .collect();
+    let legacy_ids: Vec<_> = ctx.list_boards().unwrap().iter().map(|b| b.id).collect();
+    assert_eq!(
+        filtered_ids, legacy_ids,
+        "unconfigured list_boards_filtered stays position-ordered, byte-identical to list_boards()"
+    );
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -170,6 +170,22 @@ macro_rules! context_contract_tests {
         async fn test_list_boards_archived_selector_roundtrip() {
             $crate::test_helpers::contract::archive::test_list_boards_archived_selector_roundtrip(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_boards_filtered_sorts_by_request_sort() {
+            $crate::test_helpers::contract::archive::test_list_boards_filtered_sorts_by_request_sort(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_boards_filtered_order_desc_reverses() {
+            $crate::test_helpers::contract::archive::test_list_boards_filtered_order_desc_reverses(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_boards_filtered_falls_back_to_config_default() {
+            $crate::test_helpers::contract::archive::test_list_boards_filtered_falls_back_to_config_default(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_boards_no_config_no_request_is_position_order() {
+            $crate::test_helpers::contract::archive::test_list_boards_no_config_no_request_is_position_order(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Parent: KAN-941 (BOARD-SORT). Layer: service. Depends S2 (KAN-943, merged), S3.

## What

Apply the board sort server-side in `list_boards_filtered_impl` so every surface (CLI/MCP/TUI) gets consistent ordering for live AND archived board heads.

- After gathering the head set, harvest an `archived_at: HashMap<Uuid, DateTime<Utc>>` from `list_archived_boards()` markers (mirroring the TUI harvest) and call `kanban_domain::filter_and_sort_boards(&heads, &filter, &archived_at, default)`.
- The request `filter.sort`/`sort_order` override the AppConfig default via `resolve_board_sort` (already implemented in S2).
- The AppConfig `board_sort_field`/`board_sort_order` (`Option<String>`) are parsed at the service edge (`parse_board_sort_field`/`parse_sort_order`) into the domain enums, falling back to a built-in `(Position, Ascending)` default when unset or unrecognized.
- `list_boards()` (the LiveOnly sugar) is untouched — it still reads the backend's position order directly, byte-identical to before.

## How the context reaches AppConfig

`KanbanContext` holds `app_config: AppConfig` (set at `KanbanContext::open`). The new `board_sort_default()` helper reads `self.app_config.board_sort_field/order`.

## Tests (strict TDD, split test/impl commits)

Four new backend-parametrized contract tests, registered in the `context_contract_tests` macro so in-memory, JSON, and SQLite are all held to one spec:

- `test_list_boards_filtered_sorts_by_request_sort` — `sort = Name` → alphabetical.
- `test_list_boards_filtered_order_desc_reverses` — `sort_order = Descending` reverses.
- `test_list_boards_filtered_falls_back_to_config_default` — AppConfig `board_sort_field=Name`, no request sort → alphabetical.
- `test_list_boards_no_config_no_request_is_position_order` — byte-identical guard: unconfigured filtered list == `list_boards()` position order.

Red first (9 failures across 3 backends), then green.

## Verification

- `cargo test -p kanban-service --features test-helpers`: all green (incl. the 15 board-list contract tests across 3 backends).
- `cargo check -p kanban-service -p kanban-cli -p kanban-mcp -p kanban-tui`: green — confirms no `BoardListFilter` struct-literal breakage anywhere (S2 gave the new fields `Default`).
- `cargo clippy -p kanban-service --features test-helpers --all-targets -D warnings`: clean.
- `cargo fmt`: applied.