### PR TITLE
KAN-980 fix(tui): wire 'e' (edit card) through the help-menu dispatch path

### DIFF
--- a/.changeset/max-kan-980.md
+++ b/.changeset/max-kan-980.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+Pressing `e` (edit) through the in-app Help overlay now works everywhere it
+should. Previously, selecting "Edit card" from the Help menu (or pressing `?`
+then jumping straight to `e`) silently did nothing in every context: the card
+list, card detail (title, description, or metadata), sprint detail, and the
+settings configuration editor. Pressing `e` directly, outside the Help menu,
+already worked correctly in all of these places.
+
+The two paths now share one dispatch, so editing a card through the Help
+menu opens the same editor as pressing `e` directly, in every mode.

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -642,13 +642,8 @@ impl App {
                         }
                         self.ui_state.help_list.reset();
 
-                        use crate::keybindings::KeybindingAction;
-                        should_restart = if binding.action == KeybindingAction::EditCard {
-                            self.execute_edit_card_action(terminal, event_handler)
-                        } else {
-                            self.execute_action(&binding.action);
-                            false
-                        };
+                        should_restart =
+                            self.dispatch_help_action(binding.action, terminal, event_handler);
                     }
                 }
             }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -113,7 +113,9 @@ impl App {
             AppMode::Settings => {
                 should_restart_events = self.handle_settings_key(key.code, terminal, event_handler);
             }
-            AppMode::Help(_) => self.handle_help_mode(key.code),
+            AppMode::Help(_) => {
+                should_restart_events = self.handle_help_mode(key.code, terminal, event_handler);
+            }
             AppMode::ErrorLog => self.handle_error_log_mode(key.code),
             AppMode::Dialog(ref dialog) => match dialog {
                 DialogMode::CreateBoard => self.handle_create_board_dialog(key.code),
@@ -601,9 +603,16 @@ impl App {
                     && self.selection.active_board_id.is_some()))
     }
 
-    fn handle_help_mode(&mut self, key_code: crossterm::event::KeyCode) {
+    fn handle_help_mode(
+        &mut self,
+        key_code: crossterm::event::KeyCode,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
         use crate::keybindings::KeybindingRegistry;
         use crossterm::event::KeyCode;
+
+        let mut should_restart = false;
 
         match key_code {
             KeyCode::Char('j') | KeyCode::Down => {
@@ -633,7 +642,13 @@ impl App {
                         }
                         self.ui_state.help_list.reset();
 
-                        self.execute_action(&binding.action);
+                        use crate::keybindings::KeybindingAction;
+                        should_restart = if binding.action == KeybindingAction::EditCard {
+                            self.execute_edit_card_action(terminal, event_handler)
+                        } else {
+                            self.execute_action(&binding.action);
+                            false
+                        };
                     }
                 }
             }
@@ -662,5 +677,7 @@ impl App {
                 }
             }
         }
+
+        should_restart
     }
 }

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -1,4 +1,16 @@
 use super::{App, AppMode, Focus};
