### PR TITLE
KAN-955 fix(tui): live-board sort keys + recency archived default + canonical strings + rename/guard/doc

### DIFF
--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -98,9 +98,7 @@ impl App {
             KeybindingAction::ToggleArchivedBoardsView => self.handle_toggle_archived_boards_view(),
             KeybindingAction::RestoreBoard => self.handle_restore_board(),
             KeybindingAction::DeleteArchivedBoard => self.handle_delete_archived_board(),
-            KeybindingAction::ToggleArchivedBoardsSortOrder => {
-                self.handle_toggle_board_sort_order()
-            }
+            KeybindingAction::ToggleBoardsSortOrder => self.handle_toggle_board_sort_order(),
             KeybindingAction::ToggleTaskListView => self.handle_toggle_task_list_view(),
             KeybindingAction::ToggleCardSelection => self.handle_card_selection_toggle(),
             KeybindingAction::ClearCardSelection => self.handle_clear_card_selection(),

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -545,6 +545,68 @@ mod tests {
     }
 
     #[test]
+    fn test_archived_board_view_defaults_to_recency() {
+        // With no explicit user sort, the ARCHIVED partition defaults to recency
+        // (ArchivedAt DESC) — newest-archived first — while the LIVE partition
+        // keeps Position ASC. `second` was archived later, so it leads the
+        // archived list; `first` (pos 0) still leads the live list (KAN-955).
+        let mut m = Model::default();
+        let (first_id, second_id) = seed_two_archived_boards(&mut m);
+        let archived: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
+        assert_eq!(
+            archived,
+            vec![second_id, first_id],
+            "archived board view defaults to recency DESC (newest archived first)"
+        );
+    }
+
+    #[test]
+    fn test_live_board_view_defaults_to_position() {
+        // The LIVE partition default is unchanged: Position ASC. `first` at
+        // position 0 precedes `second` at position 1.
+        let mut m = Model::default();
+        let mut first = Board::new("First", None::<String>);
+        first.position = 0;
+        let mut second = Board::new("Second", None::<String>);
+        second.position = 1;
+        let first_id = first.id;
+        let second_id = second.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![second, first],
+            archived_boards: vec![],
+            ..Default::default()
+        });
+        let live: Vec<Uuid> = m.displayed_boards(false).iter().map(|b| b.id).collect();
+        assert_eq!(
+            live,
+            vec![first_id, second_id],
+            "live board view defaults to Position ASC"
+        );
+    }
+
+    #[test]
+    fn test_board_sort_field_config_string_is_canonical() {
+        // The on-disk board_sort_field string is the domain `Display` spelling,
+        // and it round-trips back through the domain `FromStr` — one canonical
+        // spelling, no TUI-local PascalCase divergence (KAN-955).
+        use std::str::FromStr;
+        for field in [
+            BoardSortField::Position,
+            BoardSortField::Name,
+            BoardSortField::CreatedAt,
+            BoardSortField::ArchivedAt,
+        ] {
+            let s = field.to_string();
+            assert_eq!(
+                BoardSortField::from_str(&s),
+                Ok(field),
+                "config string {s:?} must round-trip through the domain FromStr"
+            );
+        }
+        assert_eq!(BoardSortField::ArchivedAt.to_string(), "archived_at");
+    }
+
+    #[test]
     fn test_archived_boards_sort_by_recency_orders_newest_first() {
         // Recency DESC (archived_at) puts the newest-archived board first.
         let mut m = Model::default();

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -2,59 +2,12 @@ use chrono::{DateTime, Utc};
 use kanban_core::AppConfig;
 use kanban_domain::{
     sort_boards_in_place, ArchivedBoard, ArchivedCard, Board, BoardSortField, Card, Column,
-    DependencyGraph, Snapshot, SortOrder, Sprint,
+    DependencyGraph, Snapshot, SortOrder, Sprint, DEFAULT_ARCHIVED_BOARD_SORT,
+    DEFAULT_BOARD_SORT_LIVE,
 };
 use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
 use uuid::Uuid;
-
-/// The built-in board-list sort applied when the AppConfig sets no default:
-/// Position ascending, so the live projects panel stays in board order and the
-/// archived panel matches the pre-sort baseline until a dimension is chosen.
-pub const DEFAULT_BOARD_SORT: (BoardSortField, SortOrder) =
-    (BoardSortField::Position, SortOrder::Ascending);
-
-/// Parse an AppConfig `board_sort_field` string into a [`BoardSortField`].
-/// Case-insensitive and tolerant of `-`/`_` separators; unknown strings yield
-/// `None` so the caller can fall back to the built-in default.
-pub fn parse_board_sort_field(s: &str) -> Option<BoardSortField> {
-    match s.to_lowercase().replace(['-', '_'], "").as_str() {
-        "position" => Some(BoardSortField::Position),
-        "name" => Some(BoardSortField::Name),
-        "createdat" => Some(BoardSortField::CreatedAt),
-        "archivedat" => Some(BoardSortField::ArchivedAt),
-        _ => None,
-    }
-}
-
-/// Parse an AppConfig `board_sort_order` string into a [`SortOrder`].
-/// Case-insensitive; unknown strings yield `None`.
-pub fn parse_board_sort_order(s: &str) -> Option<SortOrder> {
-    match s.to_lowercase().as_str() {
-        "asc" | "ascending" => Some(SortOrder::Ascending),
-        "desc" | "descending" => Some(SortOrder::Descending),
-        _ => None,
-    }
-}
-
-/// The canonical AppConfig string for a [`BoardSortField`] (round-trips with
-/// [`parse_board_sort_field`]).
-pub fn board_sort_field_to_config(field: BoardSortField) -> &'static str {
-    match field {
-        BoardSortField::Position => "Position",
-        BoardSortField::Name => "Name",
-        BoardSortField::CreatedAt => "CreatedAt",
-        BoardSortField::ArchivedAt => "ArchivedAt",
-    }
-}
-
-/// The canonical AppConfig string for a [`SortOrder`] (round-trips with
-/// [`parse_board_sort_order`]).
-pub fn board_sort_order_to_config(order: SortOrder) -> &'static str {
-    match order {
-        SortOrder::Ascending => "Ascending",
-        SortOrder::Descending => "Descending",
-    }
-}
 
 pub struct Model {
     boards: Option<Vec<Board>>,
@@ -84,15 +37,16 @@ pub struct Model {
     // `prepare_frame` (→ `load_from_snapshot`) after mutating the set — it
     // cannot go stale relative to the archived partition it sorts.
     archived_board_at: HashMap<Uuid, DateTime<Utc>>,
-    // Unified sort dimension for the PROJECTS panel — the board-specific
-    // `BoardSortField` (NOT the card `SortField`) paired with the shared
-    // `SortOrder` toggle. Applied to BOTH the live and archived partitions in
-    // `rebuild_displayed_partitions`, so one field/order drives the whole
-    // projects panel (KAN-948, superseding the KAN-937 archived-only state).
-    // Seeded from `AppConfig.board_sort_field/order` on start, defaulting to the
-    // built-in Position ASC.
+    // Sort dimension for the PROJECTS panel — the board-specific `BoardSortField`
+    // (NOT the card `SortField`) paired with the shared `SortOrder` toggle. Once
+    // the user picks a sort it drives BOTH the live and archived partitions
+    // (KAN-948). Until then (`board_sort_explicit == false`) the two partitions
+    // fall back to their OWN built-in defaults: live → Position ASC, archived →
+    // recency (ArchivedAt DESC) (KAN-955). Seeded from `AppConfig.board_sort_*`
+    // on start; a config value flips `board_sort_explicit` true.
     board_sort_field: BoardSortField,
     board_sort_order: SortOrder,
+    board_sort_explicit: bool,
     graph: DependencyGraph,
 }
 
@@ -114,8 +68,9 @@ impl Default for Model {
             displayed_boards_live: Vec::new(),
             displayed_boards_archived: Vec::new(),
             archived_board_at: HashMap::new(),
-            board_sort_field: DEFAULT_BOARD_SORT.0,
-            board_sort_order: DEFAULT_BOARD_SORT.1,
+            board_sort_field: DEFAULT_BOARD_SORT_LIVE.0,
+            board_sort_order: DEFAULT_BOARD_SORT_LIVE.1,
+            board_sort_explicit: false,
             graph: DependencyGraph::default(),
         }
     }
