### PR TITLE
KAN-970 fix(tui): drilled-in archived board D/q/e parity

### DIFF
--- a/.changeset/max-kan-970.md
+++ b/.changeset/max-kan-970.md
@@ -6,6 +6,19 @@ Fixed the TUI so viewing and restoring archived cards works on an archived
 board, matching a live board. Previously, once you drilled into an archived
 board, pressing `D` to view its archived cards silently did nothing, which
 also made restore (`r`) and permanent-delete (`x`) for those cards
-unreachable. `q`/`Q` (back out one level) and `e` (edit) were similarly dead
-in that view despite being advertised in the footer/help. All four now work
-exactly as they do on a live board.
+unreachable. `e` (edit) was similarly dead in that view despite being
+advertised in the footer/help, and now works exactly as it does on a live
+board.
+
+`q`/`Q` in that view now correctly back out one level to the archived-boards
+list, instead of silently doing nothing. This isn't identical to a live
+board, where `q`/`Q` quits the application entirely — the drilled-in archived
+view uses `q`/`Q` for back-navigation instead, matching how `Esc` already
+behaved there.
+
+Also fixed two related state-leak bugs surfaced while writing this: a stray
+key sequence (e.g. `g` awaiting a second `g` for "jump to top") could survive
+backing out with `q` and misfire on the next keystroke; and opening search
+from the archived-cards view and closing it could strand you in the live
+view with a stale reference to the archived board instead of returning you
+to the archived-cards view.

--- a/.changeset/max-kan-970.md
+++ b/.changeset/max-kan-970.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Fixed the TUI so viewing and restoring archived cards works on an archived
+board, matching a live board. Previously, once you drilled into an archived
+board, pressing `D` to view its archived cards silently did nothing, which
+also made restore (`r`) and permanent-delete (`x`) for those cards
+unreachable. `q`/`Q` (back out one level) and `e` (edit) were similarly dead
+in that view despite being advertised in the footer/help. All four now work
+exactly as they do on a live board.

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -369,6 +369,15 @@ impl App {
                 self.pending_key = None;
                 self.handle_escape_key();
             }
