### PR TITLE
KAN-717 feat(server): add board write routes (POST, PATCH, DELETE /v1/boards)

### DIFF
--- a/.changeset/max-kan-717.md
+++ b/.changeset/max-kan-717.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change).
+`kanban-server` can now create, replace, update, and delete boards over HTTP
+(`POST`/`PUT`/`PATCH`/`DELETE /v1/boards`), not just read them. This is the
+first entity to get a complete CRUD surface, establishing the pattern the
+remaining entities (columns, cards, sprints) will follow.

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -23,5 +23,6 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
         .merge(crate::routes::boards::read_router())
+        .merge(crate::routes::boards::write_router())
         .with_state(state)
 }

--- a/crates/kanban-server/src/error.rs
+++ b/crates/kanban-server/src/error.rs
@@ -1,7 +1,9 @@
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{FromRequest, Request};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use kanban_service::api::ApiError;
+use kanban_service::api::{ApiError, ErrorCode};
 
 pub struct AppError(pub ApiError);
 
@@ -22,5 +24,30 @@ impl From<ApiError> for AppError {
 impl From<&kanban_domain::KanbanError> for AppError {
     fn from(e: &kanban_domain::KanbanError) -> Self {
         AppError(ApiError::from(e))
+    }
+}
+
+/// Drop-in replacement for `axum::Json` that converts a deserialization
+/// failure (missing/wrong-typed field, malformed syntax) into the same
+/// `{"code", "message"}` envelope every other error already uses, instead of
+/// axum's default plain-text rejection body. Use this for every request body
+/// extractor on a write route, not `axum::Json` directly.
+pub struct AppJson<T>(pub T);
+
+impl<T, S> FromRequest<S> for AppJson<T>
+where
+    axum::Json<T>: FromRequest<S, Rejection = JsonRejection>,
+    S: Send + Sync,
+{
+    type Rejection = AppError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(AppJson(value)),
+            Err(rejection) => Err(AppError(ApiError::new(
+                ErrorCode::ValidationFailed,
+                rejection.body_text(),
+            ))),
+        }
     }
 }

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -1,13 +1,12 @@
-use crate::error::AppError;
+use crate::error::{AppError, AppJson};
 use crate::handlers::boards::{create_board, create_or_replace_board};
 use crate::state::AppState;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
-use kanban_core::ClientId;
 use kanban_service::api::{
-    BoardResponse, ChangeEventFrame, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest,
+    BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest,
 };
 use kanban_service::{KanbanError, KanbanOperations};
 use uuid::Uuid;
@@ -39,36 +38,28 @@ pub fn read_router() -> Router<AppState> {
         .route("/v1/boards/{id}", get(get_board))
 }
 
-fn broadcast(state: &AppState) {
-    let _ = state.event_tx.send(ChangeEventFrame::now(
-        state.instance_id,
-        Uuid::new_v4(),
-        ClientId::nil(),
-    ));
-}
-
 async fn post_board(
     State(state): State<AppState>,
-    Json(req): Json<CreateBoardRequest>,
+    AppJson(req): AppJson<CreateBoardRequest>,
 ) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
     let resp = {
         let mut ctx = state.ctx.lock().await;
         create_board(&mut ctx, req).map_err(AppError::from)?
     };
-    broadcast(&state);
+    state.broadcast_change();
     Ok((StatusCode::CREATED, Json(resp)))
 }
 
 async fn put_board(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
-    Json(req): Json<ReplaceBoardRequest>,
+    AppJson(req): AppJson<ReplaceBoardRequest>,
 ) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
     let (resp, created) = {
         let mut ctx = state.ctx.lock().await;
         create_or_replace_board(&mut ctx, id, req).map_err(AppError::from)?
     };
