### PR TITLE
KAN-1026 refactor(persistence-sqlite): move the SQLite backend adapter out of kanban-service

### DIFF
--- a/.changeset/kan-1026-move-sqlite-backend-adapter-out-of-service.md
+++ b/.changeset/kan-1026-move-sqlite-backend-adapter-out-of-service.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal groundwork with no user-visible effect: the SQLite backend adapter now lives in `kanban-persistence-sqlite`, alongside the store it wraps, instead of `kanban-service`. The `KanbanBackendFactory` trait's `scheme()` method is renamed to `name()` to match the registry's dispatch-by-backend-name semantics. `kanban-service` still constructs the SQLite backend directly; behaviour, storage formats, and commands are unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,7 @@ dependencies = [
  "kanban-domain",
  "kanban-persistence",
  "kanban-persistence-json",
+ "kanban-persistence-sqlite",
  "kanban-service",
  "predicates",
  "prometheus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "flate2",
+ "kanban-backend",
+ "kanban-backend-memory",
  "kanban-core",
  "kanban-domain",
  "kanban-persistence",

--- a/crates/kanban-backend-memory/tests/factory_creates_backend.rs
+++ b/crates/kanban-backend-memory/tests/factory_creates_backend.rs
@@ -8,7 +8,7 @@ struct MemoryFactory;
 
 #[async_trait::async_trait]
 impl KanbanBackendFactory for MemoryFactory {
-    fn scheme(&self) -> &str {
+    fn name(&self) -> &str {
         "memory"
     }
 
@@ -24,12 +24,12 @@ impl KanbanBackendFactory for MemoryFactory {
 /// Lives here rather than in `kanban-backend` because that crate has no
 /// `KanbanBackend` implementation to hand back, and cannot depend on one.
 #[tokio::test]
-async fn test_factory_creates_backend_for_its_scheme() -> KanbanResult<()> {
+async fn test_factory_creates_backend_for_its_name() -> KanbanResult<()> {
     let mut registry = KanbanBackendRegistry::new();
     registry.register(Box::new(MemoryFactory));
 
     let factory = registry
-        .for_scheme("memory")
+        .for_name("memory")
         .expect("memory factory registered");
     let backend = factory.create("ignored", &AppConfig::default()).await?;
 

--- a/crates/kanban-backend/src/factory.rs
+++ b/crates/kanban-backend/src/factory.rs
@@ -3,14 +3,15 @@ use kanban_core::AppConfig;
 use kanban_domain::KanbanResult;
 use std::sync::Arc;
 
-/// Creates a [`KanbanBackend`] for locators belonging to one URI scheme.
+/// Creates a [`KanbanBackend`] for locators belonging to one backend.
 ///
 /// Implemented beside each backend and registered by the application, so that
 /// adding a backend does not require editing the service layer.
 #[async_trait::async_trait]
 pub trait KanbanBackendFactory: Send + Sync {
-    /// Scheme this factory claims, e.g. `"file"`, `"http"`, `"memory"`.
-    fn scheme(&self) -> &str;
+    /// Backend this factory builds, e.g. "json", "sqlite", "http", "memory".
+    /// Matches `StoreFactory::name()` one layer down.
+    fn name(&self) -> &str;
 
     async fn create(
         &self,
@@ -39,15 +40,15 @@ impl KanbanBackendRegistry {
         self.factories.is_empty()
     }
 
-    pub fn schemes(&self) -> Vec<&str> {
-        self.factories.iter().map(|f| f.scheme()).collect()
+    pub fn names(&self) -> Vec<&str> {
+        self.factories.iter().map(|f| f.name()).collect()
     }
 
-    /// First registration wins when two factories claim the same scheme.
-    pub fn for_scheme(&self, scheme: &str) -> Option<&dyn KanbanBackendFactory> {
+    /// First registration wins when two factories claim the same name.
+    pub fn for_name(&self, name: &str) -> Option<&dyn KanbanBackendFactory> {
         self.factories
             .iter()
             .map(|f| f.as_ref())
-            .find(|f| f.scheme() == scheme)
+            .find(|f| f.name() == name)
     }
 }

--- a/crates/kanban-backend/tests/backend_factory.rs
+++ b/crates/kanban-backend/tests/backend_factory.rs
@@ -4,13 +4,13 @@ use kanban_domain::{KanbanError, KanbanResult};
 use std::sync::Arc;
 
 struct StubFactory {
-    scheme: &'static str,
+    name: &'static str,
 }
 
 #[async_trait::async_trait]
 impl KanbanBackendFactory for StubFactory {
-    fn scheme(&self) -> &str {
-        self.scheme
+    fn name(&self) -> &str {
+        self.name
     }
 
     async fn create(
@@ -20,61 +20,59 @@ impl KanbanBackendFactory for StubFactory {
     ) -> KanbanResult<Arc<dyn KanbanBackend>> {
         Err(KanbanError::validation(format!(
             "{} factory reached with {locator}",
-            self.scheme
+            self.name
         )))
     }
 }
 
-fn stub(scheme: &'static str) -> Box<dyn KanbanBackendFactory> {
-    Box::new(StubFactory { scheme })
+fn stub(name: &'static str) -> Box<dyn KanbanBackendFactory> {
+    Box::new(StubFactory { name })
 }
 
 #[test]
 fn test_registry_is_empty_when_no_factories_registered() {
     let registry = KanbanBackendRegistry::new();
     assert!(registry.is_empty());
-    assert!(registry.schemes().is_empty());
+    assert!(registry.names().is_empty());
 }
 
 #[test]
-fn test_registry_returns_factory_for_registered_scheme() {
+fn test_registry_returns_factory_for_registered_name() {
     let mut registry = KanbanBackendRegistry::new();
     registry.register(stub("file"));
 
     assert!(!registry.is_empty());
-    let found = registry
-        .for_scheme("file")
-        .expect("file factory registered");
-    assert_eq!(found.scheme(), "file");
+    let found = registry.for_name("file").expect("file factory registered");
+    assert_eq!(found.name(), "file");
 }
 
 #[test]
-fn test_registry_returns_none_for_unregistered_scheme() {
+fn test_registry_returns_none_for_unregistered_name() {
     let mut registry = KanbanBackendRegistry::new();
     registry.register(stub("file"));
 
-    assert!(registry.for_scheme("http").is_none());
+    assert!(registry.for_name("http").is_none());
 }
 
 #[test]
-fn test_registry_lists_registered_schemes() {
+fn test_registry_lists_registered_names() {
     let mut registry = KanbanBackendRegistry::new();
     registry.register(stub("file"));
     registry.register(stub("http"));
     registry.register(stub("memory"));
 
-    assert_eq!(registry.schemes(), vec!["file", "http", "memory"]);
+    assert_eq!(registry.names(), vec!["file", "http", "memory"]);
 }
 
-/// Pins duplicate-scheme resolution so it is a decision rather than an artifact
+/// Pins duplicate-name resolution so it is a decision rather than an artifact
 /// of `Vec` iteration order.
 #[test]
-fn test_registry_first_registration_wins_for_duplicate_scheme() {
+fn test_registry_first_registration_wins_for_duplicate_name() {
     struct Marked;
 
     #[async_trait::async_trait]
     impl KanbanBackendFactory for Marked {
-        fn scheme(&self) -> &str {
+        fn name(&self) -> &str {
             "file"
         }
         async fn create(
@@ -90,9 +88,7 @@ fn test_registry_first_registration_wins_for_duplicate_scheme() {
     registry.register(stub("file"));
     registry.register(Box::new(Marked));
 
-    let found = registry
-        .for_scheme("file")
-        .expect("a file factory resolves");
+    let found = registry.for_name("file").expect("a file factory resolves");
     let err = tokio_test_block_on(found.create("x", &AppConfig::default()))
         .err()
         .expect("stub factories always fail");
@@ -117,9 +113,7 @@ async fn test_registry_dispatches_locator_and_config_to_the_matching_factory() {
     let mut registry = KanbanBackendRegistry::new();
     registry.register(stub("file"));
 
-    let factory = registry
-        .for_scheme("file")
-        .expect("file factory registered");
+    let factory = registry.for_name("file").expect("file factory registered");
     let err = factory
         .create("/tmp/board.json", &AppConfig::default())
         .await

--- a/crates/kanban-persistence-sqlite/Cargo.toml
+++ b/crates/kanban-persistence-sqlite/Cargo.toml
@@ -21,6 +21,8 @@ test-helpers = []
 kanban-persistence = { path = "../kanban-persistence", version = "^0.7" }
 kanban-core = { path = "../kanban-core", version = "^0.7" }
 kanban-domain = { path = "../kanban-domain", version = "^0.7" }
+kanban-backend = { path = "../kanban-backend", version = "^0.7" }
+kanban-backend-memory = { path = "../kanban-backend-memory", version = "^0.7" }
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
 tokio.workspace = true
 async-trait.workspace = true

--- a/crates/kanban-persistence-sqlite/src/backend_factory.rs
+++ b/crates/kanban-persistence-sqlite/src/backend_factory.rs
@@ -1,0 +1,22 @@
+use crate::SqliteBackend;
+use kanban_backend::{KanbanBackend, KanbanBackendFactory};
+use kanban_core::AppConfig;
+use kanban_domain::KanbanResult;
+use std::sync::Arc;
+
+pub struct SqliteBackendFactory;
+
+#[async_trait::async_trait]
+impl KanbanBackendFactory for SqliteBackendFactory {
+    fn name(&self) -> &str {
+        "sqlite"
+    }
+
+    async fn create(
+        &self,
+        locator: &str,
+        _config: &AppConfig,
+    ) -> KanbanResult<Arc<dyn KanbanBackend>> {
+        Ok(Arc::new(SqliteBackend::open(locator).await?))
+    }
+}

--- a/crates/kanban-persistence-sqlite/src/lib.rs
+++ b/crates/kanban-persistence-sqlite/src/lib.rs
@@ -1,4 +1,9 @@
+pub mod backend_factory;
+pub mod sqlite_backend;
 pub mod sqlite_store;
+
+pub use backend_factory::SqliteBackendFactory;
+pub use sqlite_backend::SqliteBackend;
 
 pub use sqlite_store::SqliteStore;
 pub use sqlite_store::SUPPORTED_SCHEMA_VERSION;

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -1,3 +1,4 @@
+use crate::SqliteStore;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use kanban_backend_memory::InMemoryStore;
@@ -9,7 +10,6 @@ use kanban_domain::{
     KanbanResult, Snapshot, Sprint,
 };
 use kanban_persistence::{PersistenceMetadata, PersistenceStore};
-use kanban_persistence_sqlite::SqliteStore;
 use uuid::Uuid;
 
 pub struct SqliteBackend {
@@ -229,7 +229,7 @@ impl CommandStore for SqliteBackend {
 // ─── KanbanBackend ────────────────────────────────────────────────────────────
 
 #[async_trait]
-impl crate::backend::KanbanBackend for SqliteBackend {
+impl kanban_backend::KanbanBackend for SqliteBackend {
     fn as_data_store(&self) -> &dyn DataStore {
         self
     }
@@ -266,7 +266,7 @@ mod tests {
     use kanban_domain::{Board, DataStore};
 
     use super::SqliteBackend;
-    use crate::backend::KanbanBackend;
+    use kanban_backend::KanbanBackend;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sqlite_backend_needs_flush_returns_false() {
@@ -293,7 +293,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sqlite_backend_exposes_metadata_after_flush() {
         use super::SqliteBackend;
-        use crate::backend::KanbanBackend;
+        use kanban_backend::KanbanBackend;
 
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("md.sqlite3");

--- a/crates/kanban-persistence-sqlite/tests/backend_factory.rs
+++ b/crates/kanban-persistence-sqlite/tests/backend_factory.rs
@@ -1,0 +1,35 @@
+use kanban_backend::{KanbanBackend, KanbanBackendFactory};
+use kanban_core::AppConfig;
+use kanban_persistence_sqlite::SqliteBackendFactory;
+
+#[test]
+fn test_sqlite_factory_reports_its_backend_name() {
+    assert_eq!(SqliteBackendFactory.name(), "sqlite");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_factory_creates_backend_from_locator() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("factory.sqlite3");
+
+    let backend: std::sync::Arc<dyn KanbanBackend> = SqliteBackendFactory
+        .create(path.to_str().unwrap(), &AppConfig::default())
+        .await
+        .expect("factory creates a sqlite backend");
+
+    assert!(backend.list_boards().unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_factory_propagates_open_error_for_unusable_locator() {
+    let dir = tempfile::tempdir().unwrap();
+    let unusable = dir.path().join("no-such-dir").join("x.sqlite3");
+
+    let err = SqliteBackendFactory
+        .create(unusable.to_str().unwrap(), &AppConfig::default())
+        .await
+        .err()
+        .expect("opening under a missing directory must fail");
+
+    assert!(!err.to_string().is_empty());
+}

--- a/crates/kanban-server/Cargo.toml
+++ b/crates/kanban-server/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { workspace = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 kanban-persistence-json = { path = "../kanban-persistence-json" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite" }
 serde_json = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -278,7 +278,7 @@ async fn test_delete_board_removes_owned_columns_and_cards() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_delete_board_removes_owned_subtree_on_sqlite_backend() {
-    use kanban_service::sqlite_backend::SqliteBackend;
+    use kanban_persistence_sqlite::SqliteBackend;
 
     let dir = tempdir().unwrap();
     let path = dir.path().join("s.sqlite");

--- a/crates/kanban-server/tests/external_reload.rs
+++ b/crates/kanban-server/tests/external_reload.rs
@@ -62,7 +62,7 @@ async fn test_watch_for_external_changes_is_noop_for_sqlite_locator() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("s.sqlite");
     let backend: Arc<dyn KanbanBackend> = Arc::new(
-        kanban_service::sqlite_backend::SqliteBackend::open(path.to_str().unwrap())
+        kanban_persistence_sqlite::SqliteBackend::open(path.to_str().unwrap())
             .await
             .unwrap(),
     );

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -20,8 +20,6 @@ mod context;
 #[cfg(feature = "json")]
 pub mod json_backend;
 mod path;
-#[cfg(feature = "sqlite")]
-pub mod sqlite_backend;
 mod store_manager;
 pub mod undo_stack;
 pub use config::AppConfigDto;

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -106,7 +106,7 @@ impl StoreManager {
                 // UnsupportedFutureVersion survive across make_backend to the
                 // CLI / MCP / TUI surfaces, mirroring the JSON path's preserved
                 // From<PersistenceError> for KanbanError mapping.
-                let backend = crate::sqlite_backend::SqliteBackend::open(locator).await?;
+                let backend = kanban_persistence_sqlite::SqliteBackend::open(locator).await?;
                 return Ok(std::sync::Arc::new(backend));
             }
             #[cfg(not(feature = "sqlite"))]

--- a/crates/kanban-service/tests/archival_contract.rs
+++ b/crates/kanban-service/tests/archival_contract.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use kanban_backend_memory::InMemoryStore;
 use kanban_persistence_json::JsonFileStore;
-use kanban_service::sqlite_backend::SqliteBackend;
+use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::test_helpers::BackendFactory;
 use kanban_service::{json_backend::JsonDataStore, KanbanBackend};
 

--- a/crates/kanban-service/tests/card_graph.rs
+++ b/crates/kanban-service/tests/card_graph.rs
@@ -9,10 +9,8 @@
 
 use kanban_domain::{Board, Card, CardEdgeType, Column, GraphOperations, KanbanOperations};
 use kanban_persistence_json::JsonFileStore;
-use kanban_service::{
-    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
-    KanbanContext,
-};
+use kanban_persistence_sqlite::SqliteBackend;
+use kanban_service::{json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
 use tempfile::tempdir;
 

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -91,7 +91,7 @@ async fn test_context_open_returns_typed_unsupported_future_version_for_v99_json
 /// `KanbanContext::open` — not as a stringified `Database(...)` or `Internal`.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_context_open_returns_typed_unsupported_future_version_for_v99_sqlite_file() {
-    use kanban_service::sqlite_backend::SqliteBackend;
+    use kanban_persistence_sqlite::SqliteBackend;
     let dir = tempdir().unwrap();
     let path = dir.path().join("future.db");
     kanban_persistence_sqlite::write_test_metadata_with_schema_version(&path, 99)
@@ -329,7 +329,7 @@ async fn test_reload_after_external_json_change_returns_updated_data() -> Kanban
 mod sqlite_tests {
     use super::*;
     use kanban_domain::DataStore;
-    use kanban_service::sqlite_backend::SqliteBackend;
+    use kanban_persistence_sqlite::SqliteBackend;
 
     /// `open_deferred` with a SQLite backend issues no DB queries at
     /// construction; a fresh `KanbanContext` reports no undo history.

--- a/crates/kanban-service/tests/create_sprint_from_spec.rs
+++ b/crates/kanban-service/tests/create_sprint_from_spec.rs
@@ -204,7 +204,7 @@ async fn test_carry_over_still_requires_completed_source_and_planning_target() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_sprint_from_spec_sqlite_smoke() {
-    use kanban_service::sqlite_backend::SqliteBackend;
+    use kanban_persistence_sqlite::SqliteBackend;
 
     let dir = tempdir().unwrap();
     let path = dir.path().join("smoke.db");

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -8,9 +8,9 @@ use kanban_domain::{
     ArchivedCard, Board, Card, Column, Sprint,
 };
 use kanban_persistence_json::JsonFileStore;
+use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::{
-    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
-    KanbanContext, KanbanOperations,
+    json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext, KanbanOperations,
 };
 use std::sync::Arc;
 use tempfile::tempdir;

--- a/crates/kanban-service/tests/export_import_archived_roundtrip.rs
+++ b/crates/kanban-service/tests/export_import_archived_roundtrip.rs
@@ -13,10 +13,8 @@ use kanban_domain::{
     DependencyGraph, GraphOperations, KanbanOperations, KanbanResult, Severity, Snapshot,
 };
 use kanban_persistence_json::JsonFileStore;
-use kanban_service::{
-    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
-    KanbanContext,
-};
+use kanban_persistence_sqlite::SqliteBackend;
+use kanban_service::{json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
 use tempfile::tempdir;
 

--- a/crates/kanban-service/tests/migrate_sprint_logs.rs
+++ b/crates/kanban-service/tests/migrate_sprint_logs.rs
@@ -6,10 +6,8 @@
 
 use kanban_domain::{Board, Card, Column, Sprint};
 use kanban_persistence_json::JsonFileStore;
-use kanban_service::{
-    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
-    KanbanContext,
-};
+use kanban_persistence_sqlite::SqliteBackend;
+use kanban_service::{json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
 use tempfile::tempdir;
 

--- a/crates/kanban-service/tests/move_cards.rs
+++ b/crates/kanban-service/tests/move_cards.rs
@@ -6,9 +6,9 @@
 
 use kanban_domain::{Board, Card, Column};
 use kanban_persistence_json::JsonFileStore;
+use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::{
-    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
-    KanbanContext, KanbanOperations,
+    json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext, KanbanOperations,
 };
 use std::sync::Arc;
 use tempfile::tempdir;

--- a/crates/kanban-service/tests/restore_card_deleted_column.rs
+++ b/crates/kanban-service/tests/restore_card_deleted_column.rs
@@ -3,10 +3,8 @@
 
 use kanban_domain::{Board, Card, Column, KanbanOperations};
 use kanban_persistence_json::JsonFileStore;
-use kanban_service::{
-    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
-    KanbanContext,
-};
+use kanban_persistence_sqlite::SqliteBackend;
+use kanban_service::{json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
 use tempfile::tempdir;
 

--- a/crates/kanban-service/tests/update_cards_move_semantics.rs
+++ b/crates/kanban-service/tests/update_cards_move_semantics.rs
@@ -11,9 +11,9 @@
 
 use kanban_domain::{CardUpdate, FieldUpdate};
 use kanban_persistence_json::JsonFileStore;
+use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::{
-    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
-    KanbanContext, KanbanOperations,
+    json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext, KanbanOperations,
 };
 use std::sync::Arc;
 use tempfile::tempdir;

--- a/crates/kanban-service/tests/update_cards_position.rs
+++ b/crates/kanban-service/tests/update_cards_position.rs
@@ -8,9 +8,9 @@
 
 use kanban_domain::{Board, Card, CardUpdate, Column};
 use kanban_persistence_json::JsonFileStore;
+use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::{
-    json_backend::JsonDataStore, sqlite_backend::SqliteBackend, AppConfig, KanbanBackend,
-    KanbanContext, KanbanOperations,
+    json_backend::JsonDataStore, AppConfig, KanbanBackend, KanbanContext, KanbanOperations,
 };
 use std::sync::Arc;
 use tempfile::tempdir;


### PR DESCRIPTION
## Summary

Slice 3 of KAN-1021: moves the SQLite `KanbanBackend` adapter out of `kanban-service` into `kanban-persistence-sqlite`, alongside the store it wraps, and renames `KanbanBackendFactory::scheme()` to `name()` so the registry dispatches on backend name (matching `StoreFactory::name()` one layer down) rather than URI scheme.

- Add `SqliteBackendFactory` in `kanban-persistence-sqlite`, implementing `KanbanBackendFactory`
- Rename `KanbanBackendFactory::scheme` to `name` (`for_scheme` to `for_name`, `schemes` to `names`) across `kanban-backend` and its test suites, including `kanban-backend-memory`
- Move `SqliteBackend` from `kanban-service/src/sqlite_backend.rs` to `kanban-persistence-sqlite/src/sqlite_backend.rs`
- Repoint `StoreManager` and 13 test files across `kanban-service` and `kanban-server` at the new `kanban_persistence_sqlite::SqliteBackend` path
- Add a path-only `kanban-persistence-sqlite` dev-dependency to `kanban-server`

`StoreManager` still constructs `SqliteBackend` directly; registry dispatch is KAN-1027.

## Commits

1. `test(persistence-sqlite): specify SqliteBackendFactory` - red tests for the new factory (fails to compile: unresolved import)
2. `refactor(backend): rename KanbanBackendFactory::scheme to name` - green on its own
3. `refactor(persistence-sqlite): move the SQLite backend adapter out of kanban-service` - the move plus all call-site repoints
4. `chore: add changeset`

## Testing

- `cargo test -p kanban-persistence-sqlite --lib` - 93 passed
- `cargo test -p kanban-persistence-sqlite --test backend_factory` - 3 passed
- `cargo test --workspace --all-features` - 3282 passed, 0 failed, 3 ignored
- `cargo clippy --all-targets --all-features -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean
- `bash scripts/validate-release.sh` - clean
- `bash scripts/check-crate-list-sync.sh` - clean
- `bash scripts/check-factory-compile-lock.sh` - clean

`grep -rn 'scheme' crates/kanban-backend/ crates/kanban-backend-memory/` returns nothing.
