### PR TITLE
KAN-974 fix(tui): help-menu no-op actions (EditCard/CarryOver/ExportBoards)

### DIFF
--- a/.changeset/max-kan-974.md
+++ b/.changeset/max-kan-974.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Actions invoked through the in-app help overlay (`?`) now actually run instead of silently doing nothing for four of them: copying a card's branch name (`y`) or git checkout command (`Y`) from the card or sprint detail views, carrying over a completed sprint's tasks (`M`), and exporting all boards (`x`). These all already worked as direct keypresses; only reaching them through the help menu was broken.

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -161,6 +161,8 @@ impl App {
             KeybindingAction::DismissExternalChange => {
                 self.handle_external_change_detected_popup(KeyCode::Esc);
             }
+            KeybindingAction::CopyBranchName => {}
+            KeybindingAction::CopyGitCheckoutCommand => {}
         }
     }
 }
@@ -301,6 +303,134 @@ mod tests {
             app.mode,
             AppMode::Dialog(DialogMode::ExternalChangeDetected),
             "DismissExternalChange must reach the same behavior as pressing Esc directly"
+        );
+    }
+
+    fn seed_board_with_card(app: &mut App) -> uuid::Uuid {
+        use kanban_domain::{CreateCardOptions, KanbanOperations};
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "TODO".into(), None)
+            .unwrap();
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Task".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        app.prepare_frame();
+        card.id
+    }
+
+    #[test]
+    fn test_execute_action_copy_branch_name_in_card_detail_reaches_copy() {
+        let mut app = App::test_default();
+        let card_id = seed_board_with_card(&mut app);
+        app.mode = AppMode::CardDetail;
+        app.selection.active_card_id = Some(card_id);
+
+        app.execute_action(&KeybindingAction::CopyBranchName);
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "CopyBranchName in CardDetail must reach the copy call (observable via a result banner)"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_copy_git_checkout_command_in_card_detail_reaches_copy() {
+        let mut app = App::test_default();
+        let card_id = seed_board_with_card(&mut app);
+        app.mode = AppMode::CardDetail;
+        app.selection.active_card_id = Some(card_id);
+
+        app.execute_action(&KeybindingAction::CopyGitCheckoutCommand);
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "CopyGitCheckoutCommand in CardDetail must reach the copy call"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_copy_branch_name_in_sprint_detail_reaches_copy() {
+        use crate::app::sprint_view::SprintTaskPanel;
+        let mut app = App::test_default();
+        let card_id = seed_board_with_card(&mut app);
+        app.sprint_view.panel = SprintTaskPanel::Uncompleted;
+        app.sprint_view
+            .uncompleted_component
+            .update_cards(vec![card_id]);
+        app.sprint_view
+            .uncompleted_component
+            .set_selected_index(Some(0));
+        app.mode = AppMode::SprintDetail;
+
+        app.execute_action(&KeybindingAction::CopyBranchName);
+
+        assert_eq!(
+            app.selection.active_card_id,
+            Some(card_id),
+            "CopyBranchName in SprintDetail must resolve and activate the panel's selected card"
+        );
+        assert!(
+            app.ui_state.banner.is_some(),
+            "CopyBranchName in SprintDetail must reach the copy call"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_carry_over_opens_dialog_for_eligible_sprint() {
+        use kanban_domain::{KanbanOperations, SprintStatus};
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        // A Planning sprint must exist for carry-over to have a target.
+        app.ctx
+            .create_sprint(board.id, None, Some("Next".into()))
+            .unwrap();
+        let completed = app
+            .ctx
+            .create_sprint(board.id, None, Some("Current".into()))
+            .unwrap();
+        app.ctx.activate_sprint(completed.id, None).unwrap();
+        app.ctx.complete_sprint(completed.id).unwrap();
+        app.prepare_frame();
+        let sprint_idx = app
+            .model
+            .sprints()
+            .iter()
+            .position(|s| s.id == completed.id && s.status == SprintStatus::Completed)
+            .expect("completed sprint present");
+        app.selection.active_sprint_index = Some(sprint_idx);
+        app.mode = AppMode::SprintDetail;
+
+        app.execute_action(&KeybindingAction::CarryOver);
+
+        assert_eq!(
+            app.mode,
+            AppMode::Dialog(DialogMode::CarryOverSprint),
+            "CarryOver on an eligible (Completed) sprint must open the carry-over dialog"
+        );
+    }
+
+    #[test]
+    fn test_execute_action_export_boards_opens_dialog() {
+        use kanban_domain::KanbanOperations;
+        let mut app = App::test_default();
+        app.ctx.create_board("Board".into(), None).unwrap();
+        app.prepare_frame();
+        app.mode = AppMode::Settings;
+
+        app.execute_action(&KeybindingAction::ExportBoards);
+
+        assert_eq!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ExportBoards),
+            "ExportBoards with a live board must open the export dialog"
         );
     }
 }

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -121,7 +121,7 @@ impl App {
             KeybindingAction::JumpHalfViewportDown => self.handle_jump_half_viewport_down(),
             KeybindingAction::ManageParents => self.handle_manage_parents(),
             KeybindingAction::ManageChildren => self.handle_manage_children(),
-            KeybindingAction::CarryOver => {}
+            KeybindingAction::CarryOver => self.carry_over_active_sprint_if_eligible(),
             KeybindingAction::Undo => {
                 if let Err(e) = self.undo() {
                     self.set_error(format!("Undo failed: {}", e));
@@ -133,7 +133,7 @@ impl App {
                 }
             }
             KeybindingAction::OpenSettings => self.handle_open_settings(),
-            KeybindingAction::ExportBoards => {}
+            KeybindingAction::ExportBoards => self.open_export_boards_dialog(),
             KeybindingAction::ConfirmPrefixCollision => {
                 self.handle_confirm_sprint_prefix_collision_popup(KeyCode::Enter);
             }
@@ -161,8 +161,28 @@ impl App {
             KeybindingAction::DismissExternalChange => {
                 self.handle_external_change_detected_popup(KeyCode::Esc);
             }
-            KeybindingAction::CopyBranchName => {}
-            KeybindingAction::CopyGitCheckoutCommand => {}
+            KeybindingAction::CopyBranchName => {
+                if self.mode == AppMode::SprintDetail {
+                    if let Some(card_id) = self.sprint_detail_selected_card_id() {
+                        if self.activate_card(card_id) {
+                            self.copy_branch_name();
+                        }
+                    }
+                } else {
+                    self.copy_branch_name();
+                }
+            }
+            KeybindingAction::CopyGitCheckoutCommand => {
+                if self.mode == AppMode::SprintDetail {
+                    if let Some(card_id) = self.sprint_detail_selected_card_id() {
+                        if self.activate_card(card_id) {
+                            self.copy_git_checkout_command();
+                        }
+                    }
+                } else {
+                    self.copy_git_checkout_command();
+                }
+            }
         }
     }
 }
@@ -323,6 +343,10 @@ mod tests {
             )
             .unwrap();
         app.prepare_frame();
+        // copy_branch_name/copy_git_checkout_command resolve the board via
+        // active_board_id, which real navigation always sets before either
+        // CardDetail or SprintDetail is reached.
+        app.selection.active_board_id = Some(board.id);
         card.id
     }
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -623,7 +623,24 @@ impl App {
     /// The single card highlighted in whichever sprint-detail panel is active
     /// (uncompleted or completed), for single-target actions like assign-to-
     /// sprint or clipboard copy (as opposed to the multi-select-driven `c`/`d`).
-    fn sprint_detail_selected_card_id(&self) -> Option<uuid::Uuid> {
+    /// Carry over the active sprint's uncompleted tasks if it is eligible
+    /// (Completed or Cancelled); no-op otherwise, matching the direct `M`
+    /// keypress's existing guard exactly.
+    pub(crate) fn carry_over_active_sprint_if_eligible(&mut self) {
+        if let Some(sprint_idx) = self.selection.active_sprint_index {
+            if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+                use kanban_domain::SprintStatus;
+                if sprint.status == SprintStatus::Completed
+                    || sprint.status == SprintStatus::Cancelled
+                {
+                    let sprint_id = sprint.id;
+                    self.handle_carry_over_for_sprint(sprint_id);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn sprint_detail_selected_card_id(&self) -> Option<uuid::Uuid> {
         match self.sprint_view.panel {
             SprintTaskPanel::Uncompleted => self
                 .sprint_view
@@ -752,17 +769,7 @@ impl App {
                 }
             }
             KeyCode::Char('M') => {
-                if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.model.sprints().get(sprint_idx) {
-                        use kanban_domain::SprintStatus;
-                        if sprint.status == SprintStatus::Completed
-                            || sprint.status == SprintStatus::Cancelled
-                        {
-                            let sprint_id = sprint.id;
-                            self.handle_carry_over_for_sprint(sprint_id);
-                        }
-                    }
-                }
+                self.carry_over_active_sprint_if_eligible();
             }
             KeyCode::Char('h') | KeyCode::Left => {
                 if let Some(sprint_idx) = self.selection.active_sprint_index {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -620,9 +620,6 @@ impl App {
         should_restart
     }
 
-    /// The single card highlighted in whichever sprint-detail panel is active
-    /// (uncompleted or completed), for single-target actions like assign-to-
-    /// sprint or clipboard copy (as opposed to the multi-select-driven `c`/`d`).
     /// Carry over the active sprint's uncompleted tasks if it is eligible
     /// (Completed or Cancelled); no-op otherwise, matching the direct `M`
     /// keypress's existing guard exactly.
@@ -640,6 +637,9 @@ impl App {
         }
     }
 
+    /// The single card highlighted in whichever sprint-detail panel is active
+    /// (uncompleted or completed), for single-target actions like assign-to-
+    /// sprint or clipboard copy (as opposed to the multi-select-driven `c`/`d`).
     pub(crate) fn sprint_detail_selected_card_id(&self) -> Option<uuid::Uuid> {
         match self.sprint_view.panel {
             SprintTaskPanel::Uncompleted => self

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -374,13 +374,7 @@ impl App {
             | KeyCode::Enter => self.handle_settings_key_nav(key),
             KeyCode::Char('e') => self.open_config_editor(terminal, event_handler),
             KeyCode::Char('x') => {
-                let board_count = self.model.live_boards().count();
-                if board_count == 0 {
-                    self.set_error("No boards to export".to_string());
-                    return false;
-                }
-                self.export_dialog = Some(ExportDialogState::new(board_count));
-                self.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
+                self.open_export_boards_dialog();
                 false
             }
             KeyCode::Esc | KeyCode::Char('q') => {
@@ -672,5 +666,17 @@ impl App {
 
         self.export_dialog = None;
         self.pop_mode();
+    }
+
+    /// Open the export-all-boards dialog, or set an error if there are no
+    /// live boards to export. Matches the direct `x` keypress's guard exactly.
+    pub(crate) fn open_export_boards_dialog(&mut self) {
+        let board_count = self.model.live_boards().count();
+        if board_count == 0 {
+            self.set_error("No boards to export".to_string());
+            return;
+        }
+        self.export_dialog = Some(ExportDialogState::new(board_count));
+        self.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
     }
 }

--- a/crates/kanban-tui/src/keybindings/card_detail.rs
+++ b/crates/kanban-tui/src/keybindings/card_detail.rs
@@ -119,13 +119,13 @@ impl KeybindingProvider for CardDetailProvider {
                 "y",
                 "copy branch",
                 "Copy branch name to clipboard",
-                KeybindingAction::EditCard,
+                KeybindingAction::CopyBranchName,
             ),
             Keybinding::new(
                 "Y",
                 "copy cmd",
                 "Copy git checkout command",
-                KeybindingAction::EditCard,
+                KeybindingAction::CopyGitCheckoutCommand,
             ),
             Keybinding::new(
                 "a",

--- a/crates/kanban-tui/src/keybindings/mod.rs
+++ b/crates/kanban-tui/src/keybindings/mod.rs
@@ -69,6 +69,8 @@ pub enum KeybindingAction {
     Redo,
     OpenSettings,
     ExportBoards,
+    CopyBranchName,
+    CopyGitCheckoutCommand,
     ConfirmPrefixCollision,
     RejectPrefixCollision,
     CancelPrefixCollision,

--- a/crates/kanban-tui/src/keybindings/sprint_detail.rs
+++ b/crates/kanban-tui/src/keybindings/sprint_detail.rs
@@ -98,13 +98,13 @@ impl KeybindingProvider for SprintDetailProvider {
                     "y",
                     "copy branch",
                     "Copy branch name to clipboard",
-                    KeybindingAction::EditCard,
+                    KeybindingAction::CopyBranchName,
                 ),
                 Keybinding::new(
                     "Y",
                     "copy cmd",
                     "Copy git checkout command",
-                    KeybindingAction::EditCard,
+                    KeybindingAction::CopyGitCheckoutCommand,
                 ),
                 Keybinding::new(
                     "M",


### PR DESCRIPTION
`execute_action` (`app/keybindings.rs`) is a second key-dispatch path reachable via the in-app Help overlay (`?`) — selecting a highlighted binding there fires purely off the `KeybindingAction` enum tag, independent of the raw keypress. Three arms were literal no-ops (`{}`), so invoking them via the help menu silently did nothing even though the direct keypress worked:

```rust
KeybindingAction::EditCard => {}
KeybindingAction::CarryOver => {}
KeybindingAction::ExportBoards => {}
```

Investigation found `EditCard` is not a 1:1 tag — it's shared across at least 5 distinct real behaviors depending on mode/focus (actual field editing, copying a branch name, copying a git checkout command, opening an external editor, ...). Wiring the shared tag to any one of them would be wrong for the others.

**Scope decision**: fix the four keys this card's own Red test targets (`y`/`Y`/`M`/`x`), which are all cheaply fixable without new plumbing. `e` (actual card-field editing) needs `terminal`/`event_handler` threaded through `execute_action`'s signature — several of its real handlers open an external editor and `execute_action` doesn't receive those parameters at all today. That's a materially bigger, cross-cutting change split out to **KAN-980**.

**What**:
- Split `y`/`Y`'s shared `EditCard` tag into two new dedicated actions, `CopyBranchName`/`CopyGitCheckoutCommand`, used consistently by both `CardDetailProvider` and `SprintDetailProvider`. Their `execute_action` arms branch on `self.mode` (mirroring the existing `Search` action's mode-check) to resolve the right card: CardDetail already has `active_card_id` set; SprintDetail resolves the panel's highlighted card first (via the `sprint_detail_selected_card_id` helper introduced in KAN-973, widened to `pub(crate)`).
- Extracted the inline `M` (carry-over) and `x` (export-boards) guard-and-dispatch logic out of their raw-key handlers into two small `pub(crate)` helpers (`carry_over_active_sprint_if_eligible`, `open_export_boards_dialog`), called from both the direct keypress and the new `execute_action` arms — no duplicated logic, no behavior change to the direct-key paths.

**Why**: A help entry that does nothing when selected is worse than not offering it at all — this reconciles the help-menu dispatch path with what's actually advertised, for the keys where that's a small, well-contained fix.

**Testing**: 5 new tests in `app/keybindings.rs`'s test module proving `execute_action` for each of `CopyBranchName`, `CopyGitCheckoutCommand` (both CardDetail and SprintDetail contexts), `CarryOver`, and `ExportBoards` reaches the same observable outcome the direct keypress does — confirmed to fail against the pre-fix no-op arms first. `cargo test -p kanban-tui` (346 tests, no regressions), `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).