-    broadcast(&state);
+    state.broadcast_change();
     let status = if created {
         StatusCode::CREATED
     } else {
@@ -80,14 +71,14 @@ async fn put_board(
 async fn patch_board(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
-    Json(req): Json<UpdateBoardRequest>,
+    AppJson(req): AppJson<UpdateBoardRequest>,
 ) -> Result<Json<BoardResponse>, AppError> {
     let board = {
         let mut ctx = state.ctx.lock().await;
         ctx.update_board(id, req.into())
             .map_err(|e| AppError::from(&e))?
     };
-    broadcast(&state);
+    state.broadcast_change();
     Ok(Json(BoardResponse::from(&board)))
 }
 
@@ -99,7 +90,7 @@ async fn delete_board(
         let mut ctx = state.ctx.lock().await;
         ctx.delete_board(id).map_err(|e| AppError::from(&e))?;
     }
-    broadcast(&state);
+    state.broadcast_change();
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -1,9 +1,14 @@
 use crate::error::AppError;
+use crate::handlers::boards::{create_board, create_or_replace_board};
 use crate::state::AppState;
 use axum::extract::{Path, State};
-use axum::routing::get;
+use axum::http::StatusCode;
+use axum::routing::{get, post, put};
 use axum::{Json, Router};
-use kanban_service::api::BoardResponse;
+use kanban_core::ClientId;
+use kanban_service::api::{
+    BoardResponse, ChangeEventFrame, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest,
+};
 use kanban_service::{KanbanError, KanbanOperations};
 use uuid::Uuid;
 
@@ -32,4 +37,75 @@ pub fn read_router() -> Router<AppState> {
     Router::new()
         .route("/v1/boards", get(list_boards))
         .route("/v1/boards/{id}", get(get_board))
+}
+
+fn broadcast(state: &AppState) {
+    let _ = state.event_tx.send(ChangeEventFrame::now(
+        state.instance_id,
+        Uuid::new_v4(),
+        ClientId::nil(),
+    ));
+}
+
+async fn post_board(
+    State(state): State<AppState>,
+    Json(req): Json<CreateBoardRequest>,
+) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
+    let resp = {
+        let mut ctx = state.ctx.lock().await;
+        create_board(&mut ctx, req).map_err(AppError::from)?
+    };
+    broadcast(&state);
+    Ok((StatusCode::CREATED, Json(resp)))
+}
+
+async fn put_board(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<ReplaceBoardRequest>,
+) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
+    let (resp, created) = {
+        let mut ctx = state.ctx.lock().await;
+        create_or_replace_board(&mut ctx, id, req).map_err(AppError::from)?
+    };
+    broadcast(&state);
+    let status = if created {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+    Ok((status, Json(resp)))
+}
+
+async fn patch_board(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateBoardRequest>,
+) -> Result<Json<BoardResponse>, AppError> {
+    let board = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.update_board(id, req.into())
+            .map_err(|e| AppError::from(&e))?
+    };
+    broadcast(&state);
+    Ok(Json(BoardResponse::from(&board)))
+}
+
+async fn delete_board(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.delete_board(id).map_err(|e| AppError::from(&e))?;
+    }
+    broadcast(&state);
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub fn write_router() -> Router<AppState> {
+    Router::new().route("/v1/boards", post(post_board)).route(
+        "/v1/boards/{id}",
+        put(put_board).patch(patch_board).delete(delete_board),
+    )
 }

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -1,3 +1,4 @@
+use kanban_core::ClientId;
 use kanban_service::api::ChangeEventFrame;
 use kanban_service::KanbanContext;
 use std::sync::Arc;
@@ -24,5 +25,17 @@ impl AppState {
             instance_id: Uuid::new_v4(),
             event_tx,
         }
+    }
+
+    /// Broadcast a change event after a successful mutation. Shared across
+    /// every entity's write routes so each doesn't reimplement it; call after
+    /// the context lock guard has been dropped. A missing subscriber (no SSE
+    /// consumer connected yet) is not an error, hence the discarded result.
+    pub fn broadcast_change(&self) {
+        let _ = self.event_tx.send(ChangeEventFrame::now(
+            self.instance_id,
+            Uuid::new_v4(),
+            ClientId::nil(),
+        ));
     }
 }

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -1,14 +1,16 @@
 //! Board write routes (POST, PUT, PATCH, DELETE /v1/boards*).
-//! Each handler acquires the context lock, calls the seam layer (KAN-994),
-//! broadcasts a change event on success, then returns the appropriate status.
+//! Each handler acquires the context lock, calls the seam layer, broadcasts
+//! a change event on success, then returns the appropriate status.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use axum::response::Response;
 use kanban_persistence_json::JsonFileStore;
 use kanban_server::app;
 use kanban_server::state::AppState;
 use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use serde_json::{json, Value};
 use std::sync::Arc;
 use tempfile::tempdir;
 use tower::ServiceExt;
@@ -21,55 +23,48 @@ fn make_state(path: &std::path::Path) -> AppState {
     AppState::new(ctx)
 }
 
