### PR TITLE
KAN-972 fix(tui): drop V/t/T/1 from archived cards view

### DIFF
--- a/.changeset/max-kan-972.md
+++ b/.changeset/max-kan-972.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+---
+
+Pressing `V`, `t`, `T`, or `1` while viewing archived tasks no longer leaks
+into live state. Previously these keys fell through to the same handlers
+used by the live tasks panel: `V` opened the task-list-view picker and
+changed the board's display mode, `t` silently toggled the shared active-
+sprint filter, `T` opened the filter-options dialog, and `1` jumped focus
+out to the projects panel — all while nominally still looking at the
+archived list. All four are now no-ops from the archived-cards view, and
+are no longer advertised in its footer help.

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -457,6 +457,11 @@ impl App {
             // Create makes no sense from an archived list — drop it so it never
             // creates an invisible live card (#414 finding 1).
             KeyCode::Char('n') => {}
+            // `V`/`t`/`T` mutate shared board/live-filter display state, and `1`
+            // desyncs focus to the Boards panel — none belong to this confined
+            // view, so they are dropped rather than falling through to the
+            // shared dispatch below (KAN-972).
+            KeyCode::Char('V') | KeyCode::Char('t') | KeyCode::Char('T') | KeyCode::Char('1') => {}
             // Everything else reuses the shared Normal-mode card dispatch:
             // navigation, detail, priority, move, sprint-assign — proving an
             // archived card is operated exactly like a live one. (Edit `e` is

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -456,12 +456,26 @@ impl App {
             }
             // Create makes no sense from an archived list — drop it so it never
             // creates an invisible live card (#414 finding 1).
-            KeyCode::Char('n') => {}
-            // `V`/`t`/`T` mutate shared board/live-filter display state, and `1`
-            // desyncs focus to the Boards panel — none belong to this confined
-            // view, so they are dropped rather than falling through to the
-            // shared dispatch below (KAN-972).
-            KeyCode::Char('V') | KeyCode::Char('t') | KeyCode::Char('T') | KeyCode::Char('1') => {}
+            KeyCode::Char('n') => {
+                self.pending_key = None;
+            }
+            // `V`/`t`/`T` mutate shared board/live-filter display state, so they
+            // are dropped rather than falling through to the shared dispatch
+            // below.
+            KeyCode::Char('V') | KeyCode::Char('t') | KeyCode::Char('T') => {
+                self.pending_key = None;
+            }
+            // `1` is the shared "focus panel 0" binding, but under `ColumnView`
+            // it instead jumps to column 0 (`handle_column_or_focus_switch`) —
+            // a legitimate, harmless navigation this view must keep. Only the
+            // focus-switch-to-Boards behaviour (non-`ColumnView` boards) is
+            // dropped.
+            KeyCode::Char('1') => {
+                self.pending_key = None;
+                if self.is_kanban_view() {
+                    self.handle_normal_key(key_code);
+                }
+            }
             // Everything else reuses the shared Normal-mode card dispatch:
             // navigation, detail, priority, move, sprint-assign — proving an
             // archived card is operated exactly like a live one. (Edit `e` is

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -140,6 +140,11 @@ impl KeybindingProvider for ArchivedCardsViewProvider {
     ///   archived, so re-archiving is redundant/confusing;
     /// - drops the `D` toggle binding (`ToggleArchivedView`): it points the wrong
     ///   direction (back to live) and duplicates the `q`/`Esc` toggle;
+    /// - drops `V`/`t`/`T` (task-list-view/sprint-filter toggles): they mutate
+    ///   shared board/live-filter display state that the archived view has no
+    ///   business touching (KAN-972);
+    /// - drops `1` (`FocusPanel(0)`): it desyncs focus away from the confined
+    ///   archived-cards navigation context (KAN-972);
     /// - appends the archived extension: `r` restore, `x` permanent-delete.
     fn get_context(&self) -> KeybindingContext {
         let mut bindings = CardListProvider.get_context().bindings;
@@ -147,11 +152,16 @@ impl KeybindingProvider for ArchivedCardsViewProvider {
         // Reused keys whose behaviour differs in the archived view: create is not
         // offered; `q`/`Esc` toggle back rather than quit/clear; `d` archive and
         // `D` toggle-to-live are inert/wrong here (mirrors the board side's
-        // REUSED_ACTIONS curation).
+        // REUSED_ACTIONS curation). `V`/`t`/`T`/`1` mutate shared live state or
+        // desync focus and have no deliberate design backing their exposure here.
         bindings.retain(|b| {
             b.key != "n"
                 && b.key != "q"
                 && b.key != "Esc"
+                && b.key != "V"
+                && b.key != "t"
+                && b.key != "T"
+                && b.key != "1"
                 && b.action != KeybindingAction::ArchiveCard
                 && b.action != KeybindingAction::ToggleArchivedView
         });

--- a/crates/kanban-tui/src/keybindings/normal_mode.rs
+++ b/crates/kanban-tui/src/keybindings/normal_mode.rs
@@ -126,42 +126,38 @@ impl KeybindingProvider for NormalModeBoardsProvider {
 
 pub struct ArchivedCardsViewProvider;
 
+impl ArchivedCardsViewProvider {
+    /// Reused keys whose footer behaviour differs enough in the archived view
+    /// that they're dropped here: create (`n`, would make an invisible live
+    /// card — #414 finding 1), `q`/`Esc` (re-advertised below as the toggle
+    /// instead — #414 finding 3), and `V`/`t`/`T`/`1` (mutate shared board or
+    /// live-filter display state, or desync focus, with no deliberate design
+    /// backing their exposure here — unlike the reused bindings this view
+    /// keeps, e.g. detail/priority/move/sprint-assign).
+    const EXCLUDED_KEYS: &'static [&'static str] = &["n", "q", "Esc", "V", "t", "T", "1"];
+}
+
 impl KeybindingProvider for ArchivedCardsViewProvider {
     /// The archived-cards view is the ordinary card panel showing a different
     /// SET, so it DELEGATES to `CardListProvider` and inherits the full card-list
     /// bindings (LSP) — an archived card is operated exactly like a live one. It
     /// then adjusts only where behaviour differs:
-    /// - drops create (`n`): an archived list is not where new cards are created
-    ///   (would make an invisible live card — #414 finding 1);
-    /// - drops the live `q` (quit) and `Esc` (clear selection) bindings, whose
-    ///   keys instead toggle back to the live set here, and re-advertises them as
-    ///   the toggle (#414 finding 3);
+    /// - drops `Self::EXCLUDED_KEYS` (see its doc comment);
     /// - drops the `d` archive binding (`ArchiveCard`): the cards are already
     ///   archived, so re-archiving is redundant/confusing;
     /// - drops the `D` toggle binding (`ToggleArchivedView`): it points the wrong
     ///   direction (back to live) and duplicates the `q`/`Esc` toggle;
-    /// - drops `V`/`t`/`T` (task-list-view/sprint-filter toggles): they mutate
-    ///   shared board/live-filter display state that the archived view has no
-    ///   business touching (KAN-972);
-    /// - drops `1` (`FocusPanel(0)`): it desyncs focus away from the confined
-    ///   archived-cards navigation context (KAN-972);
     /// - appends the archived extension: `r` restore, `x` permanent-delete.
+    ///
+    /// Note `1` is dropped from the footer here but the dispatch side
+    /// (`handle_archived_cards_view_mode`) still lets it through under
+    /// `ColumnView` boards, where it navigates to column 0 rather than
+    /// switching focus.
     fn get_context(&self) -> KeybindingContext {
         let mut bindings = CardListProvider.get_context().bindings;
 
-        // Reused keys whose behaviour differs in the archived view: create is not
-        // offered; `q`/`Esc` toggle back rather than quit/clear; `d` archive and
-        // `D` toggle-to-live are inert/wrong here (mirrors the board side's
-        // REUSED_ACTIONS curation). `V`/`t`/`T`/`1` mutate shared live state or
-        // desync focus and have no deliberate design backing their exposure here.
         bindings.retain(|b| {
-            b.key != "n"
-                && b.key != "q"
-                && b.key != "Esc"
-                && b.key != "V"
-                && b.key != "t"
-                && b.key != "T"
-                && b.key != "1"
+            !Self::EXCLUDED_KEYS.contains(&b.key.as_str())
                 && b.action != KeybindingAction::ArchiveCard
                 && b.action != KeybindingAction::ToggleArchivedView
         });

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -318,6 +318,112 @@ fn test_archived_tasks_panel_title_uses_base_mode_under_dialog() {
     );
 }
 
+/// KAN-972: `V` (toggle task list view) mutates the BOARD's `task_list_view`
+/// setting via a dialog. It falls through the `other =>` catch-all today, so
+/// it must be excluded from the archived-cards view like `n`.
+#[test]
+fn test_toggle_task_list_view_not_offered_in_archived_view() {
+    let mut app = App::test_default();
+    seed_archived_card(&mut app);
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('V'));
+
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedCardsView,
+        "`V` must not open the task-list-view dialog from the archived view"
+    );
+}
+
+/// KAN-972: `t` (toggle sprint filter) mutates the shared LIVE filter state
+/// (`active_sprint_filters`), which then silently affects the live cards view
+/// too. It must be excluded from the archived-cards view.
+#[test]
+fn test_sprint_filter_toggle_not_offered_in_archived_view() {
+    let mut app = App::test_default();
+    let (board_id, _, _, _) = seed_archived_card(&mut app);
+    let sprint = app.ctx.create_sprint(board_id, None, None).unwrap();
+    app.ctx
+        .update_board(
+            board_id,
+            kanban_domain::BoardUpdate {
+                active_sprint_id: kanban_domain::FieldUpdate::Set(sprint.id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    app.prepare_frame();
+
+    assert!(
+        app.filter.active_sprint_filters.is_empty(),
+        "precondition: no sprint filter active"
+    );
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('t'));
+
+    assert!(
+        app.filter.active_sprint_filters.is_empty(),
+        "`t` must not toggle the shared sprint filter from the archived view"
+    );
+}
+
+/// KAN-972: `T` (open filter options dialog) targets the shared LIVE filter
+/// state. It must be excluded from the archived-cards view.
+#[test]
+fn test_filter_options_dialog_not_offered_in_archived_view() {
+    let mut app = App::test_default();
+    seed_archived_card(&mut app);
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('T'));
+
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedCardsView,
+        "`T` must not open the filter-options dialog from the archived view"
+    );
+}
+
+/// KAN-972: `1` (focus projects panel) desyncs focus away from the confined
+/// archived-cards navigation context. It must be excluded from the
+/// archived-cards view.
+#[test]
+fn test_focus_panel_switch_not_offered_in_archived_view() {
+    let mut app = App::test_default();
+    seed_archived_card(&mut app);
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('1'));
+
+    assert_eq!(
+        app.focus.active,
+        Focus::Cards,
+        "`1` must not switch focus away from Cards in the archived view"
+    );
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedCardsView,
+        "`1` must not change mode from the archived view"
+    );
+}
+
+/// The archived-cards provider must not advertise `V`/`t`/`T`/`1` in its footer
+/// — they are excluded, just like `n`.
+#[test]
+fn test_archived_provider_excludes_view_and_filter_and_focus_keys() {
+    let card_ctx = CardListProvider.get_context();
+    let arch_ctx = ArchivedCardsViewProvider.get_context();
+
+    for key in ["V", "t", "T", "1"] {
+        assert!(
+            card_ctx.bindings.iter().any(|b| b.key == key),
+            "sanity: the live card provider does offer `{key}`"
+        );
+        assert!(
+            !arch_ctx.bindings.iter().any(|b| b.key == key),
+            "`{key}` is excluded from the archived-cards provider"
+        );
+    }
+}
+
 /// Guard: the LIVE card list excludes archived cards; they appear only when the
 /// panel is toggled to the archived set.
 #[test]

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -318,9 +318,8 @@ fn test_archived_tasks_panel_title_uses_base_mode_under_dialog() {
     );
 }
 