+use crate::events::EventHandler;
+use ratatui::{backend::CrosstermBackend, Terminal};
+use std::io;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(in crate::app) enum EditCardDispatch {
+    CardList,
+    CardDetail,
+    SprintDetail(uuid::Uuid),
+    SettingsConfig,
+    Noop,
+}
 
 impl App {
     pub(in crate::app) fn keycode_matches_binding_key(
@@ -55,6 +67,67 @@ impl App {
                 trimmed == "→" || trimmed == "Right" || trimmed == "RIGHT"
             }),
             _ => false,
+        }
+    }
+
+    /// Which real handler `EditCard` reaches for the app's current mode/focus.
+    /// Pure and terminal-free so the dispatch decision is unit-testable on its
+    /// own, mirroring `edit_key_active`.
+    pub(in crate::app) fn resolve_edit_card_dispatch(&self) -> EditCardDispatch {
+        if self.edit_key_active() {
+            EditCardDispatch::CardList
+        } else if self.mode == AppMode::CardDetail {
+            EditCardDispatch::CardDetail
+        } else if self.mode == AppMode::SprintDetail {
+            match self.sprint_detail_selected_card_id() {
+                Some(card_id) => EditCardDispatch::SprintDetail(card_id),
+                None => EditCardDispatch::Noop,
+            }
+        } else if self.mode == AppMode::Settings
+            && self.focus.settings_focus == crate::app::SettingsFocus::Configuration
+        {
+            EditCardDispatch::SettingsConfig
+        } else {
+            EditCardDispatch::Noop
+        }
+    }
+
+    /// SprintDetail's `EditCard` target: identical to `CardListAction::Edit`'s
+    /// effect on the shared `CardListComponent` dispatch, needs no terminal.
+    pub(in crate::app) fn open_sprint_detail_card_for_edit(&mut self, card_id: uuid::Uuid) {
+        if self.activate_card(card_id) {
+            let parents = self.get_current_card_parents();
+            let children = self.get_current_card_children();
+            self.relationship
+                .parents_list
+                .update_item_count(parents.len());
+            self.relationship
+                .children_list
+                .update_item_count(children.len());
+            self.push_mode(AppMode::CardDetail);
+            self.focus.card_focus = crate::app::CardFocus::Title;
+        }
+    }
+
+    // EditCard can launch the external editor, which needs the terminal — kept
+    // out of execute_action (terminal-free, unit-testable) and called directly
+    // by both Help-mode call sites instead.
+    pub(in crate::app) fn execute_edit_card_action(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
+        match self.resolve_edit_card_dispatch() {
+            EditCardDispatch::CardList => self.handle_edit_card_key(terminal, event_handler),
+            EditCardDispatch::CardDetail => {
+                self.edit_card_detail_focused_field(terminal, event_handler)
+            }
+            EditCardDispatch::SprintDetail(card_id) => {
+                self.open_sprint_detail_card_for_edit(card_id);
+                false
+            }
+            EditCardDispatch::SettingsConfig => self.open_config_editor(terminal, event_handler),
+            EditCardDispatch::Noop => false,
         }
     }
 

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -612,13 +612,17 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_edit_card_dispatch_is_noop_in_settings_storage_focus() {
+    fn test_resolve_edit_card_dispatch_targets_settings_config_in_storage_focus() {
         use crate::app::SettingsFocus;
         let mut app = App::test_default();
         app.mode = AppMode::Settings;
         app.focus.settings_focus = SettingsFocus::Storage;
 
-        assert_eq!(app.resolve_edit_card_dispatch(), EditCardDispatch::Noop);
+        assert_eq!(
+            app.resolve_edit_card_dispatch(),
+            EditCardDispatch::SettingsConfig,
+            "handle_settings_key's Char('e') arm opens the config editor regardless of focus"
+        );
     }
 
     #[test]

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -457,4 +457,90 @@ mod tests {
             "ExportBoards with a live board must open the export dialog"
         );
     }
