### PR TITLE
KAN-703 test(server): integration test harness spinning up kanban-server in-process

### DIFF
--- a/.changeset/max-kan-703.md
+++ b/.changeset/max-kan-703.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change). Adds a
+real-socket integration test harness for `kanban-server` — every existing
+route test drove the router in-process without an actual network socket;
+this proves the server also works end-to-end as a real running process,
+and is the fixture future work on a collaborative HTTP backend will build on.

--- a/crates/kanban-server/tests/common/mod.rs
+++ b/crates/kanban-server/tests/common/mod.rs
@@ -1,0 +1,78 @@
+use kanban_domain::InMemoryStore;
+use kanban_server::app;
+use kanban_server::state::AppState;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+pub struct TestServer {
+    addr: SocketAddr,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    handle: JoinHandle<()>,
+}
+
+impl TestServer {
+    /// Bind 127.0.0.1:0 (OS-assigned port), build AppState over a zero-I/O
+    /// InMemoryStore-backed KanbanContext, spawn axum::serve with graceful
+    /// shutdown, and return once the listener is bound (so base_url()/addr()
+    /// are valid the moment start() returns -- no race with a test hitting
+    /// the port before bind completes).
+    pub async fn start() -> Self {
+        let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
+        let ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        let state = AppState::new(ctx);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let router = app::router(state);
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        Self {
+            addr,
+            shutdown_tx: Some(shutdown_tx),
+            handle,
+        }
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    pub fn client(&self) -> reqwest::Client {
+        reqwest::Client::new()
+    }
+
+    /// Send the graceful-shutdown signal and await the server task.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        let _ = (&mut self.handle).await;
+    }
+}
+
+impl Drop for TestServer {
+    /// Safety net if a test panics before calling `shutdown()` -- aborts the
+    /// spawned server task rather than leaking it for the rest of the test
+    /// process. A no-op if `shutdown()` already ran.
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}

--- a/crates/kanban-server/tests/server_harness.rs
+++ b/crates/kanban-server/tests/server_harness.rs
@@ -1,0 +1,68 @@
+mod common;
+
+use common::TestServer;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_health_endpoint_returns_ok_over_real_socket() {
+    let server = TestServer::start().await;
+
+    let response = server
+        .client()
+        .get(format!("{}/health", server.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let json: serde_json::Value = response.json().await.unwrap();
+    let instance_id = json["instance_id"].as_str().expect("instance_id present");
+    Uuid::parse_str(instance_id).expect("instance_id is a valid uuid");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_two_test_servers_bind_distinct_nonzero_ports() {
+    let server_a = TestServer::start().await;
+    let server_b = TestServer::start().await;
+
+    assert!(server_a.addr().port() > 0);
+    assert!(server_b.addr().port() > 0);
+    assert_ne!(
+        server_a.addr().port(),
+        server_b.addr().port(),
+        "each TestServer must be bound to its own OS-assigned port"
+    );
+
+    server_a.shutdown().await;
+    server_b.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_and_fetch_board_over_real_socket() {
+    let server = TestServer::start().await;
+
+    let create_response = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .json(&serde_json::json!({"name": "Real Socket Board", "card_prefix": "RS"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_response.status(), reqwest::StatusCode::CREATED);
+    let created: serde_json::Value = create_response.json().await.unwrap();
+    let board_id = created["id"].as_str().unwrap();
+
+    let get_response = server
+        .client()
+        .get(format!("{}/v1/boards/{board_id}", server.base_url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get_response.status(), reqwest::StatusCode::OK);
+    let fetched: serde_json::Value = get_response.json().await.unwrap();
+    assert_eq!(fetched["name"], "Real Socket Board");
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
Adds the in-process, real-socket integration test harness for `kanban-server`. Every existing route test (`boards_read.rs`, `boards_write.rs`, `health.rs`) drives the router via `tower::ServiceExt::oneshot` — full `Service` stack, but never an actual `TcpListener`/OS socket. This harness proves the server also works as a real running process over a real network socket.

- New `crates/kanban-server/tests/common/mod.rs`: `TestServer` — binds `127.0.0.1:0` (OS-assigned port, read back before returning so `base_url()`/`addr()` are valid immediately), builds `AppState` over a zero-I/O `InMemoryStore`-backed `KanbanContext`, spawns `axum::serve(...).with_graceful_shutdown(...)`, and exposes `client()`/`shutdown()`. A `Drop` impl aborts the spawned task as a safety net if a test panics before calling `shutdown()`.
  - Lives at `tests/common/mod.rs` specifically (not a bare `tests/harness.rs`) so Cargo doesn't compile it as its own (empty) integration-test binary — verified this empirically: `cargo test -p kanban-server --test common` lists no such target, only the real test files.
  - Uses the exact same `kanban_server::app::router` and `axum::serve` call shape `main.rs` already uses (no `.into_make_service()`, matching this axum version) — no second/parallel router definition.
- New `crates/kanban-server/tests/server_harness.rs` (3 tests): `/health` over a real socket, two `TestServer`s binding to distinct nonzero ports, and a full `POST` → `GET` board round-trip over a real `reqwest::Client` — the first test in the crate proving the actual CRUD surface (not just `/health`) works over a genuine TCP connection.

**Testing**: Ran the new tests repeatedly (single-threaded, multi-threaded, and 3 sequential full runs) to build confidence the dynamic port binding genuinely avoids collisions rather than passing by luck — all green every time. Confirmed no lingering process after the suite completes (no leaked background task). `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).

This is pure internal test infrastructure — no user-facing change, changeset is a no-op patch note. Blocks KAN-704 (running the `kanban-service` behavior suite against `HttpBackend` by pointing it at this `TestServer`).
