### PR TITLE
KAN-965 fix(service,tui): archived-boards view independent recency default

### DIFF
--- a/.changeset/max-kan-965.md
+++ b/.changeset/max-kan-965.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-The archived-boards view now always defaults to recency order (most recently archived first), independent of whatever sort preference is saved for the live boards list. Previously, changing the live list's default sort (for example to sort by name) also silently changed the archived view's default, since both shared the same saved preference. The two are now independent: setting a live-view sort no longer affects how the archived view is ordered by default.
+The archived-boards view now always defaults to recency order (most recently archived first), independent of whatever sort preference is saved for the live boards list. Previously, changing the live list's default sort (for example to sort by name) also silently changed the archived view's default, since both shared the same saved preference. This is now consistent everywhere: at the service layer (MCP/CLI/API) and in the terminal UI. The archived-boards panel in the TUI is still independently sortable via its own `s`/`o` keys, but that choice is session-only and no longer bleeds into the live view's default or gets persisted.

--- a/.changeset/max-kan-965.md
+++ b/.changeset/max-kan-965.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+The archived-boards view now always defaults to recency order (most recently archived first), independent of whatever sort preference is saved for the live boards list. Previously, changing the live list's default sort (for example to sort by name) also silently changed the archived view's default, since both shared the same saved preference. The two are now independent: setting a live-view sort no longer affects how the archived view is ordered by default.

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -159,18 +159,19 @@ impl KanbanContext {
         ))
     }
 
-    /// Resolve the board sort default from the AppConfig `board_sort_field` /
-    /// `board_sort_order`, falling back to the per-context built-in default for
-    /// any unset or unrecognized value. The built-in is chosen from the archived
-    /// selector: `ArchivedOnly` → [`DEFAULT_ARCHIVED_BOARD_SORT`] (recency), else
-    /// [`DEFAULT_BOARD_SORT_LIVE`] (Position ASC). An unset field with a set
-    /// order (or vice versa) layers onto the built-in default's other half.
+    /// Resolve the board sort default. The archived-boards view always
+    /// defaults to [`DEFAULT_ARCHIVED_BOARD_SORT`] (recency), independent of
+    /// the AppConfig `board_sort_field`/`board_sort_order` preference — that
+    /// preference is scoped to the live view only. For any other selector, the
+    /// AppConfig value applies, falling back to [`DEFAULT_BOARD_SORT_LIVE`]
+    /// (Position ASC) for any unset or unrecognized value. An unset field with
+    /// a set order (or vice versa) layers onto the built-in default's other
+    /// half.
     fn board_sort_default(&self, archived: ArchivedFilter) -> (BoardSortField, SortOrder) {
-        let builtin = if archived == ArchivedFilter::ArchivedOnly {
-            DEFAULT_ARCHIVED_BOARD_SORT
-        } else {
-            DEFAULT_BOARD_SORT_LIVE
-        };
+        if archived == ArchivedFilter::ArchivedOnly {
+            return DEFAULT_ARCHIVED_BOARD_SORT;
+        }
+        let builtin = DEFAULT_BOARD_SORT_LIVE;
         let field = self
             .app_config
             .board_sort_field

--- a/crates/kanban-service/tests/archived_board_sort_independence.rs
+++ b/crates/kanban-service/tests/archived_board_sort_independence.rs
@@ -1,0 +1,61 @@
+//! The archived-boards view has its own default sort (recency:
+//! `ArchivedAt` descending), independent of whatever the live view's saved
+//! `board_sort_field`/`board_sort_order` preference is set to.
+
+use kanban_domain::{ArchivedFilter, BoardListFilter, BoardSortField, SortOrder};
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{
+    json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext, KanbanOperations,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn make_json_backend(path: &std::path::Path) -> Arc<dyn KanbanBackend> {
+    Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))))
+}
+
+/// Setting the live view's saved sort preference to Name must not change the
+/// archived view's default: it should still resolve to recency (`ArchivedAt`
+/// descending), not `Name`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archived_board_default_sort_ignores_live_sort_preference() {
+    let dir = tempdir().unwrap();
+    let store_path = dir.path().join("board.json");
+    let config_path = dir.path().join("config.toml");
+
+    let config = AppConfig {
+        configuration_location: Some(config_path.to_string_lossy().into_owned()),
+        ..Default::default()
+    };
+    let mut ctx = KanbanContext::open(make_json_backend(&store_path), config)
+        .await
+        .unwrap();
+
+    // Names chosen so name-ascending and recency-descending disagree: Apple
+    // archived first (older), Zebra archived second (more recent).
+    let apple = ctx.create_board("Apple".into(), None).unwrap();
+    let zebra = ctx.create_board("Zebra".into(), None).unwrap();
+    ctx.archive_board(apple.id).unwrap();
+    ctx.archive_board(zebra.id).unwrap();
+
+    // Setting the live sort to Name would, before the fix, also become the
+    // archived view's default (since board_sort_default consulted the same
+    // global app_config field for every archived selector).
+    ctx.set_board_sort(BoardSortField::Name, SortOrder::Ascending)
+        .unwrap();
+
+    let archived = ctx
+        .list_boards_filtered(BoardListFilter {
+            archived: ArchivedFilter::ArchivedOnly,
+            ..Default::default()
+        })
+        .unwrap();
+
+    // Recency order: Zebra was archived after Apple, so it sorts first under
+    // the archived-view's recency default — the opposite of name-ascending.
+    assert_eq!(
+        archived.iter().map(|b| b.name.clone()).collect::<Vec<_>>(),
+        vec!["Zebra", "Apple"],
+        "archived view must stay on its own recency default, unaffected by the live sort preference"
+    );
+}

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -38,15 +38,15 @@ pub struct Model {
     // cannot go stale relative to the archived partition it sorts.
     archived_board_at: HashMap<Uuid, DateTime<Utc>>,
     // Sort dimension for the PROJECTS panel — the board-specific `BoardSortField`
-    // (NOT the card `SortField`) paired with the shared `SortOrder` toggle. Once
-    // the user picks a sort it drives BOTH the live and archived partitions
-    // (KAN-948). Until then (`board_sort_explicit == false`) the two partitions
-    // fall back to their OWN built-in defaults: live → Position ASC, archived →
-    // recency (ArchivedAt DESC) (KAN-955). Seeded from `AppConfig.board_sort_*`
-    // on start; a config value flips `board_sort_explicit` true.
-    board_sort_field: BoardSortField,
-    board_sort_order: SortOrder,
-    board_sort_explicit: bool,
+    // (NOT the card `SortField`) paired with the shared `SortOrder` toggle. The
+    // live and archived partitions each carry their own independent field/order
+    // pair: the live pair is seeded from and persisted to `AppConfig.board_sort_*`,
+    // while the archived pair is session-only (never persisted) and defaults to
+    // recency (ArchivedAt DESC). Setting one pair never affects the other.
+    live_board_sort_field: BoardSortField,
+    live_board_sort_order: SortOrder,
+    archived_board_sort_field: BoardSortField,
+    archived_board_sort_order: SortOrder,
     graph: DependencyGraph,
 }
 
