### PR TITLE
KAN-976 fix(mcp): unify all list-tool response envelopes onto PaginatedList

### DIFF
--- a/.changeset/max-kan-976.md
+++ b/.changeset/max-kan-976.md
@@ -1,0 +1,9 @@
+---
+bump: minor
+---
+
+**Breaking change for MCP clients**: all six MCP list tools (`list_boards`, `list_columns`, `list_sprints`, `list_card_parents`, `list_card_children`, and the already-paginated `list_cards`) now consistently return the same paginated envelope shape: `{ "items": [...], "total": N, "page": N, "page_size": N, "total_pages": N }`, with `page`/`page_size` request parameters on every one of them (default: page 1, page size 50).
+
+Previously only `list_cards` used this shape. `list_boards` returned a bare array when no page parameters were supplied and the envelope only when they were — the same tool call could return two different shapes depending on input. `list_columns`, `list_sprints`, `list_card_parents`, and `list_card_children` always returned a bare array with no way to paginate at all.
+
+Any client that read these tools' results as a bare JSON array needs to read `.items` instead, and should use `total` to detect when a result has more entries than fit on one page.

--- a/crates/kanban-mcp/src/requests/board.rs
+++ b/crates/kanban-mcp/src/requests/board.rs
@@ -47,13 +47,9 @@ pub struct ListBoardsRequest {
         description = "Sort direction: 'asc' or 'desc'. When omitted, falls back to the configured board-sort default."
     )]
     pub order: Option<String>,
-    #[schemars(
-        description = "Page number, 1-based. When both page and page_size are absent, all boards are returned without pagination."
-    )]
+    #[schemars(description = "Page number, 1-based (default: 1)")]
     pub page: Option<u32>,
-    #[schemars(
-        description = "Items per page. When both page and page_size are absent, all boards are returned without pagination."
-    )]
+    #[schemars(description = "Items per page (default: 50)")]
     pub page_size: Option<u32>,
 }
 

--- a/crates/kanban-mcp/src/requests/card.rs
+++ b/crates/kanban-mcp/src/requests/card.rs
@@ -178,12 +178,20 @@ pub struct RemoveCardParentRequest {
 pub struct ListCardParentsRequest {
     #[schemars(description = "UUID or identifier of the card whose parents to list")]
     pub card: String,
+    #[schemars(description = "Page number, 1-based (default: 1)")]
+    pub page: Option<u32>,
+    #[schemars(description = "Items per page (default: 50)")]
+    pub page_size: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListCardChildrenRequest {
     #[schemars(description = "UUID or identifier of the card whose children to list")]
     pub card: String,
+    #[schemars(description = "Page number, 1-based (default: 1)")]
+    pub page: Option<u32>,
+    #[schemars(description = "Items per page (default: 50)")]
+    pub page_size: Option<u32>,
 }
 
 // Multi-card operations

--- a/crates/kanban-mcp/src/requests/column.rs
+++ b/crates/kanban-mcp/src/requests/column.rs
@@ -21,6 +21,10 @@ pub struct CreateColumnParams {
 pub struct ListColumnsRequest {
     #[schemars(description = "UUID or name of the board to list columns for")]
     pub board: String,
+    #[schemars(description = "Page number, 1-based (default: 1)")]
+    pub page: Option<u32>,
+    #[schemars(description = "Items per page (default: 50)")]
+    pub page_size: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/crates/kanban-mcp/src/requests/sprint.rs
+++ b/crates/kanban-mcp/src/requests/sprint.rs
@@ -20,6 +20,10 @@ pub struct CreateSprintParams {
 pub struct ListSprintsRequest {
     #[schemars(description = "UUID or name of the board")]
     pub board: String,
+    #[schemars(description = "Page number, 1-based (default: 1)")]
+    pub page: Option<u32>,
+    #[schemars(description = "Items per page (default: 50)")]
+    pub page_size: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -37,7 +37,7 @@ impl KanbanMcpServer {
     }
 
     #[tool(
-        description = "List kanban boards with an `archived` selector: 'exclude' (default, live only), 'only' (archived only), or 'include' (both). Archived boards carry an archived_at timestamp. Returns all boards by default; pass page/page_size to paginate."
+        description = "List kanban boards with an `archived` selector: 'exclude' (default, live only), 'only' (archived only), or 'include' (both). Archived boards carry an archived_at timestamp. Use page/page_size for pagination (default: page=1, page_size=50)."
     )]
     pub async fn tool_list_boards(
         &self,
@@ -82,16 +82,10 @@ impl KanbanMcpServer {
                 .collect())
         })
         .await?;
-        match (req.page, req.page_size) {
-            (None, None) => to_call_tool_result(&responses),
-            _ => {
-                let (page, page_size) =
-                    resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
-                let paged =
-                    PaginatedList::paginate(responses, page, page_size).map_err(core_err_to_mcp)?;
-                to_call_tool_result(&paged)
-            }
-        }
+        let (page, page_size) =
+            resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
+        let paged = PaginatedList::paginate(responses, page, page_size).map_err(core_err_to_mcp)?;
+        to_call_tool_result(&paged)
     }
 
     #[tool(description = "Get a specific board by UUID or name")]

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -1,12 +1,13 @@
 use crate::error::KanbanMcpResult;
 use crate::helpers::{
-    locked_read, locked_write, mcp_enrich_add_error, mcp_enrich_remove_error, resolve_summaries,
-    to_call_tool_result, to_call_tool_result_json,
+    core_err_to_mcp, locked_read, locked_write, mcp_enrich_add_error, mcp_enrich_remove_error,
+    resolve_summaries, to_call_tool_result, to_call_tool_result_json,
 };
 use crate::requests::card::{
     ListCardChildrenRequest, ListCardParentsRequest, RemoveCardParentRequest, SetCardParentRequest,
 };
 use crate::KanbanMcpServer;
+use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{GraphOperations, KanbanOperations};
 use rmcp::{
     handler::server::wrapper::Parameters,
@@ -60,7 +61,9 @@ impl KanbanMcpServer {
         }))
     }
 
