### PR TITLE
KAN-947 feat(mcp): list_boards sort/order params + set_board_sort tool

### DIFF
--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -83,15 +83,19 @@ Most tool inputs accept either an opaque UUID or a friendlier reference, resolve
 - `card`: UUID or a short identifier like `KAN-5`. If the identifier matches multiple cards, the tool returns the full list for disambiguation.
 - `cards` (bulk operations): array of UUIDs or card identifiers (for example `["KAN-1", "KAN-2", "42"]`); all referenced cards must share a board.
 
-### Boards (5 tools)
+### Boards (9 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
 | `tool_create_board` | Create a new kanban board | `name: String` | `card_prefix: String` |
-| `tool_list_boards` | List all boards | — | — |
+| `tool_list_boards` | List boards (honors sort/order; falls back to the configured default) | — | `archived`, `sort` (position/name/created_at/archived_at), `order` (asc/desc), `page: u32`, `page_size: u32` |
 | `tool_get_board` | Get a specific board by UUID or name | `board: String` | — |
-| `tool_update_board` | Update board properties | `board: String` | `name`, `description`, `sprint_prefix`, `card_prefix` |
+| `tool_update_board` | Update board properties | `board: String` | `name`, `description`, `sprint_prefix`, `card_prefix`, `task_sort_field`, `task_sort_order` |
+| `tool_set_board_sort` | Persist the default board-list sort in app config | — | `sort` (position/name/created_at/archived_at), `order` (asc/desc) |
 | `tool_delete_board` | Delete board and all its columns, cards, sprints | `board: String` | — |
+| `tool_archive_board` | Archive a board (hides it from the live list) | `board: String` | — |
+| `tool_restore_board` | Restore an archived board to the live list | `board: String` | — |
+| `tool_delete_archived_board` | Permanently delete an archived board and its subtree | `board: String` | — |
 
 ### Columns (6 tools)
 

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -36,6 +36,32 @@ impl McpContext {
         self.inner.reload().await
     }
 
+    /// Persist the default board-list sort into `AppConfig`
+    /// (`board_sort_field` / `board_sort_order`) and make the running context
+    /// reflect it immediately. Either dimension may be left unchanged by passing
+    /// `None`. The default is applied server-side inside
+    /// `KanbanContext::list_boards_filtered`, so we rebuild the inner context on
+    /// the same backend with the updated config; the config is then flushed to
+    /// disk via `kanban_service::config::save`.
+    pub fn set_board_sort(
+        &mut self,
+        sort: Option<String>,
+        order: Option<String>,
+    ) -> KanbanResult<()> {
+        let mut config = self.inner.app_config().clone();
+        if let Some(field) = sort {
+            config.board_sort_field = Some(field);
+        }
+        if let Some(dir) = order {
+            config.board_sort_order = Some(dir);
+        }
+        let backend = self.inner.backend();
+        self.inner =
+            KanbanContext::open_deferred(backend, config.clone()).with_app_type(AppType::Mcp);
+        kanban_service::config::save(&config)?;
+        Ok(())
+    }
+
     /// Create a board from a full spec + optional client id, funneling through
     /// the Board factory (`create_board_from_spec`). The MCP create tool calls
     /// this after splitting the shared `CreateBoardRequest` via `into_new_board`.

--- a/crates/kanban-mcp/src/helpers/mod.rs
+++ b/crates/kanban-mcp/src/helpers/mod.rs
@@ -9,8 +9,8 @@ pub(crate) use error_mapping::{
 };
 pub(crate) use macros::{locked_read, locked_write, mutating_op, read_op};
 pub(crate) use parsers::{
-    parse_archived_selector, parse_datetime, parse_priority, parse_sort_field, parse_sort_order,
-    parse_status,
+    parse_archived_selector, parse_board_sort_field, parse_datetime, parse_priority,
+    parse_sort_field, parse_sort_order, parse_status,
 };
 pub(crate) use resolvers::{card_board, project_sprint, resolve_summaries, McpResolve};
 pub(crate) use serialization::{to_call_tool_result, to_call_tool_result_json};

--- a/crates/kanban-mcp/src/helpers/parsers.rs
+++ b/crates/kanban-mcp/src/helpers/parsers.rs
@@ -1,5 +1,7 @@
 use kanban_core::parse_datetime_input;
-use kanban_domain::{ArchivedFilter, CardPriority, CardStatus, SortField, SortOrder};
+use kanban_domain::{
+    ArchivedFilter, BoardSortField, CardPriority, CardStatus, SortField, SortOrder,
+};
 use rmcp::model::ErrorData as McpError;
 
 /// Parse the `archived` list selector: `exclude` (live only, the default),
