### PR TITLE
KAN-993 build(nix): package kanban-server and expose it in the flake

### DIFF
--- a/.changeset/max-kan-993.md
+++ b/.changeset/max-kan-993.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+`kanban-server` is now available as a Nix package (`nix build .#kanban-server`),
+alongside the existing `kanban-cli` and `kanban-mcp` packages.

--- a/crates/kanban-server/default.nix
+++ b/crates/kanban-server/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, rustPlatform
+, src
+, gitRev ? null
+}:
+
+let
+  cargoToml = lib.importTOML ../../Cargo.toml;
+in
+rustPlatform.buildRustPackage {
+  inherit (cargoToml.workspace.package) version;
+  pname = "kanban-server";
+
+  inherit src;
+
+  cargoLock = {
+    lockFile = ../../Cargo.lock;
+  };
+
+  preBuild = lib.optionalString (gitRev != null) ''
+    export GIT_COMMIT_HASH="${gitRev}"
+  '';
+
+  # Only build the kanban-server binary
+  cargoBuildFlags = [ "--package" "kanban-server" ];
+  cargoTestFlags = [ "--package" "kanban-server" ];
+
+  meta = {
+    inherit (cargoToml.workspace.package) description homepage;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fulsomenko ];
+    mainProgram = "kanban-server";
+    platforms = lib.platforms.all;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
           default = kanban;
           kanban-cli = kanban-cli;
           kanban-mcp = pkgs.callPackage ./crates/kanban-mcp/default.nix { src = self; gitRev = self.rev or null; };
+          kanban-server = pkgs.callPackage ./crates/kanban-server/default.nix { src = self; gitRev = self.rev or null; };
           kanban-web = pkgs.callPackage ./web/default.nix {};
           aggregate-changelog = aggregateChangelog;
           bump-version = bumpVersion;


### PR DESCRIPTION
Packages `kanban-server` for Nix and exposes it as a flake output, alongside the existing `kanban-cli` and `kanban-mcp` packages. Previously `kanban-server` had no Nix packaging at all — not referenced anywhere in `flake.nix`'s `packages` set.

- New `crates/kanban-server/default.nix`, mirroring `crates/kanban-mcp/default.nix` exactly: `rustPlatform.buildRustPackage`, `pname = "kanban-server"`, `cargoBuildFlags`/`cargoTestFlags = [ "--package" "kanban-server" ]`, `mainProgram = "kanban-server"`. No extra `buildInputs` needed — same dependency profile as `kanban-mcp` (sqlx's `sqlite` feature bundles its own SQLite, `reqwest` is dev-only and already uses `rustls-tls`, no GUI deps).
- `flake.nix`'s `packages` set now includes `kanban-server = pkgs.callPackage ./crates/kanban-server/default.nix { src = self; gitRev = self.rev or null; };`.

**Why this needed manual verification, not just CI**: `.github/workflows/ci.yml` only runs `nix develop --command cargo ...` — it never runs `nix build` against any flake package, so a broken `default.nix` wouldn't be caught by CI either before or after this change.

**Testing**: `nix build .#kanban-server -L` — builds clean, `cargoCheckHook` runs `cargo test --package kanban-server` as part of the build and all 21 tests pass. Manually smoke-tested the resulting `result/bin/kanban-server` binary against a tempdir locator (`KANBAN_FILE=<tmp>/kanban.json`) — `/health` and `/v1/boards` both respond correctly over a real socket.

This is pure packaging — no Rust code changed, changeset is a small informational patch note.
