### PR TITLE
KAN-1018 feat(server): accept positional data-file argument, matching kanban-cli/kanban-mcp

### DIFF
--- a/.changeset/max-kan-1018.md
+++ b/.changeset/max-kan-1018.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+`kanban-server` now accepts the data file path as a positional argument (`kanban-server <path>`), matching `kanban-cli` and `kanban-mcp`. Previously it only read the `KANBAN_FILE` environment variable, falling back to the config file's `storage_location`. Precedence is unchanged for existing setups: an explicit positional argument now wins over `KANBAN_FILE`, which still wins over the config-file default.

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -9,16 +9,21 @@ use kanban_service::config;
     version = CLI_VERSION_DISPLAY,
     about = "HTTP API server for the kanban project management tool"
 )]
-struct Args {}
+struct Args {
+    /// Path to kanban data file (or set KANBAN_FILE env var)
+    #[arg(value_name = "FILE", env = "KANBAN_FILE")]
+    file: Option<String>,
+}
 
 #[tokio::main]
 async fn main() {
-    let _args = Args::parse();
+    let args = Args::parse();
     tracing_subscriber::fmt::init();
 
     let config = config::load();
-    let locator =
-        std::env::var("KANBAN_FILE").unwrap_or_else(|_| config::resolve_storage_location(&config));
+    let locator = args
+        .file
+        .unwrap_or_else(|| config::resolve_storage_location(&config));
 
     if let Err(e) = run(&locator, config).await {
         eprintln!("Error: failed to start kanban-server with data file '{locator}': {e}");

--- a/crates/kanban-server/tests/cli_positional_file_arg.rs
+++ b/crates/kanban-server/tests/cli_positional_file_arg.rs
@@ -1,0 +1,130 @@
+//! `kanban-server` accepts a positional data-file path, matching the
+//! established `kanban-cli`/`kanban-mcp` convention (`kanban <path>`,
+//! `kanban-mcp <path>`), rather than only reading `KANBAN_FILE`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Child, Command as StdCommand, Stdio};
+use std::time::Duration;
+use tempfile::tempdir;
+
+fn kanban_server() -> Command {
+    assert_cmd::cargo_bin_cmd!("kanban-server")
+}
+
+/// Spawns `kanban-server` with the given extra env vars and CLI args, waits
+/// for it to log its bound port on stdout, and returns the child (for
+/// cleanup) plus the port. Mirrors `cli_error_reporting.rs`'s own
+/// `test_no_env_var_falls_back_to_shared_config_default` spawn/read approach.
+fn spawn_and_wait_for_port(dir: &Path, env: &[(&str, &str)], args: &[&str]) -> (Child, u16) {
+    let bin_path = assert_cmd::cargo_bin!("kanban-server");
+
+    let mut cmd = StdCommand::new(bin_path);
+    cmd.current_dir(dir)
+        .env_remove("KANBAN_FILE")
+        .env("NO_COLOR", "1")
+        .env("RUST_LOG", "info")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd.spawn().expect("failed to spawn kanban-server");
+    let stdout = child.stdout.take().expect("stdout must be piped");
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    if let Some(idx) = line.find("addr=127.0.0.1:") {
+                        let rest = &line[idx + "addr=127.0.0.1:".len()..];
+                        if let Ok(port) = rest.trim().parse::<u16>() {
+                            let _ = tx.send(port);
+                        }
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let port = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("server did not report its bound port within 5s");
+    (child, port)
+}
+
+fn post_board(port: u16) {
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/boards"))
+        .json(&serde_json::json!({"name": "Positional Arg Probe", "card_prefix": "PA"}))
+        .send()
+        .expect("failed to POST board");
+    assert!(resp.status().is_success(), "POST /v1/boards must succeed");
+}
+
+#[test]
+fn test_positional_file_arg_is_used_when_provided() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("via-positional.json");
+
+    let (mut child, port) = spawn_and_wait_for_port(dir.path(), &[], &[target.to_str().unwrap()]);
+    post_board(port);
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        target.exists(),
+        "the positionally-specified file must be created"
+    );
+    assert!(
+        !dir.path().join("boards.json").exists(),
+        "the default filename must not be used when a positional arg is given"
+    );
+}
+
+#[test]
+fn test_positional_file_arg_takes_precedence_over_kanban_file_env() {
+    let dir = tempdir().unwrap();
+    let positional_target = dir.path().join("via-positional.json");
+    let env_target = dir.path().join("via-env.json");
+
+    let (mut child, port) = spawn_and_wait_for_port(
+        dir.path(),
+        &[("KANBAN_FILE", env_target.to_str().unwrap())],
+        &[positional_target.to_str().unwrap()],
+    );
+    post_board(port);
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        positional_target.exists(),
+        "an explicit positional argument must win over KANBAN_FILE"
+    );
+    assert!(
+        !env_target.exists(),
+        "KANBAN_FILE's file must not be used when a positional arg is also given"
+    );
+}
+
+#[test]
+fn test_help_documents_the_file_argument() {
+    kanban_server()
+        .env_remove("KANBAN_FILE")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FILE").or(predicate::str::contains("file")));
+}


### PR DESCRIPTION
`kanban-server` now accepts the data file path as a positional argument, matching `kanban-cli`/`kanban-mcp`:

- `Args` gains a `file: Option<String>` field with `value_name = "FILE"` and `env = "KANBAN_FILE"` — the exact same clap pattern `kanban-cli` already uses
- Precedence (handled by clap itself): explicit positional argument > `KANBAN_FILE` env var > config-file `storage_location` > default `boards.json`

**What**: `kanban-server /path/to/data.json` now works, instead of only `KANBAN_FILE=/path/to/data.json kanban-server`.

**Why**: found while diagnosing a `KANBAN_FILE`-resolution question — `kanban-server`'s `Args` struct had zero fields, so there was no way to pass the file as an argument at all, unlike its sibling binaries. KAN-1005 (merged) already aligned the config-file fallback default filename between `kanban-server` and `kanban-cli`/`kanban-mcp`, but explicitly did not add a positional argument — this closes that remaining gap.

**How**: mirrors `kanban-cli`'s exact `#[arg(value_name = "FILE", env = "KANBAN_FILE")]` attribute, so the precedence logic lives entirely in clap rather than a hand-rolled `std::env::var(...).unwrap_or_else(...)` check.

**Testing**: `cargo test -p kanban-server` (3 new tests in `tests/cli_positional_file_arg.rs`: positional arg is used when given, positional arg wins over `KANBAN_FILE` when both are set, `--help` documents the new argument — plus the full existing suite, including `cli_error_reporting.rs`'s `KANBAN_FILE`-only tests, unaffected), `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check` — all clean.