### PR TITLE
KAN-968 fix(service): split CreateBoardRequest into pure-create vs create-or-replace types

### DIFF
--- a/.changeset/max-kan-968.md
+++ b/.changeset/max-kan-968.md
@@ -4,9 +4,10 @@ bump: minor
 
 Creating a new board no longer accepts a completion-column setting, since a
 brand-new board never has any columns yet for it to point at — that field
-was always silently invalid there and is now rejected instead of being
-accepted and ignored. To set which column marks a card as complete, create
-the board's columns first, then set it via the board-update API.
+was always silently ineffective there (accepted and stored, but with nothing
+to match against) and is now rejected instead. To set which column marks a
+card as complete, create the board's columns first, then set it via the
+board-update API.
 
 This applies to MCP's board-creation tool and the underlying create API; the
 separate "replace an existing board" API is unaffected and can still set the

--- a/.changeset/max-kan-968.md
+++ b/.changeset/max-kan-968.md
@@ -1,0 +1,13 @@
+---
+bump: minor
+---
+
+Creating a new board no longer accepts a completion-column setting, since a
+brand-new board never has any columns yet for it to point at — that field
+was always silently invalid there and is now rejected instead of being
+accepted and ignored. To set which column marks a card as complete, create
+the board's columns first, then set it via the board-update API.
+
+This applies to MCP's board-creation tool and the underlying create API; the
+separate "replace an existing board" API is unaffected and can still set the
+completion column, since a board being replaced may already have columns.

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -769,7 +769,6 @@ fn board_req(name: &str, card_prefix: Option<String>) -> CreateBoardRequest {
         task_sort_order: None,
         sprint_duration_days: None,
         task_list_view: None,
-        completion_column_id: None,
     }
 }
 
@@ -1547,7 +1546,6 @@ fn test_mcp_create_board_request_is_the_shared_service_type() {
         task_sort_order: None,
         sprint_duration_days: None,
         task_list_view: None,
-        completion_column_id: None,
     };
     assert_same(&req);
 }

--- a/crates/kanban-server/src/handlers/boards.rs
+++ b/crates/kanban-server/src/handlers/boards.rs
@@ -3,12 +3,12 @@
 //! The server itself is still a stub (no router/transport yet), but the
 //! create-from-spec wiring is real and tested here: this is the single funnel a
 //! future `PUT /v1/boards/:id` handler binds to. It takes the shared
-//! [`CreateBoardRequest`], splits it via `into_new_board`, runs the idempotent
-//! PUT-create (`create_or_replace_board`), and projects the resulting domain
-//! `Board` onto the wire [`BoardResponse`]. The `created` flag lets the eventual
-//! HTTP layer answer 201 (created) vs 200 (replaced).
+//! [`CreateOrReplaceBoardRequest`], splits it via `into_new_board`, runs the
+//! idempotent PUT-create (`create_or_replace_board`), and projects the
+//! resulting domain `Board` onto the wire [`BoardResponse`]. The `created`
+//! flag lets the eventual HTTP layer answer 201 (created) vs 200 (replaced).
 
-use kanban_service::api::{ApiError, BoardResponse, CreateBoardRequest};
+use kanban_service::api::{ApiError, BoardResponse, CreateOrReplaceBoardRequest};
 use kanban_service::KanbanContext;
 
 /// Idempotent create-or-replace for a board, returning the wire projection plus