+
+    #[test]
+    fn test_resolve_edit_card_dispatch_targets_card_list_when_edit_key_active() {
+        let mut app = App::test_default();
+        app.focus.active = Focus::Cards;
+        app.mode = AppMode::Normal;
+
+        assert_eq!(app.resolve_edit_card_dispatch(), EditCardDispatch::CardList);
+    }
+
+    #[test]
+    fn test_resolve_edit_card_dispatch_targets_card_detail_in_card_detail_mode() {
+        let mut app = App::test_default();
+        let card_id = seed_board_with_card(&mut app);
+        app.mode = AppMode::CardDetail;
+        app.selection.active_card_id = Some(card_id);
+
+        assert_eq!(
+            app.resolve_edit_card_dispatch(),
+            EditCardDispatch::CardDetail
+        );
+    }
+
+    #[test]
+    fn test_resolve_edit_card_dispatch_targets_sprint_detail_selected_card() {
+        use crate::app::sprint_view::SprintTaskPanel;
+        let mut app = App::test_default();
+        let card_id = seed_board_with_card(&mut app);
+        app.sprint_view.panel = SprintTaskPanel::Uncompleted;
+        app.sprint_view
+            .uncompleted_component
+            .update_cards(vec![card_id]);
+        app.sprint_view
+            .uncompleted_component
+            .set_selected_index(Some(0));
+        app.mode = AppMode::SprintDetail;
+
+        assert_eq!(
+            app.resolve_edit_card_dispatch(),
+            EditCardDispatch::SprintDetail(card_id)
+        );
+    }
+
+    #[test]
+    fn test_resolve_edit_card_dispatch_is_noop_in_sprint_detail_with_no_selection() {
+        let mut app = App::test_default();
+        app.mode = AppMode::SprintDetail;
+
+        assert_eq!(app.resolve_edit_card_dispatch(), EditCardDispatch::Noop);
+    }
+
+    #[test]
+    fn test_resolve_edit_card_dispatch_targets_settings_config_in_configuration_focus() {
+        use crate::app::SettingsFocus;
+        let mut app = App::test_default();
+        app.mode = AppMode::Settings;
+        app.focus.settings_focus = SettingsFocus::Configuration;
+
+        assert_eq!(
+            app.resolve_edit_card_dispatch(),
+            EditCardDispatch::SettingsConfig
+        );
+    }
+
+    #[test]
+    fn test_resolve_edit_card_dispatch_is_noop_in_settings_storage_focus() {
+        use crate::app::SettingsFocus;
+        let mut app = App::test_default();
+        app.mode = AppMode::Settings;
+        app.focus.settings_focus = SettingsFocus::Storage;
+
+        assert_eq!(app.resolve_edit_card_dispatch(), EditCardDispatch::Noop);
+    }
+
+    #[test]
+    fn test_open_sprint_detail_card_for_edit_opens_card_detail_on_title() {
+        let mut app = App::test_default();
+        let card_id = seed_board_with_card(&mut app);
+        app.mode = AppMode::SprintDetail;
+
+        app.open_sprint_detail_card_for_edit(card_id);
+
+        assert_eq!(app.mode, AppMode::CardDetail);
+        assert_eq!(app.selection.active_card_id, Some(card_id));
+        assert_eq!(app.focus.card_focus, crate::app::CardFocus::Title);
+    }
 }

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -83,9 +83,9 @@ impl App {
                 Some(card_id) => EditCardDispatch::SprintDetail(card_id),
                 None => EditCardDispatch::Noop,
             }
-        } else if self.mode == AppMode::Settings
-            && self.focus.settings_focus == crate::app::SettingsFocus::Configuration
-        {
+        } else if self.mode == AppMode::Settings {
+            // Matches handle_settings_key's own Char('e') arm, which opens the
+            // config editor regardless of settings_focus.
             EditCardDispatch::SettingsConfig
         } else {
             EditCardDispatch::Noop
@@ -128,6 +128,23 @@ impl App {
             }
             EditCardDispatch::SettingsConfig => self.open_config_editor(terminal, event_handler),
             EditCardDispatch::Noop => false,
+        }
+    }
+
+    /// Single entry point for firing a Help-menu binding, shared by the
+    /// Enter-immediate and deferred jump-then-fire call sites so they can't
+    /// drift on which actions need the terminal restarted afterward.
+    pub(in crate::app) fn dispatch_help_action(
+        &mut self,
+        action: crate::keybindings::KeybindingAction,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
+        if action == crate::keybindings::KeybindingAction::EditCard {
+            self.execute_edit_card_action(terminal, event_handler)
+        } else {
+            self.execute_action(&action);
+            false
         }
     }
 

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -212,7 +212,15 @@ impl App {
 
                                         let action = *action;
                                         self.ui_state.help_pending_action = None;
-                                        self.execute_action(&action);
+                                        if action == crate::keybindings::KeybindingAction::EditCard
+                                        {
+                                            self.execute_edit_card_action(
+                                                &mut terminal,
+                                                &events,
+                                            );
+                                        } else {
+                                            self.execute_action(&action);
+                                        }
                                     }
                                 }
 

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -212,14 +212,10 @@ impl App {
 
                                         let action = *action;
                                         self.ui_state.help_pending_action = None;
-                                        if action == crate::keybindings::KeybindingAction::EditCard
-                                        {
-                                            self.execute_edit_card_action(
-                                                &mut terminal,
-                                                &events,
-                                            );
-                                        } else {
-                                            self.execute_action(&action);
+                                        let should_restart =
+                                            self.dispatch_help_action(action, &mut terminal, &events);
+                                        if should_restart {
+                                            break;
                                         }
                                     }
                                 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -595,50 +595,51 @@ impl App {
                 }
                 true
             }
