### PR TITLE
refactor(cli): converge board set-sort --field to --sort

### DIFF
--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -367,12 +367,12 @@ Provide the file path in one of these ways:
                 }
             }
             Some(Commands::Board(BoardCommand {
-                action: BoardAction::SetSort { field, order },
+                action: BoardAction::SetSort { sort, order },
             })) => {
                 init_tracing_cli();
-                if field.is_none() && order.is_none() {
+                if sort.is_none() && order.is_none() {
                     return crate::output::output_error(
-                        "board set-sort requires at least one of --field and/or --order",
+                        "board set-sort requires at least one of --sort and/or --order",
                     );
                 }
                 if !std::path::Path::new(&effective_file).exists() {
@@ -385,7 +385,7 @@ Provide the file path in one of these ways:
                 // service/MCP/TUI.
                 let mut ctx = CliContext::load(&store_manager, &effective_file, config).await?;
                 let (cur_field, cur_order) = ctx.effective_board_sort();
-                let field = field.map(|f| f.to_board_sort_field()).unwrap_or(cur_field);
+                let field = sort.map(|f| f.to_board_sort_field()).unwrap_or(cur_field);
                 let order = order.map(|o| o.to_sort_order()).unwrap_or(cur_order);
                 ctx.set_board_sort(field, order)?;
                 output::output_success(serde_json::json!({

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -112,9 +112,9 @@ pub enum BoardAction {
     },
     /// Persist the default board-list sort (written to AppConfig).
     SetSort {
-        /// Board sort field to persist as the default.
+        /// Board sort dimension to persist as the default.
         #[arg(long, value_enum)]
-        field: Option<BoardSortKey>,
+        sort: Option<BoardSortKey>,
         /// Board sort direction to persist as the default.
         #[arg(long, value_enum)]
         order: Option<SortDir>,

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5272,7 +5272,7 @@ mod board_sort_tests {
                 file.to_str().unwrap(),
                 "board",
                 "set-sort",
-                "--field",
+                "--sort",
                 "name",
             ])
             .assert()
@@ -5307,7 +5307,7 @@ mod board_sort_tests {
                 file.to_str().unwrap(),
                 "board",
                 "set-sort",
-                "--field",
+                "--sort",
                 "created_at",
                 "--order",
                 "desc",
@@ -5333,7 +5333,7 @@ mod board_sort_tests {
 
     #[test]
     fn test_board_set_sort_no_args_errors() {
-        // `board set-sort` with neither --field nor --order must be a clear
+        // `board set-sort` with neither --sort nor --order must be a clear
         // error, not a silent success that writes nothing.
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
@@ -5346,7 +5346,7 @@ mod board_sort_tests {
             .args([file.to_str().unwrap(), "board", "set-sort"])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("--field"))
+            .stderr(predicate::str::contains("--sort"))
             .stderr(predicate::str::contains("--order"));
     }
 }


### PR DESCRIPTION
## What

Renames the `board set-sort` subcommand's `--field` flag to `--sort` so it matches the sibling `board list --sort`, which reads the same persisted board-list sort default. Both now speak `--sort` for the board-sort dimension.

`board update --sort-field` (a separate, already-shipped card-sort concept) is left unchanged.

## Changes

- `crates/kanban-cli/src/cli.rs`: `SetSort` arg `field` -> `sort` (same `BoardSortKey` value_enum); help text now reads "Board sort dimension". `--order` unchanged.
- `crates/kanban-cli/src/app.rs`: destructure `SetSort { sort, order }`; error message updated to "requires at least one of --sort and/or --order".
- `crates/kanban-cli/tests/cli_integration.rs`: the three `set-sort` tests now invoke `--sort` and assert the missing-args error mentions `--sort`.

## Verification

- `cargo test -p kanban-cli`: green (142 + 10 + doctest passed).
- `cargo clippy -p kanban-cli --all-targets -D warnings`: clean.
- `cargo fmt`: clean.
- Runtime: `board set-sort --sort name --order asc` succeeds; `--field` now errors with "unexpected argument '--field'".

Pure rename, no behavior change.