+            // Live-board `q`/`Q` never reaches this arm (the top-level dispatch
+            // in `handle_key_event` intercepts it first and quits). It's only
+            // reached when delegated from a drilled-in archived board or the
+            // archived-cards view's catch-all, where it must back out one level,
+            // exactly like Esc, rather than silently no-op.
+            KeyCode::Char('q') | KeyCode::Char('Q') => {
+                self.pending_key = None;
+                self.handle_escape_key();
+            }
             KeyCode::Char('j') | KeyCode::Down => {
                 self.pending_key = None;
                 self.handle_navigation_down();
@@ -476,14 +485,6 @@ impl App {
         // archived LIST with no archival-specific branch. This is the decorator
         // principle: an archived board is substitutable for a live one.
         if self.selection.active_board_id.is_some() {
-            // `handle_normal_key` has no `q`/`Q` arm (for a live board those keys
-            // never reach it — the top-level dispatch quits the app first). Here
-            // they must back out one level, exactly like Esc, rather than
-            // silently no-op.
-            if matches!(key_code, KeyCode::Char('q') | KeyCode::Char('Q')) {
-                self.handle_escape_key();
-                return;
-            }
             self.handle_normal_key(key_code);
             return;
         }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -412,7 +412,7 @@ impl App {
         }
     }
 
-    fn handle_search_mode(&mut self, key_code: crossterm::event::KeyCode) {
+    pub fn handle_search_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
         match key_code {
             KeyCode::Char(c) => {

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -86,14 +86,12 @@ impl App {
         }
 
         // Edit (`e`) on the cards panel launches the external editor, which needs
-        // the terminal — pre-intercepted here (where the terminal is in scope) for
-        // BOTH the live Normal view and the archived-cards view, so edit works
-        // identically on a live or archived card and the shared Normal/archived
-        // dispatch below stays terminal-free (and unit-testable).
-        if matches!(key.code, KeyCode::Char('e'))
-            && self.focus.active == Focus::Cards
-            && matches!(self.mode, AppMode::Normal | AppMode::ArchivedCardsView)
-        {
+        // the terminal — pre-intercepted here (where the terminal is in scope),
+        // eligible per `edit_key_active` (live Normal view, archived-cards view,
+        // or a drilled-in archived board), so edit works identically on a live or
+        // archived card and the shared Normal/archived dispatch below stays
+        // terminal-free (and unit-testable).
+        if matches!(key.code, KeyCode::Char('e')) && self.edit_key_active() {
             self.pending_key = None;
             return self.handle_edit_card_key(terminal, event_handler);
         }
@@ -478,6 +476,14 @@ impl App {
         // archived LIST with no archival-specific branch. This is the decorator
         // principle: an archived board is substitutable for a live one.
         if self.selection.active_board_id.is_some() {
+            // `handle_normal_key` has no `q`/`Q` arm (for a live board those keys
+            // never reach it — the top-level dispatch quits the app first). Here
+            // they must back out one level, exactly like Esc, rather than
+            // silently no-op.
+            if matches!(key_code, KeyCode::Char('q') | KeyCode::Char('Q')) {
+                self.handle_escape_key();
+                return;
+            }
             self.handle_normal_key(key_code);
             return;
         }
@@ -561,6 +567,18 @@ impl App {
         if h1 != h0 {
             self.ui_state.help_list.ensure_selected_visible(h1);
         }
+    }
+
+    /// Whether `e` should launch the external editor for the currently focused
+    /// card: the live Normal view, the archived-cards view, or a drilled-in
+    /// archived board (`ArchivedBoardsView` with an active board) — an archived
+    /// card is substitutable for a live one, so edit works identically there too.
+    /// Extracted so this eligibility logic is unit-testable without a terminal.
+    pub fn edit_key_active(&self) -> bool {
+        self.focus.active == Focus::Cards
+            && (matches!(self.mode, AppMode::Normal | AppMode::ArchivedCardsView)
+                || (self.mode == AppMode::ArchivedBoardsView
+                    && self.selection.active_board_id.is_some()))
     }
 
     fn handle_help_mode(&mut self, key_code: crossterm::event::KeyCode) {

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -184,7 +184,7 @@ impl App {
                 self.pending_key = None;
                 if self.focus.active == Focus::Cards {
                     self.filter.search.activate();
-                    self.mode = AppMode::Search;
+                    self.push_mode(AppMode::Search);
                 }
             }
             KeyCode::Char('g') => {
@@ -422,11 +422,11 @@ impl App {
                 self.filter.search.input.backspace();
             }
             KeyCode::Enter => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
             }
             KeyCode::Esc => {
                 self.filter.search.deactivate();
-                self.mode = AppMode::Normal;
+                self.pop_mode();
             }
             _ => {}
         }

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -108,7 +108,7 @@ impl App {
             KeybindingAction::Search => {
                 if self.focus.active == Focus::Cards {
                     self.filter.search.activate();
-                    self.mode = AppMode::Search;
+                    self.push_mode(AppMode::Search);
                 }
             }
             KeybindingAction::ShowHelp => {}

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -786,8 +786,12 @@ impl App {
 
     pub fn handle_toggle_archived_cards_view(&mut self) {
         match self.mode {
-            AppMode::Normal => {
-                self.mode = AppMode::ArchivedCardsView;
+            // `push_mode` snapshots whichever context we're toggling from (a live
+            // board's Normal mode, or a drilled-in archived board), so `pop_mode`
+            // below always returns to the correct origin — not a hardcoded
+            // `Normal`, which would strand a drilled-in archived board.
+            AppMode::Normal | AppMode::ArchivedBoardsView => {
+                self.push_mode(AppMode::ArchivedCardsView);
                 self.prepare_frame();
 
                 // Initialize selection in view strategy
@@ -800,7 +804,7 @@ impl App {
                 self.needs_redraw = true;
             }
             AppMode::ArchivedCardsView => {
-                self.mode = AppMode::Normal;
+                self.pop_mode();
                 self.prepare_frame();
 
                 // Re-initialize selection when returning to normal view

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -785,39 +785,33 @@ impl App {
     }
 
     pub fn handle_toggle_archived_cards_view(&mut self) {
-        match self.mode {
-            // `push_mode` snapshots whichever context we're toggling from (a live
-            // board's Normal mode, or a drilled-in archived board), so `pop_mode`
-            // below always returns to the correct origin — not a hardcoded
-            // `Normal`, which would strand a drilled-in archived board.
-            AppMode::Normal | AppMode::ArchivedBoardsView => {
-                self.push_mode(AppMode::ArchivedCardsView);
-                self.prepare_frame();
-
-                // Initialize selection in view strategy
-                if let Some(list) = self.view.strategy.get_active_task_list_mut() {
-                    if !list.is_empty() {
-                        list.set_selected_index(Some(0));
-                        list.ensure_selected_visible(self.view.viewport_height);
-                    }
-                }
-                self.needs_redraw = true;
-            }
-            AppMode::ArchivedCardsView => {
-                self.pop_mode();
-                self.prepare_frame();
-
-                // Re-initialize selection when returning to normal view
-                if let Some(list) = self.view.strategy.get_active_task_list_mut() {
-                    if !list.is_empty() {
-                        list.set_selected_index(Some(0));
-                        list.ensure_selected_visible(self.view.viewport_height);
-                    }
-                }
-                self.needs_redraw = true;
-            }
-            _ => {}
+        // A drilled-in archived board can only toggle into the archived-cards
+        // view with a board actually active -- merely browsing the
+        // archived-boards LIST (no active_board_id) has no cards panel to show.
+        let entering = matches!(self.mode, AppMode::Normal)
+            || matches!(self.mode, AppMode::ArchivedBoardsView if self.selection.active_board_id.is_some());
+        let exiting = matches!(self.mode, AppMode::ArchivedCardsView);
+        if !entering && !exiting {
+            return;
         }
+
+        // `push_mode` snapshots whichever context we're toggling from (a live
+        // board's Normal mode, or a drilled-in archived board), so `pop_mode`
+        // always returns to the correct origin — not a hardcoded `Normal`,
+        // which would strand a drilled-in archived board.
+        if entering {
+            self.push_mode(AppMode::ArchivedCardsView);
+        } else {
+            self.pop_mode();
+        }
+        self.prepare_frame();
+        if let Some(list) = self.view.strategy.get_active_task_list_mut() {
+            if !list.is_empty() {
+                list.set_selected_index(Some(0));
+                list.ensure_selected_visible(self.view.viewport_height);
+            }
+        }
+        self.needs_redraw = true;
     }
 
     pub fn handle_manage_children_from_list(&mut self) {

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -478,6 +478,11 @@ fn test_restore_card_reachable_from_drilled_in_archived_board() {
     if let Some(list) = app.view.strategy.get_active_task_list_mut() {
         list.set_selected_index(Some(0));
     }
+    assert_eq!(
+        app.get_selected_card_id(),
+        Some(card.id),
+        "the archived card is selected before restoring it"
+    );
 
     app.handle_restore_card();
 

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -352,12 +352,12 @@ fn test_archived_board_drill_in_archives_card_via_key() {
     );
 }
 
-// --- KAN-970: `D`/`e`/`q` follow-on. KAN-958 fixed the DISPATCH delegation
-// (drilled-in keys reach `handle_normal_key`), but `D`'s target handler and
-// the `e`/`q` pre-intercepts still don't recognise `ArchivedBoardsView` as a
-// valid origin, so they silently no-op even after delegation. This is why
-// restoring an archived card on an archived board was unreachable: `D` never
-// transitioned into the mode that exposes `r`/`x`.
+// --- `D`/`e`/`q` still no-op once drilled into an archived board even though
+// the DISPATCH delegation above reaches `handle_normal_key`: `D`'s target
+// handler and the `e`/`q` pre-intercepts don't recognise `ArchivedBoardsView`
+// as a valid origin, so they silently drop the key. This is why restoring an
+// archived card on an archived board was unreachable: `D` never transitioned
+// into the mode that exposes `r`/`x`.
 
 #[test]
 fn test_toggle_archived_cards_view_enters_from_drilled_in_archived_board() {

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -400,6 +400,37 @@ fn test_toggle_archived_cards_view_returns_to_archived_board_not_normal() {
 }
 
 #[test]
+fn test_search_from_archived_cards_view_returns_to_drilled_in_archived_board() {
+    let mut app = App::test_default();
+    let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('D'));
+    assert_eq!(app.mode, AppMode::ArchivedCardsView);
+
+    // '/' delegates to the shared Normal-mode dispatch (handle_normal_key),
+    // exactly like every other unhandled key in the archived-cards view.
+    app.handle_archived_cards_view_mode(crossterm::event::KeyCode::Char('/'));
+    assert_eq!(app.mode, AppMode::Search);
+
+    app.handle_search_mode(crossterm::event::KeyCode::Esc);
+
+    // Search must return to wherever it was opened FROM (the archived-cards
+    // view, itself entered from the drilled-in archived board) rather than
+    // hardcoding Normal, which would strand active_board_id pointing at an
+    // archived board while mode claims to be a live Normal view.
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedCardsView,
+        "closing search returns to the archived-cards view it was opened from"
+    );
+    assert_eq!(
+        app.selection.active_board_id,
+        Some(board_id),
+        "the archived board is still active after closing search"
+    );
+}
+
+#[test]
 fn test_restore_card_reachable_from_drilled_in_archived_board() {
     use kanban_domain::KanbanOperations;
 

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -472,3 +472,28 @@ fn test_shift_q_backs_out_of_drilled_in_archived_board() {
     assert_eq!(app.focus.active, Focus::Boards);
     assert_eq!(app.mode, AppMode::ArchivedBoardsView);
 }
+
+#[test]
+fn test_edit_key_active_true_when_drilled_into_archived_board() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+
+    assert!(
+        app.edit_key_active(),
+        "`e` is eligible on a drilled-in archived board, as it is for a live board"
+    );
+}
+
+#[test]
+fn test_edit_key_active_false_when_browsing_archived_board_list() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    app.mode = AppMode::ArchivedBoardsView;
+    app.focus.active = Focus::Boards;
+
+    assert!(
+        !app.edit_key_active(),
+        "`e` is not eligible while merely browsing the archived-boards list (no active board)"
+    );
+}

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -351,3 +351,124 @@ fn test_archived_board_drill_in_archives_card_via_key() {
         "archiving a card on an archived board behaves like a live board"
     );
 }
+
+// --- KAN-970: `D`/`e`/`q` follow-on. KAN-958 fixed the DISPATCH delegation
+// (drilled-in keys reach `handle_normal_key`), but `D`'s target handler and
+// the `e`/`q` pre-intercepts still don't recognise `ArchivedBoardsView` as a
+// valid origin, so they silently no-op even after delegation. This is why
+// restoring an archived card on an archived board was unreachable: `D` never
+// transitioned into the mode that exposes `r`/`x`.
+
+#[test]
+fn test_toggle_archived_cards_view_enters_from_drilled_in_archived_board() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+
+    app.handle_toggle_archived_cards_view();
+
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedCardsView,
+        "`D` on a drilled-in archived board enters the archived-cards view, as it does for a live board"
+    );
+}
+
+#[test]
+fn test_toggle_archived_cards_view_returns_to_archived_board_not_normal() {
+    let mut app = App::test_default();
+    let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+    app.handle_toggle_archived_cards_view();
+
+    // Toggling back must return to the drilled-in ARCHIVED board, not fall
+    // through to `Normal` — a naive fix that hardcodes `ArchivedCardsView =>
+    // Normal` would strand the user in `Normal` with `active_board_id` still
+    // set to an archived board.
+    app.handle_toggle_archived_cards_view();
+
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedBoardsView,
+        "toggling back from the archived-cards view returns to the drilled-in archived board"
+    );
+    assert_eq!(
+        app.selection.active_board_id,
+        Some(board_id),
+        "the archived board is still active after toggling back"
+    );
+}
+
+#[test]
+fn test_restore_card_reachable_from_drilled_in_archived_board() {
+    use kanban_domain::KanbanOperations;
+
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Arch".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "ArchiveMe".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+    app.ctx.archive_board(board.id).unwrap();
+    let snap = app.ctx.snapshot().unwrap();
+    app.model.load_from_snapshot(snap);
+
+    open_archived_board(&mut app);
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('D'));
+    assert_eq!(app.mode, AppMode::ArchivedCardsView);
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+
+    app.handle_restore_card();
+
+    // Restore is animation-driven (`start_restore_animation`), same as archive
+    // in `test_archived_board_drill_in_archives_card_via_key` above — reaching
+    // this state at all is the proof `r` is no longer dead here.
+    assert!(
+        app.animation.animating.contains_key(&card.id),
+        "restoring an archived card is reachable from a drilled-in archived board"
+    );
+}
+
+#[test]
+fn test_q_backs_out_of_drilled_in_archived_board() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('q'));
+
+    assert_eq!(
+        app.selection.active_board_id, None,
+        "`q` leaves the archived board, returning to the list, like Esc"
+    );
+    assert_eq!(app.focus.active, Focus::Boards);
+    assert_eq!(app.mode, AppMode::ArchivedBoardsView);
+}
+
+#[test]
+fn test_shift_q_backs_out_of_drilled_in_archived_board() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('Q'));
+
+    assert_eq!(
+        app.selection.active_board_id, None,
+        "`Q` leaves the archived board, returning to the list, like Esc"
+    );
+    assert_eq!(app.focus.active, Focus::Boards);
+    assert_eq!(app.mode, AppMode::ArchivedBoardsView);
+}

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -400,6 +400,24 @@ fn test_toggle_archived_cards_view_returns_to_archived_board_not_normal() {
 }
 
 #[test]
+fn test_toggle_archived_cards_view_from_archived_boards_list_without_active_board_is_noop() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    // Browsing the archived-boards LIST, not drilled into one.
+    app.mode = AppMode::ArchivedBoardsView;
+    app.focus.active = Focus::Boards;
+    app.selection.active_board_id = None;
+
+    app.handle_toggle_archived_cards_view();
+
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedBoardsView,
+        "with no active board, `D` must not transition into the archived-cards view"
+    );
+}
+
+#[test]
 fn test_search_from_archived_cards_view_returns_to_drilled_in_archived_board() {
     let mut app = App::test_default();
     let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -474,6 +474,24 @@ fn test_shift_q_backs_out_of_drilled_in_archived_board() {
 }
 
 #[test]
+fn test_g_then_q_does_not_leave_pending_key_stale() {
+    let mut app = App::test_default();
+    seed_and_archive_board(&mut app, "Arch");
+    open_archived_board(&mut app);
+
+    // Start a 'gg' jump-to-top sequence, then back out before completing it.
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('g'));
+    assert_eq!(app.pending_key, Some('g'), "first 'g' arms the sequence");
+
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('q'));
+
+    assert_eq!(
+        app.pending_key, None,
+        "backing out with `q` clears any pending 'g' sequence, like every other key path"
+    );
+}
+
+#[test]
 fn test_edit_key_active_true_when_drilled_into_archived_board() {
     let mut app = App::test_default();
     seed_and_archive_board(&mut app, "Arch");

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -441,36 +441,31 @@ fn test_restore_card_reachable_from_drilled_in_archived_board() {
     );
 }
 
-#[test]
-fn test_q_backs_out_of_drilled_in_archived_board() {
+/// Shared body for `q`/`Q` back-out assertions: both keys must leave the
+/// drilled-in archived board and return to the list, exactly like Esc.
+fn assert_key_backs_out_of_drilled_in_archived_board(key: char) {
     let mut app = App::test_default();
     seed_and_archive_board(&mut app, "Arch");
     open_archived_board(&mut app);
 
-    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('q'));
+    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char(key));
 
     assert_eq!(
         app.selection.active_board_id, None,
-        "`q` leaves the archived board, returning to the list, like Esc"
+        "'{key}' leaves the archived board, returning to the list, like Esc"
     );
     assert_eq!(app.focus.active, Focus::Boards);
     assert_eq!(app.mode, AppMode::ArchivedBoardsView);
 }
 
 #[test]