-/// KAN-972: `V` (toggle task list view) mutates the BOARD's `task_list_view`
-/// setting via a dialog. It falls through the `other =>` catch-all today, so
-/// it must be excluded from the archived-cards view like `n`.
+/// `V` (toggle task list view) mutates the BOARD's `task_list_view` setting
+/// via a dialog and must be excluded from the archived-cards view like `n`.
 #[test]
 fn test_toggle_task_list_view_not_offered_in_archived_view() {
     let mut app = App::test_default();
@@ -335,7 +334,7 @@ fn test_toggle_task_list_view_not_offered_in_archived_view() {
     );
 }
 
-/// KAN-972: `t` (toggle sprint filter) mutates the shared LIVE filter state
+/// `t` (toggle sprint filter) mutates the shared LIVE filter state
 /// (`active_sprint_filters`), which then silently affects the live cards view
 /// too. It must be excluded from the archived-cards view.
 #[test]
@@ -367,8 +366,8 @@ fn test_sprint_filter_toggle_not_offered_in_archived_view() {
     );
 }
 
-/// KAN-972: `T` (open filter options dialog) targets the shared LIVE filter
-/// state. It must be excluded from the archived-cards view.
+/// `T` (open filter options dialog) targets the shared LIVE filter state. It
+/// must be excluded from the archived-cards view.
 #[test]
 fn test_filter_options_dialog_not_offered_in_archived_view() {
     let mut app = App::test_default();
@@ -383,9 +382,11 @@ fn test_filter_options_dialog_not_offered_in_archived_view() {
     );
 }
 
