### PR TITLE
hotfix(server): fix flat_routes.rs build break after parallel KAN-1011/KAN-703 merge

### DIFF
--- a/.changeset/max-kan-1011-hotfix.md
+++ b/.changeset/max-kan-1011-hotfix.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Fixes a `kanban-server` build break introduced by two independently-developed changes landing back to back: the flat-route integration tests (`tests/flat_routes.rs`) still referenced a test helper module that had been relocated in a parallel change, so `kanban-server` failed to compile with the `test-helpers` feature enabled. No functional change — the test file now imports from the correct location.

--- a/crates/kanban-server/tests/flat_routes.rs
+++ b/crates/kanban-server/tests/flat_routes.rs
@@ -1,16 +1,16 @@
+#![cfg(feature = "test-helpers")]
+
 //! Flat entity routes: GET/PATCH/DELETE /v1/columns/{id} and /v1/cards/{id}
 //! These are aliases to the board-scoped routes, without requiring the caller
 //! to know the owning board id. Response shape is identical to board-scoped routes.
 
 use axum::http::StatusCode;
 use kanban_domain::KanbanOperations;
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_state, send};
 use serde_json::json;
 use tempfile::tempdir;
 use uuid::Uuid;
-
-mod common;
-use common::{json_of, make_state, send};
-use kanban_server::state::AppState;
 
 async fn seed_board_column_and_card(state: &AppState) -> (Uuid, Uuid, Uuid) {
     let mut ctx = state.ctx.lock().await;


### PR DESCRIPTION
`develop` currently fails to build `kanban-server` with the `test-helpers` feature enabled (this is what several downstream consumers, including nix flake builds pinned to this repo, use).

**Root cause**: KAN-1011 (flat entity routes) and KAN-703 (`TestServer` promotion) were developed in isolated worktrees off the same base commit, in parallel. KAN-703 deleted `crates/kanban-server/tests/common/mod.rs`, moving its contents into `crates/kanban-server/src/test_helpers.rs` behind a `test-helpers` feature. KAN-1011's `tests/flat_routes.rs` was written against the old location (`mod common; use common::{...};`) and never saw KAN-703's change. Both PRs passed CI independently and merged cleanly (no textual conflict, since they touch different files) — but the combined result on `develop` doesn't compile, because `flat_routes.rs` now references a deleted module.

This is a gap in per-branch verification, not a flaw in either individual PR: each branch was tested in isolation against its own base commit, but the *integrated* `develop` after both merged was never rebuilt before now.

**Fix**: update `flat_routes.rs`'s imports to `kanban_server::test_helpers::{json_of, make_state, send}` and add the same `#![cfg(feature = "test-helpers")]` gate every other migrated test file already has. No behavior change — same 8 tests, same assertions.

**Testing**: `cargo test -p kanban-server --features test-helpers` (all 8 `flat_routes` tests + full suite green), `cargo test -p kanban-server` (no feature, compiles clean), `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo fmt --all --check` — all clean. Also reproduced the original failure via a fresh `cargo build -p kanban-server --all-features --tests` before applying the fix, and confirmed it's resolved after.