+async fn send(state: &AppState, method: &str, uri: &str, body: Option<&Value>) -> Response {
+    let mut builder = Request::builder().method(method).uri(uri);
+    let body = match body {
+        Some(v) => {
+            builder = builder.header("content-type", "application/json");
+            Body::from(serde_json::to_string(v).unwrap())
+        }
+        None => Body::empty(),
+    };
+    app::router(state.clone())
+        .oneshot(builder.body(body).unwrap())
+        .await
+        .unwrap()
+}
+
+async fn json_of(response: Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&body).unwrap()
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_post_board_creates_and_returns_201() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    let request_body = serde_json::json!({
-        "name": "My New Board",
-        "card_prefix": "KAN"
-    });
-
-    let response = app::router(state.clone())
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/boards")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = send(
+        &state,
+        "POST",
+        "/v1/boards",
+        Some(&json!({"name": "My New Board", "card_prefix": "KAN"})),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::CREATED);
+    let json = json_of(response).await;
+    let board_id = Uuid::parse_str(json["id"].as_str().unwrap()).unwrap();
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-
-    let board_id_str = json["id"].as_str().expect("response should have an id");
-    let board_id = Uuid::parse_str(board_id_str).expect("id should be a valid UUID");
-
-    // Verify it persisted by doing a GET
-    let get_response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .uri(format!("/v1/boards/{}", board_id))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
+    let get_response = send(&state, "GET", &format!("/v1/boards/{board_id}"), None).await;
     assert_eq!(get_response.status(), StatusCode::OK);
-    let get_body = axum::body::to_bytes(get_response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let get_json: serde_json::Value = serde_json::from_slice(&get_body).unwrap();
-    assert_eq!(get_json["name"], "My New Board");
+    assert_eq!(json_of(get_response).await["name"], "My New Board");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -78,79 +73,37 @@ async fn test_post_board_existing_id_conflicts_409() {
     let state = make_state(&dir.path().join("s.json"));
 
     let board_id = Uuid::new_v4();
-    let request_body = serde_json::json!({
-        "id": board_id,
-        "name": "First Board",
-        "card_prefix": "KB"
-    });
+    let body = json!({"id": board_id, "name": "First Board", "card_prefix": "KB"});
 
-    // First POST should succeed
-    let first_response = app::router(state.clone())
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/boards")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let first = send(&state, "POST", "/v1/boards", Some(&body)).await;
+    assert_eq!(first.status(), StatusCode::CREATED);
 
-    assert_eq!(first_response.status(), StatusCode::CREATED);
-
-    // Second POST with same ID should fail
-    let second_response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/boards")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(second_response.status(), StatusCode::CONFLICT);
-    let body = axum::body::to_bytes(second_response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["code"], "ALREADY_EXISTS");
+    let second = send(&state, "POST", "/v1/boards", Some(&body)).await;
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+    assert_eq!(json_of(second).await["code"], "ALREADY_EXISTS");
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_put_board_creates_when_absent_returns_201() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
-
     let fresh_id = Uuid::new_v4();
-    let request_body = serde_json::json!({
-        "name": "Brand New Board",
-        "task_sort_field": "priority",
-        "task_sort_order": "descending",
-        "task_list_view": "grouped_by_column"
-    });
 
-    let response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri(format!("/v1/boards/{}", fresh_id))
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{fresh_id}"),
+        Some(&json!({
+            "name": "Brand New Board",
+            "task_sort_field": "priority",
+            "task_sort_order": "descending",
+            "task_list_view": "grouped_by_column"
+        })),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::CREATED);
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["id"], fresh_id.to_string());
+    assert_eq!(json_of(response).await["id"], fresh_id.to_string());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -158,39 +111,28 @@ async fn test_put_board_replaces_when_present_returns_200() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    let board_id: Uuid;
-    {
+    let board_id = {
         let mut ctx = state.ctx.lock().await;
-        board_id = ctx
-            .create_board("Original Board".to_string(), Some("OB".to_string()))
+        ctx.create_board("Original Board".to_string(), Some("OB".to_string()))
             .unwrap()
-            .id;
-    }
+            .id
+    };
 
