### PR TITLE
docs: release-hardening — changelog coverage + README/version-doc corrections for v0.8.0

### DIFF
--- a/.changeset/kan-864-unified-reference-marker-archival.md
+++ b/.changeset/kan-864-unified-reference-marker-archival.md
@@ -13,8 +13,8 @@ separate, limited mode.
   `board restore`, and `board delete-archived` commands.
 - MCP: `list_cards` and `list_boards` take an `archived` filter (`exclude`,
   `only`, `include`), and there are board archive, restore, and delete-archived
-  tools. The separate `list_archived_cards` tool remains as a thin deprecated
-  wrapper over the unified list.
+  tools. The separate `list_archived_cards` tool has been removed; use
+  `list_cards` with `archived: "only"` instead.
 - TUI: an archived boards view you can open into and browse like any live board,
   drilling into its columns and cards, with archive, restore, and
   permanent-delete affordances.

--- a/.changeset/kan-946-board-list-sort.md
+++ b/.changeset/kan-946-board-list-sort.md
@@ -1,0 +1,21 @@
+---
+bump: minor
+---
+
+The board list is now sortable. You can order boards by position, name,
+creation time, or archival recency, and persist a default so every surface
+respects it.
+
+- CLI: `kanban board list --sort <field> --order <dir>` sorts a single listing
+  (`field` is one of `position`, `name`, `created_at`, `archived_at`; `dir` is
+  `asc` or `desc`). `kanban board set-sort --field <field> --order <dir>`
+  persists a default in the app config; later `board list` calls without an
+  explicit sort/order use it.
+- MCP: `list_boards` gains `sort` and `order` parameters, and a new
+  `set_board_sort` tool persists the default.
+- TUI: the projects panel gets a sort field picker (`o`) and an order toggle
+  (`s`) that work for both the live and archived board views, and the choice is
+  persisted across sessions.
+
+The archived-boards view defaults to recency (most recently archived first)
+rather than position.

--- a/.changeset/kan-946-board-list-sort.md
+++ b/.changeset/kan-946-board-list-sort.md
@@ -8,7 +8,7 @@ respects it.
 
 - CLI: `kanban board list --sort <field> --order <dir>` sorts a single listing
   (`field` is one of `position`, `name`, `created_at`, `archived_at`; `dir` is
-  `asc` or `desc`). `kanban board set-sort --field <field> --order <dir>`
+  `asc` or `desc`). `kanban board set-sort --sort <field> --order <dir>`
   persists a default in the app config; later `board list` calls without an
   explicit sort/order use it.
 - MCP: `list_boards` gains `sort` and `order` parameters, and a new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,8 @@ cargo tarpaulin        # Code coverage
 
 - `JsonFileStore` - `PersistenceStore` impl with atomic writes (temp file + rename)
 - `JsonStoreFactory` - `matches_content` sniffs the first non-whitespace byte (`{` or `[`); no extension matching
-- Envelope: `{ version, metadata, data }`, current version V7; reader accepts V1..V7
-- Migration chain V1 → V2 → V3 → (V4/V5 are shape-stable bumps) → V6 (split-graph) → V7 (spawns-bucket rename); legacy steps write `.v{N}.backup` on the way forward, including `.v6.backup` on the V6→V7 step
+- Envelope: `{ version, metadata, data }`, current version V10; reader accepts V1..V10
+- Migration chain V1 → V2 → V3 → (V4/V5 are shape-stable bumps) → V6 (split-graph) → V7 (spawns-bucket rename) → V8 (archived-card board_id backfill) → V9 (archived-board-capable marker) → V10 (archival wrapper collapsed to a pure reference marker); legacy steps write `.v{N}.backup` on the way forward, including `.v9.backup` on the V9→V10 step
 - Debounced saving (500ms minimum interval)
 
 ### kanban-persistence-sqlite
@@ -150,8 +150,8 @@ cargo tarpaulin        # Code coverage
 
 - `SqliteStore` - `PersistenceStore` impl with WAL mode, foreign keys, max 2 connections
 - `SqliteStoreFactory` - `matches_content` sniffs the SQLite magic bytes (`SQLite format 3\0`); no extension matching
