### PR TITLE
KAN-967 fix(mcp): set_board_sort echoes resolved value, not null

### DIFF
--- a/.changeset/max-kan-967.md
+++ b/.changeset/max-kan-967.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+The `set_board_sort` MCP tool now reports the actual sort field and order it resolved and persisted, instead of echoing back exactly what the caller sent. Previously, omitting either `sort` or `order` (to leave that dimension unchanged) made the response report `null` for the omitted half, even though a concrete value was computed and saved. The response now always reflects the real, effective sort configuration, matching how the CLI's equivalent command already behaved.

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -65,7 +65,9 @@ impl McpContext {
     /// (`board_sort_field` / `board_sort_order`) and reflect it in the running
     /// context. Either dimension may be left unchanged by passing `None`; the
     /// omitted dimension is resolved from the current config (falling back to the
-    /// live built-in default) so `None` truly means "leave as-is".
+    /// live built-in default) so `None` truly means "leave as-is". Returns the
+    /// resolved, persisted `(field, order)` so callers can report the concrete
+    /// value rather than the raw (possibly omitted) request.
     ///
     /// Delegates to `KanbanContext::set_board_sort` (R3), which persists first
     /// then mutates `app_config` in place. It deliberately does NOT rebuild the
@@ -75,7 +77,7 @@ impl McpContext {
         &mut self,
         sort: Option<BoardSortField>,
         order: Option<SortOrder>,
-    ) -> KanbanResult<()> {
+    ) -> KanbanResult<(BoardSortField, SortOrder)> {
         let config = self.inner.app_config();
         let field = sort.unwrap_or_else(|| {
             config
@@ -91,7 +93,8 @@ impl McpContext {
                 .and_then(|s| SortOrder::from_str(s).ok())
                 .unwrap_or(DEFAULT_BOARD_SORT_LIVE.1)
         });
-        self.inner.set_board_sort(field, order)
+        self.inner.set_board_sort(field, order)?;
+        Ok((field, order))
     }
 
     /// Create a board from a full spec + optional client id, funneling through

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -176,13 +176,13 @@ impl KanbanMcpServer {
             .map(parse_board_sort_field)
             .transpose()?;
         let order = req.order.as_deref().map(parse_sort_order).transpose()?;
-        locked_write(&self.ctx, |ctx| {
+        let (resolved_field, resolved_order) = locked_write(&self.ctx, |ctx| {
             ctx.set_board_sort(field, order).map_err(kanban_err_to_mcp)
         })
         .await?;
         to_call_tool_result_json(serde_json::json!({
-            "board_sort_field": field.map(|f| f.to_string()),
-            "board_sort_order": order.map(|o| o.to_string()),
+            "board_sort_field": resolved_field.to_string(),
+            "board_sort_order": resolved_order.to_string(),
         }))
     }
 

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -2808,6 +2808,43 @@ async fn test_mcp_set_board_sort_persists_default() {
     );
 }
 
+#[tokio::test]
+async fn test_mcp_set_board_sort_echoes_resolved_order_not_null() {
+    let dir = TempDir::new().unwrap();
+    let data_path = dir.path().join("test.json");
+    let config_path = dir.path().join("config.toml");
+    let store_manager = default_store_manager();
+    let config = AppConfig {
+        configuration_location: Some(config_path.to_string_lossy().to_string()),
+        ..AppConfig::default()
+    };
+    let server = KanbanMcpServer::new(&store_manager, &data_path.to_string_lossy(), config)
+        .await
+        .unwrap();
+
+    // Only `sort` is supplied; `order` is omitted and must be resolved (to the
+    // live default, Ascending, since no prior sort was persisted) rather than
+    // echoed back as the raw `null` the caller sent.
+    let response = text_payload(
+        &server
+            .tool_set_board_sort(Parameters(kanban_mcp::SetBoardSortRequest {
+                sort: Some("name".into()),
+                order: None,
+            }))
+            .await
+            .unwrap(),
+    );
+
+    assert_eq!(
+        response["board_sort_field"], "name",
+        "resolved field must be echoed"
+    );
+    assert_eq!(
+        response["board_sort_order"], "ascending",
+        "omitted order must be echoed as the resolved+persisted value, not null: {response}"
+    );
+}
+
 // KAN-954 (BSF-R5): the MCP board-sort setter now routes through R3's
 // persist-first, in-place `KanbanContext::set_board_sort` instead of rebuilding
 // the context via `open_deferred`. The rebuild minted a fresh session id and


### PR DESCRIPTION
`tool_set_board_sort` (`tools/board.rs`) echoed the raw, possibly-omitted request values (`field.map(|f| f.to_string())`, `order.map(|o| o.to_string())`) in its response — so calling it with only `{sort: "name"}` reported `"board_sort_order": null`, even though `McpContext::set_board_sort` internally resolves the omitted half from the current config (or the live built-in default) and persists a concrete value. The CLI's equivalent `board set-sort` command already resolves both halves before calling the setter and reports the resolved values; MCP's flow just never returned what it resolved internally, so it had nothing but the raw request to echo.

**What**: `McpContext::set_board_sort` now returns the resolved `(BoardSortField, SortOrder)` it persisted, and the tool response uses that instead of the raw request.

**Why**: The response should always describe the actual effective sort configuration, not just whatever the caller happened to pass — an omitted dimension is not "no value," it has a concrete resolved value the tool already computed and discarded.

**How**: Changed `McpContext::set_board_sort`'s return type from `KanbanResult<()>` to `KanbanResult<(BoardSortField, SortOrder)>`, returning the `field`/`order` it already resolves internally. `tool_set_board_sort` uses that returned tuple to build its JSON response.

**Testing**: New test `test_mcp_set_board_sort_echoes_resolved_order_not_null` (call with only `sort` set, confirm the response's `board_sort_order` is the resolved `"ascending"` default, not `null`) — confirmed to fail against the pre-fix code. `cargo test -p kanban-mcp` (83 tests, no regressions, including the existing session/undo-preservation test that calls `McpContext::set_board_sort` directly), `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).