### PR TITLE
KAN-1010 feat(service): RemoteWrites hook — KanbanBackend capability + KanbanContext execute() guard

### DIFF
--- a/.changeset/max-kan-1010.md
+++ b/.changeset/max-kan-1010.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP collaborative backend: `kanban-service` gained a `RemoteWrites` capability hook that lets a future backend delegate board/column/card create/update/delete directly to a remote server instead of applying them locally. This release has no user-visible effect — no backend uses the hook yet, and every existing local backend (JSON, SQLite, in-memory) behaves exactly as before.

--- a/crates/kanban-service/src/backend.rs
+++ b/crates/kanban-service/src/backend.rs
@@ -107,7 +107,7 @@ impl KanbanBackend for InMemoryStore {
 }
 
 #[cfg(test)]
-pub mod tests {
+pub(crate) mod tests {
     use super::*;
     use kanban_domain::InMemoryStore;
 

--- a/crates/kanban-service/src/backend.rs
+++ b/crates/kanban-service/src/backend.rs
@@ -99,7 +99,7 @@ impl KanbanBackend for InMemoryStore {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use kanban_domain::InMemoryStore;
 
@@ -152,6 +152,235 @@ mod tests {
         let store = InMemoryStore::new();
         let backend: &dyn KanbanBackend = &store;
         assert!(backend.health_checker().is_none());
+    }
+
+    #[test]
+    fn test_remote_writes_defaults_to_none_for_local_backends() {
+        let store = InMemoryStore::new();
+        let backend: &dyn KanbanBackend = &store;
+        assert!(backend.remote_writes().is_none());
+    }
+
+    pub mod test_support {
+        use crate::KanbanBackend;
+        use crate::RemoteWrites;
+        use kanban_domain::{
+            Board, BoardUpdate, Card, CardUpdate, Column, ColumnUpdate, CommandBatch, CommandStore,
+            DataStore, InMemoryStore, KanbanResult, NewBoard, NewCard, NewColumn, Snapshot,
+        };
+        use uuid::Uuid;
+
+        pub struct MockRemoteWritesImpl;
+
+        impl RemoteWrites for MockRemoteWritesImpl {
+            fn create_board(&self, _id: Option<Uuid>, _spec: &NewBoard) -> KanbanResult<Board> {
+                unimplemented!("test should not call this")
+            }
+            fn update_board(&self, _id: Uuid, _updates: &BoardUpdate) -> KanbanResult<Board> {
+                unimplemented!("test should not call this")
+            }
+            fn delete_board(&self, _id: Uuid) -> KanbanResult<()> {
+                unimplemented!("test should not call this")
+            }
+            fn create_column(&self, _board_id: Uuid, _spec: &NewColumn) -> KanbanResult<Column> {
+                unimplemented!("test should not call this")
+            }
+            fn update_column(&self, _id: Uuid, _updates: &ColumnUpdate) -> KanbanResult<Column> {
+                unimplemented!("test should not call this")
+            }
+            fn delete_column(&self, _id: Uuid) -> KanbanResult<()> {
+                unimplemented!("test should not call this")
+            }
+            fn create_card(&self, _id: Option<Uuid>, _spec: &NewCard) -> KanbanResult<Card> {
+                unimplemented!("test should not call this")
+            }
+            fn update_card(&self, _id: Uuid, _updates: &CardUpdate) -> KanbanResult<Card> {
+                unimplemented!("test should not call this")
+            }
+            fn delete_card(&self, _id: Uuid) -> KanbanResult<()> {
+                unimplemented!("test should not call this")
+            }
+        }
+
+        pub struct MockBackend {
+            inner: InMemoryStore,
+            mock: MockRemoteWritesImpl,
+        }
+
+        impl MockBackend {
+            pub fn new() -> Self {
+                Self {
+                    inner: InMemoryStore::new(),
+                    mock: MockRemoteWritesImpl,
+                }
+            }
+        }
+
+        impl Default for MockBackend {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl DataStore for MockBackend {
+            fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+                self.inner.get_board(id)
+            }
+            fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+                self.inner.list_boards()
+            }
+            fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+                self.inner.upsert_board(board)
+            }
+            fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+                self.inner.delete_board(id)
+            }
+            fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+                self.inner.get_column(id)
+            }
+            fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+                self.inner.list_columns_by_board(board_id)
+            }
+            fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+                self.inner.list_all_columns()
+            }
+            fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+                self.inner.upsert_column(column)
+            }
+            fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+                self.inner.delete_column(id)
+            }
+            fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+                self.inner.delete_columns_by_board(board_id)
+            }
+            fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+                self.inner.get_card(id)
+            }
+            fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+                self.inner.list_all_cards()
+            }
+            fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+                self.inner.list_cards_by_column(column_id)
+            }
+            fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+                self.inner.list_cards_by_sprint(sprint_id)
+            }
+            fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+                self.inner.count_cards_in_column(column_id)
+            }
+            fn count_cards_in_column_excluding(
+                &self,
+                column_id: Uuid,
+                exclude_ids: &[Uuid],
+            ) -> KanbanResult<usize> {
+                self.inner
+                    .count_cards_in_column_excluding(column_id, exclude_ids)
+            }
+            fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+                self.inner.upsert_card(card)
+            }
+            fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+                self.inner.delete_card(id)
+            }
+            fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+                self.inner.delete_cards_by_columns(column_ids)
+            }
+            fn clear_sprint_from_cards(
+                &self,
+                sprint_id: Uuid,
+                cleared_at: chrono::DateTime<chrono::Utc>,
+            ) -> KanbanResult<()> {
+                self.inner.clear_sprint_from_cards(sprint_id, cleared_at)
+            }
+            fn get_archived_card(
+                &self,
+                card_id: Uuid,
+            ) -> KanbanResult<Option<kanban_domain::ArchivedCard>> {
+                self.inner.get_archived_card(card_id)
+            }
+            fn list_archived_cards(&self) -> KanbanResult<Vec<kanban_domain::ArchivedCard>> {
+                self.inner.list_archived_cards()
+            }
+            fn insert_archived_card(&self, ac: kanban_domain::ArchivedCard) -> KanbanResult<()> {
+                self.inner.insert_archived_card(ac)
+            }
+            fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+                self.inner.delete_archived_card(card_id)
+            }
+            fn get_archived_board(
+                &self,
+                board_id: Uuid,
+            ) -> KanbanResult<Option<kanban_domain::ArchivedBoard>> {
+                self.inner.get_archived_board(board_id)
+            }
+            fn list_archived_boards(&self) -> KanbanResult<Vec<kanban_domain::ArchivedBoard>> {
+                self.inner.list_archived_boards()
+            }
+            fn insert_archived_board(&self, ab: kanban_domain::ArchivedBoard) -> KanbanResult<()> {
+                self.inner.insert_archived_board(ab)
+            }
+            fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+                self.inner.delete_archived_board(board_id)
+            }
+            fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+                self.inner.unarchive_board(board_id)
+            }
+            fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<kanban_domain::Sprint>> {
+                self.inner.get_sprint(id)
+            }
+            fn list_sprints_by_board(
+                &self,
+                board_id: Uuid,
+            ) -> KanbanResult<Vec<kanban_domain::Sprint>> {
+                self.inner.list_sprints_by_board(board_id)
+            }
+            fn list_all_sprints(&self) -> KanbanResult<Vec<kanban_domain::Sprint>> {
+                self.inner.list_all_sprints()
+            }
+            fn upsert_sprint(&self, sprint: kanban_domain::Sprint) -> KanbanResult<()> {
+                self.inner.upsert_sprint(sprint)
+            }
+            fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+                self.inner.delete_sprint(id)
+            }
+            fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+                self.inner.delete_sprints_by_board(board_id)
+            }
+            fn get_graph(&self) -> KanbanResult<kanban_domain::DependencyGraph> {
+                self.inner.get_graph()
+            }
+            fn set_graph(&self, graph: kanban_domain::DependencyGraph) -> KanbanResult<()> {
+                self.inner.set_graph(graph)
+            }
+            fn snapshot(&self) -> KanbanResult<Snapshot> {
+                self.inner.snapshot()
+            }
+            fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+                self.inner.apply_snapshot(snapshot)
+            }
+        }
+
+        impl CommandStore for MockBackend {
+            fn append_batch(&self, batch: &CommandBatch) -> KanbanResult<u64> {
+                self.inner.append_batch(batch)
+            }
+            fn batch_count(&self) -> KanbanResult<u64> {
+                self.inner.batch_count()
+            }
+            fn load_batches(&self, offset: u64, limit: u64) -> KanbanResult<Vec<CommandBatch>> {
+                self.inner.load_batches(offset, limit)
+            }
+        }
+
+        impl KanbanBackend for MockBackend {
+            fn as_data_store(&self) -> &dyn DataStore {
+                self
+            }
+
+            fn remote_writes(&self) -> Option<&dyn RemoteWrites> {
+                Some(&self.mock)
+            }
+        }
     }
 
     // SQLite KanbanBackend lifecycle tests

