### PR TITLE
KAN-997 fix(domain): reject negative column position in UpdateColumn::execute

### DIFF
--- a/.changeset/max-kan-997.md
+++ b/.changeset/max-kan-997.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Updating a column (rename, position change, WIP limit) now rejects a negative position, matching the rule already enforced when creating a column. This closes a gap where reordering a column through the MCP server accepted a negative position with no validation at all.

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -51,6 +51,13 @@ pub struct UpdateColumn {
 impl UpdateColumn {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         let mut column = context.get_column(self.column_id)?;
+        if let Some(position) = self.updates.position {
+            if position < 0 {
+                return Err(KanbanError::validation(format!(
+                    "column position must be >= 0, got {position}"
+                )));
+            }
+        }
         column.update(self.updates.clone());
         context.store.upsert_column(column)?;
         Ok(())

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -288,14 +288,12 @@ mod tests {
         let tc = TestContext::new();
         let context = tc.as_command_context();
 
-        // Create a column with a valid position first.
         let board_id = Uuid::new_v4();
         let column = crate::Column::new(board_id, "Test Column", 0);
         let column_id = column.id;
         let original_position = column.position;
         tc.store.upsert_column(column).unwrap();
 
-        // Attempt to update the column with a negative position.
         let cmd = UpdateColumn {
             column_id,
             updates: ColumnUpdate {
@@ -304,12 +302,13 @@ mod tests {
             },
         };
 
-        // The command should reject the negative position before mutating.
         let err = cmd.execute(&context).unwrap_err();
         assert!(err.is_validation());
 
-        // Verify the column's position is unchanged (execute must reject before mutating).
         let column = tc.store.get_column(column_id).unwrap().unwrap();
-        assert_eq!(column.position, original_position);
+        assert_eq!(
+            column.position, original_position,
+            "execute must reject before mutating"
+        );
     }
 }

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -275,4 +275,34 @@ mod tests {
         let err = cmd.execute(&context).unwrap_err();
         assert!(err.is_validation());
     }
+
+    #[test]
+    fn test_update_column_execute_rejects_negative_position() {
+        let tc = TestContext::new();
+        let context = tc.as_command_context();
+
+        // Create a column with a valid position first.
+        let board_id = Uuid::new_v4();
+        let column = crate::Column::new(board_id, "Test Column", 0);
+        let column_id = column.id;
+        let original_position = column.position;
+        tc.store.upsert_column(column).unwrap();
+
+        // Attempt to update the column with a negative position.
+        let cmd = UpdateColumn {
+            column_id,
+            updates: ColumnUpdate {
+                position: Some(-1),
+                ..Default::default()
+            },
+        };
+
+        // The command should reject the negative position before mutating.
+        let err = cmd.execute(&context).unwrap_err();
+        assert!(err.is_validation());
+
+        // Verify the column's position is unchanged (execute must reject before mutating).
+        let column = tc.store.get_column(column_id).unwrap().unwrap();
+        assert_eq!(column.position, original_position);
+    }
 }


### PR DESCRIPTION
`Column::create` rejects `position < 0`; `Column::update` (the shared apply path for PATCH, PUT-replace, and reorder) never did. Every DTO-layer caller worked around this by re-implementing its own guard — except `kanban-mcp`'s `tool_reorder_column`, which called `ctx.reorder_column(id, req.position)` with zero validation, letting an MCP client persist a negative column position undetected.

Cheaper fix than originally scoped: rather than changing `Column::update`'s own signature (which would ripple through every caller), the guard lives in `UpdateColumn::execute` — the single call site of `Column::update` in the entire codebase, which already returns `KanbanResult<()>`. Every path that mutates a column's position (HTTP PATCH/PUT/reorder, `kanban-mcp`, `kanban-tui`, `kanban-cli`) already funnels through `ColumnCommand::Update` dispatch, so this is the one true enforcement point without a breaking change.

Verified the MCP gap actually closes: traced `ctx.reorder_column()` → `reorder_column_impl` → `update_column_impl` → dispatches the exact `UpdateColumn` command this PR fixes.

**Severity note**: discussed with Max before implementing — this was downgraded from the original card's proposal after tracing every consumer of `column.position`. It's not a crash/data-corruption risk (sorting tolerates negative values fine, nothing casts position to an array index); the one observable effect is a cosmetic numbered-label glitch in the TUI. Fixed for consistency and to close the one real (MCP) gap, not because it's dangerous.

**Testing**: `test_update_column_execute_rejects_negative_position` — asserts the command returns a validation error AND that the column's position is left unchanged (rejects before mutating). Independently verified via a from-scratch revert-and-confirm-fail. `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean).