### PR TITLE
KAN-1006 fix(persistence): detect own file writes by content, not event timing

### DIFF
--- a/.changeset/max-kan-1006.md
+++ b/.changeset/max-kan-1006.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Fixed an intermittent test failure and closed a related edge case in how the TUI detects file changes made by other processes. Own writes are now identified by comparing a stamped identifier in the saved file against the running instance, rather than guessing from how many filesystem events arrived in a short window — a guess that could occasionally be wrong under heavy load, causing the app to briefly (and incorrectly) treat its own save as an external change.

--- a/crates/kanban-persistence/src/watch/file_watcher.rs
+++ b/crates/kanban-persistence/src/watch/file_watcher.rs
@@ -2,11 +2,53 @@ use crate::traits::{ChangeDetector, ChangeEvent};
 use crate::{PersistenceError, PersistenceResult};
 use chrono::Utc;
 use notify::{RecursiveMode, Watcher};
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use tokio::sync::Mutex as TokioMutex;
+use uuid::Uuid;
+
+/// Fallback suppression window used only when ownership can't be determined
+/// from file content (non-JSON backends, unparseable/unreadable file).
+const SUPPRESS_WINDOW: Duration = Duration::from_millis(500);
+
+#[derive(Deserialize)]
+struct EnvelopeMetadataProbe {
+    metadata: MetadataInstanceProbe,
+}
+
+#[derive(Deserialize)]
+struct MetadataInstanceProbe {
+    instance_id: Uuid,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Ownership {
+    Own,
+    External,
+    Unknown,
+}
+
+/// Determine whether the file at `path` was last written by `expected`
+/// (our own instance) by comparing against the `instance_id` stamped into
+/// the JSON envelope on every save. Returns `Unknown` when this can't be
+/// determined (no expected id configured, unreadable file, non-JSON
+/// content) rather than guessing.
+fn determine_ownership(path: &Path, expected: Option<Uuid>) -> Ownership {
+    let Some(expected) = expected else {
+        return Ownership::Unknown;
+    };
+    let Ok(bytes) = std::fs::read(path) else {
+        return Ownership::Unknown;
+    };
+    match serde_json::from_slice::<EnvelopeMetadataProbe>(&bytes) {
+        Ok(probe) if probe.metadata.instance_id == expected => Ownership::Own,
+        Ok(_) => Ownership::External,
+        Err(_) => Ownership::Unknown,
+    }
+}
 
 /// File system watcher for detecting changes to the persistence file
 /// Uses the `notify` crate for cross-platform file watching
@@ -34,7 +76,8 @@ use tokio::sync::Mutex as TokioMutex;
 pub struct FileWatcher {
     tx: broadcast::Sender<ChangeEvent>,
     task_handle: Arc<TokioMutex<Option<tokio::task::JoinHandle<()>>>>,
-    suppress_remaining: Arc<AtomicUsize>,
+    own_instance_id: Arc<StdMutex<Option<Uuid>>>,
+    suppress_until: Arc<StdMutex<Option<Instant>>>,
 }
 
 impl FileWatcher {
@@ -45,28 +88,39 @@ impl FileWatcher {
         Self {
             tx,
             task_handle: Arc::new(TokioMutex::new(None)),
-            suppress_remaining: Arc::new(AtomicUsize::new(0)),
+            own_instance_id: Arc::new(StdMutex::new(None)),
+            suppress_until: Arc::new(StdMutex::new(None)),
         }
     }
 
-    /// Returns the number of events that will still be suppressed.
+    /// Record this process's own persistence instance id, so own-write
+    /// events can be identified definitively by comparing it against the
+    /// `instance_id` stamped into the saved JSON envelope, instead of
+    /// guessing from event timing/count.
+    pub fn set_own_instance_id(&self, instance_id: Uuid) {
+        *self.own_instance_id.lock().unwrap() = Some(instance_id);
+    }
+
+    /// Returns whether the fallback suppression window is currently open.
     ///
     /// Intended for tests only; not part of the stable API.
     #[doc(hidden)]
-    pub fn suppress_remaining(&self) -> usize {
-        self.suppress_remaining.load(Ordering::SeqCst)
+    pub fn is_suppressing(&self) -> bool {
+        self.suppress_until
+            .lock()
+            .unwrap()
+            .is_some_and(|deadline| Instant::now() < deadline)
     }
 
-    /// Suppress the next 2 own-write events.
+    /// Open the fallback suppression window for the next own-write.
     ///
-    /// Call immediately before each atomic rename. Each OS event from that
-    /// rename decrements the counter; when the counter reaches 0, subsequent
-    /// events are delivered normally. Using 2 is conservative — Linux fires
-    /// only 1 event per rename on the target path (after `has_our_file`
-    /// filtering), so the counter is typically fully consumed by 1 event.
+    /// Only consulted when ownership can't be determined from file content
+    /// (see [`determine_ownership`]) — e.g. non-JSON backends. Call
+    /// immediately before each atomic rename so it does not expire if the
+    /// writer is delayed.
     pub fn suppress_next_event(&self) {
-        self.suppress_remaining.store(2, Ordering::SeqCst);
-        tracing::debug!("File watcher suppress counter set to 2");
+        *self.suppress_until.lock().unwrap() = Some(Instant::now() + SUPPRESS_WINDOW);
+        tracing::debug!("File watcher suppression window opened");
     }
 }
 
@@ -81,7 +135,8 @@ impl ChangeDetector for FileWatcher {
     async fn start_watching(&self, path: PathBuf) -> PersistenceResult<()> {
         let tx = self.tx.clone();
         let task_handle = self.task_handle.clone();
-        let suppress_remaining = self.suppress_remaining.clone();
+        let own_instance_id = self.own_instance_id.clone();
+        let suppress_until = self.suppress_until.clone();
 
         // Canonicalize the parent directory rather than `path` itself, so a
         // locator that hasn't been written yet can still be watched — the OS
@@ -119,7 +174,8 @@ impl ChangeDetector for FileWatcher {
                 .expect("Canonicalized path should always have parent")
                 .to_path_buf();
             let watch_path = canonical_path.clone();
-            let suppress_remaining_clone = suppress_remaining.clone();
+            let own_instance_id_clone = own_instance_id.clone();
+            let suppress_until_clone = suppress_until.clone();
 
             match notify::recommended_watcher(move |res: notify::Result<notify::Event>| match res {
                 Ok(event) => {
@@ -144,12 +200,24 @@ impl ChangeDetector for FileWatcher {
                     }
 
                     if is_relevant_event && has_our_file {
-                        let suppressed = suppress_remaining_clone
-                            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
-                            .is_ok();
+                        let expected_id = *own_instance_id_clone.lock().unwrap();
+                        let suppressed = match determine_ownership(&watch_path, expected_id) {
+                            Ownership::Own => true,
+                            Ownership::External => false,
+                            Ownership::Unknown => {
+                                let mut guard = suppress_until_clone.lock().unwrap();
+                                match *guard {
+                                    Some(deadline) if Instant::now() < deadline => true,
+                                    _ => {
+                                        *guard = None;
+                                        false
+                                    }
+                                }
+                            }
+                        };
                         if suppressed {
                             tracing::debug!(
-                                "Own-write event suppressed (counter): kind={:?}, path={}",
+                                "Own-write event suppressed: kind={:?}, path={}",
                                 event.kind,
                                 watch_path.display()
                             );
@@ -340,51 +408,102 @@ mod tests {
         }
     }
 
-    /// Pure unit test: `suppress_next_event` loads the counter to 2.
-    /// No I/O, no async, no timing.
+    fn envelope_json(instance_id: Uuid) -> Vec<u8> {
+        format!(r#"{{"version":1,"metadata":{{"instance_id":"{instance_id}"}},"data":{{}}}}"#)
+            .into_bytes()
+    }
+
+    // -- determine_ownership: pure, no I/O timing, deterministic --
+
     #[test]
-    fn test_suppress_next_event_sets_counter() {
-        let watcher = FileWatcher::new();
-        assert_eq!(watcher.suppress_remaining(), 0, "counter must start at 0");
-        watcher.suppress_next_event();
+    fn test_determine_ownership_matching_instance_id_returns_own() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("own.json");
+        let id = Uuid::new_v4();
+        std::fs::write(&path, envelope_json(id)).unwrap();
+
+        assert_eq!(determine_ownership(&path, Some(id)), Ownership::Own);
+    }
+
+    #[test]
+    fn test_determine_ownership_different_instance_id_returns_external() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("external.json");
+        std::fs::write(&path, envelope_json(Uuid::new_v4())).unwrap();
+
         assert_eq!(
-            watcher.suppress_remaining(),
-            2,
-            "suppress_next_event must set counter to 2"
+            determine_ownership(&path, Some(Uuid::new_v4())),
+            Ownership::External
         );
     }
 
-    /// After our own atomic rename, the counter is decremented and no event
-    /// reaches the channel.  Replaces the 500 ms timeout test.
+    #[test]
+    fn test_determine_ownership_non_json_content_returns_unknown() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("db.sqlite");
+        std::fs::write(&path, b"SQLite format 3\0not really json").unwrap();
+
+        assert_eq!(
+            determine_ownership(&path, Some(Uuid::new_v4())),
+            Ownership::Unknown
+        );
+    }
+
+    #[test]
+    fn test_determine_ownership_no_expected_id_returns_unknown() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("own.json");
+        std::fs::write(&path, envelope_json(Uuid::new_v4())).unwrap();
+
+        assert_eq!(determine_ownership(&path, None), Ownership::Unknown);
+    }
+
+    // -- suppression window: fallback path only, used when ownership is Unknown --
+
+    #[test]
+    fn test_suppress_next_event_opens_suppression_window() {
+        let watcher = FileWatcher::new();
+        assert!(!watcher.is_suppressing(), "window must start closed");
+        watcher.suppress_next_event();
+        assert!(
+            watcher.is_suppressing(),
+            "suppress_next_event must open the window"
+        );
+    }
+
+    /// With an own instance id configured and a matching envelope on disk,
+    /// suppression is definitive: no window needs to be armed at all. This
+    /// is the regression test for the flake — an arbitrary number of raw OS
+    /// events for the same on-disk content can never leak, since each is
+    /// checked against actual content rather than a fixed count/deadline.
     #[tokio::test]
-    async fn test_own_write_decrements_suppress_counter() {
+    async fn test_own_write_with_matching_instance_id_is_suppressed_without_window() {
         use std::fs;
         use tempfile::NamedTempFile;
 
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("own.json");
-        tokio::fs::write(&file_path, b"initial").await.unwrap();
+        let my_id = Uuid::new_v4();
+        tokio::fs::write(&file_path, envelope_json(Uuid::new_v4()))
+            .await
+            .unwrap();
 
         let watcher = FileWatcher::new();
+        watcher.set_own_instance_id(my_id);
         let mut rx = watcher.subscribe();
         watcher.start_watching(file_path.clone()).await.unwrap();
         sleep(Duration::from_millis(100)).await;
 
-        watcher.suppress_next_event();
-        assert_eq!(watcher.suppress_remaining(), 2);
-
         let temp = NamedTempFile::new_in(dir.path()).unwrap();
-        std::fs::write(temp.path(), b"own write").unwrap();
+        std::fs::write(temp.path(), envelope_json(my_id)).unwrap();
         fs::rename(temp.path(), &file_path).unwrap();
 
-        // Give the OS time to deliver the event to the handler.
         sleep(Duration::from_millis(150)).await;
 
         assert!(
-            watcher.suppress_remaining() < 2,
-            "counter must have been decremented by the OS event"
+            !watcher.is_suppressing(),
+            "no window was ever opened for this write"
         );
-        // No event must have been forwarded to subscribers.
         let result = rx.try_recv();
         assert!(
             result.is_err(),
@@ -395,10 +514,49 @@ mod tests {
         watcher.stop_watching().await.unwrap();
     }
 
-    /// After the counter is exhausted, a subsequent external write IS delivered.
-    /// Guards against a "counter stuck at MAX" regression.
+    /// A definitively external write (different stamped instance id) is
+    /// delivered even while a suppression window happens to be open —
+    /// content-based detection overrides the timing fallback.
     #[tokio::test]
-    async fn test_external_write_delivered_after_counter_exhausted() {
+    async fn test_external_write_with_different_instance_id_is_delivered_even_within_window() {
+        use std::fs;
+        use tempfile::NamedTempFile;
+
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("shared.json");
+        let my_id = Uuid::new_v4();
+        tokio::fs::write(&file_path, envelope_json(my_id))
+            .await
+            .unwrap();
+
+        let watcher = FileWatcher::new();
+        watcher.set_own_instance_id(my_id);
+        let mut rx = watcher.subscribe();
+        watcher.start_watching(file_path.clone()).await.unwrap();
+        sleep(Duration::from_millis(100)).await;
+
+        watcher.suppress_next_event();
+
+        let temp = NamedTempFile::new_in(dir.path()).unwrap();
+        std::fs::write(temp.path(), envelope_json(Uuid::new_v4())).unwrap();
+        fs::rename(temp.path(), &file_path).unwrap();
+
+        let result = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+        watcher.stop_watching().await.unwrap();
+
+        assert!(
+            result.is_ok(),
+            "external write with a different instance id must be delivered even within an open suppression window, got: {:?}",
+            result
+        );
+    }
+
+    /// Fallback path: with no own instance id configured (or unparseable
+    /// content), ownership can't be determined, so the timing window is
+    /// consulted. After it expires, a subsequent write IS delivered —
+    /// guards against the window getting stuck open.
+    #[tokio::test]
+    async fn test_external_write_delivered_after_suppression_window_expires() {
         use std::fs;
         use tempfile::NamedTempFile;
 
@@ -411,14 +569,16 @@ mod tests {
         watcher.start_watching(file_path.clone()).await.unwrap();
         sleep(Duration::from_millis(100)).await;
 
-        // Own write — suppress counter counts it down.
+        // Own write — no instance id configured, falls back to the window.
         watcher.suppress_next_event();
         let temp = NamedTempFile::new_in(dir.path()).unwrap();
         std::fs::write(temp.path(), b"own write").unwrap();
         fs::rename(temp.path(), &file_path).unwrap();
-        sleep(Duration::from_millis(150)).await;
 
-        // Second rename simulates an external write after counter is exhausted.
+        // Wait past the window so it has definitively expired.
+        sleep(SUPPRESS_WINDOW + Duration::from_millis(150)).await;
+
+        // Second rename simulates an external write after the window closed.
         let temp2 = NamedTempFile::new_in(dir.path()).unwrap();
         std::fs::write(temp2.path(), b"external write").unwrap();
         fs::rename(temp2.path(), &file_path).unwrap();
@@ -428,7 +588,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "external write after counter is exhausted must fire an event, got: {:?}",
+            "external write after the suppression window expires must fire an event, got: {:?}",
             result
         );
     }

--- a/crates/kanban-persistence/src/watch/file_watcher.rs
+++ b/crates/kanban-persistence/src/watch/file_watcher.rs
@@ -112,6 +112,14 @@ impl FileWatcher {
             .is_some_and(|deadline| Instant::now() < deadline)
     }
 
+    /// Returns the currently-configured own instance id, if any.
+    ///
+    /// Intended for tests only; not part of the stable API.
+    #[doc(hidden)]
+    pub fn own_instance_id(&self) -> Option<Uuid> {
+        *self.own_instance_id.lock().unwrap()
+    }
+
     /// Open the fallback suppression window for the next own-write.
     ///
     /// Only consulted when ownership can't be determined from file content
@@ -206,13 +214,10 @@ impl ChangeDetector for FileWatcher {
                             Ownership::External => false,
                             Ownership::Unknown => {
                                 let mut guard = suppress_until_clone.lock().unwrap();
-                                match *guard {
-                                    Some(deadline) if Instant::now() < deadline => true,
-                                    _ => {
-                                        *guard = None;
-                                        false
-                                    }
-                                }
+                                let suppress =
+                                    matches!(*guard, Some(deadline) if Instant::now() < deadline);
+                                *guard = None;
+                                suppress
                             }
                         };
                         if suppressed {
@@ -328,7 +333,6 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("test.json");
 
-        // Create initial file
         tokio::fs::write(&file_path, b"initial content")
             .await
             .unwrap();
@@ -346,7 +350,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Wait for change event (with timeout)
         let result = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await;
 
         watcher.stop_watching().await.unwrap();
@@ -372,7 +375,6 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("test.json");
 
-        // Create initial file
         tokio::fs::write(&file_path, b"initial content")
             .await
             .unwrap();
@@ -391,7 +393,6 @@ mod tests {
         std::fs::write(&temp_path, b"atomic write content").unwrap();
         fs::rename(&temp_path, &file_path).unwrap();
 
-        // Wait for change event (with timeout)
         let result = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await;
 
         watcher.stop_watching().await.unwrap();
@@ -575,7 +576,6 @@ mod tests {
         std::fs::write(temp.path(), b"own write").unwrap();
         fs::rename(temp.path(), &file_path).unwrap();
 
-        // Wait past the window so it has definitively expired.
         sleep(SUPPRESS_WINDOW + Duration::from_millis(150)).await;
 
         // Second rename simulates an external write after the window closed.
@@ -593,6 +593,47 @@ mod tests {
         );
     }
 
+    /// Regression test for unbounded suppression window: a single suppress_next_event()
+    /// call should suppress only ONE event within the window, not all of them until
+    /// the window expires.
+    #[tokio::test]
+    async fn test_single_arm_only_suppresses_one_event_within_window() {
+        use std::fs;
+        use tempfile::NamedTempFile;
+
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("suppress.json");
+        tokio::fs::write(&file_path, b"initial content")
+            .await
+            .unwrap();
+
+        let watcher = FileWatcher::new();
+        let mut rx = watcher.subscribe();
+        watcher.start_watching(file_path.clone()).await.unwrap();
+        sleep(Duration::from_millis(100)).await;
+
+        watcher.suppress_next_event();
+
+        let temp1 = NamedTempFile::new_in(dir.path()).unwrap();
+        std::fs::write(temp1.path(), b"first write").unwrap();
+        fs::rename(temp1.path(), &file_path).unwrap();
+
+        sleep(Duration::from_millis(50)).await;
+
+        let temp2 = NamedTempFile::new_in(dir.path()).unwrap();
+        std::fs::write(temp2.path(), b"second write").unwrap();
+        fs::rename(temp2.path(), &file_path).unwrap();
+
+        let result = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+        watcher.stop_watching().await.unwrap();
+
+        assert!(
+            result.is_ok(),
+            "Second write within the window should be delivered after first clears it, got: {:?}",
+            result
+        );
+    }
+
     #[tokio::test]
     async fn test_file_watcher_does_not_fire_for_unrelated_temp_file() {
         use tempfile::NamedTempFile;
@@ -600,7 +641,6 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("test.json");
 
-        // Create the watched file
         tokio::fs::write(&file_path, b"initial content")
             .await
             .unwrap();

--- a/crates/kanban-server/src/watch.rs
+++ b/crates/kanban-server/src/watch.rs
@@ -22,6 +22,7 @@ pub async fn watch_for_external_changes(
     }
 
     let watcher = kanban_persistence::FileWatcher::new();
+    watcher.set_own_instance_id(state.ctx.lock().await.backend().instance_id());
     let mut rx = watcher.subscribe();
     watcher.start_watching(PathBuf::from(locator)).await?;
 

--- a/crates/kanban-server/tests/external_reload.rs
+++ b/crates/kanban-server/tests/external_reload.rs
@@ -1,3 +1,6 @@
+mod common;
+
+use common::{json_of, send};
 use kanban_persistence_json::JsonFileStore;
 use kanban_server::state::AppState;
 use kanban_server::watch::watch_for_external_changes;
@@ -73,4 +76,61 @@ async fn test_watch_for_external_changes_is_noop_for_sqlite_locator() {
     watch_for_external_changes(state, path.to_str().unwrap())
         .await
         .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_own_write_does_not_trigger_external_reload_path() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("s.json");
+
+    // "Server" side: the context the watcher will keep fresh.
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let state = AppState::new(ctx);
+
+    // Start watching for external changes — this spawns a background task that
+    // will reload + broadcast when it detects file changes.
+    watch_for_external_changes(state.clone(), path.to_str().unwrap())
+        .await
+        .unwrap();
+
+    // Subscribe to the broadcast channel BEFORE making any writes, so we capture
+    // exactly the events from our test write.
+    let mut event_rx = state.event_tx.subscribe();
+
+    // Make a board creation via the HTTP route. This internally calls
+    // persist_and_broadcast, which broadcasts event #1 immediately.
+    let req = serde_json::json!({"name": "Test Board", "card_prefix": "TB"});
+    let resp = send(&state, "POST", "/v1/boards", Some(&req)).await;
+    assert_eq!(resp.status(), axum::http::StatusCode::CREATED);
+    let _board = json_of(resp).await;
+
+    // Wait long enough for the file to be flushed (500ms debounce) and the
+    // watcher to detect the change and fire its own reload+broadcast.
+    // With the bug, the watcher doesn't know this was its own write, so it
+    // sends event #2. With the fix, it recognizes instance_id and doesn't.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    // Count how many events arrived. Use try_recv() to drain all pending events.
+    let mut event_count = 0;
+    loop {
+        match event_rx.try_recv() {
+            Ok(_) => event_count += 1,
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => break,
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => {
+                panic!("Broadcast channel lagged; increase capacity")
+            }
+            Err(tokio::sync::broadcast::error::TryRecvError::Closed) => break,
+        }
+    }
+
+    // Assert we received exactly 1 event (from persist_and_broadcast in the route).
+    // If the watcher also fired its own reload+broadcast (the bug), we'd see 2.
+    assert_eq!(
+        event_count, 1,
+        "expected exactly 1 event from persist_and_broadcast; if > 1, the watcher is firing for own writes (bug)"
+    );
 }

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -46,6 +46,7 @@ impl App {
             use kanban_persistence::ChangeDetector;
             tracing::info!("Initializing file watcher for: {}", save_file);
             let watcher = kanban_persistence::FileWatcher::new();
+            watcher.set_own_instance_id(self.ctx.backend().instance_id());
             let rx = watcher.subscribe();
             self.persistence.file_change_rx = Some(rx);
             tracing::debug!("File change broadcast receiver subscribed");

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -257,6 +257,9 @@ impl App {
         };
 
         self.ctx.replace_backend(new_backend);
+        if let Some(watcher) = &self.persistence.file_watcher {
+            watcher.set_own_instance_id(self.ctx.backend().instance_id());
+        }
         let (save_rx, completion_rx) = self.ctx.save_coordinator.reset_save_channels();
         use crate::state::snapshot::TuiSnapshot;
         if let Err(e) = snapshot.apply_to_app(self) {

--- a/crates/kanban-tui/src/state/mod.rs
+++ b/crates/kanban-tui/src/state/mod.rs
@@ -190,9 +190,8 @@ mod tests {
 
         coordinator.queue_flush();
 
-        assert_eq!(
-            watcher.suppress_remaining(),
-            0,
+        assert!(
+            !watcher.is_suppressing(),
             "queue_flush must not open the suppress window"
         );
     }

--- a/crates/kanban-tui/tests/settings_config_edit_tests.rs
+++ b/crates/kanban-tui/tests/settings_config_edit_tests.rs
@@ -476,7 +476,11 @@ async fn test_migration_complete_syncs_file_watcher_instance_id() {
     old_watcher.set_own_instance_id(old_id);
     app.persistence.file_watcher = Some(old_watcher.clone());
     assert_eq!(
-        app.persistence.file_watcher.as_ref().unwrap().own_instance_id(),
+        app.persistence
+            .file_watcher
+            .as_ref()
+            .unwrap()
+            .own_instance_id(),
         Some(old_id),
         "watcher should have the old instance_id before migration"
     );
@@ -499,7 +503,11 @@ async fn test_migration_complete_syncs_file_watcher_instance_id() {
         "migration should create a new backend with a different instance_id"
     );
     assert_eq!(
-        app.persistence.file_watcher.as_ref().unwrap().own_instance_id(),
+        app.persistence
+            .file_watcher
+            .as_ref()
+            .unwrap()
+            .own_instance_id(),
         Some(new_backend_id),
         "watcher's instance_id must be synced to the new backend's instance_id after migration"
     );

--- a/crates/kanban-tui/tests/settings_config_edit_tests.rs
+++ b/crates/kanban-tui/tests/settings_config_edit_tests.rs
@@ -464,3 +464,43 @@ fn test_apply_config_edit_syncs_prefixes() {
     assert_eq!(app.app_config.effective_default_card_prefix(), "myprefix");
     assert_eq!(app.app_config.effective_default_sprint_prefix(), "mysprint");
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_migration_complete_syncs_file_watcher_instance_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut app = helpers::setup_app_with_json_file(dir.path()).await;
+
+    // Set up a file watcher with an initial instance_id
+    let old_watcher = kanban_persistence::FileWatcher::new();
+    let old_id = uuid::Uuid::new_v4();
+    old_watcher.set_own_instance_id(old_id);
+    app.persistence.file_watcher = Some(old_watcher.clone());
+    assert_eq!(
+        app.persistence.file_watcher.as_ref().unwrap().own_instance_id(),
+        Some(old_id),
+        "watcher should have the old instance_id before migration"
+    );
+
+    // Prepare migration from JSON to SQLite
+    let old_config = app.app_config.clone();
+    let old_storage = kanban_service::config::resolve_storage_location(&app.app_config);
+    let sqlite_path = dir.path().join("migrated.sqlite");
+    app.app_config.storage_location = Some(sqlite_path.to_str().unwrap().to_string());
+
+    app.apply_storage_location_change(old_config.clone(), &old_storage);
+    app.await_migration().await;
+
+    // After migration completes, the watcher's instance_id should be synced to
+    // the new backend's instance_id (which is different from the old id since
+    // JsonFileStore::new() generates a fresh one).
+    let new_backend_id = app.ctx.backend().instance_id();
+    assert_ne!(
+        old_id, new_backend_id,
+        "migration should create a new backend with a different instance_id"
+    );
+    assert_eq!(
+        app.persistence.file_watcher.as_ref().unwrap().own_instance_id(),
+        Some(new_backend_id),
+        "watcher's instance_id must be synced to the new backend's instance_id after migration"
+    );
+}


### PR DESCRIPTION
Fixes task filtering behavior in file-change detection:

- Own writes are now identified definitively by comparing the `instance_id` stamped into every JSON envelope's metadata against the watcher's own instance id, no timing or event-count guess involved
- The old count-based suppression (a fixed budget of 2 OS events after arming) is kept only as a fallback for when ownership can't be determined from content (no instance id configured, non-JSON backend), reimplemented as a real expiring window instead of a raw counter
- Wires the backend's `instance_id()` into `FileWatcher` on startup so the TUI actually gets definitive detection instead of always falling back to the timing guess

**What**: `FileWatcher`'s own-write suppression compares stamped file content instead of counting/timing filesystem events.

**Why**: The fixed event-count budget (2 events after arming) could be exhausted by more raw OS events than expected under contended builds (e.g. Nix sandboxed test runs), letting the real own-write event leak through as a false external-change notification — the root cause of the `test_own_write_decrements_suppress_counter` flake.

**How**: Every JSON save already stamps a per-process `instance_id` into the envelope's metadata. `determine_ownership(path, expected_id)` reads the file on a matching filesystem event and compares its stamped id against the watcher's own: a match is definitively `Own`, a mismatch is definitively `External`, regardless of raw event count or delivery timing. The count-based path remains only as a fallback for content that can't establish ownership (non-JSON, no instance id configured), now expressed as an expiring `Instant`-based window rather than a raw counter.

## Found and fixed during full review (before merge)

A full 4-angle review turned up two real regressions and one correctness gap in the original version of this PR, all fixed before merge (Sonnet-orchestrated, Haiku-executed, independently re-verified by me — see below):

1. **`kanban-server` never got `set_own_instance_id` wired in.** Every one of `kanban-server`'s own writes (durable since KAN-1004) would have been treated as an external change by its own watcher, triggering a needless reload + SSE broadcast on every API write. Fixed with a one-line call in `crates/kanban-server/src/watch.rs`, plus a regression test (`test_own_write_does_not_trigger_external_reload_path`) asserting exactly one broadcast event reaches subscribers per own-write, not two.
2. **TUI live storage-backend migration reintroduced the exact bug this PR fixes.** `JsonFileStore::new` mints a fresh random `instance_id` on every construction, but `handle_migration_complete` never re-armed the watcher's cached id after `replace_backend`. After any live migration, the stale cached id would definitively *mismatch* the new file's stamped id, so every subsequent own-save got misclassified as external, permanently, until restart. Fixed by re-calling `set_own_instance_id` right after `replace_backend`, plus a new test (`test_migration_complete_syncs_file_watcher_instance_id`) and a test-only `FileWatcher::own_instance_id()` accessor.
3. **The fallback suppression window was unbounded during active editing.** The window was only cleared on *expiry*, not on successfully suppressing an event — so a single `suppress_next_event()` call swallowed every content-undeterminable event (e.g. all SQLite events, which can never resolve ownership from content) for the full 500ms, not just the one write it was armed for. During active editing (a save more often than every 500ms), the window never fully closed, silently swallowing external writes indefinitely. Fixed by unconditionally clearing the window on every check, plus a regression test (`test_single_arm_only_suppresses_one_event_within_window`).

Also removed several WHAT-comments in the test bodies flagged by the review (narrating the next line instead of explaining something non-obvious).

Two narrower, lower-severity findings were **not** fixed here and are tracked as follow-ups instead (kanban cards 1007, 1008): a residual read-time-vs-event-time race in `determine_ownership` under the same kind of scheduling contention this PR targets, and the fact that `determine_ownership`'s file read + JSON parse runs synchronously on the `notify` callback thread for every event (wasted overhead for SQLite specifically, which can never resolve ownership from content).

**Testing**: `cargo test -p kanban-persistence --lib` (38 passed, including the 3 new/regression tests above), `cargo test -p kanban-tui --lib --test settings_config_edit_tests` (355 lib + 21 in that file, all passed), `cargo test -p kanban-server --test external_reload` (3 passed), `cargo test --workspace` (0 failures), `cargo clippy --all-targets --all-features -- -D warnings` (clean, whole workspace), `cargo fmt --all --check` (clean) — all independently re-verified by me on top of the orchestrator's own validation, including a genuine revert-and-confirm-fail for each of the three fixes above.

Tracked as kanban card 1006. Originally opened as #492 on branch `fix/persistence-own-write-detection`; that PR was closed as a side effect of renaming the branch to match this repo's convention (added a changeset, which the original PR was missing).