@@ -66,6 +68,22 @@ pub(crate) fn parse_sort_field(s: &str) -> Result<SortField, McpError> {
         _ => Err(McpError::invalid_params(
             format!(
                 "Invalid sort field '{}'. Valid: points, priority, created_at, updated_at, due_date, status, position, default",
+                s
+            ),
+            None,
+        )),
+    }
+}
+
+pub(crate) fn parse_board_sort_field(s: &str) -> Result<BoardSortField, McpError> {
+    match s.to_lowercase().replace(['-', '_'], "").as_str() {
+        "position" => Ok(BoardSortField::Position),
+        "name" => Ok(BoardSortField::Name),
+        "createdat" => Ok(BoardSortField::CreatedAt),
+        "archivedat" => Ok(BoardSortField::ArchivedAt),
+        _ => Err(McpError::invalid_params(
+            format!(
+                "Invalid board sort field '{}'. Valid: position, name, created_at, archived_at",
                 s
             ),
             None,
@@ -221,6 +239,35 @@ mod tests {
     fn parse_sort_field_rejects_unknown() {
         let err = parse_sort_field("magnitude").unwrap_err();
         assert!(err.message.contains("Invalid sort field"));
+    }
+
+    // parse_board_sort_field
+
+    #[test]
+    fn parse_board_sort_field_covers_every_variant() {
+        use kanban_domain::BoardSortField;
+        assert_eq!(
+            parse_board_sort_field("position").unwrap(),
+            BoardSortField::Position
+        );
+        assert_eq!(
+            parse_board_sort_field("name").unwrap(),
+            BoardSortField::Name
+        );
+        assert_eq!(
+            parse_board_sort_field("created-at").unwrap(),
+            BoardSortField::CreatedAt
+        );
+        assert_eq!(
+            parse_board_sort_field("archived_at").unwrap(),
+            BoardSortField::ArchivedAt
+        );
+    }
+
+    #[test]
+    fn parse_board_sort_field_rejects_unknown() {
+        let err = parse_board_sort_field("priority").unwrap_err();
+        assert!(err.message.contains("Invalid board sort field"));
     }
 
     // parse_sort_order

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -11,7 +11,8 @@ pub use server::McpServer;
 
 pub use requests::board::{
     ArchiveBoardRequest, CreateBoardRequest, DeleteArchivedBoardRequest, DeleteBoardRequest,
-    GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, UpdateBoardRequest,
+    GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, SetBoardSortRequest,
+    UpdateBoardRequest,
 };
 pub use requests::card::{
     ArchiveCardRequest, ArchiveCardsRequest, AssignCardToSprintRequest, AssignCardsToSprintRequest,

--- a/crates/kanban-mcp/src/requests/board.rs
+++ b/crates/kanban-mcp/src/requests/board.rs
@@ -40,6 +40,14 @@ pub struct ListBoardsRequest {
     )]
     pub archived: Option<String>,
     #[schemars(
+        description = "Sort field. Valid: position, name, created_at, archived_at. When omitted, falls back to the configured board-sort default."
+    )]
+    pub sort: Option<String>,
+    #[schemars(
+        description = "Sort direction: 'asc' or 'desc'. When omitted, falls back to the configured board-sort default."
+    )]
+    pub order: Option<String>,
+    #[schemars(
         description = "Page number, 1-based. When both page and page_size are absent, all boards are returned without pagination."
     )]
     pub page: Option<u32>,
@@ -47,6 +55,18 @@ pub struct ListBoardsRequest {
         description = "Items per page. When both page and page_size are absent, all boards are returned without pagination."
     )]
     pub page_size: Option<u32>,
+}
+
+/// Params for the `set_board_sort` tool: the AppConfig default board-list sort.
+/// Either field may be omitted to leave that dimension unchanged.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SetBoardSortRequest {
+    #[schemars(
+        description = "Default sort field for the board list. Valid: position, name, created_at, archived_at."
+    )]
+    pub sort: Option<String>,
+    #[schemars(description = "Default sort direction for the board list. Valid: asc, desc.")]
+    pub order: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -1,11 +1,12 @@
 use crate::helpers::{
     core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, mutating_op,
-    parse_archived_selector, parse_sort_field, parse_sort_order, to_call_tool_result,
-    to_call_tool_result_json, McpResolve,
+    parse_archived_selector, parse_board_sort_field, parse_sort_field, parse_sort_order,
+    to_call_tool_result, to_call_tool_result_json, McpResolve,
 };
 use crate::requests::board::{
     ArchiveBoardRequest, CreateBoardRequest, DeleteArchivedBoardRequest, DeleteBoardRequest,
-    GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, UpdateBoardRequest,
+    GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, SetBoardSortRequest,
+    UpdateBoardRequest,
 };
 use crate::KanbanMcpServer;
 use chrono::{DateTime, Utc};
