### PR TITLE
KAN-971 fix(tui): dedicated keybinding providers for confirm/choice dialogs

### DIFF
--- a/.changeset/max-kan-971.md
+++ b/.changeset/max-kan-971.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Three confirmation dialogs — sprint-prefix collision, storage conflict resolution, and the external-file-change prompt — now show footer hints that match what the keys actually do. Previously all three borrowed a generic list-picker's hints (`j`/`k`/`Enter`), which did nothing in any of these dialogs, while their real keys went unlisted. This was most serious on the external-change dialog: `k` (keep local changes, discarding the external write) looked like harmless "navigate up" in the footer, so it was easy to press by accident and silently lose someone else's saved changes. The footer now shows the real keys with accurate, specific descriptions, and the in-app help overlay (`?`) invoked from within any of these three dialogs now performs the same action the direct keypress does, instead of a mismatched or no-op one.

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -133,6 +133,152 @@ impl App {
             }
             KeybindingAction::OpenSettings => self.handle_open_settings(),
             KeybindingAction::ExportBoards => {}
+            KeybindingAction::ConfirmPrefixCollision => {}
+            KeybindingAction::RejectPrefixCollision => {}
+            KeybindingAction::CancelPrefixCollision => {}
+            KeybindingAction::ForceOverwriteConflict => {}
+            KeybindingAction::TakeTheirsConflict => {}
+            KeybindingAction::CancelConflictResolution => {}
+            KeybindingAction::ReloadDiscardLocal => {}
+            KeybindingAction::KeepLocalChanges => {}
+            KeybindingAction::DismissExternalChange => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::DialogMode;
+    use crate::keybindings::KeybindingAction;
+    use crate::App;
+
+    #[test]
+    fn test_execute_action_confirm_prefix_collision_pops_dialog() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ConfirmSprintPrefixCollision);
+
+        app.execute_action(&KeybindingAction::ConfirmPrefixCollision);
+
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ConfirmSprintPrefixCollision),
+            "ConfirmPrefixCollision must reach the same confirm behavior as pressing Enter/'y' directly"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_reject_prefix_collision_reopens_prefix_dialog() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ConfirmSprintPrefixCollision);
+
+        app.execute_action(&KeybindingAction::RejectPrefixCollision);
+
+        assert_eq!(
+            app.mode,
+            AppMode::Dialog(DialogMode::SetSprintPrefix),
+            "RejectPrefixCollision must reach the same 'go back to prefix dialog' behavior as pressing 'n' directly"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_cancel_prefix_collision_pops_dialog() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ConfirmSprintPrefixCollision);
+
+        app.execute_action(&KeybindingAction::CancelPrefixCollision);
+
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ConfirmSprintPrefixCollision),
+            "CancelPrefixCollision must reach the same cancel behavior as pressing Esc directly"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_force_overwrite_conflict_sets_pending_key() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ConflictResolution);
+
+        app.execute_action(&KeybindingAction::ForceOverwriteConflict);
+
+        assert_eq!(
+            app.pending_key,
+            Some('o'),
+            "ForceOverwriteConflict must reach the same behavior as pressing 'o' directly"
+        );
+        assert_ne!(app.mode, AppMode::Dialog(DialogMode::ConflictResolution));
+    }
+
+    #[test]
+    fn test_execute_action_take_theirs_conflict_sets_pending_key() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ConflictResolution);
+
+        app.execute_action(&KeybindingAction::TakeTheirsConflict);
+
+        assert_eq!(
+            app.pending_key,
+            Some('t'),
+            "TakeTheirsConflict must reach the same behavior as pressing 't' directly"
+        );
+        assert_ne!(app.mode, AppMode::Dialog(DialogMode::ConflictResolution));
+    }
+
+    #[test]
+    fn test_execute_action_cancel_conflict_resolution_pops_dialog() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ConflictResolution);
+
+        app.execute_action(&KeybindingAction::CancelConflictResolution);
+
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ConflictResolution),
+            "CancelConflictResolution must reach the same cancel behavior (incl. clear_conflict()) as pressing Esc directly"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_reload_discard_local_sets_pending_key() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ExternalChangeDetected);
+
+        app.execute_action(&KeybindingAction::ReloadDiscardLocal);
+
+        assert_eq!(
+            app.pending_key,
+            Some('r'),
+            "ReloadDiscardLocal must reach the same behavior as pressing 'r' directly"
+        );
+        assert_ne!(app.mode, AppMode::Dialog(DialogMode::ExternalChangeDetected));
+    }
+
+    #[test]
+    fn test_execute_action_keep_local_changes_pops_dialog() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ExternalChangeDetected);
+
+        app.execute_action(&KeybindingAction::KeepLocalChanges);
+
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ExternalChangeDetected),
+            "KeepLocalChanges must reach the same behavior as pressing 'k' directly"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_dismiss_external_change_pops_dialog() {
+        let mut app = App::test_default();
+        app.open_dialog(DialogMode::ExternalChangeDetected);
+
+        app.execute_action(&KeybindingAction::DismissExternalChange);
+
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ExternalChangeDetected),
+            "DismissExternalChange must reach the same behavior as pressing Esc directly"
+        );
     }
 }

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -60,6 +60,7 @@ impl App {
 
     pub(in crate::app) fn execute_action(&mut self, action: &crate::keybindings::KeybindingAction) {
         use crate::keybindings::KeybindingAction;
+        use crossterm::event::KeyCode;
 
         match action {
             KeybindingAction::NavigateDown => self.handle_navigation_down(),
@@ -134,33 +135,31 @@ impl App {
             KeybindingAction::OpenSettings => self.handle_open_settings(),
             KeybindingAction::ExportBoards => {}
             KeybindingAction::ConfirmPrefixCollision => {
-                self.handle_confirm_sprint_prefix_collision_popup(crossterm::event::KeyCode::Enter);
+                self.handle_confirm_sprint_prefix_collision_popup(KeyCode::Enter);
             }
             KeybindingAction::RejectPrefixCollision => {
-                self.handle_confirm_sprint_prefix_collision_popup(crossterm::event::KeyCode::Char(
-                    'n',
-                ));
+                self.handle_confirm_sprint_prefix_collision_popup(KeyCode::Char('n'));
             }
             KeybindingAction::CancelPrefixCollision => {
-                self.handle_confirm_sprint_prefix_collision_popup(crossterm::event::KeyCode::Esc);
+                self.handle_confirm_sprint_prefix_collision_popup(KeyCode::Esc);
             }
             KeybindingAction::ForceOverwriteConflict => {
-                self.handle_conflict_resolution_popup(crossterm::event::KeyCode::Char('o'));
+                self.handle_conflict_resolution_popup(KeyCode::Char('o'));
             }
             KeybindingAction::TakeTheirsConflict => {
-                self.handle_conflict_resolution_popup(crossterm::event::KeyCode::Char('t'));
+                self.handle_conflict_resolution_popup(KeyCode::Char('t'));
             }
             KeybindingAction::CancelConflictResolution => {
-                self.handle_conflict_resolution_popup(crossterm::event::KeyCode::Esc);
+                self.handle_conflict_resolution_popup(KeyCode::Esc);
             }
             KeybindingAction::ReloadDiscardLocal => {
-                self.handle_external_change_detected_popup(crossterm::event::KeyCode::Char('r'));
+                self.handle_external_change_detected_popup(KeyCode::Char('r'));
             }
             KeybindingAction::KeepLocalChanges => {
-                self.handle_external_change_detected_popup(crossterm::event::KeyCode::Char('k'));
+                self.handle_external_change_detected_popup(KeyCode::Char('k'));
             }
             KeybindingAction::DismissExternalChange => {
-                self.handle_external_change_detected_popup(crossterm::event::KeyCode::Esc);
+                self.handle_external_change_detected_popup(KeyCode::Esc);
             }
         }
     }

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -134,19 +134,15 @@ impl App {
             KeybindingAction::OpenSettings => self.handle_open_settings(),
             KeybindingAction::ExportBoards => {}
             KeybindingAction::ConfirmPrefixCollision => {
-                self.handle_confirm_sprint_prefix_collision_popup(
-                    crossterm::event::KeyCode::Enter,
-                );
+                self.handle_confirm_sprint_prefix_collision_popup(crossterm::event::KeyCode::Enter);
             }
             KeybindingAction::RejectPrefixCollision => {
-                self.handle_confirm_sprint_prefix_collision_popup(
-                    crossterm::event::KeyCode::Char('n'),
-                );
+                self.handle_confirm_sprint_prefix_collision_popup(crossterm::event::KeyCode::Char(
+                    'n',
+                ));
             }
             KeybindingAction::CancelPrefixCollision => {
-                self.handle_confirm_sprint_prefix_collision_popup(
-                    crossterm::event::KeyCode::Esc,
-                );
+                self.handle_confirm_sprint_prefix_collision_popup(crossterm::event::KeyCode::Esc);
             }
             KeybindingAction::ForceOverwriteConflict => {
                 self.handle_conflict_resolution_popup(crossterm::event::KeyCode::Char('o'));
@@ -275,7 +271,10 @@ mod tests {
             Some('r'),
             "ReloadDiscardLocal must reach the same behavior as pressing 'r' directly"
         );
-        assert_ne!(app.mode, AppMode::Dialog(DialogMode::ExternalChangeDetected));
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ExternalChangeDetected)
+        );
     }
 
     #[test]

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -133,15 +133,39 @@ impl App {
             }
             KeybindingAction::OpenSettings => self.handle_open_settings(),
             KeybindingAction::ExportBoards => {}
-            KeybindingAction::ConfirmPrefixCollision => {}
-            KeybindingAction::RejectPrefixCollision => {}
-            KeybindingAction::CancelPrefixCollision => {}
-            KeybindingAction::ForceOverwriteConflict => {}
-            KeybindingAction::TakeTheirsConflict => {}
-            KeybindingAction::CancelConflictResolution => {}
-            KeybindingAction::ReloadDiscardLocal => {}
-            KeybindingAction::KeepLocalChanges => {}
-            KeybindingAction::DismissExternalChange => {}
+            KeybindingAction::ConfirmPrefixCollision => {
+                self.handle_confirm_sprint_prefix_collision_popup(
+                    crossterm::event::KeyCode::Enter,
+                );
+            }
+            KeybindingAction::RejectPrefixCollision => {
+                self.handle_confirm_sprint_prefix_collision_popup(
+                    crossterm::event::KeyCode::Char('n'),
+                );
+            }
+            KeybindingAction::CancelPrefixCollision => {
+                self.handle_confirm_sprint_prefix_collision_popup(
+                    crossterm::event::KeyCode::Esc,
+                );
+            }
+            KeybindingAction::ForceOverwriteConflict => {
+                self.handle_conflict_resolution_popup(crossterm::event::KeyCode::Char('o'));
+            }
+            KeybindingAction::TakeTheirsConflict => {
+                self.handle_conflict_resolution_popup(crossterm::event::KeyCode::Char('t'));
+            }
+            KeybindingAction::CancelConflictResolution => {
+                self.handle_conflict_resolution_popup(crossterm::event::KeyCode::Esc);
+            }
+            KeybindingAction::ReloadDiscardLocal => {
+                self.handle_external_change_detected_popup(crossterm::event::KeyCode::Char('r'));
+            }
+            KeybindingAction::KeepLocalChanges => {
+                self.handle_external_change_detected_popup(crossterm::event::KeyCode::Char('k'));
+            }
+            KeybindingAction::DismissExternalChange => {
+                self.handle_external_change_detected_popup(crossterm::event::KeyCode::Esc);
+            }
         }
     }
 }