-            CardFocus::Metadata => {
-                if let Some(card) = self.get_card_for_detail_view() {
-                    let card_id = card.id;
-                    let dto = CardMetadataDto::from_entity(&card);
-                    let json =
-                        serde_json::to_string_pretty(&dto).unwrap_or_else(|_| "{}".to_string());
-                    let temp_file =
-                        std::env::temp_dir().join(format!("kanban-card-{}-metadata.json", card_id));
-                    match edit_in_external_editor(terminal, event_handler, temp_file, &json) {
-                        Ok(Some(new_content)) => {
-                            match serde_json::from_str::<CardMetadataDto>(&new_content) {
-                                Ok(new_dto) => {
-                                    let cmd = kanban_domain::commands::Command::Card(
-                                        kanban_domain::commands::CardCommand::ApplyMetadata(
-                                            kanban_domain::commands::ApplyCardMetadata {
-                                                card_id,
-                                                dto: new_dto,
-                                            },
-                                        ),
-                                    );
-                                    if let Err(e) = self.ctx.execute_command(cmd) {
-                                        tracing::error!("Failed to apply metadata: {}", e);
-                                        self.set_error(format!("Failed to apply metadata: {}", e));
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Failed to parse metadata JSON: {}", e);
-                                    self.set_error(format!("Failed to parse metadata JSON: {}", e));
-                                }
-                            }
-                        }
-                        Ok(None) => {}
-                        Err(e) => {
-                            tracing::error!("Failed to edit metadata: {}", e);
-                            self.set_error(format!("Failed to edit metadata: {}", e));
-                        }
-                    }
-                    true
-                } else {
-                    false
-                }
-            }
+            CardFocus::Metadata => self.edit_card_metadata_field(terminal, event_handler),
             CardFocus::Parents | CardFocus::Children => false,
         }