+fn test_q_backs_out_of_drilled_in_archived_board() {
+    assert_key_backs_out_of_drilled_in_archived_board('q');
+}
+
+#[test]
 fn test_shift_q_backs_out_of_drilled_in_archived_board() {
-    let mut app = App::test_default();
-    seed_and_archive_board(&mut app, "Arch");
-    open_archived_board(&mut app);
-
-    app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('Q'));
-
-    assert_eq!(
-        app.selection.active_board_id, None,
-        "`Q` leaves the archived board, returning to the list, like Esc"
-    );
-    assert_eq!(app.focus.active, Focus::Boards);
-    assert_eq!(app.mode, AppMode::ArchivedBoardsView);
+    assert_key_backs_out_of_drilled_in_archived_board('Q');
 }
 
 #[test]


### PR DESCRIPTION
Fixes viewing/restoring archived cards on an archived board, a follow-on to KAN-958:

- `handle_toggle_archived_cards_view` (`D`) now uses the existing `push_mode`/`pop_mode` stack instead of a hardcoded `Normal <-> ArchivedCardsView` match, so toggling into the archived-cards view from a drilled-in archived board returns to the correct origin instead of stranding the user in `Normal` with a stale `active_board_id`. Its two near-identical match arms are collapsed into one shared tail, and it now validates its own precondition (`active_board_id.is_some()`) instead of trusting callers.
- `q`/`Q` now have their own arm in `handle_normal_key` (mirroring its existing `Esc` arm) instead of a special-cased shim in `handle_archived_boards_view_mode`. The shim bypassed `handle_normal_key`'s `pending_key` reset, leaking a stale key-sequence state across a `q` back-out; the root-cause fix closes that and is safe for every current and future mode that delegates to `handle_normal_key` (verified: live-board `q`/`Q` never reaches `handle_normal_key`, since the top-level dispatch intercepts and quits first).
- `e`'s eligibility check is extracted into a new `edit_key_active` predicate (unit-testable without a terminal) and now covers `ArchivedBoardsView` with an active board, not just `Normal`/`ArchivedCardsView`.
- Search mode's entry/exit (the `/` key and `KeybindingAction::Search`, and `handle_search_mode`'s `Enter`/`Esc`) now route through `push_mode`/`pop_mode` instead of a hardcoded `Normal` assignment, closing a related state leak: opening search from the archived-cards view and closing it could orphan a `mode_stack` entry and strand the user in `Normal` with a stale `active_board_id`, bypassing the quit-guard exclusion for archived views.

