### PR TITLE
fix(tui): guard archived-board ops when drilled in + curate archived-view keybindings (release hardening)

### DIFF
--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -476,8 +476,16 @@ impl App {
         }
 
         match key_code {
-            KeyCode::Char('r') => self.handle_restore_board(),
-            KeyCode::Char('x') => self.handle_delete_archived_board_key(),
+            // Restore / permanent-delete act on the board LIST. They are gated on
+            // no board being activated: once drilled into an archived board
+            // (`active_board_id` set, focus on Cards), `r`/`x` must NOT restore or
+            // delete the highlighted list board out from under the user.
+            KeyCode::Char('r') if self.selection.active_board_id.is_none() => {
+                self.handle_restore_board()
+            }
+            KeyCode::Char('x') if self.selection.active_board_id.is_none() => {
+                self.handle_delete_archived_board_key()
+            }
             KeyCode::Char('s') => self.handle_toggle_board_sort_order(),
             KeyCode::Char('o') => self.handle_order_boards_key(),
             KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q')

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1553,4 +1553,85 @@ mod tests {
         );
         let _ = (arch1, arch2);
     }
+
+    /// Data-loss guard: once an archived board is ACTIVATED (drilled into —
+    /// `active_board_id` set, focus on Cards, mode still ArchivedBoardsView),
+    /// pressing `x` must NOT permanently delete the board highlighted in the
+    /// underlying list. `x` operates on the board LIST, not while viewing a
+    /// board's contents.
+    #[test]
+    fn test_archived_board_drilled_in_x_does_not_delete_list_board() {
+        let mut app = App::test_default();
+        let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
+        let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+
+        // Drill into an archived board: active id set, focus on the tasks panel.
+        app.selection.active_board_id = Some(arch1);
+        app.focus.active = Focus::Cards;
+        app.selection.board.set(Some(0));
+
+        let archived_before = app.ctx.list_archived_boards().unwrap().len();
+        app.handle_archived_boards_view_mode(KeyCode::Char('x'));
+
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm),
+            "x must not open the permanent-delete dialog while drilled into a board"
+        );
+        assert_eq!(
+            app.ctx.list_archived_boards().unwrap().len(),
+            archived_before,
+            "no archived board removed while drilled in"
+        );
+        assert!(
+            app.ctx
+                .list_archived_boards()
+                .unwrap()
+                .iter()
+                .any(|ab| ab.entity_id == arch1),
+            "the activated board is still archived (not deleted)"
+        );
+        let _ = arch2;
+    }
+
+    /// Companion guard: `r` (restore) must be inert while drilled into an
+    /// archived board — it would otherwise restore the wrong (highlighted) board
+    /// out from under the user.
+    #[test]
+    fn test_archived_board_drilled_in_r_does_not_restore_list_board() {
+        let mut app = App::test_default();
+        let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
+        let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+
+        app.selection.active_board_id = Some(arch1);
+        app.focus.active = Focus::Cards;
+        app.selection.board.set(Some(0));
+
+        let archived_before = app.ctx.list_archived_boards().unwrap().len();
+        app.handle_archived_boards_view_mode(KeyCode::Char('r'));
+
+        assert_eq!(
+            app.ctx.list_archived_boards().unwrap().len(),
+            archived_before,
+            "no archived board restored while drilled in"
+        );
+        assert!(
+            app.ctx
+                .list_archived_boards()
+                .unwrap()
+                .iter()
+                .any(|ab| ab.entity_id == arch1)
+                && app
+                    .ctx
+                    .list_archived_boards()
+                    .unwrap()
+                    .iter()
+                    .any(|ab| ab.entity_id == arch2),
+            "both archived boards remain archived (nothing restored)"
+        );
+    }
 }

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -136,13 +136,25 @@ impl KeybindingProvider for ArchivedCardsViewProvider {
     /// - drops the live `q` (quit) and `Esc` (clear selection) bindings, whose
     ///   keys instead toggle back to the live set here, and re-advertises them as
     ///   the toggle (#414 finding 3);
+    /// - drops the `d` archive binding (`ArchiveCard`): the cards are already
+    ///   archived, so re-archiving is redundant/confusing;
+    /// - drops the `D` toggle binding (`ToggleArchivedView`): it points the wrong
+    ///   direction (back to live) and duplicates the `q`/`Esc` toggle;
     /// - appends the archived extension: `r` restore, `x` permanent-delete.
     fn get_context(&self) -> KeybindingContext {
         let mut bindings = CardListProvider.get_context().bindings;
 
         // Reused keys whose behaviour differs in the archived view: create is not
-        // offered; `q`/`Esc` toggle back rather than quit/clear.
-        bindings.retain(|b| b.key != "n" && b.key != "q" && b.key != "Esc");
+        // offered; `q`/`Esc` toggle back rather than quit/clear; `d` archive and
+        // `D` toggle-to-live are inert/wrong here (mirrors the board side's
+        // REUSED_ACTIONS curation).
+        bindings.retain(|b| {
+            b.key != "n"
+                && b.key != "q"
+                && b.key != "Esc"
+                && b.action != KeybindingAction::ArchiveCard
+                && b.action != KeybindingAction::ToggleArchivedView
+        });
 
         // Archived extension keys.
         bindings.push(Keybinding::new(

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -405,4 +405,25 @@ mod tests {
             KeybindingAction::DeleteColumn
         );
     }
+
+    /// The archived-cards view must not advertise inert/wrong keys: `d`
+    /// (`ArchiveCard`) archives an already-archived card (redundant), and `D`
+    /// (`ToggleArchivedView`) points the wrong direction. Mirror the board side's
+    /// REUSED_ACTIONS curation: exclude both from the archived-cards provider.
+    #[test]
+    fn test_archived_cards_provider_excludes_archive_key() {
+        let ctx = ArchivedCardsViewProvider.get_context();
+        assert!(
+            !ctx.bindings
+                .iter()
+                .any(|b| b.action == KeybindingAction::ArchiveCard),
+            "archived-cards view must not advertise the `d` archive key"
+        );
+        assert!(
+            !ctx.bindings
+                .iter()
+                .any(|b| b.action == KeybindingAction::ToggleArchivedView),
+            "archived-cards view must not advertise `D` toggle back to live (dropped)"
+        );
+    }
 }

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -25,6 +25,7 @@ impl KeybindingRegistry {
             app.focus.card_focus,
             app.focus.board_focus,
             app.focus.settings_focus,
+            app.selection.active_board_id.is_some(),
         )
     }
 
@@ -34,6 +35,7 @@ impl KeybindingRegistry {
         card_focus: crate::app::CardFocus,
         board_focus: crate::app::BoardFocus,
         settings_focus: SettingsFocus,
+        board_activated: bool,
     ) -> Box<dyn KeybindingProvider> {
         match mode {
             AppMode::Normal => match focus {
@@ -45,6 +47,12 @@ impl KeybindingRegistry {
             AppMode::SprintDetail => Box::new(SprintDetailProvider),
             AppMode::Search => Box::new(SearchModeProvider),
             AppMode::ArchivedCardsView => Box::new(ArchivedCardsViewProvider),
+            // Once an archived board is ACTIVATED (drilled into), the tasks panel
+            // is the context: advertise the card-list keys that actually work
+            // there (Enter detail, e edit, p priority, H/L move) rather than the
+            // board-list keys. Only while browsing the board list does the
+            // archived-boards provider apply.
+            AppMode::ArchivedBoardsView if board_activated => Box::new(CardListProvider),
             AppMode::ArchivedBoardsView => Box::new(ArchivedBoardsViewProvider),
             AppMode::Settings => Box::new(SettingsViewProvider::new(settings_focus)),
             AppMode::Help(previous_mode) => Self::get_provider_for_mode(
@@ -53,6 +61,7 @@ impl KeybindingRegistry {
                 card_focus,
                 board_focus,
                 settings_focus,
+                board_activated,
             ),
             AppMode::Dialog(dialog) => match dialog {
                 DialogMode::CreateBoard => Box::new(DialogInputProvider::new("Create Project")),

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -257,3 +257,45 @@ fn test_live_projects_panel_lists_live_boards_only() {
         "archived set shows the archived head"
     );
 }
+
+/// When drilled into an archived board (mode still ArchivedBoardsView but a
+/// board is activated and focus is on Cards), the keybinding provider must
+/// advertise the CARD-list keys that actually work there (Enter detail, `e`
+/// edit, `p` priority), not the board-list keys (restore/delete/nav). The
+/// provider selection keys off `active_board_id`, mirroring the input router's
+/// drill-in guard.
+#[test]
+fn test_archived_board_drillin_advertises_card_keys() {
+    use kanban_tui::keybindings::{KeybindingAction, KeybindingRegistry};
+
+    let mut app = App::test_default();
+    let (_, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+
+    // Sanity: we are drilled in (active board set, focus on Cards, mode still
+    // ArchivedBoardsView).
+    assert!(app.selection.active_board_id.is_some());
+    assert_eq!(app.focus.active, Focus::Cards);
+    assert_eq!(app.mode, AppMode::ArchivedBoardsView);
+
+    let ctx = KeybindingRegistry::get_provider(&app).get_context();
+    let has = |action: KeybindingAction| ctx.bindings.iter().any(|b| b.action == action);
+
+    assert!(
+        has(KeybindingAction::SelectItem),
+        "drill-in advertises Enter/Space detail (card key)"
+    );
+    assert!(
+        has(KeybindingAction::EditCard),
+        "drill-in advertises `e` edit (card key)"
+    );
+    assert!(
+        has(KeybindingAction::SetCardPriority),
+        "drill-in advertises `p` priority (card key)"
+    );
+    // Board-list ops must NOT be advertised while viewing a board's contents.
+    assert!(
+        !has(KeybindingAction::RestoreBoard) && !has(KeybindingAction::DeleteArchivedBoard),
+        "board-list restore/delete keys are not advertised while drilled in"
+    );
+}


### PR DESCRIPTION
Three TUI release-hardening fixes, each driven test-first (Red then Green), split into a test commit and an implementation commit.

## Issue 1: data-loss bug (most important)
In `handle_archived_boards_view_mode`, the `r` (restore) and `x` (permanent-delete) arms had no guard, while the `Esc`/`q` arm was gated on `active_board_id.is_none()`. `handle_restore_board`/`handle_delete_archived_board_key` only guard on `mode == ArchivedBoardsView`. So when a user drilled into an archived board (Enter set `active_board_id` to Some, focus on Cards, mode still ArchivedBoardsView), pressing `x` permanently deleted the highlighted list board out from under them, and `r` restored the wrong one.

Fix: gate the `r` and `x` arms on `self.selection.active_board_id.is_none()`, mirroring the Esc/q arm. When drilled in, both keys fall through to the shared boards dispatch and are inert.

## Issue 2: wrong keybinding context when drilled in
`get_provider_for_mode` selected `ArchivedBoardsViewProvider` purely on `mode`, so while drilled into an archived board the footer and `?` help advertised board keys (restore/delete/nav) instead of the card keys that actually work.

Fix: `get_provider_for_mode` now takes a `board_activated` flag (from `active_board_id.is_some()`) and returns `CardListProvider` when a board is activated in `ArchivedBoardsView`, so the advertised keys (Enter detail, `e` edit, `p` priority, H/L move) match what works.

## Issue 3: archived-cards view advertised inert/wrong keys
`ArchivedCardsViewProvider` inherits `CardListProvider` and still advertised `d` = "archive" (`ArchiveCard`, redundant on an already-archived card) and `D` = "View archived tasks" (`ToggleArchivedView`, wrong direction).

Fix: the provider now also retains-out the `ArchiveCard` and `ToggleArchivedView` bindings, mirroring the board side's `REUSED_ACTIONS` curation. The `q`/`Esc` toggle-back binding already covers returning to the live view.

## Tests (Red first)
- `test_archived_board_drilled_in_x_does_not_delete_list_board`
- `test_archived_board_drilled_in_r_does_not_restore_list_board`
- `test_archived_board_drillin_advertises_card_keys`
- `test_archived_cards_provider_excludes_archive_key`

## Verification
- `cargo test -p kanban-tui`: all 48 test binaries pass
- `cargo clippy -p kanban-tui --all-targets -- -D warnings`: clean
- `cargo fmt`: clean