### PR TITLE
KAN-938 fix(service): single-board export carries the board's archived cards

### DIFF
--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -232,30 +232,49 @@ impl KanbanContext {
 
     pub(super) fn export_board_impl(&self, board_id: Option<Uuid>) -> KanbanResult<String> {
         let snapshot = if let Some(id) = board_id {
-            let boards: Vec<_> = self
-                .backend
-                .list_boards()?
-                .into_iter()
-                .filter(|b| b.id == id)
-                .collect();
+            // C3b FIDELITY: raw unfiltered board-head read — `list_boards` is
+            // live-scoped and would drop an archived board, so a single-board export
+            // of an archived board would carry no board head. `get_board` is
+            // unfiltered.
+            let boards: Vec<_> = self.backend.get_board(id)?.into_iter().collect();
             let columns = self.backend.list_columns_by_board(id)?;
             let column_ids: Vec<_> = columns.iter().map(|c| c.id).collect();
+            // KAN-938: gather the board's archived cards by board_id (marker-based,
+            // deleted-column-safe) at parity with the full-export path
+            // (BoardExporter::export_board).
+            let archived_cards = self.backend.list_archived_cards_by_board(id)?;
+            let archived_card_ids: std::collections::HashSet<_> =
+                archived_cards.iter().map(|ac| ac.entity_id).collect();
             // C3b FIDELITY: raw read — exporting a board (even an archived one)
-            // must include its full subtree; do NOT live-scope here.
-            let cards: Vec<_> = self
+            // must include its full subtree; do NOT live-scope here. `list_all_cards`
+            // hides archived cards (F1 marker model), so carry their live rows too
+            // (fetched unfiltered by id), even when their column was deleted after
+            // archival (dangling column_id), so the markers are not orphaned on
+            // import.
+            let mut cards: Vec<_> = self
                 .backend
                 .list_all_cards()?
                 .into_iter()
                 .filter(|c| column_ids.contains(&c.column_id))
                 .collect();
+            let live_ids: std::collections::HashSet<_> = cards.iter().map(|c| c.id).collect();
+            for ac_id in &archived_card_ids {
+                if !live_ids.contains(ac_id) {
+                    if let Some(card) = self.backend.get_card(*ac_id)? {
+                        cards.push(card);
+                    }
+                }
+            }
+            // If the board itself is archived, carry its marker.
+            let archived_boards = self.backend.get_archived_board(id)?.into_iter().collect();
             let sprints = self.backend.list_sprints_by_board(id)?;
             let graph = self.backend.get_graph()?;
             Snapshot {
-                archived_boards: Vec::new(),
+                archived_boards,
                 boards,
                 columns,
                 cards,
-                archived_cards: vec![],
+                archived_cards,
                 sprints,
                 graph,
             }
@@ -333,7 +352,7 @@ impl KanbanContext {
             columns: imported.columns,
             cards: imported.cards,
             archived_cards: imported.archived_cards,
-            archived_boards: vec![],
+            archived_boards: imported.archived_boards,
             sprints: imported.sprints,
             graph: Some(imported.graph),
         }))];

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -616,6 +616,179 @@ pub async fn test_board_delete_undo_full_graph_roundtrip(factory: &BackendFactor
     );
 }
 