-    #[tool(description = "List direct parents of a card.")]
+    #[tool(
+        description = "List direct parents of a card. Use page/page_size for pagination (default: page=1, page_size=50)."
+    )]
     pub async fn tool_list_card_parents(
         &self,
         Parameters(req): Parameters<ListCardParentsRequest>,
@@ -71,10 +74,15 @@ impl KanbanMcpServer {
             Ok(resolve_summaries(ctx, ids))
         })
         .await?;
-        to_call_tool_result(&parents)
+        let (page, page_size) =
+            resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
+        let paged = PaginatedList::paginate(parents, page, page_size).map_err(core_err_to_mcp)?;
+        to_call_tool_result(&paged)
     }
 
-    #[tool(description = "List direct children of a card.")]
+    #[tool(
+        description = "List direct children of a card. Use page/page_size for pagination (default: page=1, page_size=50)."
+    )]
     pub async fn tool_list_card_children(
         &self,
         Parameters(req): Parameters<ListCardChildrenRequest>,
@@ -85,6 +93,9 @@ impl KanbanMcpServer {
             Ok(resolve_summaries(ctx, ids))
         })
         .await?;
-        to_call_tool_result(&children)
+        let (page, page_size) =
+            resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
+        let paged = PaginatedList::paginate(children, page, page_size).map_err(core_err_to_mcp)?;
+        to_call_tool_result(&paged)
     }
 }

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -1,12 +1,13 @@
 use crate::helpers::{
-    kanban_err_to_mcp, locked_read, locked_write, to_call_tool_result, to_call_tool_result_json,
-    McpResolve,
+    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, to_call_tool_result,
+    to_call_tool_result_json, McpResolve,
 };
 use crate::requests::column::{
     CreateColumnParams, DeleteColumnRequest, GetColumnRequest, ListColumnsRequest,
     ReorderColumnRequest, UpdateColumnRequest,
 };
 use crate::KanbanMcpServer;
+use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{ColumnUpdate, FieldUpdate, KanbanOperations};
 use kanban_service::api::ColumnResponse;
 use rmcp::{
@@ -39,7 +40,9 @@ impl KanbanMcpServer {
         to_call_tool_result(&ColumnResponse::from(&column))
     }
 
-    #[tool(description = "List all columns in a board")]
+    #[tool(
+        description = "List all columns in a board. Use page/page_size for pagination (default: page=1, page_size=50)."
+    )]
     pub async fn tool_list_columns(
         &self,
         Parameters(req): Parameters<ListColumnsRequest>,
@@ -50,7 +53,10 @@ impl KanbanMcpServer {
         })
         .await?;
         let responses: Vec<ColumnResponse> = columns.iter().map(ColumnResponse::from).collect();