-    let request_body = serde_json::json!({
-        "name": "Replaced Board",
-        "task_sort_field": "created_at",
-        "task_sort_order": "ascending",
-        "task_list_view": "flat"
-    });
-
-    let response = app::router(state.clone())
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri(format!("/v1/boards/{}", board_id))
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}"),
+        Some(&json!({
+            "name": "Replaced Board",
+            "task_sort_field": "created_at",
+            "task_sort_order": "ascending",
+            "task_list_view": "flat"
+        })),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let json = json_of(response).await;
     assert_eq!(json["id"], board_id.to_string());
     assert_eq!(json["name"], "Replaced Board");
 }
@@ -199,28 +141,27 @@ async fn test_put_board_replaces_when_present_returns_200() {
 async fn test_put_board_missing_required_field_returns_422() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
-
     let board_id = Uuid::new_v4();
-    // Missing task_sort_field
-    let request_body = serde_json::json!({
-        "name": "Incomplete Board",
-        "task_sort_order": "ascending",
-        "task_list_view": "flat"
-    });
 
-    let response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri(format!("/v1/boards/{}", board_id))
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    // task_sort_field deliberately omitted.
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}"),
+        Some(&json!({
+            "name": "Incomplete Board",
+            "task_sort_order": "ascending",
+            "task_list_view": "flat"
+        })),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(
+        json["code"], "VALIDATION_FAILED",
+        "a bad request body must use the same {{code, message}} envelope as every other error, not axum's default rejection body: {json}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -228,78 +169,41 @@ async fn test_patch_board_applies_merge_patch_and_returns_200() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    let board_id: Uuid;
-    {
+    let board_id = {
         let mut ctx = state.ctx.lock().await;
-        board_id = ctx
-            .create_board("Original Name".to_string(), Some("ON".to_string()))
+        ctx.create_board("Original Name".to_string(), Some("ON".to_string()))
             .unwrap()
-            .id;
-    }
+            .id
+    };
 
-    let request_body = serde_json::json!({
-        "name": "Renamed Board"
-    });
-
-    let response = app::router(state.clone())
-        .oneshot(
-            Request::builder()
-                .method("PATCH")
-                .uri(format!("/v1/boards/{}", board_id))
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}"),
+        Some(&json!({"name": "Renamed Board"})),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["name"], "Renamed Board");
+    assert_eq!(json_of(response).await["name"], "Renamed Board");
 
