### PR TITLE
fix(service): get stamps archived_at so archived entities aren't returned as live (KAN-962)

### DIFF
--- a/.changeset/kan-962-get-stamps-archived-at.md
+++ b/.changeset/kan-962-get-stamps-archived-at.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Fixed single-entity reads returning archived entities as if they were live.
+`card get` and `board get` (CLI and MCP, by UUID or identifier) now stamp the
+archival marker's `archived_at`, so an archived card or board is clearly marked
+instead of being indistinguishable from a live one. This matches what
+`card list --archived` already did and keeps the get and list views consistent.

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -15,6 +15,23 @@ pub struct CliContext {
 }
 
 impl CliContext {
+    /// The archival marker's `archived_at` for a card / board, or `None` if
+    /// live. Lets `card get` / `board get` stamp the archived projection so an
+    /// archived entity is never returned looking live.
+    pub fn card_archived_at(
+        &self,
+        id: Uuid,
+    ) -> KanbanResult<Option<chrono::DateTime<chrono::Utc>>> {
+        self.inner.card_archived_at(id)
+    }
+
+    pub fn board_archived_at(
+        &self,
+        id: Uuid,
+    ) -> KanbanResult<Option<chrono::DateTime<chrono::Utc>>> {
+        self.inner.board_archived_at(id)
+    }
+
     pub async fn load(
         store_manager: &StoreManager,
         file_path: &str,

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -52,7 +52,12 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                 Err(e) => return output::output_error(&e.to_string()),
             };
             match ctx.get_board(uuid)? {
-                Some(b) => output::output_success(BoardResponse::from(&b)),
+                // Stamp the marker's `archived_at` so an archived board is not
+                // returned looking live.
+                Some(b) => output::output_success(BoardResponse::with_archived_at(
+                    &b,
+                    ctx.board_archived_at(uuid)?,
+                )),
                 None => return output::output_error(&format!("Board not found: {}", board)),
             }
         }

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -51,17 +51,30 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
         CardAction::Get { card } => {
             if let Ok(uuid) = Uuid::parse_str(&card) {
                 match ctx.get_card(uuid)? {
-                    Some(c) => output::output_success(CardResponse::from(&c)),
+                    // Stamp the marker's `archived_at` so an archived card is
+                    // not returned looking live (get and list must agree).
+                    Some(c) => output::output_success(CardResponse::with_archived_at(
+                        &c,
+                        ctx.card_archived_at(uuid)?,
+                    )),
                     None => return output::output_error(&format!("Card not found: '{}'", card)),
                 }
             } else {
                 let cards = ctx.find_cards_by_identifier(&card)?;
                 match cards.as_slice() {
                     [] => return output::output_error(&format!("Card not found: '{}'", card)),
-                    [c] => output::output_success(CardResponse::from(c)),
+                    [c] => output::output_success(CardResponse::with_archived_at(
+                        c,
+                        ctx.card_archived_at(c.id)?,
+                    )),
                     _ => {
-                        let responses: Vec<CardResponse> =
-                            cards.iter().map(CardResponse::from).collect();
+                        let mut responses: Vec<CardResponse> = Vec::with_capacity(cards.len());
+                        for c in cards.iter() {
+                            responses.push(CardResponse::with_archived_at(
+                                c,
+                                ctx.card_archived_at(c.id)?,
+                            ));
+                        }
                         output::output_success(&responses)
                     }
                 }

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -44,6 +44,23 @@ impl McpContext {
         self.inner.session_id()
     }
 
+    /// The archival marker's `archived_at` for a card / board, or `None` if
+    /// live. Lets `get_card` / `get_board` stamp the archived projection so an
+    /// archived entity is never returned looking live.
+    pub fn card_archived_at(
+        &self,
+        id: Uuid,
+    ) -> KanbanResult<Option<chrono::DateTime<chrono::Utc>>> {
+        self.inner.card_archived_at(id)
+    }
+
+    pub fn board_archived_at(
+        &self,
+        id: Uuid,
+    ) -> KanbanResult<Option<chrono::DateTime<chrono::Utc>>> {
+        self.inner.board_archived_at(id)
+    }
+
     /// Persist the default board-list sort into `AppConfig`
     /// (`board_sort_field` / `board_sort_order`) and reflect it in the running
     /// context. Either dimension may be left unchanged by passing `None`; the

--- a/crates/kanban-mcp/src/helpers/macros.rs
+++ b/crates/kanban-mcp/src/helpers/macros.rs
@@ -96,12 +96,4 @@ macro_rules! mutating_op {
     }};
 }
 
