### PR TITLE
KAN-1032 feat(backend): add locator-dispatch to KanbanBackendFactory/KanbanBackendRegistry

### DIFF
--- a/.changeset/kan-1032-add-locator-dispatch-to-backend-registry.md
+++ b/.changeset/kan-1032-add-locator-dispatch-to-backend-registry.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal groundwork with no user-visible effect: `KanbanBackendFactory` gains a `matches_locator` method (default: never matches by content) and `KanbanBackendRegistry` gains `for_locator`, which reads up to the first 32 bytes of a locator and asks each registered factory in registration order whether it should handle it. This mirrors the existing `StoreRegistry::detect_backend` dispatch pattern one layer down. `SqliteBackendFactory` now matches SQLite magic bytes or a `.sqlite`/`.sqlite3`/`.db` extension on a new file; `JsonBackendFactory` is the catch-all. Nothing calls `for_locator` yet, so behaviour, storage formats, and commands are unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,7 @@ dependencies = [
  "kanban-core",
  "kanban-domain",
  "kanban-persistence",
+ "tempfile",
  "tokio",
  "uuid",
 ]

--- a/crates/kanban-backend/Cargo.toml
+++ b/crates/kanban-backend/Cargo.toml
@@ -24,3 +24,4 @@ chrono.workspace = true
 [dev-dependencies]
 kanban-core = { path = "../kanban-core" }
 tokio = { workspace = true, features = ["full"] }
+tempfile.workspace = true

--- a/crates/kanban-backend/src/factory.rs
+++ b/crates/kanban-backend/src/factory.rs
@@ -13,6 +13,15 @@ pub trait KanbanBackendFactory: Send + Sync {
     /// Matches `StoreFactory::name()` one layer down.
     fn name(&self) -> &str;
 
+    /// True if this factory should handle `locator`. `header` is up to the
+    /// first 32 bytes of the file at `locator` if it exists and is readable
+    /// (empty otherwise) — mirrors `StoreFactory::matches_content` one layer
+    /// down (`kanban_persistence::registry`). Default: never matches by
+    /// content; only reachable via `for_name`.
+    fn matches_locator(&self, _locator: &str, _header: &[u8]) -> bool {
+        false
+    }
+
     async fn create(
         &self,
         locator: &str,
@@ -51,4 +60,29 @@ impl KanbanBackendRegistry {
             .map(|f| f.as_ref())
             .find(|f| f.name() == name)
     }
+
+    /// First-registration-wins, same contract as `for_name`. Reads the
+    /// locator's header once and asks each factory in registration order.
+    pub fn for_locator(&self, locator: &str) -> Option<&dyn KanbanBackendFactory> {
+        let header = read_header_best_effort(locator, 32);
+        self.factories
+            .iter()
+            .map(|f| f.as_ref())
+            .find(|f| f.matches_locator(locator, &header))
+    }
+}
+
+fn read_header_best_effort(locator: &str, n: usize) -> Vec<u8> {
+    let path = std::path::Path::new(locator);
+    if !path.exists() {
+        return Vec::new();
+    }
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    use std::io::Read;
+    let mut buf = vec![0u8; n];
+    let read = file.read(&mut buf).unwrap_or(0);
+    buf.truncate(read);
+    buf
 }

--- a/crates/kanban-backend/tests/backend_factory.rs
+++ b/crates/kanban-backend/tests/backend_factory.rs
@@ -105,6 +105,89 @@ fn tokio_test_block_on<F: std::future::Future>(f: F) -> F::Output {
         .block_on(f)
 }
 
+struct ContentMatchingStub {
+    name: &'static str,
+    matcher: fn(&str, &[u8]) -> bool,
+}
+
+#[async_trait::async_trait]
+impl KanbanBackendFactory for ContentMatchingStub {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn matches_locator(&self, locator: &str, header: &[u8]) -> bool {
+        (self.matcher)(locator, header)
+    }
+
+    async fn create(
+        &self,
+        locator: &str,
+        _config: &AppConfig,
+    ) -> KanbanResult<Arc<dyn KanbanBackend>> {
+        Err(KanbanError::validation(format!(
+            "{} factory reached with {locator}",
+            self.name
+        )))
+    }
+}
+
+fn matches_sqlite_content(_locator: &str, header: &[u8]) -> bool {
+    header.starts_with(b"SQLite format 3\0")
+}
+
+fn matches_json_catch_all(_locator: &str, header: &[u8]) -> bool {
+    let trimmed = header.iter().find(|b| !b.is_ascii_whitespace());
+    header.is_empty() || matches!(trimmed, Some(b'{') | Some(b'['))
+}
+
+#[test]
+fn test_registry_for_locator_prefers_sqlite_over_json_content_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let sqlite_path = dir.path().join("board.data");
+    std::fs::write(&sqlite_path, b"SQLite format 3\0rest-of-header").unwrap();
+    let json_path = dir.path().join("board.json");
+    std::fs::write(&json_path, b"{\"boards\":[]}").unwrap();
+
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(Box::new(ContentMatchingStub {
+        name: "sqlite",
+        matcher: matches_sqlite_content,
+    }));
+    registry.register(Box::new(ContentMatchingStub {
+        name: "json",
+        matcher: matches_json_catch_all,
+    }));
+
+    let found = registry
+        .for_locator(sqlite_path.to_str().unwrap())
+        .expect("sqlite-content locator resolves");
+    assert_eq!(found.name(), "sqlite");
+
+    let found = registry
+        .for_locator(json_path.to_str().unwrap())
+        .expect("json-content locator resolves");
+    assert_eq!(found.name(), "json");
+}
+
+#[test]
+fn test_registry_for_locator_returns_none_for_unmatched_locator() {
+    let registry = KanbanBackendRegistry::new();
+    assert!(registry.for_locator("/nonexistent/board.sqlite3").is_none());
+
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(Box::new(ContentMatchingStub {
+        name: "sqlite",
+        matcher: matches_sqlite_content,
+    }));
+
+    let dir = tempfile::tempdir().unwrap();
+    let json_path = dir.path().join("board.json");
+    std::fs::write(&json_path, b"{\"boards\":[]}").unwrap();
+
+    assert!(registry.for_locator(json_path.to_str().unwrap()).is_none());
+}
+
 /// The registry must be able to dispatch a locator plus config to a factory and
 /// receive the factory's own error, proving the async signature is usable as
 /// `StoreManager::make_backend` needs it.

