### PR TITLE
KAN-963 fix(domain): durable Card.board_id, no more nil-board archive leak

### DIFF
--- a/.changeset/max-kan-963.md
+++ b/.changeset/max-kan-963.md
@@ -1,0 +1,22 @@
+---
+bump: patch
+---
+
+Fixed a data-integrity bug where an archived card could permanently lose its
+board association, making it invisible to that board's archived-cards list
+and unreachable by the cleanup that runs when a board is deleted. This
+happened in an edge case: archiving a card, then deleting its now-empty
+column (allowed since archived cards don't block column deletion), then
+archiving that same card again (e.g. a retried save or an undo/redo replay) —
+the second archive used to silently overwrite the card's board with "unknown"
+instead of leaving the already-correct value alone.
+
+Under the hood, every card now carries its own durable reference to its
+board, kept up to date whenever a card moves to a different column (including
+moving it to a column on a different board, which continues to work exactly
+as before). This removes the need to look up a card's board through its
+column at archive time, so the board reference can no longer go stale even
+if the column is later removed.
+
+Existing boards, cards, and databases are migrated automatically the next
+time they're opened — no action needed.

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -3,7 +3,13 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use uuid::Uuid;
 
-use crate::{board::Board, column::ColumnId, field_update::FieldUpdate, sprint::Sprint, SprintLog};
+use crate::{
+    board::{Board, BoardId},
+    column::ColumnId,
+    field_update::FieldUpdate,
+    sprint::Sprint,
+    SprintLog,
+};
 use kanban_core::GraphNode;
 
 pub type CardId = Uuid;
@@ -59,6 +65,11 @@ pub enum AnimationType {
 pub struct Card {
     pub id: CardId,
     pub column_id: ColumnId,
+    /// Durable board reference, independent of `column_id`. Set at creation
+    /// and kept in sync on every move (including cross-board moves). Exists
+    /// so a card's board is always resolvable even if its column is later
+    /// deleted (archived cards don't block column deletion) — see KAN-963.
+    pub board_id: BoardId,
     pub title: String,
     pub description: Option<String>,
     pub priority: CardPriority,
@@ -133,6 +144,7 @@ impl Card {
         Self {
             id: Uuid::new_v4(),
             column_id,
+            board_id: board.id,
             title: title.into(),
             description: None,
             priority: CardPriority::Medium,

--- a/crates/kanban-domain/src/card_factory.rs
+++ b/crates/kanban-domain/src/card_factory.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::board::BoardId;
 use crate::card::{Card, CardId, CardPriority, CardStatus};
 use crate::column::ColumnId;
 use crate::error::KanbanResult;
@@ -31,6 +32,8 @@ pub struct NewCard {
 pub struct CardRecord {
     pub id: CardId,
     pub column_id: ColumnId,
+    #[serde(default)]
+    pub board_id: BoardId,
     pub title: String,
     pub description: Option<String>,
     pub priority: CardPriority,
@@ -52,16 +55,20 @@ pub struct CardRecord {
 
 impl Card {
     /// Construct a brand-new card from client-supplied CREATE fields plus an
-    /// injected id, server-minted `card_number`, and clock. No internal
-    /// `Uuid::new_v4`/`Utc::now`/`Board` access. Seeds `status = Todo`,
-    /// `completed_at = None`, an empty `sprint_logs`, and
-    /// `created_at == updated_at == now`. Sprint-log seeding (which needs a
-    /// Sprint object) stays in the service tier even when `sprint_id` is set.
+    /// injected id, server-minted `card_number`, clock, and the owning
+    /// `board_id` (resolved from `spec.column_id` by the caller — a durable
+    /// value stored directly on `Card`, not re-derived from the column on
+    /// every read; see KAN-963). No internal `Uuid::new_v4`/`Utc::now`/`Board`
+    /// access. Seeds `status = Todo`, `completed_at = None`, an empty
+    /// `sprint_logs`, and `created_at == updated_at == now`. Sprint-log
+    /// seeding (which needs a Sprint object) stays in the service tier even
+    /// when `sprint_id` is set.
     pub fn create(
         spec: NewCard,
         id: CardId,
         card_number: u32,
         now: DateTime<Utc>,
+        board_id: BoardId,
     ) -> KanbanResult<Card> {
         let NewCard {
             column_id,
@@ -75,6 +82,7 @@ impl Card {
         Ok(Card {
             id,
             column_id,
+            board_id,
             title,
             description,
             priority,
@@ -97,6 +105,7 @@ impl Card {
         let CardRecord {
             id,
             column_id,
+            board_id,
             title,
             description,
             priority,
@@ -114,6 +123,7 @@ impl Card {
         Ok(Card {
             id,
             column_id,
+            board_id,
             title,
             description,
             priority,
@@ -136,6 +146,7 @@ impl From<&Card> for CardRecord {
         let Card {
             id,
             column_id,
+            board_id,
             title,
             description,
             priority,
@@ -153,6 +164,7 @@ impl From<&Card> for CardRecord {
         CardRecord {
             id: *id,
             column_id: *column_id,
+            board_id: *board_id,
             title: title.clone(),
             description: description.clone(),
             priority: *priority,
@@ -245,7 +257,7 @@ mod factory_tests {
     fn test_card_create_seeds_server_managed_defaults() -> KanbanResult<()> {
         let id = Uuid::new_v4();
         let now = fixed_now();
-        let card = Card::create(spec(), id, 7, now)?;
+        let card = Card::create(spec(), id, 7, now, Uuid::new_v4())?;
         assert_eq!(card.status, CardStatus::Todo);
         assert_eq!(card.completed_at, None);
         assert!(card.sprint_logs.is_empty());
@@ -259,6 +271,7 @@ mod factory_tests {
     #[test]
     fn test_card_create_applies_client_fields_from_spec() -> KanbanResult<()> {
         let column_id = Uuid::new_v4();
+        let board_id = Uuid::new_v4();
         let sprint_id = Uuid::new_v4();
         let due = "2024-06-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let card = Card::create(
@@ -274,8 +287,13 @@ mod factory_tests {
             Uuid::new_v4(),
             1,
             fixed_now(),
+            board_id,
         )?;
         assert_eq!(card.column_id, column_id);
+        assert_eq!(
+            card.board_id, board_id,
+            "board_id is carried through, not derived from spec"
+        );
         assert_eq!(card.title, "Title");
         assert_eq!(card.description, Some("desc".to_string()));
         assert_eq!(card.priority, CardPriority::Critical);
@@ -301,6 +319,7 @@ mod factory_tests {
             Uuid::new_v4(),
             1,
             fixed_now(),
+            Uuid::new_v4(),
         )?;
         assert_eq!(card.sprint_id, Some(sprint_id));
         assert!(card.sprint_logs.is_empty());
@@ -312,8 +331,9 @@ mod factory_tests {
         let id = Uuid::new_v4();
         let now = fixed_now();
         let s = spec();
-        let a = Card::create(s.clone(), id, 3, now)?;
-        let b = Card::create(s, id, 3, now)?;
+        let board_id = Uuid::new_v4();
+        let a = Card::create(s.clone(), id, 3, now, board_id)?;
+        let b = Card::create(s, id, 3, now, board_id)?;
         assert_eq!(a, b);
         Ok(())
     }
@@ -323,6 +343,7 @@ mod factory_tests {
         CardRecord {
             id: Uuid::new_v4(),
             column_id: Uuid::new_v4(),
+            board_id: Uuid::new_v4(),
             title: "Done card".to_string(),
             description: Some("finished".to_string()),
             priority: CardPriority::Low,

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -316,22 +316,24 @@ impl ArchiveCards {
             ));
         }
         for id in &valid_ids {
+            // Idempotency guard: if a marker already exists for this id (a
+            // re-issued archive command, an undo/redo replay, or a retry
+            // after a flaky save), leave it untouched. Its board_id was
+            // already durably settled on the FIRST archive; re-deriving it
+            // here would read the card's CURRENT state, which may have
+            // changed since (e.g. its column has since been legitimately
+            // deleted), clobbering a correct value with a worse one.
+            if context.store.get_archived_card(*id)?.is_some() {
+                continue;
+            }
             let card = context
                 .store
                 .get_card(*id)?
                 .ok_or_else(|| KanbanError::not_found("Card", *id))?;
-            // Best-effort board capture: a missing/dangling column yields
-            // nil rather than aborting the archive (D2 "may dangle"). The
-            // fallible resolver would propagate NotFound and break that.
-            let board_id = context
-                .store
-                .get_column(card.column_id)?
-                .map(|c| c.board_id)
-                .unwrap_or_else(Uuid::nil);
             // Reference-marker model: the card STAYS live in `cards`; we only
             // record the marker. `delete_card` is a guarded no-op on an archived
             // id (F1), so it is not called here — the card is the source of truth.
-            let archived = crate::ArchivedCard::new(card.id, board_id);
+            let archived = crate::ArchivedCard::new(card.id, card.board_id);
             context.store.insert_archived_card(archived)?;
         }
         context.store.modify_graph(Box::new(move |graph| {

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -121,7 +121,7 @@ impl CreateCard {
             points: self.options.points,
             sprint_id: None,
         };
-        let mut card = crate::Card::create(spec, self.id, self.card_number, now)?;
+        let mut card = crate::Card::create(spec, self.id, self.card_number, now, self.board_id)?;
         card.position = self.position;
 
         if board.card_counter <= self.card_number {

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -201,6 +201,11 @@ impl RestoreCard {
             .get_card(self.card_id)?
             .ok_or_else(|| KanbanError::not_found("Card", self.card_id))?;
         card.column_id = self.column_id;
+        // Keep board_id in sync with wherever the card actually lands -- the
+        // normal capture_inverse-driven restore always targets the card's own
+        // current column (a no-op here), but nothing else validates that
+        // `column_id` belongs to the card's original board (KAN-963).
+        card.board_id = context.require_column(self.column_id)?.board_id;
         card.position = self.position;
         card.updated_at = self.timestamp;
 

--- a/crates/kanban-domain/src/commands/card/positioning.rs
+++ b/crates/kanban-domain/src/commands/card/positioning.rs
@@ -17,10 +17,13 @@ impl MoveCard {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         // Canonical target-column membership check (KAN-248): reject a move to a
         // non-existent column up front via the shared helper.
-        context.require_column(self.new_column_id)?;
+        let column = context.require_column(self.new_column_id)?;
         context.check_wip_limit(self.new_column_id, 1, &[self.card_id])?;
         let mut card = context.get_card(self.card_id)?;
         card.move_to_column(self.new_column_id, self.new_position);
+        // Keep board_id in sync with the target column's board -- cross-board
+        // moves are intentionally permitted, not guarded against (KAN-963).
+        card.board_id = column.board_id;
         context.store.upsert_card(card)?;
         Ok(())
     }
@@ -150,6 +153,43 @@ mod tests {
         };
         let result = cmd.execute(&context);
         assert!(result.unwrap_err().is_wip_limit_exceeded());
+    }
+
+    #[test]
+    fn test_move_card_updates_board_id_on_cross_board_move() {
+        let tc = TestContext::new();
+        let mut board_a = crate::Board::new("A", Some("AAA"));
+        let board_a_id = board_a.id;
+        let col_a = crate::Column::new(board_a_id, "Col", 0);
+        let card = crate::Card::new(&mut board_a, col_a.id, "Card", 0);
+        let card_id = card.id;
+
+        let board_b = crate::Board::new("B", Some("BBB"));
+        let board_b_id = board_b.id;
+        let col_b = crate::Column::new(board_b_id, "Col", 0);
+        let col_b_id = col_b.id;
+
+        tc.store.upsert_board(board_a).unwrap();
+        tc.store.upsert_column(col_a).unwrap();
+        tc.store.upsert_card(card).unwrap();
+        tc.store.upsert_board(board_b).unwrap();
+        tc.store.upsert_column(col_b).unwrap();
+
+        let context = tc.as_command_context();
+        let cmd = MoveCard {
+            card_id,
+            new_column_id: col_b_id,
+            new_position: 0,
+        };
+        cmd.execute(&context).unwrap();
+
+        let moved = tc.store.get_card(card_id).unwrap().unwrap();
+        assert_eq!(moved.column_id, col_b_id);
+        assert_eq!(
+            moved.board_id, board_b_id,
+            "moving a card to a column on a different board keeps board_id in sync -- \
+             cross-board moves stay possible and correct, not blocked"
+        );
     }
 
     #[test]

--- a/crates/kanban-domain/src/commands/card/tests/archive_update.rs
+++ b/crates/kanban-domain/src/commands/card/tests/archive_update.rs
@@ -1,4 +1,5 @@
 use crate::commands::card::{ArchiveCards, UpdateCard};
+use crate::commands::column_commands::DeleteColumn;
 use crate::commands::test_helpers::TestContext;
 use crate::{CardUpdate, DataStore};
 use uuid::Uuid;
@@ -138,21 +139,113 @@ fn test_archive_batch_captures_each_cards_own_board() {
 }
 
 #[test]
-fn test_archive_with_dangling_column_captures_nil_board_id() {
+fn test_archive_with_corrupted_board_id_captures_nil_board_id() {
+    // Since KAN-963, ArchiveCards reads card.board_id directly (a durable
+    // field set at creation and kept in sync on every move) rather than
+    // deriving it via a column lookup, so a dangling column_id alone no
+    // longer affects board_id resolution -- Card::new(&mut board, ..) always
+    // sets a valid board_id regardless of column_id. The only way archive
+    // still sees a nil board_id is genuinely corrupted/legacy data where the
+    // card's OWN board_id is nil (e.g. imported pre-migration data), which a
+    // raw literal simulates here (bypassing Card::new/Card::create).
     let tc = TestContext::new();
-    let mut board = crate::Board::new("Test", Some("TST"));
-    // column_id references a column that is never inserted (dangling).
-    let card = crate::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
+    let board = crate::Board::new("Test", Some("TST"));
+    let card = crate::Card {
+        id: Uuid::new_v4(),
+        column_id: Uuid::new_v4(),
+        board_id: Uuid::nil(),
+        title: "Card".to_string(),
+        description: None,
+        priority: crate::CardPriority::Medium,
+        status: crate::CardStatus::Todo,
+        position: 0,
+        due_date: None,
+        points: None,
+        card_number: 1,
+        sprint_id: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        completed_at: None,
+        sprint_logs: Vec::new(),
+    };
     let card_id = card.id;
+    tc.store.upsert_board(board).unwrap();
     tc.store.upsert_card(card).unwrap();
 
     let context = tc.as_command_context();
     let cmd = ArchiveCards { ids: vec![card_id] };
-    // Best-effort capture: a missing column must NOT abort the archive.
+    // Best-effort capture: a corrupted board_id must NOT abort the archive.
     assert!(cmd.execute(&context).is_ok());
 
     let archived = tc.store.get_archived_card(card_id).unwrap().unwrap();
     assert_eq!(archived.context.board_id, Uuid::nil());
+}
+
+#[test]
+fn test_archive_card_after_column_deleted_preserves_board_id() {
+    let tc = TestContext::new();
+    let mut board = crate::Board::new("Test", Some("TST"));
+    let board_id = board.id;
+    let col = crate::Column::new(board_id, "Col", 0);
+    let col_id = col.id;
+    let card = crate::Card::new(&mut board, col_id, "Card", 0);
+    let card_id = card.id;
+    tc.store.upsert_board(board).unwrap();
+    tc.store.upsert_column(col).unwrap();
+    tc.store.upsert_card(card).unwrap();
+
+    let context = tc.as_command_context();
+    ArchiveCards { ids: vec![card_id] }
+        .execute(&context)
+        .unwrap();
+
+    // The column is now empty (its only card is archived) and legitimately
+    // deletable -- archived cards don't block column deletion (D2).
+    DeleteColumn { column_id: col_id }
+        .execute(&context)
+        .unwrap();
+
+    let archived = tc.store.get_archived_card(card_id).unwrap().unwrap();
+    assert_eq!(
+        archived.context.board_id, board_id,
+        "board_id survives the column's deletion"
+    );
+}
+
+#[test]
+fn test_double_archive_after_column_deleted_does_not_clobber_board_id() {
+    let tc = TestContext::new();
+    let mut board = crate::Board::new("Test", Some("TST"));
+    let board_id = board.id;
+    let col = crate::Column::new(board_id, "Col", 0);
+    let col_id = col.id;
+    let card = crate::Card::new(&mut board, col_id, "Card", 0);
+    let card_id = card.id;
+    tc.store.upsert_board(board).unwrap();
+    tc.store.upsert_column(col).unwrap();
+    tc.store.upsert_card(card).unwrap();
+
+    let context = tc.as_command_context();
+    ArchiveCards { ids: vec![card_id] }
+        .execute(&context)
+        .unwrap();
+    DeleteColumn { column_id: col_id }
+        .execute(&context)
+        .unwrap();
+
+    // Re-archive the SAME already-archived card (idempotent retry / re-issued
+    // command / undo-redo replay) after its column is gone. This must not
+    // re-derive board_id from the now-dangling column_id and clobber the
+    // value already correctly captured on the first archive.
+    ArchiveCards { ids: vec![card_id] }
+        .execute(&context)
+        .unwrap();
+
+    let archived = tc.store.get_archived_card(card_id).unwrap().unwrap();
+    assert_eq!(
+        archived.context.board_id, board_id,
+        "re-archiving after the column is gone must not clobber the already-correct board_id"
+    );
 }
 
 #[test]

--- a/crates/kanban-domain/src/commands/card/tests/archive_update.rs
+++ b/crates/kanban-domain/src/commands/card/tests/archive_update.rs
@@ -249,6 +249,55 @@ fn test_double_archive_after_column_deleted_does_not_clobber_board_id() {
 }
 
 #[test]
+fn test_double_archive_of_already_archived_card_preserves_archived_at() {
+    // The idempotency guard skips the marker insert entirely when one already
+    // exists, so re-archiving must not refresh `archived_at` either -- not
+    // just `board_id`. Stamp the marker with an obviously-distinct sentinel
+    // timestamp after the first archive (standing in for "the original
+    // archive time") so the assertion doesn't depend on real wall-clock
+    // timing to distinguish it from whatever a second archive's `Utc::now()`
+    // would otherwise produce.
+    let tc = TestContext::new();
+    let mut board = crate::Board::new("Test", Some("TST"));
+    let board_id = board.id;
+    let col = crate::Column::new(board_id, "Col", 0);
+    let col_id = col.id;
+    let card = crate::Card::new(&mut board, col_id, "Card", 0);
+    let card_id = card.id;
+    tc.store.upsert_board(board).unwrap();
+    tc.store.upsert_column(col).unwrap();
+    tc.store.upsert_card(card).unwrap();
+
+    let context = tc.as_command_context();
+    ArchiveCards { ids: vec![card_id] }
+        .execute(&context)
+        .unwrap();
+
+    let sentinel_archived_at: chrono::DateTime<chrono::Utc> =
+        "2000-01-01T00:00:00Z".parse().unwrap();
+    tc.store
+        .insert_archived_card(crate::Archived::with_context(
+            card_id,
+            crate::CardRestoreContext { board_id },
+            crate::ArchiveMetadata::at(sentinel_archived_at),
+        ))
+        .unwrap();
+
+    DeleteColumn { column_id: col_id }
+        .execute(&context)
+        .unwrap();
+    ArchiveCards { ids: vec![card_id] }
+        .execute(&context)
+        .unwrap();
+
+    let archived = tc.store.get_archived_card(card_id).unwrap().unwrap();
+    assert_eq!(
+        archived.metadata.archived_at, sentinel_archived_at,
+        "re-archiving an already-archived card must not refresh archived_at"
+    );
+}
+
+#[test]
 fn test_archive_cards_missing_card_after_filter_returns_error() {
     let tc = TestContext::new();
     let mut board = crate::Board::new("Test", Some("TST"));

--- a/crates/kanban-domain/src/commands/card/tests/create.rs
+++ b/crates/kanban-domain/src/commands/card/tests/create.rs
@@ -51,6 +51,38 @@ fn test_create_card_command_funnels_through_factory_seeds_defaults() {
 }
 
 #[test]
+fn test_create_card_sets_board_id() {
+    let tc = TestContext::new();
+    let mut board = crate::Board::new("B", Some("TST"));
+    let col = crate::Column::new(board.id, "Col", 0);
+    let board_id = board.id;
+    let column_id = col.id;
+    board.card_counter = 1;
+    tc.store.upsert_board(board).unwrap();
+    tc.store.upsert_column(col).unwrap();
+
+    let context = tc.as_command_context();
+    let card_id = Uuid::new_v4();
+    let cmd = CreateCard {
+        id: card_id,
+        card_number: 1,
+        board_id,
+        column_id,
+        title: "Test".to_string(),
+        position: 0,
+        options: CreateCardOptions::default(),
+        timestamp: Utc::now(),
+    };
+    cmd.execute(&context).unwrap();
+
+    let card = tc.store.get_card(card_id).unwrap().unwrap();
+    assert_eq!(
+        card.board_id, board_id,
+        "the created card carries its own durable board_id, not just column_id"
+    );
+}
+
+#[test]
 fn test_create_card_board_not_found_returns_error() {
     let tc = TestContext::new();
     let context = tc.as_command_context();

--- a/crates/kanban-domain/src/commands/card/tests/restore.rs
+++ b/crates/kanban-domain/src/commands/card/tests/restore.rs
@@ -60,6 +60,83 @@ fn test_restore_card_to_valid_column_succeeds() {
 }
 
 #[test]
+fn test_restore_card_preserves_board_id() {
+    let tc = TestContext::new();
+    let mut board = crate::Board::new("Test", Some("TST"));
+    let board_id = board.id;
+    let col = crate::Column::new(board_id, "Col", 0);
+    let col_id = col.id;
+    let card = crate::Card::new(&mut board, col_id, "Card", 0);
+    let card_id = card.id;
+    tc.store.upsert_board(board).unwrap();
+    tc.store.upsert_column(col).unwrap();
+    tc.store.upsert_card(card).unwrap();
+    tc.store
+        .insert_archived_card(crate::ArchivedCard::new(card_id, board_id))
+        .unwrap();
+
+    let context = tc.as_command_context();
+    let cmd = RestoreCard {
+        card_id,
+        column_id: col_id,
+        position: 0,
+        timestamp: Utc::now(),
+    };
+    cmd.execute(&context).unwrap();
+
+    let restored = tc.store.get_card(card_id).unwrap().unwrap();
+    assert_eq!(
+        restored.board_id, board_id,
+        "restoring to the same board's column leaves board_id unchanged"
+    );
+}
+
+#[test]
+fn test_restore_card_to_column_on_different_board_updates_board_id() {
+    // Not the normal restore flow (capture_inverse always targets the card's
+    // own current column, never a different board's), but RestoreCard's
+    // column_id isn't otherwise validated to belong to the card's original
+    // board, so board_id must stay in sync with wherever it actually lands,
+    // mirroring MoveCard.
+    let tc = TestContext::new();
+    let mut board_a = crate::Board::new("A", Some("AAA"));
+    let board_a_id = board_a.id;
+    let col_a = crate::Column::new(board_a_id, "Col", 0);
+    let card = crate::Card::new(&mut board_a, col_a.id, "Card", 0);
+    let card_id = card.id;
+
+    let board_b = crate::Board::new("B", Some("BBB"));
+    let board_b_id = board_b.id;
+    let col_b = crate::Column::new(board_b_id, "Col", 0);
+    let col_b_id = col_b.id;
+
+    tc.store.upsert_board(board_a).unwrap();
+    tc.store.upsert_column(col_a).unwrap();
+    tc.store.upsert_card(card).unwrap();
+    tc.store.upsert_board(board_b).unwrap();
+    tc.store.upsert_column(col_b).unwrap();
+    tc.store
+        .insert_archived_card(crate::ArchivedCard::new(card_id, board_a_id))
+        .unwrap();
+
+    let context = tc.as_command_context();
+    let cmd = RestoreCard {
+        card_id,
+        column_id: col_b_id,
+        position: 0,
+        timestamp: Utc::now(),
+    };
+    cmd.execute(&context).unwrap();
+
+    let restored = tc.store.get_card(card_id).unwrap().unwrap();
+    assert_eq!(restored.column_id, col_b_id);
+    assert_eq!(
+        restored.board_id, board_b_id,
+        "board_id syncs to the column actually restored into"
+    );
+}
+
+#[test]
 fn test_restore_card_exceeding_wip_limit_returns_error() {
     let tc = TestContext::new();
     let mut board = crate::Board::new("Test", Some("TST"));

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -860,6 +860,7 @@ mod tests {
         let card = crate::Card {
             id: Uuid::new_v4(),
             column_id: col.id,
+            board_id,
             title: "C".to_string(),
             description: None,
             priority: crate::CardPriority::Medium,

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -321,6 +321,7 @@ mod tests {
         let record = CardRecord {
             id: Uuid::new_v4(),
             column_id: Uuid::new_v4(),
+            board_id: Uuid::new_v4(),
             title: "Done card".to_string(),
             description: Some("finished".to_string()),
             priority: CardPriority::High,

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -1,8 +1,9 @@
 use crate::atomic_writer::AtomicWriter;
 use crate::conflict::FileMetadata;
 use crate::migration::{
-    transform_to_v6_split_graph_value, transform_v2_to_v3_value, transform_v6_to_v7_value,
-    transform_v7_to_v8_value, transform_v8_to_v9_value, transform_v9_to_v10_value, Migrator,
+    transform_to_v6_split_graph_value, transform_v10_to_v11_value, transform_v2_to_v3_value,
+    transform_v6_to_v7_value, transform_v7_to_v8_value, transform_v8_to_v9_value,
+    transform_v9_to_v10_value, Migrator,
 };
 use kanban_persistence::{
     FormatVersion, PersistenceError, PersistenceMetadata, PersistenceResult, PersistenceStore,
@@ -97,7 +98,7 @@ fn migrate_to_latest_sync(from: FormatVersion, path: &Path) -> PersistenceResult
     let backup_path = crate::migration::pre_latest_backup_path_for(from, path);
     if let Some(backup) = &backup_path {
         std::fs::copy(path, backup)?;
-        tracing::info!("Created pre-V10 backup at {}", backup.display());
+        tracing::info!("Created pre-V11 backup at {}", backup.display());
     }
 
     let result = (|| -> PersistenceResult<Vec<u8>> {
@@ -119,14 +120,14 @@ fn migrate_to_latest_sync(from: FormatVersion, path: &Path) -> PersistenceResult
                     e
                 );
             } else {
-                tracing::info!("Migration to V10 verified, backup removed");
+                tracing::info!("Migration to V11 verified, backup removed");
             }
             Ok(bytes)
         }
         (Ok(bytes), None) => Ok(bytes),
         (Err(e), Some(backup)) => {
             tracing::error!(
-                "Migration to V10 failed: {}. Backup preserved at {}",
+                "Migration to V11 failed: {}. Backup preserved at {}",
                 e,
                 backup.display()
             );
@@ -139,8 +140,8 @@ fn migrate_to_latest_sync(from: FormatVersion, path: &Path) -> PersistenceResult
 /// Sync sibling of [`Migrator::run_split_and_upgrade_chain`]. Runs the V6
 /// split-graph transform (only if the file is pre-V6), the v6→v7
 /// spawns-bucket rename, the v7→v8 archived-cards backfill, the v8→v9
-/// archived-boards bump, then the v9→v10 archival reference-marker collapse,
-/// returning the final on-disk bytes.
+/// archived-boards bump, the v9→v10 archival reference-marker collapse, then
+/// the v10→v11 cards.board_id backfill, returning the final on-disk bytes.
 fn run_split_and_upgrade_chain_sync(
     from: FormatVersion,
     path: &Path,
@@ -151,7 +152,8 @@ fn run_split_and_upgrade_chain_sync(
     v6_to_v7_rename_sync(path)?;
     v7_to_v8_archived_cards_sync(path)?;
     v8_to_v9_archived_boards_sync(path)?;
-    v9_to_v10_archival_refs_sync(path)
+    v9_to_v10_archival_refs_sync(path)?;
+    v10_to_v11_card_board_id_sync(path)
 }
 
 fn migrate_v1_to_v2_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
@@ -211,6 +213,24 @@ fn v9_to_v10_archival_refs_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
     AtomicWriter::write_atomic_sync(path, &json_bytes)?;
     tracing::info!(
         "Migrated {} from V9 to V10 (archival reference-marker collapse, sync)",
+        path.display()
+    );
+    Ok(json_bytes)
+}
+
+fn v10_to_v11_card_board_id_sync(path: &Path) -> PersistenceResult<Vec<u8>> {
+    let content = std::fs::read_to_string(path)?;
+    let mut envelope: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    if !transform_v10_to_v11_value(&mut envelope)? {
+        return Ok(content.into_bytes());
+    }
+    let json_str = serde_json::to_string_pretty(&envelope)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    let json_bytes = json_str.into_bytes();
+    AtomicWriter::write_atomic_sync(path, &json_bytes)?;
+    tracing::info!(
+        "Migrated {} from V10 to V11 (cards.board_id backfill, sync)",
         path.display()
     );
     Ok(json_bytes)
@@ -399,12 +419,12 @@ impl PersistenceStore for JsonFileStore {
 
         if current_version < FormatVersion::MAX {
             tracing::info!(
-                "Detected {:?} format at {}. Migrating to V10...",
+                "Detected {:?} format at {}. Migrating to current...",
                 current_version,
                 self.path.display()
             );
             Migrator::migrate(current_version, FormatVersion::MAX, &self.path).await?;
-            tracing::info!("Migration to V10 completed successfully");
+            tracing::info!("Migration to current format completed successfully");
         }
 
         let file_bytes = tokio::fs::read(&self.path).await?;
@@ -423,9 +443,11 @@ impl PersistenceStore for JsonFileStore {
             }
         }
 
-        // The migration chain above upgrades any pre-V10 file to V10, which lifts
-        // embedded archived entities to pure reference markers on disk; a V10 file
-        // already deserializes directly into the collapsed `Snapshot`.
+        // The migration chain above upgrades any pre-current file to the
+        // current format (V10 lifts embedded archived entities to pure
+        // reference markers on disk, V11 backfills cards.board_id); a
+        // current-format file already deserializes directly into the
+        // collapsed `Snapshot`.
         let data = serde_json::to_vec(&envelope.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
         let mut metadata = envelope.metadata;
@@ -462,7 +484,7 @@ impl PersistenceStore for JsonFileStore {
 
         let final_bytes = if current_version < FormatVersion::MAX {
             tracing::info!(
-                "Detected {:?} format at {}. Migrating to V10 (sync)...",
+                "Detected {:?} format at {}. Migrating to current (sync)...",
                 current_version,
                 self.path.display()
             );
@@ -486,8 +508,9 @@ impl PersistenceStore for JsonFileStore {
             }
         }
 
-        // The migration chain above upgrades any pre-V10 file to V10 (lifting
-        // embedded archived entities to reference markers on disk); a V10 file
+        // The migration chain above upgrades any pre-current file to the
+        // current format (lifting embedded archived entities to reference
+        // markers on disk, backfilling cards.board_id); a current-format file
         // deserializes directly into the collapsed `Snapshot`.
         let data = serde_json::to_vec(&envelope.data)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
@@ -616,7 +639,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 10
+                    binary_max: 11
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -646,7 +669,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 10
+                    binary_max: 11
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -749,7 +772,10 @@ mod tests {
 
         let after = tokio::fs::read_to_string(&file_path).await.unwrap();
         let v: serde_json::Value = serde_json::from_str(&after).unwrap();
-        assert_eq!(v["version"], 10, "load must migrate V6 to V10 on disk");
+        assert_eq!(
+            v["version"], 11,
+            "load must migrate V6 to current (V11) on disk"
+        );
         let graph = v["data"]["graph"].as_object().expect("graph object");
         assert!(
             graph.contains_key("spawns"),
@@ -809,7 +835,10 @@ mod tests {
 
         let after = std::fs::read_to_string(&file_path).unwrap();
         let v: serde_json::Value = serde_json::from_str(&after).unwrap();
-        assert_eq!(v["version"], 10, "load_sync must migrate V6 to V10 on disk");
+        assert_eq!(
+            v["version"], 11,
+            "load_sync must migrate V6 to current (V11) on disk"
+        );
         let graph = v["data"]["graph"].as_object().expect("graph object");
         assert!(
             graph.contains_key("spawns"),
@@ -882,8 +911,8 @@ mod tests {
         let on_disk: serde_json::Value =
             serde_json::from_slice(&tokio::fs::read(&file_path).await.unwrap()).unwrap();
         assert_eq!(
-            on_disk["version"], 10,
-            "load must migrate V7 to V10 on disk"
+            on_disk["version"], 11,
+            "load must migrate V7 to current (V11) on disk"
         );
         assert_eq!(
             on_disk["data"]["archived_cards"][0]["board_id"]
@@ -980,7 +1009,10 @@ mod tests {
 
         let on_disk: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&file_path).unwrap()).unwrap();
-        assert_eq!(on_disk["version"], 10, "load_sync must migrate V7 to V10");
+        assert_eq!(
+            on_disk["version"], 11,
+            "load_sync must migrate V7 to current (V11)"
+        );
         let loaded_data: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
         assert_eq!(
             loaded_data["archived_cards"][0]["board_id"]
@@ -1119,7 +1151,7 @@ mod tests {
         let file_path = dir.path().join("clean.json");
 
         let clean = json!({
-            "version": 10,
+            "version": 11,
             "metadata": {
                 "instance_id": "550e8400-e29b-41d4-a716-446655440000",
                 "saved_at": "2024-01-01T00:00:00Z"
@@ -1385,7 +1417,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
 
         assert!(
             !path.with_extension("v6.backup").exists(),
@@ -1418,7 +1450,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
 
         assert!(
             !path.with_extension("v5.backup").exists(),
@@ -1449,7 +1481,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
 
         assert!(
             !path.with_extension("v4.backup").exists(),
@@ -1480,7 +1512,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
 
         assert!(
             !path.with_extension("v3.backup").exists(),
@@ -1517,7 +1549,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
 
         assert!(
             !path.with_extension("v2.backup").exists(),
@@ -1547,7 +1579,7 @@ mod tests {
 
         let after: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
 
         assert!(
             !path.with_extension("v1.backup").exists(),

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -1563,6 +1563,7 @@ mod tests {
         let record = CardRecord {
             id: Uuid::new_v4(),
             column_id: Uuid::new_v4(),
+            board_id: Uuid::new_v4(),
             title: "Done card".to_string(),
             description: Some("finished".to_string()),
             priority: CardPriority::High,

--- a/crates/kanban-persistence-json/src/migration/backup.rs
+++ b/crates/kanban-persistence-json/src/migration/backup.rs
@@ -26,6 +26,7 @@ pub(crate) fn pre_latest_backup_path_for(from: FormatVersion, path: &Path) -> Op
         FormatVersion::V7 => Some(path.with_extension("v7.backup")),
         FormatVersion::V8 => Some(path.with_extension("v8.backup")),
         FormatVersion::V9 => Some(path.with_extension("v9.backup")),
+        FormatVersion::V10 => Some(path.with_extension("v10.backup")),
         _ => None,
     }
 }
@@ -115,8 +116,17 @@ mod tests {
     }
 
     #[test]
-    fn returns_none_for_v10() {
-        // V10→V10 is a no-op upstream; should never reach the chain.
-        assert_eq!(pre_latest_backup_path_for(FormatVersion::V10, &p()), None);
+    fn returns_some_for_v10() {
+        // V10 is now a migratable source (V10→V11 cards.board_id backfill).
+        assert_eq!(
+            pre_latest_backup_path_for(FormatVersion::V10, &p()),
+            Some(PathBuf::from("/tmp/board.v10.backup"))
+        );
+    }
+
+    #[test]
+    fn returns_none_for_v11() {
+        // V11→V11 is a no-op upstream; should never reach the chain.
+        assert_eq!(pre_latest_backup_path_for(FormatVersion::V11, &p()), None);
     }
 }

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -62,18 +62,19 @@ impl Migrator {
                 super::v2_to_v3::migrate_v2_to_v3(path).await
             }
             (FormatVersion::V2, FormatVersion::V3) => super::v2_to_v3::migrate_v2_to_v3(path).await,
-            (_, FormatVersion::V10) if from < FormatVersion::V10 => {
+            (_, FormatVersion::V11) if from < FormatVersion::V11 => {
                 // See `migration::backup` for the source-version → backup-path
                 // policy shared with the sync orchestrator. A `.v{N}.backup`
                 // is the user's escape hatch if the upgrade has to be rolled
                 // back, since a migrated file cannot be opened by an older
                 // binary. The backup is taken BEFORE any per-step migration runs
                 // so it covers the entire chain (V1→V2, V2→V3, split_graph,
-                // v6→v7, v7→v8, v8→v9, v9→v10), not just the destructive tail.
+                // v6→v7, v7→v8, v8→v9, v9→v10, v10→v11), not just the
+                // destructive tail.
                 let backup_path = super::pre_latest_backup_path_for(from, path);
                 if let Some(backup) = &backup_path {
                     tokio::fs::copy(path, backup).await?;
-                    tracing::info!("Created pre-V10 backup at {}", backup.display());
+                    tracing::info!("Created pre-V11 backup at {}", backup.display());
                 }
 
                 let result: PersistenceResult<()> = async {
@@ -100,14 +101,14 @@ impl Migrator {
                                 e
                             );
                         } else {
-                            tracing::info!("Migration to V10 verified, backup removed");
+                            tracing::info!("Migration to V11 verified, backup removed");
                         }
                         Ok(())
                     }
                     (Ok(()), None) => Ok(()),
                     (Err(e), Some(backup)) => {
                         tracing::error!(
-                            "Migration to V10 failed: {}. Backup preserved at {}",
+                            "Migration to V11 failed: {}. Backup preserved at {}",
                             e,
                             backup.display()
                         );
@@ -125,11 +126,11 @@ impl Migrator {
 
     /// Run the V6 split-graph transform (only if the file is pre-V6), the
     /// v6→v7 spawns-bucket rename, the v7→v8 archived-cards backfill, the
-    /// v8→v9 archived-boards bump, then the v9→v10 archival reference-marker
-    /// collapse. Every step is a no-op when it doesn't apply (each transform
-    /// short-circuits on a file already at or beyond its target version), so
-    /// this is safe to call for any `from < V10` and always leaves the file at
-    /// V10.
+    /// v8→v9 archived-boards bump, the v9→v10 archival reference-marker
+    /// collapse, then the v10→v11 cards.board_id backfill. Every step is a
+    /// no-op when it doesn't apply (each transform short-circuits on a file
+    /// already at or beyond its target version), so this is safe to call for
+    /// any `from < V11` and always leaves the file at V11.
     async fn run_split_and_upgrade_chain(
         from: FormatVersion,
         path: &Path,
@@ -140,7 +141,8 @@ impl Migrator {
         super::v6_to_v7_rename::migrate_v6_to_v7(path).await?;
         super::v7_to_v8_archived_cards::migrate_v7_to_v8(path).await?;
         super::v8_to_v9_archived_boards::migrate_v8_to_v9(path).await?;
-        super::v9_to_v10_archival_refs::migrate_v9_to_v10(path).await
+        super::v9_to_v10_archival_refs::migrate_v9_to_v10(path).await?;
+        super::v10_to_v11_card_board_id::migrate_v10_to_v11(path).await
     }
 
     /// Migrate from V1 format to V2 format. Per-step backup removed: the
@@ -351,7 +353,7 @@ mod tests {
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(
             after["data"]["graph"]
@@ -396,7 +398,7 @@ mod tests {
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(after["data"]["graph"]["relates"].is_object());
         assert!(
@@ -439,7 +441,7 @@ mod tests {
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
         assert!(after["data"]["graph"]["spawns"].is_object());
         assert!(after["data"]["graph"]
             .as_object()
@@ -530,7 +532,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 10
+                    binary_max: 11
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -552,7 +554,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                PersistenceError::UnsupportedFutureVersion { binary_max: 10, .. }
+                PersistenceError::UnsupportedFutureVersion { binary_max: 11, .. }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
         );
@@ -577,7 +579,7 @@ mod tests {
                 err,
                 PersistenceError::UnsupportedFutureVersion {
                     file_version: 99,
-                    binary_max: 10
+                    binary_max: 11
                 }
             ),
             "expected UnsupportedFutureVersion, got: {err:?}"
@@ -678,7 +680,7 @@ mod tests {
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
 
         assert!(
             !path.with_extension("v2.backup").exists(),
@@ -706,7 +708,7 @@ mod tests {
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
 
         assert!(
             !path.with_extension("v1.backup").exists(),
@@ -756,7 +758,7 @@ mod tests {
 
         let after: Value =
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
-        assert_eq!(after["version"], 10);
+        assert_eq!(after["version"], 11);
         assert_eq!(
             after["data"]["archived_cards"][0]["board_id"]
                 .as_str()

--- a/crates/kanban-persistence-json/src/migration/mod.rs
+++ b/crates/kanban-persistence-json/src/migration/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod backup;
 pub mod migrator;
 pub mod split_graph;
+pub mod v10_to_v11_card_board_id;
 pub mod v1_to_v2;
 pub mod v2_to_v3;
 pub mod v6_to_v7_rename;
@@ -11,6 +12,7 @@ pub mod v9_to_v10_archival_refs;
 pub(crate) use backup::pre_latest_backup_path_for;
 pub use migrator::Migrator;
 pub(crate) use split_graph::transform_to_v6_split_graph_value;
+pub(crate) use v10_to_v11_card_board_id::transform_v10_to_v11_value;
 pub use v1_to_v2::V1ToV2Migration;
 pub(crate) use v2_to_v3::transform_v2_to_v3_value;
 pub(crate) use v6_to_v7_rename::transform_v6_to_v7_value;

--- a/crates/kanban-persistence-json/src/migration/v10_to_v11_card_board_id.rs
+++ b/crates/kanban-persistence-json/src/migration/v10_to_v11_card_board_id.rs
@@ -1,0 +1,227 @@
+//! V11 backfills `board_id` onto each historical `cards` entry that lacks it,
+//! mirroring V8's `archived_cards.board_id` backfill one layer earlier:
+//! `Card.board_id` is now a durable field set at creation and kept in sync on
+//! every move (KAN-963), independent of `column_id` -- a card whose column is
+//! later deleted (archived cards don't block column deletion) must still
+//! resolve its board.
+//!
+//! V10 envelopes carry live cards without a `board_id` key:
+//!
+//! ```json
+//! "data": {
+//!   "columns": [{ "id": "col-1", "board_id": "board-1" }],
+//!   "cards": [{ "id": "card-1", "column_id": "col-1", ... }]
+//! }
+//! ```
+//!
+//! V11 envelopes carry the backfilled `board_id`:
+//!
+//! ```json
+//! "cards": [{ "id": "card-1", "column_id": "col-1", "board_id": "board-1", ... }]
+//! ```
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use kanban_persistence::{PersistenceError, PersistenceResult};
+use serde_json::Value;
+
+/// Apply the V11 cards.board_id backfill to a JSON file in-place (atomic
+/// write). Skips the write when the file is already at version >= 11.
+pub(crate) async fn migrate_v10_to_v11(path: &Path) -> PersistenceResult<()> {
+    let content = tokio::fs::read_to_string(path).await?;
+    let mut envelope: Value = serde_json::from_str(&content)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    if !transform_v10_to_v11_value(&mut envelope)? {
+        return Ok(());
+    }
+    let out = serde_json::to_string_pretty(&envelope)
+        .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+    crate::atomic_writer::AtomicWriter::write_atomic(path, out.as_bytes()).await?;
+    tracing::info!(
+        "Migrated {} from V10 to V11 (cards.board_id backfill)",
+        path.display()
+    );
+    Ok(())
+}
+
+/// Pure transform on an already-parsed envelope. Returns `true` if the
+/// envelope was changed (needs writing back). Idempotent: a file already at
+/// version >= 11 is left untouched (returns `false`).
+///
+/// For each live card lacking a `board_id` key, backfills it from the
+/// `column_id`->column->`board_id` map. A dangling `column_id` (no matching
+/// column) yields a nil UUID, matching the tolerance already established for
+/// `archived_cards.board_id` in the V8 migration.
+pub(crate) fn transform_v10_to_v11_value(envelope: &mut Value) -> PersistenceResult<bool> {
+    let version = envelope.get("version").and_then(Value::as_u64).unwrap_or(0);
+    if version >= 11 {
+        return Ok(false);
+    }
+
+    if let Some(data) = envelope.get_mut("data").and_then(|d| d.as_object_mut()) {
+        // Build column_id -> board_id map from the live column graph.
+        let col_to_board: HashMap<String, Value> = data
+            .get("columns")
+            .and_then(|c| c.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|c| {
+                let id = c.get("id")?.as_str()?.to_string();
+                let board_id = c.get("board_id")?.clone();
+                Some((id, board_id))
+            })
+            .collect();
+
+        let nil = || Value::String(uuid::Uuid::nil().to_string());
+
+        if let Some(cards) = data.get_mut("cards").and_then(|c| c.as_array_mut()) {
+            for card in cards.iter_mut() {
+                if card.get("board_id").is_some() {
+                    continue;
+                }
+                let board_id = card
+                    .get("column_id")
+                    .and_then(|v| v.as_str())
+                    .and_then(|c| col_to_board.get(c))
+                    .cloned()
+                    .unwrap_or_else(nil);
+                if let Some(obj) = card.as_object_mut() {
+                    obj.insert("board_id".to_string(), board_id);
+                }
+            }
+        }
+    }
+
+    envelope["version"] = Value::Number(11.into());
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    const BOARD: &str = "11111111-1111-1111-1111-111111111111";
+    const COLUMN: &str = "22222222-2222-2222-2222-222222222222";
+    const CARD: &str = "33333333-3333-3333-3333-333333333333";
+
+    fn make_v10_envelope(cards: Value) -> Value {
+        json!({
+            "version": 10,
+            "metadata": {
+                "instance_id": "00000000-0000-0000-0000-000000000001",
+                "saved_at": "2024-01-01T00:00:00Z"
+            },
+            "data": {
+                "boards": [{ "id": BOARD, "name": "B" }],
+                "columns": [{ "id": COLUMN, "board_id": BOARD }],
+                "cards": cards,
+                "archived_cards": [],
+                "sprints": [],
+                "graph": {
+                    "spawns": { "edges": [] },
+                    "blocks": { "edges": [] },
+                    "relates": { "edges": [] }
+                }
+            }
+        })
+    }
+
+    fn card(column_id: &str) -> Value {
+        json!({ "id": CARD, "column_id": column_id, "title": "T" })
+    }
+
+    #[test]
+    fn test_transform_backfills_board_id_from_column_id() {
+        let mut env = make_v10_envelope(json!([card(COLUMN)]));
+
+        let changed = transform_v10_to_v11_value(&mut env).unwrap();
+
+        assert!(changed);
+        assert_eq!(env["version"], 11);
+        assert_eq!(
+            env["data"]["cards"][0]["board_id"].as_str().unwrap(),
+            BOARD,
+            "board_id must be backfilled from column_id -> column.board_id"
+        );
+    }
+
+    #[test]
+    fn test_transform_sets_nil_board_id_when_column_missing() {
+        let missing = "99999999-9999-9999-9999-999999999999";
+        let mut env = make_v10_envelope(json!([card(missing)]));
+
+        transform_v10_to_v11_value(&mut env).unwrap();
+
+        assert_eq!(
+            env["data"]["cards"][0]["board_id"].as_str().unwrap(),
+            uuid::Uuid::nil().to_string(),
+            "a dangling column_id yields a nil board_id, not an error"
+        );
+    }
+
+    #[test]
+    fn test_transform_preserves_existing_board_id() {
+        // If board_id is already present (e.g. a card created by a V11 binary
+        // before the migration ran), it must not be overwritten.
+        let existing = "44444444-4444-4444-4444-444444444444";
+        let mut c = card(COLUMN);
+        c.as_object_mut()
+            .unwrap()
+            .insert("board_id".to_string(), json!(existing));
+        let mut env = make_v10_envelope(json!([c]));
+
+        transform_v10_to_v11_value(&mut env).unwrap();
+
+        assert_eq!(
+            env["data"]["cards"][0]["board_id"].as_str().unwrap(),
+            existing,
+            "an already-present board_id must be preserved, not clobbered"
+        );
+    }
+
+    #[test]
+    fn test_transform_is_noop_on_v11_envelope() {
+        let v11 = json!({
+            "version": 11,
+            "data": {
+                "columns": [{ "id": COLUMN, "board_id": BOARD }],
+                "cards": [card(COLUMN)]
+            }
+        });
+        let mut env = v11.clone();
+        let changed = transform_v10_to_v11_value(&mut env).unwrap();
+        assert!(!changed);
+        assert_eq!(env, v11, "a version:11 envelope must be returned unchanged");
+    }
+
+    #[test]
+    fn test_transform_bumps_version_when_no_cards() {
+        let mut env = make_v10_envelope(json!([]));
+        let changed = transform_v10_to_v11_value(&mut env).unwrap();
+        assert!(changed);
+        assert_eq!(env["version"], 11);
+    }
+
+    #[tokio::test]
+    async fn test_migrate_v10_to_v11_writes_file_with_version_11() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v10.json");
+        let env = make_v10_envelope(json!([card(COLUMN)]));
+        tokio::fs::write(&path, serde_json::to_string_pretty(&env).unwrap())
+            .await
+            .unwrap();
+
+        migrate_v10_to_v11(&path).await.unwrap();
+
+        let after: Value =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert_eq!(after["version"], 11);
+        assert_eq!(
+            after["data"]["cards"][0]["board_id"].as_str().unwrap(),
+            BOARD
+        );
+    }
+}

--- a/crates/kanban-persistence-json/tests/v10_migration.rs
+++ b/crates/kanban-persistence-json/tests/v10_migration.rs
@@ -46,7 +46,10 @@ async fn test_migrate_v9_to_max_lifts_embeds_writes_v10_and_removes_backup() {
         .expect("V9 -> V10 must succeed");
 
     let after = read_json(&path);
-    assert_eq!(after["version"], 10, "file migrated to V10 on disk");
+    assert_eq!(
+        after["version"], 11,
+        "file migrated to current (V11) on disk"
+    );
 
     // The formerly-embedded archived card is now a LIVE row plus a pure marker.
     let card_ids = ids_in(&after["data"]["cards"], "id");
@@ -114,7 +117,7 @@ fn test_load_sync_on_v9_fixture_returns_marker_snapshot() {
     assert!(data["archived_cards"][0].get("card").is_none());
     assert!(data["archived_cards"][0].get("entity").is_none());
     // On-disk migrated to V10 too.
-    assert_eq!(read_json(&path)["version"], 10);
+    assert_eq!(read_json(&path)["version"], 11);
 }
 
 #[tokio::test]
@@ -180,7 +183,10 @@ async fn test_load_v7_embedded_archived_card_full_chain_to_collapsed_snapshot() 
 
     // File must have been upgraded to V10 on disk.
     let on_disk: Value = read_json(&path);
-    assert_eq!(on_disk["version"], 10, "file must be migrated to V10");
+    assert_eq!(
+        on_disk["version"], 11,
+        "file must be migrated to current (V11)"
+    );
 
     // Deserialize into the collapsed Snapshot domain type.
     let domain = kanban_persistence::snapshot_from_json_bytes(&snapshot.data)
@@ -262,11 +268,11 @@ async fn test_load_v4_full_chain_reaches_collapsed_snapshot() {
     let store = JsonFileStore::new(&path);
     let (snapshot, _meta) = store.load().await.unwrap();
 
-    // On disk must be V10.
+    // On disk must be current (V11).
     assert_eq!(
         read_json(&path)["version"],
-        10,
-        "V4 fixture must be migrated to V10 via the full chain"
+        11,
+        "V4 fixture must be migrated to current (V11) via the full chain"
     );
 
     // Must deserialize cleanly into the collapsed Snapshot.

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -90,6 +90,10 @@ CREATE TABLE IF NOT EXISTS sprints (
 -- delete the archived card's row when its column is dropped; instead, live-card
 -- cleanup on column delete is performed explicitly by the command tier
 -- (DeleteCardsByColumns), so no cascade is needed here.
+-- NOTE (schema 5, KAN-963): board_id is a durable, denormalized reference set
+-- at creation and kept in sync on every move -- independent of column_id, so
+-- it survives the column being deleted (same rationale as
+-- archived_cards.board_id below; no FK, for the same "may dangle" tolerance).
 -- KEEP IN SYNC: the 2->3 migration rebuilds this table as `cards_new` in
 -- `init.rs::migrate_v2_to_v3_archived_cards` (same columns, same non-FK shape).
 -- Adding/removing a column here must be mirrored in that CREATE + its INSERT
@@ -97,6 +101,7 @@ CREATE TABLE IF NOT EXISTS sprints (
 CREATE TABLE IF NOT EXISTS cards (
     id TEXT PRIMARY KEY,
     column_id TEXT NOT NULL,
+    board_id TEXT NOT NULL,
     title TEXT NOT NULL,
     description TEXT,
     priority TEXT NOT NULL DEFAULT 'Medium',
@@ -191,6 +196,7 @@ CREATE INDEX IF NOT EXISTS idx_columns_position ON columns(board_id, position);
 CREATE INDEX IF NOT EXISTS idx_sprints_board_id ON sprints(board_id);
 CREATE INDEX IF NOT EXISTS idx_sprints_status ON sprints(status);
 
+CREATE INDEX IF NOT EXISTS idx_cards_board_id ON cards(board_id);
 CREATE INDEX IF NOT EXISTS idx_cards_column_id ON cards(column_id);
 CREATE INDEX IF NOT EXISTS idx_cards_sprint_id ON cards(sprint_id);
 CREATE INDEX IF NOT EXISTS idx_cards_position ON cards(column_id, position);

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -78,6 +78,7 @@ pub(crate) fn row_to_column(row: &SqliteRow) -> KanbanResult<Column> {
 pub(crate) fn row_to_card(row: &SqliteRow, sprint_logs: Vec<SprintLog>) -> KanbanResult<Card> {
     let id_str: String = row.try_get("id").map_err(db_err)?;
     let column_id_str: String = row.try_get("column_id").map_err(db_err)?;
+    let board_id_str: String = row.try_get("board_id").map_err(db_err)?;
     let sprint_id_str: Option<String> = row.try_get("sprint_id").map_err(db_err)?;
     let created_at_str: String = row.try_get("created_at").map_err(db_err)?;
     let updated_at_str: String = row.try_get("updated_at").map_err(db_err)?;
@@ -90,6 +91,7 @@ pub(crate) fn row_to_card(row: &SqliteRow, sprint_logs: Vec<SprintLog>) -> Kanba
     let record = CardRecord {
         id: p_uuid(&id_str)?,
         column_id: p_uuid(&column_id_str)?,
+        board_id: p_uuid(&board_id_str)?,
         title: row.try_get("title").map_err(db_err)?,
         description: row.try_get("description").map_err(db_err)?,
         priority: p_enum(&priority_str, "priority")?,

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -139,7 +139,7 @@ impl DataStore for SqliteStore {
             // `cards` behind a marker and is reachable by id (it is an ordinary,
             // editable card). The archived/live distinction is a LIST-level filter.
             let row = sqlx::query(
-                "SELECT id, column_id, title, description, priority, status, position,
+                "SELECT id, column_id, board_id, title, description, priority, status, position,
                         due_date, points, card_number, sprint_id, created_at, updated_at,
                         completed_at
                  FROM cards

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
@@ -30,11 +30,12 @@ impl SqliteStore {
         let id = card.id.to_string();
 
         sqlx::query(
-            "INSERT INTO cards (id, column_id, title, description, priority, status, position,
-                due_date, points, card_number, sprint_id, created_at, updated_at, completed_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO cards (id, column_id, board_id, title, description, priority, status,
+                position, due_date, points, card_number, sprint_id, created_at, updated_at,
+                completed_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
-                column_id=excluded.column_id, title=excluded.title,
+                column_id=excluded.column_id, board_id=excluded.board_id, title=excluded.title,
                 description=excluded.description, priority=excluded.priority,
                 status=excluded.status, position=excluded.position,
                 due_date=excluded.due_date, points=excluded.points,
@@ -43,6 +44,7 @@ impl SqliteStore {
         )
         .bind(&id)
         .bind(card.column_id.to_string())
+        .bind(card.board_id.to_string())
         .bind(required_str(&card.title, "card.title")?)
         .bind(&card.description)
         .bind(format!("{:?}", card.priority))
@@ -214,7 +216,7 @@ impl SqliteStore {
         binds: &[String],
     ) -> KanbanResult<Vec<Card>> {
         let sql = format!(
-            "SELECT id, column_id, title, description, priority, status, position,
+            "SELECT id, column_id, board_id, title, description, priority, status, position,
                     due_date, points, card_number, sprint_id, created_at, updated_at, completed_at
              FROM cards {} {}
              ORDER BY position ASC, created_at ASC",

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -447,6 +447,69 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Schema 4 -> 5 (KAN-963): add `cards.board_id`, a durable board reference
+    /// independent of `column_id` (same rationale as `archived_cards.board_id`
+    /// above — a card's column can be legitimately deleted once the card is
+    /// archived, and board resolution must survive that). Unlike the 2->3
+    /// migration, `cards` needs no table rebuild here: `column_id` already
+    /// carries no FK, so a plain `ALTER TABLE ADD COLUMN` + backfill suffices.
+    pub(crate) async fn migrate_v4_to_v5_cards_board_id(pool: &Pool<Sqlite>) -> KanbanResult<()> {
+        // Fresh DB: SCHEMA creates `cards` in the correct v5 shape. Nothing to
+        // migrate.
+        let has_cards: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='cards'",
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
+        if !has_cards {
+            return Ok(());
+        }
+        // Idempotent: already migrated if board_id is present.
+        let has_board_id: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('cards') WHERE name = 'board_id'",
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
+        if has_board_id {
+            return Ok(());
+        }
+
+        tracing::info!("migrating SQLite schema 4 -> 5: cards.board_id + backfill");
+
+        let unresolved: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM cards
+              WHERE (SELECT c.board_id FROM columns c
+                       WHERE c.id = cards.column_id) IS NULL",
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
+        if unresolved > 0 {
+            tracing::warn!(
+                count = unresolved,
+                "cards board_id backfill: unresolvable column_id; setting board_id = nil"
+            );
+        }
+
+        sqlx::raw_sql(
+            "BEGIN;
+            ALTER TABLE cards ADD COLUMN board_id TEXT;
+            UPDATE cards
+               SET board_id = (SELECT c.board_id FROM columns c
+                                 WHERE c.id = cards.column_id);
+            UPDATE cards
+               SET board_id = '00000000-0000-0000-0000-000000000000'
+             WHERE board_id IS NULL;
+            COMMIT;",
+        )
+        .execute(pool)
+        .await
+        .map_err(db_err)?;
+        Ok(())
+    }
+
     /// Drop the pre-KAN-504 `card_edges` table (single table with an
     /// `edge_type` column) if present. The per-kind `spawns_edges` /
     /// `blocks_edges` / `relates_edges` tables created by SCHEMA

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -31,7 +31,7 @@ const SCHEMA: &str = include_str!("../schema.sql");
 /// added to `init::migrate` or a sibling `migrate_*` function MUST be
 /// paired with bumping this constant, or it will run unbacked-up — the two
 /// are intentionally coupled but not enforced by the type system.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 4;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 5;
 
 /// (instance_id, saved_at, writer_version, writer_commit, schema_version).
 /// Tuple shape returned by the metadata-singleton SELECT — extracted to a
@@ -122,6 +122,11 @@ impl SqliteStore {
         // deletion. Must run BEFORE SCHEMA: SCHEMA declares
         // idx_archived_cards_board_id, which fails against the old-shape table.
         Self::migrate_v2_to_v3_archived_cards(&pool).await?;
+
+        // schema 4 -> 5: add cards.board_id (+ backfill). Must also run BEFORE
+        // SCHEMA: SCHEMA declares idx_cards_board_id, which fails against the
+        // old-shape table.
+        Self::migrate_v4_to_v5_cards_board_id(&pool).await?;
 
         sqlx::raw_sql(SCHEMA)
             .execute(&pool)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
@@ -29,10 +29,11 @@ fn seed_board_and_column(store: &SqliteStore, board_name: &str) -> (Uuid, Uuid) 
     (board_id, column_id)
 }
 
-fn card_in(column_id: Uuid, title: &str) -> Card {
+fn card_in(board_id: Uuid, column_id: Uuid, title: &str) -> Card {
     Card::reconstitute(CardRecord {
         id: Uuid::new_v4(),
         column_id,
+        board_id,
         title: title.to_string(),
         description: Some("body".to_string()),
         priority: CardPriority::High,
@@ -59,7 +60,7 @@ fn test_archived_card_round_trip_preserves_board_id_and_all_fields() {
         let store = SqliteStore::open(&path).await.unwrap();
         let (board_id, column_id) = seed_board_and_column(&store, "B");
 
-        let card = card_in(column_id, "Archived");
+        let card = card_in(board_id, column_id, "Archived");
         let card_id = card.id;
         store.upsert_card(card).unwrap();
 
@@ -103,10 +104,10 @@ fn test_list_archived_cards_by_board_filters_by_board_id() {
         let (board_a, col_a) = seed_board_and_column(&store, "A");
         let (board_b, col_b) = seed_board_and_column(&store, "B");
 
-        let card_a = card_in(col_a, "A1");
+        let card_a = card_in(board_a, col_a, "A1");
         let a_id = card_a.id;
         store.upsert_card(card_a).unwrap();
-        let card_b = card_in(col_b, "B1");
+        let card_b = card_in(board_b, col_b, "B1");
         let b_id = card_b.id;
         store.upsert_card(card_b).unwrap();
 
@@ -131,7 +132,7 @@ fn test_delete_column_does_not_cascade_delete_archived_card() {
         let store = SqliteStore::open(&path).await.unwrap();
         let (board_id, column_id) = seed_board_and_column(&store, "B");
 
-        let card = card_in(column_id, "Survivor");
+        let card = card_in(board_id, column_id, "Survivor");
         let card_id = card.id;
         store.upsert_card(card).unwrap();
         store
@@ -170,11 +171,11 @@ fn test_list_all_cards_excludes_archived_via_not_exists() {
         let store = SqliteStore::open(&path).await.unwrap();
         let (board_id, column_id) = seed_board_and_column(&store, "B");
 
-        let live = card_in(column_id, "Live");
+        let live = card_in(board_id, column_id, "Live");
         let live_id = live.id;
         store.upsert_card(live).unwrap();
 
-        let archived_card = card_in(column_id, "Archived");
+        let archived_card = card_in(board_id, column_id, "Archived");
         let archived_id = archived_card.id;
         store.upsert_card(archived_card).unwrap();
         store

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -85,7 +85,7 @@ fn test_unarchive_board_drops_marker_keeps_row_and_subtree() {
 }
 
 #[test]
-fn test_open_migrates_old_db_to_v4_with_board_archival_and_backup() {
+fn test_open_migrates_old_db_to_current_schema_with_board_archival_and_backup() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("old.db");
     let rt = make_rt();
@@ -99,7 +99,7 @@ fn test_open_migrates_old_db_to_v4_with_board_archival_and_backup() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 4, "old DB migrates to current schema v4");
+        assert_eq!(version, 5, "old DB migrates to current schema v5 (KAN-963)");
 
         // board_archival table exists after the schema step.
         let has_table: bool = sqlx::query_scalar(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
@@ -16,6 +16,7 @@ fn fully_populated_card(column_id: Uuid) -> Card {
     let record = CardRecord {
         id: Uuid::new_v4(),
         column_id,
+        board_id: Uuid::new_v4(),
         title: "Done card".to_string(),
         description: Some("finished".to_string()),
         priority: CardPriority::High,
@@ -126,13 +127,15 @@ fn test_sqlite_card_reconstitute_rejects_malformed_row() {
         let id = Uuid::new_v4();
 
         sqlx::query(
-            "INSERT INTO cards (id, column_id, title, description, priority, status, position,
-                due_date, points, card_number, sprint_id, created_at, updated_at, completed_at)
-             VALUES (?, ?, 'Bad', NULL, 'Medium', 'NotAStatus', 0, NULL, NULL, 1, NULL,
+            "INSERT INTO cards (id, column_id, board_id, title, description, priority, status,
+                position, due_date, points, card_number, sprint_id, created_at, updated_at,
+                completed_at)
+             VALUES (?, ?, ?, 'Bad', NULL, 'Medium', 'NotAStatus', 0, NULL, NULL, 1, NULL,
                 '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z', NULL)",
         )
         .bind(id.to_string())
         .bind(column_id.to_string())
+        .bind(Uuid::new_v4().to_string())
         .execute(store.pool())
         .await
         .unwrap();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/filtered_reads.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/filtered_reads.rs
@@ -33,6 +33,7 @@ fn card_in(column_id: Uuid, title: &str, position: i32) -> Card {
     Card::reconstitute(CardRecord {
         id: Uuid::new_v4(),
         column_id,
+        board_id: Uuid::new_v4(),
         title: title.to_string(),
         description: None,
         priority: CardPriority::Medium,

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
@@ -79,7 +79,7 @@ fn test_open_drops_legacy_card_edges_table() {
 }
 
 #[test]
-fn test_fresh_db_records_schema_version_4() {
+fn test_fresh_db_records_current_schema_version() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("fresh.db");
     let rt = make_rt();
@@ -90,7 +90,7 @@ fn test_fresh_db_records_schema_version_4() {
             .await
             .unwrap();
         assert_eq!(version, SUPPORTED_SCHEMA_VERSION);
-        assert_eq!(version, 4, "fresh DB stamps schema_version 4");
+        assert_eq!(version, 5, "fresh DB stamps schema_version 5 (KAN-963)");
     });
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
@@ -81,8 +81,8 @@ fn test_migration_base_case_empty_db_backs_up_and_migrates_clean() {
 
         assert_eq!(
             store_schema_version(&store).await,
-            4,
-            "migrated to current v4"
+            5,
+            "migrated to current v5"
         );
         assert_eq!(
             backup_schema_version(&path).await,
@@ -130,7 +130,7 @@ fn test_migration_cards_case_preserves_live_and_archived_cards() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 4);
+        assert_eq!(store_schema_version(&store).await, 5);
         assert_eq!(backup_schema_version(&path).await, 2);
 
         // Board survived.
@@ -218,7 +218,7 @@ fn test_migration_boards_case_preserves_multiple_board_subtrees() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 4);
+        assert_eq!(store_schema_version(&store).await, 5);
         assert_eq!(backup_schema_version(&path).await, 2);
 
         // Both boards survived with their subtrees.
@@ -249,7 +249,7 @@ fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
         // First open: migrates + writes the v2 backup.
         {
             let store = SqliteStore::open(&path).await.unwrap();
-            assert_eq!(store_schema_version(&store).await, 4);
+            assert_eq!(store_schema_version(&store).await, 5);
         }
         let backup = SqliteStore::backup_path_for(&path, 2);
         assert!(backup.exists());
@@ -258,7 +258,7 @@ fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
         // Second open on the now-v3 DB: no migration, backup untouched.
         {
             let store = SqliteStore::open(&path).await.unwrap();
-            assert_eq!(store_schema_version(&store).await, 4);
+            assert_eq!(store_schema_version(&store).await, 5);
             assert_eq!(store.list_archived_cards().unwrap().len(), 1, "data intact");
         }
         assert_eq!(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
@@ -208,8 +208,8 @@ fn test_migrate_v2_db_adds_board_id_and_backfills() {
             .await
             .unwrap();
         assert_eq!(
-            version, 4,
-            "schema_version bumped to 4 (2->3 archived_cards then generic bump)"
+            version, 5,
+            "schema_version bumped to current (2->3 archived_cards, 4->5 cards.board_id)"
         );
     });
 }
@@ -274,7 +274,7 @@ fn test_migrate_is_idempotent_on_v3_db() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 4);
+        assert_eq!(version, 5);
 
         let still_there: bool =
             sqlx::query_scalar("SELECT COUNT(*) > 0 FROM archived_cards WHERE card_id = ?")

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
@@ -127,7 +127,7 @@ fn test_existing_backup_not_clobbered() {
             .await
             .unwrap();
         assert_eq!(
-            version, 4,
+            version, 5,
             "main DB must still migrate to the current schema even when the backup is skipped"
         );
     });

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -66,6 +66,7 @@ pub fn fully_populated_snapshot() -> Snapshot {
     let card = Card {
         id: card_id,
         column_id: col_id,
+        board_id,
         title: "Full Card".into(),
         description: Some("desc".into()),
         priority: CardPriority::High,
@@ -93,6 +94,7 @@ pub fn fully_populated_snapshot() -> Snapshot {
     let archived_live_card = Card {
         id: archived_card_inner_id,
         column_id: col_id,
+        board_id,
         title: "Archived Card".into(),
         description: Some("archived desc".into()),
         priority: CardPriority::Critical,

--- a/crates/kanban-persistence/src/traits.rs
+++ b/crates/kanban-persistence/src/traits.rs
@@ -191,11 +191,18 @@ pub enum FormatVersion {
     /// (`{ entity_id, archived_at, board_id? }`), dropping the retired
     /// `original_column_id`/`original_position` restore context.
     V10,
+    /// V11 backfills `board_id` onto each historical `cards` entry that lacks
+    /// it, mirroring V8's `archived_cards.board_id` backfill one layer
+    /// earlier: `Card.board_id` is now a durable field set at creation and
+    /// kept in sync on every move (KAN-963), independent of `column_id` --
+    /// derived here from `column_id`→column→`board_id` for files predating
+    /// the field (nil when the column no longer resolves).
+    V11,
 }
 
 impl FormatVersion {
     /// The highest format version this binary can read or produce.
-    pub const MAX: Self = Self::V10;
+    pub const MAX: Self = Self::V11;
 
     pub fn as_u32(self) -> u32 {
         match self {
@@ -209,6 +216,7 @@ impl FormatVersion {
             Self::V8 => 8,
             Self::V9 => 9,
             Self::V10 => 10,
+            Self::V11 => 11,
         }
     }
 
@@ -224,6 +232,7 @@ impl FormatVersion {
             8 => Some(Self::V8),
             9 => Some(Self::V9),
             10 => Some(Self::V10),
+            11 => Some(Self::V11),
             _ => None,
         }
     }
@@ -268,20 +277,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_format_version_max_equals_v10() {
-        assert_eq!(FormatVersion::MAX, FormatVersion::V10);
+    fn test_format_version_max_equals_v11() {
+        assert_eq!(FormatVersion::MAX, FormatVersion::V11);
     }
 
     #[test]
     fn test_format_version_max_as_u32_matches_largest_variant() {
-        assert_eq!(FormatVersion::MAX.as_u32(), 10);
+        assert_eq!(FormatVersion::MAX.as_u32(), 11);
     }
 
     #[test]
-    fn test_from_u32_accepts_10_rejects_11() {
-        assert_eq!(FormatVersion::from_u32(9), Some(FormatVersion::V9));
+    fn test_from_u32_accepts_11_rejects_12() {
         assert_eq!(FormatVersion::from_u32(10), Some(FormatVersion::V10));
-        assert_eq!(FormatVersion::from_u32(11), None);
+        assert_eq!(FormatVersion::from_u32(11), Some(FormatVersion::V11));
+        assert_eq!(FormatVersion::from_u32(12), None);
     }
 
     #[test]

--- a/crates/kanban-service/src/api/v1/cards/response.rs
+++ b/crates/kanban-service/src/api/v1/cards/response.rs
@@ -51,6 +51,7 @@ impl From<&Card> for CardResponse {
         let Card {
             id,
             column_id,
+            board_id: _,
             title,
             description,
             priority,
@@ -101,7 +102,7 @@ mod tests {
             points: Some(3),
             sprint_id: None,
         };
-        Card::create(spec, Uuid::new_v4(), 5, Utc::now()).unwrap()
+        Card::create(spec, Uuid::new_v4(), 5, Utc::now(), Uuid::new_v4()).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Fixes a data-integrity bug: archiving a card whose column has since been legitimately deleted, then archiving the same card again (idempotent retry, undo/redo replay, re-issued command), overwrote the archived marker's correct `board_id` with nil, permanently orphaning it (board-delete cascade cleanup matches archived cards by `board_id`, so a nil-stamped marker is never found and never cleaned up).

Root cause: `Card` had no `board_id` field, only `column_id` — board affiliation was always resolved transitively via `column_id -> column.board_id`. This is fragile since a column can be legitimately deleted once its last card is archived (archived cards don't block column deletion). `ArchiveCards::execute` tolerated this with a `Uuid::nil()` fallback, which is correct for a card that genuinely never had a valid column, but also silently fires on re-archive once the column is gone.

**What changed**:
- `Card` gains a durable `board_id` field, set at creation (`Card::new`/`Card::create`) and kept in sync on every column move (`MoveCard::execute`, `RestoreCard::execute`), including moves to a column on a different board — cross-board moves stay intentionally permitted, not guarded against.
- `ArchiveCards::execute` reads `card.board_id` directly instead of deriving it via a column lookup, eliminating the whole class of dangling-column bugs at the source. It also gains an idempotency guard: if a marker already exists for an id, re-archiving leaves it untouched instead of re-deriving and clobbering it.
- Both persistence backends are migrated: SQLite bumps to schema v5 (`cards.board_id` column + backfill via `column_id -> columns.board_id`, mirroring the existing `archived_cards.board_id` migration), and the JSON backend bumps to format V11 (same backfill, mirroring the V7->V8 archived-cards migration).

**Why**: `ArchivedCard` already solved exactly this problem for itself (`board_id` denormalized onto the marker so it survives column deletion). This applies the same fix one layer earlier, at the true source, so both live and archived cards get a durable board reference instead of only archived cards.

**How**: `Card::create` takes `board_id` as a resolved parameter (mirroring how `card_number` is server-minted rather than client-supplied), rather than threading it through `NewCard` — `NewCard` is also used by service-layer call sites that only have `column_id` at construction time and resolve `board_id` downstream via the existing column lookup. Both migrations mirror the exact shape of their `archived_cards.board_id` precedent (KAN-829/832): a pure transform operating on raw data (JSON `Value` / SQL) so old records missing the field don't fail before the migration runs, with the existing nil-on-dangling-reference tolerance preserved for genuinely corrupted/legacy data.

**Testing**: `cargo test --workspace` (all green, including new regression tests for the double-archive clobber, cross-board move/restore, and both persistence migrations), `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean). Existing databases/files migrate automatically on next open; no manual action needed.