### PR TITLE
KAN-697 feat(backend-http): scaffold kanban-backend-http crate with stub HttpBackend

### DIFF
--- a/.changeset/max-kan-697.md
+++ b/.changeset/max-kan-697.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal groundwork for the upcoming HTTP collaborative backend: a new `kanban-backend-http` crate now exists, scaffolding `HttpBackend` (a `KanbanBackend` implementation that will eventually talk to a remote `kanban-server` over HTTP). This release has no user-visible effect — the crate isn't wired into any consumer yet, and every read/write method is an explicit stub returning "not supported." `kanban-service` itself gained no new dependencies from this work.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanban-backend-http"
+version = "0.7.2"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "kanban-core",
+ "kanban-domain",
+ "kanban-server",
+ "kanban-service",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "kanban-cli"
 version = "0.7.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/kanban-persistence-json",
     "crates/kanban-persistence-sqlite",
     "crates/kanban-service",
+    "crates/kanban-backend-http",
     "crates/kanban-tui",
     "crates/kanban-cli",
     "crates/kanban-mcp",

--- a/crates/kanban-backend-http/Cargo.toml
+++ b/crates/kanban-backend-http/Cargo.toml
@@ -26,5 +26,5 @@ uuid.workspace = true
 chrono.workspace = true
 
 [dev-dependencies]
-kanban-server = { path = "../kanban-server", version = "^0.7", features = ["test-helpers"] }
+kanban-server = { path = "../kanban-server", features = ["test-helpers"] }
 tempfile.workspace = true

--- a/crates/kanban-backend-http/Cargo.toml
+++ b/crates/kanban-backend-http/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "kanban-backend-http"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "HttpBackend: a KanbanBackend implementation backed by a remote kanban-server over HTTP"
+
+[lib]
+name = "kanban_backend_http"
+path = "src/lib.rs"
+
+[dependencies]
+kanban-core = { path = "../kanban-core", version = "^0.7" }
+kanban-domain = { path = "../kanban-domain", version = "^0.7" }
+kanban-service = { path = "../kanban-service", version = "^0.7" }
+async-trait.workspace = true
+tokio.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+uuid.workspace = true
+chrono.workspace = true
+
+[dev-dependencies]
+kanban-server = { path = "../kanban-server", version = "^0.7", features = ["test-helpers"] }
+tempfile.workspace = true