--- a/crates/kanban-service/src/backend.rs
+++ b/crates/kanban-service/src/backend.rs
@@ -67,6 +67,14 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
         None
     }
 
+    /// Some(...) when this backend wants create/update/delete for board/column/
+    /// card to bypass local command execution entirely (an HTTP backend, where
+    /// the remote server is authoritative). `None` (the default) for every local
+    /// backend — zero behavior change for JSON/SQLite/InMemory.
+    fn remote_writes(&self) -> Option<&dyn crate::RemoteWrites> {
+        None
+    }
+
     /// Run `f` as an atomic batch: every mutation commits or rolls
     /// back together. The default impl snapshots state before `f`
     /// runs and restores it on failure — cheap for in-memory backends,

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -15,6 +15,11 @@ impl KanbanContext {
     /// per-command inverses in reverse order, so undoing each `Fk_inv`
     /// runs against the state `Fk` itself saw at capture time.
     pub fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<()> {
+        if self.backend.remote_writes().is_some() {
+            return Err(KanbanError::unsupported(
+                "this operation is not supported over the HTTP backend in v1 (only board/column/card create/update/delete are)",
+            ));
+        }
         let backend = Arc::clone(&self.backend);
         let cmds = &commands;
         let mut per_cmd_inverses: Vec<Vec<Command>> = Vec::new();

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -1,7 +1,7 @@
 use super::KanbanContext;
 use kanban_core::{ClientId, KANBAN_VERSION};
 use kanban_domain::commands::{Command, CommandContext};
-use kanban_domain::{DataStore, KanbanResult};
+use kanban_domain::{DataStore, KanbanError, KanbanResult};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -110,5 +110,30 @@ impl KanbanContext {
 
     pub fn redo_depth(&self) -> usize {
         self.undo_stack.redo_depth()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::tests::test_support::MockBackend;
+    use kanban_core::AppConfig;
+
+    #[tokio::test]
+    async fn test_execute_returns_unsupported_when_remote_writes_present() {
+        let backend = Arc::new(MockBackend::new());
+        let mut ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+
+        let result = ctx.execute(vec![]);
+        assert!(
+            result.is_err(),
+            "execute should return an error when remote_writes is present"
+        );
+        assert!(
+            result.unwrap_err().is_unsupported(),
+            "error should be unsupported"
+        );
     }
 }

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -18,6 +18,7 @@ mod context;
 #[cfg(feature = "json")]
 pub mod json_backend;
 mod path;
+pub mod remote_writes;
 #[cfg(feature = "sqlite")]
 pub mod sqlite_backend;
 mod store_manager;
@@ -29,6 +30,7 @@ pub use context::{
     CardCreateOutcome, ColumnCreateOutcome, KanbanContext, SprintCreateOutcome,
 };
 pub use path::validate_path;
+pub use remote_writes::RemoteWrites;
 pub use store_manager::StoreManager;
 
 #[cfg(feature = "test-helpers")]

--- a/crates/kanban-service/src/remote_writes.rs
+++ b/crates/kanban-service/src/remote_writes.rs
@@ -1,0 +1,25 @@
+use kanban_domain::{
+    Board, BoardUpdate, Card, CardUpdate, Column, ColumnUpdate, KanbanResult, NewBoard, NewCard,
+    NewColumn,
+};
+use uuid::Uuid;
+
+/// Optional backend capability: delegate the nine core CRUD mutations
+/// directly to a remote authority (a `kanban-server` instance) instead of
+/// `KanbanContext`'s local command-execute-then-log path. `HttpBackend`
+/// (KAN-697) is the only real implementor; local backends (JSON/SQLite/
+/// InMemory) never override `KanbanBackend::remote_writes()`, so this trait
+/// has exactly one live implementation.
+pub trait RemoteWrites: Send + Sync {
+    fn create_board(&self, id: Option<Uuid>, spec: &NewBoard) -> KanbanResult<Board>;
+    fn update_board(&self, id: Uuid, updates: &BoardUpdate) -> KanbanResult<Board>;
+    fn delete_board(&self, id: Uuid) -> KanbanResult<()>;
+
+    fn create_column(&self, board_id: Uuid, spec: &NewColumn) -> KanbanResult<Column>;
+    fn update_column(&self, id: Uuid, updates: &ColumnUpdate) -> KanbanResult<Column>;
+    fn delete_column(&self, id: Uuid) -> KanbanResult<()>;
+
+    fn create_card(&self, id: Option<Uuid>, spec: &NewCard) -> KanbanResult<Card>;
+    fn update_card(&self, id: Uuid, updates: &CardUpdate) -> KanbanResult<Card>;
+    fn delete_card(&self, id: Uuid) -> KanbanResult<()>;
+}


### PR DESCRIPTION
Foundational capability hook for the HTTP collaborative backend epic (KAN-684):

- Adds `RemoteWrites` trait (`crates/kanban-service/src/remote_writes.rs`) with nine methods covering create/update/delete for board, column, and card
- Adds `KanbanBackend::remote_writes() -> Option<&dyn RemoteWrites>` capability hook, defaulting to `None`
- Adds a safety-net guard at the top of `KanbanContext::execute()`: when `remote_writes()` is `Some`, every mutation that doesn't go through the (not-yet-implemented) `RemoteWrites` path returns a clear `unsupported` error instead of silently misbehaving against a backend with no local write support

**What**: lets a future backend (an HTTP client talking to `kanban-server`) delegate board/column/card CRUD directly to a remote server instead of `KanbanContext`'s local command-execute-then-log path, which assumes the backend itself is authoritative.

**Why**: traced during KAN-684 design — `KanbanContext::execute()` applies commands against the local `DataStore` before logging them, which is backwards for a remote backend where the server must decide authoritative values (card numbers, cascades). No sibling card implements `RemoteWrites` yet (that's three follow-up cards, KAN-1014/1015/1016, plus the `HttpBackend` implementation, KAN-1012/1013) — this card is purely the mechanism, with zero behavior change for existing local backends (JSON/SQLite/in-memory never override the new hook).

**How**: `remote_writes()` mirrors the existing `health_checker()` capability-hook pattern already on `KanbanBackend`. The guard is checked before `with_transaction`/`DataStore` are touched at all, so it's a true no-op for every backend returning `None`.

**Testing**: `cargo test -p kanban-service` (2 new unit tests: default-is-none, execute-rejects-when-present via a mock `RemoteWrites` impl), `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check` — all clean.