### PR TITLE
fix(persistence): V8->V9 migration writes atomically (KAN-966)

### DIFF
--- a/.changeset/kan-966-v8v9-atomic-write.md
+++ b/.changeset/kan-966-v8v9-atomic-write.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Hardened the JSON V8 to V9 migration to write atomically (temp file plus rename),
+matching every other migration step. Previously it wrote the upgraded file in
+place, so a crash mid-write could truncate it; recovery still needed the backup.
+Now a crash leaves the original file intact.

--- a/crates/kanban-persistence-json/src/migration/v8_to_v9_archived_boards.rs
+++ b/crates/kanban-persistence-json/src/migration/v8_to_v9_archived_boards.rs
@@ -19,7 +19,9 @@ pub(crate) async fn migrate_v8_to_v9(path: &Path) -> PersistenceResult<()> {
     }
     let out = serde_json::to_string_pretty(&envelope)
         .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-    tokio::fs::write(path, out).await?;
+    // Atomic write (temp file + rename) like every other migration step and the
+    // sync V8->V9 twin: a crash mid-write must not truncate the live file.
+    crate::atomic_writer::AtomicWriter::write_atomic(path, out.as_bytes()).await?;
     Ok(())
 }
 
@@ -63,5 +65,25 @@ mod tests {
     fn test_v8_to_v9_is_idempotent_on_v9() {
         let mut env = json!({ "version": 9, "data": {} });
         assert!(!transform_v8_to_v9_value(&mut env).unwrap());
+    }
+
+    // KAN-966: the async on-disk step must write the upgraded envelope through
+    // the atomic writer (temp file + rename) and leave a valid V9 file, matching
+    // every sibling step and the sync twin. Round-trips the on-disk write path.
+    #[tokio::test]
+    async fn test_migrate_v8_to_v9_writes_valid_v9_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("v8.json");
+        let env = json!({ "version": 8, "data": { "boards": [] } });
+        tokio::fs::write(&path, serde_json::to_string_pretty(&env).unwrap())
+            .await
+            .unwrap();
+
+        migrate_v8_to_v9(&path).await.unwrap();
+
+        let after: Value =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert_eq!(after["version"], 9);
+        assert_eq!(after["data"]["archived_boards"], json!([]));
     }
 }


### PR DESCRIPTION
## Bug (v0.8.0 bug-hunt, epic KAN-960)

The async `migrate_v8_to_v9` step wrote the upgraded envelope with a bare `tokio::fs::write` (truncate in place), while every other migration step and its own sync twin use `AtomicWriter::write_atomic` (temp file + rename). A crash mid-write could leave the live file truncated, recoverable only via the `.v8.backup`.

## Fix

Use `AtomicWriter::write_atomic`, closing the crash-truncation window. Adds an on-disk round-trip test that migrates a real V8 file and asserts a valid V9 result.

persistence-json suite green; clippy -D + fmt clean.