### PR TITLE
KAN-986 refactor(tui): rename Model::cards() to all_cards(), fix board-delete count

### DIFF
--- a/.changeset/max-kan-986.md
+++ b/.changeset/max-kan-986.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+The board delete/archive confirmation dialog's task count no longer
+double-counts archived cards against the separate archived-task figure.
+This was the last of a small cluster of display counts (see the previous
+release's card-count fixes) that read from an internal collection without
+excluding archived cards.

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -24,7 +24,7 @@ impl App {
             self.animation.animating.remove(&card_id);
             match animation_type {
                 AnimationType::Archiving => {
-                    let cards = self.model.cards();
+                    let cards = self.model.all_cards();
                     if let Some(card_pos) = cards.iter().position(|c| c.id == card_id) {
                         let card = &cards[card_pos];
                         if !affected_columns.contains(&card.column_id) {
@@ -95,7 +95,7 @@ impl App {
     fn complete_restore_animation(&mut self, card_id: uuid::Uuid) {
         if let Some(archived_card) = self
             .model
-            .archived_cards()
+            .archived_card_markers()
             .iter()
             .find(|dc| dc.entity_id == card_id)
             .cloned()

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -6,7 +6,7 @@ impl App {
         let filter = self.board_card_filter(board_id);
         let board = self.model.boards().iter().find(|b| b.id == board_id);
         kanban_domain::count_filtered_cards(
-            self.model.cards(),
+            self.model.live_cards(),
             self.model.columns(),
             self.model.sprints(),
             board,
@@ -18,7 +18,7 @@ impl App {
         let filter = self.board_card_filter(board_id);
         let board = self.model.boards().iter().find(|b| b.id == board_id);
         kanban_domain::filter_and_sort_cards(
-            self.model.cards(),
+            self.model.live_cards(),
             self.model.columns(),
             self.model.sprints(),
             board,
@@ -109,7 +109,7 @@ impl App {
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
-        let cards = self.model.displayed_cards(false);
+        let cards = self.model.live_cards();
         let board_opt = self
             .selection
             .active_board_id
@@ -157,7 +157,7 @@ impl App {
     }
 
     pub fn apply_sort_to_sprint_lists(&mut self, sort_field: SortField, sort_order: SortOrder) {
-        let cards = self.model.cards();
+        let cards = self.model.live_cards();
         let sorted_uncompleted_ids = sort_card_ids(
             &self.sprint_view.uncompleted_cards.cards,
             cards,

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -113,9 +113,8 @@ impl Model {
     }
 
     /// The full unified live+archived collection. Only for callers that
-    /// genuinely need id resolution regardless of archival status (graph
-    /// traversal, detail-view resolution, ArchivedCardsView's own rendering,
-    /// or internal plumbing like `rebuild_displayed_partitions`).
+    /// genuinely need id resolution regardless of archival status — see
+    /// `live_cards`/`archived_cards` for the common display case.
     pub fn all_cards(&self) -> &[Card] {
         self.cards.as_deref().unwrap_or(&[])
     }

--- a/crates/kanban-tui/src/app/model.rs
+++ b/crates/kanban-tui/src/app/model.rs
@@ -81,7 +81,7 @@ impl Model {
     /// The single unified board collection (live AND archived heads). Which of
     /// these are archived is recorded in `archived_board_ids`; consumers that
     /// want only one subset filter this collection by that set (the projects
-    /// panel does so via `displayed_boards`). Mirrors the unified `cards()`.
+    /// panel does so via `displayed_boards`). Mirrors the unified `all_cards()`.
     pub fn boards(&self) -> &[Board] {
         self.boards.as_deref().unwrap_or(&[])
     }
@@ -112,7 +112,11 @@ impl Model {
         self.columns.as_deref().unwrap_or(&[])
     }
 
-    pub fn cards(&self) -> &[Card] {
+    /// The full unified live+archived collection. Only for callers that
+    /// genuinely need id resolution regardless of archival status (graph
+    /// traversal, detail-view resolution, ArchivedCardsView's own rendering,
+    /// or internal plumbing like `rebuild_displayed_partitions`).
+    pub fn all_cards(&self) -> &[Card] {
         self.cards.as_deref().unwrap_or(&[])
     }
 
@@ -128,11 +132,14 @@ impl Model {
         self.sprints.as_deref().unwrap_or(&[])
     }
 
-    pub fn archived_cards(&self) -> &[ArchivedCard] {
+    /// The archived-card MARKER records (id + archived_at + restore context).
+    /// For restore/permanent-delete logic that needs the marker itself, not the
+    /// live entity. See `archived_cards()` for the full `Card` entities.
+    pub fn archived_card_markers(&self) -> &[ArchivedCard] {
         self.archived_cards.as_deref().unwrap_or(&[])
     }
 
-    /// Ids of the archived cards. Rows themselves live in the unified `cards()`
+    /// Ids of the archived cards. Rows themselves live in the unified `all_cards()`
     /// collection; this set records which of them are archived (built from the
     /// markers). The live/archived partition is precomputed on load and served by
     /// [`displayed_cards`](Self::displayed_cards); this set backs that split.
@@ -163,6 +170,18 @@ impl Model {
         } else {
             &self.displayed_cards_live
         }
+    }
+
+    /// The live cards — the common case for anything rendering to the user.
+    /// Thin wrapper over the cached live/archived partition.
+    pub fn live_cards(&self) -> &[Card] {
+        self.displayed_cards(false)
+    }
+
+    /// The archived cards, as full `Card` entities (not the marker records —
+    /// see `archived_card_markers` for those).
+    pub fn archived_cards(&self) -> &[Card] {
+        self.displayed_cards(true)
     }
 
     /// The boards the projects panel should display, selected by `want_archived`.
@@ -258,7 +277,7 @@ impl Model {
         // archived — with archival recorded by markers in `snapshot.archived_cards`
         // (keyed by `entity_id`). Unify: one collection holds all rows, and an
         // id set records which are archived. The live/archived distinction is a
-        // consumption decision applied by filtering `cards()` on this set.
+        // consumption decision applied by filtering `all_cards()` on this set.
         let archived_card_ids: HashSet<Uuid> = snapshot
             .archived_cards
             .iter()
@@ -315,7 +334,7 @@ impl Model {
 
     fn rebuild_displayed_partitions(&mut self) {
         let (archived_cards, live_cards): (Vec<Card>, Vec<Card>) = self
-            .cards()
+            .all_cards()
             .iter()
             .cloned()
             .partition(|c| self.archived_card_ids.contains(&c.id));
@@ -366,9 +385,9 @@ mod tests {
         let m = Model::default();
         assert!(m.boards().is_empty());
         assert!(m.columns().is_empty());
-        assert!(m.cards().is_empty());
+        assert!(m.all_cards().is_empty());
         assert!(m.sprints().is_empty());
-        assert!(m.archived_cards().is_empty());
+        assert!(m.archived_card_markers().is_empty());
         assert!(m.archived_card_ids().is_empty());
     }
 
@@ -408,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_card_by_id_resolves_live_and_archived_from_one_collection() {
-        // After unification `cards()` holds live AND archived rows, and
+        // After unification `all_cards()` holds live AND archived rows, and
         // `card_by_id` resolves either from the single collection — no
         // `or_else(archived_card())` re-join.
         let mut m = Model::default();
@@ -426,7 +445,7 @@ mod tests {
         });
 
         // Both live and archived rows live in the single unified collection.
-        assert_eq!(m.cards().len(), 2);
+        assert_eq!(m.all_cards().len(), 2);
 
         // The single index resolves both.
         assert_eq!(m.card_by_id(live_id).map(|c| c.id), Some(live_id));
@@ -439,9 +458,9 @@ mod tests {
 
     #[test]
     fn test_archived_view_filter_shows_archived_card_from_unified_collection() {
-        // `archived_card_ids` records the archived subset of the unified `cards()`
+        // `archived_card_ids` records the archived subset of the unified `all_cards()`
         // collection (the same set that backs `displayed_cards`). Assert an
-        // archived card is reachable by filtering `cards()` through that set.
+        // archived card is reachable by filtering `all_cards()` through that set.
         let mut m = Model::default();
         let mut board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
@@ -456,7 +475,7 @@ mod tests {
         });
 
         let displayed: Vec<Uuid> = m
-            .cards()
+            .all_cards()
             .iter()
             .filter(|c| m.archived_card_ids().contains(&c.id))
             .map(|c| c.id)

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -229,13 +229,13 @@ impl App {
         let columns = col_ids.len();
         let cards = self
             .model
-            .cards()
+            .live_cards()
             .iter()
             .filter(|c| col_ids.contains(&c.column_id))
             .count();
         let archived = self
             .model
-            .archived_cards()
+            .archived_card_markers()
             .iter()
             .filter(|a| a.context.board_id == board_id)
             .count();

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -292,7 +292,7 @@ impl App {
             .filter_map(|card_id| {
                 let card = self
                     .model
-                    .cards()
+                    .all_cards()
                     .iter()
                     .find(|c| c.id == *card_id)?
                     .clone();
@@ -371,7 +371,7 @@ impl App {
                     },
                 };
 
-                let cards = self.model.cards();
+                let cards = self.model.all_cards();
                 let position =
                     kanban_domain::card_lifecycle::next_position_in_column(cards, column.id);
 
@@ -460,7 +460,7 @@ impl App {
             // Use the pure helper only to resolve the target column for the
             // given direction; the service handles any status sync.
             let columns = self.model.columns();
-            let cards = self.model.cards();
+            let cards = self.model.all_cards();
             let move_result = kanban_domain::card_lifecycle::compute_card_column_move(
                 &card, board, columns, cards, direction,
             );
@@ -534,7 +534,7 @@ impl App {
         // Use the pure helper only to resolve the per-card target column;
         // status sync is chained by the service layer's `update_cards`.
         let columns = self.model.columns();
-        let cards = self.model.cards();
+        let cards = self.model.all_cards();
         let updates: Vec<(uuid::Uuid, CardUpdate)> = card_ids
             .iter()
             .filter_map(|card_id| {
@@ -602,7 +602,7 @@ impl App {
     fn cursor_archive_anchor(&self) -> Option<(uuid::Uuid, i32)> {
         let card_id = self.get_selected_card_id()?;
         self.model
-            .cards()
+            .all_cards()
             .iter()
             .find(|c| c.id == card_id)
             .map(|c| (c.column_id, c.position))
@@ -622,7 +622,7 @@ impl App {
         use kanban_domain::AnimationType;
         use std::time::Instant;
 
-        if self.model.cards().iter().any(|c| c.id == card_id) {
+        if self.model.all_cards().iter().any(|c| c.id == card_id) {
             self.animation.animating.insert(
                 card_id,
                 CardAnimation {
@@ -641,14 +641,14 @@ impl App {
         // Try to find a card in the same column at or after the deleted position
         if let Some(next_card) = self
             .model
-            .cards()
+            .live_cards()
             .iter()
             .find(|c| c.column_id == deleted_column_id && c.position >= deleted_position)
         {
             self.select_card_by_id(next_card.id);
         } else if let Some(prev_card) = self
             .model
-            .cards()
+            .live_cards()
             .iter()
             .rev()
             .find(|c| c.column_id == deleted_column_id)
@@ -687,7 +687,7 @@ impl App {
 
         if self
             .model
-            .archived_cards()
+            .archived_card_markers()
             .iter()
             .any(|dc| dc.entity_id == card_id)
         {
@@ -770,7 +770,7 @@ impl App {
 
         if self
             .model
-            .archived_cards()
+            .archived_card_markers()
             .iter()
             .any(|dc| dc.entity_id == card_id)
         {
@@ -841,7 +841,7 @@ impl App {
             .map(|c| c.id)
             .collect();
 
-        let cards = self.model.cards();
+        let cards = self.model.all_cards();
         let eligible_cards: Vec<_> = cards
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -319,7 +319,7 @@ impl App {
                         if let Some((column_id, column_name)) = column_to_delete {
                             let cards_to_move: Vec<(uuid::Uuid, i32)> = self
                                 .model
-                                .cards()
+                                .live_cards()
                                 .iter()
                                 .filter(|card| card.column_id == column_id)
                                 .map(|card| (card.id, card.position))

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -833,7 +833,8 @@ impl App {
                             }
                         }
                         CardListAction::Complete(card_id) => {
-                            if let Some(card) = self.model.cards().iter().find(|c| c.id == card_id)
+                            if let Some(card) =
+                                self.model.all_cards().iter().find(|c| c.id == card_id)
                             {
                                 use kanban_domain::{CardStatus, CardUpdate, KanbanOperations};
                                 let new_status = if card.status == CardStatus::Done {
@@ -893,8 +894,12 @@ impl App {
                             }
                         }
                         CardListAction::MoveColumn(card_id, is_right) => {
-                            if let Some(card) =
-                                self.model.cards().iter().find(|c| c.id == card_id).cloned()
+                            if let Some(card) = self
+                                .model
+                                .all_cards()
+                                .iter()
+                                .find(|c| c.id == card_id)
+                                .cloned()
                             {
                                 let direction = if is_right {
                                     kanban_domain::card_lifecycle::MoveDirection::Right
@@ -903,7 +908,7 @@ impl App {
                                 };
 
                                 let columns = self.model.columns();
-                                let cards = self.model.cards();
+                                let cards = self.model.all_cards();
                                 let move_result = self.active_board().and_then(|board| {
                                     kanban_domain::card_lifecycle::compute_card_column_move(
                                         &card, board, columns, cards, direction,
@@ -1008,7 +1013,7 @@ impl App {
 
                     let eligible_cards: Vec<_> = self
                         .model
-                        .cards()
+                        .all_cards()
                         .iter()
                         .filter(|c| column_ids.contains(&c.column_id))
                         .filter(|c| c.id != card_id)
@@ -1061,7 +1066,7 @@ impl App {
 
                     let eligible_cards: Vec<_> = self
                         .model
-                        .cards()
+                        .all_cards()
                         .iter()
                         .filter(|c| column_ids.contains(&c.column_id))
                         .filter(|c| c.id != card_id)
@@ -1183,7 +1188,7 @@ impl App {
             .filter_map(|card_id| {
                 let card = self
                     .model
-                    .cards()
+                    .all_cards()
                     .iter()
                     .find(|c| c.id == *card_id)?
                     .clone();

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -540,7 +540,7 @@ impl App {
                 .iter()
                 .filter(|card_id| {
                     self.model
-                        .cards()
+                        .all_cards()
                         .iter()
                         .find(|c| c.id == **card_id)
                         .map(|c| c.title.to_lowercase().contains(&search_lower))
@@ -653,7 +653,7 @@ impl App {
                 .iter()
                 .filter(|card_id| {
                     self.model
-                        .cards()
+                        .all_cards()
                         .iter()
                         .find(|c| c.id == **card_id)
                         .map(|c| c.title.to_lowercase().contains(&search_lower))

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -121,11 +121,8 @@ impl App {
                     });
 
                     if has_planning
-                        && !get_sprint_uncompleted_cards(
-                            sprint_id,
-                            self.model.displayed_cards(false),
-                        )
-                        .is_empty()
+                        && !get_sprint_uncompleted_cards(sprint_id, self.model.live_cards())
+                            .is_empty()
                     {
                         self.dialog_input.carry_over_source_sprint_id = Some(sprint_id);
                         self.dialog_input.carry_over_sprint_selection.set(Some(0));

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -37,7 +37,7 @@ pub struct ReloadResortFixture {
 }
 
 /// Simulates the KAN-534 scenario: an external write triggers a TUI
-/// reload that reorders `model.cards()`, leaving `ActiveCard.index`
+/// reload that reorders `model.all_cards()`, leaving `ActiveCard.index`
 /// pointing at a different card than `ActiveCard.id`.
 ///
 /// Seeds five cards in the same column with edges P -> A -> D, sets the

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -162,7 +162,7 @@ fn render_board_sprints_list(
             label_text(),
         )));
     } else {
-        let all_cards = app.model.displayed_cards(false);
+        let all_cards = app.model.live_cards();
         for (sprint_idx, sprint) in board_sprints.iter().enumerate() {
             let is_selected = app.selection.sprint.get() == Some(sprint_idx);
             let is_focused = app.focus.board_focus == BoardFocus::Sprints;
@@ -260,7 +260,7 @@ fn render_board_columns_list(
             label_text(),
         )));
     } else {
-        let all_cards = app.model.displayed_cards(false);
+        let all_cards = app.model.live_cards();
         for (column_idx, column) in board_columns.iter().enumerate() {
             let is_selected = app.dialog_input.column_selection.get() == Some(column_idx);
             let is_focused = app.focus.board_focus == BoardFocus::Columns;

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -32,7 +32,7 @@ pub(super) fn render_relationship_boxes(
     let parents_config = FieldSectionConfig::new("Parents")
         .with_focus_indicator("Parents [4]")
         .focused(app.focus.card_focus == CardFocus::Parents);
-    let all_cards: Vec<kanban_domain::Card> = app.model.cards().to_vec();
+    let all_cards: Vec<kanban_domain::Card> = app.model.all_cards().to_vec();
     let parents_lines = render_relationship_section(
         parents,
         &all_cards,

--- a/crates/kanban-tui/src/ui/dialogs/sprints.rs
+++ b/crates/kanban-tui/src/ui/dialogs/sprints.rs
@@ -40,7 +40,7 @@ pub(crate) fn render_carry_over_sprint_popup(app: &App, frame: &mut Frame) {
         .carry_over_source_sprint_id
         .map(|id| {
             use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-            get_sprint_uncompleted_cards(id, app.model.displayed_cards(false)).len()
+            get_sprint_uncompleted_cards(id, app.model.live_cards()).len()
         })
         .unwrap_or(0);
     CarryOverSprintDialog { card_count }.render(app, frame);

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -104,7 +104,7 @@ fn sprint_card_assignment_lines(
 ) -> Vec<Line<'static>> {
     let card_count = app
         .model
-        .displayed_cards(false)
+        .live_cards()
         .iter()
         .filter(|c| c.sprint_id == Some(sprint.id))
         .count();

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -143,7 +143,7 @@ fn test_permanent_delete_removes_archived_card() {
     app.prepare_frame();
 
     assert!(
-        app.model.archived_cards().is_empty(),
+        app.model.archived_card_markers().is_empty(),
         "archived cards should be empty after permanent delete"
     );
     assert!(

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -147,7 +147,7 @@ fn test_permanent_delete_removes_archived_card() {
         "archived cards should be empty after permanent delete"
     );
     assert!(
-        app.model.cards().iter().all(|c| c.id != card_id),
+        app.model.all_cards().iter().all(|c| c.id != card_id),
         "card should not be restored to active cards"
     );
     assert!(
@@ -194,10 +194,10 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
     app.handle_animation_tick();
     app.prepare_frame();
 
-    // Unified model: the row stays in `cards()`; archival is recorded by the
+    // Unified model: the row stays in `all_cards()`; archival is recorded by the
     // id set. "Archived" means present in `archived_card_ids`, not removed.
     assert!(
-        app.model.cards().iter().any(|c| c.id == card_id)
+        app.model.all_cards().iter().any(|c| c.id == card_id)
             && app.model.archived_card_ids().contains(&card_id),
         "card must be archived (marked) after animation completion"
     );
@@ -206,7 +206,7 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
     app.prepare_frame();
 
     assert!(
-        app.model.cards().iter().any(|c| c.id == card_id)
+        app.model.all_cards().iter().any(|c| c.id == card_id)
             && !app.model.archived_card_ids().contains(&card_id),
         "card must be live again after one undo press — archive + compact must \
          live in a single undo batch"
@@ -283,7 +283,7 @@ fn test_multi_column_archive_compacts_every_affected_column() {
     app.handle_animation_tick();
     app.prepare_frame();
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let k1 = cards.iter().find(|c| c.id == keep1.id).unwrap();
     let k2 = cards.iter().find(|c| c.id == keep2.id).unwrap();
     assert_eq!(

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -185,7 +185,7 @@ fn test_move_in_archived_view_matches_c1() {
 fn test_create_not_offered_in_archived_view() {
     let mut app = App::test_default();
     let (_, _, _, _) = seed_archived_card(&mut app);
-    let live_before = app.model.cards().len();
+    let live_before = app.model.all_cards().len();
 
     app.handle_archived_cards_view_mode(KeyCode::Char('n'));
 
@@ -196,7 +196,7 @@ fn test_create_not_offered_in_archived_view() {
     );
     app.prepare_frame();
     assert_eq!(
-        app.model.cards().len(),
+        app.model.all_cards().len(),
         live_before,
         "`n` must not create an invisible live card from the archived view"
     );

--- a/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
+++ b/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
@@ -1,0 +1,77 @@
+//! The board delete/archive confirmation dialog's "task(s)" count currently
+//! includes archived cards sitting in a to-be-deleted column, double-counting
+//! them against the separate "archived task(s)" figure.
+
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::App;
+
+fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
+}
+
+#[test]
+fn test_board_delete_confirmation_card_count_excludes_archived_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+
+    let live = app
+        .ctx
+        .create_card(board.id, col.id, "Live".to_string(), Default::default())
+        .unwrap();
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+    let _ = live;
+
+    app.prepare_frame();
+    app.selection.board.set(Some(0));
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Boards;
+
+    app.handle_delete_board_key();
+    app.prepare_frame();
+
+    let output = render_to_string(&mut app, 100, 30);
+
+    assert!(
+        output.contains("1 task(s)"),
+        "the live task count must exclude the archived card, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("2 task(s)"),
+        "count must not double-count the archived card, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("1 archived task(s)"),
+        "the archived task count must remain 1, got:\n{}",
+        output
+    );
+}

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -42,7 +42,7 @@ fn test_card_description_appears_in_detail_view() {
 
     // Verify the card has the description
     app.prepare_frame();
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     assert_eq!(cards.len(), 1);
     let displayed_card = &cards[0];
 
@@ -87,7 +87,7 @@ fn test_card_description_preserved_after_edit() {
 
     // Verify description exists
     app.prepare_frame();
-    let cards_before = app.model.cards();
+    let cards_before = app.model.all_cards();
     assert_eq!(
         cards_before[0].description,
         Some("Original description".to_string())
@@ -109,7 +109,7 @@ fn test_card_description_preserved_after_edit() {
 
     // Verify description is still there after update
     app.prepare_frame();
-    let cards_after = app.model.cards();
+    let cards_after = app.model.all_cards();
     assert_eq!(cards_after.len(), 1);
     assert_eq!(cards_after[0].title, "Updated Title");
     assert_eq!(
@@ -199,7 +199,7 @@ fn test_card_with_empty_string_description_displays_placeholder() {
 
     // Verify the card has an empty string description (not None)
     app.prepare_frame();
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     assert_eq!(cards[0].description, Some("".to_string()));
 
     // Verify rendering shows placeholder text instead of blank

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -48,7 +48,7 @@ fn test_create_card_dialog_auto_assigns_sole_active_sprint_on_open() {
 
     confirm_create_card_dialog(&mut app, "Task");
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let created = cards
         .iter()
         .find(|c| c.title == "Task")
@@ -81,7 +81,7 @@ fn test_create_card_dialog_space_on_pre_checked_sprint_unchecks_it() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.prepare_frame();
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let created = cards
         .iter()
         .find(|c| c.title == "Task")
@@ -99,7 +99,7 @@ fn test_create_card_dialog_leaves_card_unassigned_when_no_active_sprint() {
 
     confirm_create_card_dialog(&mut app, "Plain");
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let created = cards
         .iter()
         .find(|c| c.title == "Plain")
@@ -119,7 +119,7 @@ fn test_create_card_dialog_leaves_card_unassigned_when_multiple_active_sprints()
 
     confirm_create_card_dialog(&mut app, "Ambig");
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let created = cards
         .iter()
         .find(|c| c.title == "Ambig")
@@ -214,7 +214,7 @@ fn test_j_on_sprint_focus_navigates_picker_like_down() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.prepare_frame();
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let created = cards
         .iter()
         .find(|c| c.title == "Vim")
@@ -257,7 +257,7 @@ fn test_arrow_to_none_row_then_space_explicitly_leaves_card_unassigned() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.prepare_frame();
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let created = cards
         .iter()
         .find(|c| c.title == "NoSprint")
@@ -297,7 +297,7 @@ fn test_arrow_down_then_space_assigns_navigated_sprint() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.prepare_frame();
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let created = cards
         .iter()
         .find(|c| c.title == "Picked")

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -5,7 +5,7 @@
 //! live list).
 //!
 //! Before the fix, `export_all_boards_with_filename` / `auto_save` read the
-//! live-scoped `model.boards()` / `model.cards()`, so an archived board's head
+//! live-scoped `model.boards()` / `model.all_cards()`, so an archived board's head
 //! and subtree were omitted and the exported `archived_boards` marker referenced
 //! a board absent from the file → orphan / silent data loss on re-import. These
 //! tests drive the ACTUAL TUI export entry point (not the snapshot path

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -164,8 +164,8 @@ fn test_import_valid_format() {
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "Imported Board");
     assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.cards().len(), 1);
-    assert_eq!(app.model.cards()[0].title, "Imported Task");
+    assert_eq!(app.model.all_cards().len(), 1);
+    assert_eq!(app.model.all_cards()[0].title, "Imported Task");
 }
 
 #[test]
@@ -427,6 +427,6 @@ fn test_backward_compat_old_export_format() {
     assert_eq!(app.model.boards()[0].card_prefix, None);
 
     // Verify cards still work
-    assert_eq!(app.model.cards().len(), 1);
-    assert_eq!(app.model.cards()[0].title, "Old Card");
+    assert_eq!(app.model.all_cards().len(), 1);
+    assert_eq!(app.model.all_cards()[0].title, "Old Card");
 }

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -127,8 +127,8 @@ async fn test_v2_format_is_imported_correctly() {
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "My Project");
     assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.cards().len(), 1);
-    assert_eq!(app.model.cards()[0].title, "Important Task");
+    assert_eq!(app.model.all_cards().len(), 1);
+    assert_eq!(app.model.all_cards()[0].title, "Important Task");
     assert!(
         app.persistence.save_file.is_some(),
         "save_file should remain enabled after successful V2 import"

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -32,7 +32,7 @@ fn test_prepare_frame_populates_model_from_snapshot() {
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "Board");
     assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.cards().len(), 1);
+    assert_eq!(app.model.all_cards().len(), 1);
     assert_eq!(app.model.card_by_id(card.id).unwrap().title, "Task");
 }
 

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -13,7 +13,7 @@ fn test_empty_model_returns_empty_slices() {
     assert!(model.columns().is_empty());
     assert!(model.all_cards().is_empty());
     assert!(model.sprints().is_empty());
-    assert!(model.archived_cards().is_empty());
+    assert!(model.archived_card_markers().is_empty());
     assert_eq!(model.graph(), &DependencyGraph::default());
 }
 

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -11,7 +11,7 @@ fn test_empty_model_returns_empty_slices() {
     let model = Model::default();
     assert!(model.boards().is_empty());
     assert!(model.columns().is_empty());
-    assert!(model.cards().is_empty());
+    assert!(model.all_cards().is_empty());
     assert!(model.sprints().is_empty());
     assert!(model.archived_cards().is_empty());
     assert_eq!(model.graph(), &DependencyGraph::default());
@@ -42,8 +42,8 @@ fn test_load_from_snapshot_populates_all_fields() {
     assert_eq!(model.boards()[0].name, "Board1");
     assert_eq!(model.columns().len(), 1);
     assert_eq!(model.columns()[0].name, "Col1");
-    assert_eq!(model.cards().len(), 1);
-    assert_eq!(model.cards()[0].title, "Card1");
+    assert_eq!(model.all_cards().len(), 1);
+    assert_eq!(model.all_cards()[0].title, "Card1");
     assert_eq!(model.sprints().len(), 1);
     assert_eq!(model.sprints()[0].sprint_number, 1);
 }
@@ -121,7 +121,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
 fn archived_titles(model: &Model) -> Vec<String> {
     let ids = model.archived_card_ids();
     model
-        .cards()
+        .all_cards()
         .iter()
         .filter(|c| ids.contains(&c.id))
         .map(|c| c.title.clone())

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -92,7 +92,7 @@ fn test_manage_parents_popup_enter_creates_parent_edge() {
         )
         .unwrap();
 
-    // Wire the model so popup_handlers' `self.model.cards()` reflects
+    // Wire the model so popup_handlers' `self.model.all_cards()` reflects
     // the data store. `selection.active_card` points at child.
     let snapshot = Snapshot {
         archived_boards: Vec::new(),

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -83,7 +83,7 @@ fn test_create_card_selects_newly_created_card() {
         "a card should be selected after creation"
     );
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let created = cards.iter().find(|c| c.title == "My Card");
     assert!(created.is_some(), "card should exist in model");
     assert_eq!(selected_id.unwrap(), created.unwrap().id);
@@ -107,7 +107,7 @@ fn test_create_card_selects_newly_created_card_when_prior_selection_exists() {
     app.create_card();
     app.prepare_frame();
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let second = cards
         .iter()
         .find(|c| c.title == "Second")
@@ -161,7 +161,7 @@ fn test_create_card_auto_completes_in_done_column() {
     app.create_card();
     app.prepare_frame();
 
-    let cards = app.model.cards();
+    let cards = app.model.all_cards();
     let done_card = cards
         .iter()
         .find(|c| c.title == "Done Card" && c.column_id == done_col.id);
@@ -254,7 +254,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
 
     let card_id = app
         .model
-        .cards()
+        .all_cards()
         .iter()
         .find(|c| c.title == "Task")
         .unwrap()
@@ -320,7 +320,7 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
 
     let card_id = app
         .model
-        .cards()
+        .all_cards()
         .iter()
         .find(|c| c.title == "Task")
         .unwrap()


### PR DESCRIPTION
Root-cause hardening for the archived-card-leak bug class traced through KAN-981/982/984/985: `Model::cards()` (the unified live+archived card collection) was the shortest, most discoverable accessor on `Model`, and the wrong default for almost every call site that renders something to the user. The correct accessor, `displayed_cards(bool)`, already existed and was precomputed, but its less-obvious name meant new code kept reaching for `cards()` instead.

- Added `Model::live_cards()`/`Model::archived_cards() -> &[Card]` as thin wrappers over the existing `displayed_cards(bool)`.
- Renamed `cards()` → `all_cards()` and repointed every call site (~74 across `src` and `tests`, including ~40 more than originally scoped once test files were counted) to whichever of `all_cards()`/`live_cards()` matches its actual need.
- Renamed the marker-returning `archived_cards() -> &[ArchivedCard]` to `archived_card_markers()`, freeing the `archived_cards()` name for the more useful `Card`-entity meaning.
- Fixed the board delete/archive confirmation dialog's task count, which was double-counting archived cards against the separate archived-task figure (KAN-984).

**What changed in scope during implementation** (both found by writing an actual failing test and checking why it failed, not by re-reading the code):
- This card originally also claimed 4 "position-math bugs" (archived cards inflating `next_position_in_column`/`compute_card_column_move` results). Investigating turned up an already-shipped, deliberate service-layer design (`crates/kanban-service/src/context/cards.rs`, comment cites KAN-916/O1-A): position assignment on card create/move deliberately counts the full live+archived set, specifically so a moved card never collides with an archived sibling's position. Reclassifying those sites to `live_cards()` would have been a regression, not a fix — they're repointed to `all_cards()` instead, with no behavior change.
- KAN-985 (Card Detail's relationship display) was also folded in originally, then investigated and closed as invalid: archiving a card cascades to archive its incident graph edges (`ArchiveCards::execute` → `graph.archive_node`), and `Graph::children()`/`parents()` already only return live edges (`outgoing_active`/`incoming_active`). There was nothing left for Card Detail to leak.
- A real, different bug surfaced along the way: bulk multi-select column moves never recompute position at all (unrelated to archival — filed separately as KAN-987).
- KAN-982 (manage-children/parents candidate filtering) is blocked by this rename but stays its own card/PR — not absorbed here.

**Why**: the reference-marker archival model means any TUI code that reads the unified collection without an explicit live/archived choice is systemically at risk of this exact bug class. Making the safe accessor (`live_cards()`) the short, obvious name — instead of `cards()` — removes the trap for the next feature that touches this code, rather than patching one leak at a time.

**How**: a bulk mechanical repoint (compiler-driven) for the rename itself, plus one targeted one-line fix for the confirmed board-delete-count bug.

**Testing**: `cargo test -p kanban-tui --test board_delete_confirmation_count_tests` (new test, Red confirmed against current `develop` before the fix), `cargo test --workspace` (126 test binaries, no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean), plus a manual `git grep` sweep confirming zero stale references to the old method names or their doc comments.