+/// KAN-938: the single-board export path (`export_board(Some(id))`, the CLI/MCP
+/// V2 path) must carry the board's archived cards in the exported snapshot, at
+/// parity with the full/all-boards export path. Seed a board with a live card
+/// and an archived card, export just that board, and assert the archived card's
+/// marker is present in the exported snapshot on every backend.
+pub async fn test_single_board_export_includes_archived_cards(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let _live = ctx
+        .create_card(board.id, col.id, "Live".into(), CreateCardOptions::default())
+        .unwrap();
+    let archived = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(archived.id).unwrap();
+
+    let json = ctx.export_board(Some(board.id)).unwrap();
+    let snapshot: kanban_domain::Snapshot = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(
+        snapshot.archived_cards.len(),
+        1,
+        "single-board export must carry the board's archived-card marker"
+    );
+    assert_eq!(
+        snapshot.archived_cards[0].entity_id(),
+        archived.id,
+        "exported archived-card marker references the archived card"
+    );
+    assert_eq!(
+        snapshot.archived_cards[0].context.board_id, board.id,
+        "exported archived-card marker carries its board_id"
+    );
+    // The live row of the archived card must still be present so the marker is
+    // not orphaned on import.
+    assert!(
+        snapshot.cards.iter().any(|c| c.id == archived.id),
+        "live row of the archived card is carried in the export"
+    );
+}
+
+/// KAN-938: a single-board export→import round-trip must preserve the board's
+/// archived card — it stays archived and scoped to the same board — on every
+/// backend. This is the reversibility invariant for the CLI/MCP V2 export path.
+pub async fn test_single_board_export_roundtrips_archived_card(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("src.store");
+    let mut src = KanbanContext::open(factory(&src_path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = src.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = src.create_column(board.id, "Col".into(), None).unwrap();
+    let _live = src
+        .create_card(board.id, col.id, "Live".into(), CreateCardOptions::default())
+        .unwrap();
+    let archived = src
+        .create_card(
+            board.id,
+            col.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    src.archive_card(archived.id).unwrap();
+
+    let json = src.export_board(Some(board.id)).unwrap();
+
+    let dst_path = dir.path().join("dst.store");
+    let mut dst = KanbanContext::open(factory(&dst_path), AppConfig::default())
+        .await
+        .unwrap();
+    dst.import_board(&json).unwrap();
+
+    dst.save().await.unwrap();
+    let dst = KanbanContext::open_deferred(factory(&dst_path), AppConfig::default());
+
+    let imported_archived = dst.list_archived_cards().unwrap();
+    assert_eq!(
+        imported_archived.len(),
+        1,
+        "imported single-board export keeps the archived card archived"
+    );
+    assert_eq!(
+        imported_archived[0].entity_id(),
+        archived.id,
+        "imported archived card is the same card"
+    );
+    assert_eq!(
+        imported_archived[0].context.board_id, board.id,
+        "imported archived card stays scoped to its board"
+    );
+    // It is hidden from the live list but reachable by id (F1 marker model).
+    assert!(
+        !dst.list_all_cards()
+            .unwrap()
+            .iter()
+            .any(|c| c.id == archived.id),
+        "restored archived card is hidden from the live list"
+    );
+    assert!(
+        dst.get_card(archived.id).unwrap().is_some(),
+        "archived card is reachable by id after round-trip"
+    );
+}
+
+/// KAN-938: a board that is ITSELF archived must carry its `ArchivedBoard` marker
+/// through a single-board export→import round-trip on every backend. The board
+/// comes back as archived (a marker present, hidden from the live list).
+pub async fn test_single_board_export_roundtrips_archived_board_marker(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("src.store");
+    let mut src = KanbanContext::open(factory(&src_path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = src.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = src.create_column(board.id, "Col".into(), None).unwrap();
+    let _card = src
+        .create_card(board.id, col.id, "Task".into(), CreateCardOptions::default())
+        .unwrap();
+    src.archive_board(board.id).unwrap();
+
+    let json = src.export_board(Some(board.id)).unwrap();
+    let snapshot: kanban_domain::Snapshot = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        snapshot.archived_boards.len(),
+        1,
+        "single-board export of an archived board carries its ArchivedBoard marker"
+    );
+    assert_eq!(
+        snapshot.archived_boards[0].entity_id(),
+        board.id,
+        "exported archived-board marker references the board"
+    );
+
+    let dst_path = dir.path().join("dst.store");
+    let mut dst = KanbanContext::open(factory(&dst_path), AppConfig::default())
+        .await
+        .unwrap();
+    dst.import_board(&json).unwrap();
+
+    dst.save().await.unwrap();
+    let dst = KanbanContext::open_deferred(factory(&dst_path), AppConfig::default());
+
+    let imported = dst.data_store().snapshot().unwrap();
+    assert_eq!(
+        imported.archived_boards.len(),
+        1,
+        "imported board stays archived (marker survives the round-trip)"
+    );
+    assert_eq!(imported.archived_boards[0].entity_id(), board.id);
+    assert!(
+        !dst.list_boards().unwrap().iter().any(|b| b.id == board.id),
+        "archived board is hidden from the live board list after round-trip"
+    );
+    assert!(
+        dst.data_store().get_board(board.id).unwrap().is_some(),
+        "archived board head is reachable after round-trip"
+    );
+}
+
 /// KAN-901: archived card with a deleted column is still returned by
 /// list_cards(ArchivedOnly) — the selector path scopes by marker board_id,
 /// not by current column membership.

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -631,7 +631,12 @@ pub async fn test_single_board_export_includes_archived_cards(factory: &BackendF
     let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
     let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
     let _live = ctx
-        .create_card(board.id, col.id, "Live".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
     let archived = ctx
         .create_card(
@@ -681,7 +686,12 @@ pub async fn test_single_board_export_roundtrips_archived_card(factory: &Backend
     let board = src.create_board("Board".into(), Some("B".into())).unwrap();
     let col = src.create_column(board.id, "Col".into(), None).unwrap();
     let _live = src
-        .create_card(board.id, col.id, "Live".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
     let archived = src
         .create_card(
@@ -746,7 +756,12 @@ pub async fn test_single_board_export_roundtrips_archived_board_marker(factory: 
     let board = src.create_board("Board".into(), Some("B".into())).unwrap();
     let col = src.create_column(board.id, "Col".into(), None).unwrap();
     let _card = src
-        .create_card(board.id, col.id, "Task".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Task".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
     src.archive_board(board.id).unwrap();
 

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -155,6 +155,18 @@ macro_rules! context_contract_tests {
             $crate::test_helpers::contract::archive::test_list_cards_archived_only_explicit_override_wins(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
+        async fn test_single_board_export_includes_archived_cards() {
+            $crate::test_helpers::contract::archive::test_single_board_export_includes_archived_cards(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_single_board_export_roundtrips_archived_card() {
+            $crate::test_helpers::contract::archive::test_single_board_export_roundtrips_archived_card(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_single_board_export_roundtrips_archived_board_marker() {
+            $crate::test_helpers::contract::archive::test_single_board_export_roundtrips_archived_board_marker(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
         async fn test_delete_board_is_noop_on_archived_board() {
             $crate::test_helpers::contract::archive::test_delete_board_is_noop_on_archived_board(&$factory_fn()).await;
         }


### PR DESCRIPTION
## What

The single-board CLI/MCP export path `export_board_impl` (`crates/kanban-service/src/context/sprints.rs`) built its `Snapshot` with `archived_boards: Vec::new()` and `archived_cards: vec![]`, so exporting a single board dropped all of its archival data: the board's archived cards, and the board's own archived marker when the board itself was archived. The full/all-boards export path (KAN-895, `kanban-domain/src/export/exporter.rs`) already includes archival; this residual gap on the V2 single-board path was flagged by KAN-895's spike as out of scope at the time.

## Fix

Mirror `BoardExporter::export_board` inside `export_board_impl`:

- Gather the board's archived cards via `list_archived_cards_by_board(board_id)` (marker-based, deleted-column-safe) into `snapshot.archived_cards`.
- Carry the live rows of those archived cards. `list_all_cards` hides archived cards under the F1 marker model, so their live rows are fetched unfiltered by id and unioned in (dangling-column-safe, so a marker whose original column was deleted after archival is not orphaned on import).
- Read the board head unfiltered via `get_board` instead of the live-scoped `list_boards`, so a single-board export of an archived board still carries its head.
- Carry the `ArchivedBoard` marker via `get_archived_board(board_id)` when the board itself is archived.

`import_board_impl` now threads `imported.archived_boards` through `ImportEntities` (it previously hardcoded `vec![]`), so the board marker round-trips symmetrically; the import machinery already inserts archived boards.

## Tests (strict TDD, per backend)

Three cross-backend contract tests were added to `kanban-service/src/test_helpers/contract/archive.rs` and registered in the `context_contract_tests!` macro, so each runs on in-memory, JSON, and SQLite (9 test instances):

- `test_single_board_export_includes_archived_cards`
- `test_single_board_export_roundtrips_archived_card`
- `test_single_board_export_roundtrips_archived_board_marker`

All 9 failed Red first (snapshot built with empty archival collections), and pass Green after the fix. The full `kanban-service --features test-helpers` suite is green; `cargo clippy -p kanban-service --all-targets` is clean; `cargo fmt` applied; `cargo check -p kanban-cli -p kanban-mcp` passes.

Relates KAN-895.