### PR TITLE
KAN-978 refactor(tui): replace ad-hoc column position sorts with sorted_board_columns

### DIFF
--- a/.changeset/max-kan-978.md
+++ b/.changeset/max-kan-978.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Hardened the board view's column ordering so it can no longer disagree with
+itself in edge cases (two columns ending up sharing the same internal
+position value, which can happen after deleting and recreating columns).
+Column list rendering, the move-column-up/down commands, and the board
+detail view now all resolve column order the same consistent way instead of
+each computing it separately.
+

--- a/.changeset/max-kan-978.md
+++ b/.changeset/max-kan-978.md
@@ -5,7 +5,7 @@ bump: patch
 Hardened the board view's column ordering so it can no longer disagree with
 itself in edge cases (two columns ending up sharing the same internal
 position value, which can happen after deleting and recreating columns).
-Column list rendering, the move-column-up/down commands, and the board
-detail view now all resolve column order the same consistent way instead of
-each computing it separately.
+Column list rendering, the move-column-up/down commands, the rename/delete
+column dialogs, and the board detail view now all resolve column order the
+same consistent way instead of each computing it separately.
 

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -688,4 +688,51 @@ mod tests {
             "Complete must take New's old position"
         );
     }
+
+    #[test]
+    fn test_rename_column_resolves_correct_column_regardless_of_model_iteration_order() {
+        use kanban_domain::KanbanOperations;
+
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Roadmap");
+        let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
+
+        let doing_id = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap()
+            .iter()
+            .find(|c| c.name == "Doing")
+            .unwrap()
+            .id;
+        let new_col = app
+            .ctx
+            .create_column(board_id, "New".to_string(), Some(1))
+            .unwrap();
+
+        let mut snapshot = app.ctx.snapshot().unwrap();
+        let doing_idx = snapshot
+            .columns
+            .iter()
+            .position(|c| c.id == doing_id)
+            .unwrap();
+        let new_idx = snapshot
+            .columns
+            .iter()
+            .position(|c| c.id == new_col.id)
+            .unwrap();
+        snapshot.columns.swap(doing_idx, new_idx);
+        app.model.load_from_snapshot(snapshot);
+        app.selection.active_board_id = Some(board_id);
+
+        // Canonical index 2 is "New" (Doing was created first). Selecting
+        // index 2 and opening rename must populate "New"'s name, not
+        // "Doing"'s, regardless of the scrambled model order.
+        app.focus.board_focus = BoardFocus::Columns;
+        app.dialog_input.column_selection.set(Some(2));
+        app.handle_rename_column_key();
+
+        assert_eq!(app.input.as_str(), "New");
+    }
 }

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -1,5 +1,6 @@
 use crate::app::{App, BoardFocus, DialogMode};
 use crossterm::event::KeyCode;
