### PR TITLE
fix(tui): archived-board drill-in behaves like a live board (KAN-958)

### DIFF
--- a/.changeset/kan-958-archived-board-drill-in-parity.md
+++ b/.changeset/kan-958-archived-board-drill-in-parity.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Fixed the TUI archived-board drill-in so it behaves exactly like a live board.
+After opening an archived board's card list, `Esc` (or `q`) now backs out to the
+archived-boards list instead of leaving you stranded, and card actions such as
+archive (`d`), set priority (`p`), open detail, and move now work on an archived
+board's cards, matching a live board. Previously the drill-in used a
+boards-list-only key dispatch that silently dropped both the back-out and every
+card key, even though the help overlay advertised them.

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -469,28 +469,33 @@ impl App {
     /// THE active board and every view/operation is board-agnostic.
     pub fn handle_archived_boards_view_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
+        // Once drilled into an archived board the experience must be identical
+        // to a live board: card detail/edit/archive/priority/move, column
+        // navigation, and Esc to back out to the projects panel. Delegate to the
+        // exact same dispatch a live board uses (`handle_normal_key`) rather than
+        // the boards-only list handler below. The projects panel keeps showing
+        // the archived set, so Esc's `handle_escape_key` lands back on the
+        // archived LIST with no archival-specific branch. This is the decorator
+        // principle: an archived board is substitutable for a live one.
+        if self.selection.active_board_id.is_some() {
+            self.handle_normal_key(key_code);
+            return;
+        }
         // While browsing the list (no board activated) the Boards panel is the
-        // context. Once a board is active the focus is on Cards; leave it.
-        if self.focus.active != Focus::Boards && self.selection.active_board_id.is_none() {
+        // context.
+        if self.focus.active != Focus::Boards {
             self.focus.active = Focus::Boards;
         }
 
+        // From here on a board is never active (the drilled-in case returned
+        // above), so these are pure board-LIST operations.
         match key_code {
-            // Restore / permanent-delete act on the board LIST. They are gated on
-            // no board being activated: once drilled into an archived board
-            // (`active_board_id` set, focus on Cards), `r`/`x` must NOT restore or
-            // delete the highlighted list board out from under the user.
-            KeyCode::Char('r') if self.selection.active_board_id.is_none() => {
-                self.handle_restore_board()
-            }
-            KeyCode::Char('x') if self.selection.active_board_id.is_none() => {
-                self.handle_delete_archived_board_key()
-            }
+            // Restore / permanently delete the highlighted archived board.
+            KeyCode::Char('r') => self.handle_restore_board(),
+            KeyCode::Char('x') => self.handle_delete_archived_board_key(),
             KeyCode::Char('s') => self.handle_toggle_board_sort_order(),
             KeyCode::Char('o') => self.handle_order_boards_key(),
-            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q')
-                if self.selection.active_board_id.is_none() =>
-            {
+            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {
                 self.handle_toggle_archived_boards_view();
             }
             KeyCode::Char('g') => {

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -299,3 +299,55 @@ fn test_archived_board_drillin_advertises_card_keys() {
         "board-list restore/delete keys are not advertised while drilled in"
     );
 }
+
+// --- KAN-958: the DRILL-IN key DISPATCH must match a live board, not just the
+// advertised keybindings. The provider already lists card keys (test above);
+// these drive the real dispatch (`handle_archived_boards_view_mode`) to prove
+// the keys are actually HANDLED, closing the advertise/dispatch gap.
+
+#[test]
+fn test_archived_board_drill_in_esc_returns_to_list() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+
+    assert!(app.selection.active_board_id.is_some());
+    assert_eq!(app.focus.active, Focus::Cards);
+
+    // Esc must back out to the archived boards LIST, exactly as it does for a
+    // live board (handle_escape_key: clear active board, return focus to the
+    // projects panel, which is still showing the archived set).
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Esc);
+
+    assert_eq!(
+        app.selection.active_board_id, None,
+        "Esc leaves the archived board, returning to the list"
+    );
+    assert_eq!(app.focus.active, Focus::Boards);
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedBoardsView,
+        "still browsing the archived set, now back at the list level"
+    );
+}
+
+#[test]
+fn test_archived_board_drill_in_archives_card_via_key() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+    let card_id = app.get_selected_card_id().expect("a card is selected");
+
+    // `d` on the cards panel archives the focused card — identical to a live
+    // board. Currently the drill-in routes to the boards-only handler, so `d`
+    // is silently dropped.
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('d'));
+
+    assert!(
+        app.animation.animating.contains_key(&card_id),
+        "archiving a card on an archived board behaves like a live board"
+    );
+}


### PR DESCRIPTION
## What

Found in manual TUI testing: after drilling into an archived board's card list, there was no way back to the archived-boards list, and card actions did nothing.

Both symptoms shared one root cause. Once drilled in (`active_board_id` set, focus on Cards, mode still `ArchivedBoardsView`), the key dispatch fell through to a boards-list-only handler that handles neither `Esc` nor any card key. Meanwhile the keybinding provider already advertised the card keys, so the help overlay and the dispatch disagreed.

## Fix

In `handle_archived_boards_view_mode`, when a board is active, delegate to `handle_normal_key` — the exact focus-aware dispatch a live board uses. This is the archival decorator principle: an archived board is substitutable for a live one (LSP).

- `Esc`/`q` back out to the archived-boards list (`handle_escape_key` clears the active board and returns focus to the projects panel, which still shows the archived set, so it lands on the archived list with no archival-specific branch).
- Card ops (`d` archive, `p` priority, detail, move, column nav) work identically to a live board.
- The now-dead `active_board_id.is_none()` guards on the list-level match were removed.
- The KAN-951 drilled-in delete guard is preserved and improved: `x` now routes to export the board rather than deleting the highlighted list board.

## Tests

TDD, driving the real key dispatch (not handlers directly, which is how the existing parity tests missed this):

- `test_archived_board_drill_in_esc_returns_to_list`
- `test_archived_board_drill_in_archives_card_via_key`

Both RED before the fix, GREEN after. Full `kanban-tui` suite green; `clippy -D warnings` + `fmt` clean.