### PR TITLE
KAN-967 fix(mcp): set_board_sort echoes the resolved value, not null

### DIFF
--- a/.changeset/kan-967-set-board-sort-echo.md
+++ b/.changeset/kan-967-set-board-sort-echo.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Fixed the MCP `set_board_sort` tool reporting `null` for a dimension that was
+omitted from the request but actually resolved and persisted. When you set only
+the field (or only the order), the response now echoes the concrete value that
+was saved, matching the CLI.

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -75,7 +75,7 @@ impl McpContext {
         &mut self,
         sort: Option<BoardSortField>,
         order: Option<SortOrder>,
-    ) -> KanbanResult<()> {
+    ) -> KanbanResult<(BoardSortField, SortOrder)> {
         let config = self.inner.app_config();
         let field = sort.unwrap_or_else(|| {
             config
@@ -91,7 +91,10 @@ impl McpContext {
                 .and_then(|s| SortOrder::from_str(s).ok())
                 .unwrap_or(DEFAULT_BOARD_SORT_LIVE.1)
         });
-        self.inner.set_board_sort(field, order)
+        self.inner.set_board_sort(field, order)?;
+        // Return the RESOLVED pair so the tool echoes the value actually
+        // persisted, not the (possibly-omitted) raw request.
+        Ok((field, order))
     }
 
     /// Create a board from a full spec + optional client id, funneling through

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -176,13 +176,15 @@ impl KanbanMcpServer {
             .map(parse_board_sort_field)
             .transpose()?;
         let order = req.order.as_deref().map(parse_sort_order).transpose()?;
-        locked_write(&self.ctx, |ctx| {
+        let (resolved_field, resolved_order) = locked_write(&self.ctx, |ctx| {
             ctx.set_board_sort(field, order).map_err(kanban_err_to_mcp)
         })
         .await?;
+        // Echo the RESOLVED values actually persisted, so an omitted dimension
+        // is reported concretely instead of null (CLI parity).
         to_call_tool_result_json(serde_json::json!({
-            "board_sort_field": field.map(|f| f.to_string()),
-            "board_sort_order": order.map(|o| o.to_string()),
+            "board_sort_field": resolved_field.to_string(),
+            "board_sort_order": resolved_order.to_string(),
         }))
     }
 

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -2966,3 +2966,24 @@ async fn tool_get_board_stamps_archived_at_for_archived_board() {
         "archived board get must stamp archived_at: {archived}"
     );
 }
+
+// KAN-967: set_board_sort must echo the RESOLVED value actually persisted, not
+// the raw (possibly-omitted) request. Omitting `order` must not report null.
+#[tokio::test]
+async fn test_mcp_set_board_sort_echoes_resolved_order_when_omitted() {
+    let (server, _tmp) = setup_server().await;
+    let resp = text_payload(
+        &server
+            .tool_set_board_sort(Parameters(kanban_mcp::SetBoardSortRequest {
+                sort: Some("name".into()),
+                order: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(resp["board_sort_field"], "name");
+    assert!(
+        resp["board_sort_order"].is_string(),
+        "omitted order must echo the resolved value, not null: {resp}"
+    );
+}


### PR DESCRIPTION
## Bug (v0.8.0 bug-hunt, epic KAN-960)

`set_board_sort {"sort":"name"}` (order omitted) persisted a concrete order to disk but the JSON response reported `board_sort_order: null` because it echoed the raw request (`order.map(...)`) rather than the resolved value. The CLI reports the resolved pair, so the two surfaces disagreed.

## Fix

`McpContext::set_board_sort` now returns the resolved `(field, order)` pair (it already computed it to persist), and the tool echoes that. An omitted dimension is reported concretely.

## Test

MCP integration: `set_board_sort` with `order` omitted echoes a concrete `board_sort_order` string (was `null` before). mcp suite green; clippy -D + fmt clean.