@@ -48,6 +49,12 @@ impl KanbanMcpServer {
             .map(parse_archived_selector)
             .transpose()?
             .unwrap_or_default();
+        let sort = req
+            .sort
+            .as_deref()
+            .map(parse_board_sort_field)
+            .transpose()?;
+        let sort_order = req.order.as_deref().map(parse_sort_order).transpose()?;
         // One gather path: the service filter yields the live/archived/both head
         // set (mirroring `filter_cards`). The archive markers only supply the
         // per-board `archived_at`, so we decorate the filtered heads by looking
@@ -62,7 +69,8 @@ impl KanbanMcpServer {
                 .collect();
             let filter = BoardListFilter {
                 archived,
-                ..Default::default()
+                sort,
+                sort_order,
             };
             Ok(ctx
                 .list_boards_filtered(filter)
@@ -141,6 +149,33 @@ impl KanbanMcpServer {
         })
         .await?;
         to_call_tool_result(&BoardResponse::from(&board))
+    }
+
+    #[tool(
+        description = "Set the default board-list sort persisted in the app config (board_sort_field / board_sort_order). Sort field valid: position, name, created_at, archived_at. Order valid: asc, desc. Either may be omitted to leave that dimension unchanged. Subsequent list_boards calls without an explicit sort/order use this default."
+    )]
+    pub async fn tool_set_board_sort(
+        &self,
+        Parameters(req): Parameters<SetBoardSortRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        // Validate the raw strings up front so an invalid value is rejected
+        // before any config write. The config stores the string form (the
+        // service re-parses it on read), so the validated raw strings are what
+        // we persist.
+        req.sort
+            .as_deref()
+            .map(parse_board_sort_field)
+            .transpose()?;
+        req.order.as_deref().map(parse_sort_order).transpose()?;
+        locked_write(&self.ctx, |ctx| {
+            ctx.set_board_sort(req.sort.clone(), req.order.clone())
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
+        to_call_tool_result_json(serde_json::json!({
+            "board_sort_field": req.sort,
+            "board_sort_order": req.order,
+        }))
     }
 
     #[tool(description = "Delete a board and all its columns, cards, and sprints")]

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1775,6 +1775,8 @@ async fn read_tools_project_through_v1_response_dtos_hiding_internal_state() {
         &server
             .tool_list_boards(Parameters(ListBoardsRequest {
                 archived: None,
+                sort: None,
+                order: None,
                 page: None,
                 page_size: None,
             }))
@@ -2040,6 +2042,8 @@ async fn test_mcp_list_cards_archived_selector() {
 fn list_boards_req(archived: Option<&str>) -> ListBoardsRequest {
     ListBoardsRequest {
         archived: archived.map(|s| s.to_string()),
+        sort: None,
+        order: None,
         page: None,
         page_size: None,
     }
@@ -2534,6 +2538,8 @@ async fn test_list_boards_default_returns_all_boards() {
         &server
             .tool_list_boards(Parameters(ListBoardsRequest {
                 archived: None,
+                sort: None,
+                order: None,
                 page: None,
                 page_size: None,
             }))
@@ -2559,6 +2565,8 @@ async fn test_list_boards_explicit_pagination_still_works() {
         &server
             .tool_list_boards(Parameters(ListBoardsRequest {
                 archived: None,
+                sort: None,
+                order: None,
                 page: Some(1),
                 page_size: Some(10),
             }))
@@ -2591,6 +2599,8 @@ async fn test_list_boards_include_archived_not_truncated() {
         &server
             .tool_list_boards(Parameters(ListBoardsRequest {
                 archived: Some("include".into()),
+                sort: None,
+                order: None,
                 page: None,
                 page_size: None,
             }))
@@ -2675,4 +2685,125 @@ async fn test_list_archived_cards_returns_card_summary_shape() {
         "no original_column_id"
     );
     assert!(obj.get("board_id").is_none(), "no first-class board_id");
+}
+
+// KAN-947: list_boards honors sort/order params, and set_board_sort persists
+// the AppConfig board-sort default so subsequent unsorted list calls reflect it.
+
+/// Read the ordered board names from a flat-array list_boards payload.
+fn board_names(val: &Value) -> Vec<String> {
+    val.as_array()
+        .expect("no-arg list_boards returns a flat array")
+        .iter()
+        .map(|b| b["name"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// Seed three boards in an order that makes position and name orderings differ.
+/// Positions are assigned on create (Charlie=0, Alpha=1, Bravo=2), so the
+/// built-in Position-ASC default yields [Charlie, Alpha, Bravo], while Name-ASC
+/// yields [Alpha, Bravo, Charlie].
+async fn seed_three_boards(server: &KanbanMcpServer) {
+    for name in ["Charlie", "Alpha", "Bravo"] {
+        mcp_create_board(server, name).await;
+    }
+}
+
+#[tokio::test]
+async fn test_mcp_list_boards_sort_by_name() {
+    let (server, _tmp) = setup_server().await;
+    seed_three_boards(&server).await;
+    let result = text_payload(
+        &server
+            .tool_list_boards(Parameters(ListBoardsRequest {
+                archived: None,
+                sort: Some("name".into()),
+                order: None,
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        board_names(&result),
+        vec!["Alpha", "Bravo", "Charlie"],
+        "sort=name must order boards alphabetically ascending"
+    );
+}
+
+#[tokio::test]
+async fn test_mcp_list_boards_order_desc() {
+    let (server, _tmp) = setup_server().await;
+    seed_three_boards(&server).await;
+    let result = text_payload(
+        &server
+            .tool_list_boards(Parameters(ListBoardsRequest {
+                archived: None,
+                sort: Some("name".into()),
+                order: Some("desc".into()),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        board_names(&result),
+        vec!["Charlie", "Bravo", "Alpha"],
+        "order=desc must reverse the name ordering"
+    );
+}
+
+#[tokio::test]
+async fn test_mcp_set_board_sort_persists_default() {
+    let dir = TempDir::new().unwrap();
+    let data_path = dir.path().join("test.json");
+    let config_path = dir.path().join("config.toml");
+    let store_manager = default_store_manager();
+    // Point the config at a temp file so config::save writes there, not the
+    // global user config location.
+    let config = AppConfig {
+        configuration_location: Some(config_path.to_string_lossy().to_string()),
+        ..AppConfig::default()
+    };
+    let server = KanbanMcpServer::new(&store_manager, &data_path.to_string_lossy(), config)
+        .await
+        .unwrap();
+    seed_three_boards(&server).await;
+
+    // Set the default board sort to Name-ASC.
+    server
+        .tool_set_board_sort(Parameters(kanban_mcp::SetBoardSortRequest {
+            sort: Some("name".into()),
+            order: Some("asc".into()),
+        }))
+        .await
+        .unwrap();
+
+    // An unsorted list must now reflect the configured default.
+    let result = text_payload(
+        &server
+            .tool_list_boards(Parameters(ListBoardsRequest {
+                archived: None,
+                sort: None,
+                order: None,
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        board_names(&result),
+        vec!["Alpha", "Bravo", "Charlie"],
+        "after set_board_sort, unsorted list must use the Name-ASC default"
+    );
+
+    // And the default must be persisted to the config file on disk.
+    let persisted = std::fs::read_to_string(&config_path).expect("config file must be written");
+    assert!(
+        persisted.contains("board_sort_field"),
+        "persisted config must carry board_sort_field, got: {persisted}"
+    );
 }


### PR DESCRIPTION
## Summary

Adds board-list sorting to the MCP layer (S6 of BOARD-SORT, parent KAN-941), mirroring the existing `list_cards` sort pattern.

- `ListBoardsRequest` gains `sort` and `order` params (schemars-described: `position`/`name`/`created_at`/`archived_at`; `asc`/`desc`; "falls back to the configured board-sort default"), wired into `BoardListFilter { archived, sort, sort_order }` in `tool_list_boards`.
- New `parse_board_sort_field` helper mirrors `parse_sort_field`, reusing `parse_sort_order`.
- New `tool_set_board_sort` tool persists the `AppConfig.board_sort_field` / `board_sort_order` default via `kanban_service::config::save` and rebuilds the running context on the same backend so subsequent unsorted `list_boards` calls reflect the new default.

The service (`list_boards_filtered`, KAN-945) already resolves the AppConfig default server-side; the MCP context has no config setter, so `McpContext::set_board_sort` updates the config and reopens the inner `KanbanContext` on the existing backend Arc.

## Tests (TDD, red first)

Integration tests against a real `KanbanContext`:
- `test_mcp_list_boards_sort_by_name`
- `test_mcp_list_boards_order_desc`
- `test_mcp_set_board_sort_persists_default` (points `configuration_location` at a temp file, asserts the unsorted list reflects the default and the config is written to disk)

Plus unit tests for `parse_board_sort_field` (all variants + rejection).

## Checks

`cargo test -p kanban-mcp` green, `cargo clippy -p kanban-mcp --all-targets -D warnings` clean, `cargo fmt` clean. MCP README tool table updated (Boards section now lists all 9 board tools including the new `tool_set_board_sort`; total remains 46).