### PR TITLE
KAN-954 refactor(mcp): canonical board-sort parse + set_board_sort via service helper

### DIFF
--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -1,11 +1,12 @@
 use kanban_core::{AppConfig, PaginatedList};
 use kanban_domain::KanbanResult;
 use kanban_domain::{
-    ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter, CardSummary,
-    CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations, KanbanOperations, Sprint,
-    SprintUpdate,
+    ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
+    CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
+    KanbanOperations, SortOrder, Sprint, SprintUpdate, DEFAULT_BOARD_SORT_LIVE,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
+use std::str::FromStr;
 use uuid::Uuid;
 
 pub struct McpContext {
@@ -36,30 +37,44 @@ impl McpContext {
         self.inner.reload().await
     }
 
+    /// The stable session id of the running context (per-process). Exposed so
+    /// callers can assert that a config-only mutation (e.g. `set_board_sort`)
+    /// leaves the session — and thus the per-session undo history — intact.
+    pub fn session_id(&self) -> Uuid {
+        self.inner.session_id()
+    }
+
     /// Persist the default board-list sort into `AppConfig`
-    /// (`board_sort_field` / `board_sort_order`) and make the running context
-    /// reflect it immediately. Either dimension may be left unchanged by passing
-    /// `None`. The default is applied server-side inside
-    /// `KanbanContext::list_boards_filtered`, so we rebuild the inner context on
-    /// the same backend with the updated config; the config is then flushed to
-    /// disk via `kanban_service::config::save`.
+    /// (`board_sort_field` / `board_sort_order`) and reflect it in the running
+    /// context. Either dimension may be left unchanged by passing `None`; the
+    /// omitted dimension is resolved from the current config (falling back to the
+    /// live built-in default) so `None` truly means "leave as-is".
+    ///
+    /// Delegates to `KanbanContext::set_board_sort` (R3), which persists first
+    /// then mutates `app_config` in place. It deliberately does NOT rebuild the
+    /// context via `open_deferred`, so the session id and per-session undo/redo
+    /// history survive the change.
     pub fn set_board_sort(
         &mut self,
-        sort: Option<String>,
-        order: Option<String>,
+        sort: Option<BoardSortField>,
+        order: Option<SortOrder>,
     ) -> KanbanResult<()> {
-        let mut config = self.inner.app_config().clone();
-        if let Some(field) = sort {
-            config.board_sort_field = Some(field);
-        }
-        if let Some(dir) = order {
-            config.board_sort_order = Some(dir);
-        }
-        let backend = self.inner.backend();
-        self.inner =
-            KanbanContext::open_deferred(backend, config.clone()).with_app_type(AppType::Mcp);
-        kanban_service::config::save(&config)?;
-        Ok(())
+        let config = self.inner.app_config();
+        let field = sort.unwrap_or_else(|| {
+            config
+                .board_sort_field
+                .as_deref()
+                .and_then(|s| BoardSortField::from_str(s).ok())
+                .unwrap_or(DEFAULT_BOARD_SORT_LIVE.0)
+        });
+        let order = order.unwrap_or_else(|| {
+            config
+                .board_sort_order
+                .as_deref()
+                .and_then(|s| SortOrder::from_str(s).ok())
+                .unwrap_or(DEFAULT_BOARD_SORT_LIVE.1)
+        });
+        self.inner.set_board_sort(field, order)
     }
 
     /// Create a board from a full spec + optional client id, funneling through

--- a/crates/kanban-mcp/src/helpers/parsers.rs
+++ b/crates/kanban-mcp/src/helpers/parsers.rs
@@ -3,6 +3,7 @@ use kanban_domain::{
     ArchivedFilter, BoardSortField, CardPriority, CardStatus, SortField, SortOrder,
 };
 use rmcp::model::ErrorData as McpError;
+use std::str::FromStr;
 
 /// Parse the `archived` list selector: `exclude` (live only, the default),
 /// `only` (archived only), or `include` (both). Mirrors the three-state
@@ -75,31 +76,27 @@ pub(crate) fn parse_sort_field(s: &str) -> Result<SortField, McpError> {
     }
 }
 
+/// Parse a board-list sort field via the canonical domain [`BoardSortField`]
+/// `FromStr` (R1, KAN-950), mapping the unit parse error to an MCP
+/// `invalid_params`. The MCP layer owns only the error-type mapping; the
+/// accepted token set lives in the domain.
 pub(crate) fn parse_board_sort_field(s: &str) -> Result<BoardSortField, McpError> {
-    match s.to_lowercase().replace(['-', '_'], "").as_str() {
-        "position" => Ok(BoardSortField::Position),
-        "name" => Ok(BoardSortField::Name),
-        "createdat" => Ok(BoardSortField::CreatedAt),
-        "archivedat" => Ok(BoardSortField::ArchivedAt),
-        _ => Err(McpError::invalid_params(
+    BoardSortField::from_str(s).map_err(|()| {
+        McpError::invalid_params(
             format!(
-                "Invalid board sort field '{}'. Valid: position, name, created_at, archived_at",
-                s
+                "Invalid board sort field '{s}'. Valid: position, name, created_at, archived_at"
             ),
             None,
-        )),
-    }
+        )
+    })
 }
 
+/// Parse a sort order via the canonical domain [`SortOrder`] `FromStr` (R1,
+/// KAN-950), mapping the unit parse error to an MCP `invalid_params`.
 pub(crate) fn parse_sort_order(s: &str) -> Result<SortOrder, McpError> {
-    match s.to_lowercase().as_str() {
-        "asc" | "ascending" => Ok(SortOrder::Ascending),
-        "desc" | "descending" => Ok(SortOrder::Descending),
-        _ => Err(McpError::invalid_params(
-            format!("Invalid sort order '{}'. Valid: asc, desc", s),
-            None,
-        )),
-    }
+    SortOrder::from_str(s).map_err(|()| {
+        McpError::invalid_params(format!("Invalid sort order '{s}'. Valid: asc, desc"), None)
+    })
 }
 
 #[cfg(test)]

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -158,23 +158,23 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<SetBoardSortRequest>,
     ) -> Result<CallToolResult, McpError> {
-        // Validate the raw strings up front so an invalid value is rejected
-        // before any config write. The config stores the string form (the
-        // service re-parses it on read), so the validated raw strings are what
-        // we persist.
-        req.sort
+        // Parse the raw strings at the tool boundary via the canonical domain
+        // `FromStr` (R1). An invalid value is rejected here, before any config
+        // write. Either dimension may be omitted to leave it unchanged; the
+        // context resolves the omitted half from the current config.
+        let field = req
+            .sort
             .as_deref()
             .map(parse_board_sort_field)
             .transpose()?;
-        req.order.as_deref().map(parse_sort_order).transpose()?;
+        let order = req.order.as_deref().map(parse_sort_order).transpose()?;
         locked_write(&self.ctx, |ctx| {
-            ctx.set_board_sort(req.sort.clone(), req.order.clone())
-                .map_err(kanban_err_to_mcp)
+            ctx.set_board_sort(field, order).map_err(kanban_err_to_mcp)
         })
         .await?;
         to_call_tool_result_json(serde_json::json!({
-            "board_sort_field": req.sort,
-            "board_sort_order": req.order,
+            "board_sort_field": field.map(|f| f.to_string()),
+            "board_sort_order": order.map(|o| o.to_string()),
         }))
     }
 

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -2807,3 +2807,63 @@ async fn test_mcp_set_board_sort_persists_default() {
         "persisted config must carry board_sort_field, got: {persisted}"
     );
 }