+    }
+
+    fn edit_card_metadata_field(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
+        let Some(card) = self.get_card_for_detail_view() else {
+            return false;
+        };
+        let card_id = card.id;
+        let dto = CardMetadataDto::from_entity(&card);
+        let json = serde_json::to_string_pretty(&dto).unwrap_or_else(|_| "{}".to_string());
+        let temp_file = std::env::temp_dir().join(format!("kanban-card-{}-metadata.json", card_id));
+        match edit_in_external_editor(terminal, event_handler, temp_file, &json) {
+            Ok(Some(new_content)) => match serde_json::from_str::<CardMetadataDto>(&new_content) {
+                Ok(new_dto) => {
+                    let cmd = kanban_domain::commands::Command::Card(
+                        kanban_domain::commands::CardCommand::ApplyMetadata(
+                            kanban_domain::commands::ApplyCardMetadata {
+                                card_id,
+                                dto: new_dto,
+                            },
+                        ),
+                    );
+                    if let Err(e) = self.ctx.execute_command(cmd) {
+                        tracing::error!("Failed to apply metadata: {}", e);
+                        self.set_error(format!("Failed to apply metadata: {}", e));
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to parse metadata JSON: {}", e);
+                    self.set_error(format!("Failed to parse metadata JSON: {}", e));
+                }
+            },
+            Ok(None) => {}
+            Err(e) => {
+                tracing::error!("Failed to edit metadata: {}", e);
+                self.set_error(format!("Failed to edit metadata: {}", e));
+            }
+        }
+        true
     }
 
     /// The single card highlighted in whichever sprint-detail panel is active

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -214,77 +214,9 @@ impl App {
             KeyCode::Char('Y') => {
                 self.copy_git_checkout_command();
             }
-            KeyCode::Char('e') => match self.focus.card_focus {
-                CardFocus::Title => {
-                    if let Err(e) = self.edit_card_field(terminal, event_handler, CardField::Title)
-                    {
-                        tracing::error!("Failed to edit title: {}", e);
-                        self.set_error(format!("Failed to edit title: {}", e));
-                    }
-                    should_restart = true;
-                }
-                CardFocus::Description => {
-                    if let Err(e) =
-                        self.edit_card_field(terminal, event_handler, CardField::Description)
-                    {
-                        tracing::error!("Failed to edit description: {}", e);
-                        self.set_error(format!("Failed to edit description: {}", e));
-                    }
-                    should_restart = true;
-                }
-                CardFocus::Metadata => {
-                    if let Some(card) = self.get_card_for_detail_view() {
-                        let card_id = card.id;
-                        let dto = CardMetadataDto::from_entity(&card);
-                        let json =
-                            serde_json::to_string_pretty(&dto).unwrap_or_else(|_| "{}".to_string());
-                        let temp_file = std::env::temp_dir()
-                            .join(format!("kanban-card-{}-metadata.json", card_id));
-                        match edit_in_external_editor(terminal, event_handler, temp_file, &json) {
-                            Ok(Some(new_content)) => {
-                                match serde_json::from_str::<CardMetadataDto>(&new_content) {
-                                    Ok(new_dto) => {
-                                        let cmd = kanban_domain::commands::Command::Card(
-                                            kanban_domain::commands::CardCommand::ApplyMetadata(
-                                                kanban_domain::commands::ApplyCardMetadata {
-                                                    card_id,
-                                                    dto: new_dto,
-                                                },
-                                            ),
-                                        );
-                                        if let Err(e) = self.ctx.execute_command(cmd) {
-                                            tracing::error!("Failed to apply metadata: {}", e);
-                                            self.set_error(format!(
-                                                "Failed to apply metadata: {}",
-                                                e
-                                            ));
-                                        }
-                                    }
-                                    Err(e) => {
-                                        tracing::error!("Failed to parse metadata JSON: {}", e);
-                                        self.set_error(format!(
-                                            "Failed to parse metadata JSON: {}",
-                                            e
-                                        ));
-                                    }
-                                }
-                            }
-                            Ok(None) => {}
-                            Err(e) => {
-                                tracing::error!("Failed to edit metadata: {}", e);
-                                self.set_error(format!("Failed to edit metadata: {}", e));
-                            }
-                        }
-                        should_restart = true;
-                    }
-                }
-                CardFocus::Parents => {
-                    // Parents section - use 'r' to manage parents
-                }
-                CardFocus::Children => {
-                    // Children section - use 'R' to manage children
-                }
-            },
+            KeyCode::Char('e') => {
+                should_restart = self.edit_card_detail_focused_field(terminal, event_handler);
+            }
             KeyCode::Char('d') => {
                 self.handle_archive_card();
                 self.pop_mode();
@@ -634,6 +566,78 @@ impl App {
                     self.handle_carry_over_for_sprint(sprint_id);
                 }
             }
+        }
+    }
+
+    /// Edit whichever Card Detail field is currently focused: `Title`/
+    /// `Description` open the inline editor, `Metadata` opens the card's JSON
+    /// in an external editor. `Parents`/`Children` are no-ops here (`r`/`R`
+    /// manage those). Returns whether the terminal needs restarting.
+    pub(crate) fn edit_card_detail_focused_field(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
+        match self.focus.card_focus {
+            CardFocus::Title => {
+                if let Err(e) = self.edit_card_field(terminal, event_handler, CardField::Title) {
+                    tracing::error!("Failed to edit title: {}", e);
+                    self.set_error(format!("Failed to edit title: {}", e));
+                }
+                true
+            }
+            CardFocus::Description => {
+                if let Err(e) =
+                    self.edit_card_field(terminal, event_handler, CardField::Description)
+                {
+                    tracing::error!("Failed to edit description: {}", e);
+                    self.set_error(format!("Failed to edit description: {}", e));
+                }
+                true
+            }
+            CardFocus::Metadata => {
+                if let Some(card) = self.get_card_for_detail_view() {
+                    let card_id = card.id;
+                    let dto = CardMetadataDto::from_entity(&card);
+                    let json =
+                        serde_json::to_string_pretty(&dto).unwrap_or_else(|_| "{}".to_string());
+                    let temp_file =
+                        std::env::temp_dir().join(format!("kanban-card-{}-metadata.json", card_id));
+                    match edit_in_external_editor(terminal, event_handler, temp_file, &json) {
+                        Ok(Some(new_content)) => {
+                            match serde_json::from_str::<CardMetadataDto>(&new_content) {
+                                Ok(new_dto) => {
+                                    let cmd = kanban_domain::commands::Command::Card(
+                                        kanban_domain::commands::CardCommand::ApplyMetadata(
+                                            kanban_domain::commands::ApplyCardMetadata {
+                                                card_id,
+                                                dto: new_dto,
+                                            },
+                                        ),
+                                    );
+                                    if let Err(e) = self.ctx.execute_command(cmd) {
+                                        tracing::error!("Failed to apply metadata: {}", e);
+                                        self.set_error(format!("Failed to apply metadata: {}", e));
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to parse metadata JSON: {}", e);
+                                    self.set_error(format!("Failed to parse metadata JSON: {}", e));
+                                }
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            tracing::error!("Failed to edit metadata: {}", e);
+                            self.set_error(format!("Failed to edit metadata: {}", e));
+                        }
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
+            CardFocus::Parents | CardFocus::Children => false,
         }
     }
 

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -307,7 +307,7 @@ impl App {
         }
     }
 
-    fn open_config_editor(
+    pub(crate) fn open_config_editor(
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
         event_handler: &EventHandler,


### PR DESCRIPTION
Pressing `e` via the Help overlay (`?` -> select a binding -> Enter, or typing the raw key to jump-then-fire) was a no-op everywhere: `KeybindingAction::EditCard`'s `execute_action` arm was empty, even though the direct `e` keypress works correctly in every mode. Same root cause as KAN-971/KAN-974: the raw-keypress dispatch path and the Help-menu dispatch path (`execute_action`) can silently drift.

- Adds `execute_edit_card_action`, a dedicated dispatch method called by both Help-mode call sites (the Enter-immediate path and the deferred jump-then-fire tick) instead of going through `execute_action`. Editing a card can spawn a real external editor and needs the terminal, which every other `execute_action` arm does not — kept out of `execute_action` so the other ~60 arms and their existing tests stay terminal-free.
- Adds `resolve_edit_card_dispatch`, a pure, terminal-free resolver (mirroring the existing `edit_key_active()` idiom) that decides which of the 4 real `e` targets applies for the app's current mode/focus: the card list, card detail (title/description/metadata), sprint detail, or the settings configuration editor.
- Adds `dispatch_help_action`, a single shared entry point used by both Help call sites so they can't drift on which actions need the terminal restarted afterward.
- Extracts `edit_card_detail_focused_field` (and its `edit_card_metadata_field` sub-helper) out of the raw `Char('e')` handler in `CardDetail` so both dispatch paths share one implementation instead of duplicating the title/description/metadata branching.
- Extracts `open_sprint_detail_card_for_edit`, matching the existing `CardListAction::Edit`/`Select` behavior (activate card, refresh relationship counts, push `CardDetail`, focus `Title`) — needs no terminal, so it's directly unit-testable.
- Widens `open_config_editor` from private to `pub(crate)` so it's reachable from `keybindings.rs`.

**Why**: no existing test in this suite constructs a real `Terminal<CrosstermBackend<io::Stdout>>` (production code only ever builds one after `enable_raw_mode()` succeeds, which requires a real controlling terminal and isn't reliable in headless CI). Extracting the dispatch *decision* into a pure resolver keeps the actual bug (the missing dispatch) fully unit-tested without needing a real terminal anywhere in the test suite.

**Found and fixed during self-review** (ran the code-review skill against this PR before requesting review): the first pass discarded the `bool` `execute_edit_card_action` returns on the deferred jump-then-fire path in `main_loop.rs`. Editing a card stops the background event poller before shelling out to `$EDITOR`; without propagating that bool into a `break` (to rebuild the poller), the app would silently swallow all keyboard input, including `q`, after the editor closed. Fixed by threading the bool through and factoring the duplicated dispatch check into `dispatch_help_action`. Also widened `resolve_edit_card_dispatch`'s Settings case to match `handle_settings_key`'s actual (focus-independent) behavior, and split `edit_card_detail_focused_field`'s Metadata branch into its own helper to bring both under the project's function-size guideline.

**Testing**: `cargo test -p kanban-tui --lib` (8 new tests: 6 for `resolve_edit_card_dispatch` covering all 4 targets plus 2 noop cases, 1 for `open_sprint_detail_card_for_edit`, 1 confirming the Settings case is focus-independent), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean). Manual verification in a live terminal wasn't performed (no interactive terminal in this environment) — the 3 terminal-touching targets (card list, card detail, settings) are covered only by the resolver correctly identifying them, matching how `handle_edit_card_key`/`edit_card_detail_focused_field`/`open_config_editor` are untested directly elsewhere in this codebase today.