### PR TITLE
KAN-952 refactor(service): set_board_sort helper + canonical parse + lazy archived_at + per-context default

### DIFF
--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -2,40 +2,13 @@ use super::KanbanContext;
 use chrono::{DateTime, Utc};
 use kanban_domain::commands::{ArchiveBoards, BoardCommand, Command, ImportEntities, RestoreBoard};
 use kanban_domain::{
-    filter_and_sort_boards, ArchivedBoard, ArchivedFilter, Board, BoardListFilter, BoardSortField,
-    BoardUpdate, FieldUpdate, KanbanError, KanbanResult, NewBoard, SortOrder,
+    filter_and_sort_boards, resolve_board_sort, ArchivedBoard, ArchivedFilter, Board,
+    BoardListFilter, BoardSortField, BoardUpdate, FieldUpdate, KanbanError, KanbanResult, NewBoard,
+    SortOrder, DEFAULT_ARCHIVED_BOARD_SORT, DEFAULT_BOARD_SORT_LIVE,
 };
 use std::collections::HashMap;
+use std::str::FromStr;
 use uuid::Uuid;
-
-/// The built-in board sort applied when the AppConfig sets no default: Position
-/// ascending, so the live board list stays in insertion/position order and is
-/// byte-identical to `list_boards()` when nothing is configured.
-const DEFAULT_BOARD_SORT: (BoardSortField, SortOrder) =
-    (BoardSortField::Position, SortOrder::Ascending);
-
-/// Parse an AppConfig `board_sort_field` string into a [`BoardSortField`].
-/// Case-insensitive and tolerant of `-`/`_` separators. Unknown strings fall
-/// back to `None` so the caller can apply the built-in default.
-fn parse_board_sort_field(s: &str) -> Option<BoardSortField> {
-    match s.to_lowercase().replace(['-', '_'], "").as_str() {
-        "position" => Some(BoardSortField::Position),
-        "name" => Some(BoardSortField::Name),
-        "createdat" => Some(BoardSortField::CreatedAt),
-        "archivedat" => Some(BoardSortField::ArchivedAt),
-        _ => None,
-    }
-}
-
-/// Parse an AppConfig `board_sort_order` string into a [`SortOrder`].
-/// Case-insensitive; unknown strings fall back to `None`.
-fn parse_sort_order(s: &str) -> Option<SortOrder> {
-    match s.to_lowercase().as_str() {
-        "asc" | "ascending" => Some(SortOrder::Ascending),
-        "desc" | "descending" => Some(SortOrder::Descending),
-        _ => None,
-    }
-}
 
 /// Result of an idempotent PUT-create ([`KanbanContext::create_or_replace_board`]):
 /// the resulting board plus whether this call created it (`true`, HTTP 201) or
