### PR TITLE
KAN-982 feat(tui): manage-children/parents defaults to live-only candidates

### DIFF
--- a/.changeset/max-kan-982.md
+++ b/.changeset/max-kan-982.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+Managing a card's children or parents (from either the tasks panel or Card
+Detail) now defaults to offering only live cards as candidates. Previously
+an archived card could show up in the picker as if it were a normal,
+selectable relative, which wasn't particularly useful in the common case.
+Managing relationships from an already-archived card (via the archived
+tasks view) is unaffected: archived candidates are still fully available
+there, matching how every other action on an archived card already works.

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -841,12 +841,18 @@ impl App {
             .map(|c| c.id)
             .collect();
 
+        // A live target defaults to live-only candidates; an archived target
+        // (managed from ArchivedCardsView) keeps full parity with the live
+        // panel and stays unrestricted.
+        let target_is_archived = self.model.archived_card_ids().contains(&card_id);
+
         let cards = self.model.all_cards();
         let eligible_cards: Vec<_> = cards
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))
             .filter(|c| c.id != card_id)
             .filter(|c| !ancestors.contains(&c.id))
+            .filter(|c| target_is_archived || !self.model.archived_card_ids().contains(&c.id))
             .map(|c| c.id)
             .collect();
 

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -841,9 +841,6 @@ impl App {
             .map(|c| c.id)
             .collect();
 
-        // A live target defaults to live-only candidates; an archived target
-        // (managed from ArchivedCardsView) keeps full parity with the live
-        // panel and stays unrestricted.
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
         let cards = self.model.all_cards();

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1011,8 +1011,6 @@ impl App {
                         .map(|c| c.id)
                         .collect();
 
-                    // A live target defaults to live-only candidates; an
-                    // archived target keeps full parity and stays unrestricted.
                     let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
                     let eligible_cards: Vec<_> = self
@@ -1071,8 +1069,6 @@ impl App {
                         .map(|c| c.id)
                         .collect();
 
-                    // A live target defaults to live-only candidates; an
-                    // archived target keeps full parity and stays unrestricted.
                     let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
                     let eligible_cards: Vec<_> = self

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -984,7 +984,7 @@ impl App {
         }
     }
 
-    pub(crate) fn handle_manage_parents(&mut self) {
+    pub fn handle_manage_parents(&mut self) {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id(active_id) {
                 let card_id = card.id;
@@ -1011,6 +1011,10 @@ impl App {
                         .map(|c| c.id)
                         .collect();
 
+                    // A live target defaults to live-only candidates; an
+                    // archived target keeps full parity and stays unrestricted.
+                    let target_is_archived = self.model.archived_card_ids().contains(&card_id);
+
                     let eligible_cards: Vec<_> = self
                         .model
                         .all_cards()
@@ -1018,6 +1022,9 @@ impl App {
                         .filter(|c| column_ids.contains(&c.column_id))
                         .filter(|c| c.id != card_id)
                         .filter(|c| !descendants.contains(&c.id))
+                        .filter(|c| {
+                            target_is_archived || !self.model.archived_card_ids().contains(&c.id)
+                        })
                         .map(|c| c.id)
                         .collect();
 
@@ -1037,7 +1044,7 @@ impl App {
         }
     }
 
-    pub(crate) fn handle_manage_children(&mut self) {
+    pub fn handle_manage_children(&mut self) {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id(active_id) {
                 let card_id = card.id;
@@ -1064,6 +1071,10 @@ impl App {
                         .map(|c| c.id)
                         .collect();
 
+                    // A live target defaults to live-only candidates; an
+                    // archived target keeps full parity and stays unrestricted.
+                    let target_is_archived = self.model.archived_card_ids().contains(&card_id);
+
                     let eligible_cards: Vec<_> = self
                         .model
                         .all_cards()
@@ -1071,6 +1082,9 @@ impl App {
                         .filter(|c| column_ids.contains(&c.column_id))
                         .filter(|c| c.id != card_id)
                         .filter(|c| !ancestors.contains(&c.id))
+                        .filter(|c| {
+                            target_is_archived || !self.model.archived_card_ids().contains(&c.id)
+                        })
                         .map(|c| c.id)
                         .collect();
 

--- a/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
+++ b/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
@@ -1,0 +1,220 @@
+//! `handle_manage_children_from_list`, `handle_manage_parents`, and
+//! `handle_manage_children` each build their eligible-candidates list from
+//! the unified live+archived card collection with no archived exclusion, so
+//! managing relationships from a LIVE card currently offers archived cards
+//! as candidates too. Per KAN-972's resolution: a live target should default
+//! to live-only candidates; an archived target (ArchivedCardsView's `s` key)
+//! keeps full parity and still offers archived candidates.
+
+use kanban_domain::{CreateCardOptions, KanbanOperations, Snapshot};
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::App;
+
+fn sync_model_from_store(app: &mut App) {
+    let snapshot = Snapshot {
+        archived_boards: Vec::new(),
+        boards: app.ctx.data_store().list_boards().unwrap(),
+        columns: app.ctx.data_store().list_all_columns().unwrap(),
+        cards: app.ctx.data_store().list_all_cards().unwrap(),
+        archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+        sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+        graph: app.ctx.data_store().get_graph().unwrap(),
+    };
+    app.model.load_from_snapshot(snapshot);
+}
+
+/// Seed a board/column with a target card plus a live and an archived
+/// candidate, all otherwise eligible (same board, no ancestor/descendant
+/// relation to the target).
+fn seed_target_and_candidates(app: &mut App) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid, uuid::Uuid) {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+
+    let target = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Target".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let live_candidate = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "LiveCandidate".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived_candidate = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "ArchivedCandidate".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(archived_candidate.id).unwrap();
+
+    (
+        board.id,
+        target.id,
+        live_candidate.id,
+        archived_candidate.id,
+    )
+}
+
+#[test]
+fn test_manage_children_from_live_card_excludes_archived_candidates() {
+    let mut app = App::test_default();
+    let (board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    sync_model_from_store(&mut app);
+
+    app.selection.active_board_id = Some(board_id);
+    app.prepare_frame();
+    let list = app.view.strategy.get_active_task_list_mut().unwrap();
+    let idx = list
+        .cards
+        .iter()
+        .position(|&id| id == target_id)
+        .expect("target card is in the active task list");
+    list.set_selected_index(Some(idx));
+
+    app.handle_manage_children_from_list();
+
+    assert!(
+        app.relationship.card_ids.contains(&live_id),
+        "live candidate must be offered"
+    );
+    assert!(
+        !app.relationship.card_ids.contains(&archived_id),
+        "archived candidate must be excluded when the target is live"
+    );
+}
+
+#[test]
+fn test_manage_children_from_archived_card_still_offers_archived_candidates() {
+    let mut app = App::test_default();
+    let (board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    app.ctx.archive_card(target_id).unwrap();
+    sync_model_from_store(&mut app);
+
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::ArchivedCardsView;
+    app.prepare_frame();
+    let list = app.view.strategy.get_active_task_list_mut().unwrap();
+    let idx = list
+        .cards
+        .iter()
+        .position(|&id| id == target_id)
+        .expect("archived target card is in the archived task list");
+    list.set_selected_index(Some(idx));
+
+    app.handle_manage_children_from_list();
+
+    assert!(
+        app.relationship.card_ids.contains(&live_id),
+        "live candidate must still be offered"
+    );
+    assert!(
+        app.relationship.card_ids.contains(&archived_id),
+        "archived candidate must still be offered when the target itself is archived (parity)"
+    );
+}
+
+#[test]
+fn test_manage_children_from_live_card_still_offers_live_candidates() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let target = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Target".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let live_a = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "LiveA".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let live_b = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "LiveB".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    sync_model_from_store(&mut app);
+
+    app.selection.active_board_id = Some(board.id);
+    app.prepare_frame();
+    let list = app.view.strategy.get_active_task_list_mut().unwrap();
+    let idx = list
+        .cards
+        .iter()
+        .position(|&id| id == target.id)
+        .expect("target card is in the active task list");
+    list.set_selected_index(Some(idx));
+
+    app.handle_manage_children_from_list();
+
+    assert!(app.relationship.card_ids.contains(&live_a.id));
+    assert!(app.relationship.card_ids.contains(&live_b.id));
+}
+
+#[test]
+fn test_card_detail_manage_children_excludes_archived_candidates() {
+    let mut app = App::test_default();
+    let (_board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_card_id = Some(target_id);
+
+    app.handle_manage_children();
+
+    assert!(
+        app.relationship.card_ids.contains(&live_id),
+        "live candidate must be offered"
+    );
+    assert!(
+        !app.relationship.card_ids.contains(&archived_id),
+        "archived candidate must be excluded when the target is live"
+    );
+}
+
+#[test]
+fn test_card_detail_manage_parents_excludes_archived_candidates() {
+    let mut app = App::test_default();
+    let (_board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_card_id = Some(target_id);
+
+    app.handle_manage_parents();
+
+    assert!(
+        app.relationship.card_ids.contains(&live_id),
+        "live candidate must be offered"
+    );
+    assert!(
+        !app.relationship.card_ids.contains(&archived_id),
+        "archived candidate must be excluded when the target is live"
+    );
+}


### PR DESCRIPTION
Split out of the KAN-972 investigation (KAN-960 epic), unblocked by KAN-986's `Model::cards()` rename.

There are three near-identical implementations of the eligible-candidates computation for managing a card's children/parents, reachable from two different entry points:

- `handle_manage_children_from_list` (`crates/kanban-tui/src/handlers/card_handlers.rs`) — the tasks-panel `'s'` key.
- `handle_manage_parents` / `handle_manage_children` (`crates/kanban-tui/src/handlers/detail_view_handlers.rs`) — Card Detail's own dedicated actions.

All three built their candidate list from the unified live+archived card collection with no archived exclusion, so managing relationships from a live card offered an archived card as a selectable candidate — not particularly useful in the common case.

**What**: all three now default to live-only candidates when the target card is live. Managing relationships from an already-archived card (reached via the archived tasks view) is unaffected — archived candidates stay fully available there, matching how every other action on an archived card already works (LSP parity established in KAN-972).

**Why**: the model/domain layer imposes no restriction on spawns-relation candidates by design (a live card *can* be related to an archived one, if some interface allows it) — this is a TUI-consuming-interface default, not a model invariant, and different consuming contexts (the live tasks panel vs. the archived tasks view) can reasonably make different defaults.

**How**: added a `target_is_archived` check (via the existing `Model::archived_card_ids()`) to each of the three functions' filter chain, identically. Also widened `handle_manage_parents`/`handle_manage_children` from `pub(crate)` to `pub` for testability, matching `handle_manage_children_from_list`'s existing visibility.

**Testing**: `cargo test -p kanban-tui --test manage_children_parents_archived_candidates_tests` (5 new tests: one per entry point proving live-target exclusion, one proving archived-target parity is preserved, one live-only sanity baseline), `cargo test --workspace` (127 test binaries, no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).