### PR TITLE
KAN-994 refactor(service): board PUT seam uses ReplaceBoardRequest, retire CreateOrReplaceBoardRequest

### DIFF
--- a/.changeset/max-kan-994.md
+++ b/.changeset/max-kan-994.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change). Aligns
+how the board create/replace logic will handle PUT requests with the same
+convention every other entity in the API already uses, ahead of the routes
+themselves landing.

--- a/.changeset/max-kan-994.md
+++ b/.changeset/max-kan-994.md
@@ -3,6 +3,7 @@ bump: patch
 ---
 
 Internal groundwork for the upcoming HTTP API (no user-facing change). Aligns
-how the board create/replace logic will handle PUT requests with the same
-convention every other entity in the API already uses, ahead of the routes
-themselves landing.
+how the board create/replace logic will handle PUT requests with the wire
+convention the API's design already calls for (sprints already follow it;
+columns and cards will be brought in line as their own write-route work
+lands), ahead of the routes themselves landing.

--- a/crates/kanban-server/src/handlers/boards.rs
+++ b/crates/kanban-server/src/handlers/boards.rs
@@ -1,28 +1,38 @@
-//! Typed board-create seam for the HTTP server.
+//! Typed board create/replace seams for the HTTP server.
 //!
-//! The server itself is still a stub (no router/transport yet), but the
-//! create-from-spec wiring is real and tested here: this is the single funnel a
-//! future `PUT /v1/boards/:id` handler binds to. It takes the shared
-//! [`CreateOrReplaceBoardRequest`], splits it via `into_new_board`, runs the
-//! idempotent PUT-create (`create_or_replace_board`), and projects the
-//! resulting domain `Board` onto the wire [`BoardResponse`]. The `created`
-//! flag lets the eventual HTTP layer answer 201 (created) vs 200 (replaced).
+//! `create_board` is the `POST /v1/boards` seam (pure create, always mints or
+//! accepts a client id, 409 on collision). `create_or_replace_board` is the
+//! `PUT /v1/boards/:id` seam (idempotent create-or-replace keyed on the path
+//! id). Both project the resulting domain `Board` onto the wire
+//! [`BoardResponse`].
 
-use kanban_service::api::{ApiError, BoardResponse, CreateOrReplaceBoardRequest};
+use kanban_service::api::{ApiError, BoardResponse, CreateBoardRequest, ReplaceBoardRequest};
 use kanban_service::KanbanContext;
+use uuid::Uuid;
 