**What**: Once drilled into an archived board, `D` (view archived cards), `e` (edit), and `q`/`Q` (back out) were advertised in the footer/help but dead — `D` never transitioned into the mode that exposes restore (`r`)/permanent-delete (`x`), so archived cards on an archived board were unreachable. A follow-up review of the initial fix surfaced two further state-leak bugs (`pending_key`, `mode_stack`) and a bandaid (the `q`/`Q` shim) that this PR also resolves at the root.

**Why**: KAN-958 delegated most drilled-in keys to the same dispatch a live board uses (archive, priority, detail, move), but these three had guards that didn't recognise `ArchivedBoardsView` as a valid origin even after delegation, so they kept no-oping. This was reported as: an archived board should be substitutable for a live one everywhere.

**How**: `handle_restore_card`/`handle_delete_card_permanent` already gated correctly on `AppMode::ArchivedCardsView` and needed zero changes — fixing `D` makes them reachable "for free." The mode-stack fix reuses the same mechanism already used by `CardDetail`/`BoardDetail`/`Settings`/dialogs, rather than introducing a new `AppMode` variant, and the same mechanism is now extended to Search mode for the same reason.

**Testing**: `cargo test -p kanban-tui --test archived_board_parity_tests --test archived_card_parity_tests` (10 new tests, all passing), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --check` (clean).