### PR TITLE
KAN-946 feat(cli): board list --sort/--order + board set-sort

### DIFF
--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -1,4 +1,4 @@
-use crate::cli::{Cli, Commands};
+use crate::cli::{BoardAction, BoardCommand, Cli, Commands};
 use crate::context::CliContext;
 use crate::handlers;
 use crate::output;
@@ -296,6 +296,9 @@ impl CliApp {
             None | Some(Commands::Completions { .. })
                 | Some(Commands::Migrate(_))
                 | Some(Commands::Init { .. })
+                | Some(Commands::Board(BoardCommand {
+                    action: BoardAction::SetSort { .. },
+                }))
         );
         if needs_data_file && validated_file.is_none() && config.storage_location.is_none() {
             anyhow::bail!(
@@ -362,6 +365,26 @@ Provide the file path in one of these ways:
                         });
                     }
                 }
+            }
+            Some(Commands::Board(BoardCommand {
+                action: BoardAction::SetSort { field, order },
+            })) => {
+                init_tracing_cli();
+                // Config-only: persist the default board-list sort to AppConfig
+                // without opening a data file. The service's list path reads
+                // these string forms when a `board list` omits --sort/--order.
+                let mut config = config;
+                if let Some(field) = field {
+                    config.board_sort_field = Some(field.to_config_string());
+                }
+                if let Some(order) = order {
+                    config.board_sort_order = Some(order.to_config_string());
+                }
+                kanban_service::config::save(&config)?;
+                output::output_success(serde_json::json!({
+                    "board_sort_field": config.board_sort_field,
+                    "board_sort_order": config.board_sort_order,
+                }));
             }
             Some(cmd) => {
                 init_tracing_cli();

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -70,6 +70,14 @@ pub enum BoardAction {
         /// Include archived boards alongside live ones.
         #[arg(long)]
         include_archived: bool,
+        /// Sort key. When omitted, falls back to the persisted
+        /// `board_sort_field` default (else board position).
+        #[arg(long, value_enum)]
+        sort: Option<BoardSortKey>,
+        /// Sort direction. When omitted, falls back to the persisted
+        /// `board_sort_order` default (else ascending).
+        #[arg(long, value_enum)]
+        order: Option<SortDir>,
         #[arg(long)]
         page: Option<u32>,
         #[arg(long)]
@@ -102,6 +110,51 @@ pub enum BoardAction {
         /// Board UUID or name
         board: String,
     },
+    /// Persist the default board-list sort (written to AppConfig).
+    SetSort {
+        /// Board sort field to persist as the default.
+        #[arg(long, value_enum)]
+        field: Option<BoardSortKey>,
+        /// Board sort direction to persist as the default.
+        #[arg(long, value_enum)]
+        order: Option<SortDir>,
+    },
+}
+
+/// Sort key for `kanban board list` / the persisted board-list default.
+/// The board-view dimensions (NOT the card `SortKey`): board position, name,
+/// creation time, and archival recency.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum BoardSortKey {
+    Position,
+    Name,
+    CreatedAt,
+    ArchivedAt,
+}
+
+impl BoardSortKey {
+    pub fn to_board_sort_field(self) -> kanban_domain::BoardSortField {
+        use kanban_domain::BoardSortField;
+        match self {
+            BoardSortKey::Position => BoardSortField::Position,
+            BoardSortKey::Name => BoardSortField::Name,
+            BoardSortKey::CreatedAt => BoardSortField::CreatedAt,
+            BoardSortKey::ArchivedAt => BoardSortField::ArchivedAt,
+        }
+    }
+
+    /// The `AppConfig::board_sort_field` string form. The service parser is
+    /// case-insensitive and tolerant of `-`/`_`, so the enum's clap value name
+    /// (e.g. `created-at`) round-trips back to the same field.
+    pub fn to_config_string(self) -> String {
+        match self {
+            BoardSortKey::Position => "position",
+            BoardSortKey::Name => "name",
+            BoardSortKey::CreatedAt => "created_at",
+            BoardSortKey::ArchivedAt => "archived_at",
+        }
+        .to_string()
+    }
 }
 
 #[derive(Args)]
@@ -349,6 +402,16 @@ impl SortDir {
             SortDir::Asc => kanban_domain::SortOrder::Ascending,
             SortDir::Desc => kanban_domain::SortOrder::Descending,
         }
+    }
+
+    /// The `AppConfig::board_sort_order` string form (the service parser
+    /// accepts `asc`/`desc` case-insensitively).
+    pub fn to_config_string(self) -> String {
+        match self {
+            SortDir::Asc => "asc",
+            SortDir::Desc => "desc",
+        }
+        .to_string()
     }
 }
 

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -17,6 +17,8 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
         BoardAction::List {
             archived,
             include_archived,
+            sort,
+            order,
             page,
             page_size,
         } => {
@@ -34,7 +36,8 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                 } else {
                     ArchivedFilter::LiveOnly
                 },