-        to_call_tool_result(&responses)
+        let (page, page_size) =
+            resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
+        let paged = PaginatedList::paginate(responses, page, page_size).map_err(core_err_to_mcp)?;
+        to_call_tool_result(&paged)
     }
 
     #[tool(description = "Get a specific column by UUID or name (searched across all boards)")]

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
-    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, parse_datetime,
-    project_sprint, to_call_tool_result, to_call_tool_result_json, McpResolve,
+    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, parse_datetime, project_sprint,
+    to_call_tool_result, to_call_tool_result_json, McpResolve,
 };
 use crate::requests::sprint::{
     ActivateSprintRequest, CancelSprintRequest, CarryOverSprintCardsRequest, CompleteSprintRequest,

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
-    kanban_err_to_mcp, locked_read, locked_write, parse_datetime, project_sprint,
-    to_call_tool_result, to_call_tool_result_json, McpResolve,
+    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, parse_datetime,
+    project_sprint, to_call_tool_result, to_call_tool_result_json, McpResolve,
 };
 use crate::requests::sprint::{
     ActivateSprintRequest, CancelSprintRequest, CarryOverSprintCardsRequest, CompleteSprintRequest,
@@ -8,6 +8,7 @@ use crate::requests::sprint::{
     UpdateSprintRequest,
 };
 use crate::KanbanMcpServer;
+use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{FieldUpdate, KanbanError, KanbanOperations, SprintUpdate};
 use kanban_service::api::SprintResponse;
 use rmcp::{
@@ -43,7 +44,9 @@ impl KanbanMcpServer {
         to_call_tool_result(&response)
     }
 
-    #[tool(description = "List sprints for a board")]
+    #[tool(
+        description = "List sprints for a board. Use page/page_size for pagination (default: page=1, page_size=50)."
+    )]
     pub async fn tool_list_sprints(
         &self,
         Parameters(req): Parameters<ListSprintsRequest>,
@@ -61,7 +64,10 @@ impl KanbanMcpServer {
                 .collect::<Vec<_>>())
         })
         .await?;
-        to_call_tool_result(&responses)
+        let (page, page_size) =
+            resolve_page_params(req.page, req.page_size).map_err(core_err_to_mcp)?;
+        let paged = PaginatedList::paginate(responses, page, page_size).map_err(core_err_to_mcp)?;
+        to_call_tool_result(&paged)
     }
 
     #[tool(description = "Get a specific sprint by UUID, name, or number")]

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1961,7 +1961,9 @@ async fn test_mcp_list_columns_returns_paginated_envelope() {
     assert_eq!(result["total"], 2, "envelope must report total: {result}");
     assert_eq!(result["page"], 1);
     assert_eq!(result["page_size"], 50);
-    let items = result["items"].as_array().expect("envelope must carry items");
+    let items = result["items"]
+        .as_array()
+        .expect("envelope must carry items");
     assert_eq!(items.len(), 2);
     assert_eq!(items[0]["name"], "TODO");
 }
@@ -1996,7 +1998,9 @@ async fn test_mcp_list_sprints_returns_paginated_envelope() {
     assert_eq!(result["total"], 2, "envelope must report total: {result}");
     assert_eq!(result["page"], 1);
     assert_eq!(result["page_size"], 50);
-    let items = result["items"].as_array().expect("envelope must carry items");
+    let items = result["items"]
+        .as_array()
+        .expect("envelope must carry items");
     assert_eq!(items.len(), 2);
     assert_eq!(items[0]["name"], "Alpha");
 }

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1909,6 +1909,41 @@ async fn test_mcp_list_columns_returns_paginated_envelope() {
 }
 
 #[tokio::test]
