### PR TITLE
KAN-987 fix(service): bulk multi-select column move never recomputes position

### DIFF
--- a/.changeset/max-kan-987.md
+++ b/.changeset/max-kan-987.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Fixed a bug where moving multiple selected cards to another column at once
+(multi-select `H`/`L`) could silently place a card on top of an existing
+card in the destination column instead of appending it after the others.
+The moved card kept its old position from the source column rather than
+getting a fresh position in the destination, so it would only avoid
+colliding by coincidence. Moving several cards into the same column in one
+action now gives each of them its own position, in order.

--- a/crates/kanban-service/src/context/cards_batch.rs
+++ b/crates/kanban-service/src/context/cards_batch.rs
@@ -9,9 +9,11 @@ impl KanbanContext {
     /// column) to maintain the status ↔ completion column invariant. Returns
     /// None when no chained move is needed.
     ///
-    /// The position is computed via a column-scoped `list_cards_by_column`
-    /// query — same convention as `KanbanContext::move_card(_, _, None)` — so
-    /// we only ever read the target column, never the full cards table.
+    /// The position is computed via `count_cards_in_column_filtered(_, Include)`
+    /// — same convention as `KanbanContext::move_card(_, _, None)` and as
+    /// `update_cards_impl`'s plain column-move branch, so the two share one
+    /// `position_offsets` counter without disagreeing on the base count when a
+    /// batch mixes both kinds of chained move into one column.
     pub(super) fn compute_target_column_for_status(
         &self,
         card_id: Uuid,
@@ -32,7 +34,10 @@ impl KanbanContext {
         ) else {
             return Ok(None);
         };
-        let pos = self.backend.list_cards_by_column(target_col)?.len() as i32;
+        let pos = self
+            .backend
+            .count_cards_in_column_filtered(target_col, kanban_domain::ArchivedFilter::Include)?
+            as i32;
         Ok(Some((target_col, pos)))
     }
 
@@ -192,8 +197,8 @@ impl KanbanContext {
         let mut batch: Vec<Command> = Vec::with_capacity(count * 2);
         // Track per-column position offsets within this batch so chained moves
         // into the same target column don't all collapse onto the same
-        // position. `compute_target_column_for_status` reads `list_cards_by_column`
-        // once per call against the pre-batch state.
+        // position. Both branches below read the target column's count once
+        // per call against the pre-batch state.
         let mut position_offsets: HashMap<Uuid, i32> = HashMap::new();
 
         enum Chained {
@@ -213,16 +218,18 @@ impl KanbanContext {
                     }),
                 (None, Some(new_col)) => {
                     // A genuine column change needs its position recomputed the
-                    // same way move_card/move_cards do (KAN-987) — otherwise the
-                    // card keeps its old position and collides with whatever
-                    // already sits there in the new column. Re-affirming the
-                    // card's current column (e.g. a PUT-replace that resubmits
-                    // every field) is not a move, so it must not touch position.
+                    // same way move_card/move_cards do — otherwise the card keeps
+                    // its old position and collides with whatever already sits
+                    // there in the new column. Skipped when the caller already
+                    // pinned an explicit position (that takes precedence), and
+                    // when the "new" column is actually the card's current one
+                    // (e.g. a PUT-replace that resubmits every field) — that's
+                    // not a move, so it must not touch position.
                     let already_in_column = self
                         .backend
                         .get_card(card_id)?
                         .is_some_and(|c| c.column_id == new_col);
-                    if !already_in_column {
+                    if !already_in_column && card_updates.position.is_none() {
                         let base_pos = self
                             .backend
                             .count_cards_in_column_filtered(new_col, ArchivedFilter::Include)?

--- a/crates/kanban-service/src/context/cards_batch.rs
+++ b/crates/kanban-service/src/context/cards_batch.rs
@@ -185,6 +185,7 @@ impl KanbanContext {
         updates: Vec<(Uuid, CardUpdate)>,
     ) -> KanbanResult<usize> {
         use kanban_domain::commands::{MoveCard, UpdateCard};
+        use kanban_domain::ArchivedFilter;
         use std::collections::HashMap;
 
         let count = updates.len();
@@ -200,7 +201,7 @@ impl KanbanContext {
             Status(CardStatus),
         }
 
-        for (card_id, card_updates) in updates {
+        for (card_id, mut card_updates) in updates {
             let chained = match (card_updates.status, card_updates.column_id) {
                 (Some(new_status), None) => self
                     .compute_target_column_for_status(card_id, new_status)?
@@ -210,9 +211,29 @@ impl KanbanContext {
                         *offset += 1;
                         Chained::Move(col, pos)
                     }),
-                (None, Some(new_col)) => self
-                    .compute_target_status_for_move(card_id, new_col)?
-                    .map(Chained::Status),
+                (None, Some(new_col)) => {
+                    // A genuine column change needs its position recomputed the
+                    // same way move_card/move_cards do (KAN-987) — otherwise the
+                    // card keeps its old position and collides with whatever
+                    // already sits there in the new column. Re-affirming the
+                    // card's current column (e.g. a PUT-replace that resubmits
+                    // every field) is not a move, so it must not touch position.
+                    let already_in_column = self
+                        .backend
+                        .get_card(card_id)?
+                        .is_some_and(|c| c.column_id == new_col);
+                    if !already_in_column {
+                        let base_pos = self
+                            .backend
+                            .count_cards_in_column_filtered(new_col, ArchivedFilter::Include)?
+                            as i32;
+                        let offset = position_offsets.entry(new_col).or_insert(0);
+                        card_updates.position = Some(base_pos + *offset);
+                        *offset += 1;
+                    }
+                    self.compute_target_status_for_move(card_id, new_col)?
+                        .map(Chained::Status)
+                }
                 _ => None,
             };
 

--- a/crates/kanban-service/tests/completion_sync.rs
+++ b/crates/kanban-service/tests/completion_sync.rs
@@ -454,6 +454,62 @@ async fn test_update_cards_batch_column_to_completion_sets_status_done() -> Kanb
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_update_cards_batch_mixes_status_and_column_chains_into_same_column_without_collision(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let fx = build_fixture(&mut ctx, true).await;
+    let board_id = ctx.boards()?[0].id;
+
+    // An archived card already occupies a position in the completion column;
+    // both chained-move branches must count it so they don't collide.
+    let archived_in_done =
+        ctx.create_card(board_id, fx.done_id, "Archived".into(), Default::default())?;
+    ctx.archive_cards(vec![archived_in_done.id])?;
+
+    let status_card = ctx.create_card(
+        board_id,
+        fx.backlog_id,
+        "StatusChain".into(),
+        Default::default(),
+    )?;
+    let column_card = ctx.create_card(
+        board_id,
+        fx.progress_id,
+        "ColumnChain".into(),
+        Default::default(),
+    )?;
+
+    ctx.update_cards(vec![
+        (
+            status_card.id,
+            CardUpdate {
+                status: Some(CardStatus::Done),
+                ..Default::default()
+            },
+        ),
+        (
+            column_card.id,
+            CardUpdate {
+                column_id: Some(fx.done_id),
+                ..Default::default()
+            },
+        ),
+    ])?;
+
+    let status_card = ctx.get_card(status_card.id)?.unwrap();
+    let column_card = ctx.get_card(column_card.id)?.unwrap();
+    assert_eq!(status_card.column_id, fx.done_id);
+    assert_eq!(column_card.column_id, fx.done_id);
+    assert_eq!(
+        (status_card.position, column_card.position),
+        (1, 2),
+        "status-chained and column-chained moves into the same column must count the same \
+         archived-inclusive base and not collide"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_update_cards_per_entry_explicit_column_and_status_respects_both() -> KanbanResult<()>
 {
     let mut ctx = make_ctx().await;

--- a/crates/kanban-service/tests/update_cards_position.rs
+++ b/crates/kanban-service/tests/update_cards_position.rs
@@ -1,0 +1,177 @@
+//! KAN-987: `update_cards`'s plain column-move case (column_id set, status/position
+//! left None) must recompute position like `move_card`/`move_cards` do. Left
+//! unfixed, the card keeps its old position, silently colliding with whatever
+//! already sits at that position in the target column.
+//!
+//! Run against both `JsonDataStore` and `SqliteBackend` (see `move_cards.rs`) since
+//! the fix reads `count_cards_in_column_filtered`, a per-backend `DataStore` method.
+
+use kanban_domain::{Board, Card, CardUpdate, Column};
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{
+    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
+    KanbanContext, KanbanOperations,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+async fn open_json_ctx() -> (KanbanContext, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.json");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    (ctx, dir)
+}
+
+async fn open_sqlite_ctx() -> (KanbanContext, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.sqlite");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap());
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    (ctx, dir)
+}
+
+macro_rules! update_cards_position_tests {
+    ($mod_name:ident, $open_ctx:expr) => {
+        mod $mod_name {
+            use super::*;
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_update_cards_column_move_appends_after_existing_card_in_target() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let mut board = Board::new("B", Some("TST"));
+                let col_from = Column::new(board.id, "From", 0);
+                let col_to = Column::new(board.id, "To", 1);
+                let col_from_id = col_from.id;
+                let col_to_id = col_to.id;
+
+                let existing = Card::new(&mut board, col_to_id, "Existing", 0);
+                let moving = Card::new(&mut board, col_from_id, "Moving", 0);
+                let moving_id = moving.id;
+                backend.upsert_board(board).unwrap();
+                backend.upsert_column(col_from).unwrap();
+                backend.upsert_column(col_to).unwrap();
+                backend.upsert_card(existing).unwrap();
+                backend.upsert_card(moving).unwrap();
+
+                ctx.update_cards(vec![(
+                    moving_id,
+                    CardUpdate {
+                        column_id: Some(col_to_id),
+                        ..Default::default()
+                    },
+                )])
+                .unwrap();
+
+                let moved = backend.get_card(moving_id).unwrap().unwrap();
+                assert_eq!(moved.column_id, col_to_id);
+                assert_eq!(
+                    moved.position, 1,
+                    "column-only batch move must append after the existing card, not collide at position 0"
+                );
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_update_cards_column_move_multiple_cards_into_same_column_get_sequential_positions(
+            ) {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let mut board = Board::new("B", Some("TST"));
+                let col_from = Column::new(board.id, "From", 0);
+                let col_to = Column::new(board.id, "To", 1);
+                let col_from_id = col_from.id;
+                let col_to_id = col_to.id;
+
+                // Both start at the same source position so that, pre-fix, retaining
+                // the old (unrecomputed) position on both would land them on the same
+                // position in the target column too -- the collision this test pins.
+                let move1 = Card::new(&mut board, col_from_id, "M1", 0);
+                let move2 = Card::new(&mut board, col_from_id, "M2", 0);
+                let move1_id = move1.id;
+                let move2_id = move2.id;
+                backend.upsert_board(board).unwrap();
+                backend.upsert_column(col_from).unwrap();
+                backend.upsert_column(col_to).unwrap();
+                backend.upsert_card(move1).unwrap();
+                backend.upsert_card(move2).unwrap();
+
+                ctx.update_cards(vec![
+                    (
+                        move1_id,
+                        CardUpdate {
+                            column_id: Some(col_to_id),
+                            ..Default::default()
+                        },
+                    ),
+                    (
+                        move2_id,
+                        CardUpdate {
+                            column_id: Some(col_to_id),
+                            ..Default::default()
+                        },
+                    ),
+                ])
+                .unwrap();
+
+                let mut positions: Vec<i32> = [move1_id, move2_id]
+                    .iter()
+                    .map(|id| backend.get_card(*id).unwrap().unwrap().position)
+                    .collect();
+                positions.sort();
+                assert_eq!(
+                    positions,
+                    vec![0, 1],
+                    "chained moves into the same column must use distinct positions, not collide"
+                );
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_update_cards_reaffirming_current_column_does_not_move_position() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let mut board = Board::new("B", Some("TST"));
+                let col = Column::new(board.id, "Col", 0);
+                let col_id = col.id;
+
+                let other = Card::new(&mut board, col_id, "Other", 0);
+                let card = Card::new(&mut board, col_id, "Card", 1);
+                let card_id = card.id;
+                backend.upsert_board(board).unwrap();
+                backend.upsert_column(col).unwrap();
+                backend.upsert_card(other).unwrap();
+                backend.upsert_card(card).unwrap();
+
+                // column_id resubmits the card's current column (e.g. a PUT-replace
+                // that always sets every field) -- not a real move, so position
+                // must be left untouched, not recomputed as an append.
+                ctx.update_cards(vec![(
+                    card_id,
+                    CardUpdate {
+                        column_id: Some(col_id),
+                        ..Default::default()
+                    },
+                )])
+                .unwrap();
+
+                let unchanged = backend.get_card(card_id).unwrap().unwrap();
+                assert_eq!(
+                    unchanged.position, 1,
+                    "resubmitting the same column must not recompute position"
+                );
+            }
+        }
+    };
+}
+
+update_cards_position_tests!(json_backend, open_json_ctx());
+update_cards_position_tests!(sqlite_backend, open_sqlite_ctx());

--- a/crates/kanban-service/tests/update_cards_position.rs
+++ b/crates/kanban-service/tests/update_cards_position.rs
@@ -1,4 +1,4 @@
-//! KAN-987: `update_cards`'s plain column-move case (column_id set, status/position
+//! `update_cards`'s plain column-move case (column_id set, status/position
 //! left None) must recompute position like `move_card`/`move_cards` do. Left
 //! unfixed, the card keeps its old position, silently colliding with whatever
 //! already sits at that position in the target column.
@@ -167,6 +167,46 @@ macro_rules! update_cards_position_tests {
                 assert_eq!(
                     unchanged.position, 1,
                     "resubmitting the same column must not recompute position"
+                );
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_update_cards_column_move_respects_explicit_position() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let mut board = Board::new("B", Some("TST"));
+                let col_from = Column::new(board.id, "From", 0);
+                let col_to = Column::new(board.id, "To", 1);
+                let col_from_id = col_from.id;
+                let col_to_id = col_to.id;
+
+                let existing = Card::new(&mut board, col_to_id, "Existing", 0);
+                let moving = Card::new(&mut board, col_from_id, "Moving", 0);
+                let moving_id = moving.id;
+                backend.upsert_board(board).unwrap();
+                backend.upsert_column(col_from).unwrap();
+                backend.upsert_column(col_to).unwrap();
+                backend.upsert_card(existing).unwrap();
+                backend.upsert_card(moving).unwrap();
+
+                // Caller pins both column_id and position explicitly -- the
+                // recompute must not override a value the caller already chose.
+                ctx.update_cards(vec![(
+                    moving_id,
+                    CardUpdate {
+                        column_id: Some(col_to_id),
+                        position: Some(0),
+                        ..Default::default()
+                    },
+                )])
+                .unwrap();
+
+                let moved = backend.get_card(moving_id).unwrap().unwrap();
+                assert_eq!(moved.column_id, col_to_id);
+                assert_eq!(
+                    moved.position, 0,
+                    "an explicit position on the same entry must not be overridden by the recompute"
                 );
             }
         }


### PR DESCRIPTION
Moving multiple selected cards to another column at once (`move_selected_cards`, multi-select `H`/`L`) built `CardUpdate { column_id: Some(new_col), ..Default::default() }` per card, leaving `position` at `None`. `update_cards_impl` only chained a position recompute for the `(Some(status), None)` case (status-driven completion-column sync) — the `(None, Some(new_col))` case, a bare column change with no status flip and exactly what a bulk multi-select move produces, left `position: None`, and `UpdateCard::execute` treats `None` as "leave unchanged." The moved card kept its old position from the source column, silently colliding with whatever already occupied that position in the destination column.

- `update_cards_impl` (`crates/kanban-service/src/context/cards_batch.rs`) now recomputes position for a genuine column change the same way `move_card`/`move_cards` do: `count_cards_in_column_filtered(new_col, ArchivedFilter::Include)`, sharing the batch's existing per-column `position_offsets` map so multiple cards moving into the same target column in one call get sequential positions instead of colliding with each other.
- Guards the recompute on the column actually changing. Re-affirming a card's current column (the PUT-replace seam always sets `column_id`, even unchanged) must not touch position — caught by `test_put_card_replace_preserves_server_managed_number_and_position` regressing while developing this fix.

**Found and fixed during self-review** (ran the code-review skill against this PR before requesting review):
- The recompute unconditionally overwrote `card_updates.position` even when the caller had already pinned an explicit position alongside `column_id` — a combination the public `UpdateCardRequest` DTO supports. Now skipped whenever the caller already set `position`.
- The sibling status-driven chain (`compute_target_column_for_status`) based its position on `list_cards_by_column` (live-only), while the new column-move chain uses `count_cards_in_column_filtered(_, Include)` (live+archived). Both write into the same per-batch `position_offsets` map keyed by column, so a batch mixing a status-chained move and a plain column-chained move into the same archived-holding column could still collide — the exact bug class this PR closes. Both branches now share the live+archived counting convention.

**Left out of scope** (pre-existing, not introduced by this fix, tracked separately as KAN-989): the plain column-move branch emits a single `UpdateCard` rather than a chained `MoveCard`, so it doesn't get `MoveCard::execute`'s WIP-limit check or its cross-board `board_id` sync — both already absent for this specific caller before this PR, since the branch previously did nothing extra at all. Fixing those would mean restructuring to chain a `MoveCard` for two match arms simultaneously (a real move plus a possible status flip), which felt like real scope beyond "fix the position collision," so it's logged as a follow-up.

**Testing**: `crates/kanban-service/tests/update_cards_position.rs` (new, run against both `JsonDataStore` and `SqliteBackend` mirroring `move_cards.rs`'s multi-backend macro, since the fix reads `count_cards_in_column_filtered`, a per-backend `DataStore` method) — appends after an existing card instead of colliding, multiple cards into the same column get sequential positions, resubmitting the current column leaves position untouched, and an explicit position on the same entry isn't overridden. Plus one new test in `completion_sync.rs` pinning that a status-chained move and a column-chained move into the same (archived-holding) column don't collide. `cargo test --workspace` (no regressions, including the PUT-replace seam test caught above), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).