-                ..Default::default()
+                sort: sort.map(|s| s.to_board_sort_field()),
+                sort_order: order.map(|o| o.to_sort_order()),
             };
             let responses = match project_board_list(ctx, filter) {
                 Ok(r) => r,
@@ -100,6 +103,11 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             ctx.delete_board(uuid)?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
+        }
+        BoardAction::SetSort { .. } => {
+            // Config-only: intercepted in `CliApp::run_with_args` before a data
+            // file is opened, so it never reaches the data-file dispatch path.
+            unreachable!("board set-sort is handled before context load");
         }
     }
     Ok(())

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5167,3 +5167,117 @@ mod relation_tests {
         assert_eq!(json["data"].as_array().unwrap().len(), 0);
     }
 }
+
+mod board_sort_tests {
+    use super::*;
+
+    /// Names in the order they appear in the paginated `board list` output.
+    fn board_names(json: &Value) -> Vec<String> {
+        json["data"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b["name"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_board_list_sort_by_name_orders_alphabetically() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        // Create out of alphabetical order so the default (position) order
+        // differs from the name order.
+        for name in ["Charlie", "Alpha", "Bravo"] {
+            kanban()
+                .args([file.to_str().unwrap(), "board", "create", "--name", name])
+                .assert()
+                .success();
+        }
+
+        let out = kanban()
+            .args([file.to_str().unwrap(), "board", "list", "--sort", "name"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&out));
+        assert_eq!(board_names(&json), vec!["Alpha", "Bravo", "Charlie"]);
+    }
+
+    #[test]
+    fn test_board_list_order_desc_reverses() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        for name in ["Charlie", "Alpha", "Bravo"] {
+            kanban()
+                .args([file.to_str().unwrap(), "board", "create", "--name", name])
+                .assert()
+                .success();
+        }
+
+        let out = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "list",
+                "--sort",
+                "name",
+                "--order",
+                "desc",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&out));
+        assert_eq!(board_names(&json), vec!["Charlie", "Bravo", "Alpha"]);
+    }
+
+    #[test]
+    fn test_board_set_sort_persists_to_config() {
+        // Isolate the config to a tempdir HOME so `set-sort` writes and a later
+        // `board list` reads back the persisted default (server-side sort).
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban_no_config(dir.path())
+            .args([file.to_str().unwrap()])
+            .assert()
+            .success();
+
+        for name in ["Charlie", "Alpha", "Bravo"] {
+            kanban_no_config(dir.path())
+                .args([file.to_str().unwrap(), "board", "create", "--name", name])
+                .assert()
+                .success();
+        }
+
+        // Persist the board sort default = name.
+        kanban_no_config(dir.path())
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "set-sort",
+                "--field",
+                "name",
+            ])
+            .assert()
+            .success();
+
+        // A plain `board list` (no --sort) must now honor the persisted default.
+        let out = kanban_no_config(dir.path())
+            .args([file.to_str().unwrap(), "board", "list"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&out));
+        assert_eq!(board_names(&json), vec!["Alpha", "Bravo", "Charlie"]);
+    }
+}


### PR DESCRIPTION
Implements KAN-946 (BOARD-SORT S5). Mirrors `card list --sort/--order` for boards and adds a config-only `board set-sort` that persists the default board-list sort to AppConfig.

## Scope (kanban-cli only)

1. `board list --sort <position|name|created_at|archived_at>` and `--order <asc|desc>`. New `BoardSortKey` value_enum with `to_board_sort_field()`, reusing `SortDir::to_sort_order()`. The handler builds `BoardListFilter { archived, sort, sort_order }`; the service (S4) applies the sort server-side, falling back to the AppConfig default when the flags are omitted.
2. `board set-sort --field <..> --order <..>` writes `AppConfig.board_sort_field` / `board_sort_order` (string forms) and persists via `kanban_service::config::save`. It is config-only: intercepted in `CliApp::run_with_args` (where the loaded `AppConfig` is in scope) before any data file is opened, and added to the `needs_data_file` exemption list alongside `migrate` / `init`.

## Tests (assert_cmd, TDD red first)

- `test_board_list_sort_by_name_orders_alphabetically`
- `test_board_list_order_desc_reverses`
- `test_board_set_sort_persists_to_config` (runs `board set-sort --field name`, then a plain `board list` reflects the persisted default under an isolated tempdir HOME)

All `cargo test -p kanban-cli` green; `cargo clippy -p kanban-cli --no-deps -D warnings` clean; `cargo fmt` applied.

## Notes

- The card suggested `..Default::default()` in the `BoardListFilter` construction, but since all three fields are now set explicitly, clippy `needless_update` (`-D warnings`) rejects it, so it was dropped.
- A pre-existing `clippy::large_enum_variant` warning fires in kanban-tui (`app/types.rs` `old_config: AppConfig`) because the merged AppConfig grew two fields. It reproduces with this branch's cli changes stashed, is outside this crate's scope (kanban-tui is owned by S7), and is not addressed here.