-/// Lock, read (no save).
-macro_rules! read_op {
-    ($ctx:expr, $method:ident $(, $arg:expr)*) => {{
-        $ctx.lock().await.$method($($arg),*).map_err($crate::helpers::kanban_err_to_mcp)
-    }};
-}
-
 pub(crate) use mutating_op;
-pub(crate) use read_op;

--- a/crates/kanban-mcp/src/helpers/mod.rs
+++ b/crates/kanban-mcp/src/helpers/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod serialization;
 pub(crate) use error_mapping::{
     core_err_to_mcp, kanban_err_to_mcp, mcp_enrich_add_error, mcp_enrich_remove_error,
 };
-pub(crate) use macros::{locked_read, locked_write, mutating_op, read_op};
+pub(crate) use macros::{locked_read, locked_write, mutating_op};
 pub(crate) use parsers::{
     parse_archived_selector, parse_board_sort_field, parse_datetime, parse_priority,
     parse_sort_field, parse_sort_order, parse_status,

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -99,12 +99,20 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let board = locked_read(&self.ctx, |ctx| {
+        let response = locked_read(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_board(&req.board)?;
-            ctx.get_board(id).map_err(kanban_err_to_mcp)
+            let board = ctx.get_board(id).map_err(kanban_err_to_mcp)?;
+            // Stamp the marker's `archived_at` so an archived board is not
+            // returned looking live.
+            Ok::<_, McpError>(match board.as_ref() {
+                Some(b) => Some(BoardResponse::with_archived_at(
+                    b,
+                    ctx.board_archived_at(id).map_err(kanban_err_to_mcp)?,
+                )),
+                None => None,
+            })
         })
         .await?;
-        let response = board.as_ref().map(BoardResponse::from);
         to_call_tool_result(&response)
     }
 

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -1,7 +1,7 @@
 use crate::helpers::{
     card_board, core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write,
     parse_archived_selector, parse_datetime, parse_priority, parse_sort_field, parse_sort_order,
-    parse_status, read_op, to_call_tool_result, to_call_tool_result_json, McpResolve,
+    parse_status, to_call_tool_result, to_call_tool_result_json, McpResolve,
 };
 use crate::requests::card::{
     ArchiveCardRequest, CreateCardParams, DeleteCardRequest, GetCardBranchNameRequest,
@@ -109,25 +109,38 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetCardRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let guard = self.ctx.lock().await;
         if let Ok(uuid) = uuid::Uuid::parse_str(&req.card) {
-            let card = read_op!(self.ctx, get_card, uuid)?;
-            let response = card.as_ref().map(CardResponse::from);
+            let card = guard.get_card(uuid).map_err(kanban_err_to_mcp)?;
+            let response = match card.as_ref() {
+                // Stamp the marker's `archived_at` so an archived card is not
+                // returned looking live (get and list must agree).
+                Some(c) => Some(CardResponse::with_archived_at(
+                    c,
+                    guard.card_archived_at(uuid).map_err(kanban_err_to_mcp)?,
+                )),
+                None => None,
+            };
             return to_call_tool_result(&response);
         }
-        let cards = {
-            let guard = self.ctx.lock().await;
-            guard
-                .find_cards_by_identifier(&req.card)
-                .map_err(kanban_err_to_mcp)?
-        };
+        let cards = guard
+            .find_cards_by_identifier(&req.card)
+            .map_err(kanban_err_to_mcp)?;
         match cards.as_slice() {
             [] => Err(McpError::invalid_params(
                 format!("Card not found: '{}'", req.card),
                 None,
             )),
-            [card] => to_call_tool_result(&CardResponse::from(card)),
+            [card] => {
+                let at = guard.card_archived_at(card.id).map_err(kanban_err_to_mcp)?;
+                to_call_tool_result(&CardResponse::with_archived_at(card, at))
+            }
             _ => {
-                let responses: Vec<CardResponse> = cards.iter().map(CardResponse::from).collect();
+                let mut responses: Vec<CardResponse> = Vec::with_capacity(cards.len());
+                for c in &cards {
+                    let at = guard.card_archived_at(c.id).map_err(kanban_err_to_mcp)?;
+                    responses.push(CardResponse::with_archived_at(c, at));
+                }
                 to_call_tool_result(&responses)
             }
         }

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -2867,3 +2867,102 @@ async fn test_mcp_set_board_sort_persists_and_preserves_session() {
         "persisted config must carry board_sort_order, got: {persisted}"
     );
 }
+
+// KAN-962: single-entity get must stamp the archival marker's `archived_at` so
+// an archived card/board is never returned looking live (get and list agree).
+
+#[tokio::test]
+async fn tool_get_card_stamps_archived_at_for_archived_card() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(board_req("Alpha", Some("A".into()))))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(column_req("Alpha", "TODO")))
+        .await
+        .unwrap();
+    let created = text_payload(
+        &server
+            .tool_create_card(Parameters(CreateCardParams {
+                board: "Alpha".into(),
+                column: "TODO".into(),
+                sprint: None,
+                content: kanban_service::api::CreateCardRequest {
+                    id: None,
+                    title: "arch me".into(),
+                    description: None,
+                    priority: None,
+                    due_date: None,
+                    points: None,
+                    sprint_id: None,
+                },
+            }))
+            .await
+            .unwrap(),
+    );
+    let card_id = created["id"].as_str().unwrap().to_string();
+
+    // Live: no archived_at key.
+    let live = text_payload(
+        &server
+            .tool_get_card(Parameters(GetCardRequest {
+                card: card_id.clone(),
+            }))
+            .await
+            .unwrap(),
+    );
+    assert!(
+        live.get("archived_at").is_none(),
+        "live card get must not carry archived_at: {live}"
+    );
+
+    server
+        .tool_archive_card(Parameters(kanban_mcp::ArchiveCardRequest {
+            card: card_id.clone(),
+        }))
+        .await
+        .unwrap();
+
+    // Archived: get_card stamps the marker's archived_at.
+    let archived = text_payload(
+        &server
+            .tool_get_card(Parameters(GetCardRequest { card: card_id }))
+            .await
+            .unwrap(),
+    );
+    assert!(
+        archived.get("archived_at").is_some_and(|v| !v.is_null()),
+        "archived card get must stamp archived_at: {archived}"
+    );
+}
+
+#[tokio::test]
+async fn tool_get_board_stamps_archived_at_for_archived_board() {
+    let (server, _tmp) = setup_server().await;
+    let board = text_payload(
+        &server
+            .tool_create_board(Parameters(board_req("Alpha", Some("A".into()))))
+            .await
+            .unwrap(),
+    );
+    let board_id = board["id"].as_str().unwrap().to_string();
+
+    server
+        .tool_archive_board(Parameters(kanban_mcp::ArchiveBoardRequest {
+            board: board_id.clone(),
+        }))
+        .await
+        .unwrap();
+
+    let archived = text_payload(
+        &server
+            .tool_get_board(Parameters(GetBoardRequest { board: board_id }))
+            .await
+            .unwrap(),
+    );
+    assert!(
+        archived.get("archived_at").is_some_and(|v| !v.is_null()),
+        "archived board get must stamp archived_at: {archived}"
+    );
+}

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -34,6 +34,18 @@ pub struct CardResponse {
     pub archived_at: Option<DateTime<Utc>>,
 }
 