@@ -135,33 +108,49 @@ impl KanbanContext {
 
     /// Selector-aware board gather, mirroring `filter_cards`: gathers live
     /// heads via `list_boards` and/or archived heads via the archive markers
-    /// (`get_board` is unfiltered, so it resolves an archived head). The
-    /// `LiveOnly` path is byte-identical to `list_boards_impl`.
+    /// (`get_board` is unfiltered, so it resolves an archived head). For the
+    /// plain `LiveOnly` + non-`ArchivedAt` case this is byte-identical to
+    /// `list_boards_impl` and — as of KAN-952 — skips the archived-marker fetch
+    /// entirely (no request amplification when archived data is not needed).
     pub(super) fn list_boards_filtered_impl(
         &self,
         filter: BoardListFilter,
     ) -> KanbanResult<Vec<Board>> {
+        // Per-context built-in default (ArchivedOnly → recency, else position).
+        let default = self.board_sort_default(filter.archived);
+        // The resolved sort drives whether the ArchivedAt dimension is in play.
+        let resolved = resolve_board_sort(filter.sort, filter.sort_order, Some(default));
+
         let mut out = Vec::new();
         if filter.archived != ArchivedFilter::ArchivedOnly {
             out.extend(self.backend.list_boards()?);
         }
-        // Harvest archived_at per board id (needed both to resolve archived heads
-        // and to sort by the ArchivedAt dimension), mirroring how the TUI does it.
-        let markers = self.backend.list_archived_boards()?;
-        let archived_at: HashMap<Uuid, DateTime<Utc>> = markers
-            .iter()
-            .map(|m| (m.entity_id, m.metadata.archived_at))
-            .collect();
-        if filter.archived != ArchivedFilter::LiveOnly {
-            for m in &markers {
-                if let Some(b) = self.backend.get_board(m.entity_id)? {
-                    out.push(b);
+
+        // Archived markers are only needed to (a) resolve archived heads or
+        // (b) sort by the ArchivedAt dimension. For a plain LiveOnly list that
+        // does not sort by ArchivedAt, skip the fetch to avoid amplification.
+        let needs_markers = filter.archived != ArchivedFilter::LiveOnly
+            || matches!(resolved, Some((BoardSortField::ArchivedAt, _)));
+        let archived_at: HashMap<Uuid, DateTime<Utc>> = if needs_markers {
+            let markers = self.backend.list_archived_boards()?;
+            let map = markers
+                .iter()
+                .map(|m| (m.entity_id, m.metadata.archived_at))
+                .collect();
+            if filter.archived != ArchivedFilter::LiveOnly {
+                for m in &markers {
+                    if let Some(b) = self.backend.get_board(m.entity_id)? {
+                        out.push(b);
+                    }
                 }
             }
-        }
-        // Request sort/sort_order override the AppConfig default via
+            map
+        } else {
+            HashMap::new()
+        };
+
+        // Request sort/sort_order override the built-in default via
         // `resolve_board_sort` (inside `filter_and_sort_boards`).
-        let default = self.board_sort_default();
         Ok(filter_and_sort_boards(
             &out,
             &filter,
@@ -171,23 +160,48 @@ impl KanbanContext {
     }
 
     /// Resolve the board sort default from the AppConfig `board_sort_field` /
-    /// `board_sort_order`, falling back to [`DEFAULT_BOARD_SORT`] (Position ASC)
-    /// for any unset or unrecognized value. An unset field with a set order (or
-    /// vice versa) layers onto the built-in default's other half.
-    fn board_sort_default(&self) -> (BoardSortField, SortOrder) {
+    /// `board_sort_order`, falling back to the per-context built-in default for
+    /// any unset or unrecognized value. The built-in is chosen from the archived
+    /// selector: `ArchivedOnly` → [`DEFAULT_ARCHIVED_BOARD_SORT`] (recency), else
+    /// [`DEFAULT_BOARD_SORT_LIVE`] (Position ASC). An unset field with a set
+    /// order (or vice versa) layers onto the built-in default's other half.
+    fn board_sort_default(&self, archived: ArchivedFilter) -> (BoardSortField, SortOrder) {
+        let builtin = if archived == ArchivedFilter::ArchivedOnly {
+            DEFAULT_ARCHIVED_BOARD_SORT
+        } else {
+            DEFAULT_BOARD_SORT_LIVE
+        };
         let field = self
             .app_config
             .board_sort_field
             .as_deref()
-            .and_then(parse_board_sort_field)
-            .unwrap_or(DEFAULT_BOARD_SORT.0);
+            .and_then(|s| BoardSortField::from_str(s).ok())
+            .unwrap_or(builtin.0);
         let order = self
             .app_config
             .board_sort_order
             .as_deref()
-            .and_then(parse_sort_order)
-            .unwrap_or(DEFAULT_BOARD_SORT.1);
+            .and_then(|s| SortOrder::from_str(s).ok())
+            .unwrap_or(builtin.1);
         (field, order)
+    }
+
+    /// Persist a board-sort preference and reflect it in the held `app_config`.
+    ///
+    /// The shared entry point CLI (R4) and MCP (R5) both call to change the
+    /// default board sort. Persists to disk FIRST via [`crate::config::save`] on
+    /// a clone with the canonical strings set (via `Display`); only on save
+    /// success is the in-memory `app_config` mutated IN PLACE. On save failure it
+    /// returns the error and leaves `app_config` untouched. It deliberately does
+    /// NOT rebuild the context (no `open_deferred`), so the session id and the
+    /// per-session undo/redo history survive the change.
+    pub fn set_board_sort(&mut self, field: BoardSortField, order: SortOrder) -> KanbanResult<()> {
+        let mut next = self.app_config.clone();
+        next.board_sort_field = Some(field.to_string());
+        next.board_sort_order = Some(order.to_string());
+        crate::config::save(&next)?;
+        self.app_config = next;
+        Ok(())
     }
 
     pub(super) fn get_board_impl(&self, id: Uuid) -> KanbanResult<Option<Board>> {

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -1043,3 +1043,117 @@ pub async fn test_list_boards_no_config_no_request_is_position_order(factory: &B
         "unconfigured list_boards_filtered stays position-ordered, byte-identical to list_boards()"
     );
 }
+
+/// R3 (KAN-952): with NO config and NO request sort, the built-in default is
+/// chosen PER CONTEXT from the filter's archived selector. `ArchivedOnly` picks
+/// `DEFAULT_ARCHIVED_BOARD_SORT` (most-recently-archived first), so archiving A
+/// then B returns [B, A] on every backend.
+pub async fn test_list_boards_archived_only_default_is_recency(factory: &BackendFactory) {
+    use kanban_domain::{ArchivedFilter, BoardListFilter};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    // Archive A first, then B → B is the most recently archived.
+    let a = ctx.create_board("Alpha".into(), None).unwrap();
+    let b = ctx.create_board("Bravo".into(), None).unwrap();
+    ctx.archive_board(a.id).unwrap();
+    ctx.archive_board(b.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let ids: Vec<_> = ctx
+        .list_boards_filtered(BoardListFilter {
+            archived: ArchivedFilter::ArchivedOnly,
+            ..Default::default()
+        })
+        .unwrap()
+        .iter()
+        .map(|bd| bd.id)
+        .collect();
+    assert_eq!(
+        ids,
+        vec![b.id, a.id],
+        "ArchivedOnly default is recency (most recently archived first)"
+    );
+}
+
+/// R3 (KAN-952): the LiveOnly default stays Position ascending
+/// (`DEFAULT_BOARD_SORT_LIVE`), byte-identical to `list_boards()`, even though
+/// the ArchivedOnly context now defaults to recency. Names are NOT alphabetical
+/// so a stray Name/recency default would reorder and fail.
+pub async fn test_list_boards_live_default_is_position(factory: &BackendFactory) {
+    use kanban_domain::BoardListFilter;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    ctx.create_board("Charlie".into(), None).unwrap();
+    ctx.create_board("Alpha".into(), None).unwrap();
+    ctx.create_board("Bravo".into(), None).unwrap();
+
+    let filtered_ids: Vec<_> = ctx
+        .list_boards_filtered(BoardListFilter::default())
+        .unwrap()
+        .iter()
+        .map(|b| b.id)
+        .collect();
+    let legacy_ids: Vec<_> = ctx.list_boards().unwrap().iter().map(|b| b.id).collect();
+    assert_eq!(
+        filtered_ids, legacy_ids,
+        "LiveOnly default stays Position ascending, byte-identical to list_boards()"
+    );
+}
+
+/// R3 (KAN-952) amplification guard: a plain LiveOnly, non-ArchivedAt request
+/// must not perturb its result by (lazily) skipping the archived-marker fetch.
+/// We cannot spy the backend call count through the trait, so we assert the
+/// observable invariant: the LiveOnly result is exactly `list_boards()` and is
+/// unaffected by the presence of archived boards (whose markers are NOT needed).
+pub async fn test_list_boards_liveonly_does_not_fetch_archived_markers(factory: &BackendFactory) {
+    use kanban_domain::{ArchivedFilter, BoardListFilter};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let live = ctx.create_board("Live".into(), None).unwrap();
+    let archived = ctx.create_board("Archived".into(), None).unwrap();
+    ctx.archive_board(archived.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let live_only: Vec<_> = ctx
+        .list_boards_filtered(BoardListFilter {
+            archived: ArchivedFilter::LiveOnly,
+            ..Default::default()
+        })
+        .unwrap()
+        .iter()
+        .map(|b| b.id)
+        .collect();
+    assert_eq!(
+        live_only,
+        vec![live.id],
+        "LiveOnly returns only the live head, unaffected by archived markers"
+    );
+    assert_eq!(
+        ctx.list_boards()
+            .unwrap()
+            .iter()
+            .map(|b| b.id)
+            .collect::<Vec<_>>(),
+        live_only,
+        "LiveOnly == list_boards() even with archived boards present (no marker fetch needed)"
+    );
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -186,6 +186,18 @@ macro_rules! context_contract_tests {
         async fn test_list_boards_no_config_no_request_is_position_order() {
             $crate::test_helpers::contract::archive::test_list_boards_no_config_no_request_is_position_order(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_boards_archived_only_default_is_recency() {
+            $crate::test_helpers::contract::archive::test_list_boards_archived_only_default_is_recency(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_boards_live_default_is_position() {
+            $crate::test_helpers::contract::archive::test_list_boards_live_default_is_position(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_boards_liveonly_does_not_fetch_archived_markers() {
+            $crate::test_helpers::contract::archive::test_list_boards_liveonly_does_not_fetch_archived_markers(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/set_board_sort.rs
+++ b/crates/kanban-service/tests/set_board_sort.rs
@@ -1,0 +1,119 @@
+//! Integration tests for `KanbanContext::set_board_sort` (KAN-952 / BSF-R3).
+//!
+//! `set_board_sort` is the shared entry point CLI (R4) and MCP (R5) call to
+//! persist a board-sort preference. It must:
+//!   1. persist to disk FIRST (via `kanban_service::config::save`) and only
+//!      mutate the held `app_config` in place on save success, and
+//!   2. NOT rebuild the context (no `open_deferred`), so the session_id and
+//!      per-session undo history survive the change.
+
+use kanban_domain::{BoardSortField, SortOrder};
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{
+    json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext, KanbanOperations,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn make_json_backend(path: &std::path::Path) -> Arc<dyn KanbanBackend> {
+    Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))))
+}
+
+/// Persisting a board sort must NOT rebuild the context: the session_id and the
+/// per-session undo history are preserved, and the in-memory app_config reflects
+/// the new (canonical) strings while the on-disk config file is written.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_board_sort_persists_and_preserves_session() {
+    let dir = tempdir().unwrap();
+    let store_path = dir.path().join("board.json");
+    let config_path = dir.path().join("config.toml");
+
+    let config = AppConfig {
+        configuration_location: Some(config_path.to_string_lossy().into_owned()),
+        ..Default::default()
+    };
+    let mut ctx = KanbanContext::open(make_json_backend(&store_path), config)
+        .await
+        .unwrap();
+
+    // Build some undo history so we can prove it survives the config write.
+    ctx.create_board("Alpha".into(), None).unwrap();
+    let session_before = ctx.session_id();
+    let undo_depth_before = ctx.undo_depth();
+    assert!(undo_depth_before > 0, "seeded undo history precondition");
+
+    ctx.set_board_sort(BoardSortField::Name, SortOrder::Descending)
+        .expect("set_board_sort persists successfully");
+
+    // Session identity and undo history are untouched (no context rebuild).
+    assert_eq!(
+        ctx.session_id(),
+        session_before,
+        "session_id preserved across set_board_sort"
+    );
+    assert_eq!(
+        ctx.undo_depth(),
+        undo_depth_before,
+        "undo history preserved across set_board_sort"
+    );
+
+    // In-memory app_config carries the new canonical strings (via Display).
+    assert_eq!(
+        ctx.app_config().board_sort_field.as_deref(),
+        Some("name"),
+        "field written canonically"
+    );
+    assert_eq!(
+        ctx.app_config().board_sort_order.as_deref(),
+        Some("descending"),
+        "order written canonically"
+    );
+
+    // The config file was actually written and round-trips the values.
+    let written = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        written.contains("name") && written.contains("descending"),
+        "config file persisted the new sort: {written}"
+    );
+}
+
+/// If the disk write fails (unwritable config path), `set_board_sort` returns an
+/// Err and leaves the in-memory app_config completely unchanged — persist-first
+/// ordering means no half-applied state.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_board_sort_save_failure_leaves_config_unchanged() {
+    let dir = tempdir().unwrap();
+    let store_path = dir.path().join("board.json");
+
+    // A config path whose parent is a FILE, so create_dir_all + write both fail.
+    let blocker = dir.path().join("not_a_dir");
+    std::fs::write(&blocker, b"x").unwrap();
+    let bad_config_path = blocker.join("child").join("config.toml");
+
+    let config = AppConfig {
+        configuration_location: Some(bad_config_path.to_string_lossy().into_owned()),
+        board_sort_field: Some("position".into()),
+        board_sort_order: Some("ascending".into()),
+        ..Default::default()
+    };
+    let mut ctx = KanbanContext::open(make_json_backend(&store_path), config)
+        .await
+        .unwrap();
+
+    let field_before = ctx.app_config().board_sort_field.clone();
+    let order_before = ctx.app_config().board_sort_order.clone();
+
+    let result = ctx.set_board_sort(BoardSortField::Name, SortOrder::Descending);
+    assert!(result.is_err(), "save to unwritable path must error");
+
+    assert_eq!(
+        ctx.app_config().board_sort_field,
+        field_before,
+        "app_config field unchanged after failed save"
+    );
+    assert_eq!(
+        ctx.app_config().board_sort_order,
+        order_before,
+        "app_config order unchanged after failed save"
+    );
+}


### PR DESCRIPTION
Implements KAN-952 (BSF-R3), the kanban-service consolidation slice under root KAN-949. Depends on R1 (canonical `from_str`/`Display` + default consts) and R2 (config data-loss fix), both merged.

## What changed

1. **Consolidated parsing.** Deleted the service-local `parse_board_sort_field` / `parse_sort_order` in `context/boards.rs` and switched to R1's canonical `BoardSortField::from_str` / `SortOrder::from_str`. Config strings are now written via R1's `Display` (canonical `name` / `descending`, etc.).

2. **`set_board_sort` context helper.** New `KanbanContext::set_board_sort(field, order) -> KanbanResult<()>`, the shared entry point CLI (R4) and MCP (R5) will both call. It persists to disk FIRST via `config::save` on a clone with the fields set, and only on save success assigns the clone to the held `app_config` in place. It does not rebuild the context, so `session_id` and the per-session undo/redo history survive the change. On save failure it returns the error with `app_config` untouched.

3. **Amplification + doc.** `list_boards_filtered_impl` now only fetches `list_archived_boards()` / builds the `archived_at` map when it is actually needed: when the archived set is gathered (`filter.archived != LiveOnly`) or the resolved sort field is `ArchivedAt`. The plain LiveOnly + non-ArchivedAt path skips the marker fetch. Fixed the now-false "byte-identical" doc comment.

4. **Per-context default.** The built-in default is chosen from the archived selector: `ArchivedOnly` gets `DEFAULT_ARCHIVED_BOARD_SORT` (recency), everything else `DEFAULT_BOARD_SORT_LIVE` (position). AppConfig and request-level `filter.sort` still override via `resolve_board_sort`.

## Tests (TDD, red first)

- `test_set_board_sort_persists_and_preserves_session`, `test_set_board_sort_save_failure_leaves_config_unchanged` (new `tests/set_board_sort.rs`).
- `test_list_boards_archived_only_default_is_recency`, `test_list_boards_live_default_is_position`, `test_list_boards_liveonly_does_not_fetch_archived_markers` (contract tests, run on in-memory / JSON / SQLite via the `context_contract_tests!` macro).

The backend trait offers no call-count spy, so the LiveOnly amplification test asserts the observable invariant (LiveOnly result == `list_boards()`, unaffected by archived boards present) rather than the fetch count.

## Verification

- `cargo check -p kanban-service -p kanban-cli -p kanban-mcp -p kanban-tui` green (no broken `BoardListFilter` literals or match arms).
- `cargo test -p kanban-service --features test-helpers` green (all 42 test binaries).
- `cargo clippy --all-targets -D warnings` green on all touched crates; `cargo fmt` clean.