@@ -221,17 +176,21 @@ impl Model {
         }
     }
 
-    /// The current board-list sort dimension (`BoardSortField`/`SortOrder`),
-    /// applied to BOTH the live and archived projects partitions.
+    /// The current board-list sort dimension (`BoardSortField`/`SortOrder`).
+    /// This is the user's explicit choice once set; before that it is the LIVE
+    /// default (Position ASC). The archived partition may sort differently by
+    /// default (recency) — see [`Model::sort_partitions`].
     pub fn board_sort(&self) -> (BoardSortField, SortOrder) {
         (self.board_sort_field, self.board_sort_order)
     }
 
     /// Set the board-list sort field/order and re-sort BOTH cached partitions in
-    /// place. One field/order drives the whole projects panel.
+    /// place. This is an EXPLICIT user choice, so from here it drives the whole
+    /// projects panel (both partitions), overriding the archived recency default.
     pub fn set_board_sort(&mut self, field: BoardSortField, order: SortOrder) {
         self.board_sort_field = field;
         self.board_sort_order = order;
+        self.board_sort_explicit = true;
         self.sort_partitions();
     }
 
@@ -243,21 +202,33 @@ impl Model {
     }
 
     /// Seed the board-list sort field/order from `AppConfig.board_sort_field` /
-    /// `board_sort_order`, falling back to the built-in default for any missing
-    /// or unrecognised value, and re-sort the cached partitions. Called once on
-    /// start so the projects-panel sort survives a restart.
+    /// `board_sort_order`, and re-sort the cached partitions. A recognised config
+    /// value is an EXPLICIT choice (drives both partitions); a missing or
+    /// unrecognised value leaves the per-partition defaults in force (live →
+    /// Position ASC, archived → recency). Called once on start so the
+    /// projects-panel sort survives a restart.
     pub fn set_board_sort_from_config(&mut self, config: &AppConfig) {
         let field = config
             .board_sort_field
             .as_deref()
-            .and_then(parse_board_sort_field)
-            .unwrap_or(DEFAULT_BOARD_SORT.0);
+            .and_then(|s| BoardSortField::from_str(s).ok());
         let order = config
             .board_sort_order
             .as_deref()
-            .and_then(parse_board_sort_order)
-            .unwrap_or(DEFAULT_BOARD_SORT.1);
-        self.set_board_sort(field, order);
+            .and_then(|s| SortOrder::from_str(s).ok());
+        match (field, order) {
+            // A field with an optional order is an explicit choice; a bare order
+            // with no field is ignored (there is no field to apply it to).
+            (Some(field), order) => {
+                self.set_board_sort(field, order.unwrap_or(DEFAULT_BOARD_SORT_LIVE.1));
+            }
+            _ => {
+                self.board_sort_field = DEFAULT_BOARD_SORT_LIVE.0;
+                self.board_sort_order = DEFAULT_BOARD_SORT_LIVE.1;
+                self.board_sort_explicit = false;
+                self.sort_partitions();
+            }
+        }
     }
 
     /// Resolve a board by id from the single unified collection (live AND
