### PR TITLE
KAN-989 fix(service): update_cards' plain column-move branch bypasses WIP limit and board_id sync

### DIFF
--- a/.changeset/max-kan-989.md
+++ b/.changeset/max-kan-989.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+Fixed a bug where moving cards between columns without also changing their
+status (for example the bulk multi-select "move left/right" action in the
+TUI) could silently exceed a column's WIP limit, and could leave a card
+pointing at the wrong board after a cross-board move. Both of these are now
+enforced the same way a direct drag-and-drop move already enforces them, so
+the two paths behave consistently.

--- a/crates/kanban-service/src/context/cards_batch.rs
+++ b/crates/kanban-service/src/context/cards_batch.rs
@@ -207,66 +207,87 @@ impl KanbanContext {
         }
 
         for (card_id, mut card_updates) in updates {
-            let chained = match (card_updates.status, card_updates.column_id) {
-                (Some(new_status), None) => self
-                    .compute_target_column_for_status(card_id, new_status)?
-                    .map(|(col, base_pos)| {
+            let mut chained: Vec<Chained> = Vec::new();
+
+            match (card_updates.status, card_updates.column_id) {
+                (Some(new_status), None) => {
+                    if let Some((col, base_pos)) =
+                        self.compute_target_column_for_status(card_id, new_status)?
+                    {
                         let offset = position_offsets.entry(col).or_insert(0);
                         let pos = base_pos + *offset;
                         *offset += 1;
-                        Chained::Move(col, pos)
-                    }),
+                        chained.push(Chained::Move(col, pos));
+                    }
+                }
                 (None, Some(new_col)) => {
-                    // A genuine column change needs its position recomputed the
-                    // same way move_card/move_cards do — otherwise the card keeps
-                    // its old position and collides with whatever already sits
-                    // there in the new column. Skipped when the caller already
-                    // pinned an explicit position (that takes precedence), and
+                    // A genuine column change must go through MoveCard, the same
+                    // as move_card/move_cards — that's what enforces the target
+                    // column's WIP limit and syncs card.board_id to the target
+                    // column's board on a cross-board move (KAN-963). Skipped
                     // when the "new" column is actually the card's current one
                     // (e.g. a PUT-replace that resubmits every field) — that's
-                    // not a move, so it must not touch position.
+                    // not a move, so column_id/position/board_id must stay as-is.
                     let already_in_column = self
                         .backend
                         .get_card(card_id)?
                         .is_some_and(|c| c.column_id == new_col);
-                    if !already_in_column && card_updates.position.is_none() {
-                        let base_pos = self
-                            .backend
-                            .count_cards_in_column_filtered(new_col, ArchivedFilter::Include)?
-                            as i32;
-                        let offset = position_offsets.entry(new_col).or_insert(0);
-                        card_updates.position = Some(base_pos + *offset);
-                        *offset += 1;
+                    if already_in_column {
+                        if let Some(status) =
+                            self.compute_target_status_for_move(card_id, new_col)?
+                        {
+                            chained.push(Chained::Status(status));
+                        }
+                    } else {
+                        let position = match card_updates.position.take() {
+                            Some(explicit) => explicit,
+                            None => {
+                                let base_pos = self.backend.count_cards_in_column_filtered(
+                                    new_col,
+                                    ArchivedFilter::Include,
+                                )? as i32;
+                                let offset = position_offsets.entry(new_col).or_insert(0);
+                                let pos = base_pos + *offset;
+                                *offset += 1;
+                                pos
+                            }
+                        };
+                        card_updates.column_id = None;
+                        chained.push(Chained::Move(new_col, position));
+                        if let Some(status) =
+                            self.compute_target_status_for_move(card_id, new_col)?
+                        {
+                            chained.push(Chained::Status(status));
+                        }
                     }
-                    self.compute_target_status_for_move(card_id, new_col)?
-                        .map(Chained::Status)
                 }
-                _ => None,
-            };
+                _ => {}
+            }
 
             batch.push(Command::Card(CardCommand::Update(UpdateCard {
                 card_id,
                 updates: card_updates,
             })));
 
-            match chained {
-                Some(Chained::Move(col, pos)) => {
-                    batch.push(Command::Card(CardCommand::Move(MoveCard {
-                        card_id,
-                        new_column_id: col,
-                        new_position: pos,
-                    })));
+            for op in chained {
+                match op {
+                    Chained::Move(col, pos) => {
+                        batch.push(Command::Card(CardCommand::Move(MoveCard {
+                            card_id,
+                            new_column_id: col,
+                            new_position: pos,
+                        })));
+                    }
+                    Chained::Status(status) => {
+                        batch.push(Command::Card(CardCommand::Update(UpdateCard {
+                            card_id,
+                            updates: CardUpdate {
+                                status: Some(status),
+                                ..Default::default()
+                            },
+                        })));
+                    }
                 }
-                Some(Chained::Status(status)) => {
-                    batch.push(Command::Card(CardCommand::Update(UpdateCard {
-                        card_id,
-                        updates: CardUpdate {
-                            status: Some(status),
-                            ..Default::default()
-                        },
-                    })));
-                }
-                None => {}
             }
         }
 

--- a/crates/kanban-service/src/context/cards_batch.rs
+++ b/crates/kanban-service/src/context/cards_batch.rs
@@ -194,20 +194,24 @@ impl KanbanContext {
         use std::collections::HashMap;
 
         let count = updates.len();
-        let mut batch: Vec<Command> = Vec::with_capacity(count * 2);
+        let mut batch: Vec<Command> = Vec::with_capacity(count * 3);
         // Track per-column position offsets within this batch so chained moves
         // into the same target column don't all collapse onto the same
         // position. Both branches below read the target column's count once
         // per call against the pre-batch state.
         let mut position_offsets: HashMap<Uuid, i32> = HashMap::new();
 
-        enum Chained {
-            Move(Uuid, i32),
-            Status(CardStatus),
+        // At most one chained move and one chained status update per card, in
+        // that order — the move (if any) must land the card in its target
+        // column before a completion-column status flip is applied to it.
+        #[derive(Default)]
+        struct Chained {
+            mov: Option<(Uuid, i32)>,
+            status: Option<CardStatus>,
         }
 
         for (card_id, mut card_updates) in updates {
-            let mut chained: Vec<Chained> = Vec::new();
+            let mut chained = Chained::default();
 
             match (card_updates.status, card_updates.column_id) {
                 (Some(new_status), None) => {
@@ -217,28 +221,22 @@ impl KanbanContext {
                         let offset = position_offsets.entry(col).or_insert(0);
                         let pos = base_pos + *offset;
                         *offset += 1;
-                        chained.push(Chained::Move(col, pos));
+                        chained.mov = Some((col, pos));
                     }
                 }
                 (None, Some(new_col)) => {
                     // A genuine column change must go through MoveCard, the same
                     // as move_card/move_cards — that's what enforces the target
                     // column's WIP limit and syncs card.board_id to the target
-                    // column's board on a cross-board move (KAN-963). Skipped
-                    // when the "new" column is actually the card's current one
-                    // (e.g. a PUT-replace that resubmits every field) — that's
-                    // not a move, so column_id/position/board_id must stay as-is.
+                    // column's board on a cross-board move. Skipped when the
+                    // "new" column is actually the card's current one (e.g. a
+                    // PUT-replace that resubmits every field) — that's not a
+                    // move, so column_id/position/board_id must stay as-is.
                     let already_in_column = self
                         .backend
                         .get_card(card_id)?
                         .is_some_and(|c| c.column_id == new_col);
-                    if already_in_column {
-                        if let Some(status) =
-                            self.compute_target_status_for_move(card_id, new_col)?
-                        {
-                            chained.push(Chained::Status(status));
-                        }
-                    } else {
+                    if !already_in_column {
                         let position = match card_updates.position.take() {
                             Some(explicit) => explicit,
                             None => {
@@ -253,13 +251,9 @@ impl KanbanContext {
                             }
                         };
                         card_updates.column_id = None;
-                        chained.push(Chained::Move(new_col, position));
-                        if let Some(status) =
-                            self.compute_target_status_for_move(card_id, new_col)?
-                        {
-                            chained.push(Chained::Status(status));
-                        }
+                        chained.mov = Some((new_col, position));
                     }
+                    chained.status = self.compute_target_status_for_move(card_id, new_col)?;
                 }
                 _ => {}
             }
@@ -269,25 +263,21 @@ impl KanbanContext {
                 updates: card_updates,
             })));
 
-            for op in chained {
-                match op {
-                    Chained::Move(col, pos) => {
-                        batch.push(Command::Card(CardCommand::Move(MoveCard {
-                            card_id,
-                            new_column_id: col,
-                            new_position: pos,
-                        })));
-                    }
-                    Chained::Status(status) => {
-                        batch.push(Command::Card(CardCommand::Update(UpdateCard {
-                            card_id,
-                            updates: CardUpdate {
-                                status: Some(status),
-                                ..Default::default()
-                            },
-                        })));
-                    }
-                }
+            if let Some((col, pos)) = chained.mov {
+                batch.push(Command::Card(CardCommand::Move(MoveCard {
+                    card_id,
+                    new_column_id: col,
+                    new_position: pos,
+                })));
+            }
+            if let Some(status) = chained.status {
+                batch.push(Command::Card(CardCommand::Update(UpdateCard {
+                    card_id,
+                    updates: CardUpdate {
+                        status: Some(status),
+                        ..Default::default()
+                    },
+                })));
             }
         }
 

--- a/crates/kanban-service/tests/update_cards_move_semantics.rs
+++ b/crates/kanban-service/tests/update_cards_move_semantics.rs
@@ -1,0 +1,134 @@
+//! `update_cards`' plain column-move branch (column_id set, status left None)
+//! mutates `column_id`/`position` via a single `UpdateCard` command instead of
+//! chaining a `MoveCard` like `move_card`/`move_cards` do. `UpdateCard::execute`
+//! doesn't enforce the destination column's WIP limit and doesn't sync
+//! `card.board_id` to the target column's board -- both of which
+//! `MoveCard::execute` does. This is reachable through the TUI's real bulk
+//! multi-select move (`move_selected_cards` in card_handlers.rs), not just
+//! theoretical API misuse.
+//!
+//! Run against both `JsonDataStore` and `SqliteBackend` (see `move_cards.rs`).
+
+use kanban_domain::{CardUpdate, FieldUpdate};
+use kanban_persistence_json::JsonFileStore;
+use kanban_service::{
+    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
+    KanbanContext, KanbanOperations,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+async fn open_json_ctx() -> (KanbanContext, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.json");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    (ctx, dir)
+}
+
+async fn open_sqlite_ctx() -> (KanbanContext, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.sqlite");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap());
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    (ctx, dir)
+}
+
+macro_rules! update_cards_move_semantics_tests {
+    ($mod_name:ident, $open_ctx:expr) => {
+        mod $mod_name {
+            use super::*;
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_update_cards_column_move_into_wip_limited_column_returns_error_and_leaves_card_unmoved(
+            ) {
+                // Setup must go through ctx so the cards survive snapshot rollback --
+                // direct backend writes are not in the command log and are wiped
+                // back to the open()-time baseline on rollback (see move_cards.rs).
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();
+                let src_col = ctx.create_column(board.id, "Src".into(), None).unwrap();
+                let dst_col = ctx.create_column(board.id, "Dst".into(), None).unwrap();
+                ctx.update_column(
+                    dst_col.id,
+                    kanban_domain::ColumnUpdate {
+                        wip_limit: FieldUpdate::Set(1),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+
+                let filler = ctx
+                    .create_card(board.id, dst_col.id, "Filler".into(), Default::default())
+                    .unwrap();
+                let moving = ctx
+                    .create_card(board.id, src_col.id, "Moving".into(), Default::default())
+                    .unwrap();
+                let src_id = src_col.id;
+
+                let result = ctx.update_cards(vec![(
+                    moving.id,
+                    CardUpdate {
+                        column_id: Some(dst_col.id),
+                        ..Default::default()
+                    },
+                )]);
+
+                assert!(
+                    result.is_err(),
+                    "moving into a WIP-limited column already at its limit must error, like move_cards does"
+                );
+
+                let unmoved = backend.get_card(moving.id).unwrap().unwrap();
+                assert_eq!(
+                    unmoved.column_id, src_id,
+                    "a rejected move must leave the card in its original column"
+                );
+                let filler_still_there = backend.get_card(filler.id).unwrap().unwrap();
+                assert_eq!(filler_still_there.column_id, dst_col.id);
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_update_cards_column_move_across_boards_syncs_board_id() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let board_a = ctx.create_board("A".into(), Some("A".into())).unwrap();
+                let board_b = ctx.create_board("B".into(), Some("B".into())).unwrap();
+                let col_a = ctx.create_column(board_a.id, "ColA".into(), None).unwrap();
+                let col_b = ctx.create_column(board_b.id, "ColB".into(), None).unwrap();
+
+                let card = ctx
+                    .create_card(board_a.id, col_a.id, "Card".into(), Default::default())
+                    .unwrap();
+
+                ctx.update_cards(vec![(
+                    card.id,
+                    CardUpdate {
+                        column_id: Some(col_b.id),
+                        ..Default::default()
+                    },
+                )])
+                .unwrap();
+
+                let moved = backend.get_card(card.id).unwrap().unwrap();
+                assert_eq!(moved.column_id, col_b.id);
+                assert_eq!(
+                    moved.board_id, board_b.id,
+                    "a cross-board column move must sync board_id to the new column's board, like move_card does"
+                );
+            }
+        }
+    };
+}
+
+update_cards_move_semantics_tests!(json_backend, open_json_ctx());
+update_cards_move_semantics_tests!(sqlite_backend, open_sqlite_ctx());


### PR DESCRIPTION
Fixes a real gap found during KAN-987's self-review (PR #473): `update_cards`' plain column-move branch bypassed WIP limit enforcement and board_id sync.

- `update_cards_impl`'s `(None, Some(new_col))` branch — a plain column move with no status change — mutated `column_id`/a recomputed `position` directly on the plain `UpdateCard` command, never chaining a `MoveCard`.
- `MoveCard::execute` (`crates/kanban-domain/src/commands/card/positioning.rs`) enforces the destination column's WIP limit and syncs `card.board_id` to the target column's board on a cross-board move (KAN-963). `UpdateCard::execute` (`crates/kanban-domain/src/commands/card/lifecycle.rs`) does neither.
- Confirmed this is reachable through a real, existing user-facing path, not just theoretical API misuse: the TUI's bulk multi-select move (`move_selected_cards` in `card_handlers.rs`, bound to `H`/`L`) calls `ctx.update_cards` with `CardUpdate { column_id: Some(...), ..Default::default() }` — exactly this branch.

**What**: The genuine-move case in `update_cards_impl` now chains a `MoveCard` command instead of mutating `column_id`/`position` on the plain update, matching how the status-triggered branch already does. The "already in this column" case (a resubmit, not a real move — e.g. a PUT-replace that always sets every field) is unchanged. Since a single card can now need both a column move and a status flip (moving into a completion column), the internal `Chained` bookkeeping became a per-card `Vec` instead of a single `Option`.

**Why**: A plain column move could silently push a WIP-limited column over its limit (where the equivalent `move_card`/`move_cards` call would correctly return `WipLimitExceeded`), and a cross-board move via this path left `card.board_id` stale, pointing at the old board while `column_id` pointed into the new one — making the card invisible to board-scoped queries.

**How**: Restructured `update_cards_impl`'s match arm so a genuine move computes its target position (explicit if the caller pinned one, otherwise appended) and pushes a `Chained::Move`, stripping `column_id`/`position` off the primary `UpdateCard` so `MoveCard` exclusively owns that transition. Kept the existing status-chaining behavior for a move into a completion column by allowing both a `Chained::Move` and a `Chained::Status` per card.

**Testing**: New `crates/kanban-service/tests/update_cards_move_semantics.rs` (both `JsonDataStore` and `SqliteBackend`) — one test seeds a WIP-limited destination column already at its limit and asserts the plain move now errors and rolls back (mirroring `move_cards.rs`'s existing WIP test), one test moves a card across two boards via `update_cards` and asserts `board_id` now matches the destination board. Verified both are genuine regression guards by temporarily reverting the fix and confirming all 4 (2 tests × 2 backends) fail. `cargo test --workspace` (no regressions, all pre-existing `update_cards_position.rs`/`completion_sync.rs`/`move_cards.rs` tests pass unmodified), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).


**Found and fixed during self-review**:
- The internal `Chained` bookkeeping was a `Vec` of a 2-variant enum, but every card only ever produces at most one `Move` then one `Status`, in that fixed order — replaced with a small 2-field struct, which also drops an unnecessary per-card heap allocation and makes the cardinality/ordering invariant explicit instead of implicit.
- `compute_target_status_for_move` was called identically (copy-pasted) from both the `already_in_column` and genuine-move branches — hoisted into one call so a future change to the status-chaining rule can't be applied to one copy and missed in the other.
- `batch`'s `Vec::with_capacity` was sized for the old max of 2 commands per card; a card can now produce 3 (Update + Move + Status) — fixed the capacity hint.
- Dropped a `(KAN-963)` ticket reference that had crept into a new code comment.

**Found, not fixed here (filed as KAN-990)**: the sibling `(Some(status), Some(new_col))` match arm — both fields set explicitly in the same `CardUpdate` — still falls into the catch-all and bypasses `MoveCard` entirely, so it still skips WIP-limit/board_id enforcement, the same bug class this PR fixes for the `(None, Some(col))` arm. Confirmed via grep that no current production caller (TUI/CLI/MCP/server) sets both fields at once — only a synthetic KAN-394 test exercises this combination — so it's real but unreachable today. Fixing it properly means gating `MoveCard`-chaining on "does this update touch `column_id`" independent of which other fields are set, rather than per-match-arm special-casing; that's a larger restructure than this PR's scope, so it's tracked separately.
