### PR TITLE
KAN-719 feat(server): column write routes (POST/PUT/PATCH/DELETE/reorder)

### DIFF
--- a/.changeset/max-kan-719.md
+++ b/.changeset/max-kan-719.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change, `kanban-server` is not yet released for general use). Adds column write routes to `kanban-server`: `POST`/`PUT`/`PATCH`/`DELETE` and a dedicated reorder endpoint under `/v1/boards/{board_id}/columns`. `PUT` is a true full replace — it can move a column's position, not just rename it. Every write route now verifies the target column actually belongs to the board named in the URL, matching the read routes.

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -25,5 +25,6 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::boards::read_router())
         .merge(crate::routes::boards::write_router())
         .merge(crate::routes::columns::read_router())
+        .merge(crate::routes::columns::write_router())
         .with_state(state)
 }

--- a/crates/kanban-server/src/handlers/columns.rs
+++ b/crates/kanban-server/src/handlers/columns.rs
@@ -1,15 +1,15 @@
-//! Typed column-create seam for the HTTP server.
+//! Typed column-create/replace seam for the HTTP server.
 //!
 //! The server itself is still a stub (no router/transport yet), but the
-//! create-from-spec wiring is real and tested here: this is the single funnel a
-//! future `POST /v1/boards/:id/columns` + `PUT /v1/columns/:id` handler binds
-//! to. The shared [`CreateColumnRequest`] is split via `into_new_column`
-//! (board id is path-supplied on the nested route), runs the idempotent
-//! PUT-create (`create_or_replace_column`), and the resulting domain `Column`
-//! is projected onto the wire [`ColumnResponse`]. The `created` flag lets the
-//! eventual HTTP layer answer 201 (created) vs 200 (replaced).
+//! create-from-spec and replace-from-spec wiring is real and tested here: this
+//! is the funnel `POST /v1/boards/:id/columns` + `PUT /v1/boards/:id/columns/:id`
+//! handlers bind to. The shared DTOs are split via `into_new_column` (board id
+//! is path-supplied on the nested route), runs the idempotent PUT-create
+//! (`create_or_replace_column`), and the resulting domain `Column` is projected
+//! onto the wire [`ColumnResponse`]. The `created` flag lets the HTTP layer
+//! answer 201 (created) vs 200 (replaced).
 
-use kanban_service::api::{ApiError, ColumnResponse, CreateColumnRequest};
+use kanban_service::api::{ApiError, ColumnResponse, CreateColumnRequest, ReplaceColumnRequest};
 use kanban_service::KanbanContext;
 use uuid::Uuid;
 
@@ -27,26 +27,27 @@ pub fn create_column(
         .map_err(|e| ApiError::from(&e))?;
     let id = maybe_id.unwrap_or_else(Uuid::new_v4);
     let outcome = ctx
-        .create_or_replace_column(id, spec)
+        .create_or_replace_column(id, spec, None)
         .map_err(|e| ApiError::from(&e))?;
     Ok((ColumnResponse::from(&outcome.column), outcome.created))
 }
 
 /// `PUT /v1/boards/:board_id/columns/:id`: idempotent create-or-replace for a
-/// column keyed on the path `id`. The board FK is path-supplied; `position`
-/// stays server-managed across the replace arm. Returns the wire projection
-/// plus whether the column was created (`true`) or replaced (`false`).
+/// column keyed on the path `id`. The board FK is path-supplied; `position` is
+/// set from the request (full-replace semantics of PUT). Returns the wire
+/// projection plus whether the column was created (`true`) or replaced
+/// (`false`).
 pub fn create_or_replace_column(
     ctx: &mut KanbanContext,
     board_id: Uuid,
     id: Uuid,
-    req: CreateColumnRequest,
+    req: ReplaceColumnRequest,
 ) -> Result<(ColumnResponse, bool), ApiError> {
-    let (_body_id, spec) = req
+    let (spec, position) = req
         .into_new_column(board_id)
         .map_err(|e| ApiError::from(&e))?;
     let outcome = ctx
-        .create_or_replace_column(id, spec)
+        .create_or_replace_column(id, spec, Some(position))
         .map_err(|e| ApiError::from(&e))?;
     Ok((ColumnResponse::from(&outcome.column), outcome.created))
 }

--- a/crates/kanban-server/src/handlers/columns.rs
+++ b/crates/kanban-server/src/handlers/columns.rs
@@ -10,7 +10,7 @@
 //! answer 201 (created) vs 200 (replaced).
 
 use kanban_service::api::{ApiError, ColumnResponse, CreateColumnRequest, ReplaceColumnRequest};
