### PR TITLE
KAN-1005 fix(server): align file-resolution strategy with kanban-cli/kanban-mcp + clean error message

### DIFF
--- a/.changeset/max-kan-1005.md
+++ b/.changeset/max-kan-1005.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP API (no user-facing change, `kanban-server` is not yet released for general use). `kanban-server` now resolves its data file the same way `kanban-cli` and `kanban-mcp` already do: it reads the shared config file (`~/.config/kanban/config.toml`, or `KANBAN_CONFIG` override), falling back to the same default filename (`boards.json`) instead of a `kanban-server`-specific one. `KANBAN_FILE` still overrides everything, same as before.
+
+Also improves the error message when the data file can't be opened or parsed: it now names the exact file path that failed, and shows a clean message instead of a raw internal error representation.

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -1,9 +1,7 @@
 use clap::Parser;
 use kanban_core::CLI_VERSION_DISPLAY;
 use kanban_server::{app, state::AppState};
-use kanban_service::AppConfig;
-
-const DEFAULT_LOCATOR: &str = "kanban.json";
+use kanban_service::config;
 
 #[derive(Parser)]
 #[command(
@@ -14,15 +12,25 @@ const DEFAULT_LOCATOR: &str = "kanban.json";
 struct Args {}
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() {
     let _args = Args::parse();
     tracing_subscriber::fmt::init();
 
-    let locator = std::env::var("KANBAN_FILE").unwrap_or_else(|_| DEFAULT_LOCATOR.to_string());
-    let ctx = kanban_service::open_context(&locator, AppConfig::default()).await?;
+    let config = config::load();
+    let locator =
+        std::env::var("KANBAN_FILE").unwrap_or_else(|_| config::resolve_storage_location(&config));
+
+    if let Err(e) = run(&locator, config).await {
+        eprintln!("Error: failed to start kanban-server with data file '{locator}': {e}");
+        std::process::exit(1);
+    }
+}
+
+async fn run(locator: &str, config: kanban_service::AppConfig) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = kanban_service::open_context(locator, config).await?;
     let state = AppState::new(ctx);
 
-    kanban_server::watch::watch_for_external_changes(state.clone(), &locator).await?;
+    kanban_server::watch::watch_for_external_changes(state.clone(), locator).await?;
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     tracing::info!(addr = %listener.local_addr()?, "kanban-server listening");

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -26,7 +26,10 @@ async fn main() {
     }
 }
 
