### PR TITLE
KAN-1002 feat(server): reload JSON-backed KanbanContext on external file changes

### DIFF
--- a/.changeset/max-kan-1002.md
+++ b/.changeset/max-kan-1002.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change, `kanban-server` is not yet released for general use). `kanban-server`, when backed by the JSON store, now detects and reloads when the underlying file is changed by another process (the TUI, CLI, or MCP server) — previously it only ever read the file once at startup and could go stale until restarted.
+
+Also fixes two bugs in the shared `FileWatcher` component (also used by the TUI): starting a watch on a locator whose file doesn't exist yet no longer fails, and starting a watch now waits until the OS-level watch is actually armed before returning, closing a race where a write landing immediately after startup could be missed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
  "clap",
  "kanban-core",
  "kanban-domain",
+ "kanban-persistence",
  "kanban-persistence-json",
  "kanban-service",
  "predicates",

--- a/crates/kanban-persistence/src/watch/file_watcher.rs
+++ b/crates/kanban-persistence/src/watch/file_watcher.rs
@@ -1,5 +1,5 @@
 use crate::traits::{ChangeDetector, ChangeEvent};
-use crate::PersistenceResult;
+use crate::{PersistenceError, PersistenceResult};
 use chrono::Utc;
 use notify::{RecursiveMode, Watcher};
 use std::path::PathBuf;
@@ -83,8 +83,34 @@ impl ChangeDetector for FileWatcher {
         let task_handle = self.task_handle.clone();
         let suppress_remaining = self.suppress_remaining.clone();
 
-        // Canonicalize to absolute path so it matches OS event paths
-        let canonical_path = tokio::fs::canonicalize(&path).await?;
+        // Canonicalize the parent directory rather than `path` itself, so a
+        // locator that hasn't been written yet can still be watched — the OS
+        // watch below is placed on the parent directory regardless (better
+        // for detecting atomic writes), so only the parent needs to resolve.
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| {
+                PersistenceError::Io(std::io::Error::other(format!(
+                    "watch path has no file name: {}",
+                    path.display()
+                )))
+            })?
+            .to_owned();
+        let parent_dir = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+            _ => PathBuf::from("."),
+        };
+        let canonical_parent = tokio::fs::canonicalize(&parent_dir).await?;
+        let canonical_path = canonical_parent.join(file_name);
+
+        // The OS-level watch is registered inside the spawned task below;
+        // without this signal, `start_watching` would return as soon as the
+        // task is merely scheduled, racing an immediate write against a
+        // watch that isn't armed yet. `ready_tx` reports back once the watch
+        // is actually in place (or definitively failed), so callers that
+        // `.await` this function can rely on every subsequent write being
+        // observed.
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<PersistenceResult<()>>();
 
         // Spawn file watching in a background task
         let handle = tokio::spawn(async move {
@@ -166,6 +192,10 @@ impl ChangeDetector for FileWatcher {
                         if let Err(e) = watcher.watch(&canonical_path, RecursiveMode::NonRecursive)
                         {
                             tracing::error!("Failed to watch file or parent directory: {}", e);
+                            let _ =
+                                ready_tx.send(Err(PersistenceError::Io(std::io::Error::other(
+                                    format!("failed to watch file or parent directory: {e}"),
+                                ))));
                             return;
                         }
                         tracing::info!("Watching file: {}", canonical_path.display());
@@ -173,17 +203,30 @@ impl ChangeDetector for FileWatcher {
                         tracing::info!("Watching parent directory: {}", parent.display());
                     }
 
+                    let _ = ready_tx.send(Ok(()));
+
                     // Keep watcher alive
                     std::future::pending::<()>().await;
                 }
                 Err(e) => {
                     tracing::error!("Failed to create watcher: {}", e);
+                    let _ = ready_tx.send(Err(PersistenceError::Io(std::io::Error::other(
+                        format!("failed to create watcher: {e}"),
+                    ))));
                 }
             }
         });
 
         let mut guard = task_handle.lock().await;
         *guard = Some(handle);