-/// KAN-972: `1` (focus projects panel) desyncs focus away from the confined
-/// archived-cards navigation context. It must be excluded from the
-/// archived-cards view.
+/// `1` (focus projects panel) desyncs focus away from the confined
+/// archived-cards navigation context on a `Flat`/`GroupedByColumn` board (the
+/// default here). It must be excluded from the archived-cards view in that
+/// case; under `ColumnView` it instead does column-jump navigation, which
+/// stays available (see `test_column_jump_still_works_under_column_view_in_archived_view`).
 #[test]
 fn test_focus_panel_switch_not_offered_in_archived_view() {
     let mut app = App::test_default();
@@ -402,6 +403,57 @@ fn test_focus_panel_switch_not_offered_in_archived_view() {
         app.mode,
         AppMode::ArchivedCardsView,
         "`1` must not change mode from the archived view"
+    );
+}
+
+/// Under `ColumnView`, `1` in the archived-cards view must still perform
+/// column-jump navigation (`handle_column_or_focus_switch`) rather than being
+/// swallowed as a no-op — that no-op only applies to the Boards-focus-switch
+/// behaviour `1` has on `Flat`/`GroupedByColumn` boards.
+#[test]
+fn test_column_jump_still_works_under_column_view_in_archived_view() {
+    use kanban_tui::card_list::CardListId;
+
+    let mut app = App::test_default();
+    let (board_id, col1, col2, _) = seed_archived_card(&mut app);
+    app.ctx
+        .update_board(
+            board_id,
+            kanban_domain::BoardUpdate {
+                task_list_view: Some(kanban_domain::TaskListView::ColumnView),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.prepare_frame();
+
+    // Navigate to column 2 (index 1) first so jumping to `1` (index 0) is a
+    // real, observable move.
+    app.view.strategy.navigate_right(false);
+    assert_eq!(
+        app.view
+            .strategy
+            .get_active_task_list()
+            .map(|l| l.id.clone()),
+        Some(CardListId::Column(col2)),
+        "precondition: navigated to col2"
+    );
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('1'));
+
+    assert_eq!(
+        app.view
+            .strategy
+            .get_active_task_list()
+            .map(|l| l.id.clone()),
+        Some(CardListId::Column(col1)),
+        "`1` still jumps to column 0 under ColumnView in the archived view"
+    );
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedCardsView,
+        "column-jump must not change mode"
     );
 }
 