+use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::commands::{
     BoardCommand, CardCommand, ColumnCommand, Command, CreateColumn, DeleteColumn, MoveCard,
     SetBoardTaskListView, UpdateColumn,
@@ -70,16 +71,11 @@ impl App {
         {
             {
                 if let Some(board) = self.active_board() {
-                    // Collect and sort column data before mutating
-                    let mut board_columns: Vec<_> = self
-                        .model
-                        .columns()
-                        .iter()
-                        .filter(|col| col.board_id == board.id)
-                        .map(|col| (col.id, col.position))
-                        .collect();
-
-                    board_columns.sort_by_key(|(_, pos)| *pos);
+                    let board_columns: Vec<(uuid::Uuid, i32)> =
+                        sorted_board_columns(board.id, self.model.columns())
+                            .into_iter()
+                            .map(|col| (col.id, col.position))
+                            .collect();
 
                     if let Some(selected_idx) = self.dialog_input.column_selection.get() {
                         if selected_idx > 0 && selected_idx < board_columns.len() {
@@ -126,16 +122,11 @@ impl App {
         {
             {
                 if let Some(board) = self.active_board() {
-                    // Collect and sort column data before mutating
-                    let mut board_columns: Vec<_> = self
-                        .model
-                        .columns()
-                        .iter()
-                        .filter(|col| col.board_id == board.id)
-                        .map(|col| (col.id, col.position))
-                        .collect();
-
-                    board_columns.sort_by_key(|(_, pos)| *pos);
+                    let board_columns: Vec<(uuid::Uuid, i32)> =
+                        sorted_board_columns(board.id, self.model.columns())
+                            .into_iter()
+                            .map(|col| (col.id, col.position))
+                            .collect();
 
                     if let Some(selected_idx) = self.dialog_input.column_selection.get() {
                         if selected_idx < board_columns.len() - 1 {

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -25,11 +25,7 @@ impl App {
         {
             {
                 if let Some(board) = self.active_board() {
-                    let columns = self.model.columns();
-                    let board_columns: Vec<_> = columns
-                        .iter()
-                        .filter(|col| col.board_id == board.id)
-                        .collect();
+                    let board_columns = sorted_board_columns(board.id, self.model.columns());
 
                     if let Some(column_idx) = self.dialog_input.column_selection.get() {
                         if let Some(column) = board_columns.get(column_idx) {
@@ -292,13 +288,11 @@ impl App {
             let delete_info = {
                 if let Some(board) = self.active_board() {
                     if let Some(column_idx) = self.dialog_input.column_selection.get() {
-                        let board_columns: Vec<_> = self
-                            .model
-                            .columns()
-                            .iter()
-                            .filter(|col| col.board_id == board.id)
-                            .map(|col| (col.id, col.name.clone()))
-                            .collect();
+                        let board_columns: Vec<(uuid::Uuid, String)> =
+                            sorted_board_columns(board.id, self.model.columns())
+                                .into_iter()
+                                .map(|col| (col.id, col.name.clone()))
+                                .collect();
 
                         if board_columns.len() <= 1 {
                             return;

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -527,6 +527,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    use crate::app::BoardFocus;
     use crate::App;
 
     /// Refresh the TUI model from the store so the create handlers (which read
@@ -603,5 +604,94 @@ mod tests {
             .filter(|c| c.board_id == board_id)
             .count();
         assert_eq!(after, before, "blank column name must not be written");
+    }
+
+    #[test]
+    fn test_move_column_up_swaps_correct_pair_regardless_of_model_iteration_order() {
+        use kanban_domain::KanbanOperations;
+
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Roadmap");
+        let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
+
+        // Explicit-position create ties "New" with "Doing" (position 1);
+        // "Doing" was created first, so canonical order is
+        // [TODO(0), Doing(1), New(1), Complete(2)] -- Complete is last,
+        // unambiguously, since its position (2) is unique.
+        let doing_id = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap()
+            .iter()
+            .find(|c| c.name == "Doing")
+            .unwrap()
+            .id;
+        let complete_id = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap()
+            .iter()
+            .find(|c| c.name == "Complete")
+            .unwrap()
+            .id;
+        let new_col = app
+            .ctx
+            .create_column(board_id, "New".to_string(), Some(1))
+            .unwrap();
+
+        // Feed the model a snapshot with the tied pair's relative order
+        // swapped from canonical, instead of going through the normal
+        // ctx.snapshot() pipeline -- proving handle_move_column_up no longer
+        // depends on the model happening to already be canonically ordered.
+        let mut snapshot = app.ctx.snapshot().unwrap();
+        let doing_idx = snapshot
+            .columns
+            .iter()
+            .position(|c| c.id == doing_id)
+            .unwrap();
+        let new_idx = snapshot
+            .columns
+            .iter()
+            .position(|c| c.id == new_col.id)
+            .unwrap();
+        snapshot.columns.swap(doing_idx, new_idx);
+        app.model.load_from_snapshot(snapshot);
+        app.selection.active_board_id = Some(board_id);
+
+        // Complete is unambiguously last (index 3); moving it up must swap it
+        // with "New" (its canonical predecessor, the later-created of the
+        // tied pair) -- not "Doing", regardless of the scrambled model order.
+        app.focus.board_focus = BoardFocus::Columns;
+        app.dialog_input.column_selection.set(Some(3));
+        app.handle_move_column_up();
+
+        let doing = app.ctx.data_store().get_column(doing_id).unwrap().unwrap();
+        let new = app
+            .ctx
+            .data_store()
+            .get_column(new_col.id)
+            .unwrap()
+            .unwrap();
+        let complete = app
+            .ctx
+            .data_store()
+            .get_column(complete_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            doing.position, 1,
+            "Doing is not adjacent to Complete in canonical order and must be untouched"
+        );
+        assert_eq!(
+            new.position, 2,
+            "New (Complete's canonical predecessor) must be bumped to Complete's old position"
+        );
+        assert_eq!(
+            complete.position, 1,
+            "Complete must take New's old position"
+        );
     }
 }

--- a/crates/kanban-tui/src/layout_strategy.rs
+++ b/crates/kanban-tui/src/layout_strategy.rs
@@ -1,5 +1,6 @@
 use crate::card_list::{CardList, CardListId};
 use crate::view_strategy::ViewRefreshContext;
+use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::CardQueryBuilder;
 use uuid::Uuid;
 
@@ -170,12 +171,7 @@ impl LayoutStrategy for ColumnListsLayout {
     }
 
     fn refresh_lists(&mut self, ctx: &ViewRefreshContext) {
-        let mut board_columns: Vec<_> = ctx
-            .all_columns
-            .iter()
-            .filter(|col| col.board_id == ctx.board.id)
-            .collect();
-        board_columns.sort_by_key(|col| col.position);
+        let board_columns = sorted_board_columns(ctx.board.id, ctx.all_columns);
 
         let mut new_column_lists = Vec::new();
 
@@ -267,12 +263,7 @@ impl LayoutStrategy for VirtualUnifiedLayout {
     }
 
     fn refresh_lists(&mut self, ctx: &ViewRefreshContext) {
-        let mut board_columns: Vec<_> = ctx
-            .all_columns
-            .iter()
-            .filter(|col| col.board_id == ctx.board.id)
-            .collect();
-        board_columns.sort_by_key(|col| col.position);
+        let board_columns = sorted_board_columns(ctx.board.id, ctx.all_columns);
 
         let mut unified_cards = Vec::new();
         let mut new_boundaries = Vec::new();

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -5,6 +5,7 @@ use crate::components::{
 };
 use crate::layout_strategy::ColumnBoundary;
 use crate::theme::{deleted_view_focused_border, label_text};
+use kanban_domain::card_lifecycle::sorted_board_columns;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
@@ -210,13 +211,7 @@ impl RenderStrategy for SinglePanelRenderer {
                             ));
                         }
                     } else {
-                        let mut board_columns: Vec<_> = app
-                            .model
-                            .columns()
-                            .iter()
-                            .filter(|col| col.board_id == board.id)
-                            .collect();
-                        board_columns.sort_by_key(|col| col.position);
+                        let board_columns = sorted_board_columns(board.id, app.model.columns());
 
                         if board_columns.is_empty() {
                             lines.push(Line::from(Span::styled(

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -2,6 +2,7 @@ use crate::app::{App, BoardFocus};
 use crate::components::*;
 use crate::theme::*;
 use kanban_core::pagination::scroll_offset_to_keep_visible;
+use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::{Sprint, SprintStatus};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -244,13 +245,7 @@ fn render_board_columns_list(
         .with_focus_indicator("Columns [5]")
         .focused(app.focus.board_focus == BoardFocus::Columns);
 
-    let mut board_columns: Vec<_> = app
-        .model
-        .columns()
-        .iter()
-        .filter(|col| col.board_id == board.id)
-        .collect();
-    board_columns.sort_by_key(|col| col.position);
+    let board_columns = sorted_board_columns(board.id, app.model.columns());
 
     let mut column_lines = vec![];
 


### PR DESCRIPTION
Reshaped from the original bug-fix framing after verifying the premise against actual behavior (the card claimed a live "wrong pair swapped" bug; investigation showed it isn't reachable today — see below).

5 independent `sort_by_key(|col| col.position)` call sites (`column_handlers.rs`'s move-up/down handlers, `layout_strategy.rs`'s two `refresh_lists` impls, `board_detail.rs`, `render_strategy.rs`) never called kanban-domain's `sorted_board_columns`, which breaks ties by `created_at` then `id`.

**Why this isn't a live bug today**: Rust's `sort_by_key` is stable, and both backends' `snapshot()` paths (`InMemoryStore::snapshot_impl`, `SqliteStore::snapshot_async`) already apply the exact same tiebreak before populating `Model::columns()` on every frame refresh. A stable re-sort on top of already-canonically-ordered input is a no-op for ties, so all 5 sites — reading from the same source — can't disagree with each other today. I verified this empirically (not just by reading code): my first attempt to construct the card's "archive-then-create causes a tie" scenario via the TUI's own create-column handler failed, because that handler computes new positions as `max(existing) + 1`, not a live-column count, so ordinary delete-then-create never collides.

**What's still real**: the redundant sorts are fragile in the sense that they implicitly depend on the model always arriving pre-sorted, rather than being self-sufficient. If that upstream invariant were ever weakened (e.g. a future code path that reads column order some other way), the move-column handlers specifically could pick the wrong neighbor to swap with for a tied element — verified by writing a test that feeds the model a snapshot with a tied pair's order swapped from canonical (bypassing the normal pipeline) and confirming the old code gets it wrong while the fix doesn't.

- Replaces all 5 sites with `sorted_board_columns` directly, removing the duplicated filter+sort logic.
- One new test (`test_move_column_up_swaps_correct_pair_regardless_of_model_iteration_order`) pins that `handle_move_column_up` now computes canonical order itself rather than trusting the model's iteration order — verified as a genuine regression guard by temporarily reverting to the old logic and confirming the test fails (the non-adjacent column gets disturbed instead of staying put).

**Found and fixed during self-review**: `handle_rename_column_key` and `delete_column` (`column_handlers.rs`) shared the exact same selection-index mechanism as the move handlers — indexing into a manually filtered (never sorted) `Vec` of the board's columns — but were outside the original scope of this PR. Left alone, this PR's own changeset claim ("all resolve column order the same consistent way") would have been false, and the two handlers would have remained exposed to the same latent index-mismatch risk. Fixed both to go through `sorted_board_columns`, and added `test_rename_column_resolves_correct_column_regardless_of_model_iteration_order`, verified the same way (revert-and-confirm-fail) as the original test.

**Testing**: `cargo test -p kanban-tui --lib` (355 passed, up from 353 pre-existing — all prior tests pass unmodified, confirming this is behavior-preserving), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).
