### PR TITLE
KAN-1011 feat(server): flat /v1/columns/{id} and /v1/cards/{id} routes

### DIFF
--- a/.changeset/max-kan-1011.md
+++ b/.changeset/max-kan-1011.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+`kanban-server` now exposes flat, non-board-scoped routes for columns and cards: `GET/PATCH/DELETE /v1/columns/{id}` and `GET/PATCH/DELETE /v1/cards/{id}`. These behave identically to the existing board-scoped routes (`/v1/boards/{board_id}/columns/{id}`, `/v1/boards/{board_id}/cards/{id}`) but don't require the caller to know which board owns the entity up front. The existing board-scoped routes are unchanged and continue to work exactly as before.

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -26,8 +26,12 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::boards::write_router())
         .merge(crate::routes::cards::read_router())
         .merge(crate::routes::cards::write_router())
+        .merge(crate::routes::cards::flat_read_router())
+        .merge(crate::routes::cards::flat_write_router())
         .merge(crate::routes::columns::read_router())
         .merge(crate::routes::columns::write_router())
+        .merge(crate::routes::columns::flat_read_router())
+        .merge(crate::routes::columns::flat_write_router())
         .merge(crate::routes::events::router())
         .with_state(state)
 }

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -42,11 +42,9 @@ async fn get_card(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<CardResponse>, AppError> {
-    {
-        let ctx = state.ctx.lock().await;
-        require_card_in_board(&ctx, board_id, id)?;
-    }
-    let card = do_get_card(&state, id).await?;
+    let ctx = state.ctx.lock().await;
+    require_card_in_board(&ctx, board_id, id)?;
+    let card = do_get_card(&ctx, id)?;
     Ok(Json(CardResponse::from(&card)))
 }
 
@@ -64,35 +62,22 @@ fn created_status(created: bool) -> StatusCode {
     }
 }
 
