### PR TITLE
KAN-720 feat(server): add card read routes (GET /v1/boards/:id/cards)

### DIFF
--- a/.changeset/max-kan-720.md
+++ b/.changeset/max-kan-720.md
@@ -1,0 +1,18 @@
+---
+bump: minor
+---
+
+`kanban-server` now exposes read routes for cards:
+
+- `GET /v1/boards/{board_id}/cards` — list a board's cards, optionally filtered
+  by `column_id`, `sprint_id`, and a new `archived` query parameter
+  (`live_only` [default], `archived_only`, or `include`). An unknown
+  `board_id` returns an empty array rather than an error, matching the
+  existing board/column list endpoints.
+- `GET /v1/boards/{board_id}/cards/{id}` — fetch a single card. Returns 404 if
+  the card doesn't exist or belongs to a different board than the one in the
+  path.
+
+Cards returned with `archived=include` or `archived=archived_only` carry a
+stamped `archived_at` timestamp so clients can distinguish archived cards from
+live ones without a separate lookup.

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -24,6 +24,7 @@ pub fn router(state: AppState) -> Router {
         .route("/health", get(health))
         .merge(crate::routes::boards::read_router())
         .merge(crate::routes::boards::write_router())
+        .merge(crate::routes::cards::read_router())
         .merge(crate::routes::columns::read_router())
         .merge(crate::routes::columns::write_router())
         .with_state(state)

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -10,6 +10,7 @@ pub mod watch;
 
 pub mod routes {
     pub mod boards;
+    pub mod cards;
     pub mod columns;
 }
 

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -1,0 +1,56 @@
+use crate::error::AppError;
+use crate::state::AppState;
+use axum::extract::{Path, Query, State};
+use axum::routing::get;
+use axum::{Json, Router};
+use kanban_domain::{CardListFilter, CardSummary};
+use kanban_service::api::ArchivedFilterDto;
+use kanban_service::api::CardResponse;
+use kanban_service::{KanbanError, KanbanOperations};
+use serde::Deserialize;
+use std::collections::HashSet;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+pub struct CardQuery {
+    pub column_id: Option<Uuid>,
+    pub sprint_id: Option<Uuid>,
+    #[serde(default)]
+    pub archived: ArchivedFilterDto,
+}
+
+async fn list_cards(
+    State(state): State<AppState>,
+    Path(board_id): Path<Uuid>,
+    Query(q): Query<CardQuery>,
+) -> Result<Json<Vec<CardSummary>>, AppError> {
+    let filter = CardListFilter {
+        board_id: Some(board_id),
+        column_id: q.column_id,
+        sprint_ids: q.sprint_id.map(|id| HashSet::from([id])),
+        archived: q.archived.into(),
+        ..Default::default()
+    };
+    let ctx = state.ctx.lock().await;
+    let cards = ctx.list_cards(filter).map_err(|e| AppError::from(&e))?;
+    Ok(Json(cards))
+}
+
+async fn get_card(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<CardResponse>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let card = ctx
+        .get_card(id)
+        .map_err(|e| AppError::from(&e))?
+        .filter(|c| c.board_id == board_id)
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Card", id)))?;
+    Ok(Json(CardResponse::from(&card)))
+}
+
+pub fn read_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/boards/{board_id}/cards", get(list_cards))
+        .route("/v1/boards/{board_id}/cards/{id}", get(get_card))
+}

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -1,0 +1,438 @@
+//! Card read routes (GET /v1/boards/{board_id}/cards, GET /v1/boards/{board_id}/cards/{id}).
+//! Read-only, no mutation, no event broadcast. Established via `tower::ServiceExt::oneshot`
+//! against the router directly, with no real TCP socket.
+
+use axum::http::StatusCode;
+use kanban_service::KanbanOperations;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+mod common;
+use common::{json_of, make_state, send};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_returns_all_board_cards_by_default() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+
+        let col1_id = ctx
+            .create_column(board_id, "Column 1".to_string(), None)
+            .unwrap()
+            .id;
+        let col2_id = ctx
+            .create_column(board_id, "Column 2".to_string(), None)
+            .unwrap()
+            .id;
+
+        let _ = ctx
+            .create_card(board_id, col1_id, "Card 1".to_string(), Default::default())
+            .unwrap()
+            .id;
+        let _ = ctx
+            .create_card(board_id, col2_id, "Card 2".to_string(), Default::default())
+            .unwrap()
+            .id;
+        let archived_card_id = ctx
+            .create_card(
+                board_id,
+                col1_id,
+                "Card 3 (archived)".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.archive_card(archived_card_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+
+    assert!(json.is_array(), "response should be an array");
+    let arr = json.as_array().unwrap();
+    assert_eq!(
+        arr.len(),
+        2,
+        "should have 2 live cards (archived one excluded by default)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_column_filter_returns_only_that_column() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let col1_id: Uuid;
+    let col2_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+
+        col1_id = ctx
+            .create_column(board_id, "Column 1".to_string(), None)
+            .unwrap()
+            .id;
+        col2_id = ctx
+            .create_column(board_id, "Column 2".to_string(), None)
+            .unwrap()
+            .id;
+
+        let _ = ctx
+            .create_card(
+                board_id,
+                col1_id,
+                "Card in Col 1".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let _ = ctx
+            .create_card(
+                board_id,
+                col1_id,
+                "Another Card in Col 1".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let _ = ctx
+            .create_card(
+                board_id,
+                col2_id,
+                "Card in Col 2".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?column_id={}", board_id, col1_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+
+    assert!(json.is_array(), "response should be an array");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 2, "should have 2 cards in column 1");
+
+    for card in arr {
+        assert_eq!(
+            card["column_id"],
+            col1_id.to_string(),
+            "all cards should be in column 1"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_sprint_filter_returns_only_that_sprint() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let sprint_id: Uuid;
+    let col_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+
+        col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+
+        sprint_id = ctx
+            .create_sprint(board_id, None, Some("Sprint 1".to_string()))
+            .unwrap()
+            .id;
+
+        let card1_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Card in Sprint".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let _ = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Card not in Sprint".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+
+        ctx.assign_card_to_sprint(card1_id, sprint_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?sprint_id={}", board_id, sprint_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+
+    assert!(json.is_array(), "response should be an array");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1, "should have 1 card in the sprint");
+    assert_eq!(arr[0]["sprint_id"], sprint_id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_archived_include_returns_live_and_archived_with_archived_at_stamped() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+
+        let _ = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Live Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let archived_card_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Archived Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+
+        ctx.archive_card(archived_card_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?archived=include", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+
+    assert!(json.is_array(), "response should be an array");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 2, "should have 2 cards (1 live, 1 archived)");
+
+    let mut archived_found = false;
+    for card in arr {
+        if card["title"] == "Archived Card" {
+            archived_found = true;
+            assert!(
+                !card["archived_at"].is_null(),
+                "archived card should have archived_at stamped"
+            );
+        } else if card["title"] == "Live Card" {
+            assert!(
+                card["archived_at"].is_null(),
+                "live card should have null archived_at on wire"
+            );
+        }
+    }
+    assert!(archived_found, "archived card should be in response");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_unknown_board_id_returns_200_empty_array() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_board_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards", random_board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "unknown board_id should return 200, not 404"
+    );
+    let json = json_of(response).await;
+    assert_eq!(json, serde_json::json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_returns_card_response_for_existing_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let card_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+
+        card_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Test Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards/{}", board_id, card_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+
+    assert_eq!(json["id"], card_id.to_string());
+    assert_eq!(json["title"], "Test Card");
+    assert!(!json["id"].is_null(), "card response should have an id");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_unknown_id_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let random_card_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards/{}", board_id, random_card_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_wrong_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_a_id: Uuid;
+    let board_b_id: Uuid;
+    let card_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_a_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        board_b_id = ctx
+            .create_board("Board B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+
+        let col_a_id = ctx
+            .create_column(board_a_id, "Column in A".to_string(), None)
+            .unwrap()
+            .id;
+
+        card_id = ctx
+            .create_card(
+                board_a_id,
+                col_a_id,
+                "Card in A".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards/{}", board_b_id, card_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "card from a different board should 404"
+    );
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}

--- a/crates/kanban-service/src/api/mod.rs
+++ b/crates/kanban-service/src/api/mod.rs
@@ -5,10 +5,11 @@
 //! callers into an explicit version path.
 mod v1;
 pub use v1::{
-    ApiError, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame,
-    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
-    CreateSprintRequest, ErrorCode, Page, PageParams, Patch, ReorderColumnRequest,
-    ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest,
-    SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto,
-    UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
+    ApiError, ArchivedFilterDto, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto,
+    ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
+    CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams, Patch,
+    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
+    ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
+    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
+    UpdateSprintRequest,
 };

--- a/crates/kanban-service/src/api/v1/enums.rs
+++ b/crates/kanban-service/src/api/v1/enums.rs
@@ -3,7 +3,9 @@
 //! `snake_case` and convert to/from the domain enums via exhaustive `From` impls
 //! — a renamed or added domain variant fails to compile here (the drift guard).
 
-use kanban_domain::{CardPriority, CardStatus, SortField, SortOrder, SprintStatus, TaskListView};
+use kanban_domain::{
+    ArchivedFilter, CardPriority, CardStatus, SortField, SortOrder, SprintStatus, TaskListView,
+};
 use serde::{Deserialize, Serialize};
 
 /// Wire mirror of [`kanban_domain::SortField`].
@@ -211,6 +213,37 @@ impl From<SprintStatusDto> for SprintStatus {
     }
 }
 
+/// Wire mirror of [`kanban_domain::ArchivedFilter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ArchivedFilterDto {
+    #[default]
+    LiveOnly,
+    ArchivedOnly,
+    Include,
+}
+
+impl From<ArchivedFilterDto> for ArchivedFilter {
+    fn from(value: ArchivedFilterDto) -> Self {
+        match value {
+            ArchivedFilterDto::LiveOnly => Self::LiveOnly,
+            ArchivedFilterDto::ArchivedOnly => Self::ArchivedOnly,
+            ArchivedFilterDto::Include => Self::Include,
+        }
+    }
+}
+
+impl From<ArchivedFilter> for ArchivedFilterDto {
+    fn from(value: ArchivedFilter) -> Self {
+        match value {
+            ArchivedFilter::LiveOnly => Self::LiveOnly,
+            ArchivedFilter::ArchivedOnly => Self::ArchivedOnly,
+            ArchivedFilter::Include => Self::Include,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,6 +349,23 @@ mod tests {
         assert_eq!(f, SortFieldDto::UpdatedAt);
         let v: TaskListViewDto = serde_json::from_str("\"flat\"").unwrap();
         assert_eq!(v, TaskListViewDto::Flat);
+    }
+
+    #[test]
+    fn test_archived_filter_dto_round_trips_through_domain() {
+        for dto in [
+            ArchivedFilterDto::LiveOnly,
+            ArchivedFilterDto::ArchivedOnly,
+            ArchivedFilterDto::Include,
+        ] {
+            let domain: ArchivedFilter = dto.into();
+            assert_eq!(ArchivedFilterDto::from(domain), dto);
+        }
+    }
+
+    #[test]
+    fn test_archived_filter_dto_default_is_live_only() {
+        assert_eq!(ArchivedFilterDto::default(), ArchivedFilterDto::LiveOnly);
     }
 
     #[test]

--- a/crates/kanban-service/src/api/v1/mod.rs
+++ b/crates/kanban-service/src/api/v1/mod.rs
@@ -15,7 +15,8 @@ pub use columns::{
     UpdateColumnRequest,
 };
 pub use enums::{
-    CardPriorityDto, CardStatusDto, SortFieldDto, SortOrderDto, SprintStatusDto, TaskListViewDto,
+    ArchivedFilterDto, CardPriorityDto, CardStatusDto, SortFieldDto, SortOrderDto, SprintStatusDto,
+    TaskListViewDto,
 };
 pub use error::{ApiError, ErrorCode};
 pub use events::ChangeEventFrame;


### PR DESCRIPTION
Adds read-only card routes to kanban-server, following the same board-scoped pattern already used for boards and columns:

- `GET /v1/boards/{board_id}/cards` — lists a board's cards, filterable by `column_id`, `sprint_id`, and a new `archived` query parameter (`live_only` / `archived_only` / `include`). An unknown `board_id` returns `200 []` rather than a 404, matching the existing list endpoints.
- `GET /v1/boards/{board_id}/cards/{id}` — fetches a single card, returning 404 if it doesn't exist or belongs to a different board than the one in the path.

**What**: New `crates/kanban-server/src/routes/cards.rs` with `list_cards`/`get_card` handlers and a `read_router()`, merged into `app.rs`. New `ArchivedFilterDto` wire enum in `kanban-service::api::v1::enums` with bidirectional `From` conversions to/from the domain's `ArchivedFilter`.

**Why**: Card read access was the last gap in the HTTP API's read surface (boards and columns already had it). This intentionally nests under `/v1/boards/:board_id/cards` rather than the column-nested shape used by the existing card write routes (`/v1/columns/:column_id/cards`), because `CardListFilter` is itself board-scoped: passing an explicit `board_id` is what makes the underlying `filter_cards` treat the archived selector as a deliberate, scoped request instead of a global one. The existing write routes are out of scope for this PR and keep their column nesting.

**How**: `list_cards` builds a `CardListFilter` from the path's `board_id` plus the query's optional `column_id`/`sprint_id`/`archived`, and calls into the existing `list_cards` service operation — no new domain logic. `get_card` fetches by id and cross-checks `card.board_id` against the path's `board_id`, returning `AppError::from(&KanbanError::not_found(...))` on mismatch, the same cross-board guard pattern used for columns.

**Testing**: `cargo test -p kanban-server --test cards_read` (8 new tests covering default listing, column/sprint filters, `archived=include` with `archived_at` stamping, the 200-empty-array behavior for an unknown board, single-card fetch, and the two 404 cases for missing/wrong-board card ids), `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean). Also live-smoke-tested against the real binary: confirmed `200 []` for an unknown board and `404` for a card fetched through the wrong board's path.