### PR TITLE
KAN-1024 feat(backend): add KanbanBackendFactory trait and registry

### DIFF
--- a/.changeset/kan-1024-add-kanban-backend-factory-trait-and-registry.md
+++ b/.changeset/kan-1024-add-kanban-backend-factory-trait-and-registry.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal groundwork with no user-visible effect: backends can now be described by a factory registered against a URI scheme, rather than being named directly by the service layer. Nothing uses the registry yet, so behaviour, storage formats, and commands are unchanged. This is the seam that will later let an application decide for itself which backends exist, including pointing the CLI, TUI, or MCP server at a remote server instead of a local file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,7 @@ dependencies = [
  "kanban-core",
  "kanban-domain",
  "kanban-persistence",
+ "tokio",
  "uuid",
 ]
 
@@ -1436,6 +1437,7 @@ dependencies = [
 name = "kanban-backend-memory"
 version = "0.7.2"
 dependencies = [
+ "async-trait",
  "chrono",
  "kanban-backend",
  "kanban-core",

--- a/crates/kanban-backend-memory/Cargo.toml
+++ b/crates/kanban-backend-memory/Cargo.toml
@@ -21,4 +21,5 @@ chrono.workspace = true
 
 [dev-dependencies]
 kanban-core = { path = "../kanban-core" }
+async-trait.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/kanban-backend-memory/tests/factory_creates_backend.rs
+++ b/crates/kanban-backend-memory/tests/factory_creates_backend.rs
@@ -1,0 +1,39 @@
+use kanban_backend::{KanbanBackend, KanbanBackendFactory, KanbanBackendRegistry};
+use kanban_backend_memory::InMemoryStore;
+use kanban_core::AppConfig;
+use kanban_domain::KanbanResult;
+use std::sync::Arc;
+
+struct MemoryFactory;
+
+#[async_trait::async_trait]
+impl KanbanBackendFactory for MemoryFactory {
+    fn scheme(&self) -> &str {
+        "memory"
+    }
+
+    async fn create(
+        &self,
+        _locator: &str,
+        _config: &AppConfig,
+    ) -> KanbanResult<Arc<dyn KanbanBackend>> {
+        Ok(Arc::new(InMemoryStore::new()))
+    }
+}
+
+/// Lives here rather than in `kanban-backend` because that crate has no
+/// `KanbanBackend` implementation to hand back, and cannot depend on one.
+#[tokio::test]
+async fn test_factory_creates_backend_for_its_scheme() -> KanbanResult<()> {
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(Box::new(MemoryFactory));
+
+    let factory = registry
+        .for_scheme("memory")
+        .expect("memory factory registered");
+    let backend = factory.create("ignored", &AppConfig::default()).await?;
+
+    assert!(backend.list_boards()?.is_empty());
+    assert!(backend.remote_writes().is_none());
+    Ok(())
+}

--- a/crates/kanban-backend/Cargo.toml
+++ b/crates/kanban-backend/Cargo.toml
@@ -20,3 +20,7 @@ kanban-persistence = { path = "../kanban-persistence", version = "^0.7" }
 async-trait.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+
+[dev-dependencies]
+kanban-core = { path = "../kanban-core" }
+tokio = { workspace = true, features = ["full"] }

--- a/crates/kanban-backend/src/factory.rs
+++ b/crates/kanban-backend/src/factory.rs
@@ -1,0 +1,53 @@
+use crate::KanbanBackend;
+use kanban_core::AppConfig;
+use kanban_domain::KanbanResult;
+use std::sync::Arc;
+
+/// Creates a [`KanbanBackend`] for locators belonging to one URI scheme.
+///
+/// Implemented beside each backend and registered by the application, so that
+/// adding a backend does not require editing the service layer.
+#[async_trait::async_trait]
+pub trait KanbanBackendFactory: Send + Sync {
+    /// Scheme this factory claims, e.g. `"file"`, `"http"`, `"memory"`.
+    fn scheme(&self) -> &str;
+
+    async fn create(
+        &self,
+        locator: &str,
+        config: &AppConfig,
+    ) -> KanbanResult<Arc<dyn KanbanBackend>>;
+}
+
+#[derive(Default)]
+pub struct KanbanBackendRegistry {
+    factories: Vec<Box<dyn KanbanBackendFactory>>,
+}
+
+impl KanbanBackendRegistry {
+    pub fn new() -> Self {
+        Self {
+            factories: Vec::new(),
+        }
+    }
+
+    pub fn register(&mut self, factory: Box<dyn KanbanBackendFactory>) {
+        self.factories.push(factory);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.factories.is_empty()
+    }
+
+    pub fn schemes(&self) -> Vec<&str> {
+        self.factories.iter().map(|f| f.scheme()).collect()
+    }
+
+    /// First registration wins when two factories claim the same scheme.
+    pub fn for_scheme(&self, scheme: &str) -> Option<&dyn KanbanBackendFactory> {
+        self.factories
+            .iter()
+            .map(|f| f.as_ref())
+            .find(|f| f.scheme() == scheme)
+    }
+}

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod factory;
 pub mod remote_writes;
+pub use factory::{KanbanBackendFactory, KanbanBackendRegistry};
 pub use remote_writes::RemoteWrites;
 
 use async_trait::async_trait;

--- a/crates/kanban-backend/tests/backend_factory.rs
+++ b/crates/kanban-backend/tests/backend_factory.rs
@@ -1,0 +1,122 @@
+use kanban_backend::{KanbanBackend, KanbanBackendFactory, KanbanBackendRegistry};
+use kanban_core::AppConfig;
+use kanban_domain::{KanbanError, KanbanResult};
+use std::sync::Arc;
+
+struct StubFactory {
+    scheme: &'static str,
+}
+
+#[async_trait::async_trait]
+impl KanbanBackendFactory for StubFactory {
+    fn scheme(&self) -> &str {
+        self.scheme
+    }
+
+    async fn create(
+        &self,
+        locator: &str,
+        _config: &AppConfig,
+    ) -> KanbanResult<Arc<dyn KanbanBackend>> {
+        Err(KanbanError::validation(format!(
+            "{} factory reached with {locator}",
+            self.scheme
+        )))
+    }
+}
+
+fn stub(scheme: &'static str) -> Box<dyn KanbanBackendFactory> {
+    Box::new(StubFactory { scheme })
+}
+
+#[test]
+fn test_registry_is_empty_when_no_factories_registered() {
+    let registry = KanbanBackendRegistry::new();
+    assert!(registry.is_empty());
+    assert!(registry.schemes().is_empty());
+}
+
+#[test]
+fn test_registry_returns_factory_for_registered_scheme() {
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(stub("file"));
+
+    assert!(!registry.is_empty());
+    let found = registry.for_scheme("file").expect("file factory registered");
+    assert_eq!(found.scheme(), "file");
+}
+
+#[test]
+fn test_registry_returns_none_for_unregistered_scheme() {
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(stub("file"));
+
+    assert!(registry.for_scheme("http").is_none());
+}
+
+#[test]
+fn test_registry_lists_registered_schemes() {
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(stub("file"));
+    registry.register(stub("http"));
+    registry.register(stub("memory"));
+
+    assert_eq!(registry.schemes(), vec!["file", "http", "memory"]);
+}
+
+/// Pins duplicate-scheme resolution so it is a decision rather than an artifact
+/// of `Vec` iteration order.
+#[test]
+fn test_registry_first_registration_wins_for_duplicate_scheme() {
+    struct Marked;
+
+    #[async_trait::async_trait]
+    impl KanbanBackendFactory for Marked {
+        fn scheme(&self) -> &str {
+            "file"
+        }
+        async fn create(
+            &self,
+            _locator: &str,
+            _config: &AppConfig,
+        ) -> KanbanResult<Arc<dyn KanbanBackend>> {
+            Err(KanbanError::validation("second"))
+        }
+    }
+
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(stub("file"));
+    registry.register(Box::new(Marked));
+
+    let found = registry.for_scheme("file").expect("a file factory resolves");
+    let err = tokio_test_block_on(found.create("x", &AppConfig::default()))
+        .expect_err("stub factories always fail");
+    assert!(
+        err.to_string().contains("file factory reached"),
+        "the first registration must win, got: {err}"
+    );
+}
+
+fn tokio_test_block_on<F: std::future::Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("runtime")
+        .block_on(f)
+}
+
+/// The registry must be able to dispatch a locator plus config to a factory and
+/// receive the factory's own error, proving the async signature is usable as
+/// `StoreManager::make_backend` needs it.
+#[tokio::test]
+async fn test_registry_dispatches_locator_and_config_to_the_matching_factory() {
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(stub("file"));
+
+    let factory = registry.for_scheme("file").expect("file factory registered");
+    let err = factory
+        .create("/tmp/board.json", &AppConfig::default())
+        .await
+        .expect_err("stub factory always fails");
+
+    assert!(err.to_string().contains("/tmp/board.json"));
+}

--- a/crates/kanban-backend/tests/backend_factory.rs
+++ b/crates/kanban-backend/tests/backend_factory.rs
@@ -42,7 +42,9 @@ fn test_registry_returns_factory_for_registered_scheme() {
     registry.register(stub("file"));
 
     assert!(!registry.is_empty());
-    let found = registry.for_scheme("file").expect("file factory registered");
+    let found = registry
+        .for_scheme("file")
+        .expect("file factory registered");
     assert_eq!(found.scheme(), "file");
 }
 
@@ -88,9 +90,12 @@ fn test_registry_first_registration_wins_for_duplicate_scheme() {
     registry.register(stub("file"));
     registry.register(Box::new(Marked));
 
-    let found = registry.for_scheme("file").expect("a file factory resolves");
+    let found = registry
+        .for_scheme("file")
+        .expect("a file factory resolves");
     let err = tokio_test_block_on(found.create("x", &AppConfig::default()))
-        .expect_err("stub factories always fail");
+        .err()
+        .expect("stub factories always fail");
     assert!(
         err.to_string().contains("file factory reached"),
         "the first registration must win, got: {err}"
@@ -112,11 +117,14 @@ async fn test_registry_dispatches_locator_and_config_to_the_matching_factory() {
     let mut registry = KanbanBackendRegistry::new();
     registry.register(stub("file"));
 
-    let factory = registry.for_scheme("file").expect("file factory registered");
+    let factory = registry
+        .for_scheme("file")
+        .expect("file factory registered");
     let err = factory
         .create("/tmp/board.json", &AppConfig::default())
         .await
-        .expect_err("stub factory always fails");
+        .err()
+        .expect("stub factory always fails");
 
     assert!(err.to_string().contains("/tmp/board.json"));
 }


### PR DESCRIPTION
Adds the seam that lets an application decide which backends exist, without the service layer naming any of them. Purely additive: 231 insertions, 0 deletions, and nothing dispatches through the registry yet.

- New `crates/kanban-backend/src/factory.rs` with `KanbanBackendFactory` (a `scheme()` plus an async `create()`) and `KanbanBackendRegistry` (`register`, `is_empty`, `schemes`, `for_scheme`), both exported from `lib.rs`.
- Shaped deliberately after `StoreFactory` / `StoreRegistry` in `kanban-persistence` so the two layers read the same way.
- Seven tests covering registration, lookup, miss, listing, duplicate-scheme resolution, async dispatch of a locator plus config, and construction of a real backend.

**What**: Slice 2 of KAN-1021. Defines and tests the backend factory abstraction before anything depends on it.

**Why**: Today `StoreManager::make_backend` names `JsonDataStore` and `SqliteBackend` directly, which is why a backend cannot be added or swapped without editing the service layer. Landing the abstraction on its own keeps KAN-1027, the slice that actually flips dispatch, small and reviewable.

**How**: `create` matches the contract `StoreManager::make_backend` will have to satisfy: async, taking `&str` and `&AppConfig`, returning `KanbanResult<Arc<dyn KanbanBackend>>`. Getting any of those four wrong would make the later dispatch impossible, so a test drives the full signature rather than only constructing the registry.

Duplicate schemes resolve first-registration-wins. That is pinned by a test rather than left as an artifact of `Vec` order, since it decides what happens when an application registers its own factory over a default.

Two notes for reviewers:

Scheme resolution is deliberately absent. Mapping a locator string to a scheme has to contend with `validate_path` cwd-joining URLs before `StoreManager` ever sees them, and that belongs to KAN-1027.

The tests are integration tests in two crates rather than unit tests in one. `kanban-backend` has no `KanbanBackend` implementation to hand back and cannot depend on one, since `kanban-backend-memory` depends on it. A stub there would mean about thirty-five `unimplemented!()` methods, so the single test needing a real backend lives in `kanban-backend-memory` and uses `InMemoryStore`.

**Testing**: `cargo test -p kanban-backend --test backend_factory` and `cargo test -p kanban-backend-memory --test factory_creates_backend` (new). `cargo test --workspace --all-features` gives 3279 passed / 0 failed, which is develop's 3272 plus exactly the 7 added. `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `scripts/validate-release.sh`, `scripts/check-crate-list-sync.sh`, and `scripts/check-factory-compile-lock.sh` all clean.