### PR TITLE
KAN-951 fix(service): include board_sort in is_all_defaults (prevents config deletion)

### DIFF
--- a/crates/kanban-service/src/config.rs
+++ b/crates/kanban-service/src/config.rs
@@ -197,7 +197,9 @@ fn is_all_defaults(config: &AppConfig) -> bool {
         && config.editing_format.is_none()
         && config.configuration_format.is_none()
         && config.configuration_location.is_none()
-        && config.storage_location.is_none();
+        && config.storage_location.is_none()
+        && config.board_sort_field.is_none()
+        && config.board_sort_order.is_none();
 
     if all_none {
         return true;
@@ -234,6 +236,8 @@ fn is_all_defaults(config: &AppConfig) -> bool {
             };
             loc == default
         })
+        && config.board_sort_field.is_none()
+        && config.board_sort_order.is_none()
 }
 
 /// Removes fields whose values are equal to the compile-time defaults so that

--- a/crates/kanban-service/src/config.rs
+++ b/crates/kanban-service/src/config.rs
@@ -869,6 +869,30 @@ mod tests {
     }
 
     #[test]
+    fn test_has_non_default_values_true_for_board_sort_field_only() {
+        let config = AppConfig {
+            board_sort_field: Some("name".into()),
+            ..Default::default()
+        };
+        assert!(
+            has_non_default_values(&config),
+            "a config whose only non-default value is board_sort_field must be non-default"
+        );
+    }
+
+    #[test]
+    fn test_has_non_default_values_true_for_board_sort_order_only() {
+        let config = AppConfig {
+            board_sort_order: Some("Descending".into()),
+            ..Default::default()
+        };
+        assert!(
+            has_non_default_values(&config),
+            "a config whose only non-default value is board_sort_order must be non-default"
+        );
+    }
+
+    #[test]
     fn test_apply_to_strips_default_values() {
         let dto = AppConfigDto {
             default_card_prefix: Some("task".into()),


### PR DESCRIPTION
## Summary

Critical data-loss fix. `board_sort_field`/`board_sort_order` were added to `AppConfig` in S3 but never added to the `is_all_defaults` field enumeration in `kanban-service/src/config.rs`. As a result a config whose only non-default value was the board sort was judged "all defaults", so `has_non_default_values` returned false and the TUI settings-save path (`settings_handlers.rs` else branch) `remove_file`d the config, silently wiping the persisted board-sort default.

## Fix

Add `board_sort_field.is_none()` / `board_sort_order.is_none()` to both places in `is_all_defaults`:
- the `all_none` short-circuit, and
- the final value-comparison block (which erroneously returned "all defaults" when only a board sort was set, since these fields have no non-absent default value).

`strip_defaults` needs no change: these fields have no default string value to strip, so a set board sort already survives it.

## TDD (Red → Green)

Failing tests added first (committed separately) and confirmed red before the fix:
- `test_has_non_default_values_true_for_board_sort_field_only`
- `test_has_non_default_values_true_for_board_sort_order_only`

## Verification

- `cargo test -p kanban-service` green (config: 51 passed; full suite green)
- `cargo clippy -p kanban-service --all-targets -D warnings` clean
- `cargo fmt` clean

Existing `is_all_defaults` / `strip_defaults` tests remain green.