### PR TITLE
KAN-1034 chore(service): drop the json feature and kanban-persistence-json production dependency

### DIFF
--- a/.changeset/kan-1034-drop-json-feature-from-kanban-service.md
+++ b/.changeset/kan-1034-drop-json-feature-from-kanban-service.md
@@ -1,0 +1,17 @@
+---
+bump: patch
+---
+
+Removes the `json` feature from `kanban-service`. `sqlite` is now the crate's
+only optional persistence feature; `kanban-persistence-json` and
+`kanban-backend-memory` moved from optional production dependencies to
+unconditional dev-dependencies.
+
+This is internal groundwork with no user-visible behavior change:
+`kanban-service`'s production surface no longer depends on the JSON
+persistence crate directly. `kanban-cli` and `kanban-mcp` already gate their
+own `kanban-persistence-json` dependency independently, so nothing changes
+for consumers of those binaries. Storage formats, commands, and CLI/MCP/TUI
+behavior are unchanged.
+
+Completes the KAN-1027 split (final child, after KAN-1032 and KAN-1033).

--- a/crates/kanban-service/Cargo.toml
+++ b/crates/kanban-service/Cargo.toml
@@ -9,9 +9,8 @@ homepage.workspace = true
 description = "Shared service layer implementing KanbanOperations over a pluggable PersistenceStore"
 
 [features]
-default = ["json", "sqlite"]
-json = ["dep:kanban-persistence-json", "dep:kanban-backend-memory"]
-sqlite = ["dep:kanban-persistence-sqlite", "dep:kanban-backend-memory"]
+default = ["sqlite"]
+sqlite = ["dep:kanban-persistence-sqlite"]
 test-helpers = ["kanban-persistence/test-helpers"]
 # Derive `schemars::JsonSchema` on the wire request DTOs so MCP tool handlers
 # can use them directly as `Parameters<T>` (rmcp requires a JSON Schema). Kept
@@ -24,8 +23,6 @@ kanban-domain = { path = "../kanban-domain", version = "^0.7" }
 kanban-persistence = { path = "../kanban-persistence", version = "^0.7" }
 kanban-api = { path = "../kanban-api", version = "^0.7" }
 kanban-backend = { path = "../kanban-backend", version = "^0.7" }
-kanban-backend-memory = { path = "../kanban-backend-memory", version = "^0.7", optional = true }
-kanban-persistence-json = { path = "../kanban-persistence-json", version = "^0.7", optional = true }
 kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "^0.7", optional = true }
 async-trait.workspace = true
 tokio.workspace = true
@@ -41,6 +38,7 @@ tracing.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
+kanban-backend-memory = { path = "../kanban-backend-memory" }
 kanban-persistence-json = { path = "../kanban-persistence-json" }
 kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", features = ["test-helpers"] }
 kanban-persistence = { path = "../kanban-persistence", features = ["test-helpers"] }


### PR DESCRIPTION
## What

Removes the `json` feature from `crates/kanban-service/Cargo.toml`. `sqlite` is now the crate's
sole optional persistence feature. `kanban-persistence-json` and `kanban-backend-memory` move
from optional entries in `[dependencies]` to unconditional entries in `[dev-dependencies]`.

## Why

Final child (C) of the KAN-1027 split. KAN-1032 (locator dispatch on the backend registry) and
KAN-1033 (`make_backend` dispatch through an injected `KanbanBackendRegistry`) are both merged
into `develop`. KAN-1033 already registers JSON unconditionally in `kanban-service`'s test-only
`make_sm()` helper, with no `#[cfg(feature = "json")]` gate anywhere left in the crate, which is
exactly what makes this final step pure Cargo.toml surgery with zero source-code changes.

The change is the observable SOLID payoff of the whole epic: `kanban-service`'s production
surface no longer depends on the JSON persistence crate at all. `sqlite` deliberately stays
asymmetric and remains a real optional feature, since `validate_and_load_store`,
`export_to_sqlite`, and `migrate_store` call `kanban_persistence_sqlite::SqliteStore` directly
for administrative flows unrelated to backend dispatch; that pre-existing coupling is out of
scope here.

It also fixes `cargo check -p kanban-service --no-default-features --all-targets`, which fails
on `develop` today: `kanban-backend-memory` was only reachable as a direct dependency of
`kanban-service` through the `json`/`sqlite` feature gates, but is used unconditionally by
`tests/*.rs` and `src/backend_test_support.rs` via `use kanban_backend_memory::InMemoryStore`.
With both features off there was no `dep:` edge to satisfy that import, even though the crate
still compiled transitively as a dependency of `kanban-persistence-json`/`kanban-persistence-sqlite`.

## How

One commit, pure `crates/kanban-service/Cargo.toml` edit:

- `[features]`: delete `json`; `default = ["sqlite"]`; `sqlite = ["dep:kanban-persistence-sqlite"]`
  (no longer pulls in `kanban-backend-memory`).
- `[dependencies]`: remove `kanban-backend-memory` and `kanban-persistence-json` entirely.
- `[dev-dependencies]`: add `kanban-backend-memory = { path = "../kanban-backend-memory" }`
  (unconditional, matching the existing unconditional `kanban-persistence-json` dev-dependency).

No `src/*.rs`, `tests/*.rs`, or consumer `Cargo.toml` file is touched. Neither `kanban-cli` nor
`kanban-mcp` forwards a `json` feature into `kanban-service` (their own `json` features gate only
their own direct `kanban-persistence-json` dependency), so this has no effect on either binary.

## Testing

- `cargo check -p kanban-service --no-default-features --all-targets` -> exit 0 (fails on
  `develop` today; this is the headline signal for this PR).
- `cargo check --workspace --all-targets` -> passes.
- `cargo test --workspace --all-features` -> 3295 passed, 0 failed (same count as `develop`
  today; this PR adds and removes no test).
- `cargo test -p kanban-service --lib test_make_backend` -> all 4 named tests pass.
- `rg -n 'kanban_persistence_json' crates/kanban-service/src/` -> only hits inside
  `#[cfg(test)] mod tests` in `store_manager.rs`.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all --check` ->
  clean.
- `scripts/validate-release.sh`, `scripts/check-crate-list-sync.sh`,
  `scripts/check-factory-compile-lock.sh` -> all clean.
- `git diff --shortstat develop..HEAD` -> 2 files changed (Cargo.toml + changeset), 20
  insertions, 5 deletions.

Requires KAN-1032 and KAN-1033 (both already merged into `develop`). This is the final child of
the KAN-1027 split; merging this closes the epic.