### PR TITLE
KAN-697 feat(service): scaffold http_backend module in kanban-service with stub HttpBackend

### DIFF
--- a/.changeset/max-kan-697.md
+++ b/.changeset/max-kan-697.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+Internal groundwork: `kanban-service` now has the scaffolding for an HTTP
+client backend (`HttpBackend`), which will let the TUI, CLI, and MCP server
+connect to a shared `kanban-server` instance over the network instead of only
+a local file. This release only adds the module skeleton — it isn't wired
+into any user-facing locator or connection flow yet, so there is no visible
+behavior change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ dependencies = [
  "kanban-persistence",
  "kanban-persistence-json",
  "kanban-persistence-sqlite",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/kanban-service/Cargo.toml
+++ b/crates/kanban-service/Cargo.toml
@@ -36,6 +36,7 @@ uuid.workspace = true
 chrono.workspace = true
 tracing.workspace = true
 tempfile.workspace = true
+reqwest.workspace = true
 
 [dev-dependencies]
 kanban-persistence-json = { path = "../kanban-persistence-json" }

--- a/crates/kanban-service/src/http_backend/client.rs
+++ b/crates/kanban-service/src/http_backend/client.rs
@@ -1,0 +1,11 @@
+//! HTTP request helpers for the HTTP backend.
+//! This module provides utilities for building requests, sending them,
+//! deserializing responses, and mapping errors.
+//!
+//! This is currently a minimal stub; real request/response handling
+//! will be added in later cards as actual HTTP operations are implemented.
+
+#[allow(dead_code)]
+pub fn build_url(base_url: &str, path: &str) -> String {
+    format!("{}{}", base_url, path)
+}

--- a/crates/kanban-service/src/http_backend/command_store.rs
+++ b/crates/kanban-service/src/http_backend/command_store.rs
@@ -1,0 +1,19 @@
+use kanban_domain::command_batch::CommandBatch;
+use kanban_domain::command_store::CommandStore;
+use kanban_domain::KanbanResult;
+
+use super::HttpBackend;
+
+impl CommandStore for HttpBackend {
+    fn append_batch(&self, _batch: &CommandBatch) -> KanbanResult<u64> {
+        Err(kanban_domain::KanbanError::unsupported("append_batch"))
+    }
+
+    fn batch_count(&self) -> KanbanResult<u64> {
+        Err(kanban_domain::KanbanError::unsupported("batch_count"))
+    }
+
+    fn load_batches(&self, _from: u64, _to: u64) -> KanbanResult<Vec<CommandBatch>> {
+        Err(kanban_domain::KanbanError::unsupported("load_batches"))
+    }
+}

--- a/crates/kanban-service/src/http_backend/data_store.rs
+++ b/crates/kanban-service/src/http_backend/data_store.rs
@@ -1,0 +1,208 @@
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{
+    ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult, Snapshot,
+    Sprint,
+};
+use uuid::Uuid;
+
+use super::HttpBackend;
+
+impl DataStore for HttpBackend {
+    fn get_board(&self, _id: Uuid) -> KanbanResult<Option<Board>> {
+        Err(kanban_domain::KanbanError::unsupported("get_board"))
+    }
+
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        Err(kanban_domain::KanbanError::unsupported("list_boards"))
+    }
+
+    fn upsert_board(&self, _board: Board) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("upsert_board"))
+    }
+
+    fn delete_board(&self, _id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("delete_board"))
+    }
+
+    fn get_column(&self, _id: Uuid) -> KanbanResult<Option<Column>> {
+        Err(kanban_domain::KanbanError::unsupported("get_column"))
+    }
+
+    fn list_columns_by_board(&self, _board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "list_columns_by_board",
+        ))
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        Err(kanban_domain::KanbanError::unsupported("list_all_columns"))
+    }
+
+    fn upsert_column(&self, _column: Column) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("upsert_column"))
+    }
+
+    fn delete_column(&self, _id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("delete_column"))
+    }
+
+    fn delete_columns_by_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "delete_columns_by_board",
+        ))
+    }
+
+    fn get_card(&self, _id: Uuid) -> KanbanResult<Option<Card>> {
+        Err(kanban_domain::KanbanError::unsupported("get_card"))
+    }
+
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        Err(kanban_domain::KanbanError::unsupported("list_all_cards"))
+    }
+
+    fn list_cards_by_column(&self, _column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "list_cards_by_column",
+        ))
+    }
+
+    fn list_cards_by_sprint(&self, _sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "list_cards_by_sprint",
+        ))
+    }
+
+    fn count_cards_in_column(&self, _column_id: Uuid) -> KanbanResult<usize> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "count_cards_in_column",
+        ))
+    }
+
+    fn count_cards_in_column_excluding(
+        &self,
+        _column_id: Uuid,
+        _exclude: &[Uuid],
+    ) -> KanbanResult<usize> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "count_cards_in_column_excluding",
+        ))
+    }
+
+    fn upsert_card(&self, _card: Card) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("upsert_card"))
+    }
+
+    fn delete_card(&self, _id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("delete_card"))
+    }
+
+    fn delete_cards_by_columns(&self, _column_ids: &[Uuid]) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "delete_cards_by_columns",
+        ))
+    }
+
+    fn clear_sprint_from_cards(
+        &self,
+        _sprint_id: Uuid,
+        _timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "clear_sprint_from_cards",
+        ))
+    }
+
+    fn get_archived_card(&self, _card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        Err(kanban_domain::KanbanError::unsupported("get_archived_card"))
+    }
+
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "list_archived_cards",
+        ))
+    }
+
+    fn insert_archived_card(&self, _ac: ArchivedCard) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "insert_archived_card",
+        ))
+    }
+
+    fn delete_archived_card(&self, _card_id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "delete_archived_card",
+        ))
+    }
+
+    fn get_archived_board(&self, _board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "get_archived_board",
+        ))
+    }
+
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "list_archived_boards",
+        ))
+    }
+
+    fn insert_archived_board(&self, _ab: ArchivedBoard) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "insert_archived_board",
+        ))
+    }
+
+    fn delete_archived_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "delete_archived_board",
+        ))
+    }
+
+    fn unarchive_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("unarchive_board"))
+    }
+
+    fn get_sprint(&self, _id: Uuid) -> KanbanResult<Option<Sprint>> {
+        Err(kanban_domain::KanbanError::unsupported("get_sprint"))
+    }
+
+    fn list_sprints_by_board(&self, _board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "list_sprints_by_board",
+        ))
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        Err(kanban_domain::KanbanError::unsupported("list_all_sprints"))
+    }
+
+    fn upsert_sprint(&self, _sprint: Sprint) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("upsert_sprint"))
+    }
+
+    fn delete_sprint(&self, _id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("delete_sprint"))
+    }
+
+    fn delete_sprints_by_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported(
+            "delete_sprints_by_board",
+        ))
+    }
+
+    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+        Err(kanban_domain::KanbanError::unsupported("get_graph"))
+    }
+
+    fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("set_graph"))
+    }
+
+    fn snapshot(&self) -> KanbanResult<Snapshot> {
+        Err(kanban_domain::KanbanError::unsupported("snapshot"))
+    }
+
+    fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("apply_snapshot"))
+    }
+}

