### PR TITLE
KAN-1004 fix(server): persist writes to disk on every JSON-backed write route

### DIFF
--- a/.changeset/max-kan-1004.md
+++ b/.changeset/max-kan-1004.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change, `kanban-server` is not yet released for general use). Fixes a critical data-loss bug: `kanban-server`, when backed by the JSON store, never wrote any board or column changes to disk — every mutation only ever existed in memory and was lost the moment the process exited, restarted, or crashed. Every write route now durably persists the change before reporting success back to the client.

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -44,9 +44,13 @@ async fn post_board(
 ) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
     let resp = {
         let mut ctx = state.ctx.lock().await;
-        create_board(&mut ctx, req).map_err(AppError::from)?
+        let resp = create_board(&mut ctx, req).map_err(AppError::from)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        resp
     };
-    state.broadcast_change();
     Ok((StatusCode::CREATED, Json(resp)))
 }
 
@@ -57,9 +61,13 @@ async fn put_board(
 ) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
     let (resp, created) = {
         let mut ctx = state.ctx.lock().await;
-        create_or_replace_board(&mut ctx, id, req).map_err(AppError::from)?
+        let (resp, created) = create_or_replace_board(&mut ctx, id, req).map_err(AppError::from)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        (resp, created)
     };
-    state.broadcast_change();
     let status = if created {
         StatusCode::CREATED
     } else {
@@ -75,10 +83,15 @@ async fn patch_board(
 ) -> Result<Json<BoardResponse>, AppError> {
     let board = {
         let mut ctx = state.ctx.lock().await;
-        ctx.update_board(id, req.into())
-            .map_err(|e| AppError::from(&e))?
+        let board = ctx
+            .update_board(id, req.into())
+            .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        board
     };
-    state.broadcast_change();
     Ok(Json(BoardResponse::from(&board)))
 }
 
@@ -89,8 +102,11 @@ async fn delete_board(
     {
         let mut ctx = state.ctx.lock().await;
         ctx.delete_board(id).map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
     }
-    state.broadcast_change();
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -67,9 +67,14 @@ async fn create_column_route(
 ) -> Result<(StatusCode, Json<ColumnResponse>), AppError> {
     let (resp, created) = {
         let mut ctx = state.ctx.lock().await;
-        crate::handlers::columns::create_column(&mut ctx, board_id, req).map_err(AppError::from)?
+        let result = crate::handlers::columns::create_column(&mut ctx, board_id, req)
+            .map_err(AppError::from)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        result
     };
-    state.broadcast_change();
     Ok((created_status(created), Json(resp)))
 }
 
@@ -80,10 +85,15 @@ async fn put_column_route(
 ) -> Result<(StatusCode, Json<ColumnResponse>), AppError> {
     let (resp, created) = {
         let mut ctx = state.ctx.lock().await;
-        crate::handlers::columns::create_or_replace_column(&mut ctx, board_id, id, req)
-            .map_err(AppError::from)?
+        let result =
+            crate::handlers::columns::create_or_replace_column(&mut ctx, board_id, id, req)
+                .map_err(AppError::from)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        result
     };
-    state.broadcast_change();
     Ok((created_status(created), Json(resp)))
 }
 
@@ -96,10 +106,15 @@ async fn update_column_route(
     let col = {
         let mut ctx = state.ctx.lock().await;
         require_column_in_board(&ctx, board_id, id)?;
-        ctx.update_column(id, updates)
-            .map_err(|e| AppError::from(&e))?
+        let col = ctx
+            .update_column(id, updates)
+            .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        col
     };
-    state.broadcast_change();
     Ok(Json(ColumnResponse::from(&col)))
 }
 
@@ -111,8 +126,11 @@ async fn delete_column_route(
         let mut ctx = state.ctx.lock().await;
         require_column_in_board(&ctx, board_id, id)?;
         ctx.delete_column(id).map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
     }
-    state.broadcast_change();
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -125,10 +143,15 @@ async fn reorder_column_route(
     let col = {
         let mut ctx = state.ctx.lock().await;
         require_column_in_board(&ctx, board_id, id)?;
-        ctx.reorder_column(id, position)
-            .map_err(|e| AppError::from(&e))?
+        let col = ctx
+            .reorder_column(id, position)
+            .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        col
     };
-    state.broadcast_change();
     Ok(Json(ColumnResponse::from(&col)))
 }
 

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -1,6 +1,6 @@
 use kanban_core::ClientId;
 use kanban_service::api::ChangeEventFrame;
-use kanban_service::KanbanContext;
+use kanban_service::{KanbanContext, KanbanResult};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -37,5 +37,20 @@ impl AppState {
             Uuid::new_v4(),
             ClientId::nil(),
         ));
+    }
+
+    /// Durably persist any pending changes, then broadcast. Call this from
+    /// *inside* the context lock (needs `&KanbanContext` — `save()` takes
+    /// `&self`, so no reacquire is needed), immediately after a successful
+    /// mutation and before the lock guard drops. A write whose `save()` fails
+    /// must not report success to the client — callers propagate the error via
+    /// `AppError::from(&e)` exactly like every other `KanbanResult` in this
+    /// crate, so a 201/200 response is only ever returned once the data is
+    /// actually on disk (or in SQLite's case, harmlessly redundant — `flush()`
+    /// is a no-op cost there since each statement already committed).
+    pub async fn persist_and_broadcast(&self, ctx: &KanbanContext) -> KanbanResult<()> {
+        ctx.save().await?;
+        self.broadcast_change();
+        Ok(())
     }
 }

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -3,7 +3,9 @@
 //! a change event on success, then returns the appropriate status.
 
 use axum::http::StatusCode;
+use kanban_persistence_json::JsonFileStore;
 use kanban_server::state::AppState;
