### PR TITLE
KAN-716 feat(server): add board read routes (GET /v1/boards, GET /v1/boards/:id)

### DIFF
--- a/.changeset/max-kan-716.md
+++ b/.changeset/max-kan-716.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change). Adds
+the first two live routes in `kanban-server`: listing boards and fetching a
+single board by id. This is the template every other entity's routes will
+follow.

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -22,5 +22,6 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
 pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
+        .merge(crate::routes::boards::read_router())
         .with_state(state)
 }

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -7,6 +7,10 @@ pub mod app;
 pub mod error;
 pub mod state;
 
+pub mod routes {
+    pub mod boards;
+}
+
 pub mod handlers {
     pub mod boards;
     pub mod cards;

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -1,0 +1,32 @@
+use crate::error::AppError;
+use crate::state::AppState;
+use axum::extract::{Path, State};
+use axum::routing::get;
+use axum::{Json, Router};
+use kanban_service::api::BoardResponse;
+use kanban_service::{KanbanError, KanbanOperations};
+use uuid::Uuid;
+
+async fn list_boards(State(state): State<AppState>) -> Result<Json<Vec<BoardResponse>>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let boards = ctx.list_boards().map_err(|e| AppError::from(&e))?;
+    Ok(Json(boards.iter().map(BoardResponse::from).collect()))
+}
+
+async fn get_board(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<BoardResponse>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let board = ctx
+        .get_board(id)
+        .map_err(|e| AppError::from(&e))?
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Board", id)))?;
+    Ok(Json(BoardResponse::from(&board)))
+}
+
+pub fn read_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/boards", get(list_boards))
+        .route("/v1/boards/{id}", get(get_board))
+}

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -22,7 +22,10 @@ async fn get_board(
         .get_board(id)
         .map_err(|e| AppError::from(&e))?
         .ok_or_else(|| AppError::from(&KanbanError::not_found("Board", id)))?;
-    Ok(Json(BoardResponse::from(&board)))
+    // get_board is unfiltered, so an archived board comes back looking live
+    // unless stamped with the marker's archived_at (mirrors kanban-cli/-mcp).
+    let archived_at = ctx.board_archived_at(id).map_err(|e| AppError::from(&e))?;
+    Ok(Json(BoardResponse::with_archived_at(&board, archived_at)))
 }
 
 pub fn read_router() -> Router<AppState> {

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -1,0 +1,211 @@
+//! KAN-716: board read routes (GET /v1/boards, GET /v1/boards/{id}).
+//! Read-only, no mutation, no event broadcast. Established via `tower::ServiceExt::oneshot`
+//! against the router directly, with no real TCP socket.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use kanban_persistence_json::JsonFileStore;
+use kanban_server::app;
+use kanban_server::state::AppState;
+use kanban_service::json_backend::JsonDataStore;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use std::sync::Arc;
+use tempfile::tempdir;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn make_state(path: &std::path::Path) -> AppState {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
+    let ctx = KanbanContext::open_deferred(backend, AppConfig::default());
+    AppState::new(ctx)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_empty_returns_200_empty_array() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri("/v1/boards")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json, serde_json::json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_returns_all_seeded_boards() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    // Seed two boards
+    let board1_id: Uuid;
+    let board2_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board1_id = ctx
+            .create_board("Board 1".to_string(), Some("B1".to_string()))
+            .unwrap()
+            .id;
+        board2_id = ctx
+            .create_board("Board 2".to_string(), Some("B2".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri("/v1/boards")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert!(json.is_array(), "response should be an array");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 2, "should have 2 boards");
+
+    let returned_ids: std::collections::HashSet<_> = arr
+        .iter()
+        .map(|b| Uuid::parse_str(b["id"].as_str().unwrap()).expect("id should be a valid UUID"))
+        .collect();
+
+    let expected_ids: std::collections::HashSet<_> =
+        vec![board1_id, board2_id].into_iter().collect();
+    assert_eq!(
+        returned_ids, expected_ids,
+        "returned ids should match seeded ids"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_returns_board_response_for_existing_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    // Seed one board
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("My Board".to_string(), Some("MB".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["id"], board_id.to_string());
+    assert_eq!(json["name"], "My Board");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_response_omits_internal_allocation_state() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    // Seed one board
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Assert all internal allocation state fields are absent
+    for hidden in [
+        "card_counter",
+        "next_sprint_number",
+        "sprint_counters",
+        "sprint_names",
+        "sprint_name_used_count",
+    ] {
+        assert!(
+            json.get(hidden).is_none(),
+            "field {} should be absent from response",
+            hidden
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_unknown_id_returns_404_not_found() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_id = Uuid::new_v4();
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/boards/{}", random_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["code"], "NOT_FOUND");
+}

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -1,4 +1,4 @@
-//! KAN-716: board read routes (GET /v1/boards, GET /v1/boards/{id}).
+//! Board read routes (GET /v1/boards, GET /v1/boards/{id}).
 //! Read-only, no mutation, no event broadcast. Established via `tower::ServiceExt::oneshot`
 //! against the router directly, with no real TCP socket.
 

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -50,7 +50,6 @@ async fn test_list_boards_returns_all_seeded_boards() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    // Seed two boards
     let board1_id: Uuid;
     let board2_id: Uuid;
     {
@@ -104,7 +103,6 @@ async fn test_get_board_returns_board_response_for_existing_id() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    // Seed one board
     let board_id: Uuid;
     {
         let mut ctx = state.ctx.lock().await;
@@ -140,7 +138,6 @@ async fn test_get_board_response_omits_internal_allocation_state() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    // Seed one board
     let board_id: Uuid;
     {
         let mut ctx = state.ctx.lock().await;
@@ -167,7 +164,6 @@ async fn test_get_board_response_omits_internal_allocation_state() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    // Assert all internal allocation state fields are absent
     for hidden in [
         "card_counter",
         "next_sprint_number",
@@ -208,4 +204,46 @@ async fn test_get_board_unknown_id_returns_404_not_found() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_archived_board_response_has_archived_at_stamped() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Archived Board".to_string(), Some("AB".to_string()))
+            .unwrap()
+            .id;
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "get_board is unfiltered and must still resolve an archived board"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert!(
+        json["archived_at"].is_string(),
+        "an archived board's response must be stamped with archived_at, not look live: {json}"
+    );
 }


### PR DESCRIPTION
Adds the board READ routes to `kanban-server`: list all boards and fetch one by id. Read-only, no mutation, no event broadcast. This is the first route card to actually land — `app.rs` previously only had `/health` — so it also establishes the `routes` module pattern and the merge-before-`with_state` composition idiom every subsequent route card (717-725) will reuse.

- New `crates/kanban-server/src/routes/boards.rs`: `list_boards`/`get_board` axum handlers (distinct from the pre-existing `handlers::boards`, which holds pure create-seam business logic with no axum types), exporting `pub fn read_router() -> Router<AppState>`.
- `lib.rs` gets `pub mod routes { pub mod boards; }`.
- `app.rs`'s `router()` now merges `routes::boards::read_router()` **before** the final `.with_state(state)` call — `Router<AppState>` sub-routers must merge while the state generic is still unresolved.

**A real axum 0.8 gotcha caught during grounding**: this workspace pins axum 0.8.9, which changed path-parameter syntax from the old `/:id` (axum ≤0.7) to `/{id}`. The old syntax panics at router-construction time in 0.8, confirmed straight from the installed crate's changelog. Routes here use `/v1/boards/{id}`, and this correction has been flagged on the epic's root spec card so it carries forward to the 9 remaining route cards, which were all drafted with the old syntax.

**Testing**: New `crates/kanban-server/tests/boards_read.rs` (`tower::ServiceExt::oneshot` against the router, same pattern as `tests/health.rs` — no `TestServer` harness exists yet) — empty-list, seeded-list (compared as a set since `list_boards`'s order isn't guaranteed), get-by-id, a test asserting the response omits internal allocation state (`card_counter`, `next_sprint_number`, `sprint_counters`, `sprint_names`, `sprint_name_used_count` — the exact fields `BoardResponse`'s own doc comment says it omits), and a 404-with-`NOT_FOUND`-code test. Independently reverted the implementation and confirmed all 5 tests fail without it, then restored — genuine regression guard. Also manually smoke-tested the real running binary (`cargo run -p kanban-server` against a throwaway tempdir locator, `curl /v1/boards` → `[]`, `curl` an unknown id → 404) to confirm it works over real HTTP, not just via `oneshot`. `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).

This is pure internal scaffolding — no user-facing change, changeset is a no-op patch note.


**Found and fixed during self-review**:
- `get_board` is unfiltered (it resolves archived board heads too, by design), but was projecting every result through plain `BoardResponse::from`, which hardcodes `archived_at: None`. An archived board fetched by id came back indistinguishable from a live one. Fixed to match the existing `kanban-cli`/`kanban-mcp` pattern: stamp the response via `ctx.board_archived_at(id)` + `BoardResponse::with_archived_at`. Added `test_get_board_archived_board_response_has_archived_at_stamped`, verified as a genuine regression guard (fails without the fix, passes with it).
- Dropped four WHAT-comments in the test file that restated the obviously-named code beneath them.

**Found, not fixed here (filed as KAN-992)**: the `get_board -> board_archived_at -> with_archived_at` sequence is now duplicated identically across `kanban-cli`, `kanban-mcp`, and `kanban-server` rather than living once in `KanbanContext` — a future consumer could easily forget the stamping step and reintroduce this same bug. Also, `board_archived_at` scans the *entire* archived-boards collection for a single-id lookup, which every consumer now pays on every single-board read. Both are pre-existing (shared with CLI/MCP, not introduced here) and out of this card's board-read-routes scope, so tracked separately rather than expanding this PR into a cross-crate refactor.