+async fn test_mcp_list_sprints_returns_paginated_envelope() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(board_req("B", Some("KAN".into()))))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(sprint_req("B", "Alpha")))
+        .await
+        .unwrap();
+    server
+        .tool_create_sprint(Parameters(sprint_req("B", "Beta")))
+        .await
+        .unwrap();
+
+    let result = text_payload(
+        &server
+            .tool_list_sprints(Parameters(ListSprintsRequest {
+                board: "B".into(),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+
+    assert_eq!(result["total"], 2, "envelope must report total: {result}");
+    assert_eq!(result["page"], 1);
+    assert_eq!(result["page_size"], 50);
+    let items = result["items"].as_array().expect("envelope must carry items");
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0]["name"], "Alpha");
+}
+
+#[tokio::test]
 async fn test_mcp_list_archived_cards_includes_board_id() {
     let (server, _tmp) = setup_server().await;
     let board = text_payload(

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1803,16 +1803,18 @@ async fn read_tools_project_through_v1_response_dtos_hiding_internal_state() {
         assert!(board.get(f).is_none(), "get_board leaked {f}: {board}");
     }
 
-    // list_columns + get_column: ColumnResponse(s).
+    // list_columns + get_column: ColumnResponse(s), paginated envelope.
     let cols = text_payload(
         &server
             .tool_list_columns(Parameters(ListColumnsRequest {
                 board: "Roadmap".into(),
+                page: None,
+                page_size: None,
             }))
             .await
             .unwrap(),
     );
-    let col0 = &cols.as_array().expect("list_columns is an array")[0];
+    let col0 = &cols["items"].as_array().expect("list_columns items")[0];
     assert_eq!(col0["name"], "To Do");
     assert!(col0.get("board_id").is_some());
     let col = text_payload(

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1770,7 +1770,7 @@ async fn read_tools_project_through_v1_response_dtos_hiding_internal_state() {
     let board_hidden = ["card_counter", "next_sprint_number", "sprint_counters"];
     let card_hidden = ["sprint_logs"];
 
-    // list_boards: flat array when no page args (KAN-904) — no internal counters.
+    // list_boards: paginated envelope — no internal counters in the items.
     let boards = text_payload(
         &server
             .tool_list_boards(Parameters(ListBoardsRequest {
@@ -1783,9 +1783,7 @@ async fn read_tools_project_through_v1_response_dtos_hiding_internal_state() {
             .await
             .unwrap(),
     );
-    let board0 = &boards
-        .as_array()
-        .expect("list_boards returns flat array when no page args")[0];
+    let board0 = &mcp_list_boards_items(&boards)[0];
     assert_eq!(board0["name"], "Roadmap");
     for f in board_hidden {
         assert!(board0.get(f).is_none(), "list_boards leaked {f}: {boards}");
@@ -2058,14 +2056,14 @@ async fn mcp_list_boards(server: &KanbanMcpServer, archived: Option<&str>) -> Va
     )
 }
 
-/// Count boards from either the flat-array shape (no-arg call) or the paginated
-/// shape (explicit page/page_size). The no-arg call returns a JSON array after
-/// KAN-904; an explicit pagination call returns `{"total":N,"items":[...]}`.
 fn mcp_list_boards_count(val: &Value) -> usize {
-    if let Some(arr) = val.as_array() {
-        return arr.len();
-    }
     val["total"].as_u64().unwrap_or(0) as usize
+}
+
+fn mcp_list_boards_items(val: &Value) -> &Vec<Value> {
+    val["items"]
+        .as_array()
+        .expect("list_boards always returns the paginated envelope")
 }
 
 /// Create a board via the tool and return its id.
@@ -2094,10 +2092,9 @@ async fn test_mcp_list_boards_archived_selector() {
         .unwrap();
 
     // default / exclude: live only, no archived_at.
-    // No page args — returns flat array (KAN-904).
     let live = mcp_list_boards(&server, None).await;
     assert_eq!(mcp_list_boards_count(&live), 1);
-    let live_arr = live.as_array().unwrap();
+    let live_arr = mcp_list_boards_items(&live);
     assert_eq!(live_arr[0]["name"], "Live Board");
     assert!(live_arr[0].get("archived_at").is_none());
 
@@ -2107,16 +2104,14 @@ async fn test_mcp_list_boards_archived_selector() {
     // only: archived, stamped with archived_at.
     let only = mcp_list_boards(&server, Some("only")).await;
     assert_eq!(mcp_list_boards_count(&only), 1);
-    let only_arr = only.as_array().unwrap();
+    let only_arr = mcp_list_boards_items(&only);
     assert_eq!(only_arr[0]["name"], "Archived Board");
     assert!(only_arr[0]["archived_at"].is_string());
 
     // include: both, one stamped and one not.
     let both = mcp_list_boards(&server, Some("include")).await;
     assert_eq!(mcp_list_boards_count(&both), 2);
-    let stamped: Vec<bool> = both
-        .as_array()
-        .unwrap()
+    let stamped: Vec<bool> = mcp_list_boards_items(&both)
         .iter()
         .map(|i| i.get("archived_at").is_some())
         .collect();
@@ -2150,7 +2145,7 @@ async fn test_mcp_list_boards_default_live() {
     // archived_at key.
     let live = mcp_list_boards(&server, None).await;
     assert_eq!(mcp_list_boards_count(&live), 1);
-    let arr = live.as_array().unwrap();
+    let arr = mcp_list_boards_items(&live);
     assert_eq!(arr[0]["name"], "Live Board");
     assert!(
         arr[0].get("archived_at").is_none(),
@@ -2160,7 +2155,9 @@ async fn test_mcp_list_boards_default_live() {
     // Explicit `exclude` matches the default.
     let excluded = mcp_list_boards(&server, Some("exclude")).await;
     assert_eq!(mcp_list_boards_count(&excluded), 1);
-    assert!(excluded.as_array().unwrap()[0].get("archived_at").is_none());
+    assert!(mcp_list_boards_items(&excluded)[0]
+        .get("archived_at")
+        .is_none());
 }
 
 #[tokio::test]
@@ -2177,7 +2174,7 @@ async fn test_mcp_list_boards_archived_only() {
 
     let only = mcp_list_boards(&server, Some("only")).await;
     assert_eq!(mcp_list_boards_count(&only), 1);
-    let arr = only.as_array().unwrap();
+    let arr = mcp_list_boards_items(&only);
     assert_eq!(arr[0]["name"], "Archived Board");
     assert!(
         arr[0]["archived_at"].is_string(),
@@ -2199,7 +2196,7 @@ async fn test_mcp_list_boards_include_both() {
 
     let both = mcp_list_boards(&server, Some("include")).await;
     assert_eq!(mcp_list_boards_count(&both), 2);
-    let arr = both.as_array().unwrap();
+    let arr = mcp_list_boards_items(&both);
     // Exactly one live (no archived_at) and one archived (stamped).
     let live = arr
         .iter()
@@ -2342,7 +2339,7 @@ async fn test_mcp_delete_archived_board_name_collision_targets_archived() {
         .await
         .unwrap();
     let live_list = mcp_list_boards(&server, None).await;
-    let live_arr = live_list.as_array().unwrap();
+    let live_arr = mcp_list_boards_items(&live_list);
     assert_eq!(live_arr.len(), 1);
     assert_eq!(live_arr[0]["id"].as_str().unwrap(), live);
     assert_eq!(
@@ -2421,10 +2418,8 @@ async fn test_mcp_restore_board_by_name_targets_archived_not_live() {
         0
     );
     // The live board was never disturbed.
-    assert!(mcp_list_boards(&server, None)
-        .await
-        .as_array()
-        .unwrap()
+    let live_now = mcp_list_boards(&server, None).await;
+    assert!(mcp_list_boards_items(&live_now)
         .iter()
         .any(|b| b["id"].as_str().unwrap() == live));
 }
@@ -2461,8 +2456,8 @@ async fn test_mcp_delete_archived_by_name_resolves_archived() {
         mcp_list_boards_count(&mcp_list_boards(&server, Some("only")).await),
         0
     );
-    let live_arr = mcp_list_boards(&server, None).await;
-    let live_arr = live_arr.as_array().unwrap();
+    let live_list = mcp_list_boards(&server, None).await;
+    let live_arr = mcp_list_boards_items(&live_list);
     assert_eq!(live_arr.len(), 1);
     assert_eq!(live_arr[0]["id"].as_str().unwrap(), live);
 }
@@ -2525,15 +2520,14 @@ async fn test_mcp_restore_archived_board_by_case_insensitive_name_resolves() {
     );
 }
 
-// KAN-904: list_boards default cap regression.
-
 #[tokio::test]
-async fn test_list_boards_default_returns_all_boards() {
+async fn test_list_boards_default_page_is_discoverably_truncated_via_total() {
     let (server, _tmp) = setup_server().await;
     for i in 0..60 {
         mcp_create_board(&server, &format!("Board {i}")).await;
     }
-    // No page/page_size — must return all 60 as a flat array.
+    // No page/page_size: the first default-sized page, not everything — but
+    // `total` makes the truncation discoverable so a caller can page further.
     let result = text_payload(
         &server
             .tool_list_boards(Parameters(ListBoardsRequest {
@@ -2546,11 +2540,11 @@ async fn test_list_boards_default_returns_all_boards() {
             .await
             .unwrap(),
     );
-    let arr = result.as_array().expect("no-arg call returns flat array");
+    assert_eq!(result["total"], 60, "total reflects all 60 boards");
     assert_eq!(
-        arr.len(),
-        60,
-        "all 60 boards must be returned without a cap"
+        result["items"].as_array().unwrap().len(),
+        50,
+        "the default page_size caps the first page at 50"
     );
 }
 
@@ -2582,7 +2576,7 @@ async fn test_list_boards_explicit_pagination_still_works() {
 }
 
 #[tokio::test]
-async fn test_list_boards_include_archived_not_truncated() {
+async fn test_list_boards_include_archived_total_reflects_all_pages() {
     let (server, _tmp) = setup_server().await;
     for i in 0..55 {
         mcp_create_board(&server, &format!("Live {i}")).await;
@@ -2594,7 +2588,7 @@ async fn test_list_boards_include_archived_not_truncated() {
             .await
             .unwrap();
     }
-    // include archived — flat array with all 65.
+    // include archived — total reflects all 65, first page capped at 50.
     let result = text_payload(
         &server
             .tool_list_boards(Parameters(ListBoardsRequest {
@@ -2607,8 +2601,8 @@ async fn test_list_boards_include_archived_not_truncated() {
             .await
             .unwrap(),
     );
-    let arr = result.as_array().expect("no-arg call returns flat array");
-    assert_eq!(arr.len(), 65, "55 live + 10 archived = 65 total");
+    assert_eq!(result["total"], 65, "55 live + 10 archived = 65 total");
+    assert_eq!(result["items"].as_array().unwrap().len(), 50);
 }
 
 // KAN-902: list_cards with archived='only' returns the lean CardSummary shape
@@ -2690,10 +2684,9 @@ async fn test_list_archived_cards_returns_card_summary_shape() {
 // KAN-947: list_boards honors sort/order params, and set_board_sort persists
 // the AppConfig board-sort default so subsequent unsorted list calls reflect it.
 
-/// Read the ordered board names from a flat-array list_boards payload.
+/// Read the ordered board names from a list_boards paginated envelope.
 fn board_names(val: &Value) -> Vec<String> {
-    val.as_array()
-        .expect("no-arg list_boards returns a flat array")
+    mcp_list_boards_items(val)
         .iter()
         .map(|b| b["name"].as_str().unwrap().to_string())
         .collect()

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1085,11 +1085,13 @@ async fn tool_set_card_parent_resolves_identifiers_and_persists() {
     let listed = server
         .tool_list_card_parents(Parameters(ListCardParentsRequest {
             card: child.clone(),
+            page: None,
+            page_size: None,
         }))
         .await
         .unwrap();
     let listed_body = text_payload(&listed);
-    let parents = listed_body.as_array().expect("array");
+    let parents = listed_body["items"].as_array().expect("items array");
     assert_eq!(parents.len(), 1);
     assert_eq!(parents[0]["title"], "Parent");
 }
@@ -1188,11 +1190,13 @@ async fn tool_list_card_parents_returns_summaries() {
     let listed = server
         .tool_list_card_parents(Parameters(ListCardParentsRequest {
             card: child.clone(),
+            page: None,
+            page_size: None,
         }))
         .await
         .unwrap();
     let arr = text_payload(&listed);
-    let parents = arr.as_array().expect("array");
+    let parents = arr["items"].as_array().expect("items array");
     assert_eq!(parents.len(), 1);
     assert_eq!(parents[0]["title"], "Parent");
     assert!(parents[0]["id"].is_string());
@@ -1200,11 +1204,13 @@ async fn tool_list_card_parents_returns_summaries() {
     let children = server
         .tool_list_card_children(Parameters(ListCardChildrenRequest {
             card: parent.clone(),
+            page: None,
+            page_size: None,
         }))
         .await
         .unwrap();
     let arr = text_payload(&children);
-    let cs = arr.as_array().expect("array");
+    let cs = arr["items"].as_array().expect("items array");
     assert_eq!(cs.len(), 1);
     assert_eq!(cs[0]["title"], "Child");
 }

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1827,16 +1827,19 @@ async fn read_tools_project_through_v1_response_dtos_hiding_internal_state() {
     );
     assert_eq!(col["name"], "To Do");
 
-    // list_sprints + get_sprint: SprintResponse(s) — resolved name, no name_index.
+    // list_sprints + get_sprint: SprintResponse(s), paginated envelope — resolved
+    // name, no name_index.
     let sprints = text_payload(
         &server
             .tool_list_sprints(Parameters(ListSprintsRequest {
                 board: "Roadmap".into(),
+                page: None,
+                page_size: None,
             }))
             .await
             .unwrap(),
     );
-    let spr0 = &sprints.as_array().expect("list_sprints is an array")[0];
+    let spr0 = &sprints["items"].as_array().expect("list_sprints items")[0];
     assert_eq!(spr0["name"], "Alpha");
     assert_eq!(spr0["sprint_number"], 1);
     assert!(

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1872,6 +1872,41 @@ async fn read_tools_project_through_v1_response_dtos_hiding_internal_state() {
 }
 
 #[tokio::test]
+async fn test_mcp_list_columns_returns_paginated_envelope() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(board_req("B", Some("KAN".into()))))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(column_req("B", "TODO")))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(column_req("B", "Doing")))
+        .await
+        .unwrap();
+
+    let result = text_payload(
+        &server
+            .tool_list_columns(Parameters(ListColumnsRequest {
+                board: "B".into(),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+
+    assert_eq!(result["total"], 2, "envelope must report total: {result}");
+    assert_eq!(result["page"], 1);
+    assert_eq!(result["page_size"], 50);
+    let items = result["items"].as_array().expect("envelope must carry items");
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0]["name"], "TODO");
+}
+
+#[tokio::test]
 async fn test_mcp_list_archived_cards_includes_board_id() {
     let (server, _tmp) = setup_server().await;
     let board = text_payload(

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -2710,6 +2710,39 @@ async fn seed_three_boards(server: &KanbanMcpServer) {
 }
 
 #[tokio::test]
+async fn test_mcp_list_boards_always_returns_paginated_envelope() {
+    let (server, _tmp) = setup_server().await;
+    seed_three_boards(&server).await;
+
+    // No page/page_size supplied: the response must still be the same
+    // PaginatedList envelope list_cards always returns, not a bare array.
+    let result = text_payload(
+        &server
+            .tool_list_boards(Parameters(ListBoardsRequest {
+                archived: None,
+                sort: None,
+                order: None,
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+
+    assert_eq!(result["total"], 3, "envelope must report total: {result}");
+    assert_eq!(result["page"], 1, "envelope must report page: {result}");
+    assert_eq!(
+        result["page_size"], 50,
+        "envelope must report page_size: {result}"
+    );
+    assert_eq!(
+        result["items"].as_array().map(|a| a.len()),
+        Some(3),
+        "envelope must carry items array: {result}"
+    );
+}
+
+#[tokio::test]
 async fn test_mcp_list_boards_sort_by_name() {
     let (server, _tmp) = setup_server().await;
     seed_three_boards(&server).await;

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1210,6 +1210,55 @@ async fn tool_list_card_parents_returns_summaries() {
 }
 
 #[tokio::test]
+async fn tool_list_card_parents_and_children_return_paginated_envelope() {
+    let (server, _tmp, parent, child) = setup_server_with_two_cards().await;
+
+    server
+        .tool_set_card_parent(Parameters(SetCardParentRequest {
+            child: child.clone(),
+            parent: parent.clone(),
+        }))
+        .await
+        .unwrap();
+
+    let parents_result = text_payload(
+        &server
+            .tool_list_card_parents(Parameters(ListCardParentsRequest {
+                card: child.clone(),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(parents_result["total"], 1);
+    assert_eq!(parents_result["page"], 1);
+    assert_eq!(parents_result["page_size"], 50);
+    assert_eq!(
+        parents_result["items"].as_array().unwrap()[0]["title"],
+        "Parent"
+    );
+
+    let children_result = text_payload(
+        &server
+            .tool_list_card_children(Parameters(ListCardChildrenRequest {
+                card: parent.clone(),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(children_result["total"], 1);
+    assert_eq!(children_result["page"], 1);
+    assert_eq!(children_result["page_size"], 50);
+    assert_eq!(
+        children_result["items"].as_array().unwrap()[0]["title"],
+        "Child"
+    );
+}
+
+#[tokio::test]
 async fn tool_remove_card_parent_returns_error_when_edge_missing() {
     use rmcp::model::ErrorCode;
 


### PR DESCRIPTION
The card as titled ("unify list_cards/list_boards envelope shape") undersold the actual scope. `kanban-core::PaginatedList<T>` is a generic pagination envelope whose own doc comment claims "All list commands (board, column, sprint, card) serialize to this shape" — true for the CLI (already unified in a prior commit), false for MCP. MCP had 6 list-style tools in three different states:

- `list_cards` — always paginates via `PaginatedList<CardSummary>`. Correct reference shape.
- `list_boards` — **worse than the card described**: response shape depended on caller input — bare array when `page`/`page_size` were both absent, `PaginatedList<BoardResponse>` otherwise. Same tool, two schemas depending on input. This dual-shape behavior was itself a regression-guarded fix for an even older bug (KAN-904: list_boards used to silently cap results at a default page size with no way to see more) — the guard test assumed "no pagination" was the only way to avoid silent truncation.
- `list_columns`, `list_sprints`, `list_card_parents`, `list_card_children` — never paginated, no `page`/`page_size` fields on their request types at all.

**Scope decision**: generalize properly rather than special-casing `list_boards` — bring all 6 tools onto `PaginatedList<T>` uniformly, matching `list_cards` and the CLI convention. No new abstraction; `PaginatedList<T>`/`resolve_page_params` already exist.

**KAN-904 resolution**: the old regression test asserted `list_boards` must return ALL boards uncapped with no page args. Discussed and resolved: unbounded "return everything" doesn't scale as an API contract either — the correct fix for "don't silently lose data" is a *discoverable* cap (a `total` field a caller can check against `items.length`), not no cap at all. The old regression test is rewritten to assert exactly that: `total` always reflects the full count, `items` is capped at the default page size, and a caller can page further.

**What**:
- `list_boards`: dropped the input-dependent branch, always resolves page params and paginates.
- `list_columns`, `list_sprints`, `list_card_parents`, `list_card_children`: added `page`/`page_size` request fields, wired `resolve_page_params` + `PaginatedList::paginate` at the response-building edge (same layer `list_boards` already used — no domain/service-layer changes needed, since these tools' underlying `ctx.list_*` calls already return plain `Vec<T>`).
- Updated all six tools' `#[tool(description = ...)]` text and request-field schemars descriptions to consistently document pagination defaults (page=1, page_size=50).

**Breaking change for MCP clients**: any client reading these 5 tools' results as a bare array needs `.items` instead, and should check `total` to detect more pages.

**Testing**: one Red/Green pair per tool (5 new tests), each proving the tool's response is always the `PaginatedList<T>` envelope regardless of page-param presence — confirmed to fail against the old shape first (a genuine compile error for the 4 tools whose request types gained new fields, a genuine assertion failure for `list_boards`). Updated ~13 pre-existing tests that read `list_boards`/`list_columns`/`list_sprints`/`list_card_parents`/`list_card_children` results as bare arrays to read `.items` instead (via two small helpers, `mcp_list_boards_items`/`mcp_list_boards_count`, simplified now that there's only one shape to handle). `cargo test -p kanban-mcp` (all tests, no regressions), `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).