@@ -354,10 +325,13 @@ impl Model {
         self.sort_partitions();
     }
 
-    /// Sort BOTH cached board partitions (live and archived) by the configured
-    /// `BoardSortField`/`SortOrder`, via the shared board sort primitive. Called
-    /// on load and whenever the sort dimension changes, so the rendered lists and
-    /// the selection resolvers (which read these partitions) stay consistent.
+    /// Sort BOTH cached board partitions (live and archived). The live partition
+    /// always uses the current `board_sort_field`/`order`. The archived partition
+    /// uses the same explicit choice once the user has picked one; until then it
+    /// falls back to its own recency default (ArchivedAt DESC) rather than the
+    /// live Position default (KAN-955). Called on load and whenever the sort
+    /// dimension changes, so the rendered lists and the selection resolvers
+    /// (which read these partitions) stay consistent.
     fn sort_partitions(&mut self) {
         sort_boards_in_place(
             &mut self.displayed_boards_live,
@@ -365,10 +339,15 @@ impl Model {
             self.board_sort_order,
             &self.archived_board_at,
         );
+        let (archived_field, archived_order) = if self.board_sort_explicit {
+            (self.board_sort_field, self.board_sort_order)
+        } else {
+            DEFAULT_ARCHIVED_BOARD_SORT
+        };
         sort_boards_in_place(
             &mut self.displayed_boards_archived,
-            self.board_sort_field,
-            self.board_sort_order,
+            archived_field,
+            archived_order,
             &self.archived_board_at,
         );
     }
@@ -566,21 +545,6 @@ mod tests {
     }
 
     #[test]
-    fn test_archived_boards_default_order_is_position() {
-        // The unified board-list sort defaults to the built-in Position ASC
-        // (matching the AppConfig-less service default), applied to BOTH
-        // partitions. Position 0 (first) precedes position 1 (second).
-        let mut m = Model::default();
-        let (first_id, second_id) = seed_two_archived_boards(&mut m);
-        let order: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
-        assert_eq!(
-            order,
-            vec![first_id, second_id],
-            "default board sort is Position ASC"
-        );
-    }
-
-    #[test]
     fn test_archived_boards_sort_by_recency_orders_newest_first() {
         // Recency DESC (archived_at) puts the newest-archived board first.
         let mut m = Model::default();
@@ -682,29 +646,31 @@ mod tests {
     }
 
     #[test]
-    fn test_board_sort_from_config_unknown_falls_back_to_default() {
-        // Unrecognised / missing config values fall back to the built-in default.
+    fn test_board_sort_from_config_unknown_falls_back_to_live_default() {
+        // Unrecognised / missing config values fall back to the LIVE built-in
+        // default (Position ASC); the archived partition keeps its recency default.
         let mut m = Model::default();
         m.set_board_sort_from_config(&AppConfig {
             board_sort_field: Some("nonsense".into()),
             board_sort_order: None,
             ..Default::default()
         });
-        assert_eq!(m.board_sort(), DEFAULT_BOARD_SORT);
+        assert_eq!(m.board_sort(), DEFAULT_BOARD_SORT_LIVE);
     }
 
     #[test]
     fn test_board_sort_persists_to_appconfig_and_restores() {
-        // Change the sort, write the canonical strings to AppConfig (what the TUI
-        // saves), then seed a FRESH model from that config: the choice survives a
-        // "restart". Covers the field/order round-trip through the config strings.
+        // Change the sort, write the canonical domain strings to AppConfig (what
+        // the TUI saves), then seed a FRESH model from that config: the choice
+        // survives a "restart". Covers the field/order round-trip through the
+        // canonical `Display`/`FromStr` strings (KAN-955).
         let mut m = Model::default();
         m.set_board_sort(BoardSortField::Name, SortOrder::Descending);
         let (field, order) = m.board_sort();
 
         let config = AppConfig {
-            board_sort_field: Some(board_sort_field_to_config(field).to_string()),
-            board_sort_order: Some(board_sort_order_to_config(order).to_string()),
+            board_sort_field: Some(field.to_string()),
+            board_sort_order: Some(order.to_string()),
             ..Default::default()
         };
 

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1459,4 +1459,98 @@ mod tests {
             "Recency DESC orders newest-archived (Arch2) first"
         );
     }
+
+    /// The LIVE projects panel is now sortable (KAN-955): with Normal mode +
+    /// Boards focus, the `o` field picker opens and applying Name re-sorts the
+    /// live list alphabetically. Proves the handler path reachable from the live
+    /// `NormalModeBoardsProvider` binding actually works end to end.
+    #[test]
+    fn test_board_sort_reachable_on_live_panel() {
+        use crate::components::selection_dialog::popup_index_of_board_sort_field;
+        let mut app = App::test_default();
+        let cfg_dir = tempfile::tempdir().unwrap();
+        app.app_config.configuration_location =
+            Some(cfg_dir.path().join("config.toml").display().to_string());
+        create_named_board(&mut app, "Zed");
+        create_named_board(&mut app, "Alpha");
+
+        app.mode = AppMode::Normal;
+        app.focus.active = Focus::Boards;
+        app.selection.active_board_id = None;
+        app.selection.board.set(Some(0));
+
+        // Open the picker via the live-panel `o` handler.
+        app.handle_order_boards_key();
+        assert_eq!(
+            app.mode,
+            AppMode::Dialog(DialogMode::OrderBoards),
+            "the live panel's 'o' opens the board-sort picker"
+        );
+
+        // Pick Name, confirm ascending ('a').
+        let name_idx = popup_index_of_board_sort_field(kanban_domain::BoardSortField::Name);
+        app.filter.board_sort_field_selection.set(Some(name_idx));
+        app.handle_order_boards_popup(KeyCode::Char('a'));
+
+        assert_eq!(app.mode, AppMode::Normal, "picker closed back to Normal");
+        let names: Vec<String> = app
+            .displayed_boards()
+            .iter()
+            .map(|b| b.name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["Alpha".to_string(), "Zed".to_string()],
+            "the live projects panel is sorted alphabetically by Name"
+        );
+    }
+
+    /// Once an archived board is ACTIVATED (mode stays ArchivedBoardsView but a
+    /// board is active and focus is on Cards), the board-sort keys must be inert:
+    /// they operate on the board LIST, not while viewing a board's contents
+    /// (KAN-955 focus guard).
+    #[test]
+    fn test_board_sort_keys_inert_when_archived_board_activated() {
+        let mut app = App::test_default();
+        let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
+        let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
+
+        // Sort by Name ASC so the two boards have a stable order to observe.
+        app.model
+            .set_board_sort(kanban_domain::BoardSortField::Name, SortOrder::Ascending);
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+
+        // Simulate a board being ACTIVATED (drilled into): active id set, focus
+        // on the tasks panel — the mode is still ArchivedBoardsView.
+        app.selection.active_board_id = Some(arch1);
+        app.focus.active = Focus::Cards;
+
+        let before = app.model.board_sort();
+        app.handle_toggle_board_sort_order();
+        assert_eq!(
+            app.model.board_sort(),
+            before,
+            "'s' is inert while an archived board is activated (focus on Cards)"
+        );
+
+        app.handle_order_boards_key();
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::OrderBoards),
+            "'o' must not open the picker while a board is activated"
+        );
+
+        // Sanity: sort still fires when browsing the list (no active board).
+        app.selection.active_board_id = None;
+        app.focus.active = Focus::Boards;
+        app.selection.board.set(Some(0));
+        app.handle_toggle_board_sort_order();
+        assert_eq!(
+            app.model.board_sort().1,
+            SortOrder::Descending,
+            "'s' fires again once browsing the archived board list"
+        );
+        let _ = (arch1, arch2);
+    }
 }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -285,12 +285,15 @@ impl App {
 
     /// True when the projects panel is the active context and the board-sort
     /// affordances (order toggle / field picker) should fire: either the
-    /// archived-boards view (stack-aware base mode, so it works under a pushed
-    /// dialog) or the live projects panel with Boards focus.
+    /// archived-boards view or the live projects panel with Boards focus. In both
+    /// cases the user must be BROWSING the board list, not viewing a board's
+    /// contents: once a board is activated (`active_board_id` set, focus moves to
+    /// Cards) the mode can still be `ArchivedBoardsView`, but `s`/`o` must be
+    /// inert there (KAN-955).
     fn board_sort_context_active(&self) -> bool {
-        matches!(self.get_base_mode(), AppMode::ArchivedBoardsView)
-            || (matches!(self.get_base_mode(), AppMode::Normal)
-                && self.focus.active == Focus::Boards)
+        let browsing_boards =
+            self.selection.active_board_id.is_none() && self.focus.active == Focus::Boards;
+        browsing_boards && matches!(self.mode, AppMode::ArchivedBoardsView | AppMode::Normal)
     }
 
     /// Flip the board-list sort ORDER via the shared `SortOrder::toggled` (the
@@ -300,9 +303,11 @@ impl App {
     /// different project when the order changes, and the new field/order is saved
     /// to AppConfig so the choice survives a restart.
     ///
-    /// Uses `get_base_mode()` (the stack-aware base), NOT the raw `mode`, so it
-    /// fires even when a dialog is pushed over the archived view — matching how
-    /// `displayed_boards`/render resolve which panel is showing.
+    /// The guard reads the RAW `mode`: this handler is only ever reached from the
+    /// live/archived board providers, which the keybinding router selects on the
+    /// raw mode. A pushed dialog swaps the provider, so `s`/`o` cannot dispatch
+    /// here while a dialog is open — the earlier "works under a pushed dialog via
+    /// `get_base_mode`" note described an unreachable path and has been dropped.
     pub fn handle_toggle_board_sort_order(&mut self) {
         if !self.board_sort_context_active() {
             return;
@@ -354,10 +359,9 @@ impl App {
     /// sort (there via `SetTaskSort` onto the board; here onto the global config,
     /// since the projects-panel sort is a global UI preference, not per-board).
     fn persist_board_sort(&mut self) {
-        use crate::app::model::{board_sort_field_to_config, board_sort_order_to_config};
         let (field, order) = self.model.board_sort();
-        self.app_config.board_sort_field = Some(board_sort_field_to_config(field).to_string());
-        self.app_config.board_sort_order = Some(board_sort_order_to_config(order).to_string());
+        self.app_config.board_sort_field = Some(field.to_string());
+        self.app_config.board_sort_order = Some(order.to_string());
         if let Err(e) = kanban_service::config::save(&self.app_config) {
             tracing::error!("Failed to persist board sort: {}", e);
             self.set_error(format!("Failed to persist board sort: {}", e));
@@ -1363,7 +1367,7 @@ mod tests {
     /// (folded into the unified board sort, KAN-948).
     #[test]
     fn test_archived_boards_view_s_toggles_sort_order_and_persists() {
-        use crate::app::model::parse_board_sort_order;
+        use std::str::FromStr;
         let mut app = App::test_default();
         // Route the board-sort persistence to a tempfile so the toggle's config
         // save never touches the real user config.
@@ -1412,7 +1416,7 @@ mod tests {
             app.app_config
                 .board_sort_order
                 .as_deref()
-                .and_then(parse_board_sort_order),
+                .and_then(|s| SortOrder::from_str(s).ok()),
             Some(SortOrder::Descending),
             "toggled order saved to AppConfig"
         );

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -679,10 +679,7 @@ impl App {
             }
             KeyCode::Char('O') => {
                 if let Some(current_order) = self.filter.current_sort_order {
-                    let new_order = match current_order {
-                        kanban_domain::SortOrder::Ascending => kanban_domain::SortOrder::Descending,
-                        kanban_domain::SortOrder::Descending => kanban_domain::SortOrder::Ascending,
-                    };
+                    let new_order = current_order.toggled();
                     self.filter.current_sort_order = Some(new_order);
 
                     if let Some(field) = self.filter.current_sort_field {

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -47,7 +47,7 @@ pub enum KeybindingAction {
     ToggleArchivedBoardsView,
     RestoreBoard,
     DeleteArchivedBoard,
-    ToggleArchivedBoardsSortOrder,
+    ToggleBoardsSortOrder,
     ToggleTaskListView,
     ToggleCardSelection,
     ClearCardSelection,

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -304,6 +304,26 @@ mod tests {
         );
     }
 
+    /// The LIVE projects panel must also bind the board-sort affordances (`s`
+    /// order toggle, `o` field picker); otherwise live-board sort is unreachable
+    /// from the TUI even though the service and handler support it (KAN-955).
+    #[test]
+    fn test_live_projects_panel_binds_sort_keys() {
+        let ctx = NormalModeBoardsProvider.get_context();
+        assert!(
+            ctx.bindings
+                .iter()
+                .any(|b| b.key == "s" && b.action == KeybindingAction::ToggleBoardsSortOrder),
+            "live projects panel binds 's' to toggle the board sort order"
+        );
+        assert!(
+            ctx.bindings
+                .iter()
+                .any(|b| b.key == "o" && b.action == KeybindingAction::OrderBoards),
+            "live projects panel binds 'o' to the board sort field picker"
+        );
+    }
+
     /// The archived-boards view is the ordinary projects panel showing a
     /// different SET: it reuses the shared navigation/activation bindings that the
     /// dispatch delegates to `handle_shared_boards_key`, rather than hand-rolling a

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -103,6 +103,22 @@ impl KeybindingProvider for NormalModeBoardsProvider {
                     "Open settings view",
                     KeybindingAction::OpenSettings,
                 ),
+                // Board-sort affordances on the LIVE projects panel (KAN-955):
+                // `s` flips the sort order and `o` opens the field picker, the
+                // same shared handlers the archived-boards view uses. Without
+                // these the live projects panel is unsortable from the TUI.
+                Keybinding::new(
+                    "s",
+                    "sort order",
+                    "Toggle project sort order",
+                    KeybindingAction::ToggleBoardsSortOrder,
+                ),
+                Keybinding::new(
+                    "o",
+                    "sort field",
+                    "Choose project sort field",
+                    KeybindingAction::OrderBoards,
+                ),
             ],
         )
     }
@@ -210,7 +226,7 @@ impl KeybindingProvider for ArchivedBoardsViewProvider {
                 "s",
                 "sort order",
                 "Toggle project sort order",
-                KeybindingAction::ToggleArchivedBoardsSortOrder,
+                KeybindingAction::ToggleBoardsSortOrder,
             ),
             // Open the board-sort field picker (Position / Name / Date Created /
             // Recency), the board-side analogue of the card `o` picker.
@@ -281,10 +297,10 @@ mod tests {
     fn test_archived_boards_view_provider_binds_sort_order_toggle() {
         let ctx = ArchivedBoardsViewProvider.get_context();
         assert!(
-            ctx.bindings.iter().any(
-                |b| b.key == "s" && b.action == KeybindingAction::ToggleArchivedBoardsSortOrder
-            ),
-            "'s' toggles the archived-boards sort order via the shared SortOrder toggle"
+            ctx.bindings
+                .iter()
+                .any(|b| b.key == "s" && b.action == KeybindingAction::ToggleBoardsSortOrder),
+            "'s' toggles the projects-panel sort order via the shared SortOrder toggle"
         );
     }
 


### PR DESCRIPTION
## KAN-955 (BSF-R6) — kanban-tui board-sort fixes

Parent: KAN-949. Depends on merged R1 (domain `Display`/`FromStr` + default consts) and R3 (service per-context default).

The biggest slice of the board-sort feature: it closes the functional gap (live-board sort was unreachable from the TUI) and clears several nits.

### What changed (all 7 items)
1. **Live-sort reachability** — `s` (order toggle) and `o` (field picker) are now bound on the live `NormalModeBoardsProvider`, not only the archived-boards view. The live projects panel is sortable from the TUI.
2. **Recency default for the archived board view only** — the archived partition defaults to `DEFAULT_ARCHIVED_BOARD_SORT` (ArchivedAt DESC) while the live partition keeps `DEFAULT_BOARD_SORT_LIVE` (Position ASC). An explicit user sort then drives both partitions. Card-list default untouched.
3. **Canonical strings** — dropped the TUI-local `board_sort_field_to_config`/`parse_board_sort_field` helpers in favour of the domain `Display`/`FromStr`, so there is one on-disk spelling.
4. **Rename** — `ToggleArchivedBoardsSortOrder` renamed to `ToggleBoardsSortOrder` across the enum, dispatch, and provider, with help text updated to cover both panels.
5. **Focus guard** — `board_sort_context_active` now only fires while browsing the board list (`active_board_id.is_none()` and `focus == Boards`), so `s`/`o` are inert while an archived board is activated.
6. **Sprint toggle** — the sprint-list `O` order flip routes through `SortOrder::toggled()`.
7. **Doc** — dropped the stale `get_base_mode` comment claiming the guard fires under a pushed dialog (the router matches the raw mode, so that path is unreachable).

### Tests (TDD, split from impl)
- `test_live_projects_panel_binds_sort_keys`
- `test_board_sort_reachable_on_live_panel`
- `test_archived_board_view_defaults_to_recency` / `test_live_board_view_defaults_to_position`
- `test_board_sort_keys_inert_when_archived_board_activated`
- `test_board_sort_field_config_string_is_canonical`
- Existing archived-sort tests migrated to the renamed action / canonical strings.

### Gates
`cargo test -p kanban-tui` green, `cargo clippy -p kanban-tui --all-targets -D warnings` clean, `cargo fmt --check` clean.

Scope is kanban-tui only (R4 kanban-cli and R5 kanban-mcp are separate PRs).