--- a/crates/kanban-tui/src/keybindings/dialog_modes.rs
+++ b/crates/kanban-tui/src/keybindings/dialog_modes.rs
@@ -219,3 +219,169 @@ impl KeybindingProvider for FilterOptionsProvider {
         )
     }
 }
+
+pub struct ConfirmSprintPrefixCollisionProvider;
+
+impl KeybindingProvider for ConfirmSprintPrefixCollisionProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "Confirm Sprint Prefix",
+            vec![
+                Keybinding::new(
+                    "y",
+                    "yes",
+                    "Use this prefix anyway",
+                    KeybindingAction::ConfirmPrefixCollision,
+                ),
+                Keybinding::new(
+                    "Enter",
+                    "yes",
+                    "Use this prefix anyway",
+                    KeybindingAction::ConfirmPrefixCollision,
+                ),
+                Keybinding::new(
+                    "n",
+                    "no",
+                    "Go back and choose a different prefix",
+                    KeybindingAction::RejectPrefixCollision,
+                ),
+                Keybinding::new(
+                    "ESC",
+                    "cancel",
+                    "Cancel",
+                    KeybindingAction::CancelPrefixCollision,
+                ),
+            ],
+        )
+    }
+}
+
+pub struct ConflictResolutionProvider;
+
+impl KeybindingProvider for ConflictResolutionProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "Resolve Conflict",
+            vec![
+                Keybinding::new(
+                    "o",
+                    "overwrite",
+                    "Keep your changes and overwrite the file on disk",
+                    KeybindingAction::ForceOverwriteConflict,
+                ),
+                Keybinding::new(
+                    "t",
+                    "take theirs",
+                    "Discard your changes and reload from disk",
+                    KeybindingAction::TakeTheirsConflict,
+                ),
+                Keybinding::new(
+                    "ESC",
+                    "retry later",
+                    "Cancel and decide again later",
+                    KeybindingAction::CancelConflictResolution,
+                ),
+            ],
+        )
+    }
+}
+
+pub struct ExternalChangeDetectedProvider;
+
+impl KeybindingProvider for ExternalChangeDetectedProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "External Change",
+            vec![
+                Keybinding::new(
+                    "r",
+                    "reload",
+                    "Reload from disk (discards your local changes)",
+                    KeybindingAction::ReloadDiscardLocal,
+                ),
+                Keybinding::new(
+                    "k",
+                    "keep local",
+                    "Keep local changes (discards the external write)",
+                    KeybindingAction::KeepLocalChanges,
+                ),
+                Keybinding::new(
+                    "ESC",
+                    "dismiss",
+                    "Dismiss and continue with current state",
+                    KeybindingAction::DismissExternalChange,
+                ),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod confirm_dialog_tests {
+    use super::*;
+
+    #[test]
+    fn test_confirm_sprint_prefix_collision_provider_advertises_real_keys_not_list_nav() {
+        let context = ConfirmSprintPrefixCollisionProvider.get_context();
+        let keys: Vec<&str> = context.bindings.iter().map(|b| b.key.as_str()).collect();
+        assert!(!keys.contains(&"j/↓"), "must not advertise dead list-nav 'j'");
+        assert!(!keys.contains(&"k/↑"), "must not advertise dead list-nav 'k'");
+        assert!(keys.contains(&"y"), "must advertise the real confirm key 'y'");
+        assert!(keys.contains(&"n"), "must advertise the real reject key 'n'");
+
+        let y_binding = context.bindings.iter().find(|b| b.key == "y").unwrap();
+        assert_eq!(y_binding.action, KeybindingAction::ConfirmPrefixCollision);
+        let n_binding = context.bindings.iter().find(|b| b.key == "n").unwrap();
+        assert_eq!(n_binding.action, KeybindingAction::RejectPrefixCollision);
+        let esc_binding = context.bindings.iter().find(|b| b.key == "ESC").unwrap();
+        assert_eq!(esc_binding.action, KeybindingAction::CancelPrefixCollision);
+    }
+
+    #[test]
+    fn test_conflict_resolution_provider_advertises_real_keys_not_list_nav() {
+        let context = ConflictResolutionProvider.get_context();
+        let keys: Vec<&str> = context.bindings.iter().map(|b| b.key.as_str()).collect();
+        assert!(!keys.contains(&"j/↓"), "must not advertise dead list-nav 'j'");
+        assert!(!keys.contains(&"k/↑"), "must not advertise dead list-nav 'k'");
+        assert!(
+            !keys.contains(&"Enter/Space"),
+            "must not advertise dead 'Enter' (nothing is selectable in this dialog)"
+        );
+        assert!(keys.contains(&"o"), "must advertise the real force-overwrite key 'o'");
+        assert!(keys.contains(&"t"), "must advertise the real take-theirs key 't'");
+
+        let o_binding = context.bindings.iter().find(|b| b.key == "o").unwrap();
+        assert_eq!(o_binding.action, KeybindingAction::ForceOverwriteConflict);
+        let t_binding = context.bindings.iter().find(|b| b.key == "t").unwrap();
+        assert_eq!(t_binding.action, KeybindingAction::TakeTheirsConflict);
+        let esc_binding = context.bindings.iter().find(|b| b.key == "ESC").unwrap();
+        assert_eq!(esc_binding.action, KeybindingAction::CancelConflictResolution);
+    }
+
+    #[test]
+    fn test_external_change_detected_provider_advertises_real_keys_not_list_nav() {
+        let context = ExternalChangeDetectedProvider.get_context();
+        let keys: Vec<&str> = context.bindings.iter().map(|b| b.key.as_str()).collect();
+        assert!(!keys.contains(&"j/↓"), "must not advertise dead list-nav 'j'");
+        assert!(
+            !keys.contains(&"Enter/Space"),
+            "must not advertise dead 'Enter' (nothing is selectable in this dialog)"
+        );
+        assert!(keys.contains(&"r"), "must advertise the real reload key 'r'");
+        assert!(keys.contains(&"k"), "must advertise the real keep-local key 'k'");
+
+        let r_binding = context.bindings.iter().find(|b| b.key == "r").unwrap();
+        assert_eq!(r_binding.action, KeybindingAction::ReloadDiscardLocal);
+        let k_binding = context.bindings.iter().find(|b| b.key == "k").unwrap();
+        assert_eq!(k_binding.action, KeybindingAction::KeepLocalChanges);
+        // The 'k' description must make the destructive discard explicit, not
+        // imply harmless list navigation (the exact bug this card fixes).
+        assert!(
+            k_binding.description.to_lowercase().contains("discard"),
+            "'k' must be described as discarding the external write, not 'up': {}",
+            k_binding.description
+        );
+        let esc_binding = context.bindings.iter().find(|b| b.key == "ESC").unwrap();
+        assert_eq!(esc_binding.action, KeybindingAction::DismissExternalChange);
+    }
+}

--- a/crates/kanban-tui/src/keybindings/dialog_modes.rs
+++ b/crates/kanban-tui/src/keybindings/dialog_modes.rs
@@ -324,10 +324,22 @@ mod confirm_dialog_tests {
     fn test_confirm_sprint_prefix_collision_provider_advertises_real_keys_not_list_nav() {
         let context = ConfirmSprintPrefixCollisionProvider.get_context();
         let keys: Vec<&str> = context.bindings.iter().map(|b| b.key.as_str()).collect();
-        assert!(!keys.contains(&"j/↓"), "must not advertise dead list-nav 'j'");
-        assert!(!keys.contains(&"k/↑"), "must not advertise dead list-nav 'k'");
-        assert!(keys.contains(&"y"), "must advertise the real confirm key 'y'");
-        assert!(keys.contains(&"n"), "must advertise the real reject key 'n'");
+        assert!(
+            !keys.contains(&"j/↓"),
+            "must not advertise dead list-nav 'j'"
+        );
+        assert!(
+            !keys.contains(&"k/↑"),
+            "must not advertise dead list-nav 'k'"
+        );
+        assert!(
+            keys.contains(&"y"),
+            "must advertise the real confirm key 'y'"
+        );
+        assert!(
+            keys.contains(&"n"),
+            "must advertise the real reject key 'n'"
+        );
 
         let y_binding = context.bindings.iter().find(|b| b.key == "y").unwrap();
         assert_eq!(y_binding.action, KeybindingAction::ConfirmPrefixCollision);
@@ -341,34 +353,58 @@ mod confirm_dialog_tests {
     fn test_conflict_resolution_provider_advertises_real_keys_not_list_nav() {
         let context = ConflictResolutionProvider.get_context();
         let keys: Vec<&str> = context.bindings.iter().map(|b| b.key.as_str()).collect();
-        assert!(!keys.contains(&"j/↓"), "must not advertise dead list-nav 'j'");
-        assert!(!keys.contains(&"k/↑"), "must not advertise dead list-nav 'k'");
+        assert!(
+            !keys.contains(&"j/↓"),
+            "must not advertise dead list-nav 'j'"
+        );
+        assert!(
+            !keys.contains(&"k/↑"),
+            "must not advertise dead list-nav 'k'"
+        );
         assert!(
             !keys.contains(&"Enter/Space"),
             "must not advertise dead 'Enter' (nothing is selectable in this dialog)"
         );
-        assert!(keys.contains(&"o"), "must advertise the real force-overwrite key 'o'");
-        assert!(keys.contains(&"t"), "must advertise the real take-theirs key 't'");
+        assert!(
+            keys.contains(&"o"),
+            "must advertise the real force-overwrite key 'o'"
+        );
+        assert!(
+            keys.contains(&"t"),
+            "must advertise the real take-theirs key 't'"
+        );
 
         let o_binding = context.bindings.iter().find(|b| b.key == "o").unwrap();
         assert_eq!(o_binding.action, KeybindingAction::ForceOverwriteConflict);
         let t_binding = context.bindings.iter().find(|b| b.key == "t").unwrap();
         assert_eq!(t_binding.action, KeybindingAction::TakeTheirsConflict);
         let esc_binding = context.bindings.iter().find(|b| b.key == "ESC").unwrap();
-        assert_eq!(esc_binding.action, KeybindingAction::CancelConflictResolution);
+        assert_eq!(
+            esc_binding.action,
+            KeybindingAction::CancelConflictResolution
+        );
     }
 
     #[test]
     fn test_external_change_detected_provider_advertises_real_keys_not_list_nav() {
         let context = ExternalChangeDetectedProvider.get_context();
         let keys: Vec<&str> = context.bindings.iter().map(|b| b.key.as_str()).collect();
-        assert!(!keys.contains(&"j/↓"), "must not advertise dead list-nav 'j'");
+        assert!(
+            !keys.contains(&"j/↓"),
+            "must not advertise dead list-nav 'j'"
+        );
         assert!(
             !keys.contains(&"Enter/Space"),
             "must not advertise dead 'Enter' (nothing is selectable in this dialog)"
         );
-        assert!(keys.contains(&"r"), "must advertise the real reload key 'r'");
-        assert!(keys.contains(&"k"), "must advertise the real keep-local key 'k'");
+        assert!(
+            keys.contains(&"r"),
+            "must advertise the real reload key 'r'"
+        );
+        assert!(
+            keys.contains(&"k"),
+            "must advertise the real keep-local key 'k'"
+        );
 
         let r_binding = context.bindings.iter().find(|b| b.key == "r").unwrap();
         assert_eq!(r_binding.action, KeybindingAction::ReloadDiscardLocal);

--- a/crates/kanban-tui/src/keybindings/dialog_modes.rs
+++ b/crates/kanban-tui/src/keybindings/dialog_modes.rs
@@ -410,8 +410,6 @@ mod confirm_dialog_tests {
         assert_eq!(r_binding.action, KeybindingAction::ReloadDiscardLocal);
         let k_binding = context.bindings.iter().find(|b| b.key == "k").unwrap();
         assert_eq!(k_binding.action, KeybindingAction::KeepLocalChanges);
-        // The 'k' description must make the destructive discard explicit, not
-        // imply harmless list navigation (the exact bug this card fixes).
         assert!(
             k_binding.description.to_lowercase().contains("discard"),
             "'k' must be described as discarding the external write, not 'up': {}",

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -69,6 +69,15 @@ pub enum KeybindingAction {
     Redo,
     OpenSettings,
     ExportBoards,
+    ConfirmPrefixCollision,
+    RejectPrefixCollision,
+    CancelPrefixCollision,
+    ForceOverwriteConflict,
+    TakeTheirsConflict,
+    CancelConflictResolution,
+    ReloadDiscardLocal,
+    KeepLocalChanges,
+    DismissExternalChange,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -3,10 +3,9 @@ use super::{
     card_detail::CardDetailProvider,
     card_list::CardListProvider,
     dialog_modes::{
-        ConfirmSprintPrefixCollisionProvider, ConflictResolutionProvider,
-        DeleteConfirmProvider, DialogInputProvider, DialogSelectionProvider,
-        ExternalChangeDetectedProvider, ErrorLogProvider, FilterOptionsProvider,
-        SearchModeProvider,
+        ConfirmSprintPrefixCollisionProvider, ConflictResolutionProvider, DeleteConfirmProvider,
+        DialogInputProvider, DialogSelectionProvider, ErrorLogProvider,
+        ExternalChangeDetectedProvider, FilterOptionsProvider, SearchModeProvider,
     },
     normal_mode::{
         ArchivedBoardsViewProvider, ArchivedCardsViewProvider, NormalModeBoardsProvider,

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -3,8 +3,10 @@ use super::{
     card_detail::CardDetailProvider,
     card_list::CardListProvider,
     dialog_modes::{
-        DeleteConfirmProvider, DialogInputProvider, DialogSelectionProvider, ErrorLogProvider,
-        FilterOptionsProvider, SearchModeProvider,
+        ConfirmSprintPrefixCollisionProvider, ConflictResolutionProvider,
+        DeleteConfirmProvider, DialogInputProvider, DialogSelectionProvider,
+        ExternalChangeDetectedProvider, ErrorLogProvider, FilterOptionsProvider,
+        SearchModeProvider,
     },
     normal_mode::{
         ArchivedBoardsViewProvider, ArchivedCardsViewProvider, NormalModeBoardsProvider,
@@ -129,5 +131,50 @@ impl KeybindingRegistry {
             },
             AppMode::ErrorLog => Box::new(ErrorLogProvider),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::App;
+
+    #[test]
+    fn test_registry_selects_bespoke_provider_for_confirm_sprint_prefix_collision() {
+        let mut app = App::test_default();
+        app.mode = AppMode::Dialog(DialogMode::ConfirmSprintPrefixCollision);
+
+        let context = KeybindingRegistry::get_provider(&app).get_context();
+
+        assert!(
+            context.bindings.iter().any(|b| b.key == "y"),
+            "must select the bespoke provider (advertises 'y'), not the generic list-picker provider"
+        );
+    }
+
+    #[test]
+    fn test_registry_selects_bespoke_provider_for_conflict_resolution() {
+        let mut app = App::test_default();
+        app.mode = AppMode::Dialog(DialogMode::ConflictResolution);
+
+        let context = KeybindingRegistry::get_provider(&app).get_context();
+
+        assert!(
+            context.bindings.iter().any(|b| b.key == "o"),
+            "must select the bespoke provider (advertises 'o'), not the generic list-picker provider"
+        );
+    }
+
+    #[test]
+    fn test_registry_selects_bespoke_provider_for_external_change_detected() {
+        let mut app = App::test_default();
+        app.mode = AppMode::Dialog(DialogMode::ExternalChangeDetected);
+
+        let context = KeybindingRegistry::get_provider(&app).get_context();
+
+        assert!(
+            context.bindings.iter().any(|b| b.key == "r"),
+            "must select the bespoke provider (advertises 'r'), not the generic list-picker provider"
+        );
     }
 }

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -105,15 +105,11 @@ impl KeybindingRegistry {
                 DialogMode::DeleteColumnConfirm => Box::new(DeleteConfirmProvider::new("Column")),
                 DialogMode::DeleteBoardConfirm => Box::new(DeleteConfirmProvider::new("Project")),
                 DialogMode::ConfirmSprintPrefixCollision => {
-                    Box::new(DialogSelectionProvider::new("Confirm Action"))
+                    Box::new(ConfirmSprintPrefixCollisionProvider)
                 }
                 DialogMode::FilterOptions => Box::new(FilterOptionsProvider),
-                DialogMode::ConflictResolution => {
-                    Box::new(DialogSelectionProvider::new("Resolve Conflict"))
-                }
-                DialogMode::ExternalChangeDetected => {
-                    Box::new(DialogSelectionProvider::new("External Change"))
-                }
+                DialogMode::ConflictResolution => Box::new(ConflictResolutionProvider),
+                DialogMode::ExternalChangeDetected => Box::new(ExternalChangeDetectedProvider),
                 DialogMode::ManageParents => Box::new(DialogSelectionProvider::new("Set Parents")),
                 DialogMode::ManageChildren => {
                     Box::new(DialogSelectionProvider::new("Set Children"))


### PR DESCRIPTION
`ConfirmSprintPrefixCollision`, `ConflictResolution`, and `ExternalChangeDetected` all borrowed the generic `DialogSelectionProvider` for their footer hints (`j`/`k`/`Enter`, a list-picker layout), but none of them are list pickers:

- `ConfirmSprintPrefixCollision` (`handlers/dialog_handlers.rs:436-454`): real keys are `Enter`/`y` (confirm), `n` (reject). `j`/`k` are dead.
- `ConflictResolution` (`handlers/dialog_handlers.rs:456-477`): real keys are `o` (force overwrite), `t` (take theirs/reload). `j`, `k`, and `Enter` are all dead.
- `ExternalChangeDetected` (`handlers/dialog_handlers.rs:479-497`): real keys are `r` (reload, discards local), `k` (keep local, discards the external write). `j` and `Enter` are dead.

`ExternalChangeDetected` is the serious one: this dialog fires when the file watcher detects an external write while local edits are unsaved (two `kanban-tui` instances, or an external script/CLI touching the same file). The wrong hint said `k = up`; the real behavior is "discard the external write, keep my local copy" — a user relying on the footer had no way to know `k` was about to silently throw away someone else's change, which then gets overwritten for real on the next autosave.

There's a second, non-cosmetic dimension to this bug: `KeybindingAction` also drives a real dispatch path via the in-app Help overlay (`?`) — `execute_action` (`app/keybindings.rs`) fires purely off the `KeybindingAction` tag, reachable by opening Help from inside any of these dialogs and selecting an entry. So the generic provider's mismatched actions meant the Help-menu path for these dialogs was *also* broken (e.g. selecting "Esc: cancel" from Help inside `ConflictResolution` would have called the wrong generic escape handler, which neither pops the dialog nor clears the conflict).

**What**:
- 9 new `KeybindingAction` variants (3 per dialog: confirm/reject/cancel for the prefix collision, force-overwrite/take-theirs/cancel for conflict resolution, reload/keep-local/dismiss for the external-change prompt), each wired in `execute_action` to call the *existing* popup handler with the representative key — reusing the exact logic the direct keypress already runs, no duplicated branches.
- 3 new bespoke provider structs (`ConfirmSprintPrefixCollisionProvider`, `ConflictResolutionProvider`, `ExternalChangeDetectedProvider`) advertising the real keys with accurate, specific descriptions (the `k` entry on `ExternalChangeDetected` explicitly says "discards the external write").
- Registry rewired to use the new providers for these three `DialogMode`s.

**Why**: The footer must reflect what a key actually does — this matters most where the mismatch hides a destructive action, and the Help-menu dispatch path needs to reach the same behavior as the direct key.

**How**: No changes to the popup handlers themselves — their key-dispatch logic was already correct. Only what's advertised and what the Help-menu path reaches were wrong.

**Testing**: New tests for provider content (advertised keys/actions match the real handlers, dead list-nav keys are absent), `execute_action` delegation (each new variant reaches the same observable outcome as the direct keypress — confirmed to fail against no-op placeholder arms first), and registry wiring (the three `DialogMode`s resolve to the bespoke providers, not the generic one — confirmed to fail against the old wiring first). `cargo test -p kanban-tui` (341 tests, no regressions), `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).