-use kanban_service::KanbanContext;
+use kanban_service::{KanbanContext, KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 /// `POST /v1/boards/:board_id/columns`: append-create a column under the
@@ -36,13 +36,21 @@ pub fn create_column(
 /// column keyed on the path `id`. The board FK is path-supplied; `position` is
 /// set from the request (full-replace semantics of PUT). Returns the wire
 /// projection plus whether the column was created (`true`) or replaced
-/// (`false`).
+/// (`false`). If `id` already exists under a *different* board, this 404s
+/// rather than silently replacing it — mirrors the read route's cross-board
+/// guard (`routes/columns.rs::get_column`) since `create_or_replace_column`'s
+/// replace arm never checks the existing column's board on its own.
 pub fn create_or_replace_column(
     ctx: &mut KanbanContext,
     board_id: Uuid,
     id: Uuid,
     req: ReplaceColumnRequest,
 ) -> Result<(ColumnResponse, bool), ApiError> {
+    if let Some(existing) = ctx.get_column(id).map_err(|e| ApiError::from(&e))? {
+        if existing.board_id != board_id {
+            return Err(ApiError::from(&KanbanError::not_found("Column", id)));
+        }
+    }
     let (spec, position) = req
         .into_new_column(board_id)
         .map_err(|e| ApiError::from(&e))?;

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -1,10 +1,11 @@
-use crate::error::AppError;
+use crate::error::{AppError, AppJson};
 use crate::state::AppState;
 use axum::extract::{Path, State};
-use axum::routing::get;
+use axum::http::StatusCode;
+use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use kanban_service::api::ColumnResponse;
-use kanban_service::{KanbanError, KanbanOperations};
+use kanban_service::{ColumnUpdate, KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 async fn list_columns(
@@ -33,4 +34,106 @@ pub fn read_router() -> Router<AppState> {
     Router::new()
         .route("/v1/boards/{board_id}/columns", get(list_columns))
         .route("/v1/boards/{board_id}/columns/{id}", get(get_column))
+}
+
+async fn create_column_route(
+    State(state): State<AppState>,
+    Path(board_id): Path<Uuid>,
+    AppJson(req): AppJson<kanban_service::api::CreateColumnRequest>,
+) -> Result<(StatusCode, Json<ColumnResponse>), AppError> {
+    let (resp, created) = {
+        let mut ctx = state.ctx.lock().await;
+        crate::handlers::columns::create_column(&mut ctx, board_id, req).map_err(AppError::from)?
+    };
+    state.broadcast_change();
+    Ok((
+        if created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        },
+        Json(resp),
+    ))
+}
+
+async fn put_column_route(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+    AppJson(req): AppJson<kanban_service::api::ReplaceColumnRequest>,
+) -> Result<(StatusCode, Json<ColumnResponse>), AppError> {
+    let (resp, created) = {
+        let mut ctx = state.ctx.lock().await;
+        crate::handlers::columns::create_or_replace_column(&mut ctx, board_id, id, req)
+            .map_err(AppError::from)?
+    };
+    state.broadcast_change();
+    Ok((
+        if created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        },
+        Json(resp),
+    ))
+}
+
+async fn update_column_route(
+    State(state): State<AppState>,
+    Path((_board_id, id)): Path<(Uuid, Uuid)>,
+    AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
+) -> Result<Json<ColumnResponse>, AppError> {
+    let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
+    let col = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.update_column(id, updates)
+            .map_err(|e| AppError::from(&e))?
+    };
+    state.broadcast_change();
+    Ok(Json(ColumnResponse::from(&col)))
+}
+
+async fn delete_column_route(
+    State(state): State<AppState>,
+    Path((_board_id, id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.delete_column(id).map_err(|e| AppError::from(&e))?;
+    }
+    state.broadcast_change();
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn reorder_column_route(
+    State(state): State<AppState>,
+    Path((_board_id, id)): Path<(Uuid, Uuid)>,
+    AppJson(req): AppJson<kanban_service::api::ReorderColumnRequest>,
+) -> Result<Json<ColumnResponse>, AppError> {
+    if req.position < 0 {
+        return Err(AppError::from(&kanban_domain::KanbanError::validation(
+            format!("column position must be >= 0, got {}", req.position),
+        )));
+    }
+    let col = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.reorder_column(id, req.position)
+            .map_err(|e| AppError::from(&e))?
+    };
+    state.broadcast_change();
+    Ok(Json(ColumnResponse::from(&col)))
+}
+
+pub fn write_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/boards/{board_id}/columns", post(create_column_route))
+        .route(
+            "/v1/boards/{board_id}/columns/{id}",
+            put(put_column_route)
+                .patch(update_column_route)
+                .delete(delete_column_route),
+        )
+        .route(
+            "/v1/boards/{board_id}/columns/{id}/reorder",
+            post(reorder_column_route),
+        )
 }

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -36,6 +36,30 @@ pub fn read_router() -> Router<AppState> {
         .route("/v1/boards/{board_id}/columns/{id}", get(get_column))
 }
 
+fn created_status(created: bool) -> StatusCode {
+    if created {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    }
+}
+
+/// Fetch a column and 404 unless it belongs to `board_id` — the same
+/// cross-board guard `get_column` (read route, above) applies, needed here
+/// too since `KanbanOperations::{update_column, delete_column, reorder_column}`
+/// key on the global column id alone with no board scoping of their own.
+fn require_column_in_board(
+    ctx: &kanban_service::KanbanContext,
+    board_id: Uuid,
+    id: Uuid,
+) -> Result<(), AppError> {
+    ctx.get_column(id)
+        .map_err(|e| AppError::from(&e))?
+        .filter(|c| c.board_id == board_id)
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Column", id)))?;
+    Ok(())
+}
+
 async fn create_column_route(
     State(state): State<AppState>,
     Path(board_id): Path<Uuid>,
@@ -46,14 +70,7 @@ async fn create_column_route(
         crate::handlers::columns::create_column(&mut ctx, board_id, req).map_err(AppError::from)?
     };
     state.broadcast_change();
-    Ok((
-        if created {
-            StatusCode::CREATED
-        } else {
-            StatusCode::OK
-        },
-        Json(resp),
-    ))
+    Ok((created_status(created), Json(resp)))
 }
 
 async fn put_column_route(
@@ -67,24 +84,18 @@ async fn put_column_route(
             .map_err(AppError::from)?
     };
     state.broadcast_change();
-    Ok((
-        if created {
-            StatusCode::CREATED
-        } else {
-            StatusCode::OK
-        },
-        Json(resp),
-    ))
+    Ok((created_status(created), Json(resp)))
 }
 
 async fn update_column_route(
     State(state): State<AppState>,
-    Path((_board_id, id)): Path<(Uuid, Uuid)>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
     AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
     let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
     let col = {
         let mut ctx = state.ctx.lock().await;
+        require_column_in_board(&ctx, board_id, id)?;
         ctx.update_column(id, updates)
             .map_err(|e| AppError::from(&e))?
     };
@@ -94,10 +105,11 @@ async fn update_column_route(
 
 async fn delete_column_route(
     State(state): State<AppState>,
-    Path((_board_id, id)): Path<(Uuid, Uuid)>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, AppError> {
     {
         let mut ctx = state.ctx.lock().await;
+        require_column_in_board(&ctx, board_id, id)?;
         ctx.delete_column(id).map_err(|e| AppError::from(&e))?;
     }
     state.broadcast_change();
@@ -106,17 +118,14 @@ async fn delete_column_route(
 
 async fn reorder_column_route(
     State(state): State<AppState>,
-    Path((_board_id, id)): Path<(Uuid, Uuid)>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
     AppJson(req): AppJson<kanban_service::api::ReorderColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
-    if req.position < 0 {
-        return Err(AppError::from(&kanban_domain::KanbanError::validation(
-            format!("column position must be >= 0, got {}", req.position),
-        )));
-    }
+    let position = req.validated_position().map_err(|e| AppError::from(&e))?;
     let col = {
         let mut ctx = state.ctx.lock().await;
-        ctx.reorder_column(id, req.position)
+        require_column_in_board(&ctx, board_id, id)?;
+        ctx.reorder_column(id, position)
             .map_err(|e| AppError::from(&e))?
     };
     state.broadcast_change();

--- a/crates/kanban-server/tests/column_create_seam.rs
+++ b/crates/kanban-server/tests/column_create_seam.rs
@@ -6,7 +6,7 @@
 
 use kanban_persistence_json::JsonFileStore;
 use kanban_server::handlers::columns::{create_column, create_or_replace_column};
-use kanban_service::api::{CreateColumnRequest, ReplaceColumnRequest};
+use kanban_service::api::ReplaceColumnRequest;
 use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use std::sync::Arc;
@@ -23,15 +23,6 @@ fn seed_board(ctx: &mut KanbanContext) -> Uuid {
     ctx.create_board("Board".to_string(), Some("KAN".to_string()))
         .unwrap()
         .id
-}
-
-fn req_with_id(id: Uuid, name: &str, wip_limit: Option<i32>) -> CreateColumnRequest {
-    serde_json::from_value(serde_json::json!({
-        "id": id,
-        "name": name,
-        "wip_limit": wip_limit,
-    }))
-    .unwrap()
 }
 
 fn replace_req_with_id(

--- a/crates/kanban-server/tests/column_create_seam.rs
+++ b/crates/kanban-server/tests/column_create_seam.rs
@@ -6,7 +6,7 @@
 
 use kanban_persistence_json::JsonFileStore;
 use kanban_server::handlers::columns::{create_column, create_or_replace_column};
-use kanban_service::api::CreateColumnRequest;
+use kanban_service::api::{CreateColumnRequest, ReplaceColumnRequest};
 use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use std::sync::Arc;
@@ -29,6 +29,21 @@ fn req_with_id(id: Uuid, name: &str, wip_limit: Option<i32>) -> CreateColumnRequ
     serde_json::from_value(serde_json::json!({
         "id": id,
         "name": name,
+        "wip_limit": wip_limit,
+    }))
+    .unwrap()
+}
+
+fn replace_req_with_id(
+    id: Uuid,
+    name: &str,
+    position: i32,
+    wip_limit: Option<i32>,
+) -> ReplaceColumnRequest {
+    serde_json::from_value(serde_json::json!({
+        "id": id,
+        "name": name,
+        "position": position,
         "wip_limit": wip_limit,
     }))
     .unwrap()
@@ -66,16 +81,24 @@ async fn test_put_column_create_or_replace_is_idempotent() {
     let board_id = seed_board(&mut ctx);
     let id = Uuid::new_v4();
 
-    let (first, created) =
-        create_or_replace_column(&mut ctx, board_id, id, req_with_id(id, "To Do", Some(3)))
-            .unwrap();
+    let (first, created) = create_or_replace_column(
+        &mut ctx,
+        board_id,
+        id,
+        replace_req_with_id(id, "To Do", 0, Some(3)),
+    )
+    .unwrap();
     assert!(created, "absent id must report created (201)");
     assert_eq!(first.id, id);
     assert_eq!(first.wip_limit, Some(3));
 
-    let (second, created_again) =
-        create_or_replace_column(&mut ctx, board_id, id, req_with_id(id, "To Do", Some(3)))
-            .unwrap();
+    let (second, created_again) = create_or_replace_column(
+        &mut ctx,
+        board_id,
+        id,
+        replace_req_with_id(id, "To Do", 0, Some(3)),
+    )
+    .unwrap();
     assert!(!created_again, "present id must report replace (200)");
     assert_eq!(second.id, id, "id stable across replace");
 
@@ -88,21 +111,28 @@ async fn test_put_column_create_or_replace_is_idempotent() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_put_column_replace_overwrites_content_preserves_position() {
+async fn test_put_column_replace_sets_position_from_request() {
     let dir = tempdir().unwrap();
     let mut ctx = make_ctx(&dir.path().join("s.json"));
     let board_id = seed_board(&mut ctx);
     let id = Uuid::new_v4();
 
-    create_or_replace_column(&mut ctx, board_id, id, req_with_id(id, "Original", Some(5))).unwrap();
+    create_or_replace_column(
+        &mut ctx,
+        board_id,
+        id,
+        replace_req_with_id(id, "Original", 0, Some(5)),
+    )
+    .unwrap();
     let position_before = ctx.get_column(id).unwrap().unwrap().position;
 
-    // Replace with a new name and an omitted wip_limit (wholesale clear).
+    // Replace with a different position (PUT sets position from the request).
+    let new_position = position_before + 3;
     let (resp, created) = create_or_replace_column(
         &mut ctx,
         board_id,
         id,
-        serde_json::from_value(serde_json::json!({ "name": "Renamed" })).unwrap(),
+        replace_req_with_id(id, "Renamed", new_position, None),
     )
     .unwrap();
 
@@ -110,8 +140,21 @@ async fn test_put_column_replace_overwrites_content_preserves_position() {
     assert_eq!(resp.name, "Renamed", "content replaced");
     assert_eq!(resp.wip_limit, None, "omitted wip_limit cleared on replace");
     assert_eq!(
-        resp.position, position_before,
-        "server-managed position preserved across replace"
+        resp.position, new_position,
+        "position should be set from the request, not preserved"
+    );
+
+    // Send back the same position (no-op replace).
+    let (resp2, _) = create_or_replace_column(
+        &mut ctx,
+        board_id,
+        id,
+        replace_req_with_id(id, "Renamed", new_position, None),
+    )
+    .unwrap();
+    assert_eq!(
+        resp2.position, new_position,
+        "re-sending position is a safe no-op"
     );
 }
 

--- a/crates/kanban-server/tests/columns_write.rs
+++ b/crates/kanban-server/tests/columns_write.rs
@@ -406,7 +406,7 @@ async fn test_delete_column_returns_204_and_removes_column() {
 
     // Verify it's deleted
     {
-        let mut ctx = state.ctx.lock().await;
+        let ctx = state.ctx.lock().await;
         assert!(ctx.get_column(col_id).unwrap().is_none());
     }
 }

--- a/crates/kanban-server/tests/columns_write.rs
+++ b/crates/kanban-server/tests/columns_write.rs
@@ -10,6 +10,24 @@ use uuid::Uuid;
 
 mod common;
 use common::{json_of, make_state, send};
+use kanban_server::state::AppState;
+
+async fn seed_board(state: &AppState) -> Uuid {
+    let mut ctx = state.ctx.lock().await;
+    ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id
+}
+
+async fn seed_board_and_column(state: &AppState, name: &str) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col = ctx.create_column(board_id, name.to_string(), None).unwrap();
+    (board_id, col.id)
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_post_column_creates_with_append_position_and_returns_201() {
@@ -556,4 +574,187 @@ async fn test_column_write_lifecycle() {
         .await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_column_negative_position_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = seed_board(&state).await;
+    let col_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"name": "X", "position": -1})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(json_of(response).await["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_column_negative_wip_limit_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = seed_board(&state).await;
+    let col_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"name": "X", "position": 0, "wip_limit": -1})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(json_of(response).await["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_column_create_arm_ignores_requested_position() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    // Seed one existing column so the natural append position (1) differs
+    // from whatever position a client-created id might request.
+    let (board_id, _existing) = seed_board_and_column(&state, "Existing").await;
+    let new_col_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{new_col_id}"),
+        Some(&json!({"name": "New", "position": 99})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = json_of(response).await;
+    assert_eq!(
+        json["position"], 1,
+        "create arm appends at the next server-managed position, ignoring the client's requested position"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_column_replace_wrong_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_a, col_id) = seed_board_and_column(&state, "In A").await;
+    let board_b = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_b}/columns/{col_id}"),
+        Some(&json!({"name": "Hijacked", "position": 0})),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "PUT must not replace a column that belongs to a different board"
+    );
+
+    // Confirm the column in board A was left untouched.
+    let ctx_check = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_a}/columns/{col_id}"),
+        None,
+    )
+    .await;
+    let json = json_of(ctx_check).await;
+    assert_eq!(json["name"], "In A", "column content must be unchanged");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_column_wrong_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_a, col_id) = seed_board_and_column(&state, "In A").await;
+    let board_b = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_b}/columns/{col_id}"),
+        Some(&json!({"name": "Hijacked"})),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "PATCH must not modify a column that belongs to a different board"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_column_wrong_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_a, col_id) = seed_board_and_column(&state, "In A").await;
+    let board_b = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_b}/columns/{col_id}"),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "DELETE must not remove a column that belongs to a different board"
+    );
+
+    // Confirm the column still exists under its real board.
+    let check = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_a}/columns/{col_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(check.status(), StatusCode::OK, "column must survive");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reorder_column_wrong_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_a, col_id) = seed_board_and_column(&state, "In A").await;
+    let board_b = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_b}/columns/{col_id}/reorder"),
+        Some(&json!({"position": 5})),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "reorder must not move a column that belongs to a different board"
+    );
+
+    // Confirm the column's position under its real board is unchanged.
+    let check = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_a}/columns/{col_id}"),
+        None,
+    )
+    .await;
+    let json = json_of(check).await;
+    assert_eq!(json["position"], 0, "position must be unchanged");
 }