--- a/crates/kanban-service/src/http_backend/error.rs
+++ b/crates/kanban-service/src/http_backend/error.rs
@@ -1,0 +1,14 @@
+use kanban_domain::KanbanError;
+
+/// Map a reqwest transport error to a KanbanError.
+/// Transport errors include connection refused, timeouts, DNS failures, etc.
+pub fn map_transport_error(err: reqwest::Error) -> KanbanError {
+    KanbanError::Internal(format!("http transport error: {err}"))
+}
+
+/// Map an HTTP response error (non-2xx with ApiError body) to a KanbanError.
+/// This is currently a minimal stub; fuller mapping will come in later cards
+/// as actual HTTP responses are processed.
+pub fn map_api_error(error_message: String) -> KanbanError {
+    KanbanError::Internal(format!("http api error: {error_message}"))
+}

--- a/crates/kanban-service/src/http_backend/mod.rs
+++ b/crates/kanban-service/src/http_backend/mod.rs
@@ -1,0 +1,101 @@
+use async_trait::async_trait;
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{KanbanError, KanbanResult};
+use uuid::Uuid;
+
+pub mod client;
+pub mod command_store;
+pub mod data_store;
+pub mod error;
+
+use crate::backend::KanbanBackend;
+
+/// HTTP client backend that connects to a kanban-server instance.
+/// Implements the same `KanbanBackend` interface over HTTP, allowing a TUI/CLI
+/// to work with shared boards on a remote server.
+pub struct HttpBackend {
+    base_url: String,
+    client: reqwest::blocking::Client,
+    instance_id: Uuid,
+}
+
+impl HttpBackend {
+    /// Create a new HTTP backend connected to a kanban server at the given URL.
+    /// The base URL is normalized (trailing slash removed).
+    ///
+    /// # Arguments
+    /// * `base_url` - The base URL of the kanban server (e.g., "http://localhost:8080")
+    ///
+    /// # Errors
+    /// Returns `KanbanError::Internal` if the HTTP client cannot be built.
+    pub fn new(base_url: &str) -> KanbanResult<Self> {
+        let base_url = base_url.trim_end_matches('/').to_string();
+        let client = reqwest::blocking::Client::builder()
+            .build()
+            .map_err(|e| KanbanError::Internal(format!("failed to build http client: {e}")))?;
+        Ok(Self {
+            base_url,
+            client,
+            instance_id: Uuid::new_v4(),
+        })
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn client(&self) -> &reqwest::blocking::Client {
+        &self.client
+    }
+}
+
+#[async_trait]
+impl KanbanBackend for HttpBackend {
+    fn as_data_store(&self) -> &dyn DataStore {
+        self
+    }
+
+    fn instance_id(&self) -> Uuid {
+        self.instance_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::KanbanBackend;
+
+    #[test]
+    fn test_http_backend_new_normalizes_trailing_slash() {
+        let backend = HttpBackend::new("http://localhost:8080/").unwrap();
+        assert_eq!(backend.base_url(), "http://localhost:8080");
+    }
+
+    #[test]
+    fn test_http_backend_new_mints_nonnil_instance_id() {
+        let backend = HttpBackend::new("http://localhost:8080").unwrap();
+        assert_ne!(backend.instance_id, Uuid::nil());
+    }
+
+    #[test]
+    fn test_http_backend_implements_kanban_backend_object_safe() {
+        let backend = HttpBackend::new("http://localhost:8080").unwrap();
+        let _: &dyn KanbanBackend = &backend;
+    }
+
+    #[test]
+    fn test_http_backend_as_data_store_returns_self() {
+        let backend = HttpBackend::new("http://localhost:8080").unwrap();
+        let backend_ref: &dyn KanbanBackend = &backend;
+        let _: &dyn DataStore = backend_ref.as_data_store();
+    }
+
+    #[test]
+    fn test_http_backend_stub_method_returns_unsupported_error() {
+        let backend = HttpBackend::new("http://localhost:8080").unwrap();
+        let result = backend.list_boards();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.is_unsupported());
+    }
+}

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -15,6 +15,7 @@ pub mod backend;
 mod cascade;
 pub mod config;
 mod context;
+pub mod http_backend;
 #[cfg(feature = "json")]
 pub mod json_backend;
 mod path;
@@ -28,6 +29,7 @@ pub use context::{
     BatchOperationFailure, BatchOperationResult, BoardCreateOutcome, BoardRelations,
     CardCreateOutcome, ColumnCreateOutcome, KanbanContext, SprintCreateOutcome,
 };
+pub use http_backend::HttpBackend;
 pub use path::validate_path;
 pub use store_manager::StoreManager;
 


### PR DESCRIPTION
Adds the `http_backend` module skeleton to kanban-service — a compiling `HttpBackend` struct implementing `KanbanBackend`, with every `DataStore`/`CommandStore` method stubbed. This is the foundation every other HTTP-client card (DataStore/CommandStore real implementations, lifecycle methods, StoreManager routing) builds on.

- New module `crates/kanban-service/src/http_backend/{mod,client,data_store,command_store,error}.rs`, each under 300 lines, mirroring the layout of `json_backend.rs`/`sqlite_backend.rs` but split across files per the project's file-size guideline.
- `HttpBackend { base_url, client: reqwest::blocking::Client, instance_id }`, always compiled (no feature flag — all `KanbanBackend` impls are runtime-selected modules, not gated crates).

**What**: `HttpBackend::new(base_url)` normalizes the URL and builds a blocking `reqwest` client. Every `DataStore`/`CommandStore` method returns `Err(KanbanError::unsupported("method_name"))`. `as_data_store()` returns `self`; `instance_id()` returns the minted id; every other `KanbanBackend` lifecycle method keeps its trait default.

**Why**: This scaffold is what every later HTTP-client card (real reads/writes, batch execution, SSE subscription, locator routing) implements against. It has to compile and satisfy `&dyn KanbanBackend` before any of that can start.

**How**: During grounding I found and corrected a real error in the card's original draft — it claimed `KanbanError::Unsupported` doesn't exist and said to use `KanbanError::Internal` for the stubs instead. It does exist (`Unsupported { operation: &'static str }`, with a `KanbanError::unsupported(op)` constructor) and is already the established idiom for exactly this "backend doesn't implement this yet" case — `kanban-domain`'s own `data_store.rs` uses it in its own default trait bodies, and the existing `KanbanError → ApiError` mapping already treats it as an internal-server-error code with zero extra work needed. Every stub in this PR uses `unsupported(...)`, not `Internal`. (`Internal` is still the correct choice in the one place a genuine internal fault occurs: `HttpBackend::new`'s HTTP-client-build failure.)

**Testing**: `cargo test -p kanban-service --lib http_backend` (5 tests: URL normalization, non-nil instance id, object-safety as `&dyn KanbanBackend`, `as_data_store` returns self, and a stub method's error genuinely satisfies `.is_unsupported()` — this last one is the regression test for the Unsupported-vs-Internal correction). `cargo test --workspace` (no regressions), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean). Also independently confirmed via a genuine revert that all 5 tests vanish without the module and reappear once restored, and confirmed every new file is well under the 300-line guideline (11–208 lines each).