+
+// KAN-954 (BSF-R5): the MCP board-sort setter now routes through R3's
+// persist-first, in-place `KanbanContext::set_board_sort` instead of rebuilding
+// the context via `open_deferred`. The rebuild minted a fresh session id and
+// discarded the per-session undo history; the helper leaves both intact. This
+// exercises `McpContext::set_board_sort` directly (not the locked tool wrapper,
+// which reloads on every write) so the session/undo invariants are observable.
+#[tokio::test]
+async fn test_mcp_set_board_sort_persists_and_preserves_session() {
+    use std::str::FromStr;
+
+    let dir = TempDir::new().unwrap();
+    let data_path = dir.path().join("test.json");
+    let config_path = dir.path().join("config.toml");
+    let store_manager = default_store_manager();
+    let config = AppConfig {
+        configuration_location: Some(config_path.to_string_lossy().to_string()),
+        ..AppConfig::default()
+    };
+    let mut ctx = McpContext::new(&store_manager, &data_path.to_string_lossy(), config)
+        .await
+        .unwrap();
+
+    // A mutation populates the per-session undo stack.
+    ctx.create_board("Board".into(), None).unwrap();
+    assert!(
+        ctx.can_undo(),
+        "a create must leave an undoable entry on the session stack"
+    );
+    let session_before = ctx.session_id();
+
+    // Change the default board sort mid-session.
+    ctx.set_board_sort(
+        Some(kanban_domain::BoardSortField::from_str("name").unwrap()),
+        Some(kanban_domain::SortOrder::from_str("asc").unwrap()),
+    )
+    .unwrap();
+
+    // The session id is stable: no `open_deferred` rebuild happened.
+    assert_eq!(
+        ctx.session_id(),
+        session_before,
+        "set_board_sort must not mint a new session id (no context rebuild)"
+    );
+    // The undo history from earlier in the session survives.
+    assert!(
+        ctx.can_undo(),
+        "set_board_sort must preserve the per-session undo history"
+    );
+    // And the preference is flushed to the config file on disk.
+    let persisted = std::fs::read_to_string(&config_path).expect("config file must be written");
+    assert!(
+        persisted.contains("board_sort_field"),
+        "persisted config must carry board_sort_field, got: {persisted}"
+    );
+    assert!(
+        persisted.contains("board_sort_order"),
+        "persisted config must carry board_sort_order, got: {persisted}"
+    );
+}


