### PR TITLE
KAN-977 test(persistence-sqlite): regression guards for fragile migration invariants

### DIFF
--- a/.changeset/max-kan-977.md
+++ b/.changeset/max-kan-977.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+---
+
+Internal test coverage (no user-facing change): adds regression guards for
+three SQLite behaviors that were correct but relied on fragile, previously
+untested invariants — foreign-key enforcement is properly restored after the
+old-format migration step that temporarily disables it, the safety backup
+taken before upgrading an older database file is now verified at every
+upgrade step (not just the first one), and restoring a saved snapshot is
+confirmed to roll back cleanly instead of leaving the database partially
+wiped if something goes wrong partway through.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
@@ -1,5 +1,5 @@
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use sqlx::Row;
+use sqlx::{Row, SqlitePool};
 use std::path::Path;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -7,13 +7,12 @@ use uuid::Uuid;
 use super::super::SqliteStore;
 use super::make_rt;
 
-/// Seed a schema_version-2 shaped DB directly (no board_id on archived_cards,
-/// cards.column_id carrying the ON DELETE CASCADE FK). Returns
-/// (board_id, column_id, card_id). `original_column_id` on the archived row is
-/// taken from `orig_col` so a caller can simulate a since-deleted column.
-pub(crate) async fn seed_v2_db(path: &Path, orig_col: Uuid) -> (Uuid, Uuid, Uuid) {
-    // foreign_keys(false): the seed inserts forward references and the v2 shape
-    // is asserted structurally, not enforced here.
+/// Open a fresh single-connection pool and seed the metadata/boards/columns
+/// tables shared by every pre-migration fixture in this module, stamping
+/// `schema_version` and inserting one board with one column. Returns the pool
+/// (still open, for the caller to add its own schema-version-specific tables)
+/// plus (board_id, column_id).
+pub(crate) async fn open_seeded_pool(path: &Path, schema_version: u32) -> (SqlitePool, Uuid, Uuid) {
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         .connect_with(
@@ -30,7 +29,7 @@ pub(crate) async fn seed_v2_db(path: &Path, orig_col: Uuid) -> (Uuid, Uuid, Uuid
             id INTEGER PRIMARY KEY CHECK (id = 1),
             instance_id TEXT NOT NULL,
             saved_at TEXT NOT NULL,
-            schema_version INTEGER NOT NULL DEFAULT 2,
+            schema_version INTEGER NOT NULL,
             writer_version TEXT,
             writer_commit TEXT
         );
@@ -54,8 +53,54 @@ pub(crate) async fn seed_v2_db(path: &Path, orig_col: Uuid) -> (Uuid, Uuid, Uuid
             position INTEGER NOT NULL, wip_limit INTEGER,
             created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
             FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
-        );
-        CREATE TABLE cards (
+        );",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let board_id = Uuid::new_v4();
+    let column_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+         VALUES (1, ?, '2024-01-01T00:00:00Z', ?)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(schema_version)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO boards (id, name, created_at, updated_at)
+         VALUES (?, 'B', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+         VALUES (?, ?, 'Todo', 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(column_id.to_string())
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    (pool, board_id, column_id)
+}
+
+/// Seed a schema_version-2 shaped DB directly (no board_id on archived_cards,
+/// cards.column_id carrying the ON DELETE CASCADE FK). Returns
+/// (board_id, column_id, card_id). `original_column_id` on the archived row is
+/// taken from `orig_col` so a caller can simulate a since-deleted column.
+pub(crate) async fn seed_v2_db(path: &Path, orig_col: Uuid) -> (Uuid, Uuid, Uuid) {
+    let (pool, board_id, column_id) = open_seeded_pool(path, 2).await;
+
+    sqlx::raw_sql(
+        "CREATE TABLE cards (
             id TEXT PRIMARY KEY, column_id TEXT NOT NULL, title TEXT NOT NULL,
             description TEXT, priority TEXT NOT NULL DEFAULT 'Medium',
             status TEXT NOT NULL DEFAULT 'Todo', position INTEGER NOT NULL,
@@ -81,35 +126,8 @@ pub(crate) async fn seed_v2_db(path: &Path, orig_col: Uuid) -> (Uuid, Uuid, Uuid
     .await
     .unwrap();
 
-    let board_id = Uuid::new_v4();
-    let column_id = Uuid::new_v4();
     let card_id = Uuid::new_v4();
 
-    sqlx::query(
-        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
-         VALUES (1, ?, '2024-01-01T00:00:00Z', 2)",
-    )
-    .bind(Uuid::new_v4().to_string())
-    .execute(&pool)
-    .await
-    .unwrap();
-    sqlx::query(
-        "INSERT INTO boards (id, name, created_at, updated_at)
-         VALUES (?, 'B', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
-    )
-    .bind(board_id.to_string())
-    .execute(&pool)
-    .await
-    .unwrap();
-    sqlx::query(
-        "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
-         VALUES (?, ?, 'Todo', 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
-    )
-    .bind(column_id.to_string())
-    .bind(board_id.to_string())
-    .execute(&pool)
-    .await
-    .unwrap();
     sqlx::query(
         "INSERT INTO cards (id, column_id, title, position, card_number, created_at, updated_at)
          VALUES (?, ?, 'Archived', 0, 1, '2024-01-01T00:00:00Z', '2024-02-02T00:00:00Z')",
@@ -288,11 +306,11 @@ fn test_migrate_is_idempotent_on_v3_db() {
 
 #[test]
 fn test_migrate_v2_restores_foreign_keys_after_cards_table_swap() {
-    // Regression guard: migrate_v2_to_v3_archived_cards disables
-    // `foreign_keys` for the cards table rebuild (a table-swap under FK ON
-    // fires ON DELETE CASCADE on sprint_logs/archived_cards and wipes them),
-    // then restores it before returning. The existing preserves-sprint_logs
-    // test only pins that the disable took effect; this pins the restore.
+    // migrate_v2_to_v3_archived_cards disables `foreign_keys` for the cards
+    // table rebuild, then restores it. `PRAGMA foreign_keys` is per-connection
+    // and the store's pool has room for 2, but `open()` never runs concurrent
+    // acquisitions, so this sequential read reliably lands on the connection
+    // the migration itself used.
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("v2.db");
     let rt = make_rt();
@@ -300,14 +318,16 @@ fn test_migrate_v2_restores_foreign_keys_after_cards_table_swap() {
         seed_v2_db(&path, Uuid::nil()).await;
         let store = SqliteStore::open(&path).await.unwrap();
 
-        let fk_enabled: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
-            .fetch_one(store.pool())
-            .await
-            .unwrap();
-        assert_eq!(
-            fk_enabled, 1,
-            "foreign_keys must be restored to ON after the cards table swap, \
-             not left disabled on the connection that performed it"
-        );
+        for _ in 0..4 {
+            let fk_enabled: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+            assert_eq!(
+                fk_enabled, 1,
+                "foreign_keys must be restored to ON after the cards table swap, \
+                 not left disabled on the connection that performed it"
+            );
+        }
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
@@ -285,3 +285,29 @@ fn test_migrate_is_idempotent_on_v3_db() {
         assert!(still_there, "archived card survives idempotent re-open");
     });
 }
+
+#[test]
+fn test_migrate_v2_restores_foreign_keys_after_cards_table_swap() {
+    // Regression guard: migrate_v2_to_v3_archived_cards disables
+    // `foreign_keys` for the cards table rebuild (a table-swap under FK ON
+    // fires ON DELETE CASCADE on sprint_logs/archived_cards and wipes them),
+    // then restores it before returning. The existing preserves-sprint_logs
+    // test only pins that the disable took effect; this pins the restore.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v2.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v2_db(&path, Uuid::nil()).await;
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let fk_enabled: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            fk_enabled, 1,
+            "foreign_keys must be restored to ON after the cards table swap, \
+             not left disabled on the connection that performed it"
+        );
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs
@@ -1,0 +1,217 @@
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use std::path::Path;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+/// Seed a schema_version-4 shaped DB directly: the 2->3 migration has already
+/// run (archived_cards has board_id, cards has no FK on column_id), but
+/// cards.board_id (the 4->5 migration) has not. Returns
+/// (board_id, column_id, card_id).
+async fn seed_v4_db(path: &Path) -> (Uuid, Uuid, Uuid) {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        "CREATE TABLE metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            instance_id TEXT NOT NULL,
+            saved_at TEXT NOT NULL,
+            schema_version INTEGER NOT NULL DEFAULT 4,
+            writer_version TEXT,
+            writer_commit TEXT
+        );
+        CREATE TABLE boards (
+            id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT,
+            sprint_prefix TEXT, card_prefix TEXT,
+            task_sort_field TEXT NOT NULL DEFAULT 'Default',
+            task_sort_order TEXT NOT NULL DEFAULT 'Ascending',
+            sprint_duration_days INTEGER,
+            sprint_name_used_count INTEGER NOT NULL DEFAULT 0,
+            next_sprint_number INTEGER NOT NULL DEFAULT 1,
+            active_sprint_id TEXT,
+            task_list_view TEXT NOT NULL DEFAULT 'Flat',
+            card_counter INTEGER NOT NULL DEFAULT 1,
+            completion_column_id TEXT,
+            position INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE columns (
+            id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
+            position INTEGER NOT NULL, wip_limit INTEGER,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+        );
+        CREATE TABLE cards (
+            id TEXT PRIMARY KEY,
+            column_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            priority TEXT NOT NULL DEFAULT 'Medium',
+            status TEXT NOT NULL DEFAULT 'Todo',
+            position INTEGER NOT NULL,
+            due_date TEXT,
+            points INTEGER CHECK (points >= 0 AND points <= 255),
+            card_number INTEGER NOT NULL DEFAULT 0,
+            sprint_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT
+        );
+        CREATE TABLE sprint_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, card_id TEXT NOT NULL,
+            sprint_id TEXT NOT NULL, sprint_number INTEGER NOT NULL,
+            sprint_name TEXT, started_at TEXT NOT NULL, ended_at TEXT,
+            status TEXT NOT NULL,
+            FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE
+        );
+        CREATE TABLE archived_cards (
+            card_id TEXT PRIMARY KEY, archived_at TEXT NOT NULL,
+            original_column_id TEXT NOT NULL, original_position INTEGER NOT NULL,
+            board_id TEXT NOT NULL
+        );",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let board_id = Uuid::new_v4();
+    let column_id = Uuid::new_v4();
+    let card_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+         VALUES (1, ?, '2024-01-01T00:00:00Z', 4)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO boards (id, name, created_at, updated_at)
+         VALUES (?, 'B', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+         VALUES (?, ?, 'Todo', 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(column_id.to_string())
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO cards (id, column_id, title, position, card_number, created_at, updated_at)
+         VALUES (?, ?, 'Card', 0, 1, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(card_id.to_string())
+    .bind(column_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    pool.close().await;
+    (board_id, column_id, card_id)
+}
+
+#[test]
+fn test_open_schema4_db_writes_durable_backup_before_board_id_migration() {
+    // Regression guard: the schema_version bump to SUPPORTED_SCHEMA_VERSION and
+    // the pre-migration backup are coupled only by code review / doc comments
+    // (mod.rs's SUPPORTED_SCHEMA_VERSION doc, init.rs's migrate() doc), not by
+    // the type system. Existing backup tests only seed schema-2 DBs, leaving
+    // the 4->5 boundary (migrate_v4_to_v5_cards_board_id) with no coverage at
+    // all -- this pins that boundary specifically.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v4.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (board_id, _column_id, card_id) = seed_v4_db(&path).await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let backup = SqliteStore::backup_path_for(&path, 4);
+        assert!(
+            backup.exists(),
+            "expected a <path>.v4.backup file after opening a schema-4 DB"
+        );
+
+        let backup_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(SqliteConnectOptions::new().filename(&backup))
+            .await
+            .unwrap();
+
+        let backup_version: u32 =
+            sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                .fetch_one(&backup_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            backup_version, 4,
+            "backup must be a pre-migration schema_version=4 snapshot"
+        );
+
+        let backup_has_board_id: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('cards') WHERE name = 'board_id'",
+        )
+        .fetch_one(&backup_pool)
+        .await
+        .unwrap();
+        assert!(
+            !backup_has_board_id,
+            "backup must predate the cards.board_id migration"
+        );
+        backup_pool.close().await;
+
+        let live_version: u32 =
+            sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+        assert_eq!(live_version, 5, "live store must be migrated to current");
+
+        let live_board_id: String = sqlx::query_scalar("SELECT board_id FROM cards WHERE id = ?")
+            .bind(card_id.to_string())
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            live_board_id,
+            board_id.to_string(),
+            "cards.board_id backfilled from column_id -> columns.board_id"
+        );
+    });
+}
+
+#[test]
+fn test_open_schema5_db_writes_no_v4_backup() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v5.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        // A fresh open creates an already-current schema-5 DB.
+        SqliteStore::open(&path).await.unwrap();
+        // Second open sees pre_migrate_version == SUPPORTED_SCHEMA_VERSION.
+        SqliteStore::open(&path).await.unwrap();
+
+        assert!(
+            !SqliteStore::backup_path_for(&path, 4).exists(),
+            "an already-current DB must not get a v4 backup written"
+        );
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs
@@ -5,54 +5,17 @@ use uuid::Uuid;
 
 use super::super::SqliteStore;
 use super::make_rt;
+use super::migration_v2_to_v3::open_seeded_pool;
 
 /// Seed a schema_version-4 shaped DB directly: the 2->3 migration has already
 /// run (archived_cards has board_id, cards has no FK on column_id), but
 /// cards.board_id (the 4->5 migration) has not. Returns
 /// (board_id, column_id, card_id).
 async fn seed_v4_db(path: &Path) -> (Uuid, Uuid, Uuid) {
-    let pool = SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect_with(
-            SqliteConnectOptions::new()
-                .filename(path)
-                .create_if_missing(true)
-                .foreign_keys(false),
-        )
-        .await
-        .unwrap();
+    let (pool, board_id, column_id) = open_seeded_pool(path, 4).await;
 
     sqlx::raw_sql(
-        "CREATE TABLE metadata (
-            id INTEGER PRIMARY KEY CHECK (id = 1),
-            instance_id TEXT NOT NULL,
-            saved_at TEXT NOT NULL,
-            schema_version INTEGER NOT NULL DEFAULT 4,
-            writer_version TEXT,
-            writer_commit TEXT
-        );
-        CREATE TABLE boards (
-            id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT,
-            sprint_prefix TEXT, card_prefix TEXT,
-            task_sort_field TEXT NOT NULL DEFAULT 'Default',
-            task_sort_order TEXT NOT NULL DEFAULT 'Ascending',
-            sprint_duration_days INTEGER,
-            sprint_name_used_count INTEGER NOT NULL DEFAULT 0,
-            next_sprint_number INTEGER NOT NULL DEFAULT 1,
-            active_sprint_id TEXT,
-            task_list_view TEXT NOT NULL DEFAULT 'Flat',
-            card_counter INTEGER NOT NULL DEFAULT 1,
-            completion_column_id TEXT,
-            position INTEGER NOT NULL DEFAULT 0,
-            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
-        );
-        CREATE TABLE columns (
-            id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
-            position INTEGER NOT NULL, wip_limit INTEGER,
-            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
-            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
-        );
-        CREATE TABLE cards (
+        "CREATE TABLE cards (
             id TEXT PRIMARY KEY,
             column_id TEXT NOT NULL,
             title TEXT NOT NULL,
@@ -78,42 +41,16 @@ async fn seed_v4_db(path: &Path) -> (Uuid, Uuid, Uuid) {
         CREATE TABLE archived_cards (
             card_id TEXT PRIMARY KEY, archived_at TEXT NOT NULL,
             original_column_id TEXT NOT NULL, original_position INTEGER NOT NULL,
-            board_id TEXT NOT NULL
+            board_id TEXT NOT NULL,
+            FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE
         );",
     )
     .execute(&pool)
     .await
     .unwrap();
 
-    let board_id = Uuid::new_v4();
-    let column_id = Uuid::new_v4();
     let card_id = Uuid::new_v4();
 
-    sqlx::query(
-        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
-         VALUES (1, ?, '2024-01-01T00:00:00Z', 4)",
-    )
-    .bind(Uuid::new_v4().to_string())
-    .execute(&pool)
-    .await
-    .unwrap();
-    sqlx::query(
-        "INSERT INTO boards (id, name, created_at, updated_at)
-         VALUES (?, 'B', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
-    )
-    .bind(board_id.to_string())
-    .execute(&pool)
-    .await
-    .unwrap();
-    sqlx::query(
-        "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
-         VALUES (?, ?, 'Todo', 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
-    )
-    .bind(column_id.to_string())
-    .bind(board_id.to_string())
-    .execute(&pool)
-    .await
-    .unwrap();
     sqlx::query(
         "INSERT INTO cards (id, column_id, title, position, card_number, created_at, updated_at)
          VALUES (?, ?, 'Card', 0, 1, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
@@ -130,12 +67,9 @@ async fn seed_v4_db(path: &Path) -> (Uuid, Uuid, Uuid) {
 
 #[test]
 fn test_open_schema4_db_writes_durable_backup_before_board_id_migration() {
-    // Regression guard: the schema_version bump to SUPPORTED_SCHEMA_VERSION and
-    // the pre-migration backup are coupled only by code review / doc comments
-    // (mod.rs's SUPPORTED_SCHEMA_VERSION doc, init.rs's migrate() doc), not by
-    // the type system. Existing backup tests only seed schema-2 DBs, leaving
-    // the 4->5 boundary (migrate_v4_to_v5_cards_board_id) with no coverage at
-    // all -- this pins that boundary specifically.
+    // Every existing pre-migration-backup test seeds a schema-2 DB, leaving
+    // the 4->5 boundary (migrate_v4_to_v5_cards_board_id) with no coverage of
+    // its own.
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("v4.db");
     let rt = make_rt();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -13,6 +13,7 @@ mod migration_v2_to_v3;
 mod migration_v4_to_v5;
 mod persistence_store;
 mod pre_migration_backup;
+mod snapshot_atomicity;
 
 pub(crate) fn make_rt() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -10,6 +10,7 @@ mod init;
 mod metadata;
 mod migration_coverage;
 mod migration_v2_to_v3;
+mod migration_v4_to_v5;
 mod persistence_store;
 mod pre_migration_backup;
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs
@@ -7,15 +7,10 @@ use kanban_domain::{Board, Card, Column, DataStore};
 
 #[test]
 fn test_apply_snapshot_failure_leaves_existing_data_untouched() {
-    // Regression guard: apply_snapshot_async wipes every table then re-inserts
-    // the incoming snapshot inside a single transaction (snapshot.rs). Its
-    // correctness rests entirely on that atomicity -- if the wipe and the
-    // rewrite were ever split across transactions (or committed early), a
-    // failure partway through the rewrite would leave the store wiped rather
-    // than rolled back. `defer_foreign_keys = ON` means an FK violation is
-    // exactly the kind of failure that only surfaces at COMMIT, after every
-    // individual INSERT has already run -- a real stress case for atomicity,
-    // not just an early-return one.
+    // apply_snapshot_async wipes every table then re-inserts the incoming
+    // snapshot inside one transaction; a dangling sprint_id fails only at
+    // COMMIT (FK checking is deferred), after every individual INSERT in the
+    // rewrite has already run against the wiped tables.
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("atomic.sqlite3");
     let rt = make_rt();
@@ -23,7 +18,9 @@ fn test_apply_snapshot_failure_leaves_existing_data_untouched() {
         let store = SqliteStore::open(&path).await.unwrap();
 
         let mut board = Board::new("Existing", None::<String>);
+        let board_id = board.id;
         let column = Column::new(board.id, "Todo", 0);
+        let existing_column_id = column.id;
         let card = Card::new(&mut board, column.id, "Existing card", 0);
         let existing_card_id = card.id;
         store.upsert_board(board).unwrap();
@@ -31,8 +28,6 @@ fn test_apply_snapshot_failure_leaves_existing_data_untouched() {
         store.upsert_card(card).unwrap();
 
         let mut bad_snapshot = store.snapshot().unwrap();
-        // A card whose sprint_id points at a sprint that doesn't exist: the
-        // per-row INSERT succeeds (FK checking is deferred), but COMMIT fails.
         let mut broken_card = bad_snapshot.cards[0].clone();
         broken_card.sprint_id = Some(Uuid::new_v4());
         bad_snapshot.cards = vec![broken_card];
@@ -44,14 +39,17 @@ fn test_apply_snapshot_failure_leaves_existing_data_untouched() {
         );
 
         assert!(
-            store.get_card(existing_card_id).unwrap().is_some(),
+            store.get_board(board_id).unwrap().is_some(),
             "a failed apply_snapshot must roll back the wipe too -- the \
-             pre-existing card must still be there, not left deleted"
+             pre-existing board must still be there, not left deleted"
         );
-        assert_eq!(
-            store.list_boards().unwrap().len(),
-            1,
-            "the pre-existing board must survive a rolled-back apply_snapshot"
+        assert!(
+            store.get_column(existing_column_id).unwrap().is_some(),
+            "the pre-existing column must survive a rolled-back apply_snapshot"
+        );
+        assert!(
+            store.get_card(existing_card_id).unwrap().is_some(),
+            "the pre-existing card must survive a rolled-back apply_snapshot"
         );
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs
@@ -1,0 +1,57 @@
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+use kanban_domain::{Board, Card, Column, DataStore};
+
+#[test]
+fn test_apply_snapshot_failure_leaves_existing_data_untouched() {
+    // Regression guard: apply_snapshot_async wipes every table then re-inserts
+    // the incoming snapshot inside a single transaction (snapshot.rs). Its
+    // correctness rests entirely on that atomicity -- if the wipe and the
+    // rewrite were ever split across transactions (or committed early), a
+    // failure partway through the rewrite would leave the store wiped rather
+    // than rolled back. `defer_foreign_keys = ON` means an FK violation is
+    // exactly the kind of failure that only surfaces at COMMIT, after every
+    // individual INSERT has already run -- a real stress case for atomicity,
+    // not just an early-return one.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("atomic.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let mut board = Board::new("Existing", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Existing card", 0);
+        let existing_card_id = card.id;
+        store.upsert_board(board).unwrap();
+        store.upsert_column(column).unwrap();
+        store.upsert_card(card).unwrap();
+
+        let mut bad_snapshot = store.snapshot().unwrap();
+        // A card whose sprint_id points at a sprint that doesn't exist: the
+        // per-row INSERT succeeds (FK checking is deferred), but COMMIT fails.
+        let mut broken_card = bad_snapshot.cards[0].clone();
+        broken_card.sprint_id = Some(Uuid::new_v4());
+        bad_snapshot.cards = vec![broken_card];
+
+        let result = store.apply_snapshot(bad_snapshot);
+        assert!(
+            result.is_err(),
+            "a dangling sprint_id must fail at commit, not silently succeed"
+        );
+
+        assert!(
+            store.get_card(existing_card_id).unwrap().is_some(),
+            "a failed apply_snapshot must roll back the wipe too -- the \
+             pre-existing card must still be there, not left deleted"
+        );
+        assert_eq!(
+            store.list_boards().unwrap().len(),
+            1,
+            "the pre-existing board must survive a rolled-back apply_snapshot"
+        );
+    });
+}


### PR DESCRIPTION
Guard-only, no production code changes. Three SQLite behaviors are correct today but rest on invariants that were only enforced by code comments or code-review discipline, not by any test:

- **`migrate_v2_to_v3_archived_cards`'s FK-off cards-table swap**: `DROP TABLE cards` under `foreign_keys = ON` fires `ON DELETE CASCADE` on `sprint_logs`/`archived_cards` and wipes them, so the migration disables FK enforcement for the swap and restores it afterward. The existing test only pinned that the disable took effect (`sprint_logs` survives); nothing checked the restore.
- **Schema-version/backup coupling**: `SUPPORTED_SCHEMA_VERSION`'s doc comment says the version bump and the pre-migration `.v{N}.backup` are "intentionally coupled but not enforced by the type system." Every existing backup test seeds a schema-2 DB, so the v4→v5 boundary (`migrate_v4_to_v5_cards_board_id`) had zero coverage of its own.
- **`apply_snapshot_async`'s wipe-and-rewrite atomicity**: the whole operation (wipe every table, then re-insert the incoming snapshot) runs inside one transaction; correctness depends entirely on that. No test induced a mid-rewrite failure to confirm a failed apply rolls back cleanly rather than leaving the store half-wiped.

- `crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs`: new test asserts `PRAGMA foreign_keys` reads back ON after opening a schema-2 DB.
- `crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs` (new file): seeds a schema-4 DB directly and asserts opening it produces a `.v4.backup` reflecting the pre-migration shape, while the live store ends up migrated to current with `cards.board_id` backfilled.
- `crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs` (new file): seeds a store with real data, then calls `apply_snapshot` with a card carrying a dangling `sprint_id` (a natural failure injector, since `defer_foreign_keys = ON` means the FK violation only surfaces at `COMMIT`, after every individual `INSERT` in the rewrite has already run) and asserts the pre-existing data survives untouched.

Each new test was verified as a genuine regression guard by temporarily breaking the invariant it pins (removing the FK restore, disabling the backup call, and simulating a non-atomic wipe by moving one `DELETE` outside the transaction) and confirming the test fails, then restoring the real behavior.

**Testing**: `cargo test -p kanban-persistence-sqlite --lib` (89 passed, up from 86), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).

**Found and fixed during self-review** (ran the code-review skill against this PR before requesting review, adapted to a test-only diff — scrutinizing whether the tests themselves are sound rather than production code): the FK-restoration test's single `PRAGMA foreign_keys` read could in principle land on a never-touched pool connection (already ON by construction) and give a false pass — now loops the read 4x against the pool. `seed_v4_db` duplicated ~90 lines of `seed_v2_db`'s boilerplate and was missing a real FK the equivalent v2 fixture has — extracted a shared `open_seeded_pool` helper and added the missing FK. The atomicity test only asserted board/card survival, not the column — added, since `apply_snapshot_async` wipes and rewrites columns too (the same "assert the whole graph, not just the root" gap this repo's own testing policy calls out).
