### PR TITLE
KAN-981 fix(tui): exclude archived cards from live count displays

### DIFF
--- a/.changeset/max-kan-981.md
+++ b/.changeset/max-kan-981.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+Card counts no longer include archived cards. Sprint Detail's "Cards
+Assigned" count, Board Detail's per-sprint and per-column counts, and the
+Carry-Over Sprint popup's card count could previously stay inflated
+forever after a card was archived, since archiving keeps a card's sprint
+and column assignment intact rather than clearing it. All four now count
+only live cards.

--- a/.changeset/max-kan-981.md
+++ b/.changeset/max-kan-981.md
@@ -2,9 +2,10 @@
 bump: patch
 ---
 
-Card counts no longer include archived cards. Sprint Detail's "Cards
-Assigned" count, Board Detail's per-sprint and per-column counts, and the
-Carry-Over Sprint popup's card count could previously stay inflated
-forever after a card was archived, since archiving keeps a card's sprint
-and column assignment intact rather than clearing it. All four now count
-only live cards.
+Card counts and lists no longer include archived cards. Sprint Detail's
+"Cards Assigned" count, Board Detail's per-sprint and per-column counts,
+the Carry-Over Sprint popup's card count (and the check for whether that
+popup should open at all), and a completed sprint's Uncompleted task
+panel could previously keep including an archived card forever, since
+archiving keeps a card's sprint and column assignment intact rather than
+clearing it. All of these now reflect only live cards.

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -109,7 +109,7 @@ impl App {
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
-        let cards = self.model.cards();
+        let cards = self.model.displayed_cards(false);
         let board_opt = self
             .selection
             .active_board_id

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -121,7 +121,11 @@ impl App {
                     });
 
                     if has_planning