-async fn do_get_card(state: &AppState, id: Uuid) -> Result<Card, AppError> {
-    let ctx = state.ctx.lock().await;
+fn do_get_card(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Card, AppError> {
     ctx.get_card(id)
         .map_err(|e| AppError::from(&e))?
         .ok_or_else(|| AppError::from(&KanbanError::not_found("Card", id)))
 }
 
-async fn do_update_card(state: &AppState, id: Uuid, updates: CardUpdate) -> Result<Card, AppError> {
-    let mut ctx = state.ctx.lock().await;
-    let card = ctx
-        .update_card(id, updates)
-        .map_err(|e| AppError::from(&e))?;
-    state
-        .persist_and_broadcast(&ctx)
-        .await
-        .map_err(|e| AppError::from(&e))?;
-    Ok(card)
+fn do_update_card(
+    ctx: &mut kanban_service::KanbanContext,
+    id: Uuid,
+    updates: CardUpdate,
+) -> Result<Card, AppError> {
+    ctx.update_card(id, updates).map_err(|e| AppError::from(&e))
 }
 
-async fn do_delete_card(state: &AppState, id: Uuid) -> Result<(), AppError> {
-    {
-        let mut ctx = state.ctx.lock().await;
-        ctx.delete_card(id).map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
-    }
-    Ok(())
+fn do_delete_card(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
+    ctx.delete_card(id).map_err(|e| AppError::from(&e))
 }
 
 /// Fetch a card and 404 unless it belongs to `board_id` — the same
@@ -153,11 +138,16 @@ async fn update_card_route(
     AppJson(req): AppJson<UpdateCardRequest>,
 ) -> Result<Json<CardResponse>, AppError> {
     let updates = CardUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
-    {
-        let ctx = state.ctx.lock().await;
+    let card = {
+        let mut ctx = state.ctx.lock().await;
         require_card_in_board(&ctx, board_id, id)?;
-    }
-    let card = do_update_card(&state, id, updates).await?;
+        let card = do_update_card(&mut ctx, id, updates)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        card
+    };
     Ok(Json(CardResponse::from(&card)))
 }
 
@@ -166,10 +156,14 @@ async fn delete_card_route(
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, AppError> {
     {
-        let ctx = state.ctx.lock().await;
+        let mut ctx = state.ctx.lock().await;
         require_card_in_board(&ctx, board_id, id)?;
+        do_delete_card(&mut ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
     }
-    do_delete_card(&state, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -187,7 +181,8 @@ async fn get_card_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<CardResponse>, AppError> {
-    let card = do_get_card(&state, id).await?;
+    let ctx = state.ctx.lock().await;
+    let card = do_get_card(&ctx, id)?;
     Ok(Json(CardResponse::from(&card)))
 }
 
@@ -197,7 +192,15 @@ async fn update_card_route_flat(
     AppJson(req): AppJson<UpdateCardRequest>,
 ) -> Result<Json<CardResponse>, AppError> {
     let updates = CardUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
-    let card = do_update_card(&state, id, updates).await?;
+    let card = {
+        let mut ctx = state.ctx.lock().await;
+        let card = do_update_card(&mut ctx, id, updates)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        card
+    };
     Ok(Json(CardResponse::from(&card)))
 }
 
@@ -205,7 +208,14 @@ async fn delete_card_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, AppError> {
-    do_delete_card(&state, id).await?;
+    {
+        let mut ctx = state.ctx.lock().await;
+        do_delete_card(&mut ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -163,3 +163,61 @@ pub fn write_router() -> Router<AppState> {
             patch(update_card_route).delete(delete_card_route),
         )
 }
+
+async fn get_card_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<CardResponse>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let card = ctx
+        .get_card(id)
+        .map_err(|e| AppError::from(&e))?
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Card", id)))?;
+    Ok(Json(CardResponse::from(&card)))
+}
+
+async fn update_card_route_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    AppJson(req): AppJson<UpdateCardRequest>,
+) -> Result<Json<CardResponse>, AppError> {
+    let updates = CardUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
+    let card = {
+        let mut ctx = state.ctx.lock().await;
+        let card = ctx
+            .update_card(id, updates)
+            .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        card
+    };
+    Ok(Json(CardResponse::from(&card)))
+}
+
+async fn delete_card_route_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.delete_card(id).map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub fn flat_read_router() -> Router<AppState> {
+    Router::new().route("/v1/cards/{id}", get(get_card_flat))
+}
+
+pub fn flat_write_router() -> Router<AppState> {
+    Router::new().route(
+        "/v1/cards/{id}",
+        patch(update_card_route_flat).delete(delete_card_route_flat),
+    )
+}

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -4,7 +4,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
-use kanban_domain::{CardListFilter, CardSummary};
+use kanban_domain::{Card, CardListFilter, CardSummary};
 use kanban_service::api::ArchivedFilterDto;
 use kanban_service::api::CardResponse;
 use kanban_service::api::{CreateCardRequest, UpdateCardRequest};
@@ -42,12 +42,11 @@ async fn get_card(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<CardResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let card = ctx
-        .get_card(id)
-        .map_err(|e| AppError::from(&e))?
-        .filter(|c| c.board_id == board_id)
-        .ok_or_else(|| AppError::from(&KanbanError::not_found("Card", id)))?;
+    {
+        let ctx = state.ctx.lock().await;
+        require_card_in_board(&ctx, board_id, id)?;
+    }
+    let card = do_get_card(&state, id).await?;
     Ok(Json(CardResponse::from(&card)))
 }
 
@@ -63,6 +62,37 @@ fn created_status(created: bool) -> StatusCode {
     } else {
         StatusCode::OK
     }
+}
+
+async fn do_get_card(state: &AppState, id: Uuid) -> Result<Card, AppError> {
+    let ctx = state.ctx.lock().await;
+    ctx.get_card(id)
+        .map_err(|e| AppError::from(&e))?
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Card", id)))
+}
+
+async fn do_update_card(state: &AppState, id: Uuid, updates: CardUpdate) -> Result<Card, AppError> {
+    let mut ctx = state.ctx.lock().await;
+    let card = ctx
+        .update_card(id, updates)
+        .map_err(|e| AppError::from(&e))?;
+    state
+        .persist_and_broadcast(&ctx)
+        .await
+        .map_err(|e| AppError::from(&e))?;
+    Ok(card)
+}
+
+async fn do_delete_card(state: &AppState, id: Uuid) -> Result<(), AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.delete_card(id).map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(())
 }
 
 /// Fetch a card and 404 unless it belongs to `board_id` — the same
@@ -123,18 +153,11 @@ async fn update_card_route(
     AppJson(req): AppJson<UpdateCardRequest>,
 ) -> Result<Json<CardResponse>, AppError> {
     let updates = CardUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
-    let card = {
-        let mut ctx = state.ctx.lock().await;
+    {
+        let ctx = state.ctx.lock().await;
         require_card_in_board(&ctx, board_id, id)?;
-        let card = ctx
-            .update_card(id, updates)
-            .map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
-        card
-    };
+    }
+    let card = do_update_card(&state, id, updates).await?;
     Ok(Json(CardResponse::from(&card)))
 }
 
@@ -143,14 +166,10 @@ async fn delete_card_route(
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let ctx = state.ctx.lock().await;
         require_card_in_board(&ctx, board_id, id)?;
-        ctx.delete_card(id).map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
     }
+    do_delete_card(&state, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -168,11 +187,7 @@ async fn get_card_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<CardResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let card = ctx
-        .get_card(id)
-        .map_err(|e| AppError::from(&e))?
-        .ok_or_else(|| AppError::from(&KanbanError::not_found("Card", id)))?;
+    let card = do_get_card(&state, id).await?;
     Ok(Json(CardResponse::from(&card)))
 }
 
@@ -182,17 +197,7 @@ async fn update_card_route_flat(
     AppJson(req): AppJson<UpdateCardRequest>,
 ) -> Result<Json<CardResponse>, AppError> {
     let updates = CardUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
-    let card = {
-        let mut ctx = state.ctx.lock().await;
-        let card = ctx
-            .update_card(id, updates)
-            .map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
-        card
-    };
+    let card = do_update_card(&state, id, updates).await?;
     Ok(Json(CardResponse::from(&card)))
 }
 
@@ -200,14 +205,7 @@ async fn delete_card_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, AppError> {
-    {
-        let mut ctx = state.ctx.lock().await;
-        ctx.delete_card(id).map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
-    }
+    do_delete_card(&state, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -4,6 +4,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
+use kanban_domain::Column;
 use kanban_service::api::ColumnResponse;
 use kanban_service::{ColumnUpdate, KanbanError, KanbanOperations};
 use uuid::Uuid;
@@ -21,12 +22,11 @@ async fn get_column(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<ColumnResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let column = ctx
-        .get_column(id)
-        .map_err(|e| AppError::from(&e))?
-        .filter(|c| c.board_id == board_id)
-        .ok_or_else(|| AppError::from(&KanbanError::not_found("Column", id)))?;
+    {
+        let ctx = state.ctx.lock().await;
+        require_column_in_board(&ctx, board_id, id)?;
+    }
+    let column = do_get_column(&state, id).await?;
     Ok(Json(ColumnResponse::from(&column)))
 }
 
@@ -42,6 +42,41 @@ fn created_status(created: bool) -> StatusCode {
     } else {
         StatusCode::OK
     }
+}
+
+async fn do_get_column(state: &AppState, id: Uuid) -> Result<Column, AppError> {
+    let ctx = state.ctx.lock().await;
+    ctx.get_column(id)
+        .map_err(|e| AppError::from(&e))?
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Column", id)))
+}
+
+async fn do_update_column(
+    state: &AppState,
+    id: Uuid,
+    updates: ColumnUpdate,
+) -> Result<Column, AppError> {
+    let mut ctx = state.ctx.lock().await;
+    let col = ctx
+        .update_column(id, updates)
+        .map_err(|e| AppError::from(&e))?;
+    state
+        .persist_and_broadcast(&ctx)
+        .await
+        .map_err(|e| AppError::from(&e))?;
+    Ok(col)
+}
+
+async fn do_delete_column(state: &AppState, id: Uuid) -> Result<(), AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.delete_column(id).map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(())
 }
 
 /// Fetch a column and 404 unless it belongs to `board_id` — the same
@@ -103,18 +138,11 @@ async fn update_column_route(
     AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
     let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
-    let col = {
-        let mut ctx = state.ctx.lock().await;
+    {
+        let ctx = state.ctx.lock().await;
         require_column_in_board(&ctx, board_id, id)?;
-        let col = ctx
-            .update_column(id, updates)
-            .map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
-        col
-    };
+    }
+    let col = do_update_column(&state, id, updates).await?;
     Ok(Json(ColumnResponse::from(&col)))
 }
 
@@ -123,14 +151,10 @@ async fn delete_column_route(
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let ctx = state.ctx.lock().await;
         require_column_in_board(&ctx, board_id, id)?;
-        ctx.delete_column(id).map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
     }
+    do_delete_column(&state, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -174,11 +198,7 @@ async fn get_column_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ColumnResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let column = ctx
-        .get_column(id)
-        .map_err(|e| AppError::from(&e))?
-        .ok_or_else(|| AppError::from(&KanbanError::not_found("Column", id)))?;
+    let column = do_get_column(&state, id).await?;
     Ok(Json(ColumnResponse::from(&column)))
 }
 
@@ -188,17 +208,7 @@ async fn update_column_route_flat(
     AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
     let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
-    let col = {
-        let mut ctx = state.ctx.lock().await;
-        let col = ctx
-            .update_column(id, updates)
-            .map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
-        col
-    };
+    let col = do_update_column(&state, id, updates).await?;
     Ok(Json(ColumnResponse::from(&col)))
 }
 
@@ -206,14 +216,7 @@ async fn delete_column_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, AppError> {
-    {
-        let mut ctx = state.ctx.lock().await;
-        ctx.delete_column(id).map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
-    }
+    do_delete_column(&state, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -2,7 +2,7 @@ use crate::error::{AppError, AppJson};
 use crate::state::AppState;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::routing::{get, post, put};
+use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use kanban_service::api::ColumnResponse;
 use kanban_service::{ColumnUpdate, KanbanError, KanbanOperations};
@@ -168,4 +168,62 @@ pub fn write_router() -> Router<AppState> {
             "/v1/boards/{board_id}/columns/{id}/reorder",
             post(reorder_column_route),
         )
+}
+
+async fn get_column_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ColumnResponse>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let column = ctx
+        .get_column(id)
+        .map_err(|e| AppError::from(&e))?
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Column", id)))?;
+    Ok(Json(ColumnResponse::from(&column)))
+}
+
+async fn update_column_route_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
+) -> Result<Json<ColumnResponse>, AppError> {
+    let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
+    let col = {
+        let mut ctx = state.ctx.lock().await;
+        let col = ctx
+            .update_column(id, updates)
+            .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        col
+    };
+    Ok(Json(ColumnResponse::from(&col)))
+}
+
+async fn delete_column_route_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.delete_column(id).map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub fn flat_read_router() -> Router<AppState> {
+    Router::new().route("/v1/columns/{id}", get(get_column_flat))
+}
+
+pub fn flat_write_router() -> Router<AppState> {
+    Router::new().route(
+        "/v1/columns/{id}",
+        patch(update_column_route_flat).delete(delete_column_route_flat),
+    )
 }

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -22,11 +22,9 @@ async fn get_column(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<ColumnResponse>, AppError> {
-    {
-        let ctx = state.ctx.lock().await;
-        require_column_in_board(&ctx, board_id, id)?;
-    }
-    let column = do_get_column(&state, id).await?;
+    let ctx = state.ctx.lock().await;
+    require_column_in_board(&ctx, board_id, id)?;
+    let column = do_get_column(&ctx, id)?;
     Ok(Json(ColumnResponse::from(&column)))
 }
 
@@ -44,39 +42,23 @@ fn created_status(created: bool) -> StatusCode {
     }
 }
 
-async fn do_get_column(state: &AppState, id: Uuid) -> Result<Column, AppError> {
-    let ctx = state.ctx.lock().await;
+fn do_get_column(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Column, AppError> {
     ctx.get_column(id)
         .map_err(|e| AppError::from(&e))?
         .ok_or_else(|| AppError::from(&KanbanError::not_found("Column", id)))
 }
 
-async fn do_update_column(
-    state: &AppState,
+fn do_update_column(
+    ctx: &mut kanban_service::KanbanContext,
     id: Uuid,
     updates: ColumnUpdate,
 ) -> Result<Column, AppError> {
-    let mut ctx = state.ctx.lock().await;
-    let col = ctx
-        .update_column(id, updates)
-        .map_err(|e| AppError::from(&e))?;
-    state
-        .persist_and_broadcast(&ctx)
-        .await
-        .map_err(|e| AppError::from(&e))?;
-    Ok(col)
+    ctx.update_column(id, updates)
+        .map_err(|e| AppError::from(&e))
 }
 
-async fn do_delete_column(state: &AppState, id: Uuid) -> Result<(), AppError> {
-    {
-        let mut ctx = state.ctx.lock().await;
-        ctx.delete_column(id).map_err(|e| AppError::from(&e))?;
-        state
-            .persist_and_broadcast(&ctx)
-            .await
-            .map_err(|e| AppError::from(&e))?;
-    }
-    Ok(())
+fn do_delete_column(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
+    ctx.delete_column(id).map_err(|e| AppError::from(&e))
 }
 
 /// Fetch a column and 404 unless it belongs to `board_id` — the same
@@ -138,11 +120,16 @@ async fn update_column_route(
     AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
     let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
-    {
-        let ctx = state.ctx.lock().await;
+    let col = {
+        let mut ctx = state.ctx.lock().await;
         require_column_in_board(&ctx, board_id, id)?;
-    }
-    let col = do_update_column(&state, id, updates).await?;
+        let col = do_update_column(&mut ctx, id, updates)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        col
+    };
     Ok(Json(ColumnResponse::from(&col)))
 }
 
@@ -151,10 +138,14 @@ async fn delete_column_route(
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, AppError> {
     {
-        let ctx = state.ctx.lock().await;
+        let mut ctx = state.ctx.lock().await;
         require_column_in_board(&ctx, board_id, id)?;
+        do_delete_column(&mut ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
     }
-    do_delete_column(&state, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -198,7 +189,8 @@ async fn get_column_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ColumnResponse>, AppError> {
-    let column = do_get_column(&state, id).await?;
+    let ctx = state.ctx.lock().await;
+    let column = do_get_column(&ctx, id)?;
     Ok(Json(ColumnResponse::from(&column)))
 }
 
@@ -208,7 +200,15 @@ async fn update_column_route_flat(
     AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
     let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
-    let col = do_update_column(&state, id, updates).await?;
+    let col = {
+        let mut ctx = state.ctx.lock().await;
+        let col = do_update_column(&mut ctx, id, updates)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        col
+    };
     Ok(Json(ColumnResponse::from(&col)))
 }
 
@@ -216,7 +216,14 @@ async fn delete_column_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, AppError> {
-    do_delete_column(&state, id).await?;
+    {
+        let mut ctx = state.ctx.lock().await;
+        do_delete_column(&mut ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/kanban-server/tests/flat_routes.rs
+++ b/crates/kanban-server/tests/flat_routes.rs
@@ -60,7 +60,13 @@ async fn test_get_column_flat_returns_same_shape_as_board_scoped() {
     let state = make_state(&dir.path().join("s.json"));
     let (board_id, col_id, _card_id) = seed_board_column_and_card(&state).await;
 
-    let board_scoped_response = send(&state, "GET", &format!("/v1/boards/{board_id}/columns/{col_id}"), None).await;
+    let board_scoped_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        None,
+    )
+    .await;
     let flat_response = send(&state, "GET", &format!("/v1/columns/{col_id}"), None).await;
 
     assert_eq!(board_scoped_response.status(), StatusCode::OK);
@@ -92,7 +98,13 @@ async fn test_patch_column_flat_updates_and_matches_board_scoped_route() {
     let flat_json = json_of(flat_response).await;
     assert_eq!(flat_json["name"], "Updated via flat");
 
-    let verify_response = send(&state, "GET", &format!("/v1/boards/{board_id}/columns/{col_id}"), None).await;
+    let verify_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        None,
+    )
+    .await;
     let verify_json = json_of(verify_response).await;
     assert_eq!(verify_json["name"], "Updated via flat");
 }
@@ -106,7 +118,13 @@ async fn test_delete_column_flat_deletes() {
     let delete_response = send(&state, "DELETE", &format!("/v1/columns/{col_id}"), None).await;
     assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
 
-    let verify_response = send(&state, "GET", &format!("/v1/boards/{board_id}/columns/{col_id}"), None).await;
+    let verify_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/columns/{col_id}"),
+        None,
+    )
+    .await;
     assert_eq!(verify_response.status(), StatusCode::NOT_FOUND);
 }
 
@@ -126,7 +144,13 @@ async fn test_get_card_flat_returns_same_shape_as_board_scoped() {
     let state = make_state(&dir.path().join("s.json"));
     let (board_id, _col_id, card_id) = seed_board_column_and_card(&state).await;
 
-    let board_scoped_response = send(&state, "GET", &format!("/v1/boards/{board_id}/cards/{card_id}"), None).await;
+    let board_scoped_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/cards/{card_id}"),
+        None,
+    )
+    .await;
     let flat_response = send(&state, "GET", &format!("/v1/cards/{card_id}"), None).await;
 
     assert_eq!(board_scoped_response.status(), StatusCode::OK);
@@ -158,7 +182,13 @@ async fn test_patch_card_flat_updates_and_matches_board_scoped_route() {
     let flat_json = json_of(flat_response).await;
     assert_eq!(flat_json["title"], "Updated via flat");
 
-    let verify_response = send(&state, "GET", &format!("/v1/boards/{board_id}/cards/{card_id}"), None).await;
+    let verify_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/cards/{card_id}"),
+        None,
+    )
+    .await;
     let verify_json = json_of(verify_response).await;
     assert_eq!(verify_json["title"], "Updated via flat");
 }
@@ -172,7 +202,13 @@ async fn test_delete_card_flat_deletes() {
     let delete_response = send(&state, "DELETE", &format!("/v1/cards/{card_id}"), None).await;
     assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
 
-    let verify_response = send(&state, "GET", &format!("/v1/boards/{board_id}/cards/{card_id}"), None).await;
+    let verify_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/cards/{card_id}"),
+        None,
+    )
+    .await;
     assert_eq!(verify_response.status(), StatusCode::NOT_FOUND);
 }
 

--- a/crates/kanban-server/tests/flat_routes.rs
+++ b/crates/kanban-server/tests/flat_routes.rs
@@ -1,0 +1,187 @@
+//! Flat entity routes: GET/PATCH/DELETE /v1/columns/{id} and /v1/cards/{id}
+//! These are aliases to the board-scoped routes, without requiring the caller
+//! to know the owning board id. Response shape is identical to board-scoped routes.
+
+use axum::http::StatusCode;
+use kanban_domain::KanbanOperations;
+use serde_json::json;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+mod common;
+use common::{json_of, make_state, send};
+use kanban_server::state::AppState;
+
+async fn seed_board_column_and_card(state: &AppState) -> (Uuid, Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col = ctx
+        .create_column(board_id, "To Do".to_string(), None)
+        .unwrap();
+    let card = ctx
+        .create_card(board_id, col.id, "Task".to_string(), Default::default())
+        .unwrap();
+    (board_id, col.id, card.id)
+}
+
+async fn seed_board_and_column(state: &AppState) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col = ctx
+        .create_column(board_id, "To Do".to_string(), None)
+        .unwrap();
+    (board_id, col.id)
+}
+
+async fn seed_board_and_card(state: &AppState) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col = ctx
+        .create_column(board_id, "To Do".to_string(), None)
+        .unwrap();
+    let card = ctx
+        .create_card(board_id, col.id, "Task".to_string(), Default::default())
+        .unwrap();
+    (board_id, card.id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_column_flat_returns_same_shape_as_board_scoped() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, col_id, _card_id) = seed_board_column_and_card(&state).await;
+
+    let board_scoped_response = send(&state, "GET", &format!("/v1/boards/{board_id}/columns/{col_id}"), None).await;
+    let flat_response = send(&state, "GET", &format!("/v1/columns/{col_id}"), None).await;
+
+    assert_eq!(board_scoped_response.status(), StatusCode::OK);
+    assert_eq!(flat_response.status(), StatusCode::OK);
+
+    let board_scoped_json = json_of(board_scoped_response).await;
+    let flat_json = json_of(flat_response).await;
+
+    assert_eq!(board_scoped_json["id"], flat_json["id"]);
+    assert_eq!(board_scoped_json["name"], flat_json["name"]);
+    assert_eq!(board_scoped_json["position"], flat_json["position"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_column_flat_updates_and_matches_board_scoped_route() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, col_id, _card_id) = seed_board_column_and_card(&state).await;
+
+    let flat_response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/columns/{col_id}"),
+        Some(&json!({"name": "Updated via flat"})),
+    )
+    .await;
+
+    assert_eq!(flat_response.status(), StatusCode::OK);
+    let flat_json = json_of(flat_response).await;
+    assert_eq!(flat_json["name"], "Updated via flat");
+
+    let verify_response = send(&state, "GET", &format!("/v1/boards/{board_id}/columns/{col_id}"), None).await;
+    let verify_json = json_of(verify_response).await;
+    assert_eq!(verify_json["name"], "Updated via flat");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_column_flat_deletes() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, col_id) = seed_board_and_column(&state).await;
+
+    let delete_response = send(&state, "DELETE", &format!("/v1/columns/{col_id}"), None).await;
+    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+
+    let verify_response = send(&state, "GET", &format!("/v1/boards/{board_id}/columns/{col_id}"), None).await;
+    assert_eq!(verify_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_column_flat_missing_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let unknown_col = Uuid::new_v4();
+
+    let response = send(&state, "GET", &format!("/v1/columns/{unknown_col}"), None).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_flat_returns_same_shape_as_board_scoped() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, _col_id, card_id) = seed_board_column_and_card(&state).await;
+
+    let board_scoped_response = send(&state, "GET", &format!("/v1/boards/{board_id}/cards/{card_id}"), None).await;
+    let flat_response = send(&state, "GET", &format!("/v1/cards/{card_id}"), None).await;
+
+    assert_eq!(board_scoped_response.status(), StatusCode::OK);
+    assert_eq!(flat_response.status(), StatusCode::OK);
+
+    let board_scoped_json = json_of(board_scoped_response).await;
+    let flat_json = json_of(flat_response).await;
+
+    assert_eq!(board_scoped_json["id"], flat_json["id"]);
+    assert_eq!(board_scoped_json["title"], flat_json["title"]);
+    assert_eq!(board_scoped_json["board_id"], flat_json["board_id"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_card_flat_updates_and_matches_board_scoped_route() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, _col_id, card_id) = seed_board_column_and_card(&state).await;
+
+    let flat_response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/cards/{card_id}"),
+        Some(&json!({"title": "Updated via flat"})),
+    )
+    .await;
+
+    assert_eq!(flat_response.status(), StatusCode::OK);
+    let flat_json = json_of(flat_response).await;
+    assert_eq!(flat_json["title"], "Updated via flat");
+
+    let verify_response = send(&state, "GET", &format!("/v1/boards/{board_id}/cards/{card_id}"), None).await;
+    let verify_json = json_of(verify_response).await;
+    assert_eq!(verify_json["title"], "Updated via flat");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_card_flat_deletes() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, card_id) = seed_board_and_card(&state).await;
+
+    let delete_response = send(&state, "DELETE", &format!("/v1/cards/{card_id}"), None).await;
+    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+
+    let verify_response = send(&state, "GET", &format!("/v1/boards/{board_id}/cards/{card_id}"), None).await;
+    assert_eq!(verify_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_flat_missing_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let unknown_card = Uuid::new_v4();
+
+    let response = send(&state, "GET", &format!("/v1/cards/{unknown_card}"), None).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Adds flat, non-board-scoped routes for columns and cards:

- `GET/PATCH/DELETE /v1/columns/{id}`
- `GET/PATCH/DELETE /v1/cards/{id}`

- Extracted shared handler logic (`do_get_column`/`do_update_column`/`do_delete_column`, and card equivalents) so board-scoped and flat handlers share the same core operation instead of duplicating it
- Fixed a lock-acquisition regression introduced mid-development: the board-scoped handlers now acquire the context lock exactly once per request (check + mutate + persist under one hold), restoring the atomicity the original board-scoped handlers had before the extraction

**What**: a client holding only a column or card id (not the owning board id) can now read or mutate it directly, without discovering the board first.

**Why**: found while designing the HTTP collaborative backend (KAN-684) — `RemoteWrites::update_column`/`delete_column`/`update_card`/`delete_card` only ever receive an entity id, but the existing write routes are board-scoped and there was no flat single-entity GET either, so a client would have had to enumerate every board's every column/card to find the right one.

**How**: new `flat_read_router()`/`flat_write_router()` in `routes/columns.rs` and `routes/cards.rs`, merged into `app::router()` alongside the existing board-scoped routers. Both route families call the same extracted `do_*` helper functions, which take an already-locked context rather than acquiring their own lock — this is what keeps every handler (board-scoped and flat) to exactly one lock acquisition.

**Testing**: `cargo test -p kanban-server` (8 new tests in `tests/flat_routes.rs`, plus all 121 pre-existing tests unaffected), `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check` — all clean.