--- a/crates/kanban-server/tests/columns_write.rs
+++ b/crates/kanban-server/tests/columns_write.rs
@@ -1,0 +1,559 @@
+//! Column write routes (POST, PUT, PATCH, DELETE /v1/boards/{id}/columns*).
+//! Each handler acquires the context lock, calls the seam layer, broadcasts
+//! a change event on success, then returns the appropriate status.
+
+use axum::http::StatusCode;
+use kanban_domain::KanbanOperations;
+use serde_json::json;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+mod common;
+use common::{json_of, make_state, send};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_column_creates_with_append_position_and_returns_201() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    // Seed a board
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    // POST first column
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns"),
+        Some(&json!({"name": "To Do"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "To Do");
+    assert_eq!(json["position"], 0);
+
+    // POST second column
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns"),
+        Some(&json!({"name": "Doing"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "Doing");
+    assert_eq!(json["position"], 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_column_unknown_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let unknown_board = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{unknown_board}/columns"),
+        Some(&json!({"name": "To Do"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(json_of(response).await["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_column_negative_wip_limit_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns"),
+        Some(&json!({"name": "To Do", "wip_limit": -1})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(json_of(response).await["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_column_creates_when_absent_returns_201() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let col_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"name": "New Column", "position": 0})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = json_of(response).await;
+    assert_eq!(json["id"], col_id.to_string());
+    assert_eq!(json["name"], "New Column");
+    assert_eq!(json["position"], 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_column_replace_sets_position_from_request() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id, old_position) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col = ctx
+            .create_column(board_id, "Original".to_string(), None)
+            .unwrap();
+        (board_id, col.id, col.position)
+    };
+
+    // PUT with a different position
+    let new_position = old_position + 5;
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"name": "Renamed", "position": new_position})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "Renamed");
+    assert_eq!(
+        json["position"], new_position,
+        "position should be set from request"
+    );
+
+    // Verify the same position can be sent back (no-op replace)
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"name": "Renamed", "position": new_position})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["position"], new_position);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_column_missing_required_field_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let col_id = Uuid::new_v4();
+
+    // Missing 'name' field
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"position": 0})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(json_of(response).await["code"], "VALIDATION_FAILED");
+
+    // Missing 'position' field
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"name": "Column"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_column_applies_merge_patch_and_returns_200() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col = ctx
+            .create_column(board_id, "Original".to_string(), None)
+            .unwrap();
+        (board_id, col.id)
+    };
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"name": "Patched"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "Patched");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_column_unknown_id_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let unknown_col = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/columns/{unknown_col}"),
+        Some(&json!({"name": "Patched"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_column_negative_wip_limit_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col = ctx
+            .create_column(board_id, "Original".to_string(), None)
+            .unwrap();
+        (board_id, col.id)
+    };
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"wip_limit": -1})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reorder_column_updates_position_and_returns_200() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col = ctx
+            .create_column(board_id, "Original".to_string(), None)
+            .unwrap();
+        (board_id, col.id)
+    };
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns/{col_id}/reorder"),
+        Some(&json!({"position": 5})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["position"], 5);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reorder_column_unknown_id_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let unknown_col = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns/{unknown_col}/reorder"),
+        Some(&json!({"position": 0})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reorder_column_negative_position_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col = ctx
+            .create_column(board_id, "Original".to_string(), None)
+            .unwrap();
+        (board_id, col.id)
+    };
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns/{col_id}/reorder"),
+        Some(&json!({"position": -1})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_column_returns_204_and_removes_column() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col = ctx
+            .create_column(board_id, "To Delete".to_string(), None)
+            .unwrap();
+        (board_id, col.id)
+    };
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Verify it's deleted
+    {
+        let mut ctx = state.ctx.lock().await;
+        assert!(ctx.get_column(col_id).unwrap().is_none());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_column_unknown_id_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let unknown_col = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/columns/{unknown_col}"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_column_with_cards_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col = ctx
+            .create_column(board_id, "Non-Empty".to_string(), None)
+            .unwrap();
+        // Add a card to the column
+        let _ = ctx
+            .create_card(board_id, col.id, "Task".to_string(), Default::default())
+            .unwrap();
+        (board_id, col.id)
+    };
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(json_of(response).await["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_column_write_lifecycle() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    // POST create at position 0
+    let col_id = {
+        let response = send(
+            &state,
+            "POST",
+            &format!("/v1/boards/{board_id}/columns"),
+            Some(&json!({"name": "To Do"})),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+        Uuid::parse_str(json_of(response).await["id"].as_str().unwrap()).unwrap()
+    };
+
+    // PUT replace with position change
+    {
+        let response = send(
+            &state,
+            "PUT",
+            &format!("/v1/boards/{board_id}/columns/{col_id}"),
+            Some(&json!({"name": "Doing", "position": 2})),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(json_of(response).await["position"], 2);
+    }
+
+    // PATCH merge patch
+    {
+        let response = send(
+            &state,
+            "PATCH",
+            &format!("/v1/boards/{board_id}/columns/{col_id}"),
+            Some(&json!({"name": "In Progress"})),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(json_of(response).await["name"], "In Progress");
+    }
+
+    // POST reorder
+    {
+        let response = send(
+            &state,
+            "POST",
+            &format!("/v1/boards/{board_id}/columns/{col_id}/reorder"),
+            Some(&json!({"position": 3})),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(json_of(response).await["position"], 3);
+    }
+
+    // DELETE
+    {
+        let response = send(
+            &state,
+            "DELETE",
+            &format!("/v1/boards/{board_id}/columns/{col_id}"),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    // Verify deletion
+    {
+        let response = send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/columns/{col_id}"),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/kanban-service/src/api/v1/columns/conversions.rs
+++ b/crates/kanban-service/src/api/v1/columns/conversions.rs
@@ -4,7 +4,9 @@
 //! exhaustively (no `..`).
 
 use super::super::Patch;
-use super::requests::{CreateColumnRequest, ReplaceColumnRequest, UpdateColumnRequest};
+use super::requests::{
+    CreateColumnRequest, ReorderColumnRequest, ReplaceColumnRequest, UpdateColumnRequest,
+};
 use kanban_domain::{BoardId, ColumnUpdate, KanbanError, KanbanResult, NewColumn};
 use uuid::Uuid;
 
@@ -80,6 +82,15 @@ impl ReplaceColumnRequest {
             wip_limit,
         };
         Ok((spec, position))
+    }
+}
+
+impl ReorderColumnRequest {
+    /// Validate and unwrap the target position (`>= 0`), same rule and message
+    /// every other column DTO validates through this module.
+    pub fn validated_position(self) -> KanbanResult<i32> {
+        validate_position(Some(self.position))?;
+        Ok(self.position)
     }
 }
 
@@ -199,5 +210,59 @@ mod tests {
             name: _,
             wip_limit: _,
         } = spec;
+    }
+
+    #[test]
+    fn test_replace_column_request_into_new_column_maps_fields_and_position() {
+        let board_id = Uuid::new_v4();
+        let req = ReplaceColumnRequest {
+            name: "Doing".to_string(),
+            position: 3,
+            wip_limit: Some(2),
+        };
+        let (spec, position) = req.into_new_column(board_id).unwrap();
+        assert_eq!(
+            spec,
+            NewColumn {
+                board_id,
+                name: "Doing".to_string(),
+                wip_limit: Some(2),
+            }
+        );
+        assert_eq!(position, 3);
+    }
+
+    #[test]
+    fn test_replace_column_request_rejects_negative_position() {
+        let board_id = Uuid::new_v4();
+        let req = ReplaceColumnRequest {
+            name: "X".to_string(),
+            position: -1,
+            wip_limit: None,
+        };
+        assert!(req.into_new_column(board_id).is_err());
+    }
+
+    #[test]
+    fn test_replace_column_request_rejects_negative_wip_limit() {
+        let board_id = Uuid::new_v4();
+        let req = ReplaceColumnRequest {
+            name: "X".to_string(),
+            position: 0,
+            wip_limit: Some(-1),
+        };
+        assert!(req.into_new_column(board_id).is_err());
+    }
+
+    #[test]
+    fn test_reorder_column_request_validated_position_accepts_non_negative() {
+        let req = ReorderColumnRequest { position: 5 };
+        assert_eq!(req.validated_position().unwrap(), 5);
+    }
+
+    #[test]
+    fn test_reorder_column_request_validated_position_rejects_negative() {
+        let req = ReorderColumnRequest { position: -1 };
+        assert!(req.validated_position().is_err());
     }
 }

--- a/crates/kanban-service/src/api/v1/columns/conversions.rs
+++ b/crates/kanban-service/src/api/v1/columns/conversions.rs
@@ -29,27 +29,6 @@ impl TryFrom<UpdateColumnRequest> for ColumnUpdate {
     }
 }
 
-impl TryFrom<ReplaceColumnRequest> for ColumnUpdate {
-    type Error = KanbanError;
-
-    fn try_from(req: ReplaceColumnRequest) -> KanbanResult<Self> {
-        let ReplaceColumnRequest {
-            name,
-            position,
-            wip_limit,
-        } = req;
-        validate_position(Some(position))?;
-        if let Some(limit) = wip_limit {
-            validate_wip_limit(limit)?;
-        }
-        Ok(ColumnUpdate {
-            name: Some(name),
-            position: Some(position),
-            wip_limit: wip_limit.into(),
-        })
-    }
-}
-
 impl CreateColumnRequest {
     /// Split the identity (optional client id) from the domain create spec. The
     /// service mints the id when `None` and calls
@@ -73,6 +52,34 @@ impl CreateColumnRequest {
             wip_limit,
         };
         Ok((id, spec))
+    }
+}
+
+impl ReplaceColumnRequest {
+    /// Split the full replace spec (content + position) into a domain spec and
+    /// the server-managed position to apply on the replace arm. The position is
+    /// part of the full-replace contract of PUT — the client sends back what
+    /// they read, or a new position to move the column. `board_id` is
+    /// path-supplied (nested `PUT /boards/:id/columns/:id` route), so it is a
+    /// parameter rather than a body field. Validates `name`, `position >= 0`,
+    /// and `wip_limit >= 0`; exhaustive destructure — no `..` — so a new field
+    /// is a compile error.
+    pub fn into_new_column(self, board_id: BoardId) -> KanbanResult<(NewColumn, i32)> {
+        let ReplaceColumnRequest {
+            name,
+            position,
+            wip_limit,
+        } = self;
+        validate_position(Some(position))?;
+        if let Some(limit) = wip_limit {
+            validate_wip_limit(limit)?;
+        }
+        let spec = NewColumn {
+            board_id,
+            name,
+            wip_limit,
+        };
+        Ok((spec, position))
     }
 }
 
@@ -120,26 +127,6 @@ mod tests {
             name: None,
             position: None,
             wip_limit: Patch::Set(-1),
-        };
-        assert!(ColumnUpdate::try_from(req).is_err());
-    }
-
-    #[test]
-    fn test_replace_column_request_clears_omitted_wip_limit() {
-        let req: ReplaceColumnRequest =
-            serde_json::from_str(r#"{"name":"Done","position":2}"#).unwrap();
-        let update = ColumnUpdate::try_from(req).unwrap();
-        assert_eq!(update.name, Some("Done".to_string()));
-        assert_eq!(update.position, Some(2));
-        assert_eq!(update.wip_limit, FieldUpdate::Clear);
-    }
-
-    #[test]
-    fn test_replace_column_request_rejects_negative_position() {
-        let req = ReplaceColumnRequest {
-            name: "X".to_string(),
-            position: -1,
-            wip_limit: None,
         };
         assert!(ColumnUpdate::try_from(req).is_err());
     }

--- a/crates/kanban-service/src/context/columns.rs
+++ b/crates/kanban-service/src/context/columns.rs
@@ -53,14 +53,17 @@ impl KanbanContext {
     /// client-supplied `id`: create the column with that id when absent, or
     /// fully replace the content of an existing column with that id. The
     /// returned [`ColumnCreateOutcome::created`] distinguishes the two so the
-    /// server seam can answer 201 vs 200. Server-managed `position` is preserved
-    /// across the replace arm (only `name`/`wip_limit` are content) — an absent
-    /// `wip_limit` clears (wholesale replace). The HTTP binding stays in the
-    /// server seam.
+    /// server seam can answer 201 vs 200. The optional `position` parameter
+    /// controls server-managed position on the replace arm: `None` preserves
+    /// the current position exactly as before, `Some(p)` sets it to `p` (the
+    /// full-replace semantics of PUT). Create arm ignores position (server
+    /// appends). An absent `wip_limit` clears (wholesale replace). The HTTP
+    /// binding stays in the server seam.
     pub fn create_or_replace_column(
         &mut self,
         id: Uuid,
         spec: NewColumn,
+        position: Option<i32>,
     ) -> KanbanResult<ColumnCreateOutcome> {
         if self.backend.get_column(id)?.is_none() {
             let column = self.create_column_from_spec(Some(id), spec)?;
@@ -74,7 +77,7 @@ impl KanbanContext {
         // does not move a column across boards, but a board can be deleted
         // between reads, so the guard stays.
         self.require_board(spec.board_id)?;
-        let column = self.update_column_impl(id, replace_update_from_spec(spec))?;
+        let column = self.update_column_impl(id, replace_update_from_spec(spec, position))?;
         Ok(ColumnCreateOutcome {
             column,
             created: false,
@@ -162,9 +165,10 @@ impl KanbanContext {
 /// Map a `NewColumn` create-spec onto a full-replace `ColumnUpdate` (the PUT
 /// replace arm of [`KanbanContext::create_or_replace_column`]): `name` is set,
 /// `wip_limit` maps `Option`→`FieldUpdate` (`Some`→`Set`, `None`→`Clear`, so an
-/// absent field is wiped), and the server-managed `position` is left untouched.
+/// absent field is wiped), and the server-managed `position` is set from the
+/// caller's `position` parameter (or `None` to preserve exactly as today).
 /// `board_id` is the FK key, not editable content, so it is dropped here.
-fn replace_update_from_spec(spec: NewColumn) -> ColumnUpdate {
+fn replace_update_from_spec(spec: NewColumn, position: Option<i32>) -> ColumnUpdate {
     let NewColumn {
         board_id: _,
         name,
@@ -172,7 +176,7 @@ fn replace_update_from_spec(spec: NewColumn) -> ColumnUpdate {
     } = spec;
     ColumnUpdate {
         name: Some(name),
-        position: None,
+        position,
         wip_limit: match wip_limit {
             Some(limit) => FieldUpdate::Set(limit),
             None => FieldUpdate::Clear,

--- a/crates/kanban-service/tests/create_column_from_spec.rs
+++ b/crates/kanban-service/tests/create_column_from_spec.rs
@@ -203,7 +203,7 @@ async fn test_create_or_replace_column_creates_when_absent() {
     let id = Uuid::new_v4();
 
     let ColumnCreateOutcome { column, created } = ctx
-        .create_or_replace_column(id, spec(bid, "To Do", Some(2)))
+        .create_or_replace_column(id, spec(bid, "To Do", Some(2)), None)
         .unwrap();
 
     assert!(created, "absent id reports created");
@@ -219,12 +219,12 @@ async fn test_create_or_replace_column_replaces_when_present() {
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    ctx.create_or_replace_column(id, spec(bid, "Original", Some(5)))
+    ctx.create_or_replace_column(id, spec(bid, "Original", Some(5)), None)
         .unwrap();
     let position_before = ctx.get_column(id).unwrap().unwrap().position;
 
     let ColumnCreateOutcome { column, created } = ctx
-        .create_or_replace_column(id, spec(bid, "Renamed", None))
+        .create_or_replace_column(id, spec(bid, "Renamed", None), None)
         .unwrap();
 
     assert!(!created, "present id reports replace");
@@ -247,12 +247,12 @@ async fn test_create_or_replace_column_replace_with_missing_board_returns_not_fo
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    ctx.create_or_replace_column(id, spec(bid, "Original", Some(5)))
+    ctx.create_or_replace_column(id, spec(bid, "Original", Some(5)), None)
         .unwrap();
 
     let bad_board = Uuid::new_v4();
     let err = ctx
-        .create_or_replace_column(id, spec(bad_board, "Renamed", None))
+        .create_or_replace_column(id, spec(bad_board, "Renamed", None), None)
         .unwrap_err();
     assert!(err.is_not_found(), "missing board rejected as not_found");
 
@@ -269,9 +269,9 @@ async fn test_create_or_replace_column_is_idempotent() {
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    ctx.create_or_replace_column(id, spec(bid, "X", None))
+    ctx.create_or_replace_column(id, spec(bid, "X", None), None)
         .unwrap();
-    ctx.create_or_replace_column(id, spec(bid, "X", None))
+    ctx.create_or_replace_column(id, spec(bid, "X", None), None)
         .unwrap();
 
     assert_eq!(


### PR DESCRIPTION
Adds the column WRITE routes to `kanban-server`, nested under a board: `POST` (create, append position), `PUT` (idempotent create-or-replace, full replace including position), `PATCH` (JSON Merge Patch), `DELETE`, and `POST .../reorder`. Second write surface after boards, following the pattern KAN-717 established, with one deliberate extension: `create_or_replace_column` gains a `position: Option<i32>` parameter so PUT is a true RFC 9110 full replace (a client can move a column via PUT, not just rename it) rather than reusing `CreateColumnRequest` for PUT the way the pre-existing code did.

- `KanbanContext::create_or_replace_column(id, spec, position: Option<i32>)` — `None` preserves the current position (POST's existing-id-collision path, unchanged behavior), `Some(p)` sets it (PUT).
- New `ReplaceColumnRequest::into_new_column` conversion in `kanban-service`, replacing the dead `TryFrom<ReplaceColumnRequest> for ColumnUpdate` (had zero production callers).
- `handlers::columns::create_or_replace_column` now takes `ReplaceColumnRequest`, not `CreateColumnRequest` — this is the same drift KAN-994 fixed for boards.
- All body-taking handlers use `AppJson<T>` for the shared error envelope; writes broadcast via `state.broadcast_change()` after the lock guard drops.
- `DELETE` on a non-empty column returns 422, not a silent cascade (`DeleteColumn::execute` already rejects this at the domain layer — pinned with a route-level test).

**A real bug caught and fixed during self-review** (8-angle review, correctness angle): PATCH/DELETE/reorder and PUT's replace arm never verified the target column actually belongs to the board named in the URL — unlike the read routes (KAN-718), which already guard this. A client scoped to board A could tamper with a column belonging to board B just by knowing its id. Fixed via a `require_column_in_board` guard in the route layer (mirroring the read route's existing idiom) plus the equivalent check in the PUT handler; verified with a genuine revert-and-confirm-fail (4 new tests fail, one panics, without the fix) and a live curl smoke test against the running binary.

Also fixed during self-review: `reorder_column_route` had hand-rolled its own position validation (duplicating `conversions.rs`'s `validate_position` with a copy-pasted message) — moved into `ReorderColumnRequest::validated_position()`, matching every other column DTO's validation convention. Filed a follow-up card (KAN-997) for the deeper gap this surfaced: `Column::update` itself has no position validation at all, so `kanban-mcp`'s reorder tool can persist a negative position today undetected — out of scope here since fixing it at the domain layer is a breaking signature change with a wider blast radius.

**Testing**: `crates/kanban-server/tests/columns_write.rs` (23 tests: full CRUD + reorder lifecycle, validation, 404s, the non-empty-delete guard, and the cross-board isolation fix). `cargo test -p kanban-server --test columns_write` (new/updated tests), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).