@@ -19,7 +19,7 @@ use kanban_service::KanbanContext;
 /// runs for an id that already exists.
 pub fn create_or_replace_board(
     ctx: &mut KanbanContext,
-    req: CreateBoardRequest,
+    req: CreateOrReplaceBoardRequest,
 ) -> Result<(BoardResponse, bool), ApiError> {
     let (maybe_id, spec) = req.into_new_board();
     let id = maybe_id.unwrap_or_else(uuid::Uuid::new_v4);

--- a/crates/kanban-server/tests/board_create_seam.rs
+++ b/crates/kanban-server/tests/board_create_seam.rs
@@ -1,12 +1,12 @@
 //! KAN-792: the server's board-create seam wires the shared
-//! `CreateBoardRequest` through `into_new_board` → `create_or_replace_board`
+//! `CreateOrReplaceBoardRequest` through `into_new_board` → `create_or_replace_board`
 //! (idempotent PUT-create) and projects the result via `BoardResponse`. The
 //! actual HTTP/router binding is out of scope for the stub; this pins the typed
 //! seam end-to-end against a real `KanbanContext`.
 
 use kanban_persistence_json::JsonFileStore;
 use kanban_server::handlers::boards::create_or_replace_board;
-use kanban_service::api::CreateBoardRequest;
+use kanban_service::api::CreateOrReplaceBoardRequest;
 use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
@@ -19,7 +19,7 @@ fn make_ctx(path: &std::path::Path) -> KanbanContext {
     KanbanContext::open_deferred(backend, AppConfig::default())
 }
 
-fn req_with_id(id: Uuid, name: &str) -> CreateBoardRequest {
+fn req_with_id(id: Uuid, name: &str) -> CreateOrReplaceBoardRequest {
     serde_json::from_value(serde_json::json!({
         "id": id,
         "name": name,

--- a/crates/kanban-server/tests/board_create_seam.rs
+++ b/crates/kanban-server/tests/board_create_seam.rs
@@ -8,7 +8,7 @@ use kanban_persistence_json::JsonFileStore;
 use kanban_server::handlers::boards::create_or_replace_board;
 use kanban_service::api::CreateOrReplaceBoardRequest;
 use kanban_service::json_backend::JsonDataStore;
-use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use std::sync::Arc;
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -55,6 +55,29 @@ async fn test_server_seam_put_create_replaces_when_present() {
     assert!(!created, "present id must report replace (200)");
     assert_eq!(resp.id, id, "id stable across replace");
     assert_eq!(resp.name, "Replaced");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_server_seam_put_create_with_completion_column_id_rejects() {
+    // The idempotent PUT-create seam is the only client-reachable path where
+    // completion_column_id can be set on a request that ends up CREATING a
+    // brand-new board (MCP's own create tool uses the narrower type without
+    // this field at all): a fresh id here still has zero columns, so the
+    // service must reject it, not silently persist a dangling reference.
+    let dir = tempdir().unwrap();
+    let mut ctx = make_ctx(&dir.path().join("s.json"));
+    let id = Uuid::new_v4();
+    let req: CreateOrReplaceBoardRequest = serde_json::from_value(serde_json::json!({
+        "id": id,
+        "name": "Fresh",
+        "completion_column_id": Uuid::new_v4(),
+    }))
+    .unwrap();
+
+    let err = create_or_replace_board(&mut ctx, req).unwrap_err();
+
+    assert_eq!(err.code, kanban_service::api::ErrorCode::ValidationFailed);
+    assert_eq!(ctx.list_boards().unwrap().len(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/src/api/mod.rs
+++ b/crates/kanban-service/src/api/mod.rs
@@ -6,9 +6,10 @@
 mod v1;
 pub use v1::{
     ApiError, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame,
-    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
-    CreateSprintRequest, ErrorCode, Page, PageParams, Patch, ReorderColumnRequest,
-    ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest,
-    SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto,
-    UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
+    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
+    CreateOrReplaceBoardRequest, CreateSprintParts, CreateSprintRequest, ErrorCode, Page,
+    PageParams, Patch, ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest,
+    ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse,
+    SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
+    UpdateSprintRequest,
 };

--- a/crates/kanban-service/src/api/v1/boards/conversions.rs
+++ b/crates/kanban-service/src/api/v1/boards/conversions.rs
@@ -4,7 +4,9 @@
 //! different reasons. Each conversion destructures and constructs exhaustively
 //! (no `..`) so a new field is a compile error.
 
-use super::requests::{CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
+use super::requests::{
+    CreateBoardRequest, CreateOrReplaceBoardRequest, ReplaceBoardRequest, UpdateBoardRequest,
+};
 use kanban_domain::{BoardUpdate, FieldUpdate, NewBoard};
 use uuid::Uuid;
 
@@ -42,8 +44,44 @@ impl CreateBoardRequest {
     /// Split the identity (optional client id) from the content spec. The
     /// service mints the id when `None` and calls `Board::create(spec, id, now)`.
     /// Exhaustive destructure — no `..` — so a new field is a compile error.
+    /// `completion_column_id` has no source field here (see the struct doc) —
+    /// always `None`, since a board created this way always has zero columns.
     pub fn into_new_board(self) -> (Option<Uuid>, NewBoard) {
         let CreateBoardRequest {
+            id,
+            name,
+            description,
+            sprint_prefix,
+            card_prefix,
+            task_sort_field,
+            task_sort_order,
+            sprint_duration_days,
+            task_list_view,
+        } = self;
+        let spec = NewBoard {
+            name,
+            description,
+            sprint_prefix,
+            card_prefix,
+            task_sort_field: task_sort_field.map(Into::into),
+            task_sort_order: task_sort_order.map(Into::into),
+            sprint_duration_days,
+            task_list_view: task_list_view.map(Into::into),
+            completion_column_id: None,
+        };
+        (id, spec)
+    }
+}
+
+impl CreateOrReplaceBoardRequest {
+    /// Split the identity (optional client id) from the content spec, same
+    /// convention as [`CreateBoardRequest::into_new_board`]. Unlike that
+    /// narrower type, `completion_column_id` carries straight through here —
+    /// it is legitimate when this request replaces an existing board (which
+    /// may already have columns) and only invalid at the moment it creates a
+    /// brand-new one, which the service rejects at that specific call site.
+    pub fn into_new_board(self) -> (Option<Uuid>, NewBoard) {
+        let CreateOrReplaceBoardRequest {
             id,
             name,
             description,
@@ -156,7 +194,6 @@ mod tests {
 
     #[test]
     fn test_create_board_request_into_new_board_maps_all_content_fields() {
-        let col = Uuid::new_v4();
         let req = CreateBoardRequest {
             id: None,
             name: "Roadmap".to_string(),
@@ -167,7 +204,6 @@ mod tests {
             task_sort_order: Some(SortOrderDto::Descending),
             sprint_duration_days: Some(21),
             task_list_view: Some(TaskListViewDto::GroupedByColumn),
-            completion_column_id: Some(col),
         };
         let (_id, spec) = req.into_new_board();
         assert_eq!(spec.name, "Roadmap");
@@ -178,7 +214,25 @@ mod tests {
         assert_eq!(spec.task_sort_order, Some(SortOrder::Descending));
         assert_eq!(spec.sprint_duration_days, Some(21));
         assert_eq!(spec.task_list_view, Some(TaskListView::GroupedByColumn));
-        assert_eq!(spec.completion_column_id, Some(col));
+    }
+
+    #[test]
+    fn test_create_board_request_into_new_board_always_omits_completion_column_id() {
+        // No source field exists to carry a value through -- this pins that
+        // the resulting spec's completion_column_id is unconditionally None.
+        let req = CreateBoardRequest {
+            id: None,
+            name: "B".to_string(),
+            description: None,
+            sprint_prefix: None,
+            card_prefix: None,
+            task_sort_field: None,
+            task_sort_order: None,
+            sprint_duration_days: None,
+            task_list_view: None,
+        };
+        let (_id, spec) = req.into_new_board();
+        assert_eq!(spec.completion_column_id, None);
     }
 
     #[test]
@@ -194,7 +248,6 @@ mod tests {
             task_sort_order: None,
             sprint_duration_days: None,
             task_list_view: None,
-            completion_column_id: None,
         };
         let (carried, _) = with_id.into_new_board();
         assert_eq!(carried, Some(id));
@@ -209,7 +262,6 @@ mod tests {
             task_sort_order: None,
             sprint_duration_days: None,
             task_list_view: None,
-            completion_column_id: None,
         };
         let (carried, _) = without_id.into_new_board();
         assert_eq!(carried, None);
@@ -227,5 +279,24 @@ mod tests {
         assert_eq!(spec.sprint_duration_days, None);
         assert_eq!(spec.task_list_view, None);
         assert_eq!(spec.completion_column_id, None);
+    }
+
+    #[test]
+    fn test_create_or_replace_board_request_into_new_board_maps_completion_column_id() {
+        let col = Uuid::new_v4();
+        let req = CreateOrReplaceBoardRequest {
+            id: None,
+            name: "Roadmap".to_string(),
+            description: None,
+            sprint_prefix: None,
+            card_prefix: None,
+            task_sort_field: None,
+            task_sort_order: None,
+            sprint_duration_days: None,
+            task_list_view: None,
+            completion_column_id: Some(col),
+        };
+        let (_id, spec) = req.into_new_board();
+        assert_eq!(spec.completion_column_id, Some(col));
     }
 }

--- a/crates/kanban-service/src/api/v1/boards/conversions.rs
+++ b/crates/kanban-service/src/api/v1/boards/conversions.rs
@@ -40,6 +40,46 @@ impl From<UpdateBoardRequest> for BoardUpdate {
     }
 }
 
+/// Shared by both `into_new_board` impls below — the two request structs have
+/// identical content fields and differ only in `completion_column_id`.
+struct BoardContentFields {
+    name: String,
+    description: Option<String>,
+    sprint_prefix: Option<String>,
+    card_prefix: Option<String>,
+    task_sort_field: Option<super::super::SortFieldDto>,
+    task_sort_order: Option<super::super::SortOrderDto>,
+    sprint_duration_days: Option<u32>,
+    task_list_view: Option<super::super::TaskListViewDto>,
+}
+
+fn new_board_from_content(
+    content: BoardContentFields,
+    completion_column_id: Option<Uuid>,
+) -> NewBoard {
+    let BoardContentFields {
+        name,
+        description,
+        sprint_prefix,
+        card_prefix,
+        task_sort_field,
+        task_sort_order,
+        sprint_duration_days,
+        task_list_view,
+    } = content;
+    NewBoard {
+        name,
+        description,
+        sprint_prefix,
+        card_prefix,
+        task_sort_field: task_sort_field.map(Into::into),
+        task_sort_order: task_sort_order.map(Into::into),
+        sprint_duration_days,
+        task_list_view: task_list_view.map(Into::into),
+        completion_column_id,
+    }
+}
+
 impl CreateBoardRequest {
     /// Split the identity (optional client id) from the content spec. The
     /// service mints the id when `None` and calls `Board::create(spec, id, now)`.
@@ -58,17 +98,19 @@ impl CreateBoardRequest {
             sprint_duration_days,
             task_list_view,
         } = self;
-        let spec = NewBoard {
-            name,
-            description,
-            sprint_prefix,
-            card_prefix,
-            task_sort_field: task_sort_field.map(Into::into),
-            task_sort_order: task_sort_order.map(Into::into),
-            sprint_duration_days,
-            task_list_view: task_list_view.map(Into::into),
-            completion_column_id: None,
-        };
+        let spec = new_board_from_content(
+            BoardContentFields {
+                name,
+                description,
+                sprint_prefix,
+                card_prefix,
+                task_sort_field,
+                task_sort_order,
+                sprint_duration_days,
+                task_list_view,
+            },
+            None,
+        );
         (id, spec)
     }
 }
@@ -93,17 +135,19 @@ impl CreateOrReplaceBoardRequest {
             task_list_view,
             completion_column_id,
         } = self;
-        let spec = NewBoard {
-            name,
-            description,
-            sprint_prefix,
-            card_prefix,
-            task_sort_field: task_sort_field.map(Into::into),
-            task_sort_order: task_sort_order.map(Into::into),
-            sprint_duration_days,
-            task_list_view: task_list_view.map(Into::into),
+        let spec = new_board_from_content(
+            BoardContentFields {
+                name,
+                description,
+                sprint_prefix,
+                card_prefix,
+                task_sort_field,
+                task_sort_order,
+                sprint_duration_days,
+                task_list_view,
+            },
             completion_column_id,
-        };
+        );
         (id, spec)
     }
 }

--- a/crates/kanban-service/src/api/v1/boards/mod.rs
+++ b/crates/kanban-service/src/api/v1/boards/mod.rs
@@ -1,5 +1,7 @@
 mod conversions;
 mod requests;
 mod response;
-pub use requests::{CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
+pub use requests::{
+    CreateBoardRequest, CreateOrReplaceBoardRequest, ReplaceBoardRequest, UpdateBoardRequest,
+};
 pub use response::BoardResponse;

--- a/crates/kanban-service/src/api/v1/boards/requests.rs
+++ b/crates/kanban-service/src/api/v1/boards/requests.rs
@@ -2,15 +2,45 @@ use super::super::{Patch, SortFieldDto, SortOrderDto, TaskListViewDto};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Request body for `POST /v1/boards` (and `PUT /v1/boards/:id` create arm).
-///
-/// Carries every client-settable CREATE field plus an optional client-supplied
-/// `id` for idempotent PUT-create. The service mints the id when absent and
-/// funnels the content through `NewBoard` + `Board::create`; server-managed
-/// fields (counters, `position`, `active_sprint_id`) are never on the wire.
+/// Request body for a pure `POST /v1/boards` create (also MCP's
+/// `tool_create_board`): a board created this way always has zero columns, so
+/// `completion_column_id` has no field here — it can never be set to
+/// something real by construction. Set it afterward via `update_board` once
+/// the board has columns, or use [`CreateOrReplaceBoardRequest`] to replace an
+/// existing board (which may already have columns).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CreateBoardRequest {
+    /// Client-supplied id (idempotent PUT-create); read by the service tier.
+    #[serde(default)]
+    pub id: Option<Uuid>,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub sprint_prefix: Option<String>,
+    #[serde(default)]
+    pub card_prefix: Option<String>,
+    #[serde(default)]
+    pub task_sort_field: Option<SortFieldDto>,
+    #[serde(default)]
+    pub task_sort_order: Option<SortOrderDto>,
+    #[serde(default)]
+    pub sprint_duration_days: Option<u32>,
+    #[serde(default)]
+    pub task_list_view: Option<TaskListViewDto>,
+}
+
+/// Request body for `PUT /v1/boards/:id`'s idempotent create-or-replace: create
+/// the board with this id when absent, or fully replace its content when
+/// present. Unlike [`CreateBoardRequest`], `completion_column_id` is legitimate
+/// here on the replace arm — an existing board being replaced may already have
+/// columns. It is still rejected by the service when this same request happens
+/// to create a brand-new board (the id was absent from the store), since that
+/// board has zero columns regardless of which request type asked for it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct CreateOrReplaceBoardRequest {
     /// Client-supplied id (idempotent PUT-create); read by the service tier.
     #[serde(default)]
     pub id: Option<Uuid>,
@@ -93,7 +123,6 @@ mod tests {
     #[test]
     fn test_create_board_request_serde_round_trip_includes_new_fields() {
         let id = Uuid::new_v4();
-        let col = Uuid::new_v4();
         let req = CreateBoardRequest {
             id: Some(id),
             name: "Roadmap".to_string(),
@@ -104,7 +133,6 @@ mod tests {
             task_sort_order: Some(SortOrderDto::Descending),
             sprint_duration_days: Some(14),
             task_list_view: Some(TaskListViewDto::GroupedByColumn),
-            completion_column_id: Some(col),
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: CreateBoardRequest = serde_json::from_str(&json).unwrap();
@@ -115,7 +143,6 @@ mod tests {
         assert_eq!(back.task_sort_order, req.task_sort_order);
         assert_eq!(back.sprint_duration_days, Some(14));
         assert_eq!(back.task_list_view, Some(TaskListViewDto::GroupedByColumn));
-        assert_eq!(back.completion_column_id, Some(col));
     }
 
     #[test]
@@ -128,6 +155,49 @@ mod tests {
         assert_eq!(back.task_sort_field, None);
         assert_eq!(back.sprint_duration_days, None);
         assert_eq!(back.task_list_view, None);
+    }
+
+    #[test]
+    fn test_create_board_request_has_no_completion_column_id_field() {
+        // A board created via CreateBoardRequest always has zero columns, so
+        // completion_column_id can never be set to something real -- it must
+        // be structurally absent, not just runtime-rejected. Any JSON supplied
+        // for it is simply ignored (no `deny_unknown_fields`), matching the
+        // "extra field, no-op" convention used elsewhere in this API.
+        let json =
+            r#"{"name":"Ignored","completion_column_id":"00000000-0000-0000-0000-000000000000"}"#;
+        let back: CreateBoardRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(back.name, "Ignored");
+    }
+
+    #[test]
+    fn test_create_or_replace_board_request_serde_round_trip_includes_completion_column_id() {
+        let id = Uuid::new_v4();
+        let col = Uuid::new_v4();
+        let req = CreateOrReplaceBoardRequest {
+            id: Some(id),
+            name: "Roadmap".to_string(),
+            description: Some("Q3 planning".to_string()),
+            sprint_prefix: Some("SPR".to_string()),
+            card_prefix: Some("KAN".to_string()),
+            task_sort_field: Some(SortFieldDto::Priority),
+            task_sort_order: Some(SortOrderDto::Descending),
+            sprint_duration_days: Some(14),
+            task_list_view: Some(TaskListViewDto::GroupedByColumn),
+            completion_column_id: Some(col),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: CreateOrReplaceBoardRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, Some(id));
+        assert_eq!(back.completion_column_id, Some(col));
+    }
+
+    #[test]
+    fn test_create_or_replace_board_request_minimal_omits_optionals() {
+        let json = r#"{"name":"Minimal"}"#;
+        let back: CreateOrReplaceBoardRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(back.id, None);
+        assert_eq!(back.name, "Minimal");
         assert_eq!(back.completion_column_id, None);
     }
 

--- a/crates/kanban-service/src/api/v1/mod.rs
+++ b/crates/kanban-service/src/api/v1/mod.rs
@@ -8,7 +8,10 @@ mod events;
 mod pagination;
 mod patch;
 mod sprints;
-pub use boards::{BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
+pub use boards::{
+    BoardResponse, CreateBoardRequest, CreateOrReplaceBoardRequest, ReplaceBoardRequest,
+    UpdateBoardRequest,
+};
 pub use cards::{CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
 pub use columns::{
     ColumnResponse, CreateColumnRequest, ReorderColumnRequest, ReplaceColumnRequest,

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -37,6 +37,15 @@ impl KanbanContext {
         if self.backend.get_board(id)?.is_some() {
             return Err(KanbanError::already_exists("Board", id));
         }
+        // A brand-new board has no columns yet, so any supplied
+        // `completion_column_id` necessarily dangles. Reject it fail-loud rather
+        // than persist a board pointing at a non-existent column; the caller
+        // sets it via `update_board` after creating the column.
+        if spec.completion_column_id.is_some() {
+            return Err(KanbanError::validation(
+                "completion_column_id cannot be set when creating a board: a new board has no columns yet; set it via update_board after creating the column",
+            ));
+        }
         let now = Utc::now();
         let position = self.backend.list_boards()?.len() as i32;
         let mut board = Board::create(spec, id, now)?;

--- a/crates/kanban-service/tests/create_board_from_spec.rs
+++ b/crates/kanban-service/tests/create_board_from_spec.rs
@@ -130,6 +130,51 @@ async fn test_create_board_with_duplicate_client_id_returns_conflict() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_create_board_from_spec_rejects_completion_column_id() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("reject.json");
+    let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
+
+    let mut spec = full_spec("Broken");
+    spec.completion_column_id = Some(Uuid::new_v4());
+
+    let err = ctx.create_board_from_spec(None, spec).unwrap_err();
+
+    assert!(
+        err.is_validation(),
+        "a brand-new board has no columns yet, so completion_column_id always dangles: expected Validation, got {err:?}"
+    );
+    assert_eq!(
+        ctx.list_boards().unwrap().len(),
+        0,
+        "the rejected create must not persist a board"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_board_replace_arm_accepts_completion_column_id() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("por_completion.json");
+    let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
+
+    let id = Uuid::new_v4();
+    ctx.create_or_replace_board(id, full_spec("Original"))
+        .unwrap();
+    let column = ctx.create_column(id, "Done".into(), None).unwrap();
+
+    let mut replacement = full_spec("Replaced");
+    replacement.completion_column_id = Some(column.id);
+    let outcome = ctx.create_or_replace_board(id, replacement).unwrap();
+
+    assert!(!outcome.created, "board already existed: this is a replace");
+    assert_eq!(
+        outcome.board.completion_column_id,
+        Some(column.id),
+        "the replace arm may legitimately set completion_column_id on an existing board that already has columns"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_create_or_replace_board_creates_when_absent_reports_created() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("por_create.json");


### PR DESCRIPTION
A brand-new board always has zero columns (create_board never accepts columns in the same call, confirmed across NewBoard/CreateBoardRequest/MCP/HTTP), so any `completion_column_id` supplied at pure-create time is provably dangling — it can never point at something real.

- `create_board_from_spec` (`crates/kanban-service/src/context/boards.rs`) now rejects `completion_column_id` fail-loud when creating a brand-new board, instead of persisting a board pointing at a non-existent column.
- Splits the shared wire type in two, matching REST semantics (pure create vs idempotent PUT create-or-replace), so the invalid state is structurally unrepresentable where it's *always* wrong, not just runtime-rejected:
  - `CreateBoardRequest` keeps its name and becomes the pure-create shape — no `completion_column_id` field at all. Used by MCP's `tool_create_board` (via the existing shared re-export, no MCP code change needed) and any future `POST /v1/boards` handler.
  - `CreateOrReplaceBoardRequest` is the previous shape, unchanged, renamed to reflect it specifically backs the idempotent PUT create-or-replace flow (`crates/kanban-server/src/handlers/boards.rs`'s `create_or_replace_board` seam). It still carries `completion_column_id` — legitimate on the replace arm, since an existing board being replaced may already have columns — and the runtime reject still applies when this same request happens to create a brand-new board rather than replace an existing one.
  - The pre-existing, currently-unwired `ReplaceBoardRequest` (a stricter RFC 9110 full-replace shape) is unrelated and untouched.

**Why not just delete the field everywhere?** `create_or_replace_board` funnels the same `NewBoard`/`CreateOrReplaceBoardRequest` into two branches: create (always invalid) and replace-an-existing-board (legitimately valid, via `replace_update_from_spec`). The field can't be removed from the type without breaking the replace case, so only the genuinely pure-create-only type (`CreateBoardRequest`, MCP's actual live caller today — the HTTP router is still a stub) drops it.

**Testing**: `crates/kanban-service/tests/create_board_from_spec.rs` (2 new tests: the create-arm rejection, and the replace-arm's legitimate acceptance), `crates/kanban-service/src/api/v1/boards/{requests,conversions}.rs` (new/updated unit tests per type, including a schema/serde test proving `CreateBoardRequest` structurally ignores a `completion_column_id` in incoming JSON rather than accepting it), `cargo test --workspace` (no regressions — includes `kanban-server`'s `board_create_seam.rs` and `kanban-mcp`'s `integration.rs`, both updated for the renamed/narrowed types), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).

**Found and fixed during self-review** (ran the code-review skill against this PR before requesting review): the only client-reachable path where a fresh id can carry `completion_column_id` — the PUT create-or-replace seam (`kanban-server`'s `create_or_replace_board`) — had no direct test of the rejection; added one (`test_server_seam_put_create_with_completion_column_id_rejects`). Also deduped the two `into_new_board` impls' identical `NewBoard`-construction logic into a shared `new_board_from_content` helper (kept under `clippy::too_many_arguments` via a small `BoardContentFields` struct), and tightened the changeset wording (the field wasn't silently *ignored* pre-fix, it was accepted and persisted with no effect).
