### PR TITLE
KAN-1000 fix(server): kanban-server -V/--version/--help crash instead of printing

### DIFF
--- a/.changeset/max-kan-1000.md
+++ b/.changeset/max-kan-1000.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+`kanban-server -V`/`--version`/`--help` no longer crash. The binary previously had no argument parsing at all, so any flag was ignored and it tried to open its data file before doing anything else — now these flags print immediately and exit without touching any file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,12 +1533,15 @@ dependencies = [
 name = "kanban-server"
 version = "0.7.2"
 dependencies = [
+ "assert_cmd",
  "axum",
  "chrono",
+ "clap",
  "kanban-core",
  "kanban-domain",
  "kanban-persistence-json",
  "kanban-service",
+ "predicates",
  "prometheus",
  "reqwest",
  "serde",

--- a/crates/kanban-server/Cargo.toml
+++ b/crates/kanban-server/Cargo.toml
@@ -28,6 +28,7 @@ kanban-core = { path = "../kanban-core", version = "^0.7" }
 kanban-domain = { path = "../kanban-domain", version = "^0.7" }
 kanban-service = { path = "../kanban-service", version = "^0.7" }
 prometheus = { workspace = true }
+clap = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
@@ -35,3 +36,5 @@ reqwest = { workspace = true }
 tempfile = { workspace = true }
 kanban-persistence-json = { path = "../kanban-persistence-json" }
 serde_json = { workspace = true }
+assert_cmd = { workspace = true }
+predicates = { workspace = true }

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -1,10 +1,21 @@
+use clap::Parser;
+use kanban_core::CLI_VERSION_DISPLAY;
 use kanban_server::{app, state::AppState};
 use kanban_service::AppConfig;
 
 const DEFAULT_LOCATOR: &str = "kanban.json";
 
+#[derive(Parser)]
+#[command(
+    name = "kanban-server",
+    version = CLI_VERSION_DISPLAY,
+    about = "HTTP API server for the kanban project management tool"
+)]
+struct Args {}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _args = Args::parse();
     tracing_subscriber::fmt::init();
 
     let locator = std::env::var("KANBAN_FILE").unwrap_or_else(|_| DEFAULT_LOCATOR.to_string());

--- a/crates/kanban-server/tests/cli_version.rs
+++ b/crates/kanban-server/tests/cli_version.rs
@@ -1,0 +1,49 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+fn kanban_server() -> Command {
+    assert_cmd::cargo_bin_cmd!("kanban-server")
+}
+
+#[test]
+fn test_dash_capital_v_prints_version_and_exits_zero() {
+    let dir = tempdir().unwrap();
+
+    kanban_server()
+        .current_dir(dir.path())
+        .env_remove("KANBAN_FILE")
+        .arg("-V")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("0.7").or(predicate::str::contains(env!("CARGO_PKG_VERSION"))),
+        );
+}
+
+#[test]
+fn test_dash_dash_version_prints_version_and_exits_zero() {
+    let dir = tempdir().unwrap();
+
+    kanban_server()
+        .current_dir(dir.path())
+        .env_remove("KANBAN_FILE")
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("0.7").or(predicate::str::contains(env!("CARGO_PKG_VERSION"))),
+        );
+}
+
+#[test]
+fn test_dash_dash_help_exits_zero() {
+    let dir = tempdir().unwrap();
+
+    kanban_server()
+        .current_dir(dir.path())
+        .env_remove("KANBAN_FILE")
+        .arg("--help")
+        .assert()
+        .success();
+}

--- a/crates/kanban-server/tests/cli_version.rs
+++ b/crates/kanban-server/tests/cli_version.rs
@@ -16,9 +16,7 @@ fn test_dash_capital_v_prints_version_and_exits_zero() {
         .arg("-V")
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("0.7").or(predicate::str::contains(env!("CARGO_PKG_VERSION"))),
-        );
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]
@@ -31,9 +29,7 @@ fn test_dash_dash_version_prints_version_and_exits_zero() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("0.7").or(predicate::str::contains(env!("CARGO_PKG_VERSION"))),
-        );
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]


### PR DESCRIPTION
`kanban-server` had zero CLI argument parsing — `main()` unconditionally tried to open the data file before looking at argv at all. Any flag, including `-V`/`--version`/`-h`/`--help`, was silently ignored and the binary proceeded straight to `open_context(...)`, producing an unrelated `Serialization("missing field \`id\`...")` error instead of printing anything.

- Added `clap = { workspace = true }` and a `#[derive(clap::Parser)]` `Args` struct with `version = kanban_core::CLI_VERSION_DISPLAY`, matching the existing `kanban-mcp` precedent exactly.
- `Args::parse()` at the top of `main()`, before any file access — clap's derive macro handles `-V`/`--version`/`-h`/`--help` interception and process exit internally.
- Scope deliberately minimal: `Args {}` has no real fields. Bind address/port configuration is tracked separately (KAN-991) and should extend this same struct when it lands, not introduce a second parser.

**What**: Adds argument parsing to `kanban-server`'s entry point so informational flags short-circuit before any file I/O.

**Why**: Reported directly by Max hitting this while manually testing the built binary (`kanban-server -V` crashing with a serialization error).

**How**: Mirrors `kanban-mcp/src/main.rs`'s existing `clap::Parser` + `CLI_VERSION_DISPLAY` pattern exactly — no new convention invented.

**Testing**: `crates/kanban-server/tests/cli_version.rs` (3 new tests: `-V`, `--version`, `--help` each print/exit 0, run from a fresh tempdir with `KANBAN_FILE` unset — reproducing the exact conditions that triggered the bug). Verified with a genuine revert-and-confirm-fail (reverting `main.rs`/`Cargo.toml` makes the test file fail to even compile). Manually confirmed normal server startup (`KANBAN_FILE` set) is unaffected and that no data file is created when running with `-V`/`--version`/`--help`. `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).