### PR TITLE
KAN-703 test(server): promote TestServer to a test-helpers-gated library module

### DIFF
--- a/.changeset/max-kan-703.md
+++ b/.changeset/max-kan-703.md
@@ -2,8 +2,4 @@
 bump: patch
 ---
 
-Internal groundwork for the upcoming HTTP API (no user-facing change). Adds a
-real-socket integration test harness for `kanban-server` — every existing
-route test drove the router in-process without an actual network socket;
-this proves the server also works end-to-end as a real running process,
-and is the fixture future work on a collaborative HTTP backend will build on.
+Internal test infrastructure change only, no user-visible effect: `kanban-server`'s in-process test harness (`TestServer`, used to spin up a real server over a real socket for integration tests) moved from a test-only file into a `test-helpers`-feature-gated library module, so other crates in the workspace can reuse it in their own tests. Not included in the production `kanban-server` binary.

--- a/crates/kanban-server/Cargo.toml
+++ b/crates/kanban-server/Cargo.toml
@@ -31,6 +31,9 @@ kanban-persistence = { path = "../kanban-persistence", version = "^0.7" }
 kanban-service = { path = "../kanban-service", version = "^0.7" }
 prometheus = { workspace = true }
 clap = { workspace = true }
+serde_json = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+kanban-persistence-json = { path = "../kanban-persistence-json", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
@@ -40,3 +43,6 @@ kanban-persistence-json = { path = "../kanban-persistence-json" }
 serde_json = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+
+[features]
+test-helpers = ["dep:serde_json", "dep:reqwest", "dep:kanban-persistence-json"]

--- a/crates/kanban-server/Cargo.toml
+++ b/crates/kanban-server/Cargo.toml
@@ -33,7 +33,7 @@ prometheus = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
-kanban-persistence-json = { path = "../kanban-persistence-json", optional = true }
+kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.7", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -8,6 +8,9 @@ pub mod error;
 pub mod state;
 pub mod watch;
 
+#[cfg(feature = "test-helpers")]
+pub mod test_helpers;
+
 pub mod routes {
     pub mod boards;
     pub mod cards;

--- a/crates/kanban-server/src/test_helpers.rs
+++ b/crates/kanban-server/src/test_helpers.rs
@@ -1,14 +1,16 @@
-//! Shared across separate integration-test binaries; each binary only uses a
+//! Shared test utilities for `kanban-server` integration tests.
+//!
+//! This module is shared across separate integration-test binaries; each binary only uses a
 //! subset, so unused items here would otherwise warn as dead code per-binary.
 #![allow(dead_code)]
 
+use crate::app;
+use crate::state::AppState;
 use axum::body::Body;
 use axum::http::Request;
 use axum::response::Response;
 use kanban_domain::InMemoryStore;
 use kanban_persistence_json::JsonFileStore;
-use kanban_server::app;
-use kanban_server::state::AppState;
 use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
 use serde_json::Value;

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -5,8 +5,8 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_service::KanbanOperations;
 use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
 

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -1,14 +1,14 @@
+#![cfg(feature = "test-helpers")]
+
 //! Board read routes (GET /v1/boards, GET /v1/boards/{id}).
 //! Read-only, no mutation, no event broadcast. Established via `tower::ServiceExt::oneshot`
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
 use kanban_service::KanbanOperations;
+use kanban_server::test_helpers::{json_of, make_state, send};
 use tempfile::tempdir;
 use uuid::Uuid;
-
-mod common;
-use common::{json_of, make_state, send};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_boards_empty_returns_200_empty_array() {

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-helpers")]
+
 //! Board write routes (POST, PUT, PATCH, DELETE /v1/boards*).
 //! Each handler acquires the context lock, calls the seam layer, broadcasts
 //! a change event on success, then returns the appropriate status.
@@ -5,15 +7,13 @@
 use axum::http::StatusCode;
 use kanban_persistence_json::JsonFileStore;
 use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_state, send};
 use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::tempdir;
 use uuid::Uuid;
-
-mod common;
-use common::{json_of, make_state, send};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_post_board_creates_and_returns_201() {

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -1,14 +1,14 @@
+#![cfg(feature = "test-helpers")]
+
 //! Card read routes (GET /v1/boards/{board_id}/cards, GET /v1/boards/{board_id}/cards/{id}).
 //! Read-only, no mutation, no event broadcast. Established via `tower::ServiceExt::oneshot`
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
+use kanban_server::test_helpers::{json_of, make_state, send};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
-
-mod common;
-use common::{json_of, make_state, send};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_cards_returns_all_board_cards_by_default() {

--- a/crates/kanban-server/tests/cards_write.rs
+++ b/crates/kanban-server/tests/cards_write.rs
@@ -1,16 +1,16 @@
+#![cfg(feature = "test-helpers")]
+
 //! Card write routes (POST, PUT, PATCH, DELETE /v1/columns/*/cards* and /v1/boards/*/cards*).
 //! Each handler acquires the context lock, calls the seam layer, broadcasts
 //! a change event on success, then returns the appropriate status.
 
 use axum::http::StatusCode;
 use kanban_domain::KanbanOperations;
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_state, send};
 use serde_json::json;
 use tempfile::tempdir;
 use uuid::Uuid;
-
-mod common;
-use common::{json_of, make_state, send};
-use kanban_server::state::AppState;
 
 async fn seed_board(state: &AppState) -> Uuid {
     let mut ctx = state.ctx.lock().await;

--- a/crates/kanban-server/tests/columns_read.rs
+++ b/crates/kanban-server/tests/columns_read.rs
@@ -1,14 +1,14 @@
+#![cfg(feature = "test-helpers")]
+
 //! Column read routes (GET /v1/boards/{board_id}/columns, GET /v1/boards/{board_id}/columns/{id}).
 //! Read-only, no mutation, no event broadcast. Established via `tower::ServiceExt::oneshot`
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
+use kanban_server::test_helpers::{json_of, make_state, send};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
-
-mod common;
-use common::{json_of, make_state, send};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_columns_returns_board_columns_in_position_order() {

--- a/crates/kanban-server/tests/columns_write.rs
+++ b/crates/kanban-server/tests/columns_write.rs
@@ -1,16 +1,16 @@
+#![cfg(feature = "test-helpers")]
+
 //! Column write routes (POST, PUT, PATCH, DELETE /v1/boards/{id}/columns*).
 //! Each handler acquires the context lock, calls the seam layer, broadcasts
 //! a change event on success, then returns the appropriate status.
 
 use axum::http::StatusCode;
 use kanban_domain::KanbanOperations;
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_state, send};
 use serde_json::json;
 use tempfile::tempdir;
 use uuid::Uuid;
-
-mod common;
-use common::{json_of, make_state, send};
-use kanban_server::state::AppState;
 
 async fn seed_board(state: &AppState) -> Uuid {
     let mut ctx = state.ctx.lock().await;

--- a/crates/kanban-server/tests/events_sse.rs
+++ b/crates/kanban-server/tests/events_sse.rs
@@ -1,6 +1,6 @@
-mod common;
+#![cfg(feature = "test-helpers")]
 
-use common::TestServer;
+use kanban_server::test_helpers::TestServer;
 use std::time::Duration;
 
 async fn read_one_sse_frame(response: &mut reqwest::Response) -> serde_json::Value {

--- a/crates/kanban-server/tests/external_reload.rs
+++ b/crates/kanban-server/tests/external_reload.rs
@@ -1,8 +1,8 @@
-mod common;
+#![cfg(feature = "test-helpers")]
 
-use common::{json_of, send};
 use kanban_persistence_json::JsonFileStore;
 use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, send};
 use kanban_server::watch::watch_for_external_changes;
 use kanban_service::json_backend::JsonDataStore;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};

--- a/crates/kanban-server/tests/server_harness.rs
+++ b/crates/kanban-server/tests/server_harness.rs
@@ -1,6 +1,6 @@
-mod common;
+#![cfg(feature = "test-helpers")]
 
-use common::TestServer;
+use kanban_server::test_helpers::TestServer;
 use uuid::Uuid;
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Promotes `kanban-server`'s in-process integration test harness (`TestServer`) out of `tests/common/mod.rs` into `src/test_helpers.rs`, behind a new `test-helpers` Cargo feature.

- `TestServer` binds `127.0.0.1:0`, builds an `InMemoryStore`-backed `KanbanContext`, spawns `axum::serve` with graceful shutdown, and `Drop`s the spawned task as a safety net — unchanged in design, only relocated
- Also moved the smaller `make_state`/`send`/`json_of` helpers that lived alongside it in the old `tests/common/mod.rs`
- All 9 existing test files that used `mod common;` now import `kanban_server::test_helpers::*` and are gated by `#![cfg(feature = "test-helpers")]`
- `tests/common/mod.rs` is deleted

**What**: a plain `cargo test -p kanban-server` still works unchanged (the gated files compile to empty no-op test binaries without the feature); `cargo test -p kanban-server --features test-helpers` (or CI's `--all-features`) runs everything.

**Why**: a file under `tests/` is private to that crate's own integration-test binaries — there's no way for a *different* crate's `dev-dependencies` to reach it. The upcoming `kanban-backend-http` crate (KAN-697) needs `TestServer` for its own tests, so it has to live in the library, not `tests/`. This exactly mirrors the pattern `kanban-service` already uses for its own `test_helpers` module.

**How**: `test-helpers = ["dep:serde_json", "dep:reqwest", "dep:kanban-persistence-json"]` in `Cargo.toml` — these three deps are optional and only pulled in behind the feature, so the production `kanban-server` binary's dependency tree is unaffected (no `default = [...]` includes this feature).

**Testing**: `cargo test -p kanban-server --features test-helpers` (all suites green, no hanging process afterward), `cargo test -p kanban-server` (no feature, compiles clean), `cargo test --workspace --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check` — all clean.