### PR TITLE
KAN-966 fix(persistence-json): V1->V2 and V8->V9 migrations write via atomic rename

### DIFF
--- a/.changeset/max-kan-966.md
+++ b/.changeset/max-kan-966.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+The JSON storage backend's V8-to-V9 format migration (adding archived-board support) now writes its result via the same atomic temp-file-and-rename pattern every other migration step already used. Previously this one step wrote the migrated file in place, so a crash or power loss during that specific write could leave the board file truncated or corrupted. It now benefits from the same crash-safety guarantee as the rest of the migration chain.

--- a/.changeset/max-kan-966.md
+++ b/.changeset/max-kan-966.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-The JSON storage backend's V8-to-V9 format migration (adding archived-board support) now writes its result via the same atomic temp-file-and-rename pattern every other migration step already used. Previously this one step wrote the migrated file in place, so a crash or power loss during that specific write could leave the board file truncated or corrupted. It now benefits from the same crash-safety guarantee as the rest of the migration chain.
+The JSON storage backend's V1-to-V2 and V8-to-V9 format migrations now write their results via the same atomic temp-file-and-rename pattern the rest of the migration chain already used. Previously these two steps wrote the migrated file in place, so a crash or power loss during either specific write could leave the board file truncated or corrupted. They now benefit from the same crash-safety guarantee as every other step in the chain.

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -157,7 +157,7 @@ impl Migrator {
         let json_str = v2_envelope
             .to_json_string()
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-        tokio::fs::write(path, json_str).await?;
+        crate::atomic_writer::AtomicWriter::write_atomic(path, json_str.as_bytes()).await?;
 
         tracing::info!("Migrated {} from V1 to V2 format", path.display());
 

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -287,6 +287,32 @@ mod tests {
         );
     }
 
+    // Inode identity is a POSIX-only observable: an atomic write replaces the
+    // directory entry via rename (new inode), while an in-place overwrite
+    // reuses the same inode. Windows has no equivalent notion, so this guard
+    // against a crash-window regression is Unix-only.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_migrate_v1_to_v2_writes_via_atomic_rename_not_in_place() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test.json");
+        let v1_data = json!({ "boards": [], "columns": [], "cards": [] });
+        tokio::fs::write(&file_path, v1_data.to_string())
+            .await
+            .unwrap();
+
+        let inode_before = tokio::fs::metadata(&file_path).await.unwrap().ino();
+        Migrator::migrate_v1_to_v2(&file_path).await.unwrap();
+        let inode_after = tokio::fs::metadata(&file_path).await.unwrap().ino();
+
+        assert_ne!(
+            inode_before, inode_after,
+            "migrate_v1_to_v2 must write via a temp file + atomic rename, not an in-place overwrite"
+        );
+    }
+
     #[tokio::test]
     async fn test_migrate_v7_to_v7_is_a_noop_byte_for_byte() {
         let dir = tempdir().unwrap();

--- a/crates/kanban-persistence-json/src/migration/v8_to_v9_archived_boards.rs
+++ b/crates/kanban-persistence-json/src/migration/v8_to_v9_archived_boards.rs
@@ -64,4 +64,30 @@ mod tests {
         let mut env = json!({ "version": 9, "data": {} });
         assert!(!transform_v8_to_v9_value(&mut env).unwrap());
     }
+
+    // Inode identity is a POSIX-only observable: an atomic write replaces the
+    // directory entry via rename (new inode), while an in-place overwrite
+    // reuses the same inode. Windows has no equivalent notion, so this guard
+    // against a crash-window regression is Unix-only.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_migrate_v8_to_v9_writes_via_atomic_rename_not_in_place() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("board.json");
+        let env = json!({ "version": 8, "data": { "boards": [] } });
+        tokio::fs::write(&path, serde_json::to_string_pretty(&env).unwrap())
+            .await
+            .unwrap();
+
+        let inode_before = tokio::fs::metadata(&path).await.unwrap().ino();
+        migrate_v8_to_v9(&path).await.unwrap();
+        let inode_after = tokio::fs::metadata(&path).await.unwrap().ino();
+
+        assert_ne!(
+            inode_before, inode_after,
+            "migrate_v8_to_v9 must write via a temp file + atomic rename, not an in-place overwrite"
+        );
+    }
 }

--- a/crates/kanban-persistence-json/src/migration/v8_to_v9_archived_boards.rs
+++ b/crates/kanban-persistence-json/src/migration/v8_to_v9_archived_boards.rs
@@ -19,7 +19,8 @@ pub(crate) async fn migrate_v8_to_v9(path: &Path) -> PersistenceResult<()> {
     }
     let out = serde_json::to_string_pretty(&envelope)
         .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-    tokio::fs::write(path, out).await?;
+    crate::atomic_writer::AtomicWriter::write_atomic(path, out.as_bytes()).await?;
+    tracing::info!("Migrated {} from V8 to V9", path.display());
     Ok(())
 }
 


### PR DESCRIPTION
`migrate_v8_to_v9` (`migration/v8_to_v9_archived_boards.rs:22`) wrote its migrated output via a bare `tokio::fs::write(path, out).await`, unlike every sibling migration step in the same cascade (`v7_to_v8`, `v9_to_v10`, `v10_to_v11`), which all use `AtomicWriter::write_atomic` (temp file + rename). The sync twin of this same migration (`v8_to_v9_archived_boards_sync` in `json_file_store.rs`) already correctly used `AtomicWriter::write_atomic_sync` — only the async path was inconsistent.

Review surfaced an identical gap one step earlier in the same chain: `migrate_v1_to_v2` (`migrator.rs`) had the same bare `tokio::fs::write`.

A bare in-place write reuses the file's existing inode and overwrites its contents directly; if the process crashes or loses power mid-write, the board file is left truncated/corrupted with no fallback. The atomic pattern writes to a new temp file first and only replaces the destination via `rename` once the write is complete, so a crash at any point before the rename leaves the original file untouched.

**What**: Both `migrate_v1_to_v2` and `migrate_v8_to_v9` now write via `AtomicWriter::write_atomic`, matching every other step in the V1→V11 migration chain.

**Why**: These were the two migration steps without the crash-safety guarantee the rest of the chain already has.

**How**: Swapped the bare `tokio::fs::write` calls for `AtomicWriter::write_atomic` in both functions, exactly mirroring the sibling migrations' shape.

**Testing**: New tests `test_migrate_v8_to_v9_writes_via_atomic_rename_not_in_place` and `test_migrate_v1_to_v2_writes_via_atomic_rename_not_in_place` (both Unix-only, gated `#[cfg(unix)]`) assert the file's inode changes across each migration call — a bare in-place write reuses the inode, while a temp-file-and-rename write replaces it. Confirmed both fail against the old code and pass after the fix. `cargo test -p kanban-persistence-json` (all tests, including the full V4→V11 and V7→V11 cascade integration tests in `tests/v10_migration.rs`, confirming the migration chain itself is unaffected), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).