--- a/crates/kanban-persistence-json/src/backend_factory.rs
+++ b/crates/kanban-persistence-json/src/backend_factory.rs
@@ -13,6 +13,11 @@ impl KanbanBackendFactory for JsonBackendFactory {
         "json"
     }
 
+    fn matches_locator(&self, _locator: &str, header: &[u8]) -> bool {
+        let trimmed = header.iter().find(|b| !b.is_ascii_whitespace());
+        header.is_empty() || matches!(trimmed, Some(b'{') | Some(b'['))
+    }
+
     async fn create(
         &self,
         locator: &str,

--- a/crates/kanban-persistence-json/tests/backend_factory.rs
+++ b/crates/kanban-persistence-json/tests/backend_factory.rs
@@ -34,3 +34,11 @@ async fn test_json_factory_creates_backend_without_touching_disk() {
 
     assert!(!path.exists(), "create must not touch disk");
 }
+
+#[test]
+fn test_json_backend_factory_matches_locator_as_catch_all() {
+    assert!(JsonBackendFactory.matches_locator("board.json", b"{\"boards\":[]}"));
+    assert!(JsonBackendFactory.matches_locator("board.txt", b"[1,2,3]"));
+    assert!(JsonBackendFactory.matches_locator("board.json", b"   {\"boards\":[]}"));
+    assert!(JsonBackendFactory.matches_locator("/nonexistent/board.json", &[]));
+}

--- a/crates/kanban-persistence-sqlite/src/backend_factory.rs
+++ b/crates/kanban-persistence-sqlite/src/backend_factory.rs
@@ -12,6 +12,14 @@ impl KanbanBackendFactory for SqliteBackendFactory {
         "sqlite"
     }
 
+    fn matches_locator(&self, locator: &str, header: &[u8]) -> bool {
+        header.starts_with(b"SQLite format 3\0")
+            || (header.is_empty()
+                && (locator.ends_with(".sqlite")
+                    || locator.ends_with(".sqlite3")
+                    || locator.ends_with(".db")))
+    }
+
     async fn create(
         &self,
         locator: &str,

--- a/crates/kanban-persistence-sqlite/tests/backend_factory.rs
+++ b/crates/kanban-persistence-sqlite/tests/backend_factory.rs
@@ -33,3 +33,17 @@ async fn test_sqlite_factory_propagates_open_error_for_unusable_locator() {
 
     assert!(!err.to_string().is_empty());
 }
+
+#[test]
+fn test_sqlite_backend_factory_matches_locator_by_magic_bytes() {
+    let header = b"SQLite format 3\0rest-of-header";
+    assert!(SqliteBackendFactory.matches_locator("board.data", header));
+}
+
+#[test]
+fn test_sqlite_backend_factory_matches_locator_by_extension_for_new_file() {
+    assert!(SqliteBackendFactory.matches_locator("/nonexistent/board.sqlite", &[]));
+    assert!(SqliteBackendFactory.matches_locator("/nonexistent/board.sqlite3", &[]));
+    assert!(SqliteBackendFactory.matches_locator("/nonexistent/board.db", &[]));
+    assert!(!SqliteBackendFactory.matches_locator("/nonexistent/board.json", &[]));
+}


### PR DESCRIPTION
## Summary

Child A of the KAN-1027 split (registry-based backend dispatch). Purely additive: adds locator/content-based dispatch to `KanbanBackendRegistry`, mirroring the existing `StoreRegistry::detect_backend` pattern one layer down in `kanban-persistence`.

- `KanbanBackendFactory` gains `matches_locator(&self, locator: &str, header: &[u8]) -> bool`, defaulting to `false` (only reachable via `for_name`).
- `KanbanBackendRegistry` gains `for_locator(&self, locator: &str) -> Option<&dyn KanbanBackendFactory>`, first-registration-wins, reading at most the first 32 bytes of the locator best-effort (never panics, never propagates I/O errors).
- `SqliteBackendFactory::matches_locator` matches SQLite magic bytes, or a `.sqlite`/`.sqlite3`/`.db` extension for a not-yet-existing file.
- `JsonBackendFactory::matches_locator` is the catch-all: matches a `{`/`[`-leading header (after skipping leading whitespace) or an empty header.

Nothing calls `for_locator` yet. `crates/kanban-service/**` has zero diff in this PR; the flip to actually dispatch through the registry is KAN-1027-B, which this card blocks.

## Commit split

1. `test(backend): specify KanbanBackendRegistry::for_locator dispatch` (red -- new tests fail to compile since `matches_locator`/`for_locator` do not exist yet)
2. `feat(backend): add matches_locator to KanbanBackendFactory and for_locator to the registry` (green)
3. `chore: add changeset`

## Verification

- `cargo test -p kanban-backend -p kanban-persistence-json -p kanban-persistence-sqlite`: all green (5 new tests pass)
- `cargo test --workspace --all-features`: **3290 passed, 0 failed** (baseline 3285 + 5 new tests)
- `cargo check --workspace --all-targets`: passes
- `git diff --stat develop..HEAD` touches no `kanban-service` path
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all --check`: clean
- `bash scripts/validate-release.sh`, `bash scripts/check-crate-list-sync.sh`, `bash scripts/check-factory-compile-lock.sh`: all clean

## Test plan

- [x] All 5 new tests pass: `test_registry_for_locator_prefers_sqlite_over_json_content_match`, `test_registry_for_locator_returns_none_for_unmatched_locator`, `test_sqlite_backend_factory_matches_locator_by_magic_bytes`, `test_sqlite_backend_factory_matches_locator_by_extension_for_new_file`, `test_json_backend_factory_matches_locator_as_catch_all`
- [x] Full workspace suite green at 3290 passed, 0 failed
- [x] kanban-service untouched (verified via `git diff --stat`)