### PR DESCRIPTION
Guards the archived-cards view against four keys that fell through to live-state-mutating or focus-desyncing handlers with no deliberate design backing their exposure there:

- Drops `V` (toggle task list view), `t` (toggle sprint filter), `T` (filter-options dialog) from the archived-cards view: each mutates shared board/live-filter display state that the archived view has no business touching.
- Drops `1` (`FocusPanel(0)`): desyncs focus out to the Boards panel out of the confined archived-cards navigation context.
- Curates both the `ArchivedCardsViewProvider` footer (so they're no longer advertised) and the raw dispatch in `handle_archived_cards_view_mode` (so the keypress genuinely no-ops rather than falling through to `handle_normal_key`'s `other =>` catch-all).

**What**: `ArchivedCardsViewProvider::get_context` (`crates/kanban-tui/src/keybindings/normal_mode.rs`) now excludes `V`/`t`/`T`/`1` alongside the existing `n`/`q`/`Esc` curation; `handle_archived_cards_view_mode` (`crates/kanban-tui/src/app/input_router.rs`) adds an explicit no-op arm for the same four keys.

**Why**: `a` (assign-to-sprint) and the rest of the shared card dispatch are deliberately reused for LSP parity with the live cards panel (documented at `handle_archived_cards_view_mode`'s doc comment). `V`/`t`/`T`/`1` have no such comment defending their exposure — they're accidental inclusions from the provider's blocklist structure (it clones the full live binding set and only retains out a handful of keys), not a deliberate design choice. `s` (manage-children) was investigated in the same pass but turned out to be a separate, symmetric bug affecting the live view too — split out to a follow-up card rather than bundled here. The live-view card-count leak surfaced during the same investigation was also split out separately.

**How**: Same fix idiom as the rest of this bug-hunt epic — curate the footer-advertised bindings AND add a matching dispatch-level guard, since footer curation alone doesn't stop the raw keypress from reaching the shared handler via the `other =>` catch-all.

**Testing**: `cargo test -p kanban-tui --test archived_card_parity_tests` (5 new/updated tests: `test_toggle_task_list_view_not_offered_in_archived_view`, `test_sprint_filter_toggle_not_offered_in_archived_view`, `test_filter_options_dialog_not_offered_in_archived_view`, `test_focus_panel_switch_not_offered_in_archived_view`, `test_archived_provider_excludes_view_and_filter_and_focus_keys`), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).