+
+        // Wait for the watch to actually be armed before returning, closing
+        // the race between this call returning and the first write landing.
+        ready_rx.await.map_err(|_| {
+            PersistenceError::Io(std::io::Error::other(
+                "file watcher task ended before confirming the watch was armed",
+            ))
+        })??;
 
         Ok(())
     }

--- a/crates/kanban-server/Cargo.toml
+++ b/crates/kanban-server/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 kanban-core = { path = "../kanban-core", version = "^0.7" }
 kanban-domain = { path = "../kanban-domain", version = "^0.7" }
+kanban-persistence = { path = "../kanban-persistence", version = "^0.7" }
 kanban-service = { path = "../kanban-service", version = "^0.7" }
 prometheus = { workspace = true }
 clap = { workspace = true }

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod app;
 pub mod error;
 pub mod state;
+pub mod watch;
 
 pub mod routes {
     pub mod boards;

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -22,6 +22,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = kanban_service::open_context(&locator, AppConfig::default()).await?;
     let state = AppState::new(ctx);
 
+    kanban_server::watch::watch_for_external_changes(state.clone(), &locator).await?;
+
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     tracing::info!(addr = %listener.local_addr()?, "kanban-server listening");
     axum::serve(listener, app::router(state)).await?;

--- a/crates/kanban-server/src/watch.rs
+++ b/crates/kanban-server/src/watch.rs
@@ -1,0 +1,46 @@
+use crate::state::AppState;
+use kanban_persistence::ChangeDetector;
+use kanban_service::StoreManager;
+use std::path::PathBuf;
+
+/// Watch `locator` for external changes (writes from another process — TUI,
+/// CLI, MCP) and reload `state.ctx` when they happen, broadcasting a change
+/// event afterward so any connected SSE clients see it too.
+///
+/// No-op for a SQLite locator (queries hit the live DB on every call, no
+/// in-memory cache to go stale) and safe to call with a locator whose file
+/// doesn't exist yet — `FileWatcher::start_watching` resolves the parent
+/// directory rather than the file itself, so it can watch for the file's
+/// first creation as well as later external writes.
+pub async fn watch_for_external_changes(
+    state: AppState,
+    locator: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sm = StoreManager::new(kanban_service::default_registry());
+    if sm.is_sqlite(locator) {
+        return Ok(());
+    }
+
+    let watcher = kanban_persistence::FileWatcher::new();
+    let mut rx = watcher.subscribe();
+    watcher.start_watching(PathBuf::from(locator)).await?;
+
+    tokio::spawn(async move {
+        // Keep `watcher` alive for the life of this task — its background
+        // notify task is tied to `watcher`'s own lifetime.
+        let _watcher = watcher;
+        while rx.recv().await.is_ok() {
+            let mut ctx = state.ctx.lock().await;
+            match ctx.reload().await {
+                Ok(()) => {
+                    drop(ctx);
+                    state.broadcast_change();
+                    tracing::info!("Reloaded state from external file change");
+                }
+                Err(e) => tracing::error!("Failed to reload from disk: {e}"),
+            }
+        }
+    });
+
+    Ok(())
+}

--- a/crates/kanban-server/tests/external_reload.rs
+++ b/crates/kanban-server/tests/external_reload.rs
@@ -1,0 +1,76 @@
+use kanban_persistence_json::JsonFileStore;
+use kanban_server::state::AppState;
+use kanban_server::watch::watch_for_external_changes;
+use kanban_service::json_backend::JsonDataStore;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_boards_reflects_board_created_by_external_writer() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("s.json");
+
+    // "Server" side: the context the watcher will keep fresh.
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let state = AppState::new(ctx);
+    watch_for_external_changes(state.clone(), path.to_str().unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(state.ctx.lock().await.list_boards().unwrap().len(), 0);
+
+    // "External process" (e.g. the TUI): a SEPARATE context, same file.
+    {
+        let backend: Arc<dyn KanbanBackend> =
+            Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+        let mut external_ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        external_ctx
+            .create_board("External Board".to_string(), Some("EXT".to_string()))
+            .unwrap();
+        external_ctx.save().await.unwrap(); // flush to disk — the write the watcher must see
+    }
+
+    // The watcher reacts asynchronously — poll with a bounded timeout
+    // rather than asserting immediately after the external write.
+    let mut boards_len = 0;
+    for _ in 0..50 {
+        boards_len = state.ctx.lock().await.list_boards().unwrap().len();
+        if boards_len == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(
+        boards_len, 1,
+        "server must reflect the externally-created board within 5s"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_watch_for_external_changes_is_noop_for_sqlite_locator() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("s.sqlite");
+    let backend: Arc<dyn KanbanBackend> = Arc::new(
+        kanban_service::sqlite_backend::SqliteBackend::open(path.to_str().unwrap())
+            .await
+            .unwrap(),
+    );
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let state = AppState::new(ctx);
+
+    // Must return Ok and must NOT attempt to watch a path notify can't
+    // meaningfully treat the same way — confirms the is_sqlite() guard.
+    watch_for_external_changes(state, path.to_str().unwrap())
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
`kanban-server`, when backed by the JSON store, never picked up changes written to the file by another process (TUI, CLI, MCP) — confirmed via investigation KAN-1001: `JsonDataStore` caches the whole file in memory once, and `kanban-server` never called `KanbanContext::reload()`. SQLite backend is unaffected (queries hit the DB live). Fix: reuse `kanban_persistence::FileWatcher`, the exact same component the TUI already uses to solve this for multiple local processes sharing one file.

- New `kanban_server::watch::watch_for_external_changes(state, locator)` — no-op for a SQLite locator; for JSON, starts a `FileWatcher`, subscribes to change events, and reloads `state.ctx` (broadcasting a change event afterward) on each one. Wired into `main.rs` right after `AppState::new`.
- Deliberately **not** wired into `AppState::new` itself — `AppState` is also constructed by every test harness (`TestServer`, `make_state`), including `InMemoryStore`-backed ones with no real file to watch.

**Built with a Sonnet-orchestrated, Haiku-executed workflow**: two Haiku sub-agents implemented the pinned Red test and the Green implementation in parallel from a fully pre-resolved card (exact function signature, module path, and test code were nailed down before dispatch so the two agents didn't need to coordinate). A Sonnet orchestrator validated their combined output, and found (while actually *running* the Red tests, not just reviewing them) two real bugs in the shared `FileWatcher` component that the card hadn't anticipated:

1. `FileWatcher::start_watching` canonicalized the full file path, which requires the file to already exist — but the watch is placed on the *parent directory* in the success path regardless (this was already the existing design, for atomic-write detection), so only the parent needs to resolve. Fixed by canonicalizing the parent and joining the filename, so a not-yet-created locator (e.g. a fresh `kanban-server` deploy) can still be watched.
2. `start_watching` returned as soon as its background task was merely *scheduled*, not once the OS-level watch was actually registered — a genuine race where a write landing immediately after could be silently missed. Fixed with a `tokio::sync::oneshot` so the call doesn't return until the watch is confirmed armed.

I independently re-verified both fixes myself on top of the orchestrator's own validation: reran the full workspace suite, `kanban-persistence`'s and `kanban-tui`'s test suites specifically (since this touches code the TUI also depends on — all 6 pre-existing `FileWatcher` tests plus all of `kanban-tui`'s suite pass unchanged), did my own genuine revert-and-confirm-fail on both the server-side change and the `FileWatcher` fix in isolation (reverting just the `FileWatcher` fix reproduces the missing-file panic on its own), and ran a live end-to-end smoke test against the real binaries: `kanban-server` + a separate `kanban board create` CLI invocation against the same file, confirming the server reflects the CLI's write without a restart.

**Testing**: `crates/kanban-server/tests/external_reload.rs` (2 new tests: an external writer's board appears via polling `GET /v1/boards` within a bounded timeout; a SQLite locator is a confirmed no-op). `cargo test --workspace` (no regressions, including `kanban-tui`'s full suite), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).