@@ -68,9 +68,10 @@ impl Default for Model {
             displayed_boards_live: Vec::new(),
             displayed_boards_archived: Vec::new(),
             archived_board_at: HashMap::new(),
-            board_sort_field: DEFAULT_BOARD_SORT_LIVE.0,
-            board_sort_order: DEFAULT_BOARD_SORT_LIVE.1,
-            board_sort_explicit: false,
+            live_board_sort_field: DEFAULT_BOARD_SORT_LIVE.0,
+            live_board_sort_order: DEFAULT_BOARD_SORT_LIVE.1,
+            archived_board_sort_field: DEFAULT_ARCHIVED_BOARD_SORT.0,
+            archived_board_sort_order: DEFAULT_ARCHIVED_BOARD_SORT.1,
             graph: DependencyGraph::default(),
         }
     }
@@ -176,37 +177,43 @@ impl Model {
         }
     }
 
-    /// The current board-list sort dimension (`BoardSortField`/`SortOrder`).
-    /// This is the user's explicit choice once set; before that it is the LIVE
-    /// default (Position ASC). The archived partition may sort differently by
-    /// default (recency) — see [`Model::sort_partitions`].
-    pub fn board_sort(&self) -> (BoardSortField, SortOrder) {
-        (self.board_sort_field, self.board_sort_order)
+    /// The current board-list sort dimension (`BoardSortField`/`SortOrder`) for
+    /// the requested partition. Live and archived each carry their own
+    /// independent pair — see the field docs on `Model`.
+    pub fn board_sort(&self, archived: bool) -> (BoardSortField, SortOrder) {
+        if archived {
+            (self.archived_board_sort_field, self.archived_board_sort_order)
+        } else {
+            (self.live_board_sort_field, self.live_board_sort_order)
+        }
     }
 
-    /// Set the board-list sort field/order and re-sort BOTH cached partitions in
-    /// place. This is an EXPLICIT user choice, so from here it drives the whole
-    /// projects panel (both partitions), overriding the archived recency default.
-    pub fn set_board_sort(&mut self, field: BoardSortField, order: SortOrder) {
-        self.board_sort_field = field;
-        self.board_sort_order = order;
-        self.board_sort_explicit = true;
+    /// Set the requested partition's sort field/order and re-sort both cached
+    /// partitions in place (each against its own, independent pair).
+    pub fn set_board_sort(&mut self, archived: bool, field: BoardSortField, order: SortOrder) {
+        if archived {
+            self.archived_board_sort_field = field;
+            self.archived_board_sort_order = order;
+        } else {
+            self.live_board_sort_field = field;
+            self.live_board_sort_order = order;
+        }
         self.sort_partitions();
     }
 
-    /// Flip the board-list sort ORDER via the shared `SortOrder::toggled` (the
-    /// same asc↔desc flip the card list uses), keeping the current field.
-    pub fn toggle_board_sort_order(&mut self) {
-        let next = self.board_sort_order.toggled();
-        self.set_board_sort(self.board_sort_field, next);
+    /// Flip the requested partition's sort ORDER via the shared
+    /// `SortOrder::toggled` (the same asc↔desc flip the card list uses),
+    /// keeping its current field.
+    pub fn toggle_board_sort_order(&mut self, archived: bool) {
+        let (field, order) = self.board_sort(archived);
+        self.set_board_sort(archived, field, order.toggled());
     }
 
-    /// Seed the board-list sort field/order from `AppConfig.board_sort_field` /
-    /// `board_sort_order`, and re-sort the cached partitions. A recognised config
-    /// value is an EXPLICIT choice (drives both partitions); a missing or
-    /// unrecognised value leaves the per-partition defaults in force (live →
-    /// Position ASC, archived → recency). Called once on start so the
-    /// projects-panel sort survives a restart.
+    /// Seed the LIVE partition's sort field/order from
+    /// `AppConfig.board_sort_field`/`board_sort_order`, and re-sort the cached
+    /// partitions. The archived partition is never config-seeded — it stays on
+    /// its own default (recency) unless changed in-session. Called once on
+    /// start so the live projects-panel sort survives a restart.
     pub fn set_board_sort_from_config(&mut self, config: &AppConfig) {
         let field = config
             .board_sort_field
@@ -220,12 +227,11 @@ impl Model {
             // A field with an optional order is an explicit choice; a bare order
             // with no field is ignored (there is no field to apply it to).
             (Some(field), order) => {
-                self.set_board_sort(field, order.unwrap_or(DEFAULT_BOARD_SORT_LIVE.1));
+                self.set_board_sort(false, field, order.unwrap_or(DEFAULT_BOARD_SORT_LIVE.1));
             }
             _ => {
-                self.board_sort_field = DEFAULT_BOARD_SORT_LIVE.0;
-                self.board_sort_order = DEFAULT_BOARD_SORT_LIVE.1;
-                self.board_sort_explicit = false;
+                self.live_board_sort_field = DEFAULT_BOARD_SORT_LIVE.0;
+                self.live_board_sort_order = DEFAULT_BOARD_SORT_LIVE.1;
                 self.sort_partitions();
             }
         }
@@ -335,19 +341,14 @@ impl Model {
     fn sort_partitions(&mut self) {
         sort_boards_in_place(
             &mut self.displayed_boards_live,
-            self.board_sort_field,
-            self.board_sort_order,
+            self.live_board_sort_field,
+            self.live_board_sort_order,
             &self.archived_board_at,
         );
-        let (archived_field, archived_order) = if self.board_sort_explicit {
-            (self.board_sort_field, self.board_sort_order)
-        } else {
-            DEFAULT_ARCHIVED_BOARD_SORT
-        };
         sort_boards_in_place(
             &mut self.displayed_boards_archived,
-            archived_field,
-            archived_order,
+            self.archived_board_sort_field,
+            self.archived_board_sort_order,
             &self.archived_board_at,
         );
     }
@@ -612,6 +613,7 @@ mod tests {
         let mut m = Model::default();
         let (first_id, second_id) = seed_two_archived_boards(&mut m);
         m.set_board_sort(
+            true,
             kanban_domain::BoardSortField::ArchivedAt,
             kanban_domain::SortOrder::Descending,
         );
@@ -628,6 +630,7 @@ mod tests {
         let mut m = Model::default();
         let (first_id, second_id) = seed_two_archived_boards(&mut m);
         m.set_board_sort(
+            true,
             kanban_domain::BoardSortField::Position,
             kanban_domain::SortOrder::Ascending,
         );
@@ -646,13 +649,14 @@ mod tests {
         let mut m = Model::default();
         let (first_id, second_id) = seed_two_archived_boards(&mut m);
         m.set_board_sort(
+            true,
             kanban_domain::BoardSortField::ArchivedAt,
             kanban_domain::SortOrder::Descending,
         );
         let before: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
         assert_eq!(before, vec![second_id, first_id]);
 
-        m.toggle_board_sort_order();
+        m.toggle_board_sort_order(true);
         let after: Vec<Uuid> = m.displayed_boards(true).iter().map(|b| b.id).collect();
         assert_eq!(
             after,
@@ -663,8 +667,7 @@ mod tests {
 
     #[test]
     fn test_board_sort_applies_to_live_projects_panel() {
-        // Picking Name sorts the LIVE projects panel alphabetically (the unified
-        // board sort applies to BOTH partitions, not only the archived one).
+        // Picking Name sorts the LIVE projects panel alphabetically.
         let mut m = Model::default();
         let mut zed = Board::new("Zed", None::<String>);
         zed.position = 0;
@@ -679,6 +682,7 @@ mod tests {
         });
 
         m.set_board_sort(
+            false,
             kanban_domain::BoardSortField::Name,
             kanban_domain::SortOrder::Ascending,
         );
@@ -701,7 +705,7 @@ mod tests {
         };
         m.set_board_sort_from_config(&config);
         assert_eq!(
-            m.board_sort(),
+            m.board_sort(false),
             (BoardSortField::Name, SortOrder::Ascending),
             "config field/order restored into the model state"
         );
@@ -717,7 +721,7 @@ mod tests {
             board_sort_order: None,
             ..Default::default()
         });
-        assert_eq!(m.board_sort(), DEFAULT_BOARD_SORT_LIVE);
+        assert_eq!(m.board_sort(false), DEFAULT_BOARD_SORT_LIVE);
     }
 
     #[test]
@@ -727,8 +731,8 @@ mod tests {
         // survives a "restart". Covers the field/order round-trip through the
         // canonical `Display`/`FromStr` strings (KAN-955).
         let mut m = Model::default();
-        m.set_board_sort(BoardSortField::Name, SortOrder::Descending);
-        let (field, order) = m.board_sort();
+        m.set_board_sort(false, BoardSortField::Name, SortOrder::Descending);
+        let (field, order) = m.board_sort(false);
 
         let config = AppConfig {
             board_sort_field: Some(field.to_string()),
@@ -739,7 +743,7 @@ mod tests {
         let mut restored = Model::default();
         restored.set_board_sort_from_config(&config);
         assert_eq!(
-            restored.board_sort(),
+            restored.board_sort(false),
             (BoardSortField::Name, SortOrder::Descending),
             "board sort choice survives a config round-trip"
         );

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -182,7 +182,10 @@ impl Model {
     /// independent pair — see the field docs on `Model`.
     pub fn board_sort(&self, archived: bool) -> (BoardSortField, SortOrder) {
         if archived {
-            (self.archived_board_sort_field, self.archived_board_sort_order)
+            (
+                self.archived_board_sort_field,
+                self.archived_board_sort_order,
+            )
         } else {
             (self.live_board_sort_field, self.live_board_sort_order)
         }

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -327,20 +327,15 @@ impl Model {
             .iter()
             .cloned()
             .partition(|b| self.archived_board_ids.contains(&b.id));
-        // Both partitions are sorted by the SAME configured board-list dimension
-        // (default Position ASC). The unified sort drives the whole projects panel.
         self.displayed_boards_live = live_boards;
         self.displayed_boards_archived = archived_boards;
         self.sort_partitions();
     }
 
-    /// Sort BOTH cached board partitions (live and archived). The live partition
-    /// always uses the current `board_sort_field`/`order`. The archived partition
-    /// uses the same explicit choice once the user has picked one; until then it
-    /// falls back to its own recency default (ArchivedAt DESC) rather than the
-    /// live Position default (KAN-955). Called on load and whenever the sort
-    /// dimension changes, so the rendered lists and the selection resolvers
-    /// (which read these partitions) stay consistent.
+    /// Sort BOTH cached board partitions, each against its own independent
+    /// field/order pair. Called on load and whenever either sort dimension
+    /// changes, so the rendered lists and the selection resolvers (which read
+    /// these partitions) stay consistent.
     fn sort_partitions(&mut self) {
         sort_boards_in_place(
             &mut self.displayed_boards_live,

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -1,4 +1,4 @@
-use super::App;
+use super::{App, AppMode};
 
 impl App {
     pub fn get_current_priority_selection_index(&self) -> usize {
@@ -47,7 +47,8 @@ impl App {
     /// The picker row for the projects-panel sort field: the popup index of the
     /// model's current board-list `BoardSortField`. Mirrors the card variant.
     pub fn get_current_board_sort_field_selection_index(&self) -> usize {
-        let (field, _order) = self.model.board_sort();
+        let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
+        let (field, _order) = self.model.board_sort(want_archived);
         crate::components::selection_dialog::popup_index_of_board_sort_field(field)
     }
 }

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -200,9 +200,9 @@ impl SelectionDialog for SortFieldDialog {
 }
 
 /// Field picker for the PROJECTS panel sort — the board-side analogue of
-/// [`SortFieldDialog`] (KAN-948). Same list-with-active-order-indicator layout,
-/// but backed by [`BOARD_SORT_FIELD_POPUP_ORDER`] and the unified board-list
-/// sort state on the model.
+/// [`SortFieldDialog`]. Same list-with-active-order-indicator layout, but
+/// backed by [`BOARD_SORT_FIELD_POPUP_ORDER`] and whichever partition (live or
+/// archived) is currently active on the model.
 pub struct BoardSortFieldDialog;
 
 impl SelectionDialog for BoardSortFieldDialog {

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -222,7 +222,8 @@ impl SelectionDialog for BoardSortFieldDialog {
         use crate::components::render_selection_popup_with_lines;
         use kanban_domain::SortOrder;
 
-        let (active_field, active_order) = app.model.board_sort();
+        let want_archived = matches!(app.get_base_mode(), crate::app::AppMode::ArchivedBoardsView);
+        let (active_field, active_order) = app.model.board_sort(want_archived);
         let active_idx = Some(popup_index_of_board_sort_field(active_field));
 
         render_selection_popup_with_lines(

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1388,7 +1388,10 @@ mod tests {
         app.focus.active = Focus::Boards;
         app.selection.active_board_id = None;
         app.apply_board_sort(kanban_domain::BoardSortField::Name, SortOrder::Ascending);
-        assert!(cfg_path.exists(), "live sort persisted to config (precondition)");
+        assert!(
+            cfg_path.exists(),
+            "live sort persisted to config (precondition)"
+        );
 
         // Switch to the archived view: it must stay on its own recency
         // default (Arch2 archived more recently), unaffected by the live

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -312,10 +312,13 @@ impl App {
         if !self.board_sort_context_active() {
             return;
         }
+        let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
         let highlighted_id = self.highlighted_board_id();
-        self.model.toggle_board_sort_order();
+        self.model.toggle_board_sort_order(want_archived);
         self.repin_board_selection(highlighted_id);
-        self.persist_board_sort();
+        if !want_archived {
+            self.persist_board_sort();
+        }
         self.needs_redraw = true;
     }
 
@@ -354,12 +357,14 @@ impl App {
         });
     }
 
-    /// Persist the current board-list sort field/order to AppConfig via
+    /// Persist the LIVE board-list sort field/order to AppConfig via
     /// `kanban_service::config::save`, mirroring how the card toggle persists its
     /// sort (there via `SetTaskSort` onto the board; here onto the global config,
     /// since the projects-panel sort is a global UI preference, not per-board).
+    /// Callers must only invoke this for the live context — the archived sort is
+    /// session-only and never persisted.
     fn persist_board_sort(&mut self) {
-        let (field, order) = self.model.board_sort();
+        let (field, order) = self.model.board_sort(false);
         self.app_config.board_sort_field = Some(field.to_string());
         self.app_config.board_sort_order = Some(order.to_string());
         if let Err(e) = kanban_service::config::save(&self.app_config) {
@@ -388,10 +393,13 @@ impl App {
         field: kanban_domain::BoardSortField,
         order: kanban_domain::SortOrder,
     ) {
+        let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
         let highlighted_id = self.highlighted_board_id();
-        self.model.set_board_sort(field, order);
+        self.model.set_board_sort(want_archived, field, order);
         self.repin_board_selection(highlighted_id);
-        self.persist_board_sort();
+        if !want_archived {
+            self.persist_board_sort();
+        }
         self.needs_redraw = true;
     }
 
@@ -1359,68 +1367,129 @@ mod tests {
         );
     }
 
-    /// The shared SortOrder toggle (`s`) reverses the archived projects order and
-    /// keeps the rendered list and selection resolver consistent (both read the
-    /// sorted partition), with the choice persisted. Uses the Name dimension —
-    /// which distinguishes the two boards regardless of their (possibly equal)
-    /// archived positions. Superseding KAN-937's archived-only recency toggle
-    /// (folded into the unified board sort, KAN-948).
+    /// The shared SortOrder toggle (`s`) reverses the archived projects order
+    /// while leaving the live view's persisted sort preference untouched: the
+    /// archived and live sort pairs are independent, so a live Name preference
+    /// does not leak into the archived default, and toggling the archived
+    /// order does not overwrite the live preference in AppConfig.
     #[test]
-    fn test_archived_boards_view_s_toggles_sort_order_and_persists() {
+    fn test_archived_boards_view_s_toggles_its_own_order_independent_of_live() {
         use std::str::FromStr;
         let mut app = App::test_default();
-        // Route the board-sort persistence to a tempfile so the toggle's config
-        // save never touches the real user config.
         let cfg_dir = tempfile::tempdir().unwrap();
         let cfg_path = cfg_dir.path().join("config.toml");
         app.app_config.configuration_location = Some(cfg_path.display().to_string());
         let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
         let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
 
-        // Sort by Name ASC so the two boards have a stable, distinguishable order.
-        app.model
-            .set_board_sort(kanban_domain::BoardSortField::Name, SortOrder::Ascending);
+        // Persist a LIVE sort preference (Name/Ascending) via the real handler
+        // path, exactly like a user setting it from the live projects panel.
+        app.mode = AppMode::Normal;
+        app.focus.active = Focus::Boards;
+        app.selection.active_board_id = None;
+        app.apply_board_sort(kanban_domain::BoardSortField::Name, SortOrder::Ascending);
+        assert!(cfg_path.exists(), "live sort persisted to config (precondition)");
+
+        // Switch to the archived view: it must stay on its own recency
+        // default (Arch2 archived more recently), unaffected by the live
+        // Name preference.
         app.mode = AppMode::ArchivedBoardsView;
         app.prepare_frame();
-        app.focus.active = Focus::Boards;
         app.selection.board.set(Some(0));
-
-        // Name ASC → Arch1 first.
-        let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
-        assert_eq!(rendered, vec![arch1, arch2], "Name ASC orders Arch1 first");
-
-        // Highlight the top row (Arch1), then toggle order via the shared 's'.
-        app.selection.board.set(Some(0));
-        app.handle_archived_boards_view_mode(KeyCode::Char('s'));
-
-        // Reversed: Name DESC → Arch2 first.
         let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
         assert_eq!(
             rendered,
             vec![arch2, arch1],
-            "'s' reverses the order via the shared SortOrder toggle"
+            "archived view keeps its own recency default, unaffected by the live Name sort"
         );
 
-        // Render and selection stay consistent: the highlight followed Arch1 to
-        // its NEW index (1), so the resolved id still matches the rendered row.
-        let sel_idx = app.selection.board.get().unwrap();
-        assert_eq!(sel_idx, 1, "highlight tracked Arch1 to its new position");
+        // Toggle order via the shared 's' while viewing the archived list.
+        app.selection.board.set(Some(0));
+        app.handle_archived_boards_view_mode(KeyCode::Char('s'));
+
+        // Recency ASC → oldest (Arch1) first: only the archived partition moved.
+        let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
         assert_eq!(
-            app.displayed_boards()[sel_idx].id,
-            arch1,
-            "the rendered row at the selected index is the same board the resolver returns"
+            rendered,
+            vec![arch1, arch2],
+            "'s' reverses only the archived partition's own order"
         );
 
-        // The toggled order was persisted to AppConfig (Descending) and written.
+        // The live preference is completely untouched by the archived-view
+        // toggle: still Name/Ascending, not overwritten.
+        assert_eq!(
+            app.app_config.board_sort_field.as_deref(),
+            Some("name"),
+            "live sort field in AppConfig is unaffected by the archived-view toggle"
+        );
         assert_eq!(
             app.app_config
                 .board_sort_order
                 .as_deref()
                 .and_then(|s| SortOrder::from_str(s).ok()),
-            Some(SortOrder::Descending),
-            "toggled order saved to AppConfig"
+            Some(SortOrder::Ascending),
+            "live sort order in AppConfig must still be Ascending, not flipped by the archived toggle"
         );
-        assert!(cfg_path.exists(), "config file written to disk");
+    }
+
+    /// The converse of the test above: changing the archived view's sort must
+    /// not affect the live view's order or its persisted AppConfig preference.
+    #[test]
+    fn test_live_board_order_unaffected_by_archived_sort_change() {
+        use crate::components::selection_dialog::popup_index_of_board_sort_field;
+        let mut app = App::test_default();
+        let cfg_dir = tempfile::tempdir().unwrap();
+        app.app_config.configuration_location =
+            Some(cfg_dir.path().join("config.toml").display().to_string());
+        create_named_board(&mut app, "Zed");
+        create_named_board(&mut app, "Alpha");
+        seed_archived_board_with_cards(&mut app, "Arch1");
+        seed_archived_board_with_cards(&mut app, "Arch2");
+
+        // Live default is Position ASC: Zed (created first) then Alpha.
+        app.mode = AppMode::Normal;
+        app.focus.active = Focus::Boards;
+        app.selection.active_board_id = None;
+        app.prepare_frame();
+        app.selection.board.set(Some(0));
+        let live_before: Vec<String> = app
+            .displayed_boards()
+            .iter()
+            .map(|b| b.name.clone())
+            .collect();
+        assert_eq!(
+            live_before,
+            vec!["Zed", "Alpha"],
+            "live default is Position ASC (precondition)"
+        );
+
+        // Change the ARCHIVED sort to Name ascending via the picker, from
+        // within the archived view.
+        app.mode = AppMode::ArchivedBoardsView;
+        app.prepare_frame();
+        app.selection.board.set(Some(0));
+        app.handle_archived_boards_view_mode(KeyCode::Char('o'));
+        let name_idx = popup_index_of_board_sort_field(kanban_domain::BoardSortField::Name);
+        app.filter.board_sort_field_selection.set(Some(name_idx));
+        app.handle_order_boards_popup(KeyCode::Char('a'));
+
+        // Switch back to the live view: order and persisted config unaffected.
+        app.mode = AppMode::Normal;
+        app.prepare_frame();
+        let live_after: Vec<String> = app
+            .displayed_boards()
+            .iter()
+            .map(|b| b.name.clone())
+            .collect();
+        assert_eq!(
+            live_after,
+            vec!["Zed", "Alpha"],
+            "live order unaffected by the archived sort change"
+        );
+        assert_eq!(
+            app.app_config.board_sort_field, None,
+            "archived-only sort change must not write the live AppConfig field"
+        );
     }
 
     /// The board-sort field picker (`o`) opens over the archived-boards view and
@@ -1516,8 +1585,11 @@ mod tests {
         let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
 
         // Sort by Name ASC so the two boards have a stable order to observe.
-        app.model
-            .set_board_sort(kanban_domain::BoardSortField::Name, SortOrder::Ascending);
+        app.model.set_board_sort(
+            true,
+            kanban_domain::BoardSortField::Name,
+            SortOrder::Ascending,
+        );
         app.mode = AppMode::ArchivedBoardsView;
         app.prepare_frame();
 
@@ -1526,10 +1598,10 @@ mod tests {
         app.selection.active_board_id = Some(arch1);
         app.focus.active = Focus::Cards;
 
-        let before = app.model.board_sort();
+        let before = app.model.board_sort(true);
         app.handle_toggle_board_sort_order();
         assert_eq!(
-            app.model.board_sort(),
+            app.model.board_sort(true),
             before,
             "'s' is inert while an archived board is activated (focus on Cards)"
         );
@@ -1547,7 +1619,7 @@ mod tests {
         app.selection.board.set(Some(0));
         app.handle_toggle_board_sort_order();
         assert_eq!(
-            app.model.board_sort().1,
+            app.model.board_sort(true).1,
             SortOrder::Descending,
             "'s' fires again once browsing the archived board list"
         );

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -296,18 +296,18 @@ impl App {
         browsing_boards && matches!(self.mode, AppMode::ArchivedBoardsView | AppMode::Normal)
     }
 
-    /// Flip the board-list sort ORDER via the shared `SortOrder::toggled` (the
-    /// SAME asc↔desc flip the task list's `handle_toggle_sort_order_key` applies)
-    /// applied to the projects panel — LIVE and archived alike. The highlight
-    /// tracks the same board across the re-sort so the cursor does not jump to a
-    /// different project when the order changes, and the new field/order is saved
-    /// to AppConfig so the choice survives a restart.
+    /// Flip the active partition's sort ORDER via the shared `SortOrder::toggled`
+    /// (the SAME asc↔desc flip the task list's `handle_toggle_sort_order_key`
+    /// applies), independently for live vs archived. The highlight tracks the
+    /// same board across the re-sort so the cursor does not jump to a different
+    /// project when the order changes; only the live choice is saved to
+    /// AppConfig so it survives a restart.
     ///
     /// The guard reads the RAW `mode`: this handler is only ever reached from the
     /// live/archived board providers, which the keybinding router selects on the
-    /// raw mode. A pushed dialog swaps the provider, so `s`/`o` cannot dispatch
-    /// here while a dialog is open — the earlier "works under a pushed dialog via
-    /// `get_base_mode`" note described an unreachable path and has been dropped.
+    /// raw mode, so a pushed dialog can never reach this handler. `get_base_mode`
+    /// is still used below (rather than the already-equivalent raw `mode`) to stay
+    /// consistent with `apply_board_sort`, which does need it.
     pub fn handle_toggle_board_sort_order(&mut self) {
         if !self.board_sort_context_active() {
             return;
@@ -1496,8 +1496,8 @@ mod tests {
     }
 
     /// The board-sort field picker (`o`) opens over the archived-boards view and
-    /// picking Recency (ArchivedAt) re-sorts to newest-archived first, applied to
-    /// the archived partition via the unified board sort (KAN-948).
+    /// picking Recency (ArchivedAt) re-sorts the archived partition to
+    /// newest-archived first.
     #[test]
     fn test_order_boards_picker_recency_orders_newest_first() {
         use crate::components::selection_dialog::popup_index_of_board_sort_field;

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::App;
+use crate::app::{App, AppMode};
 use crossterm::event::KeyCode;
 use kanban_domain::{GraphOperations, KanbanOperations, SortOrder};
 
@@ -253,7 +253,9 @@ impl App {
                         None => return,
                     };
 
-                    let (current_field, current_order) = self.model.board_sort();
+                    let want_archived =
+                        matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
+                    let (current_field, current_order) = self.model.board_sort(want_archived);
                     let order = if current_field == field
                         && matches!(key_code, KeyCode::Enter | KeyCode::Char(' '))
                     {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -253,8 +253,7 @@ impl App {
                         None => return,
                     };
 
-                    let want_archived =
-                        matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
+                    let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
                     let (current_field, current_order) = self.model.board_sort(want_archived);
                     let order = if current_field == field
                         && matches!(key_code, KeyCode::Enter | KeyCode::Char(' '))

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -224,11 +224,12 @@ impl App {
         }
     }
 
-    /// Key handling for the projects-panel sort field picker (KAN-948), the
-    /// board-side analogue of [`handle_order_cards_popup`](Self::handle_order_cards_popup).
+    /// Key handling for the projects-panel sort field picker, the board-side
+    /// analogue of [`handle_order_cards_popup`](Self::handle_order_cards_popup).
     /// `Enter`/`Space` on the already-active field toggles its order; `a`/`d`
-    /// force ascending/descending. The chosen field/order is applied to BOTH
-    /// board partitions and persisted to AppConfig via `apply_board_sort`.
+    /// force ascending/descending. The chosen field/order is applied to
+    /// whichever partition (live or archived) is currently active, via
+    /// `apply_board_sort` — only the live choice is persisted to AppConfig.
     pub fn handle_order_boards_popup(&mut self, key_code: KeyCode) {
         use crate::components::selection_dialog::{
             board_sort_field_at_popup_index, BOARD_SORT_FIELD_POPUP_ORDER,


### PR DESCRIPTION
The archived-boards view is supposed to default to recency (most recently archived first), independent of the live view's default (position ascending). Two layers implemented this incorrectly, in opposite ways:

**Service layer** (`context/boards.rs`): `board_sort_default` always consulted the global `app_config.board_sort_field`/`board_sort_order` preference first, regardless of which view was being resolved — only the *fallback* differed by selector. Since `set_board_sort` is the single shared entry point CLI/MCP use to change the default board sort, setting any live sort preference silently overrode the archived view's default too.

**TUI** (`app/model.rs`): `Model` held a single shared `board_sort_field`/`board_sort_order`/`board_sort_explicit` triple. Once `board_sort_explicit` was true (any saved config value, or any in-session sort change), `sort_partitions` applied that same field/order to BOTH the live and archived partitions — a deliberate design from an earlier ticket (KAN-948) that this epic explicitly decided to reverse.

## Service layer fix
- `board_sort_default`: when `archived == ArchivedFilter::ArchivedOnly`, return `DEFAULT_ARCHIVED_BOARD_SORT` unconditionally, bypassing the AppConfig lookup entirely. Any other selector keeps the existing AppConfig-with-live-builtin-fallback behavior unchanged.
- An explicit per-request sort override (`BoardListFilter.sort`/`sort_order`, resolved via `resolve_board_sort`) is unaffected — it still wins over any default.

## TUI fix
- Split `Model`'s shared sort triple into two fully independent pairs: a **live pair** (persisted to `AppConfig`, exactly as before) and an **archived pair** (session-only, never persisted, defaults to recency).
- The archived-boards panel's own `s`/`o` sort actions (KAN-955) still work — the archived view remains independently sortable from within itself — but that choice no longer leaks into the live view's default and is never written to `AppConfig`.
- `board_sort`/`set_board_sort`/`toggle_board_sort_order` now take an explicit `archived: bool`, threaded through every caller (`board_handlers.rs`, `popup_handlers.rs`, `query.rs`, `selection_dialog.rs`) via the existing `get_base_mode()`-derived `want_archived` pattern already used elsewhere in these files.

**Why**: Setting a custom live-view sort (e.g. by name) silently changed the archived view's default away from recency at both layers, which the epic explicitly decided should not happen — the two views' defaults should be independent everywhere, not just at the service layer.

**Testing**: `cargo test -p kanban-service --test archived_board_sort_independence` (service-layer independence), `cargo test -p kanban-tui` (321 tests, including two new/rewritten tests proving TUI independence in both directions — archived-unaffected-by-live and live-unaffected-by-archived), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).