-async fn run(locator: &str, config: kanban_service::AppConfig) -> Result<(), Box<dyn std::error::Error>> {
+async fn run(
+    locator: &str,
+    config: kanban_service::AppConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
     let ctx = kanban_service::open_context(locator, config).await?;
     let state = AppState::new(ctx);
 

--- a/crates/kanban-server/tests/cli_error_reporting.rs
+++ b/crates/kanban-server/tests/cli_error_reporting.rs
@@ -1,0 +1,66 @@
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+use std::process::{Command as StdCommand, Stdio};
+use std::time::Duration;
+
+fn kanban_server() -> Command {
+    assert_cmd::cargo_bin_cmd!("kanban-server")
+}
+
+#[test]
+fn test_malformed_data_file_reports_path_and_clean_message() {
+    let dir = tempdir().unwrap();
+    let bad_file = dir.path().join("broken.json");
+    std::fs::write(&bad_file, r#"{"not":"a valid kanban store"}"#).unwrap();
+
+    kanban_server()
+        .env("KANBAN_FILE", &bad_file)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains(bad_file.to_str().unwrap())
+                .and(predicate::str::contains("serialization error"))
+                .and(predicate::str::contains("Serialization(").not()),
+        );
+}
+
+#[test]
+fn test_no_env_var_falls_back_to_shared_config_default() {
+    use std::thread;
+
+    let dir = tempdir().unwrap();
+
+    // Build the kanban-server binary path
+    let bin_path = assert_cmd::cargo::cargo_bin("kanban-server");
+
+    // Spawn kanban-server in the temp directory with KANBAN_FILE unset
+    let mut cmd = StdCommand::new(&bin_path);
+    cmd.current_dir(dir.path())
+        .env_remove("KANBAN_FILE")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let mut child = cmd.spawn().expect("Failed to spawn server");
+
+    // Give the server time to initialize
+    // The key behavior we're testing: without KANBAN_FILE set, the server should
+    // resolve to the shared default location (boards.json), not its old hardcoded default (kanban.json)
+    thread::sleep(Duration::from_millis(500));
+
+    // Kill the server
+    let _ = child.kill();
+    let _ = child.wait();
+
+    // Verify that kanban.json (the old default) was NOT created
+    // This proves the server is using the shared config resolution (boards.json)
+    // instead of the old hardcoded kanban.json default
+    let kanban_path = dir.path().join("kanban.json");
+
+    assert!(
+        !kanban_path.exists(),
+        "kanban.json should NOT be created - the old hardcoded default is gone. Server should use shared config default instead (boards.json)"
+    );
+}

--- a/crates/kanban-server/tests/cli_error_reporting.rs
+++ b/crates/kanban-server/tests/cli_error_reporting.rs
@@ -1,10 +1,9 @@
-mod common;
-
 use assert_cmd::Command;
 use predicates::prelude::*;
-use tempfile::tempdir;
+use std::io::{BufRead, BufReader};
 use std::process::{Command as StdCommand, Stdio};
 use std::time::Duration;
+use tempfile::tempdir;
 
 fn kanban_server() -> Command {
     assert_cmd::cargo_bin_cmd!("kanban-server")
@@ -29,38 +28,74 @@ fn test_malformed_data_file_reports_path_and_clean_message() {
 
 #[test]
 fn test_no_env_var_falls_back_to_shared_config_default() {
-    use std::thread;
-
     let dir = tempdir().unwrap();
+    let bin_path = assert_cmd::cargo_bin!("kanban-server");
 
-    // Build the kanban-server binary path
-    let bin_path = assert_cmd::cargo::cargo_bin("kanban-server");
-
-    // Spawn kanban-server in the temp directory with KANBAN_FILE unset
-    let mut cmd = StdCommand::new(&bin_path);
-    cmd.current_dir(dir.path())
+    // `tracing_subscriber::fmt::init()` (used by main.rs) defaults to stdout,
+    // not stderr — that's the stream that carries the "listening addr=..."
+    // line this test needs to read.
+    let mut child = StdCommand::new(bin_path)
+        .current_dir(dir.path())
         .env_remove("KANBAN_FILE")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .env("NO_COLOR", "1")
+        .env("RUST_LOG", "info")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn kanban-server");
 
-    let mut child = cmd.spawn().expect("Failed to spawn server");
+    let stdout = child.stdout.take().expect("stdout must be piped");
 
-    // Give the server time to initialize
-    // The key behavior we're testing: without KANBAN_FILE set, the server should
-    // resolve to the shared default location (boards.json), not its old hardcoded default (kanban.json)
-    thread::sleep(Duration::from_millis(500));
+    // `BufReader::read_line` blocks with no timeout of its own, so a deadline
+    // checked only between calls would never fire against a single stuck
+    // read — do the blocking read on a background thread and bound the wait
+    // with a channel `recv_timeout` instead.
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break, // EOF: process exited without ever logging the port
+                Ok(_) => {
+                    if let Some(idx) = line.find("addr=127.0.0.1:") {
+                        let rest = &line[idx + "addr=127.0.0.1:".len()..];
+                        if let Ok(port) = rest.trim().parse::<u16>() {
+                            let _ = tx.send(port);
+                        }
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
 
-    // Kill the server
+    let port = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("server did not report its bound port within 5s");
+
+    // A real write is required to prove which filename the server actually
+    // resolved to — the file is created lazily on first write, not at
+    // startup, so merely starting the server proves nothing either way.
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/boards"))
+        .json(&serde_json::json!({"name": "Default Location Probe", "card_prefix": "DL"}))
+        .send()
+        .expect("failed to POST board");
+    assert!(resp.status().is_success(), "POST /v1/boards must succeed");
+
     let _ = child.kill();
     let _ = child.wait();
 
-    // Verify that kanban.json (the old default) was NOT created
-    // This proves the server is using the shared config resolution (boards.json)
-    // instead of the old hardcoded kanban.json default
-    let kanban_path = dir.path().join("kanban.json");
-
     assert!(
-        !kanban_path.exists(),
-        "kanban.json should NOT be created - the old hardcoded default is gone. Server should use shared config default instead (boards.json)"
+        dir.path().join("boards.json").exists(),
+        "boards.json (the shared kanban-cli/kanban-mcp default) must be created after a write"
+    );
+    assert!(
+        !dir.path().join("kanban.json").exists(),
+        "kanban.json (the old kanban-server-specific default) must not be created"
     );
 }


### PR DESCRIPTION
`kanban-server` used its own bespoke, standalone file-resolution logic — a hardcoded default filename (`kanban.json`) that didn't even match the rest of the ecosystem, and no awareness of the shared persisted config file at all. This surfaced when Max hit a confusing, path-less error from a bare `kanban-server` invocation; further investigation showed the "bad file" theory didn't fully explain the symptom, and turned up the real, separate gap this PR fixes.

- `kanban-server` now calls `kanban_service::config::load()` (reads `~/.config/kanban/config.toml`, or `KANBAN_CONFIG` override) and `resolve_storage_location()` — the exact same functions `kanban-cli`/`kanban-mcp` already use — instead of a hardcoded literal. `KANBAN_FILE` still overrides everything, same precedence as before.
- The default locator now resolves to `boards.json`, matching the shared default, not the old `kanban-server`-specific `kanban.json`.
- Startup failures now report the actual locator path and a clean, Display-formatted message, instead of relying on Rust's default `Result`-returning-`main` behavior (which Debug-dumped the raw error enum variant with no context).

**What**: `kanban-server`'s data-file resolution and startup error reporting now match `kanban-cli`/`kanban-mcp`.

**Why**: Silently ignoring any config the user has set up (including a custom `storage_location`) and using an inconsistent default filename is a real correctness/UX gap, not just a cosmetic one — and a bad startup error with no file path made it hard to even diagnose.

**How**: `main()` is now a thin wrapper that resolves `config`/`locator` (env var override, else the shared config-driven default) and reports any startup error with both the path and a `Display`-formatted message; the actual server logic moved into a `run(locator, config)` function, keeping the original `?`-based flow intact.

I found and fixed two real bugs of my own while independently verifying this before opening the PR: `cargo fmt --all --check` failed on `main.rs` (a long function signature needing wrapping — fixed and reverified), and the new `test_no_env_var_falls_back_to_shared_config_default` test read the wrong stream and had an unenforced timeout — `tracing_subscriber::fmt::init()` defaults to stdout, not stderr, so the test's original stderr-only capture never saw the "listening" log line, and a blocking `read_line` with a deadline checked only *between* calls (not enforced *during* one) meant a genuinely stuck read would have ignored the intended 5-second bound entirely. Fixed by reading the correct stream on a background thread and bounding the wait with a channel `recv_timeout` instead — confirmed the rewritten test now fails fast and correctly against the pre-fix code (0.17s, not a hang) via a genuine revert-and-confirm-fail.

**Testing**: `test_malformed_data_file_reports_path_and_clean_message` and `test_no_env_var_falls_back_to_shared_config_default` (`crates/kanban-server/tests/cli_error_reporting.rs`) — both independently re-verified via revert-and-confirm-fail. `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean). Manually confirmed against the real binary: a fresh server with no `KANBAN_FILE` set creates `boards.json` after a write, not `kanban.json`.