-- Relational schema, 13 tables: metadata, boards, board_sprint_names, board_sprint_counters, columns, sprints, cards, sprint_logs, archived_cards, spawns_edges, blocks_edges, relates_edges, command_log
-- `metadata.schema_version = 1`; legacy-table drops on open for pre-KAN-405 `command_log`, the retired `undo_state`, and the pre-KAN-504 single `card_edges` table
+- Relational schema, 14 tables: metadata, boards, board_sprint_names, board_sprint_counters, columns, sprints, cards, sprint_logs, archived_cards, spawns_edges, blocks_edges, relates_edges, board_archival, command_log
+- `SUPPORTED_SCHEMA_VERSION = 4` (active migrations upgrade older databases on open, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`); legacy-table drops on open for pre-KAN-405 `command_log`, the retired `undo_state`, and the pre-KAN-504 single `card_edges` table
 - Auto-creates database file on first use
 
 ### kanban-tui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,9 +202,9 @@ moving parts are:
    `kanban-service/src/context.rs`, `CliContext`, `McpContext`, `TuiContext`.
 
 6. **Persistence**:
-   - **JSON** — add a `my_kind: { edges: [...] }` key to the V6 envelope
-     (no migration needed if a field is added cleanly with
-     `#[serde(default)]`); otherwise bump to V7 with a transform step in
+   - **JSON** — add a `my_kind: { edges: [...] }` key to the current envelope
+     (V10; no migration needed if a field is added cleanly with
+     `#[serde(default)]`); otherwise bump to V11 with a transform step in
      `kanban-persistence-json/src/migration/`.
    - **SQLite** — add a `my_kind_edges` table in
      `kanban-persistence-sqlite/src/schema.sql` with appropriate columns
@@ -278,7 +278,7 @@ pub fn handle_create_card_key(&mut self) {
 - **Progressive Auto-Save**: Changes saved immediately after each operation (not just on exit)
 - **Async Processing**: Commands queued immediately via bounded channel, processed by background worker
 - **Conflict Detection**: Multi-instance changes detected via file metadata (timestamp + size + content hash)
-- **Format Versioning**: JSON envelope versioned V1..V6 (current shipped is V6); reader auto-migrates older files on load via the V1→V2→V3→…→V6 chain, writing `.v{N}.backup` for V3/V4/V5 starting points before the split-graph step. SQLite uses `metadata.schema_version` (currently `1`) plus one-shot legacy-table drops on open.
+- **Format Versioning**: JSON envelope versioned V1..V10 (current shipped is V10); reader auto-migrates older files on load via the V1→V2→…→V10 chain, writing a one-time `.v{N}.backup` for the starting version before the upgrade. SQLite uses `metadata.schema_version` (`SUPPORTED_SCHEMA_VERSION` currently `4`) with active migrations, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`, plus one-shot legacy-table drops on open.
 - **Multi-Instance Support**: Last-write-wins resolution for concurrent edits (see [CONFLICT_RESOLUTION.md](CONFLICT_RESOLUTION.md) for data loss scenarios and limitations)
 - **Atomic Writes**: Crash-safe write pattern (temp file → atomic rename) prevents corruption
 - **Own-Write Detection**: Metadata-based filtering prevents false positives from our own saves

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **Zero latency** — pure keyboard flow — hjkl, never reach for the mouse
 - **Your data is a file on your disk** — private, offline, always yours
 - **Git-native** — generate branch names and `git checkout` commands from any card
-- **LLM-native** — full MCP server (44 tools) works with Claude Code, Cursor, and any MCP client
+- **LLM-native** — full MCP server (47 tools) works with Claude Code, Cursor, and any MCP client
 - **Offline-first** — works anywhere; JSON and SQLite backends, atomic writes, live conflict detection
 
 ---
@@ -150,6 +150,7 @@ VS Code is known not to work in the current implementation.
 - Card numbering with configurable prefix (e.g. `KAN-42`)
 - Card relations: parent/child (Spawns), blocking (with severity), and undirected relates (with sub-kind) — each with cycle / self-reference detection and dedicated `kanban relation` CLI + MCP tools
 - Archive and restore cards
+- Archive and restore whole boards: `board archive` / `board restore` / `board delete-archived`, an archived-boards TUI view you can drill into like a live board, `board list --archived` / `--include-archived`, a three-state MCP `archived` filter (`exclude` / `only` / `include`), and matching MCP archive/restore/delete-archived tools
 
 ### Sprint Planning
 - Full sprint lifecycle: Planning → Active → Completed / Cancelled
@@ -160,7 +161,8 @@ VS Code is known not to work in the current implementation.
 ### Views & Navigation
 - **3 view modes**: Flat list / Grouped by column / Kanban board — toggle with `V`
 - Real-time `/` search
-- Sort by priority, points, status, or position
+- Sort cards by priority, points, status, or position
+- Sort the board list by position, name, creation time, or archival recency: `board list --sort <field> --order <dir>`, a persisted default via `board set-sort`, and a TUI field picker (`o`) / order toggle (`s`) for both live and archived boards
 - Filter by sprint, status, or search result
 - Multi-select for bulk archive / move / sprint-assign
 
@@ -179,7 +181,7 @@ VS Code is known not to work in the current implementation.
 ### Interfaces
 - **TUI** — full keyboard-driven terminal UI
 - **CLI** — scriptable; all operations, JSON output, pagination
-- **MCP server** — 44 tools for LLM integration
+- **MCP server** — 47 tools for LLM integration
 
 ---
 
@@ -356,7 +358,8 @@ graph LR
 
 ### JSON Backend (default)
 
-- **V2 envelope format**: `{ "version": 2, "metadata": {...}, "data": {...} }`
+- **Envelope format** (current version V10): `{ "version": 10, "metadata": {...}, "data": {...} }`
+- **Automatic migrations**: older files (V1..V10) upgrade in place on open, writing a one-time `.v{N}.backup` before the upgrade
 - **Atomic writes**: crash-safe — every write is atomic (temp file → rename)
 - **Debounced saving**: 500ms minimum interval between saves
 - Default for any plain file path
@@ -366,7 +369,7 @@ graph LR
 - **WAL mode** with foreign key enforcement
 - **Connection pool**: max 2 connections
 - **Relational schema**: boards, columns, cards, archived cards, sprints, sprint logs, dependency graph edges, and more
-- Schema versioning with migration skeleton for future upgrades
+- **Schema versioning with active migrations** (current schema version 4): older databases upgrade on open, each guarded by a durable pre-migration backup (`VACUUM INTO` snapshot to `.v{N}.backup`)
 - File selected by `.sqlite`, `.sqlite3`, or `.db` extension
 
 ### Multi-Instance Support

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -1,6 +1,6 @@
 # kanban-mcp
 
-Model Context Protocol (MCP) server for kanban project management. Provides 46 tools covering boards, columns, cards, card relations (parent/child), sprints, bulk operations, import/export, and undo/redo.
+Model Context Protocol (MCP) server for kanban project management. Provides 47 tools covering boards, columns, cards, card relations (parent/child), sprints, bulk operations, import/export, and undo/redo.
 
 ## Architecture
 
@@ -108,12 +108,12 @@ Most tool inputs accept either an opaque UUID or a friendlier reference, resolve
 | `tool_delete_column` | Delete column and all its cards | `column: String` | — |
 | `tool_reorder_column` | Move column to a new position | `column: String`, `position: i32` | — |
 
-### Cards (9 tools)
+### Cards (8 tools)
 
 | Tool | Description | Required params | Optional params |
 |------|-------------|-----------------|-----------------|
 | `tool_create_card` | Create a new card in a column | `board: String`, `column: String`, `title: String` | `description`, `priority` (low/medium/high/critical), `points: u8`, `due_date` (YYYY-MM-DD or RFC 3339) |
-| `tool_list_cards` | List cards with filters. Returns `CardSummary` (title, status, priority, points — use tool_get_card for full detail). | — | `board`, `column`, `sprint`, `status`, `page: u32`, `page_size: u32` |
+| `tool_list_cards` | List cards with filters. Returns `CardSummary` (title, status, priority, points — use tool_get_card for full detail). | — | `board`, `column`, `sprint`, `status`, `archived`, `sort` (points/priority/created_at/updated_at/due_date/status/position/default), `order` (asc/desc), `page: u32`, `page_size: u32` |
 | `tool_get_card` | Get card by UUID or identifier (e.g. `KAN-5`). Returns list if ambiguous. | `card: String` | — |
 | `tool_update_card` | Update card properties | `card: String` | `title`, `description`, `priority`, `status` (todo/in_progress/blocked/done), `points: u8`, `due_date`, `clear_due_date: bool` |
 | `tool_move_card` | Move card to a different column | `card: String`, `column: String` | `position: i32` |


### PR DESCRIPTION
Release-documentation hardening ahead of cutting v0.8.0. Docs and changeset only, no source code. Every count/version below was verified against the code at this base.

## Changesets
- **Added** `.changeset/kan-946-board-list-sort.md` (minor): the board-list sort feature (KAN-937/941 + KAN-949 remediation) had no changeset, so it would have been missing from the 0.8.0 changelog. Describes `board list --sort/--order`, the persisted default via `board set-sort`, the TUI field picker (`o`) / order toggle (`s`) for live and archived boards, MCP `list_boards` sort/order params + the `set_board_sort` tool, and the recency default for archived boards.
- **Fixed** stale claim in `.changeset/kan-864-unified-reference-marker-archival.md`: it advertised `list_archived_cards` as "a thin deprecated wrapper" — that MCP tool was removed. Corrected to point at `list_cards` with `archived: "only"`.

## Docs corrected
- **crates/kanban-mcp/README.md**: header tool count 46 -> 47; Cards section 9 -> 8 (no `list_archived_cards` tool); added `archived`, `sort`, `order` optional params to the `list_cards` row (mirroring `list_boards`). Section subtotals now sum to 47.
- **README.md**: "44 tools" -> "47 tools" (both occurrences); added board archiving to Features (archive/restore/delete-archived, `--archived`/`--include-archived`, three-state MCP `archived` filter, TUI archived-boards view) and board-list sort (`board list --sort/--order`, `board set-sort`, TUI `s`/`o`); refreshed the persistence section (JSON envelope V2 example -> V10; SQLite "migration skeleton" -> schema version 4 with active migrations + `VACUUM INTO` pre-migration backups).
- **CLAUDE.md**: JSON "current V7 / V1..V7" -> "V10 / V1..V10" with the V8->V9->V10 chain noted; SQLite "13 tables" -> 14 (adds `board_archival`), `schema_version = 1` -> `SUPPORTED_SCHEMA_VERSION = 4`.
- **CONTRIBUTING.md**: JSON envelope V6 -> V10; SQLite `schema_version` 1 -> 4 (Format Versioning line and the add-a-relation-kind procedure).

## Verification
Cross-checked against code: `FormatVersion::MAX = V10` (`kanban-persistence/src/traits.rs`), `SUPPORTED_SCHEMA_VERSION = 4` (`kanban-persistence-sqlite/src/sqlite_store/mod.rs`), 14 `CREATE TABLE` in `schema.sql`, 47 `#[tool(` fns across `kanban-mcp/src/tools` (board 9, column 6, card_crud 10 = Cards 8 + Utilities 2, card_batch 5, card_relations 4, sprint 9, transfer 4), and `list_cards`/`list_boards` both carry `archived`/`sort`/`order`.

## Note for the reviewer
The board `set-sort` field flag is documented as `--field` (matches the code at this develop base: `crates/kanban-cli/src/cli.rs` `SetSort { field: Option<BoardSortKey> }`). The brief anticipated a sibling rename to `--sort`, but that rename has not landed on this base, so documenting `--sort` would have introduced a fresh inaccuracy. If the rename merges before the release cut, this one token should be flipped to `--sort` in both the changeset and any follow-up.