--- a/crates/kanban-backend-http/src/command_store.rs
+++ b/crates/kanban-backend-http/src/command_store.rs
@@ -1,0 +1,16 @@
+use crate::HttpBackend;
+use kanban_domain::{CommandBatch, CommandStore, KanbanError, KanbanResult};
+
+impl CommandStore for HttpBackend {
+    fn append_batch(&self, _batch: &CommandBatch) -> KanbanResult<u64> {
+        Err(KanbanError::unsupported("append_batch"))
+    }
+
+    fn batch_count(&self) -> KanbanResult<u64> {
+        Err(KanbanError::unsupported("batch_count"))
+    }
+
+    fn load_batches(&self, _offset: u64, _limit: u64) -> KanbanResult<Vec<CommandBatch>> {
+        Err(KanbanError::unsupported("load_batches"))
+    }
+}

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -1,0 +1,172 @@
+use crate::HttpBackend;
+use kanban_domain::{
+    ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
+    KanbanResult, Snapshot, Sprint,
+};
+use uuid::Uuid;
+
+impl DataStore for HttpBackend {
+    fn get_board(&self, _id: Uuid) -> KanbanResult<Option<Board>> {
+        Err(KanbanError::unsupported("get_board"))
+    }
+
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        Err(KanbanError::unsupported("list_boards"))
+    }
+
+    fn upsert_board(&self, _board: Board) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("upsert_board"))
+    }
+
+    fn delete_board(&self, _id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_board"))
+    }
+
+    fn get_column(&self, _id: Uuid) -> KanbanResult<Option<Column>> {
+        Err(KanbanError::unsupported("get_column"))
+    }
+
+    fn list_columns_by_board(&self, _board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        Err(KanbanError::unsupported("list_columns_by_board"))
+    }
+
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        Err(KanbanError::unsupported("list_all_columns"))
+    }
+
+    fn upsert_column(&self, _column: Column) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("upsert_column"))
+    }
+
+    fn delete_column(&self, _id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_column"))
+    }
+
+    fn delete_columns_by_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_columns_by_board"))
+    }
+
+    fn get_card(&self, _id: Uuid) -> KanbanResult<Option<Card>> {
+        Err(KanbanError::unsupported("get_card"))
+    }
+
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        Err(KanbanError::unsupported("list_all_cards"))
+    }
+
+    fn list_cards_by_column(&self, _column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        Err(KanbanError::unsupported("list_cards_by_column"))
+    }
+
+    fn list_cards_by_sprint(&self, _sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        Err(KanbanError::unsupported("list_cards_by_sprint"))
+    }
+
+    fn count_cards_in_column(&self, _column_id: Uuid) -> KanbanResult<usize> {
+        Err(KanbanError::unsupported("count_cards_in_column"))
+    }
+
+    fn count_cards_in_column_excluding(
+        &self,
+        _column_id: Uuid,
+        _exclude_ids: &[Uuid],
+    ) -> KanbanResult<usize> {
+        Err(KanbanError::unsupported("count_cards_in_column_excluding"))
+    }
+
+    fn upsert_card(&self, _card: Card) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("upsert_card"))
+    }
+
+    fn delete_card(&self, _id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_card"))
+    }
+
+    fn delete_cards_by_columns(&self, _column_ids: &[Uuid]) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_cards_by_columns"))
+    }
+
+    fn clear_sprint_from_cards(
+        &self,
+        _sprint_id: Uuid,
+        _timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("clear_sprint_from_cards"))
+    }
+
+    fn get_archived_card(&self, _card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        Err(KanbanError::unsupported("get_archived_card"))
+    }
+
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        Err(KanbanError::unsupported("list_archived_cards"))
+    }
+
+    fn insert_archived_card(&self, _ac: ArchivedCard) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("insert_archived_card"))
+    }
+
+    fn delete_archived_card(&self, _card_id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_archived_card"))
+    }
+
+    fn get_archived_board(&self, _board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        Err(KanbanError::unsupported("get_archived_board"))
+    }
+
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        Err(KanbanError::unsupported("list_archived_boards"))
+    }
+
+    fn insert_archived_board(&self, _ab: ArchivedBoard) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("insert_archived_board"))
+    }
+
+    fn delete_archived_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_archived_board"))
+    }
+
+    fn unarchive_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("unarchive_board"))
+    }
+
+    fn get_sprint(&self, _id: Uuid) -> KanbanResult<Option<Sprint>> {
+        Err(KanbanError::unsupported("get_sprint"))
+    }
+
+    fn list_sprints_by_board(&self, _board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        Err(KanbanError::unsupported("list_sprints_by_board"))
+    }
+
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        Err(KanbanError::unsupported("list_all_sprints"))
+    }
+
+    fn upsert_sprint(&self, _sprint: Sprint) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("upsert_sprint"))
+    }
+
+    fn delete_sprint(&self, _id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_sprint"))
+    }
+
+    fn delete_sprints_by_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("delete_sprints_by_board"))
+    }
+
+    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+        Err(KanbanError::unsupported("get_graph"))
+    }
+
+    fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("set_graph"))
+    }
+
+    fn snapshot(&self) -> KanbanResult<Snapshot> {
+        Err(KanbanError::unsupported("snapshot"))
+    }
+
+    fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("apply_snapshot"))
+    }
+}

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -1,8 +1,29 @@
+// Every field and the client()/base_url() accessors below are only reached
+// by this crate's own tests today; the DataStore/CommandStore stubs return
+// early without touching them. Sibling cards implementing real reads/writes
+// exercise them from production code.
+#![allow(dead_code)]
+
+mod command_store;
+mod data_store;
+mod remote_writes;
+
 pub struct HttpBackend {
     base_url: String,
     client: reqwest::Client,
     runtime: tokio::runtime::Runtime,
     instance_id: uuid::Uuid,
+}
+
+#[async_trait::async_trait]
+impl kanban_service::KanbanBackend for HttpBackend {
+    fn as_data_store(&self) -> &dyn kanban_domain::DataStore {
+        self
+    }
+
+    fn instance_id(&self) -> uuid::Uuid {
+        self.instance_id
+    }
 }
 
 impl HttpBackend {
@@ -37,7 +58,6 @@ impl HttpBackend {
         &self.base_url
     }
 
-    #[allow(dead_code)]
     pub(crate) fn client(&self) -> &reqwest::Client {
         &self.client
     }
@@ -64,8 +84,8 @@ mod tests {
     }
 
     #[test]
-    fn test_http_backend_block_on_bridges_sync_call_without_ambient_runtime()
-    -> kanban_domain::KanbanResult<()> {
+    fn test_http_backend_block_on_bridges_sync_call_without_ambient_runtime(
+    ) -> kanban_domain::KanbanResult<()> {
         let backend = HttpBackend::new("http://example.com")?;
         let result = backend.block_on(async { 1 + 1 });
         assert_eq!(result, 2);

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -1,0 +1,116 @@
+pub struct HttpBackend {
+    base_url: String,
+    client: reqwest::Client,
+    runtime: tokio::runtime::Runtime,
+    instance_id: uuid::Uuid,
+}
+
+impl HttpBackend {
+    pub fn new(base_url: &str) -> kanban_domain::KanbanResult<Self> {
+        let base_url = base_url.trim_end_matches('/').to_string();
+        let client = reqwest::Client::builder().build().map_err(|e| {
+            kanban_domain::KanbanError::Internal(format!("failed to build http client: {e}"))
+        })?;
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                kanban_domain::KanbanError::Internal(format!(
+                    "failed to build http_backend runtime: {e}"
+                ))
+            })?;
+        Ok(Self {
+            base_url,
+            client,
+            runtime,
+            instance_id: uuid::Uuid::new_v4(),
+        })
+    }
+
+    /// Bridge a synchronous DataStore/CommandStore call onto the dedicated
+    /// runtime -- never the caller's ambient one.
+    pub(crate) fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
+        self.runtime.block_on(fut)
+    }
+
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::DataStore;
+    use kanban_service::KanbanBackend;
+
+    #[test]
+    fn test_http_backend_new_normalizes_trailing_slash() -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com/")?;
+        assert_eq!(backend.base_url(), "http://example.com");
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_new_no_trailing_slash() -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        assert_eq!(backend.base_url(), "http://example.com");
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_block_on_bridges_sync_call_without_ambient_runtime()
+    -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        let result = backend.block_on(async { 1 + 1 });
+        assert_eq!(result, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_new_mints_nonnil_instance_id() -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        assert_ne!(backend.instance_id(), uuid::Uuid::nil());
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_implements_kanban_backend_object_safe() -> kanban_domain::KanbanResult<()>
+    {
+        let backend = HttpBackend::new("http://example.com")?;
+        let _: &dyn kanban_service::KanbanBackend = &backend;
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_as_data_store_returns_self() -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        let backend_ref: &dyn kanban_service::KanbanBackend = &backend;
+        let _: &dyn kanban_domain::DataStore = backend_ref.as_data_store();
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_stub_method_returns_unsupported_error() -> kanban_domain::KanbanResult<()>
+    {
+        let backend = HttpBackend::new("http://example.com")?;
+        let result = backend.list_boards();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.is_unsupported());
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_instance_id_matches_accessor() -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        let backend_ref: &dyn kanban_service::KanbanBackend = &backend;
+        assert_eq!(backend_ref.instance_id(), backend.instance_id);
+        Ok(())
+    }
+}

--- a/crates/kanban-backend-http/src/remote_writes/boards.rs
+++ b/crates/kanban-backend-http/src/remote_writes/boards.rs
@@ -1,0 +1,1 @@
+//! `RemoteWrites` board methods for `HttpBackend`.

--- a/crates/kanban-backend-http/src/remote_writes/cards.rs
+++ b/crates/kanban-backend-http/src/remote_writes/cards.rs
@@ -1,0 +1,1 @@
+//! `RemoteWrites` card methods for `HttpBackend`.

--- a/crates/kanban-backend-http/src/remote_writes/columns.rs
+++ b/crates/kanban-backend-http/src/remote_writes/columns.rs
@@ -1,0 +1,1 @@
+//! `RemoteWrites` column methods for `HttpBackend`.

--- a/crates/kanban-backend-http/src/remote_writes/mod.rs
+++ b/crates/kanban-backend-http/src/remote_writes/mod.rs
@@ -1,0 +1,3 @@
+mod boards;
+mod cards;
+mod columns;


### PR DESCRIPTION
Scaffolds a new workspace crate, `kanban-backend-http`, holding `HttpBackend` — the eventual `KanbanBackend` implementation for talking to a remote `kanban-server` over HTTP.

- `HttpBackend` owns its own dedicated background `tokio::runtime::Runtime`, spawned at construction — not `reqwest::blocking::Client`. `reqwest::blocking::Client` detects and reuses an *ambient* tokio runtime on the calling thread, a hazard this codebase has already been bitten by once (`json_backend.rs` removed a `tokio::task::block_in_place` call specifically because "it panics on a current-thread runtime"). A `block_on` method bridges every synchronous `DataStore`/`CommandStore` call onto the dedicated runtime instead.
- `DataStore` (`data_store.rs`) and `CommandStore` (`command_store.rs`) are fully stubbed — every method returns `Err(KanbanError::unsupported(...))`. No real HTTP calls yet; that's later cards.
- An empty `remote_writes/` submodule (`boards.rs`/`columns.rs`/`cards.rs`) is scaffolded so the two follow-up `RemoteWrites` implementation cards can each land in their own file without touching the other's.
- `kanban-service` itself gets **zero new dependencies** from this work (no `reqwest`, no extra runtime) — confirmed via `git diff` showing no changes to its `Cargo.toml`.

**Why its own crate, not a module inside `kanban-service`**: `json_backend.rs`/`sqlite_backend.rs` inside `kanban-service` are thin adapters delegating to a lower-level `PersistenceStore` trait implemented in separate crates — `kanban-service` itself stays free of JSON/SQLite-specific dependencies. `HttpBackend` has no equivalent lower-level trait to delegate to (a byte-blob `PersistenceStore`-shaped contract is exactly the "full app state over the wire" model this epic already ruled out), so it implements `KanbanBackend`/`DataStore`/`CommandStore` directly — keeping that surface, and its `reqwest`/runtime dependency, out of `kanban-service` means giving it its own crate instead.

**Testing**: `cargo test -p kanban-backend-http` (8 tests: base-url normalization, the `block_on` bridge working from a plain `#[test]` — proving no ambient-runtime dependency — instance id minting, object-safety, stub error behavior), `cargo test --workspace`, `cargo check --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check` — all clean.