### PR TITLE
docs: correct PR title and commit message formats in CONTRIBUTING

### DIFF
--- a/.changeset/max-contributing-pr-title.md
+++ b/.changeset/max-contributing-pr-title.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Documentation fix for contributors: `CONTRIBUTING.md` documented a PR title format (`<branch-name>`) that does not match the convention actually used in this repository, and a commit message format missing the crate scope. Both now reflect real practice.

--- a/.changeset/max-kan-contributing-pr-title.md
+++ b/.changeset/max-kan-contributing-pr-title.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- docs: correct PR title and commit message formats in CONTRIBUTING

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -433,7 +433,16 @@ bash scripts/validate-release.sh
 
 ### PR Title
 
-Use format: `<branch-name>`
+Use format: `KAN-NNN <type>(<crate>): <description>`
+
+- `KAN-NNN` — the card number, taken from the branch name (branch `max/kan-365` -> `KAN-365`). Omit if the change has no card.
+- `<type>(<crate>)` — the same semantic type as the commit messages below, scoped to the crate without its `kanban-` prefix (`tui`, `service`, `server`, `domain`, `cli`, `mcp`, `core`, `persistence`).
+- `<description>` — lowercase, concise, no trailing period.
+
+**Examples:**
+- `KAN-365 feat(tui): block quit during migration with double-q UI`
+- `KAN-1011 feat(server): flat /v1/columns/{id} and /v1/cards/{id} routes`
+- `fix(persistence): V8->V9 migration writes atomically`
 
 ### PR Description
 
@@ -460,10 +469,12 @@ And include concisely:
 Use semantic commit format:
 
 ```
-<type>: <description>
+<type>(<crate>): <description>
 
 [optional body]
 ```
+
+`<crate>` is the crate name without its `kanban-` prefix (`tui`, `service`, `server`, `domain`, `cli`, `mcp`, `core`, `persistence`). Omit the scope only for changes that span the whole workspace or touch no crate (e.g. `chore: add changeset`).
 
 **Types:**
 - `feat`: New feature
@@ -475,10 +486,10 @@ Use semantic commit format:
 - `ci`: CI/CD changes
 
 **Examples:**
-- `feat: add sprint filtering to task view`
-- `fix: handle empty board state correctly`
+- `feat(tui): add sprint filtering to task view`
+- `fix(service): handle empty board state correctly`
 - `docs: update keyboard shortcuts in README`
-- `refactor: extract dialog rendering logic`
+- `refactor(tui): extract dialog rendering logic`
 
 **Commit Strategy:**
 


### PR DESCRIPTION
Corrects two stale format specifications in `CONTRIBUTING.md`:

- PR title: documented as `<branch-name>`, corrected to `KAN-NNN <type>(<crate>): <description>` with examples
- Commit message: documented as `<type>: <description>`, corrected to `<type>(<crate>): <description>` with the crate-scope rule and updated examples

**What**: documentation only. No code changes.

**Why**: both documented formats contradict actual practice. No PR in this repository has ever used a bare branch name as its title — the real convention is `KAN-NNN <type>(<crate>): <description>` (`KAN-1020 refactor(workspace): ...`, `KAN-703 test(server): ...`, `KAN-1011 feat(server): ...`). Likewise every commit carries a crate scope, and `CLAUDE.md` already specifies `<type>(<crate>): <description>` — so the two documents disagreed with each other, with `CONTRIBUTING.md` being the wrong one.

This caused a real error: PR #508 was opened titled `max/kan-1028`, following `CONTRIBUTING.md` literally, and had to be retitled.

**How**: rewrote both sections to match observed practice, and documented the crate-scope convention (crate name without the `kanban-` prefix) along with when to omit it.

**Testing**: documentation only — no build impact. `scripts/validate-release.sh` and the workspace build are unaffected.