### PR TITLE
KAN-948 feat(tui): board sort field-picker + order toggle (live+archived), persisted

### DIFF
--- a/crates/kanban-tui/src/app/filter.rs
+++ b/crates/kanban-tui/src/app/filter.rs
@@ -12,6 +12,9 @@ pub struct FilterState {
     pub current_sort_field: Option<SortField>,
     pub current_sort_order: Option<SortOrder>,
     pub sort_field_selection: SelectionState,
+    /// Highlighted row in the PROJECTS-panel sort field picker (KAN-948), the
+    /// board-side analogue of `sort_field_selection`.
+    pub board_sort_field_selection: SelectionState,
     pub search: SearchState,
     pub dialog_state: Option<FilterDialogState>,
 }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -140,6 +140,7 @@ impl App {
                 DialogMode::OrderCards => {
                     should_restart_events = self.handle_order_cards_popup(key.code);
                 }
+                DialogMode::OrderBoards => self.handle_order_boards_popup(key.code),
                 DialogMode::AssignCardToSprint => self.handle_assign_card_to_sprint_popup(key.code),
                 DialogMode::AssignMultipleCardsToSprint => {
                     self.handle_assign_multiple_cards_to_sprint_popup(key.code)
@@ -271,11 +272,18 @@ impl App {
                 self.pending_key = None;
                 if self.focus.active == Focus::Cards {
                     self.handle_manage_children_from_list();
+                } else {
+                    // Boards focus: `s` toggles the projects-panel sort order,
+                    // mirroring the archived-boards view (persisted to config).
+                    self.handle_toggle_board_sort_order();
                 }
             }
             KeyCode::Char('o') => {
                 self.pending_key = None;
+                // Cards focus opens the card sort picker; Boards focus opens the
+                // board sort picker. Each handler guards on its own context.
                 self.handle_order_cards_key();
+                self.handle_order_boards_key();
             }
             KeyCode::Char('O') => {
                 self.pending_key = None;
@@ -470,7 +478,8 @@ impl App {
         match key_code {
             KeyCode::Char('r') => self.handle_restore_board(),
             KeyCode::Char('x') => self.handle_delete_archived_board_key(),
-            KeyCode::Char('s') => self.handle_toggle_archived_boards_sort_order(),
+            KeyCode::Char('s') => self.handle_toggle_board_sort_order(),
+            KeyCode::Char('o') => self.handle_order_boards_key(),
             KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q')
                 if self.selection.active_board_id.is_none() =>
             {

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -90,6 +90,7 @@ impl App {
             KeybindingAction::ExportAll => self.handle_export_all_key(),
             KeybindingAction::ImportBoard => self.handle_import_board_key(),
             KeybindingAction::OrderCards => self.handle_order_cards_key(),
+            KeybindingAction::OrderBoards => self.handle_order_boards_key(),
             KeybindingAction::ToggleSortOrder => self.handle_toggle_sort_order_key(),
             KeybindingAction::ToggleFilter => self.handle_toggle_sprint_filter(),
             KeybindingAction::ToggleHideAssigned => self.handle_open_filter_dialog(),
@@ -98,7 +99,7 @@ impl App {
             KeybindingAction::RestoreBoard => self.handle_restore_board(),
             KeybindingAction::DeleteArchivedBoard => self.handle_delete_archived_board(),
             KeybindingAction::ToggleArchivedBoardsSortOrder => {
-                self.handle_toggle_archived_boards_sort_order()
+                self.handle_toggle_board_sort_order()
             }
             KeybindingAction::ToggleTaskListView => self.handle_toggle_task_list_view(),
             KeybindingAction::ToggleCardSelection => self.handle_card_selection_toggle(),

--- a/crates/kanban-tui/src/app/lifecycle.rs
+++ b/crates/kanban-tui/src/app/lifecycle.rs
@@ -87,6 +87,11 @@ impl App {
             .with_app_type(kanban_service::AppType::Tui);
         let (ctx, save_rx, save_completion_rx) = TuiContext::new(inner_ctx)?;
         let store_manager = Arc::new(store_manager);
+        // Seed the projects-panel sort from the persisted AppConfig default so
+        // the choice survives a restart (KAN-948). Done before the first
+        // `prepare_frame`/`load_from_snapshot`, which re-sorts using this state.
+        let mut model = super::model::Model::default();
+        model.set_board_sort_from_config(&app_config);
         let app = Self {
             store_manager,
             should_quit: false,
@@ -107,7 +112,7 @@ impl App {
             ui_state: UiState::default(),
             sprint_view: SprintViewState::default(),
             view: ViewState::default(),
-            model: super::model::Model::default(),
+            model,
             relationship: RelationshipState::default(),
             save_error: None,
             pending_key: None,

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -232,7 +232,7 @@ impl App {
                             MigrationState::Idle => unreachable!(),
                         };
                         if let Some(result) = result {
-                            self.handle_migration_complete(old_config, result).await;
+                            self.handle_migration_complete(*old_config, result).await;
                         }
                     }
                     export_result = async {

--- a/crates/kanban-tui/src/app/mode.rs
+++ b/crates/kanban-tui/src/app/mode.rs
@@ -11,6 +11,7 @@ pub enum DialogMode {
     SetMultipleCardsPriority,
     SetBranchPrefix,
     OrderCards,
+    OrderBoards,
     CreateSprint,
     AssignCardToSprint,
     AssignMultipleCardsToSprint,

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -566,16 +566,34 @@ mod tests {
     }
 
     #[test]
-    fn test_archived_boards_default_order_is_recency() {
-        // Default archived-boards order is archived_at DESC (newest first),
-        // the conventional trash/history UX — NOT position order.
+    fn test_archived_boards_default_order_is_position() {
+        // The unified board-list sort defaults to the built-in Position ASC
+        // (matching the AppConfig-less service default), applied to BOTH
+        // partitions. Position 0 (first) precedes position 1 (second).
         let mut m = Model::default();
         let (first_id, second_id) = seed_two_archived_boards(&mut m);
         let order: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
         assert_eq!(
             order,
+            vec![first_id, second_id],
+            "default board sort is Position ASC"
+        );
+    }
+
+    #[test]
+    fn test_archived_boards_sort_by_recency_orders_newest_first() {
+        // Recency DESC (archived_at) puts the newest-archived board first.
+        let mut m = Model::default();
+        let (first_id, second_id) = seed_two_archived_boards(&mut m);
+        m.set_board_sort(
+            kanban_domain::BoardSortField::ArchivedAt,
+            kanban_domain::SortOrder::Descending,
+        );
+        let order: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
+        assert_eq!(
+            order,
             vec![second_id, first_id],
-            "newest-archived (second) must come first by default"
+            "newest-archived (second) must come first under recency DESC"
         );
     }
 
@@ -583,7 +601,7 @@ mod tests {
     fn test_archived_boards_sort_by_position_matches_board_order() {
         let mut m = Model::default();
         let (first_id, second_id) = seed_two_archived_boards(&mut m);
-        m.set_archived_boards_sort(
+        m.set_board_sort(
             kanban_domain::BoardSortField::Position,
             kanban_domain::SortOrder::Ascending,
         );
@@ -596,15 +614,19 @@ mod tests {
     }
 
     #[test]
-    fn test_toggle_reverses_archived_boards_order() {
-        // The shared SortOrder toggle flips the archived-boards order. From the
-        // default (recency DESC) a toggle yields recency ASC (oldest first).
+    fn test_toggle_reverses_board_sort_order() {
+        // The shared SortOrder toggle flips the board-list order for the shown
+        // partition. From recency DESC a toggle yields recency ASC (oldest first).
         let mut m = Model::default();
         let (first_id, second_id) = seed_two_archived_boards(&mut m);
+        m.set_board_sort(
+            kanban_domain::BoardSortField::ArchivedAt,
+            kanban_domain::SortOrder::Descending,
+        );
         let before: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
         assert_eq!(before, vec![second_id, first_id]);
 
-        m.toggle_archived_boards_sort_order();
+        m.toggle_board_sort_order();
         let after: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
         assert_eq!(
             after,
@@ -614,34 +636,85 @@ mod tests {
     }
 
     #[test]
-    fn test_live_projects_panel_order_is_position_unaffected_by_archived_sort() {
-        // Guard: the LIVE panel stays in position order regardless of the
-        // archived-boards sort dimension/direction.
-        use kanban_domain::Archived;
+    fn test_board_sort_applies_to_live_projects_panel() {
+        // Picking Name sorts the LIVE projects panel alphabetically (the unified
+        // board sort applies to BOTH partitions, not only the archived one).
         let mut m = Model::default();
-        let mut live_a = Board::new("LiveA", None::<String>);
-        live_a.position = 0;
-        let mut live_b = Board::new("LiveB", None::<String>);
-        live_b.position = 1;
-        let mut archived = Board::new("Archived", None::<String>);
-        archived.position = 2;
-        let a_id = live_a.id;
-        let b_id = live_b.id;
-        let arch_id = archived.id;
+        let mut zed = Board::new("Zed", None::<String>);
+        zed.position = 0;
+        let mut alpha = Board::new("Alpha", None::<String>);
+        alpha.position = 1;
+        let zed_id = zed.id;
+        let alpha_id = alpha.id;
         m.load_from_snapshot(Snapshot {
-            boards: vec![live_a, live_b, archived],
-            archived_boards: vec![Archived::now(arch_id)],
+            boards: vec![zed, alpha],
+            archived_boards: vec![],
             ..Default::default()
         });
 
-        // Toggle / re-sort the archived dimension; live order must not move.
-        m.toggle_archived_boards_sort_order();
-        m.set_archived_boards_sort(
-            kanban_domain::BoardSortField::ArchivedAt,
+        m.set_board_sort(
+            kanban_domain::BoardSortField::Name,
             kanban_domain::SortOrder::Ascending,
         );
         let live: Vec<Uuid> = m.displayed_boards(false).iter().map(|b| b.id).collect();
-        assert_eq!(live, vec![a_id, b_id], "live panel stays in position order");
+        assert_eq!(
+            live,
+            vec![alpha_id, zed_id],
+            "live panel sorts alphabetically by Name"
+        );
+    }
+
+    #[test]
+    fn test_board_sort_from_config_seeds_field_and_order() {
+        // The board sort field/order is restored from AppConfig on start.
+        let mut m = Model::default();
+        let config = AppConfig {
+            board_sort_field: Some("Name".into()),
+            board_sort_order: Some("Ascending".into()),
+            ..Default::default()
+        };
+        m.set_board_sort_from_config(&config);
+        assert_eq!(
+            m.board_sort(),
+            (BoardSortField::Name, SortOrder::Ascending),
+            "config field/order restored into the model state"
+        );
+    }
+
+    #[test]
+    fn test_board_sort_from_config_unknown_falls_back_to_default() {
+        // Unrecognised / missing config values fall back to the built-in default.
+        let mut m = Model::default();
+        m.set_board_sort_from_config(&AppConfig {
+            board_sort_field: Some("nonsense".into()),
+            board_sort_order: None,
+            ..Default::default()
+        });
+        assert_eq!(m.board_sort(), DEFAULT_BOARD_SORT);
+    }
+
+    #[test]
+    fn test_board_sort_persists_to_appconfig_and_restores() {
+        // Change the sort, write the canonical strings to AppConfig (what the TUI
+        // saves), then seed a FRESH model from that config: the choice survives a
+        // "restart". Covers the field/order round-trip through the config strings.
+        let mut m = Model::default();
+        m.set_board_sort(BoardSortField::Name, SortOrder::Descending);
+        let (field, order) = m.board_sort();
+
+        let config = AppConfig {
+            board_sort_field: Some(board_sort_field_to_config(field).to_string()),
+            board_sort_order: Some(board_sort_order_to_config(order).to_string()),
+            ..Default::default()
+        };
+
+        let mut restored = Model::default();
+        restored.set_board_sort_from_config(&config);
+        assert_eq!(
+            restored.board_sort(),
+            (BoardSortField::Name, SortOrder::Descending),
+            "board sort choice survives a config round-trip"
+        );
     }
 
     #[test]

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -1,10 +1,60 @@
 use chrono::{DateTime, Utc};
+use kanban_core::AppConfig;
 use kanban_domain::{
     sort_boards_in_place, ArchivedBoard, ArchivedCard, Board, BoardSortField, Card, Column,
     DependencyGraph, Snapshot, SortOrder, Sprint,
 };
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
+
+/// The built-in board-list sort applied when the AppConfig sets no default:
+/// Position ascending, so the live projects panel stays in board order and the
+/// archived panel matches the pre-sort baseline until a dimension is chosen.
+pub const DEFAULT_BOARD_SORT: (BoardSortField, SortOrder) =
+    (BoardSortField::Position, SortOrder::Ascending);
+
+/// Parse an AppConfig `board_sort_field` string into a [`BoardSortField`].
+/// Case-insensitive and tolerant of `-`/`_` separators; unknown strings yield
+/// `None` so the caller can fall back to the built-in default.
+pub fn parse_board_sort_field(s: &str) -> Option<BoardSortField> {
+    match s.to_lowercase().replace(['-', '_'], "").as_str() {
+        "position" => Some(BoardSortField::Position),
+        "name" => Some(BoardSortField::Name),
+        "createdat" => Some(BoardSortField::CreatedAt),
+        "archivedat" => Some(BoardSortField::ArchivedAt),
+        _ => None,
+    }
+}
+
+/// Parse an AppConfig `board_sort_order` string into a [`SortOrder`].
+/// Case-insensitive; unknown strings yield `None`.
+pub fn parse_board_sort_order(s: &str) -> Option<SortOrder> {
+    match s.to_lowercase().as_str() {
+        "asc" | "ascending" => Some(SortOrder::Ascending),
+        "desc" | "descending" => Some(SortOrder::Descending),
+        _ => None,
+    }
+}
+
+/// The canonical AppConfig string for a [`BoardSortField`] (round-trips with
+/// [`parse_board_sort_field`]).
+pub fn board_sort_field_to_config(field: BoardSortField) -> &'static str {
+    match field {
+        BoardSortField::Position => "Position",
+        BoardSortField::Name => "Name",
+        BoardSortField::CreatedAt => "CreatedAt",
+        BoardSortField::ArchivedAt => "ArchivedAt",
+    }
+}
+
+/// The canonical AppConfig string for a [`SortOrder`] (round-trips with
+/// [`parse_board_sort_order`]).
+pub fn board_sort_order_to_config(order: SortOrder) -> &'static str {
+    match order {
+        SortOrder::Ascending => "Ascending",
+        SortOrder::Descending => "Descending",
+    }
+}
 
 pub struct Model {
     boards: Option<Vec<Board>>,
@@ -34,13 +84,15 @@ pub struct Model {
     // `prepare_frame` (→ `load_from_snapshot`) after mutating the set — it
     // cannot go stale relative to the archived partition it sorts.
     archived_board_at: HashMap<Uuid, DateTime<Utc>>,
-    // Sort dimension for the ARCHIVED projects panel: the board-specific
+    // Unified sort dimension for the PROJECTS panel — the board-specific
     // `BoardSortField` (NOT the card `SortField`) paired with the shared
-    // `SortOrder` toggle. Defaults to archived_at DESC — the conventional
-    // trash/history "newest first" UX the #428 review flagged as lost. The LIVE
-    // panel is always position order.
-    archived_boards_sort_field: BoardSortField,
-    archived_boards_sort_order: SortOrder,
+    // `SortOrder` toggle. Applied to BOTH the live and archived partitions in
+    // `rebuild_displayed_partitions`, so one field/order drives the whole
+    // projects panel (KAN-948, superseding the KAN-937 archived-only state).
+    // Seeded from `AppConfig.board_sort_field/order` on start, defaulting to the
+    // built-in Position ASC.
+    board_sort_field: BoardSortField,
+    board_sort_order: SortOrder,
     graph: DependencyGraph,
 }
 
@@ -62,8 +114,8 @@ impl Default for Model {
             displayed_boards_live: Vec::new(),
             displayed_boards_archived: Vec::new(),
             archived_board_at: HashMap::new(),
-            archived_boards_sort_field: BoardSortField::ArchivedAt,
-            archived_boards_sort_order: SortOrder::Descending,
+            board_sort_field: DEFAULT_BOARD_SORT.0,
+            board_sort_order: DEFAULT_BOARD_SORT.1,
             graph: DependencyGraph::default(),
         }
     }
@@ -169,27 +221,43 @@ impl Model {
         }
     }
 
-    /// The current archived-boards sort dimension (`BoardSortField`/`SortOrder`).
-    pub fn archived_boards_sort(&self) -> (BoardSortField, SortOrder) {
-        (
-            self.archived_boards_sort_field,
-            self.archived_boards_sort_order,
-        )
+    /// The current board-list sort dimension (`BoardSortField`/`SortOrder`),
+    /// applied to BOTH the live and archived projects partitions.
+    pub fn board_sort(&self) -> (BoardSortField, SortOrder) {
+        (self.board_sort_field, self.board_sort_order)
     }
 
-    /// Set the archived-boards sort field/order and re-sort the cached archived
-    /// partition in place. The live partition is untouched (stays position order).
-    pub fn set_archived_boards_sort(&mut self, field: BoardSortField, order: SortOrder) {
-        self.archived_boards_sort_field = field;
-        self.archived_boards_sort_order = order;
-        self.sort_archived_partition();
+    /// Set the board-list sort field/order and re-sort BOTH cached partitions in
+    /// place. One field/order drives the whole projects panel.
+    pub fn set_board_sort(&mut self, field: BoardSortField, order: SortOrder) {
+        self.board_sort_field = field;
+        self.board_sort_order = order;
+        self.sort_partitions();
     }
 
-    /// Flip the archived-boards sort ORDER via the shared `SortOrder::toggled`
-    /// (the same asc↔desc flip the card list uses), keeping the current field.
-    pub fn toggle_archived_boards_sort_order(&mut self) {
-        let next = self.archived_boards_sort_order.toggled();
-        self.set_archived_boards_sort(self.archived_boards_sort_field, next);
+    /// Flip the board-list sort ORDER via the shared `SortOrder::toggled` (the
+    /// same asc↔desc flip the card list uses), keeping the current field.
+    pub fn toggle_board_sort_order(&mut self) {
+        let next = self.board_sort_order.toggled();
+        self.set_board_sort(self.board_sort_field, next);
+    }
+
+    /// Seed the board-list sort field/order from `AppConfig.board_sort_field` /
+    /// `board_sort_order`, falling back to the built-in default for any missing
+    /// or unrecognised value, and re-sort the cached partitions. Called once on
+    /// start so the projects-panel sort survives a restart.
+    pub fn set_board_sort_from_config(&mut self, config: &AppConfig) {
+        let field = config
+            .board_sort_field
+            .as_deref()
+            .and_then(parse_board_sort_field)
+            .unwrap_or(DEFAULT_BOARD_SORT.0);
+        let order = config
+            .board_sort_order
+            .as_deref()
+            .and_then(parse_board_sort_order)
+            .unwrap_or(DEFAULT_BOARD_SORT.1);
+        self.set_board_sort(field, order);
     }
 
     /// Resolve a board by id from the single unified collection (live AND
@@ -279,22 +347,28 @@ impl Model {
             .iter()
             .cloned()
             .partition(|b| self.archived_board_ids.contains(&b.id));
-        // Live panel stays in board (position) order — unchanged. The archived
-        // panel is sorted by the configured dimension (default archived_at DESC).
+        // Both partitions are sorted by the SAME configured board-list dimension
+        // (default Position ASC). The unified sort drives the whole projects panel.
         self.displayed_boards_live = live_boards;
         self.displayed_boards_archived = archived_boards;
-        self.sort_archived_partition();
+        self.sort_partitions();
     }
 
-    /// Sort the cached archived-boards partition by the configured
+    /// Sort BOTH cached board partitions (live and archived) by the configured
     /// `BoardSortField`/`SortOrder`, via the shared board sort primitive. Called
-    /// on load and whenever the sort dimension changes, so the rendered list and
-    /// the selection resolver (both read this partition) stay consistent.
-    fn sort_archived_partition(&mut self) {
+    /// on load and whenever the sort dimension changes, so the rendered lists and
+    /// the selection resolvers (which read these partitions) stay consistent.
+    fn sort_partitions(&mut self) {
+        sort_boards_in_place(
+            &mut self.displayed_boards_live,
+            self.board_sort_field,
+            self.board_sort_order,
+            &self.archived_board_at,
+        );
         sort_boards_in_place(
             &mut self.displayed_boards_archived,
-            self.archived_boards_sort_field,
-            self.archived_boards_sort_order,
+            self.board_sort_field,
+            self.board_sort_order,
             &self.archived_board_at,
         );
     }

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -43,6 +43,13 @@ impl App {
             .map(crate::components::selection_dialog::popup_index_of_sort_field)
             .unwrap_or(0)
     }
+
+    /// The picker row for the projects-panel sort field: the popup index of the
+    /// model's current board-list `BoardSortField`. Mirrors the card variant.
+    pub fn get_current_board_sort_field_selection_index(&self) -> usize {
+        let (field, _order) = self.model.board_sort();
+        crate::components::selection_dialog::popup_index_of_board_sort_field(field)
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-tui/src/app/types.rs
+++ b/crates/kanban-tui/src/app/types.rs
@@ -145,7 +145,9 @@ impl ExportDialogState {
 pub enum MigrationState {
     Idle,
     Migrating {
-        old_config: AppConfig,
+        // Boxed to keep the enum small: `AppConfig` is by far the largest field
+        // and the `Idle` variant carries nothing (clippy::large_enum_variant).
+        old_config: Box<AppConfig>,
         old_storage_location: String,
         result_rx: tokio::sync::oneshot::Receiver<Result<(kanban_domain::Snapshot, bool), String>>,
     },

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -452,4 +452,46 @@ mod sort_field_popup_tests {
             assert!(!label.is_empty(), "label for {:?} is empty", field);
         }
     }
+
+    #[test]
+    fn test_board_sort_picker_lists_position_name_created_recency() {
+        // The board-sort field picker offers exactly Position, Name, Date
+        // Created, and Recency (=ArchivedAt), in that order.
+        let labels: Vec<&str> = BOARD_SORT_FIELD_POPUP_ORDER
+            .iter()
+            .map(|(_, label)| *label)
+            .collect();
+        assert_eq!(
+            labels,
+            vec!["Position", "Name", "Date Created", "Recency"],
+            "board sort picker labels/order"
+        );
+        let fields: Vec<BoardSortField> = BOARD_SORT_FIELD_POPUP_ORDER
+            .iter()
+            .map(|(f, _)| *f)
+            .collect();
+        assert_eq!(
+            fields,
+            vec![
+                BoardSortField::Position,
+                BoardSortField::Name,
+                BoardSortField::CreatedAt,
+                BoardSortField::ArchivedAt,
+            ],
+            "Recency maps to the ArchivedAt board field"
+        );
+    }
+
+    #[test]
+    fn test_board_sort_popup_index_round_trip_for_every_variant() {
+        for v in [
+            BoardSortField::Position,
+            BoardSortField::Name,
+            BoardSortField::CreatedAt,
+            BoardSortField::ArchivedAt,
+        ] {
+            let idx = popup_index_of_board_sort_field(v);
+            assert_eq!(board_sort_field_at_popup_index(idx), Some(v));
+        }
+    }
 }

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::components::sprint_assign_list::build_entries;
-use kanban_domain::{SortField, SprintStatus};
+use kanban_domain::{BoardSortField, SortField, SprintStatus};
 use ratatui::Frame;
 
 pub const SORT_FIELD_POPUP_ORDER: &[(SortField, &str)] = &[
@@ -13,6 +13,28 @@ pub const SORT_FIELD_POPUP_ORDER: &[(SortField, &str)] = &[
     (SortField::Default, "Task Number"),
     (SortField::DueDate, "Due Date"),
 ];
+
+/// Board-list sort dimensions offered by the projects-panel field picker
+/// (KAN-948). Mirrors [`SORT_FIELD_POPUP_ORDER`] but with the board-specific
+/// [`BoardSortField`]: `ArchivedAt` is labelled "Recency" (the trash/history
+/// dimension) since the term is more meaningful than the raw field name.
+pub const BOARD_SORT_FIELD_POPUP_ORDER: &[(BoardSortField, &str)] = &[
+    (BoardSortField::Position, "Position"),
+    (BoardSortField::Name, "Name"),
+    (BoardSortField::CreatedAt, "Date Created"),
+    (BoardSortField::ArchivedAt, "Recency"),
+];
+
+pub fn popup_index_of_board_sort_field(field: BoardSortField) -> usize {
+    BOARD_SORT_FIELD_POPUP_ORDER
+        .iter()
+        .position(|(f, _)| *f == field)
+        .unwrap_or(0)
+}
+
+pub fn board_sort_field_at_popup_index(index: usize) -> Option<BoardSortField> {
+    BOARD_SORT_FIELD_POPUP_ORDER.get(index).map(|(f, _)| *f)
+}
 
 pub fn popup_index_of_sort_field(field: SortField) -> usize {
     SORT_FIELD_POPUP_ORDER
@@ -170,6 +192,58 @@ impl SelectionDialog for SortFieldDialog {
                 (label.to_string(), order_indicator)
             },
             app.filter.sort_field_selection.get(),
+            active_idx,
+            60,
+            50,
+        );
+    }
+}
+
+/// Field picker for the PROJECTS panel sort — the board-side analogue of
+/// [`SortFieldDialog`] (KAN-948). Same list-with-active-order-indicator layout,
+/// but backed by [`BOARD_SORT_FIELD_POPUP_ORDER`] and the unified board-list
+/// sort state on the model.
+pub struct BoardSortFieldDialog;
+
+impl SelectionDialog for BoardSortFieldDialog {
+    fn title(&self) -> &str {
+        "Order Projects By"
+    }
+
+    fn get_current_selection(&self, app: &App) -> usize {
+        app.get_current_board_sort_field_selection_index()
+    }
+
+    fn options_count(&self, _app: &App) -> usize {
+        BOARD_SORT_FIELD_POPUP_ORDER.len()
+    }
+
+    fn render(&self, app: &App, frame: &mut Frame) {
+        use crate::components::render_selection_popup_with_lines;
+        use kanban_domain::SortOrder;
+
+        let (active_field, active_order) = app.model.board_sort();
+        let active_idx = Some(popup_index_of_board_sort_field(active_field));
+
+        render_selection_popup_with_lines(
+            frame,
+            "Order Projects By",
+            Some("Select sort field:"),
+            BOARD_SORT_FIELD_POPUP_ORDER.iter(),
+            |_idx, entry, _is_selected, is_active| {
+                let (_field, label) = **entry;
+                let order_indicator = if is_active {
+                    match active_order {
+                        SortOrder::Ascending => Some(" (↑)".to_string()),
+                        SortOrder::Descending => Some(" (↓)".to_string()),
+                    }
+                } else {
+                    None
+                };
+
+                (label.to_string(), order_indicator)
+            },
+            app.filter.board_sort_field_selection.get(),
             active_idx,
             60,
             50,

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -283,31 +283,34 @@ impl App {
         }
     }
 
-    /// Flip the archived-boards sort ORDER via the shared `SortOrder::toggled`
-    /// (the SAME asc↔desc flip the task list's `handle_toggle_sort_order_key`
-    /// applies) applied to the boards list instead of the cards list. Only
-    /// meaningful in the archived-boards view; a no-op elsewhere. The highlight
+    /// True when the projects panel is the active context and the board-sort
+    /// affordances (order toggle / field picker) should fire: either the
+    /// archived-boards view (stack-aware base mode, so it works under a pushed
+    /// dialog) or the live projects panel with Boards focus.
+    fn board_sort_context_active(&self) -> bool {
+        matches!(self.get_base_mode(), AppMode::ArchivedBoardsView)
+            || (matches!(self.get_base_mode(), AppMode::Normal)
+                && self.focus.active == Focus::Boards)
+    }
+
+    /// Flip the board-list sort ORDER via the shared `SortOrder::toggled` (the
+    /// SAME asc↔desc flip the task list's `handle_toggle_sort_order_key` applies)
+    /// applied to the projects panel — LIVE and archived alike. The highlight
     /// tracks the same board across the re-sort so the cursor does not jump to a
-    /// different project when the order changes.
+    /// different project when the order changes, and the new field/order is saved
+    /// to AppConfig so the choice survives a restart.
     ///
-    /// Guards on `get_base_mode()` (the stack-aware base), NOT the raw `mode`, so
-    /// it fires even when a dialog is pushed over the archived view — matching how
+    /// Uses `get_base_mode()` (the stack-aware base), NOT the raw `mode`, so it
+    /// fires even when a dialog is pushed over the archived view — matching how
     /// `displayed_boards`/render resolve which panel is showing.
-    pub fn handle_toggle_archived_boards_sort_order(&mut self) {
-        if *self.get_base_mode() != AppMode::ArchivedBoardsView {
+    pub fn handle_toggle_board_sort_order(&mut self) {
+        if !self.board_sort_context_active() {
             return;
         }
-        let highlighted_id = self.selected_archived_board_id();
-        self.model.toggle_archived_boards_sort_order();
-        // Re-resolve the highlight to the same board's new index, so render and
-        // selection stay pinned to the same project after re-sorting.
-        let new_idx = highlighted_id
-            .and_then(|id| self.model.archived_boards_view().position(|b| b.id == id));
-        let count = self.model.archived_boards_view().count();
-        self.selection.board.set(match new_idx {
-            Some(idx) => Some(idx),
-            None => (count > 0).then_some(0),
-        });
+        let highlighted_id = self.highlighted_board_id();
+        self.model.toggle_board_sort_order();
+        self.repin_board_selection(highlighted_id);
+        self.persist_board_sort();
         self.needs_redraw = true;
     }
 
@@ -318,6 +321,74 @@ impl App {
     fn selected_archived_board_id(&self) -> Option<uuid::Uuid> {
         let idx = self.selection.board.get()?;
         self.model.archived_boards_view().nth(idx).map(|b| b.id)
+    }
+
+    /// The board currently highlighted in the projects panel, resolved against
+    /// the partition the panel is showing (archived under the archived view,
+    /// live otherwise) via the stack-aware base mode.
+    fn highlighted_board_id(&self) -> Option<uuid::Uuid> {
+        let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
+        let idx = self.selection.board.get()?;
+        self.model
+            .displayed_boards(want_archived)
+            .get(idx)
+            .map(|b| b.id)
+    }
+
+    /// Re-resolve the highlight to the same board's new index after a re-sort, so
+    /// render and selection stay pinned to the same project; clamps to the first
+    /// entry when the previously highlighted board is not present.
+    fn repin_board_selection(&mut self, highlighted_id: Option<uuid::Uuid>) {
+        let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
+        let boards = self.model.displayed_boards(want_archived);
+        let new_idx = highlighted_id.and_then(|id| boards.iter().position(|b| b.id == id));
+        let count = boards.len();
+        self.selection.board.set(match new_idx {
+            Some(idx) => Some(idx),
+            None => (count > 0).then_some(0),
+        });
+    }
+
+    /// Persist the current board-list sort field/order to AppConfig via
+    /// `kanban_service::config::save`, mirroring how the card toggle persists its
+    /// sort (there via `SetTaskSort` onto the board; here onto the global config,
+    /// since the projects-panel sort is a global UI preference, not per-board).
+    fn persist_board_sort(&mut self) {
+        use crate::app::model::{board_sort_field_to_config, board_sort_order_to_config};
+        let (field, order) = self.model.board_sort();
+        self.app_config.board_sort_field = Some(board_sort_field_to_config(field).to_string());
+        self.app_config.board_sort_order = Some(board_sort_order_to_config(order).to_string());
+        if let Err(e) = kanban_service::config::save(&self.app_config) {
+            tracing::error!("Failed to persist board sort: {}", e);
+            self.set_error(format!("Failed to persist board sort: {}", e));
+        }
+    }
+
+    /// Open the board-sort field picker when the projects panel is the active
+    /// context (live or archived). Primes the picker selection to the current
+    /// field so it opens on the active row, mirroring `handle_order_cards_key`.
+    pub fn handle_order_boards_key(&mut self) {
+        if !self.board_sort_context_active() {
+            return;
+        }
+        let sort_idx = self.get_current_board_sort_field_selection_index();
+        self.filter.board_sort_field_selection.set(Some(sort_idx));
+        self.open_dialog(DialogMode::OrderBoards);
+    }
+
+    /// Apply a board-sort field/order chosen from the picker: set the model sort,
+    /// re-pin the highlight, and persist to AppConfig. Shared by the picker
+    /// handler across live and archived.
+    pub(crate) fn apply_board_sort(
+        &mut self,
+        field: kanban_domain::BoardSortField,
+        order: kanban_domain::SortOrder,
+    ) {
+        let highlighted_id = self.highlighted_board_id();
+        self.model.set_board_sort(field, order);
+        self.repin_board_selection(highlighted_id);
+        self.persist_board_sort();
+        self.needs_redraw = true;
     }
 
     /// Restore the highlighted archived board back into the live set (direct,

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -529,7 +529,9 @@ mod tests {
     use crate::app::{AppMode, DialogMode, Focus};
     use crate::App;
     use crossterm::event::KeyCode;
-    use kanban_domain::{BoardUpdate, CreateCardOptions, KanbanOperations, TaskListView};
+    use kanban_domain::{
+        BoardUpdate, CreateCardOptions, KanbanOperations, SortOrder, TaskListView,
+    };
 
     /// Pull the store snapshot into `app.model` so handlers that read
     /// `self.model` observe prior writes (the event loop does this per frame).
@@ -1353,13 +1355,80 @@ mod tests {
         );
     }
 
-    /// The archived-boards list defaults to recency (newest-archived first) and
-    /// the shared SortOrder toggle (`s`) reverses it, with the rendered list and
-    /// the selection resolver staying consistent (both read the sorted partition).
+    /// The shared SortOrder toggle (`s`) reverses the archived projects order and
+    /// keeps the rendered list and selection resolver consistent (both read the
+    /// sorted partition), with the choice persisted. Uses the Name dimension —
+    /// which distinguishes the two boards regardless of their (possibly equal)
+    /// archived positions. Superseding KAN-937's archived-only recency toggle
+    /// (folded into the unified board sort, KAN-948).
     #[test]
-    fn test_archived_boards_view_defaults_to_recency_and_s_toggles_order() {
+    fn test_archived_boards_view_s_toggles_sort_order_and_persists() {
+        use crate::app::model::parse_board_sort_order;
         let mut app = App::test_default();
-        // Archived in sequence: Arch2 is archived AFTER Arch1, so it is newer.
+        // Route the board-sort persistence to a tempfile so the toggle's config
+        // save never touches the real user config.
+        let cfg_dir = tempfile::tempdir().unwrap();
+        let cfg_path = cfg_dir.path().join("config.toml");
+        app.app_config.configuration_location = Some(cfg_path.display().to_string());
+        let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
+        let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
+
+        // Sort by Name ASC so the two boards have a stable, distinguishable order.
+        app.model
+            .set_board_sort(kanban_domain::BoardSortField::Name, SortOrder::Ascending);
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+
+        // Name ASC → Arch1 first.
+        let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
+        assert_eq!(rendered, vec![arch1, arch2], "Name ASC orders Arch1 first");
+
+        // Highlight the top row (Arch1), then toggle order via the shared 's'.
+        app.selection.board.set(Some(0));
+        app.handle_archived_boards_view_mode(KeyCode::Char('s'));
+
+        // Reversed: Name DESC → Arch2 first.
+        let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
+        assert_eq!(
+            rendered,
+            vec![arch2, arch1],
+            "'s' reverses the order via the shared SortOrder toggle"
+        );
+
+        // Render and selection stay consistent: the highlight followed Arch1 to
+        // its NEW index (1), so the resolved id still matches the rendered row.
+        let sel_idx = app.selection.board.get().unwrap();
+        assert_eq!(sel_idx, 1, "highlight tracked Arch1 to its new position");
+        assert_eq!(
+            app.displayed_boards()[sel_idx].id,
+            arch1,
+            "the rendered row at the selected index is the same board the resolver returns"
+        );
+
+        // The toggled order was persisted to AppConfig (Descending) and written.
+        assert_eq!(
+            app.app_config
+                .board_sort_order
+                .as_deref()
+                .and_then(parse_board_sort_order),
+            Some(SortOrder::Descending),
+            "toggled order saved to AppConfig"
+        );
+        assert!(cfg_path.exists(), "config file written to disk");
+    }
+
+    /// The board-sort field picker (`o`) opens over the archived-boards view and
+    /// picking Recency (ArchivedAt) re-sorts to newest-archived first, applied to
+    /// the archived partition via the unified board sort (KAN-948).
+    #[test]
+    fn test_order_boards_picker_recency_orders_newest_first() {
+        use crate::components::selection_dialog::popup_index_of_board_sort_field;
+        let mut app = App::test_default();
+        let cfg_dir = tempfile::tempdir().unwrap();
+        app.app_config.configuration_location =
+            Some(cfg_dir.path().join("config.toml").display().to_string());
         let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
         let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
 
@@ -1368,34 +1437,22 @@ mod tests {
         app.focus.active = Focus::Boards;
         app.selection.board.set(Some(0));
 
-        // Default: recency DESC → newest (Arch2) first.
+        // Open the picker over the archived view.
+        app.handle_archived_boards_view_mode(KeyCode::Char('o'));
+        assert_eq!(app.mode, AppMode::Dialog(DialogMode::OrderBoards));
+
+        // Select the Recency row and confirm with 'd' (descending → newest first).
+        let recency_idx =
+            popup_index_of_board_sort_field(kanban_domain::BoardSortField::ArchivedAt);
+        app.filter.board_sort_field_selection.set(Some(recency_idx));
+        app.handle_order_boards_popup(KeyCode::Char('d'));
+
+        assert_eq!(app.mode, AppMode::ArchivedBoardsView, "picker closed");
         let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
         assert_eq!(
             rendered,
             vec![arch2, arch1],
-            "default archived order is newest-archived first (recency)"
-        );
-
-        // Highlight the top row (Arch2), then toggle order via the shared 's'.
-        app.selection.board.set(Some(0));
-        app.handle_archived_boards_view_mode(KeyCode::Char('s'));
-
-        // Reversed: oldest (Arch1) first.
-        let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
-        assert_eq!(
-            rendered,
-            vec![arch1, arch2],
-            "'s' reverses the archived-boards order via the shared SortOrder toggle"
-        );
-
-        // Render and selection stay consistent: the highlight followed Arch2 to
-        // its NEW index (1), so the resolved id still matches the rendered row.
-        let sel_idx = app.selection.board.get().unwrap();
-        assert_eq!(sel_idx, 1, "highlight tracked Arch2 to its new position");
-        assert_eq!(
-            app.displayed_boards()[sel_idx].id,
-            arch2,
-            "the rendered row at the selected index is the same board the resolver returns"
+            "Recency DESC orders newest-archived (Arch2) first"
         );
     }
 }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -224,6 +224,57 @@ impl App {
         }
     }
 
+    /// Key handling for the projects-panel sort field picker (KAN-948), the
+    /// board-side analogue of [`handle_order_cards_popup`](Self::handle_order_cards_popup).
+    /// `Enter`/`Space` on the already-active field toggles its order; `a`/`d`
+    /// force ascending/descending. The chosen field/order is applied to BOTH
+    /// board partitions and persisted to AppConfig via `apply_board_sort`.
+    pub fn handle_order_boards_popup(&mut self, key_code: KeyCode) {
+        use crate::components::selection_dialog::{
+            board_sort_field_at_popup_index, BOARD_SORT_FIELD_POPUP_ORDER,
+        };
+        match key_code {
+            KeyCode::Esc => {
+                self.pop_mode();
+                self.filter.board_sort_field_selection.clear();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.filter
+                    .board_sort_field_selection
+                    .next(BOARD_SORT_FIELD_POPUP_ORDER.len());
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.filter.board_sort_field_selection.prev();
+            }
+            KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('a') | KeyCode::Char('d') => {
+                if let Some(field_idx) = self.filter.board_sort_field_selection.get() {
+                    let field = match board_sort_field_at_popup_index(field_idx) {
+                        Some(f) => f,
+                        None => return,
+                    };
+
+                    let (current_field, current_order) = self.model.board_sort();
+                    let order = if current_field == field
+                        && matches!(key_code, KeyCode::Enter | KeyCode::Char(' '))
+                    {
+                        current_order.toggled()
+                    } else {
+                        match key_code {
+                            KeyCode::Char('d') => SortOrder::Descending,
+                            _ => SortOrder::Ascending,
+                        }
+                    };
+
+                    self.apply_board_sort(field, order);
+                    self.pop_mode();
+                    self.filter.board_sort_field_selection.clear();
+                    tracing::info!("Sorting projects by {:?} ({:?})", field, order);
+                }
+            }
+            _ => {}
+        }
+    }
+
     pub fn handle_assign_card_to_sprint_popup(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -216,7 +216,7 @@ impl App {
         });
 
         self.migration_state = MigrationState::Migrating {
-            old_config,
+            old_config: Box::new(old_config),
             old_storage_location: old_storage_location.to_string(),
             result_rx: rx,
         };
@@ -303,7 +303,7 @@ impl App {
                 MigrationState::Idle => return,
             };
         if let Ok(result) = rx.await {
-            self.handle_migration_complete(old_config, result).await;
+            self.handle_migration_complete(*old_config, result).await;
         }
     }
 

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -39,6 +39,7 @@ pub enum KeybindingAction {
     ExportAll,
     ImportBoard,
     OrderCards,
+    OrderBoards,
     ToggleSortOrder,
     ToggleFilter,
     ToggleHideAssigned,

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -204,13 +204,21 @@ impl KeybindingProvider for ArchivedBoardsViewProvider {
                 "Permanently delete selected project",
                 KeybindingAction::DeleteArchivedBoard,
             ),
-            // Reuse the shared SortOrder toggle to flip the archived-boards
-            // order (recency ↔ oldest under the default archived_at field).
+            // Reuse the shared SortOrder toggle to flip the projects-panel sort
+            // order (the unified board sort, persisted to config).
             Keybinding::new(
                 "s",
-                "sort",
-                "Toggle archived sort order (recency)",
+                "sort order",
+                "Toggle project sort order",
                 KeybindingAction::ToggleArchivedBoardsSortOrder,
+            ),
+            // Open the board-sort field picker (Position / Name / Date Created /
+            // Recency), the board-side analogue of the card `o` picker.
+            Keybinding::new(
+                "o",
+                "sort field",
+                "Choose project sort field",
+                KeybindingAction::OrderBoards,
             ),
             // Reused binding whose archived-view behavior DIFFERS from the live
             // panel's `q` (quit): here it toggles back to the live projects list.

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -81,6 +81,7 @@ impl KeybindingRegistry {
                     Box::new(DialogSelectionProvider::new("Set Priority (Bulk)"))
                 }
                 DialogMode::OrderCards => Box::new(DialogSelectionProvider::new("Sort Tasks")),
+                DialogMode::OrderBoards => Box::new(DialogSelectionProvider::new("Sort Projects")),
                 DialogMode::AssignCardToSprint => {
                     Box::new(DialogSelectionProvider::new("Assign to Sprint"))
                 }

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -122,6 +122,12 @@ pub(crate) fn render_order_cards_popup(app: &App, frame: &mut Frame) {
     dialog.render(app, frame);
 }
 
+pub(crate) fn render_order_boards_popup(app: &App, frame: &mut Frame) {
+    use crate::components::{BoardSortFieldDialog, SelectionDialog};
+    let dialog = BoardSortFieldDialog;
+    dialog.render(app, frame);
+}
+
 pub(crate) fn render_assign_sprint_popup(app: &App, frame: &mut Frame) {
     use crate::components::{SelectionDialog, SprintAssignDialog};
     let dialog = SprintAssignDialog;

--- a/crates/kanban-tui/src/ui/mod.rs
+++ b/crates/kanban-tui/src/ui/mod.rs
@@ -103,6 +103,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                     dialogs::render_set_sprint_card_prefix_popup(app, frame)
                 }
                 DialogMode::OrderCards => dialogs::render_order_cards_popup(app, frame),
+                DialogMode::OrderBoards => dialogs::render_order_boards_popup(app, frame),
                 DialogMode::CreateColumn => dialogs::render_create_column_popup(app, frame),
                 DialogMode::RenameColumn => dialogs::render_rename_column_popup(app, frame),
                 DialogMode::DeleteColumnConfirm => {

--- a/crates/kanban-tui/tests/settings_config_edit_tests.rs
+++ b/crates/kanban-tui/tests/settings_config_edit_tests.rs
@@ -340,7 +340,7 @@ fn test_quit_while_migrating_shows_warning_and_does_not_quit() {
     let mut app = App::test_default();
     let (_tx, rx) = tokio::sync::oneshot::channel();
     app.migration_state = MigrationState::Migrating {
-        old_config: AppConfig::default(),
+        old_config: Box::new(AppConfig::default()),
         old_storage_location: "old.json".to_string(),
         result_rx: rx,
     };
@@ -373,7 +373,7 @@ fn test_quit_twice_while_migrating_quits() {
     let mut app = App::test_default();
     let (_tx, rx) = tokio::sync::oneshot::channel();
     app.migration_state = MigrationState::Migrating {
-        old_config: AppConfig::default(),
+        old_config: Box::new(AppConfig::default()),
         old_storage_location: "old.json".to_string(),
         result_rx: rx,
     };
@@ -408,7 +408,7 @@ fn test_quit_with_both_pending_saves_and_migration_sets_both_flags_on_first_pres
     app.ctx.save_coordinator.set_pending_for_test(1);
     let (_tx, rx) = tokio::sync::oneshot::channel();
     app.migration_state = MigrationState::Migrating {
-        old_config: AppConfig::default(),
+        old_config: Box::new(AppConfig::default()),
         old_storage_location: "old.json".to_string(),
         result_rx: rx,
     };
@@ -433,7 +433,7 @@ fn test_quit_twice_with_both_pending_saves_and_migration_quits() {
     app.ctx.save_coordinator.set_pending_for_test(1);
     let (_tx, rx) = tokio::sync::oneshot::channel();
     app.migration_state = MigrationState::Migrating {
-        old_config: AppConfig::default(),
+        old_config: Box::new(AppConfig::default()),
         old_storage_location: "old.json".to_string(),
         result_rx: rx,
     };


### PR DESCRIPTION
## What

Gives the projects panel the card-list sort UX for BOTH live and archived boards, persisted to `AppConfig` (KAN-948, under root KAN-941). Supersedes the KAN-937 archived-only toggle by folding it into a single unified board-list sort.

## Changes

- **Unified board sort on `Model`**: `board_sort_field`/`board_sort_order` applied to BOTH the live and archived partitions in `rebuild_displayed_partitions` via the shared S1 core (`sort_boards_in_place`). New `set_board_sort`, `toggle_board_sort_order`, `set_board_sort_from_config`, plus String parse/emit helpers. The old `archived_boards_sort_*` state is removed.
- **Field picker**: `BoardSortFieldDialog` mirroring `SortFieldDialog`, backed by `BOARD_SORT_FIELD_POPUP_ORDER` (Position, Name, Date Created, Recency = `ArchivedAt`). New `DialogMode::OrderBoards` with popup handler, render dispatch, and keybindings.
- **Keys**: on the projects panel (live and archived), `o` opens the field picker and `s` toggles the order. Both are base-mode aware (KAN-914 `get_base_mode` pattern) so they fire under a pushed dialog on the archived view. The highlight tracks the same board across a re-sort.
- **Persistence**: on TUI start the sort is seeded from `AppConfig.board_sort_field`/`board_sort_order` (falling back to the built-in Position ASC default); on any change (picker or toggle) it is written back and saved via `kanban_service::config::save`.
- **Clippy**: boxed `MigrationState::old_config` to clear `clippy::large_enum_variant` (the merged S3 `AppConfig` grew two fields, tipping the lint under `-D warnings`).

## Tests (red-first)

- `test_board_sort_picker_lists_position_name_created_recency`
- `test_board_sort_applies_to_live_projects_panel` (pick Name → live boards alphabetical)
- `test_board_sort_persists_to_appconfig_and_restores`
- `test_order_boards_picker_recency_orders_newest_first` (picker over the archived view)
- `test_archived_boards_view_s_toggles_sort_order_and_persists` (migrated from the KAN-937 archived-only toggle test, now on the unified state + config save)
- Model-level unified-state tests migrated from the archived-only ones.

`cargo test -p kanban-tui`, `cargo clippy -p kanban-tui --all-targets -D warnings`, and `cargo fmt` all green.