### PR TITLE
fix(core): unarchive_node revives edges only to live neighbors (KAN-961)

### DIFF
--- a/.changeset/kan-961-edge-revival-partial-restore.md
+++ b/.changeset/kan-961-edge-revival-partial-restore.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Fixed a dependency-graph integrity bug: restoring one of two archived cards that
+shared a dependency edge (spawns/blocks/relates) revived the edge even though the
+other card was still archived, leaving an active dependency pointing at a hidden
+card. Restoring a card now only revives edges whose other endpoint is also live,
+matching the invariant already enforced when an edge is created.

--- a/crates/kanban-core/src/graph/core.rs
+++ b/crates/kanban-core/src/graph/core.rs
@@ -81,11 +81,23 @@ impl<E: Edge> EdgeStore<E> {
         }
     }
 
-    /// Unarchive every edge involving `node`.
-    pub fn unarchive_node(&mut self, node_id: E::NodeId) {
+    /// Unarchive the edges involving `node` whose OTHER endpoint is also live.
+    ///
+    /// `node` is the node being restored (treated as live). An edge is only
+    /// revived when `is_live(other_endpoint)` holds: reviving an edge to a
+    /// still-archived neighbor would resurrect a dependency pointing at a hidden
+    /// node, violating the born-archived invariant enforced on edge creation.
+    pub fn unarchive_node(&mut self, node_id: E::NodeId, is_live: &dyn Fn(E::NodeId) -> bool) {
         for edge in &mut self.edges {
             if edge.involves(node_id) {
-                edge.unarchive();
+                let other = if edge.source() == node_id {
+                    edge.target()
+                } else {
+                    edge.source()
+                };
+                if is_live(other) {
+                    edge.unarchive();
+                }
             }
         }
     }
@@ -332,8 +344,30 @@ mod tests {
         graph.archive_node(node_a);
         assert_eq!(graph.active_edge_count(), 0);
 
-        graph.unarchive_node(node_a);
+        graph.unarchive_node(node_a, &|_| true);
         assert_eq!(graph.active_edge_count(), 1);
+    }
+
+    #[test]
+    fn test_unarchive_node_keeps_edge_to_still_archived_neighbor_tombstoned() {
+        let mut graph: EdgeStore<EdgeBase> = EdgeStore::new();
+        let node_a = Uuid::new_v4();
+        let node_b = Uuid::new_v4();
+
+        graph.add_edge(base(node_a, node_b));
+        graph.archive_node(node_b);
+        graph.archive_node(node_a);
+        assert_eq!(graph.active_edge_count(), 0);
+
+        // Restore only node_a; node_b stays archived. The shared edge must NOT
+        // revive — an active edge to a hidden node breaks the born-archived
+        // invariant.
+        graph.unarchive_node(node_a, &|n| n == node_a);
+        assert_eq!(
+            graph.active_edge_count(),
+            0,
+            "edge to still-archived node_b must stay tombstoned"
+        );
     }
 
     #[test]

--- a/crates/kanban-core/src/graph/dag.rs
+++ b/crates/kanban-core/src/graph/dag.rs
@@ -139,8 +139,8 @@ impl<E: Edge> Cascadable for DagGraph<E> {
     fn archive_node(&mut self, node: E::NodeId) {
         self.store.archive_node(node);
     }
-    fn unarchive_node(&mut self, node: E::NodeId) {
-        self.store.unarchive_node(node);
+    fn unarchive_node(&mut self, node: E::NodeId, is_live: &dyn Fn(E::NodeId) -> bool) {
+        self.store.unarchive_node(node, is_live);
     }
     fn remove_node(&mut self, node: E::NodeId) {
         self.store.remove_node(node);
@@ -297,7 +297,7 @@ mod tests {
         let mut g: DagGraph<EdgeBase> = DagGraph::new();
         add(&mut g, a, b).unwrap();
         g.archive_node(b);
-        g.unarchive_node(b);
+        g.unarchive_node(b, &|_| true);
         assert_eq!(g.outgoing(a), vec![b]);
     }
 

--- a/crates/kanban-core/src/graph/traits.rs
+++ b/crates/kanban-core/src/graph/traits.rs
@@ -80,8 +80,10 @@ pub trait Undirected: Graph {
 pub trait Cascadable: Graph {
     /// Archive every edge involving `node` (soft delete).
     fn archive_node(&mut self, node: Self::NodeId);
-    /// Unarchive every edge involving `node`.
-    fn unarchive_node(&mut self, node: Self::NodeId);
+    /// Unarchive the edges involving `node` whose other endpoint is live
+    /// (per `is_live`). An edge to a still-archived neighbor stays tombstoned,
+    /// preserving the born-archived invariant.
+    fn unarchive_node(&mut self, node: Self::NodeId, is_live: &dyn Fn(Self::NodeId) -> bool);
     /// Remove every edge involving `node` (hard delete).
     fn remove_node(&mut self, node: Self::NodeId);
 }

--- a/crates/kanban-core/src/graph/undirected.rs
+++ b/crates/kanban-core/src/graph/undirected.rs
@@ -89,8 +89,8 @@ impl<E: Edge> Cascadable for UndirectedGraph<E> {
     fn archive_node(&mut self, node: E::NodeId) {
         self.store.archive_node(node);
     }
-    fn unarchive_node(&mut self, node: E::NodeId) {
-        self.store.unarchive_node(node);
+    fn unarchive_node(&mut self, node: E::NodeId, is_live: &dyn Fn(E::NodeId) -> bool) {
+        self.store.unarchive_node(node, is_live);
     }
     fn remove_node(&mut self, node: E::NodeId) {
         self.store.remove_node(node);
@@ -255,7 +255,7 @@ mod tests {
         let mut g: UndirectedGraph<EdgeBase> = UndirectedGraph::new();
         g.add_edge(a, b).unwrap();
         g.archive_node(a);
-        g.unarchive_node(a);
+        g.unarchive_node(a, &|_| true);
         assert_eq!(g.neighbors(b), vec![a]);
     }
 

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -207,9 +207,19 @@ impl RestoreCard {
         context.store.delete_archived_card(self.card_id)?;
         context.store.upsert_card(card)?;
 
+        // Cards still archived AFTER this restore (the marker for `card_id` was
+        // just deleted above). Reviving `card_id`'s edges must not resurrect an
+        // edge to a still-archived neighbor, so those endpoints are not live.
+        let still_archived: std::collections::HashSet<Uuid> = context
+            .store
+            .list_archived_cards()?
+            .into_iter()
+            .map(|a| a.entity_id)
+            .collect();
+
         let card_id = self.card_id;
         context.store.modify_graph(Box::new(move |graph| {
-            graph.unarchive_node(card_id);
+            graph.unarchive_node(card_id, &|other| !still_archived.contains(&other));
             Ok(())
         }))?;
         Ok(())

--- a/crates/kanban-domain/src/dependencies/dependency_graph.rs
+++ b/crates/kanban-domain/src/dependencies/dependency_graph.rs
@@ -63,9 +63,9 @@ impl DependencyGraph {
         }
     }
 
-    pub fn unarchive_node(&mut self, card: CardId) {
+    pub fn unarchive_node(&mut self, card: CardId, is_live: &dyn Fn(CardId) -> bool) {
         for sg in self.cascadable_parts_mut() {
-            sg.unarchive_node(card);
+            sg.unarchive_node(card, is_live);
         }
     }
 
@@ -673,6 +673,36 @@ mod tests {
         assert!(g.related(a).is_empty());
         assert_eq!(g.len(), 3);
         assert_eq!(g.active_len(), 0);
+    }
+
+    #[test]
+    fn test_unarchive_node_keeps_edge_to_still_archived_neighbor_tombstoned() {
+        let (a, b, _) = ids();
+        let mut g = DependencyGraph::new();
+        g.set_block(a, b).unwrap();
+        g.archive_node(b);
+        g.archive_node(a);
+        // Restore a; b remains archived, so the shared edge must not revive.
+        g.unarchive_node(a, &|id| id == a);
+        assert!(
+            !g.contains(a, b),
+            "edge to still-archived b must stay tombstoned after restoring a"
+        );
+        assert!(g.contains_archived(a, b));
+    }
+
+    #[test]
+    fn test_unarchive_node_revives_edge_when_neighbor_is_live() {
+        let (a, b, _) = ids();
+        let mut g = DependencyGraph::new();
+        g.set_block(a, b).unwrap();
+        g.archive_node(a);
+        // b was always live; restoring a brings the edge back.
+        g.unarchive_node(a, &|_| true);
+        assert!(
+            g.contains(a, b),
+            "edge revives when both endpoints are live"
+        );
     }
 
     #[test]

--- a/crates/kanban-service/tests/card_graph.rs
+++ b/crates/kanban-service/tests/card_graph.rs
@@ -244,6 +244,37 @@ macro_rules! card_graph_tests {
                 }
             }
 
+            // KAN-961: restoring one of two mutually-archived cards must not
+            // revive their shared edge while the neighbor stays archived — an
+            // active edge to a hidden card breaks the born-archived invariant.
+            // Runs on every backend: the graph persists identically, so a green
+            // here proves the restore command threads node-liveness through.
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_restore_one_archived_endpoint_keeps_edge_tombstoned() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let (a, b, _) = seed_three_cards(&ctx.backend());
+                ctx.attach_child(a, b).unwrap();
+                assert_eq!(ctx.list_children_of(a).unwrap(), vec![b]);
+
+                ctx.archive_card(b).unwrap();
+                ctx.archive_card(a).unwrap();
+                // Restore only `a`; `b` remains archived.
+                ctx.restore_card(a, None).unwrap();
+
+                assert!(
+                    ctx.list_children_of(a).unwrap().is_empty(),
+                    "edge to still-archived b must not revive when only a is restored"
+                );
+
+                // Restoring `b` too brings both endpoints live — the edge returns.
+                ctx.restore_card(b, None).unwrap();
+                assert_eq!(
+                    ctx.list_children_of(a).unwrap(),
+                    vec![b],
+                    "edge revives once both endpoints are live"
+                );
+            }
+
             #[tokio::test(flavor = "multi_thread")]
             async fn test_self_reference_rejected_for_all_kinds() {
                 for kind in ALL_KINDS {


### PR DESCRIPTION
## Bug (found in the v0.8.0 bug-hunt, epic KAN-960)

An edge's archived state is a single `Option<DateTime>`, not a refcount, and `unarchive_node` cleared it on every incident edge unconditionally. So with a dependency edge A→B: archive B (edge correctly tombstoned), archive A, then restore A → the shared edge went active again while B was still archived. Result: an active dependency pointing at a hidden card, violating the born-archived invariant the code enforces on edge creation.

## Fix

`unarchive_node` now takes a node-liveness predicate and revives an edge only when its other endpoint is live. The signature threads through `Cascadable` (core), `DependencyGraph` (domain), and the restore command, which computes the still-archived set after deleting the restored card's marker.

## Tests (TDD, all backends)

- `kanban-core`: `unarchive_node` keeps an edge to a still-archived neighbor tombstoned; revives when the neighbor is live.
- `kanban-domain`: same at the `DependencyGraph` level (both directions).
- `kanban-service` `card_graph` both-backend macro: archive two related cards, restore one, assert the edge stays tombstoned while the neighbor is archived and revives once both are live. Runs on JSON and SQLite.

core (196), domain (666), service graph/inverse/undo suites green; clippy -D + fmt clean.