### PR DESCRIPTION
Implements KAN-954 (BSF-R5), root KAN-949. Scope: kanban-mcp only.

## What changed

**Canonical board-sort parse.** `parse_board_sort_field` and `parse_sort_order` (`helpers/parsers.rs`) now delegate to the canonical domain `BoardSortField::from_str` / `SortOrder::from_str` (R1, KAN-950), mapping the unit parse error to `McpError::invalid_params` with the same message shape. The hand-rolled match arms are removed, so the accepted token set lives only in the domain and cannot drift from the CLI/TUI.

**`set_board_sort` via the service helper.** `McpContext::set_board_sort` previously rebuilt the whole context with `KanbanContext::open_deferred` (minting a fresh session id and dropping the per-session undo history) and saved after swapping. It now routes through `KanbanContext::set_board_sort(field, order)` (R3, KAN-952): persist-first, then in-place `app_config` mutation, no context rebuild. The session id and undo/redo history survive the change. The tool parses to typed `BoardSortField`/`SortOrder` at the boundary; an omitted dimension is resolved from the current config (falling back to the live built-in default) so `None` still means "leave that dimension unchanged".

A `McpContext::session_id()` accessor is added so the invariant is observable from the integration test.

## Tests (TDD, red first)

- `test_mcp_set_board_sort_persists_and_preserves_session` — new. Drives `McpContext` directly: a create populates the per-session undo stack, then `set_board_sort` mid-session must leave `session_id()` and `can_undo()` intact and flush `board_sort_field`/`board_sort_order` to the config file.
- `test_mcp_list_boards_sort_by_name` / `test_mcp_list_boards_order_desc` — unchanged, stay green against the canonical parse.

`cargo test -p kanban-mcp` (128 tests), `cargo clippy -p kanban-mcp --all-targets -D warnings`, and `cargo fmt` all green.
