### PR TITLE
KAN-695 feat(server): add POST /v1/commands batch execution endpoint

### DIFF
--- a/.changeset/max-kan-695.md
+++ b/.changeset/max-kan-695.md
@@ -1,0 +1,17 @@
+---
+bump: minor
+---
+
+`kanban-server` now supports batch command execution: `POST /v1/commands`
+accepts a batch of commands and runs them as a single atomic transaction,
+using the same transactional engine the desktop app and CLI use locally.
+
+- If every command in the batch succeeds, the response is
+  `{ "executed": <count> }` and one change event is broadcast to connected
+  clients for the whole batch.
+- If any command in the batch fails, the entire batch is rolled back — no
+  partial writes — and nothing is broadcast.
+
+This is the primary write path for programmatic/multi-step clients; the
+existing per-entity REST routes (create/update/delete a single board, column,
+or card) remain available as convenience wrappers for simpler cases.

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -28,5 +28,6 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::cards::write_router())
         .merge(crate::routes::columns::read_router())
         .merge(crate::routes::columns::write_router())
+        .merge(crate::routes::commands::router())
         .with_state(state)
 }

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod routes {
     pub mod boards;
     pub mod cards;
     pub mod columns;
+    pub mod commands;
 }
 
 pub mod handlers {

--- a/crates/kanban-server/src/routes/commands.rs
+++ b/crates/kanban-server/src/routes/commands.rs
@@ -1,0 +1,38 @@
+use crate::error::{AppError, AppJson};
+use crate::state::AppState;
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use kanban_domain::CommandBatch;
+use kanban_service::api::ChangeEventFrame;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct BatchResult {
+    executed: usize,
+}
+
+async fn execute_commands(
+    State(state): State<AppState>,
+    AppJson(batch): AppJson<CommandBatch>,
+) -> Result<Json<BatchResult>, AppError> {
+    let correlation_id = batch.correlation_id;
+    let issued_by = batch.issued_by;
+    let executed = batch.commands.len();
+
+    let mut ctx = state.ctx.lock().await;
+    ctx.execute(batch.commands)
+        .map_err(|e| AppError::from(&e))?;
+    ctx.save().await.map_err(|e| AppError::from(&e))?;
+    let _ = state.event_tx.send(ChangeEventFrame::now(
+        state.instance_id,
+        correlation_id,
+        issued_by,
+    ));
+
+    Ok(Json(BatchResult { executed }))
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/v1/commands", post(execute_commands))
+}

--- a/crates/kanban-server/tests/commands_endpoint.rs
+++ b/crates/kanban-server/tests/commands_endpoint.rs
@@ -1,0 +1,176 @@
+//! Batch commands endpoint tests (POST /v1/commands).
+//! Tests verify that CommandBatch execution is atomic, broadcasts exactly once
+//! with the request's correlation_id/issued_by, and properly handles errors.
+
+use axum::http::StatusCode;
+use kanban_core::ClientId;
+use kanban_domain::commands::{CardCommand, Command, CreateCard};
+use kanban_domain::{CardPriority, CommandBatch, CreateCardOptions};
+use serde_json::json;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+mod common;
+use common::{json_of, make_state, send};
+use kanban_domain::KanbanOperations;
+use kanban_server::state::AppState;
+
+async fn seed_board_and_column(state: &AppState, name: &str) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col = ctx.create_column(board_id, name.to_string(), None).unwrap();
+    (board_id, col.id)
+}
+
+fn make_create_card_command(board_id: Uuid, column_id: Uuid) -> Command {
+    Command::Card(CardCommand::Create(CreateCard {
+        id: Uuid::new_v4(),
+        card_number: 1,
+        board_id,
+        column_id,
+        title: "Task".to_string(),
+        position: 0,
+        options: CreateCardOptions {
+            description: None,
+            priority: Some(CardPriority::Medium),
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+        timestamp: chrono::Utc::now(),
+    }))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_commands_executes_batch_returns_executed_count() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, column_id) = seed_board_and_column(&state, "To Do").await;
+
+    let cmd1 = make_create_card_command(board_id, column_id);
+    let cmd2 = make_create_card_command(board_id, column_id);
+    let batch = CommandBatch::wrap(vec![cmd1, cmd2], ClientId::nil());
+    let batch_json = serde_json::to_value(&batch).unwrap();
+
+    let response = send(&state, "POST", "/v1/commands", Some(&batch_json)).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let resp_body = json_of(response).await;
+    assert_eq!(resp_body["executed"], 2);
+
+    let ctx = state.ctx.lock().await;
+    let cards = ctx.list_cards(Default::default()).unwrap();
+    assert_eq!(cards.len(), 2, "both commands should have been executed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_commands_is_atomic_partial_failure_rolls_back_whole_batch() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, column_id) = seed_board_and_column(&state, "To Do").await;
+
+    let valid_cmd = make_create_card_command(board_id, column_id);
+    let invalid_cmd = make_create_card_command(board_id, Uuid::new_v4());
+    let batch = CommandBatch::wrap(vec![valid_cmd, invalid_cmd], ClientId::nil());
+    let batch_json = serde_json::to_value(&batch).unwrap();
+
+    let response = send(&state, "POST", "/v1/commands", Some(&batch_json)).await;
+
+    assert!(
+        response.status().is_client_error() || response.status().is_server_error(),
+        "batch with invalid column should fail"
+    );
+
+    let ctx = state.ctx.lock().await;
+    let cards = ctx.list_cards(Default::default()).unwrap();
+    assert_eq!(
+        cards.len(),
+        0,
+        "no cards should exist after failed batch (rollback verified)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_commands_broadcasts_one_frame_per_batch_with_correlation_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, column_id) = seed_board_and_column(&state, "To Do").await;
+
+    let issued_by = ClientId::new();
+    let cmd = make_create_card_command(board_id, column_id);
+    let batch = CommandBatch::wrap(vec![cmd], issued_by);
+    let batch_correlation_id = batch.correlation_id;
+    let batch_issued_by = batch.issued_by;
+    let batch_json = serde_json::to_value(&batch).unwrap();
+
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(&state, "POST", "/v1/commands", Some(&batch_json)).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let frame = rx.try_recv().expect("should receive one broadcast frame");
+    assert_eq!(
+        frame.correlation_id, batch_correlation_id,
+        "frame correlation_id should match request batch"
+    );
+    assert_eq!(
+        frame.issued_by, batch_issued_by,
+        "frame issued_by should match request batch"
+    );
+
+    assert!(
+        rx.try_recv().is_err(),
+        "should only receive exactly one broadcast frame"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_commands_invalid_command_maps_to_error_status() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, _) = seed_board_and_column(&state, "To Do").await;
+    let nonexistent_column = Uuid::new_v4();
+
+    let cmd = make_create_card_command(board_id, nonexistent_column);
+    let batch = CommandBatch::wrap(vec![cmd], ClientId::nil());
+    let batch_json = serde_json::to_value(&batch).unwrap();
+
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(&state, "POST", "/v1/commands", Some(&batch_json)).await;
+
+    assert!(
+        response.status().is_client_error() || response.status().is_server_error(),
+        "should return error status for invalid command"
+    );
+
+    assert!(
+        rx.try_recv().is_err(),
+        "should not broadcast on failed batch"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_commands_malformed_body_returns_4xx() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let malformed_json = json!({});
+
+    let response = send(&state, "POST", "/v1/commands", Some(&malformed_json)).await;
+
+    let status = response.status();
+    assert!(
+        status.is_client_error(),
+        "malformed body should return 4xx, got {}",
+        status
+    );
+}

--- a/crates/kanban-server/tests/commands_endpoint.rs
+++ b/crates/kanban-server/tests/commands_endpoint.rs
@@ -81,9 +81,10 @@ async fn test_post_commands_is_atomic_partial_failure_rolls_back_whole_batch() {
 
     let response = send(&state, "POST", "/v1/commands", Some(&batch_json)).await;
 
-    assert!(
-        response.status().is_client_error() || response.status().is_server_error(),
-        "batch with invalid column should fail"
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "invalid column should surface as a 404 (KanbanError::not_found)"
     );
 
     let ctx = state.ctx.lock().await;
@@ -147,9 +148,10 @@ async fn test_post_commands_invalid_command_maps_to_error_status() {
 
     let response = send(&state, "POST", "/v1/commands", Some(&batch_json)).await;
 
-    assert!(
-        response.status().is_client_error() || response.status().is_server_error(),
-        "should return error status for invalid command"
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "invalid command should surface as a 404 (KanbanError::not_found)"
     );
 
     assert!(

--- a/crates/kanban-server/tests/commands_endpoint.rs
+++ b/crates/kanban-server/tests/commands_endpoint.rs
@@ -86,6 +86,12 @@ async fn test_post_commands_is_atomic_partial_failure_rolls_back_whole_batch() {
         StatusCode::NOT_FOUND,
         "invalid column should surface as a 404 (KanbanError::not_found)"
     );
+    // A 404 alone doesn't distinguish "the handler ran and rejected the
+    // column" from "the route isn't mounted at all" (axum's own fallback for
+    // an unmatched route is also a 404, with an empty body) — assert the
+    // AppError envelope's code to prove the handler actually ran.
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "NOT_FOUND");
 
     let ctx = state.ctx.lock().await;
     let cards = ctx.list_cards(Default::default()).unwrap();
@@ -153,6 +159,11 @@ async fn test_post_commands_invalid_command_maps_to_error_status() {
         StatusCode::NOT_FOUND,
         "invalid command should surface as a 404 (KanbanError::not_found)"
     );
+    let body = json_of(response).await;
+    assert_eq!(
+        body["code"], "NOT_FOUND",
+        "must be the AppError envelope, not axum's own no-route-matched 404"
+    );
 
     assert!(
         rx.try_recv().is_err(),
@@ -169,10 +180,11 @@ async fn test_post_commands_malformed_body_returns_4xx() {
 
     let response = send(&state, "POST", "/v1/commands", Some(&malformed_json)).await;
 
-    let status = response.status();
-    assert!(
-        status.is_client_error(),
-        "malformed body should return 4xx, got {}",
-        status
+    assert_eq!(
+        response.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "malformed body should be rejected by AppJson as 422, not axum's own no-route-matched 404"
     );
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "VALIDATION_FAILED");
 }


### PR DESCRIPTION
Adds the batch command execution endpoint to kanban-server — the primary machine write path, as opposed to the per-entity REST convenience routes (boards/columns/cards CRUD, all merged).

- `POST /v1/commands` accepts a `CommandBatch` and runs it atomically through `KanbanContext::execute`, returning `{ "executed": <count> }`.

**What**: New `crates/kanban-server/src/routes/commands.rs` with a single `execute_commands` handler, merged into `app.rs`.

**Why**: `KanbanContext::execute` was already the fully-built transactional path the TUI/CLI use locally (single `with_transaction` covering the whole batch, undo-stack integration, audit logging), but had no HTTP binding. This unblocks the `HttpBackend` `CommandStore` implementation (KAN-699) and any future undo/redo-over-HTTP work.

**How**: The handler captures the request's `correlation_id`/`issued_by` before moving `batch.commands` into `ctx.execute(...)` — `execute` mints its own internal audit-log provenance (a known, separately-tracked gap, KAN-751) and does not preserve the client's ids for that purpose, so the route broadcasts a `ChangeEventFrame` using the captured values directly rather than reusing `AppState::persist_and_broadcast`/`broadcast_change` (which hardcode nil provenance). On any command failure, `with_transaction`'s snapshot/restore rolls back the entire batch and the route returns before persisting or broadcasting.

**Testing**: `cargo test -p kanban-server --test commands_endpoint` (5 tests: batch execution + count, atomicity/rollback on a partial failure, exactly-one-broadcast carrying the request's own correlation_id/issued_by, error mapping for an invalid command, and malformed-body rejection). During my own review I caught that 3 of these tests initially asserted only a status code, which happened to pass even with the route entirely removed (axum's own "no route matched" fallback is also a 4xx) — tightened them to also assert the `AppError` JSON envelope's `code` field, and re-verified via a genuine revert that all 5 now fail without the feature and pass with it. `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean). Also live-smoke-tested against the real binary: POST a two-command batch, got `{"executed":2}`, confirmed both cards persisted and readable via the existing card read route.