+impl CardResponse {
+    /// Build a card projection stamping the archival marker's `archived_at`.
+    /// `None` yields the live projection (the wire key is skipped); `Some`
+    /// marks the card archived. `from(&Card)` is `with_archived_at(card, None)`.
+    pub fn with_archived_at(card: &Card, archived_at: Option<DateTime<Utc>>) -> Self {
+        Self {
+            archived_at,
+            ..Self::from(card)
+        }
+    }
+}
+
 impl From<&Card> for CardResponse {
     fn from(card: &Card) -> Self {
         let Card {

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -251,6 +251,20 @@ impl KanbanContext {
     pub(super) fn list_archived_boards_impl(&self) -> KanbanResult<Vec<ArchivedBoard>> {
         self.backend.list_archived_boards()
     }
+
+    /// The archival marker's `archived_at` for a board, or `None` if the board
+    /// is live. Lets single-entity reads (`get_board`) stamp the archived
+    /// projection so an archived board is never returned looking live.
+    pub fn board_archived_at(
+        &self,
+        id: Uuid,
+    ) -> KanbanResult<Option<chrono::DateTime<chrono::Utc>>> {
+        Ok(self
+            .list_archived_boards_impl()?
+            .into_iter()
+            .find(|ab| ab.entity_id == id)
+            .map(|ab| ab.metadata.archived_at))
+    }
 }
 
 /// Map a `NewBoard` create-spec onto a true full-replace `BoardUpdate` (the PUT

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -17,6 +17,18 @@ pub struct CardCreateOutcome {
 }
 
 impl KanbanContext {
+    /// The archival marker's `archived_at` for a card, or `None` if the card is
+    /// live. Lets single-entity reads (`get_card`) stamp the archived projection
+    /// the same way `list_cards` does, so an archived card is never returned
+    /// looking live.
+    pub fn card_archived_at(
+        &self,
+        id: Uuid,
+    ) -> KanbanResult<Option<chrono::DateTime<chrono::Utc>>> {
+        let (_ids, at_by_id) = self.archived_card_index()?;
+        Ok(at_by_id.get(&id).copied())
+    }
+
     /// Create a card from a full `NewCard` spec plus an optional client-supplied
     /// id (idempotent PUT-create). The owning board is DERIVED from
     /// `column.board_id` (no `board_id` param). Validates the dual FK: the


### PR DESCRIPTION
## Bug (v0.8.0 bug-hunt, epic KAN-960)

`card get <uuid|KAN-N>` and `board get` (CLI and MCP) projected the entity through `CardResponse::from` / `BoardResponse::from`, both of which hardcode `archived_at: None`. Since archival is a reference marker (the entity stays live in place), an archived card or board came back looking exactly like a live one. Worse, `card list` (LiveOnly) hides it while `card get` returns it, so the two read paths disagreed on whether it exists. `get KAN-N` also resolves through the live-scoped search, returning archived cards as live hits.

## Fix

- New `CardResponse::with_archived_at` (mirrors the existing board one).
- New service lookups `card_archived_at(id)` / `board_archived_at(id)` (delegated through the MCP and CLI context wrappers).
- Every get site stamps the marker's `archived_at`, so an archived entity is clearly marked and get/list agree.
- Removed the now-unused `read_op!` macro (the get_card handler was its only caller).

## Tests (TDD, end to end)

MCP integration: `tool_get_card` and `tool_get_board` now carry `archived_at` after archiving (and none while live). Both were red before the fix (the field was `None` and skipped on the wire).

service/mcp/cli suites green; clippy -D + fmt clean.