-    // Verify it persisted
-    let get_response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .uri(format!("/v1/boards/{}", board_id))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(get_response.status(), StatusCode::OK);
-    let get_body = axum::body::to_bytes(get_response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let get_json: serde_json::Value = serde_json::from_slice(&get_body).unwrap();
-    assert_eq!(get_json["name"], "Renamed Board");
+    let get_response = send(&state, "GET", &format!("/v1/boards/{board_id}"), None).await;
+    assert_eq!(json_of(get_response).await["name"], "Renamed Board");
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_patch_board_unknown_id_returns_404() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
-
     let random_id = Uuid::new_v4();
-    let request_body = serde_json::json!({
-        "name": "Attempted Patch"
-    });
 
-    let response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .method("PATCH")
-                .uri(format!("/v1/boards/{}", random_id))
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{random_id}"),
+        Some(&json!({"name": "Attempted Patch"})),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
@@ -309,39 +213,17 @@ async fn test_delete_board_returns_204_and_removes_board() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    let board_id: Uuid;
-    {
+    let board_id = {
         let mut ctx = state.ctx.lock().await;
-        board_id = ctx
-            .create_board("Board to Delete".to_string(), Some("BD".to_string()))
+        ctx.create_board("Board to Delete".to_string(), Some("BD".to_string()))
             .unwrap()
-            .id;
-    }
+            .id
+    };
 
-    let response = app::router(state.clone())
-        .oneshot(
-            Request::builder()
-                .method("DELETE")
-                .uri(format!("/v1/boards/{}", board_id))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
+    let response = send(&state, "DELETE", &format!("/v1/boards/{board_id}"), None).await;
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
-    // Verify it was deleted by attempting to GET it
-    let get_response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .uri(format!("/v1/boards/{}", board_id))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
+    let get_response = send(&state, "GET", &format!("/v1/boards/{board_id}"), None).await;
     assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
 }
 
@@ -349,20 +231,9 @@ async fn test_delete_board_returns_204_and_removes_board() {
 async fn test_delete_board_unknown_id_returns_404() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
-
     let random_id = Uuid::new_v4();
 
-    let response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .method("DELETE")
-                .uri(format!("/v1/boards/{}", random_id))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
+    let response = send(&state, "DELETE", &format!("/v1/boards/{random_id}"), None).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
@@ -371,69 +242,110 @@ async fn test_board_write_lifecycle() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    // POST: create
-    let create_body = serde_json::json!({
-        "name": "Lifecycle Board",
-        "card_prefix": "LC"
-    });
-    let create_response = app::router(state.clone())
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/boards")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&create_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let create_response = send(
+        &state,
+        "POST",
+        "/v1/boards",
+        Some(&json!({"name": "Lifecycle Board", "card_prefix": "LC"})),
+    )
+    .await;
     assert_eq!(create_response.status(), StatusCode::CREATED);
+    let board_id = Uuid::parse_str(json_of(create_response).await["id"].as_str().unwrap()).unwrap();
 
-    let body = axum::body::to_bytes(create_response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let board_id = Uuid::parse_str(json["id"].as_str().unwrap()).unwrap();
-
-    // PATCH: update
-    let patch_body = serde_json::json!({
-        "name": "Updated Lifecycle Board"
-    });
-    let patch_response = app::router(state.clone())
-        .oneshot(
-            Request::builder()
-                .method("PATCH")
-                .uri(format!("/v1/boards/{}", board_id))
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&patch_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let patch_response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}"),
+        Some(&json!({"name": "Updated Lifecycle Board"})),
+    )
+    .await;
     assert_eq!(patch_response.status(), StatusCode::OK);
 
-    // DELETE: remove
-    let delete_response = app::router(state.clone())
-        .oneshot(
-            Request::builder()
-                .method("DELETE")
-                .uri(format!("/v1/boards/{}", board_id))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let delete_response = send(&state, "DELETE", &format!("/v1/boards/{board_id}"), None).await;
     assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
 
-    // GET: verify deleted
-    let get_response = app::router(state)
-        .oneshot(
-            Request::builder()
-                .uri(format!("/v1/boards/{}", board_id))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let get_response = send(&state, "GET", &format!("/v1/boards/{board_id}"), None).await;
     assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_board_removes_owned_columns_and_cards() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, column_id, card_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board = ctx
+            .create_board("Board With Subtree".to_string(), Some("BS".to_string()))
+            .unwrap();
+        let column = ctx
+            .create_column(board.id, "Todo".to_string(), None)
+            .unwrap();
+        let card = ctx
+            .create_card(
+                board.id,
+                column.id,
+                "A card".to_string(),
+                Default::default(),
+            )
+            .unwrap();
+        (board.id, column.id, card.id)
+    };
+
+    let response = send(&state, "DELETE", &format!("/v1/boards/{board_id}"), None).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let ctx = state.ctx.lock().await;
+    assert!(
+        ctx.get_column(column_id).unwrap().is_none(),
+        "deleting a board must cascade-delete its columns"
+    );
+    assert!(
+        ctx.get_card(card_id).unwrap().is_none(),
+        "deleting a board must cascade-delete its cards"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_board_removes_owned_subtree_on_sqlite_backend() {
+    use kanban_service::sqlite_backend::SqliteBackend;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("s.sqlite");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap());
+    let ctx = KanbanContext::open_deferred(backend, AppConfig::default());
+    let state = AppState::new(ctx);
+
+    let (board_id, column_id, card_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board = ctx
+            .create_board("SQLite Board".to_string(), Some("SQ".to_string()))
+            .unwrap();
+        let column = ctx
+            .create_column(board.id, "Todo".to_string(), None)
+            .unwrap();
+        let card = ctx
+            .create_card(
+                board.id,
+                column.id,
+                "A card".to_string(),
+                Default::default(),
+            )
+            .unwrap();
+        (board.id, column.id, card.id)
+    };
+
+    let response = send(&state, "DELETE", &format!("/v1/boards/{board_id}"), None).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let ctx = state.ctx.lock().await;
+    assert!(
+        ctx.get_column(column_id).unwrap().is_none(),
+        "SQLite: deleting a board must cascade-delete its columns"
+    );
+    assert!(
+        ctx.get_card(card_id).unwrap().is_none(),
+        "SQLite: deleting a board must cascade-delete its cards"
+    );
 }

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -1,0 +1,439 @@
+//! Board write routes (POST, PUT, PATCH, DELETE /v1/boards*).
+//! Each handler acquires the context lock, calls the seam layer (KAN-994),
+//! broadcasts a change event on success, then returns the appropriate status.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use kanban_persistence_json::JsonFileStore;
+use kanban_server::app;
+use kanban_server::state::AppState;
+use kanban_service::json_backend::JsonDataStore;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use std::sync::Arc;
+use tempfile::tempdir;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn make_state(path: &std::path::Path) -> AppState {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
+    let ctx = KanbanContext::open_deferred(backend, AppConfig::default());
+    AppState::new(ctx)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_board_creates_and_returns_201() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let request_body = serde_json::json!({
+        "name": "My New Board",
+        "card_prefix": "KAN"
+    });
+
+    let response = app::router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/boards")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let board_id_str = json["id"].as_str().expect("response should have an id");
+    let board_id = Uuid::parse_str(board_id_str).expect("id should be a valid UUID");
+
+    // Verify it persisted by doing a GET
+    let get_response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_body = axum::body::to_bytes(get_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let get_json: serde_json::Value = serde_json::from_slice(&get_body).unwrap();
+    assert_eq!(get_json["name"], "My New Board");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_board_existing_id_conflicts_409() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = Uuid::new_v4();
+    let request_body = serde_json::json!({
+        "id": board_id,
+        "name": "First Board",
+        "card_prefix": "KB"
+    });
+
+    // First POST should succeed
+    let first_response = app::router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/boards")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(first_response.status(), StatusCode::CREATED);
+
+    // Second POST with same ID should fail
+    let second_response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/boards")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(second_response.status(), StatusCode::CONFLICT);
+    let body = axum::body::to_bytes(second_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["code"], "ALREADY_EXISTS");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_board_creates_when_absent_returns_201() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let fresh_id = Uuid::new_v4();
+    let request_body = serde_json::json!({
+        "name": "Brand New Board",
+        "task_sort_field": "priority",
+        "task_sort_order": "descending",
+        "task_list_view": "grouped_by_column"
+    });
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/v1/boards/{}", fresh_id))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["id"], fresh_id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_board_replaces_when_present_returns_200() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Original Board".to_string(), Some("OB".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let request_body = serde_json::json!({
+        "name": "Replaced Board",
+        "task_sort_field": "created_at",
+        "task_sort_order": "ascending",
+        "task_list_view": "flat"
+    });
+
+    let response = app::router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/v1/boards/{}", board_id))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["id"], board_id.to_string());
+    assert_eq!(json["name"], "Replaced Board");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_board_missing_required_field_returns_400() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = Uuid::new_v4();
+    // Missing task_sort_field
+    let request_body = serde_json::json!({
+        "name": "Incomplete Board",
+        "task_sort_order": "ascending",
+        "task_list_view": "flat"
+    });
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/v1/boards/{}", board_id))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_board_applies_merge_patch_and_returns_200() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Original Name".to_string(), Some("ON".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let request_body = serde_json::json!({
+        "name": "Renamed Board"
+    });
+
+    let response = app::router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/v1/boards/{}", board_id))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["name"], "Renamed Board");
+
+    // Verify it persisted
+    let get_response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_body = axum::body::to_bytes(get_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let get_json: serde_json::Value = serde_json::from_slice(&get_body).unwrap();
+    assert_eq!(get_json["name"], "Renamed Board");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_board_unknown_id_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_id = Uuid::new_v4();
+    let request_body = serde_json::json!({
+        "name": "Attempted Patch"
+    });
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/v1/boards/{}", random_id))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_board_returns_204_and_removes_board() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board to Delete".to_string(), Some("BD".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = app::router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Verify it was deleted by attempting to GET it
+    let get_response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_board_unknown_id_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_id = Uuid::new_v4();
+
+    let response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/boards/{}", random_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_board_write_lifecycle() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    // POST: create
+    let create_body = serde_json::json!({
+        "name": "Lifecycle Board",
+        "card_prefix": "LC"
+    });
+    let create_response = app::router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/boards")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&create_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+
+    let body = axum::body::to_bytes(create_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let board_id = Uuid::parse_str(json["id"].as_str().unwrap()).unwrap();
+
+    // PATCH: update
+    let patch_body = serde_json::json!({
+        "name": "Updated Lifecycle Board"
+    });
+    let patch_response = app::router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/v1/boards/{}", board_id))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&patch_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(patch_response.status(), StatusCode::OK);
+
+    // DELETE: remove
+    let delete_response = app::router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+
+    // GET: verify deleted
+    let get_response = app::router(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/boards/{}", board_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -196,7 +196,7 @@ async fn test_put_board_replaces_when_present_returns_200() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_put_board_missing_required_field_returns_400() {
+async fn test_put_board_missing_required_field_returns_422() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 


### PR DESCRIPTION
Adds the board WRITE routes to `kanban-server`: `POST /v1/boards`, `PUT /v1/boards/{id}`, `PATCH /v1/boards/{id}`, `DELETE /v1/boards/{id}`. Pure HTTP-wiring on top of the seams KAN-994 already established — no DTO/seam-layer logic lives in this PR.

- `post_board`/`put_board`/`patch_board`/`delete_board` handlers added to `routes/boards.rs`, each acquiring the context lock (`state.ctx.lock().await`), calling the appropriate seam/`KanbanOperations` method, and broadcasting a `ChangeEventFrame` on success (after the lock guard is dropped — the `?`-early-return on error means the broadcast is unreachable on any failure path).
- `write_router()` merges alongside the existing `read_router()` in `app.rs`, both merged before the single `.with_state(state)` call.
- `POST` binds to `handlers::boards::create_board` (always 201 or a conflict/validation error). `PUT` binds to `handlers::boards::create_or_replace_board` (201 created / 200 replaced). `PATCH`/`DELETE` call `KanbanOperations::{update_board, delete_board}` directly.

**Testing**: New `crates/kanban-server/tests/boards_write.rs` (10 tests, `tower::ServiceExt::oneshot` against the real router, same pattern as `tests/boards_read.rs`) — create/replace/update/delete happy paths, conflict (409), not-found (404), and a discovered-during-implementation detail: a `PUT` body missing a required field (`ReplaceBoardRequest`'s `task_sort_field`/etc. are non-optional) is rejected by axum's `Json` extractor with **422** (Unprocessable Entity), not 400 — 400 is reserved for malformed JSON syntax, 422 for a valid-JSON-but-fails-deserialization body. Fixed a test name during self-review that still said "400" despite already asserting 422. Also independently reverted the whole diff and confirmed all 10 tests fail without it, then restored — genuine regression guard, not a tautology. Manually smoke-tested the real running binary end-to-end (`cargo build`, `KANBAN_FILE=<tempdir>`, POST → PATCH → DELETE → GET-404, all over real HTTP). `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).

This is pure internal scaffolding — no user-facing change, changeset is a no-op patch note.


**Found and fixed during self-review**:
- JSON body deserialization failures (missing/wrong-typed required field) returned axum's default plain-text rejection instead of the `{code, message}` envelope every other error uses. Added `AppJson<T>`, a drop-in replacement for `axum::Json` that routes deserialization failures through `AppError` (422 `VALIDATION_FAILED`), wired into all three body-taking handlers.
- Moved the per-entity `broadcast()` helper onto `AppState` as `broadcast_change()` so columns/cards/sprints write routes reuse it instead of each reimplementing it.
- Deduped `boards_write.rs`'s ~10 repeated request-building blocks into `send()`/`json_of()` helpers, matching `board_create_seam.rs`'s established builder-helper precedent from KAN-994.
- Added `test_delete_board_removes_owned_columns_and_cards` and its SQLite counterpart — seeded a non-trivial board+column+card graph and asserted the whole subtree is gone after `DELETE`, on both backends. The original test only deleted a bare board and no test in the crate touched SQLite at all — exactly the full-graph, all-backend coverage gap this project's testing policy calls mandatory (and traces to a real prior data-loss bug, KAN-863).

**Found, not fixed here (filed as KAN-995)**: `broadcast_change`'s `ChangeEventFrame::now` mints a fresh random `correlation_id` independent of the real one `KanbanContext::execute()` already generates for the audit-log `CommandBatch`, so a broadcast SSE event and its corresponding audit-log entry carry unrelated UUIDs. Properly fixing this means `execute()` needs to expose the correlation_id it generates — a cross-cutting change affecting every mutating call site in the service layer, out of scope for a board-routes PR, and low-urgency since no SSE consumer exists yet to observe the mismatch.

**Testing (re-verified after the above fixes)**: `cargo test -p kanban-server --test boards_write` (now 12 tests, all pass), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean). Re-ran the real binary smoke test with the new `AppJson` extractor — a malformed PUT now returns `{"code":"VALIDATION_FAILED","message":"..."}` at 422 instead of axum's plain-text body.
