### PR TITLE
KAN-743 feat(server): implement KanbanError-to-HTTP response conversion for all routes

### DIFF
--- a/.changeset/max-kan-743.md
+++ b/.changeset/max-kan-743.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change). Errors
+raised inside `kanban-server` now consistently convert to the right HTTP
+status code and a flat JSON error body, instead of each future route having
+to map that itself. This is the last piece the API's routes need before they
+can start landing.

--- a/crates/kanban-server/src/error.rs
+++ b/crates/kanban-server/src/error.rs
@@ -1,0 +1,26 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use kanban_service::api::ApiError;
+
+pub struct AppError(pub ApiError);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let status = StatusCode::from_u16(self.0.code.http_status())
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        (status, Json(self.0)).into_response()
+    }
+}
+
+impl From<ApiError> for AppError {
+    fn from(e: ApiError) -> Self {
+        AppError(e)
+    }
+}
+
+impl From<&kanban_domain::KanbanError> for AppError {
+    fn from(e: &kanban_domain::KanbanError) -> Self {
+        AppError(ApiError::from(e))
+    }
+}

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -4,6 +4,7 @@
 //! cards extend it rather than building their own.
 
 pub mod app;
+pub mod error;
 pub mod state;
 
 pub mod handlers {

--- a/crates/kanban-server/tests/error_response.rs
+++ b/crates/kanban-server/tests/error_response.rs
@@ -11,7 +11,6 @@ use uuid::Uuid;
 
 #[tokio::test]
 async fn test_app_error_uses_service_http_status_for_each_code() {
-    // Exhaustive table: all 19 ErrorCode variants mapped to their expected HTTP status.
     let cases = vec![
         (ErrorCode::NotFound, 404),
         (ErrorCode::NotFoundByName, 404),
@@ -57,13 +56,11 @@ async fn test_app_error_body_is_flat_code_and_message() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    // Verify the response is a flat object with "code" and "message" at top level.
     assert!(json["code"].is_string(), "code should be a string");
     assert!(json["message"].is_string(), "message should be a string");
     assert_eq!(json["code"], "NOT_FOUND");
     assert_eq!(json["message"], "board not found");
 
-    // Ensure there is no nested "error" key (the body must be flat, not nested).
     assert!(
         json["error"].is_null(),
         "body should be flat, not nested under 'error' key"

--- a/crates/kanban-server/tests/error_response.rs
+++ b/crates/kanban-server/tests/error_response.rs
@@ -1,0 +1,101 @@
+//! Tests for the AppError IntoResponse bridge. Verify that axum error responses
+//! map correctly to HTTP status codes and flat JSON envelopes.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use kanban_domain::KanbanError;
+use kanban_server::error::AppError;
+use kanban_service::api::ApiError;
+use kanban_service::api::ErrorCode;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_app_error_uses_service_http_status_for_each_code() {
+    // Exhaustive table: all 19 ErrorCode variants mapped to their expected HTTP status.
+    let cases = vec![
+        (ErrorCode::NotFound, 404),
+        (ErrorCode::NotFoundByName, 404),
+        (ErrorCode::EdgeNotFound, 404),
+        (ErrorCode::ValidationFailed, 422),
+        (ErrorCode::SprintBoardMismatch, 422),
+        (ErrorCode::SelfReference, 422),
+        (ErrorCode::BatchResolutionFailed, 400),
+        (ErrorCode::Ambiguous, 409),
+        (ErrorCode::WipLimitExceeded, 409),
+        (ErrorCode::ConflictDetected, 409),
+        (ErrorCode::AlreadyExists, 409),
+        (ErrorCode::UnsupportedVersion, 409),
+        (ErrorCode::DependencyError, 409),
+        (ErrorCode::CycleDetected, 409),
+        (ErrorCode::DuplicateEdge, 409),
+        (ErrorCode::IoError, 500),
+        (ErrorCode::SerializationError, 500),
+        (ErrorCode::DatabaseError, 500),
+        (ErrorCode::InternalError, 500),
+    ];
+
+    for (code, expected_status) in cases {
+        let app_error = AppError(ApiError::new(code, "test message"));
+        let response = app_error.into_response();
+        assert_eq!(
+            response.status().as_u16(),
+            expected_status,
+            "ErrorCode {:?} should map to status {}",
+            code,
+            expected_status
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_app_error_body_is_flat_code_and_message() {
+    let app_error = AppError(ApiError::new(ErrorCode::NotFound, "board not found"));
+    let response = app_error.into_response();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Verify the response is a flat object with "code" and "message" at top level.
+    assert!(json["code"].is_string(), "code should be a string");
+    assert!(json["message"].is_string(), "message should be a string");
+    assert_eq!(json["code"], "NOT_FOUND");
+    assert_eq!(json["message"], "board not found");
+
+    // Ensure there is no nested "error" key (the body must be flat, not nested).
+    assert!(
+        json["error"].is_null(),
+        "body should be flat, not nested under 'error' key"
+    );
+}
+
+#[tokio::test]
+async fn test_app_error_not_found_maps_to_404() {
+    let kanban_err = KanbanError::not_found("Board", Uuid::nil());
+    let app_error = AppError::from(&kanban_err);
+    let response = app_error.into_response();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_app_error_conflict_maps_to_409() {
+    let kanban_err = KanbanError::ConflictDetected {
+        path: "test.json".into(),
+        source: None,
+    };
+    let app_error = AppError::from(&kanban_err);
+    let response = app_error.into_response();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_app_error_internal_maps_to_500() {
+    let kanban_err = KanbanError::Internal("something went wrong".into());
+    let app_error = AppError::from(&kanban_err);
+    let response = app_error.into_response();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}


### PR DESCRIPTION
Adds the single axum `IntoResponse` bridge for errors, so every future route handler returns one consistent error envelope instead of mapping status codes ad hoc. Blocks every route card (KAN-716-725), which is why it's landing directly after KAN-689 rather than after them.

- New `crates/kanban-server/src/error.rs`: `AppError(pub ApiError)` newtype implementing `axum::response::IntoResponse` — status derived solely from `ApiError::code.http_status()` (no duplicate mapping table in the server), body is the existing flat `ApiError` JSON (`{"code": "...", "message": "..."}`), no nested envelope.
- `impl From<ApiError> for AppError` and `impl From<&KanbanError> for AppError` so route handlers can `.map_err(AppError::from)` either shape directly.
- `pub mod error;` added to `lib.rs`.

**Why a thin adapter, not a re-implementation**: `kanban_service::api::{ApiError, ErrorCode}` already ships an exhaustive, tested `From<&KanbanError> for ApiError` and `ErrorCode::http_status()`. Re-deriving a second `KanbanError → status` table in the server would duplicate and drift from that tested mapping.

**Testing**: New `crates/kanban-server/tests/error_response.rs` — `test_app_error_uses_service_http_status_for_each_code` (exhaustive table over all 19 `ErrorCode` variants), `test_app_error_body_is_flat_code_and_message`, plus 3 smoke anchors (`not_found`→404, `conflict`→409, `internal`→500) that exercise `AppError::from(&KanbanError)` end-to-end rather than just `ApiError::new`. `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean). Also independently reverted the implementation and confirmed the test suite fails to compile without it, then restored — genuine regression guard, not a tautology.

This is pure internal scaffolding — no user-facing change, changeset is a no-op patch note.