+use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use serde_json::json;
 use std::sync::Arc;
@@ -316,4 +318,49 @@ async fn test_delete_board_removes_owned_subtree_on_sqlite_backend() {
         ctx.get_card(card_id).unwrap().is_none(),
         "SQLite: deleting a board must cascade-delete its cards"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_board_persists_to_disk() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("s.json");
+    let state = make_state(&path);
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/boards",
+        Some(&json!({"name": "Persistent Board", "card_prefix": "PB"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = json_of(response).await;
+    let board_id = Uuid::parse_str(json["id"].as_str().unwrap()).unwrap();
+
+    // Create a second, independent context pointing to the same file to prove
+    // the write reached disk. This is the only way to verify durability — the
+    // original state.ctx already has the mutation in memory, so reading from
+    // it would NOT catch if persist_and_broadcast failed to actually flush.
+    {
+        let backend: Arc<dyn KanbanBackend> =
+            Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+        let independent_ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        let boards = independent_ctx.list_boards().unwrap();
+        assert_eq!(
+            boards.len(),
+            1,
+            "a second, independent context against the same file must see the persisted board"
+        );
+        assert_eq!(
+            boards[0].id, board_id,
+            "the persisted board must have the same id"
+        );
+        assert_eq!(
+            boards[0].name, "Persistent Board",
+            "the persisted board must have the same name"
+        );
+    }
 }

--- a/crates/kanban-server/tests/columns_write.rs
+++ b/crates/kanban-server/tests/columns_write.rs
@@ -758,3 +758,48 @@ async fn test_reorder_column_wrong_board_returns_404() {
     let json = json_of(check).await;
     assert_eq!(json["position"], 0, "position must be unchanged");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_column_persists_to_disk() {
+    use kanban_persistence_json::JsonFileStore;
+    use kanban_service::json_backend::JsonDataStore;
+    use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+    use std::sync::Arc;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("s.json");
+
+    // Create a board and column via the HTTP API
+    let state = make_state(&path);
+    let (board_id, col_id) = seed_board_and_column(&state, "Original Name").await;
+
+    // PATCH the column through the router
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        Some(&json!({"name": "Updated Name"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "Updated Name");
+
+    // Open a SECOND, independent context against the same file to verify the write reached disk
+    let independent_backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let independent_ctx = KanbanContext::open(independent_backend, AppConfig::default())
+        .await
+        .unwrap();
+
+    // Assert that the independent context sees the updated column name on disk
+    let col_from_disk = independent_ctx
+        .get_column(col_id)
+        .unwrap()
+        .expect("column should exist on disk");
+    assert_eq!(
+        col_from_disk.name, "Updated Name",
+        "PATCH update must be persisted to disk, not just in-memory state"
+    );
+}


### PR DESCRIPTION
`kanban-server`, when backed by the JSON store, never persisted a single write to disk — confirmed via investigation KAN-1003: created a board via POST, confirmed it existed via GET, gracefully shut the server down, and the JSON file was never created on disk. Restarting came back completely empty. Root cause: nothing in `kanban-server` ever called `KanbanContext::save()` / `KanbanBackend::flush()` — every mutation only touched the in-memory `DataStore` cache. SQLite is unaffected (each statement commits immediately under WAL mode).

Confirmed **not** a regression from KAN-1002 (the file-watcher/reload card) — reproduced identically on a binary built from the commit immediately before KAN-1002 merged. Also confirmed it isn't specific to a brand-new file (reproduced against a pre-existing, `kanban init`-seeded file too), and that nothing saves on process exit either (no `Drop` impl in the persistence chain, no signal handler, no graceful-shutdown hook on `axum::serve`).

- New `AppState::persist_and_broadcast(&self, ctx: &KanbanContext)` — calls `ctx.save().await` then the existing `broadcast_change()`, called from *inside* the context lock (immediately after a successful mutation, before the guard drops) so a response is only ever returned once the write is durable.
- All 9 existing write-route call sites (4 board, 5 column) restructured to call it in place of the old standalone `broadcast_change()`.
- A `save()` failure now surfaces as a 500 via `AppError`, rather than a false-positive success response.

**Built with the same Sonnet-orchestrated, Haiku-executed workflow as KAN-1002**: the orchestrator wrote the small shared `persist_and_broadcast` helper itself (since both sub-agents' work depended on it existing first), then dispatched two Haiku sub-agents in parallel — one restructuring all 4 board write routes plus a new persistence test, one doing the identical restructuring for all 5 column write routes plus its own persistence test. The orchestrator then validated the combined result itself: full diff review, workspace build/test/clippy/fmt, a genuine revert-and-confirm-fail (both new tests fail against the pre-fix code, confirmed via assertion failure not just a compile error), and a live binary smoke test reproducing the investigation's exact scenario end-to-end.

I independently re-verified all of this myself on top of the orchestrator's validation: read every line of the diff, reran the full build/test/clippy/fmt gate, did my own from-scratch revert-and-confirm-fail (both new tests fail cleanly, everything else stays green), and ran my own live smoke test against the real binary — POST a board, confirmed the JSON file appears on disk *immediately*, synchronously, before the HTTP response even returns to the client, then killed the server and started a fresh process against the same file, which loaded it and returned the board via GET.

**Testing**: `test_post_board_persists_to_disk` (`boards_write.rs`) and `test_patch_column_persists_to_disk` (`columns_write.rs`) — both prove durability the only way that actually catches this class of bug: opening a second, independent `KanbanContext`/`JsonDataStore` against the same file after the HTTP write, rather than re-reading the same in-memory `state.ctx` the write already mutated. `cargo test --workspace` (no regressions, including the SQLite-specific cascade tests), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).