-/// Idempotent create-or-replace for a board, returning the wire projection plus
-/// whether the board was created (`true`) or replaced (`false`).
-///
-/// The `id` is taken from the request body (the PUT-create contract). When the
-/// request omits an id, one is minted by the create arm; the replace arm only
-/// runs for an id that already exists.
+/// `POST /v1/boards`: pure create. The body id is honoured when present
+/// (idempotent create with that exact id); a present id that already exists
+/// is a conflict (`AlreadyExists` -> 409), not a silent replace.
+pub fn create_board(
+    ctx: &mut KanbanContext,
+    req: CreateBoardRequest,
+) -> Result<BoardResponse, ApiError> {
+    let (id, spec) = req.into_new_board();
+    let board = ctx
+        .create_board_from_spec(id, spec)
+        .map_err(|e| ApiError::from(&e))?;
+    Ok(BoardResponse::from(&board))
+}
+
+/// `PUT /v1/boards/:id`: idempotent create-or-replace for a board keyed on
+/// the path `id`. Returns the wire projection plus whether the board was
+/// created (`true`, 201) or replaced (`false`, 200).
 pub fn create_or_replace_board(
     ctx: &mut KanbanContext,
-    req: CreateOrReplaceBoardRequest,
+    id: Uuid,
+    req: ReplaceBoardRequest,
 ) -> Result<(BoardResponse, bool), ApiError> {
-    let (maybe_id, spec) = req.into_new_board();
-    let id = maybe_id.unwrap_or_else(uuid::Uuid::new_v4);
+    let spec = req.into_new_board();
     let outcome = ctx
         .create_or_replace_board(id, spec)
         .map_err(|e| ApiError::from(&e))?;

--- a/crates/kanban-server/tests/board_create_seam.rs
+++ b/crates/kanban-server/tests/board_create_seam.rs
@@ -18,15 +18,10 @@ fn make_ctx(path: &std::path::Path) -> KanbanContext {
     KanbanContext::open_deferred(backend, AppConfig::default())
 }
 
-/// `POST /v1/boards`: pure create, server-mints id when absent.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_create_board_seam_mints_id_when_absent() {
-    let dir = tempdir().unwrap();
-    let mut ctx = make_ctx(&dir.path().join("s.json"));
-
-    let req = CreateBoardRequest {
-        id: None,
-        name: "Fresh".to_string(),
+fn create_req(id: Option<Uuid>, name: &str) -> CreateBoardRequest {
+    CreateBoardRequest {
+        id,
+        name: name.to_string(),
         description: None,
         sprint_prefix: None,
         card_prefix: None,
@@ -34,7 +29,30 @@ async fn test_create_board_seam_mints_id_when_absent() {
         task_sort_order: None,
         sprint_duration_days: None,
         task_list_view: None,
-    };
+    }
+}
+
+fn replace_req(name: &str) -> ReplaceBoardRequest {
+    ReplaceBoardRequest {
+        name: name.to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: SortFieldDto::Priority,
+        task_sort_order: SortOrderDto::Ascending,
+        sprint_duration_days: None,
+        task_list_view: TaskListViewDto::GroupedByColumn,
+        completion_column_id: None,
+    }
+}
+
+/// `POST /v1/boards`: pure create, server-mints id when absent.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_board_seam_mints_id_when_absent() {
+    let dir = tempdir().unwrap();
+    let mut ctx = make_ctx(&dir.path().join("s.json"));
+
+    let req = create_req(None, "Fresh");
 
     let resp = create_board(&mut ctx, req).unwrap();
 
@@ -49,17 +67,7 @@ async fn test_create_board_seam_honours_client_supplied_id() {
     let mut ctx = make_ctx(&dir.path().join("s.json"));
     let id = Uuid::new_v4();
 
-    let req = CreateBoardRequest {
-        id: Some(id),
-        name: "Fresh".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: None,
-        task_sort_order: None,
-        sprint_duration_days: None,
-        task_list_view: None,
-    };
+    let req = create_req(Some(id), "Fresh");
 
     let resp = create_board(&mut ctx, req).unwrap();
 
@@ -73,33 +81,10 @@ async fn test_create_board_seam_existing_id_conflicts() {
     let mut ctx = make_ctx(&dir.path().join("s.json"));
     let id = Uuid::new_v4();
 
-    let req = CreateBoardRequest {
-        id: Some(id),
-        name: "First".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: None,
-        task_sort_order: None,
-        sprint_duration_days: None,
-        task_list_view: None,
-    };
-
+    let req = create_req(Some(id), "First");
     create_board(&mut ctx, req).unwrap();
 
-    // Same id again:
-    let req2 = CreateBoardRequest {
-        id: Some(id),
-        name: "Second".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: None,
-        task_sort_order: None,
-        sprint_duration_days: None,
-        task_list_view: None,
-    };
-
+    let req2 = create_req(Some(id), "Second");
     let err = create_board(&mut ctx, req2).unwrap_err();
 
     assert_eq!(err.code, kanban_service::api::ErrorCode::AlreadyExists);
@@ -112,17 +97,7 @@ async fn test_create_or_replace_board_seam_creates_when_absent() {
     let mut ctx = make_ctx(&dir.path().join("s.json"));
     let id = Uuid::new_v4();
 
-    let req = ReplaceBoardRequest {
-        name: "Fresh".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: SortFieldDto::Priority,
-        task_sort_order: SortOrderDto::Ascending,
-        sprint_duration_days: None,
-        task_list_view: TaskListViewDto::GroupedByColumn,
-        completion_column_id: None,
-    };
+    let req = replace_req("Fresh");
 
     let (resp, created) = create_or_replace_board(&mut ctx, id, req).unwrap();
 
@@ -138,33 +113,9 @@ async fn test_create_or_replace_board_seam_replaces_when_present() {
     let mut ctx = make_ctx(&dir.path().join("s.json"));
     let id = Uuid::new_v4();
 
-    let req1 = ReplaceBoardRequest {
-        name: "Original".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: SortFieldDto::Priority,
-        task_sort_order: SortOrderDto::Ascending,
-        sprint_duration_days: None,
-        task_list_view: TaskListViewDto::GroupedByColumn,
-        completion_column_id: None,
-    };
+    create_or_replace_board(&mut ctx, id, replace_req("Original")).unwrap();
 
-    create_or_replace_board(&mut ctx, id, req1).unwrap();
-
-    let req2 = ReplaceBoardRequest {
-        name: "Replaced".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: SortFieldDto::Priority,
-        task_sort_order: SortOrderDto::Ascending,
-        sprint_duration_days: None,
-        task_list_view: TaskListViewDto::GroupedByColumn,
-        completion_column_id: None,
-    };
-
-    let (resp, created) = create_or_replace_board(&mut ctx, id, req2).unwrap();
+    let (resp, created) = create_or_replace_board(&mut ctx, id, replace_req("Replaced")).unwrap();
 
     assert!(!created, "present id must report replace (200)");
     assert_eq!(resp.id, id, "id stable across replace");
@@ -179,15 +130,8 @@ async fn test_create_or_replace_board_seam_with_completion_column_id_on_fresh_id
     let id = Uuid::new_v4();
 
     let req = ReplaceBoardRequest {
-        name: "Fresh".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: SortFieldDto::Priority,
-        task_sort_order: SortOrderDto::Ascending,
-        sprint_duration_days: None,
-        task_list_view: TaskListViewDto::GroupedByColumn,
         completion_column_id: Some(Uuid::new_v4()),
+        ..replace_req("Fresh")
     };
 
     let err = create_or_replace_board(&mut ctx, id, req).unwrap_err();
@@ -202,19 +146,7 @@ async fn test_seams_project_via_board_response() {
     let dir = tempdir().unwrap();
     let mut ctx = make_ctx(&dir.path().join("s.json"));
 
-    let create_req = CreateBoardRequest {
-        id: None,
-        name: "Create".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: None,
-        task_sort_order: None,
-        sprint_duration_days: None,
-        task_list_view: None,
-    };
-
-    let resp1 = create_board(&mut ctx, create_req).unwrap();
+    let resp1 = create_board(&mut ctx, create_req(None, "Create")).unwrap();
     let json1 = serde_json::to_string(&resp1).unwrap();
 
     for hidden in ["card_counter", "sprint_counters", "next_sprint_number"] {
@@ -224,19 +156,8 @@ async fn test_seams_project_via_board_response() {
         );
     }
 
-    let replace_req = ReplaceBoardRequest {
-        name: "Replace".to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: SortFieldDto::Priority,
-        task_sort_order: SortOrderDto::Ascending,
-        sprint_duration_days: None,
-        task_list_view: TaskListViewDto::GroupedByColumn,
-        completion_column_id: None,
-    };
-
-    let (resp2, _) = create_or_replace_board(&mut ctx, Uuid::new_v4(), replace_req).unwrap();
+    let (resp2, _) =
+        create_or_replace_board(&mut ctx, Uuid::new_v4(), replace_req("Replace")).unwrap();
     let json2 = serde_json::to_string(&resp2).unwrap();
 
     for hidden in ["card_counter", "sprint_counters", "next_sprint_number"] {

--- a/crates/kanban-server/tests/board_create_seam.rs
+++ b/crates/kanban-server/tests/board_create_seam.rs
@@ -1,12 +1,11 @@
-//! KAN-792: the server's board-create seam wires the shared
-//! `CreateOrReplaceBoardRequest` through `into_new_board` → `create_or_replace_board`
-//! (idempotent PUT-create) and projects the result via `BoardResponse`. The
-//! actual HTTP/router binding is out of scope for the stub; this pins the typed
-//! seam end-to-end against a real `KanbanContext`.
+//! Board create/replace seams for the HTTP server, wiring typed request DTOs
+//! through domain operations and projecting results via BoardResponse.
 
 use kanban_persistence_json::JsonFileStore;
-use kanban_server::handlers::boards::create_or_replace_board;
-use kanban_service::api::CreateOrReplaceBoardRequest;
+use kanban_server::handlers::boards::{create_board, create_or_replace_board};
+use kanban_service::api::{
+    CreateBoardRequest, ReplaceBoardRequest, SortFieldDto, SortOrderDto, TaskListViewDto,
+};
 use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use std::sync::Arc;
@@ -19,79 +18,231 @@ fn make_ctx(path: &std::path::Path) -> KanbanContext {
     KanbanContext::open_deferred(backend, AppConfig::default())
 }
 
-fn req_with_id(id: Uuid, name: &str) -> CreateOrReplaceBoardRequest {
-    serde_json::from_value(serde_json::json!({
-        "id": id,
-        "name": name,
-        "card_prefix": "KAN",
-    }))
-    .unwrap()
+/// `POST /v1/boards`: pure create, server-mints id when absent.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_board_seam_mints_id_when_absent() {
+    let dir = tempdir().unwrap();
+    let mut ctx = make_ctx(&dir.path().join("s.json"));
+
+    let req = CreateBoardRequest {
+        id: None,
+        name: "Fresh".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    };
+
+    let resp = create_board(&mut ctx, req).unwrap();
+
+    assert!(resp.id != Uuid::nil(), "absent id must mint a fresh one");
+    assert_eq!(resp.name, "Fresh");
 }
 
+/// `POST /v1/boards`: honour client-supplied id.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_server_seam_put_create_creates_when_absent() {
+async fn test_create_board_seam_honours_client_supplied_id() {
     let dir = tempdir().unwrap();
     let mut ctx = make_ctx(&dir.path().join("s.json"));
     let id = Uuid::new_v4();
 
-    let (resp, created) = create_or_replace_board(&mut ctx, req_with_id(id, "Fresh")).unwrap();
+    let req = CreateBoardRequest {
+        id: Some(id),
+        name: "Fresh".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    };
+
+    let resp = create_board(&mut ctx, req).unwrap();
+
+    assert_eq!(resp.id, id, "client-supplied id must be honoured");
+}
+
+/// `POST /v1/boards`: existing id conflicts (AlreadyExists error).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_board_seam_existing_id_conflicts() {
+    let dir = tempdir().unwrap();
+    let mut ctx = make_ctx(&dir.path().join("s.json"));
+    let id = Uuid::new_v4();
+
+    let req = CreateBoardRequest {
+        id: Some(id),
+        name: "First".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    };
+
+    create_board(&mut ctx, req).unwrap();
+
+    // Same id again:
+    let req2 = CreateBoardRequest {
+        id: Some(id),
+        name: "Second".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    };
+
+    let err = create_board(&mut ctx, req2).unwrap_err();
+
+    assert_eq!(err.code, kanban_service::api::ErrorCode::AlreadyExists);
+}
+
+/// `PUT /v1/boards/:id`: creates when absent.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_board_seam_creates_when_absent() {
+    let dir = tempdir().unwrap();
+    let mut ctx = make_ctx(&dir.path().join("s.json"));
+    let id = Uuid::new_v4();
+
+    let req = ReplaceBoardRequest {
+        name: "Fresh".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: SortFieldDto::Priority,
+        task_sort_order: SortOrderDto::Ascending,
+        sprint_duration_days: None,
+        task_list_view: TaskListViewDto::GroupedByColumn,
+        completion_column_id: None,
+    };
+
+    let (resp, created) = create_or_replace_board(&mut ctx, id, req).unwrap();
 
     assert!(created, "absent id must report created (201)");
     assert_eq!(resp.id, id);
     assert_eq!(resp.name, "Fresh");
-    assert_eq!(resp.card_prefix, Some("KAN".to_string()));
-    assert_eq!(resp.position, 0);
 }
 
+/// `PUT /v1/boards/:id`: replaces when present.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_server_seam_put_create_replaces_when_present() {
+async fn test_create_or_replace_board_seam_replaces_when_present() {
     let dir = tempdir().unwrap();
     let mut ctx = make_ctx(&dir.path().join("s.json"));
     let id = Uuid::new_v4();
 
-    create_or_replace_board(&mut ctx, req_with_id(id, "Original")).unwrap();
-    let (resp, created) = create_or_replace_board(&mut ctx, req_with_id(id, "Replaced")).unwrap();
+    let req1 = ReplaceBoardRequest {
+        name: "Original".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: SortFieldDto::Priority,
+        task_sort_order: SortOrderDto::Ascending,
+        sprint_duration_days: None,
+        task_list_view: TaskListViewDto::GroupedByColumn,
+        completion_column_id: None,
+    };
+
+    create_or_replace_board(&mut ctx, id, req1).unwrap();
+
+    let req2 = ReplaceBoardRequest {
+        name: "Replaced".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: SortFieldDto::Priority,
+        task_sort_order: SortOrderDto::Ascending,
+        sprint_duration_days: None,
+        task_list_view: TaskListViewDto::GroupedByColumn,
+        completion_column_id: None,
+    };
+
+    let (resp, created) = create_or_replace_board(&mut ctx, id, req2).unwrap();
 
     assert!(!created, "present id must report replace (200)");
     assert_eq!(resp.id, id, "id stable across replace");
     assert_eq!(resp.name, "Replaced");
 }
 
+/// `PUT /v1/boards/:id` with completion_column_id on fresh id rejects.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_server_seam_put_create_with_completion_column_id_rejects() {
-    // The idempotent PUT-create seam is the only client-reachable path where
-    // completion_column_id can be set on a request that ends up CREATING a
-    // brand-new board (MCP's own create tool uses the narrower type without
-    // this field at all): a fresh id here still has zero columns, so the
-    // service must reject it, not silently persist a dangling reference.
+async fn test_create_or_replace_board_seam_with_completion_column_id_on_fresh_id_rejects() {
     let dir = tempdir().unwrap();
     let mut ctx = make_ctx(&dir.path().join("s.json"));
     let id = Uuid::new_v4();
-    let req: CreateOrReplaceBoardRequest = serde_json::from_value(serde_json::json!({
-        "id": id,
-        "name": "Fresh",
-        "completion_column_id": Uuid::new_v4(),
-    }))
-    .unwrap();
 
-    let err = create_or_replace_board(&mut ctx, req).unwrap_err();
+    let req = ReplaceBoardRequest {
+        name: "Fresh".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: SortFieldDto::Priority,
+        task_sort_order: SortOrderDto::Ascending,
+        sprint_duration_days: None,
+        task_list_view: TaskListViewDto::GroupedByColumn,
+        completion_column_id: Some(Uuid::new_v4()),
+    };
+
+    let err = create_or_replace_board(&mut ctx, id, req).unwrap_err();
 
     assert_eq!(err.code, kanban_service::api::ErrorCode::ValidationFailed);
     assert_eq!(ctx.list_boards().unwrap().len(), 0);
 }
 
+/// Both seams project via BoardResponse, omitting internal allocation state.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_server_seam_projects_via_board_response() {
-    // The seam returns the wire BoardResponse, not the domain Board: its JSON
-    // omits internal allocation state.
+async fn test_seams_project_via_board_response() {
     let dir = tempdir().unwrap();
     let mut ctx = make_ctx(&dir.path().join("s.json"));
-    let (resp, _) = create_or_replace_board(&mut ctx, req_with_id(Uuid::new_v4(), "B")).unwrap();
-    let json = serde_json::to_string(&resp).unwrap();
+
+    let create_req = CreateBoardRequest {
+        id: None,
+        name: "Create".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    };
+
+    let resp1 = create_board(&mut ctx, create_req).unwrap();
+    let json1 = serde_json::to_string(&resp1).unwrap();
+
     for hidden in ["card_counter", "sprint_counters", "next_sprint_number"] {
         assert!(
-            !json.contains(hidden),
-            "BoardResponse leaked {hidden}: {json}"
+            !json1.contains(hidden),
+            "BoardResponse from create_board leaked {hidden}: {json1}"
+        );
+    }
+
+    let replace_req = ReplaceBoardRequest {
+        name: "Replace".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: SortFieldDto::Priority,
+        task_sort_order: SortOrderDto::Ascending,
+        sprint_duration_days: None,
+        task_list_view: TaskListViewDto::GroupedByColumn,
+        completion_column_id: None,
+    };
+
+    let (resp2, _) = create_or_replace_board(&mut ctx, Uuid::new_v4(), replace_req).unwrap();
+    let json2 = serde_json::to_string(&resp2).unwrap();
+
+    for hidden in ["card_counter", "sprint_counters", "next_sprint_number"] {
+        assert!(
+            !json2.contains(hidden),
+            "BoardResponse from create_or_replace_board leaked {hidden}: {json2}"
         );
     }
 }

--- a/crates/kanban-service/src/api/mod.rs
+++ b/crates/kanban-service/src/api/mod.rs
@@ -6,10 +6,9 @@
 mod v1;
 pub use v1::{
     ApiError, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame,
-    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
-    CreateOrReplaceBoardRequest, CreateSprintParts, CreateSprintRequest, ErrorCode, Page,
-    PageParams, Patch, ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest,
-    ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse,
-    SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
-    UpdateSprintRequest,
+    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
+    CreateSprintRequest, ErrorCode, Page, PageParams, Patch, ReorderColumnRequest,
+    ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest,
+    SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto,
+    UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
 };

--- a/crates/kanban-service/src/api/v1/boards/conversions.rs
+++ b/crates/kanban-service/src/api/v1/boards/conversions.rs
@@ -38,8 +38,11 @@ impl From<UpdateBoardRequest> for BoardUpdate {
     }
 }
 
-/// Shared by both `into_new_board` impls below — the two request structs have
-/// identical content fields and differ only in `completion_column_id`.
+/// Shared by both `into_new_board` impls below. `CreateBoardRequest` and
+/// `ReplaceBoardRequest` differ in more than `completion_column_id` alone —
+/// `ReplaceBoardRequest` requires `task_sort_field`/`task_sort_order`/
+/// `task_list_view` (its own impl wraps them in `Some(...)` to fit here) —
+/// but the shape below is the common subset both funnel through.
 struct BoardContentFields {
     name: String,
     description: Option<String>,

--- a/crates/kanban-service/src/api/v1/boards/conversions.rs
+++ b/crates/kanban-service/src/api/v1/boards/conversions.rs
@@ -4,9 +4,7 @@
 //! different reasons. Each conversion destructures and constructs exhaustively
 //! (no `..`) so a new field is a compile error.
 
-use super::requests::{
-    CreateBoardRequest, CreateOrReplaceBoardRequest, ReplaceBoardRequest, UpdateBoardRequest,
-};
+use super::requests::{CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
 use kanban_domain::{BoardUpdate, FieldUpdate, NewBoard};
 use uuid::Uuid;
 
@@ -115,45 +113,14 @@ impl CreateBoardRequest {
     }
 }
 
-impl CreateOrReplaceBoardRequest {
-    /// Split the identity (optional client id) from the content spec, same
-    /// convention as [`CreateBoardRequest::into_new_board`]. Unlike that
-    /// narrower type, `completion_column_id` carries straight through here —
-    /// it is legitimate when this request replaces an existing board (which
-    /// may already have columns) and only invalid at the moment it creates a
-    /// brand-new one, which the service rejects at that specific call site.
-    pub fn into_new_board(self) -> (Option<Uuid>, NewBoard) {
-        let CreateOrReplaceBoardRequest {
-            id,
-            name,
-            description,
-            sprint_prefix,
-            card_prefix,
-            task_sort_field,
-            task_sort_order,
-            sprint_duration_days,
-            task_list_view,
-            completion_column_id,
-        } = self;
-        let spec = new_board_from_content(
-            BoardContentFields {
-                name,
-                description,
-                sprint_prefix,
-                card_prefix,
-                task_sort_field,
-                task_sort_order,
-                sprint_duration_days,
-                task_list_view,
-            },
-            completion_column_id,
-        );
-        (id, spec)
-    }
-}
-
-impl From<ReplaceBoardRequest> for BoardUpdate {
-    fn from(req: ReplaceBoardRequest) -> Self {
+impl ReplaceBoardRequest {
+    /// Full-replace content spec for the `PUT /v1/boards/:id` create-or-replace
+    /// seam. `completion_column_id` carries straight through — legitimate on
+    /// the replace arm (an existing board may already have columns); the
+    /// service still rejects it at the specific call site where this same
+    /// spec ends up creating a brand-new board (zero columns regardless of
+    /// which request type supplied it).
+    pub fn into_new_board(self) -> NewBoard {
         let ReplaceBoardRequest {
             name,
             description,
@@ -164,22 +131,20 @@ impl From<ReplaceBoardRequest> for BoardUpdate {
             sprint_duration_days,
             task_list_view,
             completion_column_id,
-        } = req;
-        // True full replace: nullable fields map Option→FieldUpdate (Some→Set,
-        // None→Clear); the required non-nullable fields are always `Set`.
-        BoardUpdate {
-            name: Some(name),
-            description: description.into(),
-            sprint_prefix: sprint_prefix.into(),
-            card_prefix: card_prefix.into(),
-            task_sort_field: Some(task_sort_field.into()),
-            task_sort_order: Some(task_sort_order.into()),
-            sprint_duration_days: sprint_duration_days.into(),
-            task_list_view: Some(task_list_view.into()),
-            completion_column_id: completion_column_id.into(),
-            active_sprint_id: FieldUpdate::NoChange,
-            position: None,
-        }
+        } = self;
+        new_board_from_content(
+            BoardContentFields {
+                name,
+                description,
+                sprint_prefix,
+                card_prefix,
+                task_sort_field: Some(task_sort_field),
+                task_sort_order: Some(task_sort_order),
+                sprint_duration_days,
+                task_list_view: Some(task_list_view),
+            },
+            completion_column_id,
+        )
     }
 }
 
@@ -210,28 +175,6 @@ mod tests {
         assert_eq!(update.task_sort_field, Some(SortField::Priority));
         assert_eq!(update.task_sort_order, Some(SortOrder::Ascending));
         assert_eq!(update.task_list_view, Some(TaskListView::Flat));
-        assert_eq!(update.active_sprint_id, FieldUpdate::NoChange);
-        assert_eq!(update.position, None);
-    }
-
-    #[test]
-    fn test_replace_board_request_is_true_full_replace() {
-        let json = r#"{
-            "name":"Fresh",
-            "task_sort_field":"priority",
-            "task_sort_order":"ascending",
-            "task_list_view":"flat"
-        }"#;
-        let req: ReplaceBoardRequest = serde_json::from_str(json).unwrap();
-        let update: BoardUpdate = req.into();
-        assert_eq!(update.name, Some("Fresh".to_string()));
-        assert_eq!(update.task_sort_field, Some(SortField::Priority));
-        assert_eq!(update.task_sort_order, Some(SortOrder::Ascending));
-        assert_eq!(update.task_list_view, Some(TaskListView::Flat));
-        // Omitted nullable fields cleared (wholesale replace):
-        assert_eq!(update.description, FieldUpdate::Clear);
-        assert_eq!(update.sprint_prefix, FieldUpdate::Clear);
-        assert_eq!(update.completion_column_id, FieldUpdate::Clear);
         assert_eq!(update.active_sprint_id, FieldUpdate::NoChange);
         assert_eq!(update.position, None);
     }
@@ -326,21 +269,24 @@ mod tests {
     }
 
     #[test]
-    fn test_create_or_replace_board_request_into_new_board_maps_completion_column_id() {
+    fn test_replace_board_request_into_new_board_carries_completion_column_id() {
         let col = Uuid::new_v4();
-        let req = CreateOrReplaceBoardRequest {
-            id: None,
+        let req = ReplaceBoardRequest {
             name: "Roadmap".to_string(),
             description: None,
             sprint_prefix: None,
             card_prefix: None,
-            task_sort_field: None,
-            task_sort_order: None,
+            task_sort_field: SortFieldDto::Priority,
+            task_sort_order: SortOrderDto::Ascending,
             sprint_duration_days: None,
-            task_list_view: None,
+            task_list_view: TaskListViewDto::GroupedByColumn,
             completion_column_id: Some(col),
         };
-        let (_id, spec) = req.into_new_board();
+        let spec = req.into_new_board();
+        assert_eq!(spec.name, "Roadmap");
+        assert_eq!(spec.task_sort_field, Some(SortField::Priority));
+        assert_eq!(spec.task_sort_order, Some(SortOrder::Ascending));
+        assert_eq!(spec.task_list_view, Some(TaskListView::GroupedByColumn));
         assert_eq!(spec.completion_column_id, Some(col));
     }
 }

--- a/crates/kanban-service/src/api/v1/boards/mod.rs
+++ b/crates/kanban-service/src/api/v1/boards/mod.rs
@@ -1,7 +1,5 @@
 mod conversions;
 mod requests;
 mod response;
-pub use requests::{
-    CreateBoardRequest, CreateOrReplaceBoardRequest, ReplaceBoardRequest, UpdateBoardRequest,
-};
+pub use requests::{CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
 pub use response::BoardResponse;

--- a/crates/kanban-service/src/api/v1/boards/requests.rs
+++ b/crates/kanban-service/src/api/v1/boards/requests.rs
@@ -11,7 +11,9 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CreateBoardRequest {
-    /// Client-supplied id (idempotent PUT-create); read by the service tier.
+    /// Client-supplied id, honoured when present. An id that already exists
+    /// is a conflict (`AlreadyExists` -> 409), not an idempotent replace —
+    /// use `PUT /v1/boards/:id` with [`ReplaceBoardRequest`] for that.
     #[serde(default)]
     pub id: Option<Uuid>,
     pub name: String,

--- a/crates/kanban-service/src/api/v1/boards/requests.rs
+++ b/crates/kanban-service/src/api/v1/boards/requests.rs
@@ -6,8 +6,8 @@ use uuid::Uuid;
 /// `tool_create_board`): a board created this way always has zero columns, so
 /// `completion_column_id` has no field here — it can never be set to
 /// something real by construction. Set it afterward via `update_board` once
-/// the board has columns, or use [`CreateOrReplaceBoardRequest`] to replace an
-/// existing board (which may already have columns).
+/// the board has columns, or use `PUT /v1/boards/:id` with [`ReplaceBoardRequest`]
+/// to replace an existing board (which may already have columns).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CreateBoardRequest {
@@ -29,38 +29,6 @@ pub struct CreateBoardRequest {
     pub sprint_duration_days: Option<u32>,
     #[serde(default)]
     pub task_list_view: Option<TaskListViewDto>,
-}
-
-/// Request body for `PUT /v1/boards/:id`'s idempotent create-or-replace: create
-/// the board with this id when absent, or fully replace its content when
-/// present. Unlike [`CreateBoardRequest`], `completion_column_id` is legitimate
-/// here on the replace arm — an existing board being replaced may already have
-/// columns. It is still rejected by the service when this same request happens
-/// to create a brand-new board (the id was absent from the store), since that
-/// board has zero columns regardless of which request type asked for it.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct CreateOrReplaceBoardRequest {
-    /// Client-supplied id (idempotent PUT-create); read by the service tier.
-    #[serde(default)]
-    pub id: Option<Uuid>,
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub sprint_prefix: Option<String>,
-    #[serde(default)]
-    pub card_prefix: Option<String>,
-    #[serde(default)]
-    pub task_sort_field: Option<SortFieldDto>,
-    #[serde(default)]
-    pub task_sort_order: Option<SortOrderDto>,
-    #[serde(default)]
-    pub sprint_duration_days: Option<u32>,
-    #[serde(default)]
-    pub task_list_view: Option<TaskListViewDto>,
-    #[serde(default)]
-    pub completion_column_id: Option<Uuid>,
 }
 
 /// Request body for `PATCH /v1/boards/:id` — JSON Merge Patch (RFC 7386):
@@ -168,37 +136,6 @@ mod tests {
             r#"{"name":"Ignored","completion_column_id":"00000000-0000-0000-0000-000000000000"}"#;
         let back: CreateBoardRequest = serde_json::from_str(json).unwrap();
         assert_eq!(back.name, "Ignored");
-    }
-
-    #[test]
-    fn test_create_or_replace_board_request_serde_round_trip_includes_completion_column_id() {
-        let id = Uuid::new_v4();
-        let col = Uuid::new_v4();
-        let req = CreateOrReplaceBoardRequest {
-            id: Some(id),
-            name: "Roadmap".to_string(),
-            description: Some("Q3 planning".to_string()),
-            sprint_prefix: Some("SPR".to_string()),
-            card_prefix: Some("KAN".to_string()),
-            task_sort_field: Some(SortFieldDto::Priority),
-            task_sort_order: Some(SortOrderDto::Descending),
-            sprint_duration_days: Some(14),
-            task_list_view: Some(TaskListViewDto::GroupedByColumn),
-            completion_column_id: Some(col),
-        };
-        let json = serde_json::to_string(&req).unwrap();
-        let back: CreateOrReplaceBoardRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.id, Some(id));
-        assert_eq!(back.completion_column_id, Some(col));
-    }
-
-    #[test]
-    fn test_create_or_replace_board_request_minimal_omits_optionals() {
-        let json = r#"{"name":"Minimal"}"#;
-        let back: CreateOrReplaceBoardRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(back.id, None);
-        assert_eq!(back.name, "Minimal");
-        assert_eq!(back.completion_column_id, None);
     }
 
     #[test]

--- a/crates/kanban-service/src/api/v1/mod.rs
+++ b/crates/kanban-service/src/api/v1/mod.rs
@@ -8,10 +8,7 @@ mod events;
 mod pagination;
 mod patch;
 mod sprints;
-pub use boards::{
-    BoardResponse, CreateBoardRequest, CreateOrReplaceBoardRequest, ReplaceBoardRequest,
-    UpdateBoardRequest,
-};
+pub use boards::{BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
 pub use cards::{CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
 pub use columns::{
     ColumnResponse, CreateColumnRequest, ReorderColumnRequest, ReplaceColumnRequest,


### PR DESCRIPTION
Fixes a real drift from the API's own locked convention (every entity's PUT should use its dedicated `Replace<Entity>Request`, never the Create DTO) discovered while grooming board write routes. Boards had a unique, board-only `CreateOrReplaceBoardRequest` type (from an earlier design iteration) instead of reusing `ReplaceBoardRequest`, which already existed but was never wired to anything. This is a "core" seam/DTO fix — no axum/routing changes, no domain-layer behavior changes.

- **Deleted** `CreateOrReplaceBoardRequest` (struct + conversion + 2 tests + all 3 re-export sites) and the unused `From<ReplaceBoardRequest> for BoardUpdate` (confirmed zero call sites workspace-wide before deleting).
- **Added** `ReplaceBoardRequest::into_new_board(self) -> NewBoard`, reusing the existing shared `BoardContentFields`/`new_board_from_content` helper (the same one `CreateBoardRequest::into_new_board` already uses) — required (non-`Option`) fields on `ReplaceBoardRequest` are wrapped in `Some(...)` to fit the helper's optional-field shape.
- **Reshaped** `handlers/boards.rs` into two functions matching `create_or_replace_card`/`create_or_replace_column`'s established signature (`id` as a separate parameter, not read from the body):
  - `create_board(ctx, req: CreateBoardRequest) -> Result<BoardResponse, ApiError>` — pure create, `POST /v1/boards` seam.
  - `create_or_replace_board(ctx, id: Uuid, req: ReplaceBoardRequest) -> Result<(BoardResponse, bool), ApiError>` — idempotent create-or-replace, `PUT /v1/boards/:id` seam. The underlying domain-level `KanbanContext::create_or_replace_board(id, spec: NewBoard)` is **unchanged** — only the wire DTO feeding it changed.

**Why this matters now**: none of these seams are wired to real HTTP routes yet (that's the next card), so this is the last point where the wrong DTO shape can be corrected with zero risk of an already-shipped behavior change. The same drift exists for columns (`create_or_replace_column`) and cards (`create_or_replace_card`), tracked as a known fix for their own write-route cards rather than expanded into this one.

**Testing**: Rewrote `crates/kanban-server/tests/board_create_seam.rs` (7 tests) covering both new seam functions — id minting, client-supplied id, `AlreadyExists` conflict on POST, create-vs-replace on PUT, the `completion_column_id`-on-fresh-board rejection (mirrors the deleted type's own test), and response projection hiding internal allocation state. Added a `kanban-service`-level round-trip test for the new `into_new_board` conversion. Independently reverted the whole diff and confirmed the test suite fails to compile without it, then restored — genuine regression guard. `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean), and a workspace-wide grep confirming zero remaining `CreateOrReplaceBoardRequest` references.

This is pure internal scaffolding — no user-facing change, changeset is a no-op patch note.


**Found and fixed during self-review**:
- `CreateBoardRequest.id`'s field doc comment still described the old merged create-or-replace semantics ("idempotent PUT-create"), contradicting the surrounding docs this PR itself rewrote — fixed to accurately describe the 409-conflict behavior.
- `BoardContentFields`'s doc comment claimed the two request structs it's shared by have identical content fields, which stopped being true once `ReplaceBoardRequest` (required fields) replaced `CreateOrReplaceBoardRequest` (all optional) as the second caller.
- `board_create_seam.rs`'s ten near-identical 9-field struct literals collapsed into two small builders (`create_req`, `replace_req`), cutting the file from 248 to ~181 lines with no loss of coverage (all 7 tests still pass, verified).
- The changeset overstated the fix's scope ("the same convention every other entity in the API already uses") — corrected: only sprints already follows this convention; columns/cards have the identical drift, tracked separately (not this PR's scope).

**Testing**: re-ran `cargo test -p kanban-server --test board_create_seam` after the dedup (all 7 pass), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).