-                        && !get_sprint_uncompleted_cards(sprint_id, self.model.cards()).is_empty()
+                        && !get_sprint_uncompleted_cards(
+                            sprint_id,
+                            self.model.displayed_cards(false),
+                        )
+                        .is_empty()
                     {
                         self.dialog_input.carry_over_source_sprint_id = Some(sprint_id);
                         self.dialog_input.carry_over_sprint_selection.set(Some(0));

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -162,7 +162,7 @@ fn render_board_sprints_list(
             label_text(),
         )));
     } else {
-        let all_cards: Vec<&kanban_domain::Card> = app.model.cards().iter().collect();
+        let all_cards = app.model.displayed_cards(false);
         for (sprint_idx, sprint) in board_sprints.iter().enumerate() {
             let is_selected = app.selection.sprint.get() == Some(sprint_idx);
             let is_focused = app.focus.board_focus == BoardFocus::Sprints;
@@ -179,7 +179,6 @@ fn render_board_sprints_list(
             let card_count = all_cards
                 .iter()
                 .filter(|c| c.sprint_id == Some(sprint.id))
-                .filter(|c| !app.model.archived_card_ids().contains(&c.id))
                 .count();
 
             let is_active_sprint = board.active_sprint_id == Some(sprint.id);
@@ -261,7 +260,7 @@ fn render_board_columns_list(
             label_text(),
         )));
     } else {
-        let all_cards: Vec<&kanban_domain::Card> = app.model.cards().iter().collect();
+        let all_cards = app.model.displayed_cards(false);
         for (column_idx, column) in board_columns.iter().enumerate() {
             let is_selected = app.dialog_input.column_selection.get() == Some(column_idx);
             let is_focused = app.focus.board_focus == BoardFocus::Columns;
@@ -269,7 +268,6 @@ fn render_board_columns_list(
             let card_count = all_cards
                 .iter()
                 .filter(|c| c.column_id == column.id)
-                .filter(|c| !app.model.archived_card_ids().contains(&c.id))
                 .count();
 
             let mut base_style = normal_text();

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -179,6 +179,7 @@ fn render_board_sprints_list(
             let card_count = all_cards
                 .iter()
                 .filter(|c| c.sprint_id == Some(sprint.id))
+                .filter(|c| !app.model.archived_card_ids().contains(&c.id))
                 .count();
 
             let is_active_sprint = board.active_sprint_id == Some(sprint.id);
@@ -268,6 +269,7 @@ fn render_board_columns_list(
             let card_count = all_cards
                 .iter()
                 .filter(|c| c.column_id == column.id)
+                .filter(|c| !app.model.archived_card_ids().contains(&c.id))
                 .count();
 
             let mut base_style = normal_text();

--- a/crates/kanban-tui/src/ui/dialogs/sprints.rs
+++ b/crates/kanban-tui/src/ui/dialogs/sprints.rs
@@ -40,14 +40,7 @@ pub(crate) fn render_carry_over_sprint_popup(app: &App, frame: &mut Frame) {
         .carry_over_source_sprint_id
         .map(|id| {
             use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-            let cards: Vec<kanban_domain::Card> = app
-                .model
-                .cards()
-                .iter()
-                .filter(|c| !app.model.archived_card_ids().contains(&c.id))
-                .cloned()
-                .collect();
-            get_sprint_uncompleted_cards(id, &cards).len()
+            get_sprint_uncompleted_cards(id, app.model.displayed_cards(false)).len()
         })
         .unwrap_or(0);
     CarryOverSprintDialog { card_count }.render(app, frame);

--- a/crates/kanban-tui/src/ui/dialogs/sprints.rs
+++ b/crates/kanban-tui/src/ui/dialogs/sprints.rs
@@ -40,7 +40,13 @@ pub(crate) fn render_carry_over_sprint_popup(app: &App, frame: &mut Frame) {
         .carry_over_source_sprint_id
         .map(|id| {
             use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-            let cards: Vec<kanban_domain::Card> = app.model.cards().to_vec();
+            let cards: Vec<kanban_domain::Card> = app
+                .model
+                .cards()
+                .iter()
+                .filter(|c| !app.model.archived_card_ids().contains(&c.id))
+                .cloned()
+                .collect();
             get_sprint_uncompleted_cards(id, &cards).len()
         })
         .unwrap_or(0);

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -104,10 +104,9 @@ fn sprint_card_assignment_lines(
 ) -> Vec<Line<'static>> {
     let card_count = app
         .model
-        .cards()
+        .displayed_cards(false)
         .iter()
         .filter(|c| c.sprint_id == Some(sprint.id))
-        .filter(|c| !app.model.archived_card_ids().contains(&c.id))
         .count();
     let mut lines = vec![metadata_line_styled(
         "Cards Assigned",

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -107,6 +107,7 @@ fn sprint_card_assignment_lines(
         .cards()
         .iter()
         .filter(|c| c.sprint_id == Some(sprint.id))
+        .filter(|c| !app.model.archived_card_ids().contains(&c.id))
         .count();
     let mut lines = vec![metadata_line_styled(
         "Cards Assigned",

--- a/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
@@ -1,0 +1,216 @@
+//! KAN-981: several TUI displays compute card counts from the unified
+//! live+archived collection with no archived exclusion, so an archived card
+//! that still carries its old `sprint_id`/`column_id` keeps inflating these
+//! "live" counts forever. These tests seed one live + one archived card
+//! sharing the same sprint/column and assert the displayed count reflects
+//! only the live card.
+
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::app::BoardFocus;
+use kanban_tui::App;
+
+fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
+}
+
+fn activate_board(app: &mut App, board_id: uuid::Uuid) {
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_id = Some(board_id);
+}
+
+#[test]
+fn test_sprint_detail_card_count_excludes_archived_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+
+    let live = app
+        .ctx
+        .create_card(board.id, col.id, "Live".to_string(), Default::default())
+        .unwrap();
+    app.ctx.assign_card_to_sprint(live.id, sprint.id).unwrap();
+
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx
+        .assign_card_to_sprint(archived.id, sprint.id)
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+
+    activate_board(&mut app, board.id);
+    app.selection.active_sprint_index = Some(0);
+    app.push_mode(AppMode::SprintDetail);
+    app.prepare_frame();
+
+    let output = render_to_string(&mut app, 100, 30);
+
+    assert!(
+        output.contains("Cards Assigned: 1"),
+        "Sprint Detail's Cards Assigned count must exclude the archived card, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("Cards Assigned: 2"),
+        "count must not include the archived card, got:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_board_detail_sprint_card_count_excludes_archived_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let sprint = app
+        .ctx
+        .create_sprint(board.id, None, Some("TargetSprint".to_string()))
+        .unwrap();
+
+    let live = app
+        .ctx
+        .create_card(board.id, col.id, "Live".to_string(), Default::default())
+        .unwrap();
+    app.ctx.assign_card_to_sprint(live.id, sprint.id).unwrap();
+
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx
+        .assign_card_to_sprint(archived.id, sprint.id)
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+
+    activate_board(&mut app, board.id);
+    app.push_mode(AppMode::BoardDetail);
+    app.focus.board_focus = BoardFocus::Sprints;
+    app.prepare_frame();
+
+    let output = render_to_string(&mut app, 100, 30);
+
+    assert!(
+        output.contains("TargetSprint (1)"),
+        "Board Detail's per-sprint card count must exclude the archived card, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("TargetSprint (2)"),
+        "count must not include the archived card, got:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_board_detail_column_card_count_excludes_archived_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "TargetColumn".to_string(), None)
+        .unwrap();
+
+    let live = app
+        .ctx
+        .create_card(board.id, col.id, "Live".to_string(), Default::default())
+        .unwrap();
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+    let _ = live;
+
+    activate_board(&mut app, board.id);
+    app.push_mode(AppMode::BoardDetail);
+    app.focus.board_focus = BoardFocus::Columns;
+    app.prepare_frame();
+
+    let output = render_to_string(&mut app, 100, 30);
+
+    assert!(
+        output.contains("TargetColumn (1)"),
+        "Board Detail's per-column card count must exclude the archived card, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("TargetColumn (2)"),
+        "count must not include the archived card, got:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_carry_over_popup_card_count_excludes_archived_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let source_sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+
+    let live = app
+        .ctx
+        .create_card(board.id, col.id, "Live".to_string(), Default::default())
+        .unwrap();
+    app.ctx
+        .assign_card_to_sprint(live.id, source_sprint.id)
+        .unwrap();
+
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx
+        .assign_card_to_sprint(archived.id, source_sprint.id)
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+
+    activate_board(&mut app, board.id);
+    app.dialog_input.carry_over_source_sprint_id = Some(source_sprint.id);
+    app.push_mode(AppMode::Dialog(DialogMode::CarryOverSprint));
+    app.prepare_frame();
+
+    let output = render_to_string(&mut app, 100, 30);
+
+    assert!(
+        output.contains("Carry Over to Sprint (1 cards)"),
+        "Carry-over popup's card count must exclude the archived card, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("Carry Over to Sprint (2 cards)"),
+        "count must not include the archived card, got:\n{}",
+        output
+    );
+}

--- a/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
@@ -1,9 +1,6 @@
-//! KAN-981: several TUI displays compute card counts from the unified
-//! live+archived collection with no archived exclusion, so an archived card
-//! that still carries its old `sprint_id`/`column_id` keeps inflating these
-//! "live" counts forever. These tests seed one live + one archived card
-//! sharing the same sprint/column and assert the displayed count reflects
-//! only the live card.
+//! Each test seeds one live + one archived card sharing the same
+//! sprint/column and asserts the displayed count/list reflects only the
+//! live card.
 
 use kanban_domain::KanbanOperations;
 use kanban_tui::app::mode::{AppMode, DialogMode};
@@ -212,5 +209,84 @@ fn test_carry_over_popup_card_count_excludes_archived_cards() {
         !output.contains("Carry Over to Sprint (2 cards)"),
         "count must not include the archived card, got:\n{}",
         output
+    );
+}
+
+#[test]
+fn test_completed_sprint_uncompleted_panel_excludes_archived_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx.activate_sprint(sprint.id, None).unwrap();
+
+    let live = app
+        .ctx
+        .create_card(board.id, col.id, "Live".to_string(), Default::default())
+        .unwrap();
+    app.ctx.assign_card_to_sprint(live.id, sprint.id).unwrap();
+
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx
+        .assign_card_to_sprint(archived.id, sprint.id)
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+
+    app.ctx.complete_sprint(sprint.id).unwrap();
+
+    activate_board(&mut app, board.id);
+    app.populate_sprint_task_lists(sprint.id);
+
+    assert_eq!(
+        app.sprint_view.uncompleted_cards.cards,
+        vec![live.id],
+        "completed sprint's Uncompleted panel must exclude the archived card"
+    );
+}
+
+#[test]
+fn test_carry_over_auto_open_gate_excludes_archived_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx.activate_sprint(sprint.id, None).unwrap();
+    // A second Planning sprint must exist for carry-over to be offered at all.
+    app.ctx.create_sprint(board.id, None, None).unwrap();
+
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx
+        .assign_card_to_sprint(archived.id, sprint.id)
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+
+    activate_board(&mut app, board.id);
+    app.selection.active_sprint_index = Some(
+        app.model
+            .sprints()
+            .iter()
+            .position(|s| s.id == sprint.id)
+            .unwrap(),
+    );
+
+    app.handle_complete_sprint_key();
+    app.prepare_frame();
+
+    assert_ne!(
+        app.mode,
+        AppMode::Dialog(DialogMode::CarryOverSprint),
+        "carry-over popup must not auto-open when the only uncompleted card is archived"
     );
 }


### PR DESCRIPTION
Fixes 6 TUI display/gate sites that computed card counts or lists from the unified live+archived collection with no archived exclusion, so an archived card kept inflating "live" counts (or appearing in a "live" list) forever once it shared a sprint/column with the site in question. Found during KAN-972's investigation (KAN-960 epic); 2 more sites surfaced during this PR's own review.

- Sprint Detail's "Cards Assigned" count (`crates/kanban-tui/src/ui/sprint_detail.rs`).
- Board Detail's per-sprint card count (`crates/kanban-tui/src/ui/board_detail.rs`).
- Board Detail's per-column card count (`crates/kanban-tui/src/ui/board_detail.rs`).
- Carry-Over Sprint popup's uncompleted-card count (`crates/kanban-tui/src/ui/dialogs/sprints.rs`).
- Carry-Over popup's auto-open gate after completing a sprint (`crates/kanban-tui/src/handlers/sprint_handlers.rs`) — completing a sprint whose only "uncompleted" card is archived no longer force-opens the popup.
- A completed sprint's Uncompleted task panel (`crates/kanban-tui/src/app/card_selection.rs`, `populate_sprint_task_lists`) — this one didn't just miscount, it listed the archived card by name.

**What**: every site now reads `Model::displayed_cards(false)` — the codebase's existing precomputed live-only partition (same convention as `live_boards()`) — instead of the raw unified `Model::cards()`.

**Why**: the reference-marker archival model never clears a card's `sprint_id`/`column_id` on archive (deliberately — restore needs them). That means any TUI count/list reading the unified collection without an archived filter is systemically wrong, not an edge case: any card archived after being assigned to a sprint/column keeps counting/appearing forever. Purely a TUI display-layer bug — domain-layer WIP-limit enforcement already excludes archived cards correctly at the persistence layer.

**How**: first pass used `Model::archived_card_ids()` with a manual `.filter()` at 4 sites; review found the codebase already has `Model::displayed_cards(want_archived)`, a precomputed partition that's both simpler and (for the carry-over popup specifically) avoids cloning every live card across all boards on every redraw. Switched all sites to the existing accessor, and extended the same fix to the 2 additional sites review found reachable from the same investigation.

**Testing**: `cargo test -p kanban-tui --test archived_card_count_leak_tests` (6 tests, one per site, each seeding a live + an archived card sharing the sprint/column and asserting the rendered output reflects only the live one), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).