### PR TITLE
docs: workspace and per-crate architecture READMEs with dependency diagrams

### DIFF
--- a/.changeset/docs-crate-readmes.md
+++ b/.changeset/docs-crate-readmes.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Add architecture READMEs (root + one per crate) with dependency diagrams reflecting the post-KAN-1027 workspace graph.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ cargo tarpaulin        # Code coverage
 - `SqliteStore` - `PersistenceStore` impl with WAL mode, foreign keys, max 2 connections
 - `SqliteStoreFactory` - `matches_content` sniffs the SQLite magic bytes (`SQLite format 3\0`); no extension matching
 - Relational schema, 14 tables: metadata, boards, board_sprint_names, board_sprint_counters, columns, sprints, cards, sprint_logs, archived_cards, spawns_edges, blocks_edges, relates_edges, board_archival, command_log
-- `SUPPORTED_SCHEMA_VERSION = 4` (active migrations upgrade older databases on open, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`); legacy-table drops on open for pre-KAN-405 `command_log`, the retired `undo_state`, and the pre-KAN-504 single `card_edges` table
+- `SUPPORTED_SCHEMA_VERSION = 5` (active migrations upgrade older databases on open, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`); legacy-table drops on open for pre-KAN-405 `command_log`, the retired `undo_state`, and the pre-KAN-504 single `card_edges` table
 - Auto-creates database file on first use
 
 ### kanban-tui

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,16 +52,24 @@ crates/
 graph LR
     CLI[kanban-cli] --> TUI[kanban-tui]
     CLI --> SVC[kanban-service]
+    CLI -.->|feature: json, default-on| JSON[kanban-persistence-json]
+    CLI -.->|feature: sqlite, default-on| SQL[kanban-persistence-sqlite]
     MCP[kanban-mcp] --> SVC
+    MCP -.->|feature: json, default-on| JSON
+    MCP -.->|feature: sqlite, default-on| SQL
     TUI --> SVC
+    TUI --> MEM[kanban-backend-memory]
+    TUI --> JSON
+    TUI --> SQL
     SRV[kanban-server] --> SVC
     SRV --> API[kanban-api]
+    SRV --> JSON
+    SRV --> SQL
+    SRV -.->|feature: test-helpers| MEM
     SVC --> PER[kanban-persistence]
     SVC --> BE[kanban-backend]
-    SVC --> MEM[kanban-backend-memory]
     SVC --> API
-    SVC -.-> JSON[kanban-persistence-json]
-    SVC -.-> SQL[kanban-persistence-sqlite]
+    SVC -.->|feature: sqlite, default-on| SQL
     HTTP[kanban-backend-http] --> BE
     HTTP --> API
     MEM --> BE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,52 @@ moving parts are:
    `kanban-service/tests/card_graph.rs::card_graph_tests!`, and add
    inverse round-trip tests in `inverse_commands.rs`.
 
+### Adding a Storage Backend
+
+KAN-1027 made this the clean extension point of the persistence stack:
+`kanban-service` has no production dependency on any concrete backend, so
+adding one never means touching it. The moving parts, from lowest to highest
+layer:
+
+1. **Storage format** — implement `kanban_persistence::PersistenceStore` (the
+   async load/save trait) and a `kanban_persistence::StoreFactory`
+   (`name()`, `matches_content()`, `create()`) in a new
+   `kanban-persistence-<x>` crate. Use `kanban-persistence-json` or
+   `kanban-persistence-sqlite` as the model — and see the
+   [kanban-persistence README's "Writing a Third-Party Backend" walkthrough](crates/kanban-persistence/README.md#writing-a-third-party-backend)
+   for a full step-by-step, including the shared contract test suite you
+   should run your `PersistenceStore` against.
+
+2. **Backend abstraction** — implement `kanban_backend::KanbanBackend`
+   (`DataStore + CommandStore` plus lifecycle methods `flush()`/`reload()`/
+   `needs_flush()`/`needs_save_worker()`) and a
+   `kanban_backend::KanbanBackendFactory` (`name()`, `matches_locator()`,
+   `create()`). Model this on
+   `crates/kanban-persistence-json/src/backend_factory.rs`'s
+   `JsonBackendFactory`, which wraps a `PersistenceStore` in a `JsonDataStore`
+   and is only ~25 lines.
+
+3. **Register both factories in each application that should ship the new
+   backend** — `kanban-service` itself is not edited:
+   - `kanban-cli`: `CliApp::with_defaults()` (`kanban-cli/src/app.rs`) registers
+     the default set; ship a custom build via
+     `CliApp::with_defaults().register_backend(Box::new(MyStoreFactory), Box::new(MyBackendFactory))`,
+     or add the pair to `with_defaults()` itself to make it a first-class default.
+   - `kanban-mcp`: same pattern via `McpServer::with_defaults()` /
+     `McpServer::register_backend` (`kanban-mcp/src/server.rs`).
+   - `kanban-tui`: `default_store_manager()` (`kanban-tui/src/app/types.rs`)
+     builds the `StoreRegistry`/`KanbanBackendRegistry` pair the TUI ships with.
+   - `kanban-server`: `run()` in `kanban-server/src/main.rs` builds its own
+     `kanban_persistence::StoreRegistry` + `kanban_backend::KanbanBackendRegistry`
+     and registers factories directly (it doesn't use an app-builder type like
+     `CliApp`/`McpServer`).
+
+   See the kanban-service README's
+   ["Store / backend construction — `StoreManager`"](crates/kanban-service/README.md#store--backend-construction--storemanager)
+   section for the `StoreManager` methods (`make_backend`, `detect_backend`,
+   `sync_backend_with_file`, …) that sit downstream of whichever registries you
+   populate.
+
 ### Adding New Features
 
 **Domain First Approach:**
@@ -484,6 +530,8 @@ bash scripts/validate-release.sh
 - [ ] Run `cargo clippy --all-targets --all-features -- -D warnings` and address all warnings
 - [ ] Run `cargo test` and ensure all tests pass
 - [ ] Test manually with `cargo run`
+- [ ] Run `bash scripts/check-crate-list-sync.sh` if you touched a release script or added/removed a crate
+- [ ] Run `bash scripts/check-factory-compile-lock.sh` if you touched a `*_factory.rs`, DTO `conversions.rs`, or `response.rs`
 - [ ] Create changeset with `./scripts/create-changeset.sh`
 - [ ] Update README.md if adding user-facing features
 - [ ] Update CLAUDE.md if changing architecture/conventions
@@ -678,6 +726,11 @@ To enable automated publishing and releases, configure these secrets in GitHub r
 - Updates CHANGELOG.md
 - Publishes to crates.io
 - Creates GitHub release with tag
+
+**ci.yml**'s `release-validation` job also runs two drift guards after
+`validate-release`, both defined in `scripts/`:
+- `check-crate-list-sync.sh` — fails if `validate-release.sh`/`publish-crates.sh` hardcode a `crates/...` array instead of calling `list-crates`, or if `list-crates`'s output disagrees with the crates actually on disk under `crates/`
+- `check-factory-compile-lock.sh` — fails if a `..` rest pattern or `Default::default()` shows up in the `*_factory.rs` record types (`kanban-domain/src/*_factory.rs`) or the DTO conversion modules (`kanban-api/src/v1/**/conversions.rs`, `.../response.rs`), since those are deliberately kept exhaustive so a new field becomes a compile error instead of a silent drop
 
 ### Workflow Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,10 @@ cargo fmt --all
 - Each file should be < 300 lines
 - Extract reusable patterns into separate modules
 - Follow existing module structure in `crates/kanban-tui/src/`:
-  - `app.rs` - Application state and event handling
-  - `ui.rs` - Rendering logic
-  - `events.rs` - Event loop and input handling
-  - `input.rs` - Input state management
+  - `app/` - `App` state, `AppMode`/`DialogMode`, lifecycle (`app/mod.rs`, `app/types.rs`, `app/mode.rs`, `app/lifecycle.rs`)
+  - `ui/` - Rendering logic (one file per view: `board_detail.rs`, `card_detail.rs`, …)
+  - `events.rs` - Terminal event loop
+  - `handlers/` - Per-panel key-event handlers (`card_handlers.rs`, `dialog_handlers.rs`, …), dispatched from `app/input_router.rs`
   - `dialog.rs` - Dialog interaction patterns
   - `editor.rs` - External editor integration
 
@@ -116,31 +116,62 @@ The codebase follows SOLID principles:
 crates/
 ├── kanban-core/               # Core traits, errors, result types
 ├── kanban-domain/             # Domain models (Board, Card, Column, Sprint)
-├── kanban-persistence/        # Persistence traits, registry, and shared types
+├── kanban-api/                # REST wire DTOs shared by kanban-server and HTTP backend clients
+├── kanban-persistence/        # Persistence trait layer (StoreFactory/StoreRegistry, shared types)
 ├── kanban-persistence-json/   # JSON file storage backend
 ├── kanban-persistence-sqlite/ # SQLite storage backend
-├── kanban-service/            # Service layer: KanbanContext, persistence orchestration
+├── kanban-backend/            # KanbanBackend / KanbanBackendFactory / KanbanBackendRegistry abstractions
+├── kanban-backend-memory/     # In-memory KanbanBackend (ephemeral, no persistence)
+├── kanban-backend-http/       # KanbanBackend implementation talking to a remote kanban-server
+├── kanban-service/            # Service layer: KanbanContext, StoreManager registry dispatch, undo/redo
 ├── kanban-tui/                # Terminal UI (ratatui + crossterm)
 ├── kanban-cli/                # CLI entry point (clap)
-└── kanban-mcp/                # Model Context Protocol server for LLM integration
+├── kanban-mcp/                # Model Context Protocol server for LLM integration
+└── kanban-server/             # HTTP API server (axum)
 ```
 
-**Dependency Flow:**
+**Dependency Flow** (post-KAN-1027; see the root [README.md](README.md#workspace-dependency-graph)
+for the full per-crate graph):
 
 ```mermaid
 graph LR
     CLI[kanban-cli] --> TUI[kanban-tui]
     CLI --> SVC[kanban-service]
+    CLI -.->|feature: json, default-on| JSON[kanban-persistence-json]
+    CLI -.->|feature: sqlite, default-on| SQL[kanban-persistence-sqlite]
     MCP[kanban-mcp] --> SVC
+    MCP -.->|feature: json, default-on| JSON
+    MCP -.->|feature: sqlite, default-on| SQL
     TUI --> SVC
+    TUI --> MEM[kanban-backend-memory]
+    TUI --> JSON
+    TUI --> SQL
+    SRV[kanban-server] --> SVC
+    SRV --> API[kanban-api]
+    SRV --> JSON
+    SRV --> SQL
+    SRV -.->|feature: test-helpers| MEM
     SVC --> PER[kanban-persistence]
-    SVC -.-> JSON[kanban-persistence-json]
-    SVC -.-> SQL[kanban-persistence-sqlite]
+    SVC --> BE[kanban-backend]
+    SVC --> API
+    SVC -.->|feature: sqlite, default-on| SQL
+    HTTP[kanban-backend-http] --> BE
+    HTTP --> API
+    MEM --> BE
+    BE --> PER
     JSON --> PER
     SQL --> PER
     PER --> DOM[kanban-domain]
+    API --> DOM
     DOM --> CORE[kanban-core]
 ```
+
+The key structural change from before KAN-1027: `kanban-service` no longer depends
+directly on `kanban-persistence-json` or `kanban-backend-memory`. It depends only
+on the `kanban-backend`/`kanban-persistence` abstractions; each application crate
+(`kanban-cli`, `kanban-tui`, `kanban-mcp`, `kanban-server`) composes and registers
+the concrete backends it wants to ship with (see
+[Adding a Storage Backend](#adding-a-storage-backend) below).
 
 ### Adding a Field to a Domain Model
 
@@ -148,13 +179,13 @@ When adding a new field to any struct in `kanban-domain` (e.g., `Card`, `Board`,
 
 1. Add the field to the struct in `kanban-domain`.
 
-2. **If the field is non-optional** (no `#[serde(default)]`): `row_to_*()` in `kanban-persistence-sqlite/src/sqlite_store.rs` will **fail to compile** because the struct literal is exhaustive — add the column to `schema.sql`, write a migration if the database already exists, and update both `row_to_*()` and the corresponding `upsert_*()` binds.
+2. **If the field is non-optional** (no `#[serde(default)]`): `row_to_*()` in `kanban-persistence-sqlite/src/sqlite_store/conversions.rs` will **fail to compile** because the struct literal is exhaustive — add the column to `schema.sql`, write a migration if the database already exists, and update both `row_to_*()` (`conversions.rs`) and the corresponding `upsert_*()` bind in `kanban-persistence-sqlite/src/sqlite_store/data_store.rs`.
 
-3. **If the field is optional** (`Option<T>` with `#[serde(default)]`): the SQLite code compiles but silently returns `None` on load — manually update `row_to_*()` and `upsert_*()`, then set the new field to a non-`None` value in `fully_populated_snapshot()` inside both:
-   - `crates/kanban-persistence-sqlite/tests/roundtrip.rs`
-   - `crates/kanban-persistence-json/tests/roundtrip.rs`
+3. **If the field is optional** (`Option<T>` with `#[serde(default)]`): the SQLite code compiles but silently returns `None` on load — manually update `row_to_*()` and `upsert_*()`, then set the new field to a non-`None` value in each backend's `fully_populated_card()`/entity-builder helper and the round-trip tests that use it:
+   - `crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs` (`test_sqlite_card_round_trip_preserves_all_fields`), plus the sibling per-entity round-trip test for the struct you touched (e.g. `columns.rs::test_sqlite_column_round_trip_preserves_all_fields`, `entities.rs::test_sprint_write_then_read_round_trips_all_fields`)
+   - `crates/kanban-persistence-json/src/json_file_store.rs` (`test_json_card_round_trip_preserves_all_fields`, or the equivalent for the entity you changed)
 
-   The roundtrip test (`full_roundtrip_preserves_all_fields`) will fail until all three are updated.
+   These `*_round_trip_preserves_all_fields` tests will fail until both backends are updated.
 
 ### Adding a New Card-Relation Kind
 
@@ -199,16 +230,18 @@ moving parts are:
    `relate`/`dissociate` (undirected) depending on direction.
 
 5. **Implement the new trait methods** on `KanbanContext` in
-   `kanban-service/src/context.rs`, `CliContext`, `McpContext`, `TuiContext`.
+   `kanban-service/src/context/graph.rs` (the `impl GraphOperations for KanbanContext`
+   block), and on `CliContext`, `McpContext`, `TuiContext`.
 
 6. **Persistence**:
    - **JSON** — add a `my_kind: { edges: [...] }` key to the current envelope
-     (V10; no migration needed if a field is added cleanly with
-     `#[serde(default)]`); otherwise bump to V11 with a transform step in
+     (V11; no migration needed if a field is added cleanly with
+     `#[serde(default)]`); otherwise bump to V12 with a transform step in
      `kanban-persistence-json/src/migration/`.
    - **SQLite** — add a `my_kind_edges` table in
      `kanban-persistence-sqlite/src/schema.sql` with appropriate columns
-     and CHECK constraints; add read/write paths in `sqlite_store.rs`.
+     and CHECK constraints; add read/write paths in `sqlite_store/graph.rs`
+     (edge-table CRUD lives there, alongside `spawns_edges`/`blocks_edges`/`relates_edges`).
 
 7. **App surfaces** — expose via `kanban relation` subcommands (CLI),
    `tool_*` handlers (MCP), and TUI popup hooks as needed.
@@ -226,68 +259,77 @@ moving parts are:
    - Implement behavior methods
    - Update `updated_at` timestamps
 
-2. **Update Application State** in `kanban-tui/src/app.rs`
+2. **Update Application State** in `kanban-tui/src/app/` (`mode.rs` for
+   `AppMode`/`DialogMode`, `types.rs` for the `App` struct itself)
    - Add new `AppMode` variants if needed
-   - Implement event handlers
-   - Add business logic methods
+   - Implement business logic methods on `App`
 
-3. **Implement UI** in `kanban-tui/src/ui.rs`
+3. **Implement UI** in `kanban-tui/src/ui/`
    - Add rendering functions
    - Use existing helpers (`render_input_popup`, `centered_rect`)
    - Follow existing panel/dialog patterns
 
-4. **Wire Up Events** in event handlers
+4. **Wire Up Events** in `kanban-tui/src/handlers/` (one file per panel/domain,
+   e.g. `card_handlers.rs`, `dialog_handlers.rs`), dispatched from
+   `kanban-tui/src/app/input_router.rs::handle_key_event`
    - Add keyboard shortcuts
    - Update help text in footer
    - Handle dialog interactions
 
 ### State Management & Persistence Architecture
 
-The application uses a **command pattern** for all state mutations, enabling progressive auto-save:
+The application uses a **command pattern** for all state mutations. `KanbanContext`
+(`kanban-service/src/context/`) holds no cached domain data of its own — it wraps
+a `backend: Arc<dyn kanban_backend::KanbanBackend>`, and every read or write goes
+through that backend.
 
 **Command Pattern Flow:**
-1. **Event Handler** (kanban-tui): Processes keyboard input, collects data
-2. **Command** (kanban-domain): Encapsulates the mutation with parameters
-3. **KanbanContext** (kanban-service): Executes command via CommandContext
-4. **CommandContext**: Applies mutation to data vectors
-5. **Save**: KanbanContext writes state to disk via PersistenceStore
+1. **Event Handler** (`kanban-tui/src/handlers/*.rs`): processes keyboard input, builds one or more `kanban_domain::commands::Command` values.
+2. **`TuiContext::execute_command` / `execute_commands_batch`** (`kanban-tui/src/tui_context.rs`): forwards the batch to `KanbanContext::execute`, then queues a flush if the active backend needs one.
+3. **`KanbanContext::execute`** (`kanban-service/src/context/undo.rs`): runs the whole batch inside one `backend.with_transaction(...)` call — each command's inverse is captured via `Command::capture_inverse` against the state left by the previous command, then the command mutates state via the `DataStore` trait, and finally the batch is appended to the audit log via `backend.append_batch`. The composed inverse is pushed onto `crate::undo_stack::UndoStack`.
+4. **Save**: for the TUI, `execute_commands_batch` signals `SaveCoordinator::queue_flush()` (`kanban-tui/src/state/mod.rs`), which sends on a bounded `tokio::sync::mpsc` channel (capacity 100) to a background save-worker task (`spawn_save_worker` in `kanban-tui/src/app/lifecycle.rs`) that calls `backend.flush().await` off the UI thread. For CLI/MCP/server, `KanbanContext::save()` (`kanban-service/src/context/persistence.rs`) calls `backend.flush()` directly and is awaited inline — there is no UI thread to keep responsive, so no channel/worker is involved there.
 
-**Example Handler Pattern:**
+**Example Handler Pattern** (trimmed from `kanban-tui/src/handlers/card_handlers.rs::create_card`):
 ```rust
-pub fn handle_create_card_key(&mut self) {
-    // Collect immutable data before command execution
-    let (board_id, column_id) = { /* ... */ };
-
-    // Create command
-    let cmd = Box::new(CreateCard {
+pub fn create_card(&mut self) {
+    let card_id = uuid::Uuid::new_v4();
+    let commands: Vec<Command> = vec![Command::Card(CardCommand::Create(CreateCard {
+        id: card_id,
+        card_number,
         board_id,
-        column_id,
+        column_id: column.id,
         title: self.input.as_str().to_string(),
-        // ... other fields
-    });
+        position,
+        options: CreateCardOptions { sprint_id, ..Default::default() },
+        timestamp: chrono::Utc::now(),
+    }))];
 
-    // Execute (sets dirty flag automatically)
-    if let Err(e) = self.execute_command(cmd) {
+    // Single batch: sets dirty flag and queues a flush automatically.
+    if let Err(e) = self.execute_commands_batch(commands) {
         tracing::error!("Failed to create card: {}", e);
+        self.set_error(format!("Failed to create card: {}", e));
         return;
     }
 }
 ```
+Handlers that only ever issue one command (most of `handlers/*.rs`) call the
+single-command wrapper `self.execute_command(cmd)` instead, which is just
+`execute_commands_batch(vec![cmd])`.
 
 **Persistence Features:**
 - **Progressive Auto-Save**: Changes saved immediately after each operation (not just on exit)
-- **Async Processing**: Commands queued immediately via bounded channel, processed by background worker
+- **Async Processing** (TUI only): flush signals are queued immediately via a bounded channel and drained by a background save-worker task; other frontends `.await` `backend.flush()` inline (see flow above)
 - **Conflict Detection**: Multi-instance changes detected via file metadata (timestamp + size + content hash)
-- **Format Versioning**: JSON envelope versioned V1..V10 (current shipped is V10); reader auto-migrates older files on load via the V1→V2→…→V10 chain, writing a one-time `.v{N}.backup` for the starting version before the upgrade. SQLite uses `metadata.schema_version` (`SUPPORTED_SCHEMA_VERSION` currently `4`) with active migrations, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`, plus one-shot legacy-table drops on open.
+- **Format Versioning**: JSON envelope versioned V1..V11 (current shipped is V11); reader auto-migrates older files on load via the V1→V2→…→V11 chain, writing a one-time `.v{N}.backup` for the starting version before the upgrade. SQLite uses `metadata.schema_version` (`SUPPORTED_SCHEMA_VERSION` currently `5`) with active migrations, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`, plus one-shot legacy-table drops on open.
 - **Multi-Instance Support**: Last-write-wins resolution for concurrent edits (see [CONFLICT_RESOLUTION.md](CONFLICT_RESOLUTION.md) for data loss scenarios and limitations)
 - **Atomic Writes**: Crash-safe write pattern (temp file → atomic rename) prevents corruption
 - **Own-Write Detection**: Metadata-based filtering prevents false positives from our own saves
 
 **When Adding Features:**
 1. **Define domain command** in `kanban-domain/src/commands/`
-2. **Implement Command trait** with execute() and description()
-3. **Update handler** in kanban-tui to use `self.execute_command()`
-4. **KanbanContext** in kanban-service handles persistence automatically
+2. **Implement `Command`** with `execute()`, `description()`, and `capture_inverse()`
+3. **Update handler** in `kanban-tui/src/handlers/` to use `self.execute_command()` / `self.execute_commands_batch()`
+4. **`KanbanContext::execute`** in kanban-service applies the mutation and the undo/audit bookkeeping automatically; call `.save()` (or let the TUI's save worker do it) to persist
 
 ## Testing
 
@@ -385,13 +427,28 @@ mod tests {
 
 **Why this matters:**
 
-When publishing:
-1. `kanban-core` publishes first (no internal dependencies)
-2. `kanban-domain` publishes second (depends on kanban-core)
-3. `kanban-persistence` publishes third (depends on kanban-domain)
-4. `kanban-service` publishes fourth (depends on kanban-persistence)
-5. `kanban-tui` and `kanban-mcp` publish fifth (depend on kanban-service)
-6. `kanban-cli` publishes last (depends on all others)
+The workspace has grown to 14 crates, so the publish order is computed rather than
+hardcoded — `scripts/list-crates.sh --names` topologically sorts `cargo metadata`'s
+dependency graph (normal dependencies only; dev-dependency-only cycles like
+`kanban-persistence-json` ↔ `kanban-service` under `test-helpers` are excluded) and
+is the source of truth both scripts publish from. Its current output, grouped by
+dependency tier (a crate only needs the crates in tiers above it to already be
+published):
+
+1. `kanban-core` — no internal dependencies
+2. `kanban-domain` — depends on `kanban-core`
+3. `kanban-api`, `kanban-persistence` — depend on `kanban-core` + `kanban-domain`
+4. `kanban-backend` — depends on `kanban-persistence`
+5. `kanban-backend-memory`, `kanban-backend-http` — depend on `kanban-backend`
+6. `kanban-persistence-json`, `kanban-persistence-sqlite` — depend on `kanban-backend` + `kanban-backend-memory`
+7. `kanban-service` — depends on `kanban-backend` + `kanban-api` (+ `kanban-persistence-sqlite` behind the default-on `sqlite` feature)
+8. `kanban-tui`, `kanban-mcp`, `kanban-server` — depend on `kanban-service` and the concrete backends they ship
+9. `kanban-cli` — depends on all of the above (including `kanban-tui`, behind the default-on `tui` feature)
+
+`scripts/check-crate-list-sync.sh` (see [Adding a Storage Backend](#adding-a-storage-backend))
+fails the build if `validate-release.sh`/`publish-crates.sh` regress to a hardcoded
+crate array instead of calling `list-crates`, so this list should never drift from
+the real graph silently.
 
 If versions diverge between crates, the published versions on crates.io won't resolve dependencies correctly, causing build failures for users.
 
@@ -436,7 +493,7 @@ bash scripts/validate-release.sh
 Use format: `KAN-NNN <type>(<crate>): <description>`
 
 - `KAN-NNN` — the card number, taken from the branch name (branch `max/kan-365` -> `KAN-365`). Omit if the change has no card.
-- `<type>(<crate>)` — the same semantic type as the commit messages below, scoped to the crate without its `kanban-` prefix (`tui`, `service`, `server`, `domain`, `cli`, `mcp`, `core`, `persistence`).
+- `<type>(<crate>)` — the same semantic type as the commit messages below, scoped to the crate without its `kanban-` prefix. With 14 crates in the workspace, the rule is the prefix strip itself, not a fixed enumeration — e.g. `tui`, `service`, `server`, `domain`, `cli`, `mcp`, `core`, `persistence`, `persistence-json`, `persistence-sqlite`, `backend`, `backend-memory`, `backend-http`, `api`.
 - `<description>` — lowercase, concise, no trailing period.
 
 **Examples:**
@@ -474,7 +531,7 @@ Use semantic commit format:
 [optional body]
 ```
 
-`<crate>` is the crate name without its `kanban-` prefix (`tui`, `service`, `server`, `domain`, `cli`, `mcp`, `core`, `persistence`). Omit the scope only for changes that span the whole workspace or touch no crate (e.g. `chore: add changeset`).
+`<crate>` is the crate name without its `kanban-` prefix — e.g. `tui`, `service`, `server`, `domain`, `cli`, `mcp`, `core`, `persistence`, `persistence-json`, `persistence-sqlite`, `backend`, `backend-memory`, `backend-http`, `api`. Omit the scope only for changes that span the whole workspace or touch no crate (e.g. `chore: add changeset`).
 
 **Types:**
 - `feat`: New feature

--- a/README.md
+++ b/README.md
@@ -312,45 +312,180 @@ Press `?` in the app to see bindings for the current context.
 
 ## Architecture
 
+The workspace is layered so that every dependency points inward, toward pure
+domain logic, and outward-facing concerns (storage format, transport, UI) stay
+swappable:
+
 ```
 crates/
 ├── kanban-core               → Shared types, error handling, config, reusable state primitives
 ├── kanban-domain             → Domain models, business logic, filtering & sorting
+├── kanban-api                → Wire-format DTOs shared by kanban-server and HTTP backend clients
 ├── kanban-persistence        → Persistence trait layer — pure trait definitions, all I/O lives in backend crates
-├── kanban-persistence-json   → JSON file storage backend
-├── kanban-persistence-sqlite → SQLite storage backend
+├── kanban-backend            → KanbanBackend / KanbanBackendFactory abstractions over a pluggable backend
+├── kanban-backend-memory     → In-memory KanbanBackend (ephemeral, no persistence)
+├── kanban-backend-http       → KanbanBackend implementation talking to a remote kanban-server
+├── kanban-persistence-json   → JSON file storage backend (implements kanban-persistence + kanban-backend)
+├── kanban-persistence-sqlite → SQLite storage backend (implements kanban-persistence + kanban-backend)
 ├── kanban-service            → KanbanContext, persistence orchestration, undo/redo
 ├── kanban-tui                → Terminal UI with ratatui
 ├── kanban-cli                → CLI entry point (clap)
-└── kanban-mcp                → Model Context Protocol server
+├── kanban-mcp                → Model Context Protocol server
+└── kanban-server             → HTTP API server (axum)
 ```
 
+**Pluggable backends, registered by the app, not the service layer** (KAN-1027):
+`kanban-persistence` defines `StoreFactory` / `StoreRegistry` for the storage
+format layer, and `kanban-backend` defines the equivalent `KanbanBackendFactory`
+/ `KanbanBackendRegistry` one layer up, dispatching to the right backend by
+content-sniffing a locator (`KanbanBackendRegistry::for_locator`) or by explicit
+name (`for_name`). `kanban-service` depends only on the `kanban-backend`
+abstraction — it has no production dependency on any concrete backend crate.
+Each application (`kanban-cli`, `kanban-mcp`, `kanban-tui`, `kanban-server`)
+builds its own registry and registers the concrete backends (JSON, SQLite,
+in-memory, HTTP) it wants to ship with. This is the payoff of the KAN-1027
+refactor: adding a new storage backend no longer means touching
+`kanban-service`.
+
+### Workspace dependency graph
+
+Solid arrows are normal (`[dependencies]`) edges. Dotted arrows are
+optional/feature-gated edges (the dependency only activates when the named
+Cargo feature is enabled — most are on by default). Dev-only edges (test
+fixtures) are omitted here; see the note below.
+
 ```mermaid
-graph LR
-    CLI[kanban-cli] --> TUI[kanban-tui]
-    CLI --> SVC[kanban-service]
-    MCP[kanban-mcp] --> SVC
-    TUI --> SVC
-    SVC --> PER[kanban-persistence]
-    SVC -.-> JSON[kanban-persistence-json]
-    SVC -.-> SQL[kanban-persistence-sqlite]
+graph TD
+    subgraph "Foundation"
+        CORE[kanban-core]
+        DOM[kanban-domain]
+    end
+    subgraph "Domain-adjacent traits"
+        API[kanban-api]
+        PER[kanban-persistence]
+    end
+    subgraph "Backend abstraction"
+        BE[kanban-backend]
+        BEMEM[kanban-backend-memory]
+        BEHTTP[kanban-backend-http]
+    end
+    subgraph "Concrete storage backends"
+        JSON[kanban-persistence-json]
+        SQL[kanban-persistence-sqlite]
+    end
+    subgraph "Service"
+        SVC[kanban-service]
+    end
+    subgraph "Applications"
+        CLI[kanban-cli]
+        MCP[kanban-mcp]
+        TUI[kanban-tui]
+        SRV[kanban-server]
+    end
+
+    DOM --> CORE
+    API --> CORE
+    API --> DOM
+    PER --> CORE
+    PER --> DOM
+
+    BE --> CORE
+    BE --> DOM
+    BE --> PER
+    BEMEM --> DOM
+    BEMEM --> BE
+    BEHTTP --> CORE
+    BEHTTP --> DOM
+    BEHTTP --> BE
+    BEHTTP --> API
+
+    JSON --> CORE
+    JSON --> DOM
     JSON --> PER
+    JSON --> BE
+    JSON --> BEMEM
+    SQL --> CORE
+    SQL --> DOM
     SQL --> PER
-    PER --> DOM[kanban-domain]
-    DOM --> CORE[kanban-core]
+    SQL --> BE
+    SQL --> BEMEM
+
+    SVC --> CORE
+    SVC --> DOM
+    SVC --> PER
+    SVC --> API
+    SVC --> BE
+    SVC -.->|feature: sqlite, default-on| SQL
+
+    CLI --> CORE
+    CLI --> DOM
+    CLI --> PER
+    CLI --> BE
+    CLI --> SVC
+    CLI -.->|feature: json, default-on| JSON
+    CLI -.->|feature: sqlite, default-on| SQL
+    CLI -.->|feature: tui, default-on| TUI
+
+    MCP --> CORE
+    MCP --> DOM
+    MCP --> PER
+    MCP --> BE
+    MCP --> SVC
+    MCP -.->|feature: json, default-on| JSON
+    MCP -.->|feature: sqlite, default-on| SQL
+
+    TUI --> CORE
+    TUI --> DOM
+    TUI --> PER
+    TUI --> BE
+    TUI --> BEMEM
+    TUI --> JSON
+    TUI --> SQL
+    TUI --> SVC
+
+    SRV --> CORE
+    SRV --> DOM
+    SRV --> PER
+    SRV --> BE
+    SRV --> JSON
+    SRV --> SQL
+    SRV --> SVC
+    SRV -.->|feature: test-helpers| BEMEM
 ```
+
+**Not shown above (test-only, dev-dependencies):** `kanban-persistence-json`
+and `kanban-persistence-sqlite` each dev-depend on `kanban-service` (feature
+`test-helpers`) to run the shared service-layer contract tests against their
+backend, and `kanban-service` dev-depends back on both of them — a
+dev-dependency-only cycle that Cargo permits but a production dependency graph
+never would. Similarly `kanban-domain` and `kanban-persistence` dev-depend on
+`kanban-backend-memory` for lightweight in-memory test fixtures, and
+`kanban-backend-http` dev-depends on `kanban-server` (feature `test-helpers`)
+for integration tests against a real server. None of these are reachable from
+a release build — `cargo build --release` never touches them.
+
+The key structural change from before KAN-1027: `kanban-service` used to
+depend directly on `kanban-persistence-json` (behind a `json` feature) and on
+`kanban-backend-memory`. Both are gone from its production dependency graph;
+it depends only on the `kanban-backend`/`kanban-persistence` abstractions, and
+the four application crates now compose the concrete backends themselves.
 
 | Crate | Description | README |
 |-------|-------------|--------|
 | `kanban-core` | Shared types, config, errors, graph, pagination | [→](crates/kanban-core/README.md) |
 | `kanban-domain` | Domain models, business logic | [→](crates/kanban-domain/README.md) |
+| `kanban-api` | REST wire DTOs shared by the server and the HTTP backend | [→](crates/kanban-api/README.md) |
 | `kanban-persistence` | Persistence trait layer | [→](crates/kanban-persistence/README.md) |
+| `kanban-backend` | `KanbanBackend` / `RemoteWrites` abstractions and the backend registry | [→](crates/kanban-backend/README.md) |
+| `kanban-backend-memory` | In-memory `KanbanBackend` (ephemeral) | [→](crates/kanban-backend-memory/README.md) |
+| `kanban-backend-http` | `KanbanBackend` over HTTP against a remote `kanban-server` | [→](crates/kanban-backend-http/README.md) |
 | `kanban-persistence-json` | JSON file backend | [→](crates/kanban-persistence-json/README.md) |
 | `kanban-persistence-sqlite` | SQLite backend | [→](crates/kanban-persistence-sqlite/README.md) |
 | `kanban-service` | Service layer, KanbanContext, undo/redo | [→](crates/kanban-service/README.md) |
 | `kanban-tui` | Terminal UI | [→](crates/kanban-tui/README.md) |
 | `kanban-cli` | CLI entry point | [→](crates/kanban-cli/README.md) |
 | `kanban-mcp` | MCP server | [→](crates/kanban-mcp/README.md) |
+| `kanban-server` | HTTP API server | [→](crates/kanban-server/README.md) |
 
 ---
 
@@ -396,6 +531,27 @@ graph LR
 - [ ] HTTP API for remote access
 - [ ] Collaborative / sync features
 - [ ] Search anything, anywhere
+
+---
+
+## Building, Running, Testing
+
+```bash
+nix develop            # enter the dev shell (Rust toolchain, cargo-watch, bacon, ...)
+
+cargo build             # build all crates
+cargo build --release   # optimized production build
+cargo run                # launch the TUI
+cargo run -- tui          # explicit TUI mode
+cargo run -- init --name "My Project"  # non-interactive board init
+
+cargo test                            # run all tests
+cargo test --package kanban-domain    # test a single crate
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --all
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow, code style, and testing guidelines, and each crate's own README (linked in the architecture table above) for its scoped dependency diagram and public API.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -493,8 +493,8 @@ the four application crates now compose the concrete backends themselves.
 
 ### JSON Backend (default)
 
-- **Envelope format** (current version V10): `{ "version": 10, "metadata": {...}, "data": {...} }`
-- **Automatic migrations**: older files (V1..V10) upgrade in place on open, writing a one-time `.v{N}.backup` before the upgrade
+- **Envelope format** (current version V11): `{ "version": 11, "metadata": {...}, "data": {...} }`
+- **Automatic migrations**: older files (V1..V11) upgrade in place on open, writing a one-time `.v{N}.backup` before the upgrade
 - **Atomic writes**: crash-safe — every write is atomic (temp file → rename)
 - **Debounced saving**: 500ms minimum interval between saves
 - Default for any plain file path

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ in motion for one representative write path:
 - **WAL mode** with foreign key enforcement
 - **Connection pool**: max 2 connections
 - **Relational schema**: boards, columns, cards, archived cards, sprints, sprint logs, dependency graph edges, and more
-- **Schema versioning with active migrations** (current schema version 4): older databases upgrade on open, each guarded by a durable pre-migration backup (`VACUUM INTO` snapshot to `.v{N}.backup`)
+- **Schema versioning with active migrations** (current schema version 5): older databases upgrade on open, each guarded by a durable pre-migration backup (`VACUUM INTO` snapshot to `.v{N}.backup`)
 - File selected by `.sqlite`, `.sqlite3`, or `.db` extension
 
 ### Multi-Instance Support

--- a/README.md
+++ b/README.md
@@ -312,6 +312,16 @@ Press `?` in the app to see bindings for the current context.
 
 ## Architecture
 
+**How it fits, in 30 seconds:** `kanban-domain` holds all business rules with
+zero I/O. `kanban-persistence` and `kanban-backend` are two stacked plugin
+points — one for storage *format* (JSON/SQLite), one for storage *backend*
+(in-memory/JSON/SQLite/HTTP) — each with a factory trait a new implementation
+registers against. `kanban-service` is the single seam every frontend
+(`kanban-cli`, `kanban-tui`, `kanban-mcp`, `kanban-server`) goes through to
+reach a backend; each frontend picks which concrete backends to compile in
+and registers them itself at startup. The detailed graph below shows exactly
+which crate depends on which.
+
 The workspace is layered so that every dependency points inward, toward pure
 domain logic, and outward-facing concerns (storage format, transport, UI) stay
 swappable:
@@ -486,6 +496,31 @@ the four application crates now compose the concrete backends themselves.
 | `kanban-cli` | CLI entry point | [→](crates/kanban-cli/README.md) |
 | `kanban-mcp` | MCP server | [→](crates/kanban-mcp/README.md) |
 | `kanban-server` | HTTP API server | [→](crates/kanban-server/README.md) |
+
+### Where do I make a change?
+
+| I want to... | Touch these crates |
+|---|---|
+| Add a new storage backend (e.g. Postgres) | `kanban-persistence` (implement `StoreFactory`/`PersistenceStore`), `kanban-backend` (implement `KanbanBackendFactory`), and whichever app crate(s) should ship it (`kanban-cli`/`kanban-mcp`/`kanban-tui`/`kanban-server`) to `register_backend` it |
+| Add a field to `Card`/`Board`/`Column`/`Sprint` | `kanban-domain` (model + `*Update` struct), `kanban-persistence-json` (envelope version bump + migration), `kanban-persistence-sqlite` (schema migration), `kanban-api` (DTOs, if exposed over REST) |
+| Add a CLI command | `kanban-cli` (clap subcommand + handler in `src/handlers/`), `kanban-service` (a new `KanbanContext` method, if the operation doesn't exist yet) |
+| Add an MCP tool | `kanban-mcp` (tool handler), `kanban-service` (a new `KanbanContext` method, if needed) |
+| Add a REST endpoint | `kanban-server` (axum handler + route), `kanban-api` (request/response DTOs), `kanban-service` |
+| Add a TUI dialog or view | `kanban-tui` (`AppMode`/`DialogMode` variant, key handler, `ui::` renderer) |
+| Add or change a card relation kind (spawns / blocks / relates) | `kanban-domain` (`DependencyGraph`, `GraphOperations`), `kanban-persistence-sqlite` (edge table), `kanban-persistence-json` (migration), `kanban-service` (`GraphOperations` impl on `KanbanContext`) |
+| Change undo/redo behavior | `kanban-service` (`src/undo_stack.rs`, `src/context/undo.rs`), `kanban-domain` (`commands/` inverse capture) |
+
+### Request flow: `card create` end to end
+
+The static dependency graph above shows structure; here's the same layering
+in motion for one representative write path:
+
+1. `kanban card create --board ... --column ... --title ...` is parsed by clap in `kanban-cli` (`src/handlers/card.rs`), which resolves the board/column arguments to UUIDs.
+2. The handler calls `ctx.create_card(board_id, column_id, title, options)` — the `KanbanOperations` entry point implemented on `KanbanContext` (`kanban-service/src/context/cards.rs`).
+3. `create_card_impl` builds a `NewCard` spec and calls `create_card_from_spec`, which constructs a `Command::Card(CardCommand::Create(..))` and calls `self.execute(vec![cmd])`.
+4. `KanbanContext::execute` runs the command through `backend.with_transaction(...)`: the command mutates state via the `DataStore` trait on whichever concrete `KanbanBackend` is active, then the batch is appended to the command log via `backend.append_batch` for the undo/audit trail.
+5. The handler calls `ctx.save().await?`, which delegates to `backend.flush()` — an atomic temp-file-then-rename write for the JSON backend, or a transaction commit for SQLite.
+6. The CLI serializes the returned `Card` to JSON and prints it to stdout.
 
 ---
 

--- a/crates/kanban-api/README.md
+++ b/crates/kanban-api/README.md
@@ -1,0 +1,64 @@
+# kanban-api
+
+Wire-format DTOs for the kanban HTTP API. Owns the request/response shapes
+shared by `kanban-server` (which serializes them) and `kanban-backend-http`
+(which deserializes them), so the two sides of the HTTP boundary cannot drift
+independently. Pure data types — no I/O, no business logic.
+
+The crate's own `v1` module is private; canonical imports go through
+`kanban_service::api::*` (re-exported via `pub use kanban_api as api;` in
+`kanban-service`), keeping a single import path stable as the wire version
+evolves (`v2`, `v3`, ...).
+
+## Key public exports
+
+Re-exported from `src/lib.rs` (`pub use v1::{ ... }`):
+
+```rust
+pub use v1::{
+    ApiError, ArchivedFilterDto, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto,
+    ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
+    CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams, Patch,
+    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
+    ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
+    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
+    UpdateSprintRequest,
+};
+```
+
+- `*Response` types are the read-side DTOs returned by `kanban-server`'s REST endpoints.
+- `Create*Request` / `Replace*Request` / `Update*Request` are the write-side DTOs for `POST` / `PUT` / `PATCH` respectively — `Update*Request` follows JSON Merge Patch (RFC 7386) semantics via `Patch<T>`.
+- `ApiError` / `ErrorCode` are the shared error envelope every non-2xx response uses.
+- `ChangeEventFrame` is the payload broadcast on `kanban-server`'s internal change-event channel.
+
+The optional `schemars` feature (`dep:schemars`, `features = ["uuid1"]`) derives `schemars::JsonSchema` on these DTOs so `kanban-mcp` can use them directly as `Parameters<T>` for its tool handlers (rmcp requires a JSON Schema).
+
+## Position in the workspace
+
+`kanban-api` sits beside `kanban-persistence` in the layer just above the
+domain model: both depend only on `kanban-core` + `kanban-domain`, and both
+are depended on by the backend/service layer above them.
+
+```mermaid
+graph TD
+    DOM[kanban-domain] --> CORE[kanban-core]
+    API[kanban-api] --> CORE
+    API --> DOM
+    BEHTTP[kanban-backend-http] --> API
+    SVC[kanban-service] --> API
+```
+
+Solid arrows are normal (`[dependencies]`) edges; there are no optional or
+feature-gated edges into or out of this crate. See the [root README](../../README.md)
+for the full workspace dependency graph.
+
+## Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `kanban-core` | `KanbanError`, `KanbanResult` |
+| `kanban-domain` | Domain types the DTOs wrap (`Board`, `Card`, `Column`, `Sprint`, ...) |
+| `serde` + `serde_json` | Serialization |
+| `uuid` | `Uuid` type |
+| `chrono` | Timestamps |
+| `schemars` (optional, feature `schemars`) | JSON Schema derivation for MCP tool parameters |

--- a/crates/kanban-api/README.md
+++ b/crates/kanban-api/README.md
@@ -56,9 +56,13 @@ for the full workspace dependency graph.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-core` | `KanbanError`, `KanbanResult` |
-| `kanban-domain` | Domain types the DTOs wrap (`Board`, `Card`, `Column`, `Sprint`, ...) |
+| [`kanban-core`](../kanban-core/README.md) | `KanbanError`, `KanbanResult` |
+| [`kanban-domain`](../kanban-domain/README.md) | Domain types the DTOs wrap (`Board`, `Card`, `Column`, `Sprint`, ...) |
 | `serde` + `serde_json` | Serialization |
 | `uuid` | `Uuid` type |
 | `chrono` | Timestamps |
 | `schemars` (optional, feature `schemars`) | JSON Schema derivation for MCP tool parameters |
+
+## Related crates
+
+Used by: [kanban-backend-http](../kanban-backend-http/README.md) (HTTP request/response bodies) and [kanban-service](../kanban-service/README.md) (re-exported as `kanban_service::api` for MCP/server consumers).

--- a/crates/kanban-backend-http/README.md
+++ b/crates/kanban-backend-http/README.md
@@ -1,0 +1,81 @@
+# kanban-backend-http
+
+`HttpBackend`: a `KanbanBackend` implementation backed by a remote
+`kanban-server` over HTTP, using `kanban-api`'s DTOs on the wire. Lets a
+client (e.g. a future web UI, or a CLI/TUI pointed at a shared server instead
+of a local file) talk to boards through the same `KanbanBackend` interface
+every other backend implements.
+
+**Status: early / stub.** `HttpBackend` builds its own dedicated Tokio
+runtime and HTTP client, and implements `KanbanBackend` (so it type-checks
+against the trait and is object-safe), but its `DataStore`/`CommandStore`
+methods (in `src/data_store.rs` / `src/command_store.rs`) are stubs that
+return an unsupported-operation error — see
+`test_http_backend_stub_method_returns_unsupported_error` in `src/lib.rs`.
+Real reads/writes against `kanban-server`'s REST endpoints are follow-up work.
+
+## Key public exports
+
+```rust
+pub struct HttpBackend {
+    base_url: String,
+    client: reqwest::Client,
+    runtime: tokio::runtime::Runtime,
+    instance_id: uuid::Uuid,
+}
+
+impl HttpBackend {
+    pub fn new(base_url: &str) -> kanban_domain::KanbanResult<Self>;
+}
+
+impl kanban_backend::KanbanBackend for HttpBackend {
+    fn as_data_store(&self) -> &dyn kanban_domain::DataStore { self }
+    fn instance_id(&self) -> uuid::Uuid { self.instance_id }
+}
+```
+
+`HttpBackend::new` normalizes a trailing slash off `base_url`, builds a
+`reqwest::Client`, and spins up a dedicated multi-thread Tokio runtime — every
+synchronous `DataStore`/`CommandStore` call bridges onto that runtime via a
+private `block_on` helper rather than assuming an ambient one, since
+`KanbanBackend`'s inherent methods are synchronous but the HTTP calls
+underneath are async.
+
+## Position in the workspace
+
+```mermaid
+graph TD
+    CORE[kanban-core] 
+    DOM[kanban-domain]
+    API[kanban-api] --> CORE
+    API --> DOM
+    BE[kanban-backend] --> CORE
+    BE --> DOM
+    BEHTTP[kanban-backend-http] --> CORE
+    BEHTTP --> DOM
+    BEHTTP --> BE
+    BEHTTP --> API
+```
+
+All edges shown are normal (`[dependencies]`) edges. No crate in the workspace
+currently has a normal or optional dependency on `kanban-backend-http` — it
+has no intra-workspace dependents yet (it's meant to be composed by an
+external embedder, or by a future `kanban-cli`/`kanban-tui` "remote mode").
+The crate does have a `[dev-dependencies]` edge on `kanban-server` (feature
+`test-helpers`), used to spin up a real server for integration tests; that's
+test-only and omitted from the diagram above. See the
+[root README](../../README.md) for the full workspace dependency graph.
+
+## Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `kanban-core` | `KanbanResult`, `KanbanError` |
+| `kanban-domain` | `DataStore`, `KanbanResult`, `KanbanError` |
+| `kanban-backend` | `KanbanBackend` trait implemented by `HttpBackend` |
+| `kanban-api` | Wire DTOs for the HTTP request/response bodies |
+| `reqwest` | HTTP client |
+| `tokio` | Dedicated runtime for bridging sync trait methods onto async HTTP calls |
+| `async-trait` | Async trait methods |
+| `uuid` | Instance ID |
+| `chrono` | Timestamps |

--- a/crates/kanban-backend-http/README.md
+++ b/crates/kanban-backend-http/README.md
@@ -70,12 +70,16 @@ test-only and omitted from the diagram above. See the
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-core` | `KanbanResult`, `KanbanError` |
-| `kanban-domain` | `DataStore`, `KanbanResult`, `KanbanError` |
-| `kanban-backend` | `KanbanBackend` trait implemented by `HttpBackend` |
-| `kanban-api` | Wire DTOs for the HTTP request/response bodies |
+| [`kanban-core`](../kanban-core/README.md) | `KanbanResult`, `KanbanError` |
+| [`kanban-domain`](../kanban-domain/README.md) | `DataStore`, `KanbanResult`, `KanbanError` |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend` trait implemented by `HttpBackend` |
+| [`kanban-api`](../kanban-api/README.md) | Wire DTOs for the HTTP request/response bodies |
 | `reqwest` | HTTP client |
 | `tokio` | Dedicated runtime for bridging sync trait methods onto async HTTP calls |
 | `async-trait` | Async trait methods |
 | `uuid` | Instance ID |
 | `chrono` | Timestamps |
+
+## Related crates
+
+Used by: none yet — no crate in the workspace currently registers `HttpBackend` as a `KanbanBackendFactory`. [kanban-server](../kanban-server/README.md) depends on this crate only in reverse, as a dev-dependency (feature `test-helpers`) to spin up a real server for this crate's own integration tests.

--- a/crates/kanban-backend-memory/README.md
+++ b/crates/kanban-backend-memory/README.md
@@ -1,0 +1,60 @@
+# kanban-backend-memory
+
+An ephemeral `KanbanBackend` implementation: `InMemoryStore` holds all board
+state in a plain in-process data structure with no persistence at all. Used
+whenever the CLI/TUI/MCP server is launched without a file (`kanban` with no
+arguments), and as the lightweight fixture backend for tests across the
+workspace that need a working `KanbanBackend` without touching disk. Extracted
+out of `kanban-service` into its own crate in KAN-1023.
+
+## Key public exports
+
+From `src/lib.rs` / `src/in_memory_store.rs`:
+
+```rust
+pub use in_memory_store::InMemoryStore;
+
+impl kanban_backend::KanbanBackend for InMemoryStore {
+    fn as_data_store(&self) -> &dyn kanban_domain::DataStore {
+        self
+    }
+    // All lifecycle defaults are correct for in-memory:
+    // flush = noop, reload = noop, needs_flush = false, needs_save_worker = false.
+}
+```
+
+`InMemoryStore` itself implements `kanban_domain::DataStore` (and
+`CommandStore`) directly; the `KanbanBackend` impl above is a thin marker that
+accepts every trait default except `as_data_store`. There is no
+`persistence_metadata` (always `None`) and no `health_checker` (always
+`None`) — those only make sense for a backend with actual durable storage
+behind it.
+
+## Position in the workspace
+
+```mermaid
+graph TD
+    DOM[kanban-domain] --> CORE[kanban-core]
+    BE[kanban-backend] --> DOM
+    BEMEM[kanban-backend-memory] --> DOM
+    BEMEM --> BE
+    JSON[kanban-persistence-json] --> BEMEM
+    SQL[kanban-persistence-sqlite] --> BEMEM
+    TUI[kanban-tui] --> BEMEM
+    SRV[kanban-server] -.->|feature: test-helpers| BEMEM
+```
+
+Solid arrows are normal (`[dependencies]`) edges; the dotted arrow is
+feature-gated. Not shown: `kanban-domain` and `kanban-persistence` each
+dev-depend on this crate (test-only fixture, not part of the production
+graph). See the [root README](../../README.md) for the full workspace
+dependency graph and its note on dev-only edges.
+
+## Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `kanban-domain` | `DataStore`, `CommandStore`, and the domain model this crate stores |
+| `kanban-backend` | `KanbanBackend` trait implemented by `InMemoryStore` |
+| `uuid` | Entity IDs |
+| `chrono` | Timestamps |

--- a/crates/kanban-backend-memory/README.md
+++ b/crates/kanban-backend-memory/README.md
@@ -45,10 +45,10 @@ graph TD
 ```
 
 Solid arrows are normal (`[dependencies]`) edges; the dotted arrow is
-feature-gated. Not shown: `kanban-domain` and `kanban-persistence` each
-dev-depend on this crate (test-only fixture, not part of the production
-graph). See the [root README](../../README.md) for the full workspace
-dependency graph and its note on dev-only edges.
+feature-gated. Not shown: `kanban-domain`, `kanban-persistence`, and
+`kanban-service` each dev-depend on this crate (test-only fixture, not part
+of the production graph). See the [root README](../../README.md) for the
+full workspace dependency graph and its note on dev-only edges.
 
 ## Dependencies
 

--- a/crates/kanban-backend-memory/README.md
+++ b/crates/kanban-backend-memory/README.md
@@ -25,10 +25,10 @@ impl kanban_backend::KanbanBackend for InMemoryStore {
 
 `InMemoryStore` itself implements `kanban_domain::DataStore` (and
 `CommandStore`) directly; the `KanbanBackend` impl above is a thin marker that
-accepts every trait default except `as_data_store`. There is no
-`persistence_metadata` (always `None`) and no `health_checker` (always
-`None`) — those only make sense for a backend with actual durable storage
-behind it.
+accepts every trait default except `as_data_store`. It exposes no
+`local_persistence` capability (the accessor returns `None`) and no
+`health_checker` (always `None`) — those only make sense for a backend with
+actual durable storage behind it.
 
 ## Position in the workspace
 

--- a/crates/kanban-backend-memory/README.md
+++ b/crates/kanban-backend-memory/README.md
@@ -54,7 +54,11 @@ full workspace dependency graph and its note on dev-only edges.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-domain` | `DataStore`, `CommandStore`, and the domain model this crate stores |
-| `kanban-backend` | `KanbanBackend` trait implemented by `InMemoryStore` |
+| [`kanban-domain`](../kanban-domain/README.md) | `DataStore`, `CommandStore`, and the domain model this crate stores |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend` trait implemented by `InMemoryStore` |
 | `uuid` | Entity IDs |
 | `chrono` | Timestamps |
+
+## Related crates
+
+Used by: [kanban-persistence-json](../kanban-persistence-json/README.md), [kanban-persistence-sqlite](../kanban-persistence-sqlite/README.md), and [kanban-tui](../kanban-tui/README.md), plus [kanban-server](../kanban-server/README.md) behind its `test-helpers` feature.

--- a/crates/kanban-backend/README.md
+++ b/crates/kanban-backend/README.md
@@ -145,9 +145,13 @@ the [root README](../../README.md) for the full workspace dependency graph
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-core` | `KanbanResult`, `AppConfig`, `HealthChecker` |
-| `kanban-domain` | `DataStore`, `CommandStore` traits this crate's trait is built on |
-| `kanban-persistence` | `PersistenceMetadata` type surfaced by `persistence_metadata()` |
+| [`kanban-core`](../kanban-core/README.md) | `KanbanResult`, `AppConfig`, `HealthChecker` |
+| [`kanban-domain`](../kanban-domain/README.md) | `DataStore`, `CommandStore` traits this crate's trait is built on |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceMetadata` type surfaced by `persistence_metadata()` |
 | `async-trait` | Async trait methods |
 | `uuid` | Instance IDs |
 | `chrono` | Timestamps |
+
+## Related crates
+
+Used by: the concrete backend crates [kanban-backend-memory](../kanban-backend-memory/README.md), [kanban-backend-http](../kanban-backend-http/README.md), [kanban-persistence-json](../kanban-persistence-json/README.md), and [kanban-persistence-sqlite](../kanban-persistence-sqlite/README.md), plus [kanban-service](../kanban-service/README.md).

--- a/crates/kanban-backend/README.md
+++ b/crates/kanban-backend/README.md
@@ -70,6 +70,39 @@ the remote side is authoritative for create/update/delete (i.e. `kanban-backend-
 local command execution entirely; every local backend (JSON, SQLite,
 in-memory) returns `None`, so there's zero behavior change for them.
 
+## Implementing `KanbanBackendFactory`
+
+A minimal factory just needs a name, a content-sniffing predicate, and a
+constructor. `kanban-persistence-json`'s `JsonBackendFactory` (`src/backend_factory.rs`)
+is the smallest real example in the workspace:
+
+```rust
+pub struct JsonBackendFactory;
+
+#[async_trait::async_trait]
+impl KanbanBackendFactory for JsonBackendFactory {
+    fn name(&self) -> &str {
+        "json"
+    }
+
+    fn matches_locator(&self, _locator: &str, header: &[u8]) -> bool {
+        let trimmed = header.iter().find(|b| !b.is_ascii_whitespace());
+        header.is_empty() || matches!(trimmed, Some(b'{') | Some(b'['))
+    }
+
+    async fn create(&self, locator: &str, _config: &AppConfig) -> KanbanResult<Arc<dyn KanbanBackend>> {
+        let store: Arc<dyn PersistenceStore + Send + Sync> = Arc::new(JsonFileStore::new(locator));
+        Ok(Arc::new(JsonDataStore::new(store)))
+    }
+}
+```
+
+This is the layer above `StoreFactory`/`PersistenceStore` — see
+[`kanban-persistence`'s "Writing a Third-Party Backend"](../kanban-persistence/README.md#writing-a-third-party-backend)
+for the full walkthrough of the storage-format layer this factory wraps,
+including the contract test suite and `register_backend` wiring on
+`CliApp`/`McpServer`.
+
 ## Position in the workspace
 
 ```mermaid

--- a/crates/kanban-backend/README.md
+++ b/crates/kanban-backend/README.md
@@ -1,0 +1,120 @@
+# kanban-backend
+
+Defines the `KanbanBackend` trait and the registry/factory machinery that lets
+the service layer talk to a storage backend without knowing which one is
+plugged in. This is the abstraction `kanban-service` depends on instead of
+depending on `kanban-persistence-json` / `kanban-persistence-sqlite` /
+`kanban-backend-memory` directly (KAN-1027) — adding a new backend means
+implementing `KanbanBackend` and `KanbanBackendFactory` in its own crate and
+registering it from the application, not editing `kanban-service`.
+
+## Key public exports
+
+From `src/lib.rs`, `src/factory.rs`, `src/remote_writes.rs`:
+
+```rust
+pub use factory::{KanbanBackendFactory, KanbanBackendRegistry};
+pub use remote_writes::RemoteWrites;
+
+#[async_trait]
+pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
+    fn as_data_store(&self) -> &dyn DataStore;
+    async fn flush(&self) -> KanbanResult<()> { Ok(()) }
+    async fn reload(&self) -> KanbanResult<()> { Ok(()) }
+    fn needs_flush(&self) -> bool { false }
+    fn needs_save_worker(&self) -> bool { false }
+    fn instance_id(&self) -> Uuid { Uuid::nil() }
+    fn persistence_metadata(&self) -> Option<PersistenceMetadata> { None }
+    fn health_checker(&self) -> Option<Box<dyn kanban_core::HealthChecker>> { None }
+    fn remote_writes(&self) -> Option<&dyn RemoteWrites> { None }
+    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> { /* default: snapshot + restore on error */ }
+}
+```
+
+`KanbanBackend` combines `kanban_domain::DataStore` (entity CRUD) with
+`kanban_domain::CommandStore` (the audit/command log) plus the lifecycle hooks
+above. `with_transaction`'s default implementation snapshots state before
+running `f` and restores it on failure (cheap in-memory, expensive on disk);
+disk-backed backends override it with a native transaction.
+
+```rust
+#[async_trait::async_trait]
+pub trait KanbanBackendFactory: Send + Sync {
+    fn name(&self) -> &str;
+    fn matches_locator(&self, _locator: &str, _header: &[u8]) -> bool { false }
+    async fn create(&self, locator: &str, config: &AppConfig) -> KanbanResult<Arc<dyn KanbanBackend>>;
+}
+
+#[derive(Default)]
+pub struct KanbanBackendRegistry { /* private */ }
+
+impl KanbanBackendRegistry {
+    pub fn new() -> Self;
+    pub fn register(&mut self, factory: Box<dyn KanbanBackendFactory>);
+    pub fn is_empty(&self) -> bool;
+    pub fn names(&self) -> Vec<&str>;
+    pub fn for_name(&self, name: &str) -> Option<&dyn KanbanBackendFactory>;
+    pub fn for_locator(&self, locator: &str) -> Option<&dyn KanbanBackendFactory>;
+}
+```
+
+`for_name` and `for_locator` are both first-registration-wins. `for_locator`
+reads up to the first 32 bytes of the file at `locator` (empty if it doesn't
+exist or isn't readable) and asks each registered factory's `matches_locator`
+in registration order — the same content-sniffing pattern
+`kanban_persistence::StoreRegistry` uses one layer down.
+
+`RemoteWrites` (in `remote_writes.rs`) is the escape hatch for backends where
+the remote side is authoritative for create/update/delete (i.e. `kanban-backend-http`):
+`KanbanBackend::remote_writes()` returns `Some(&dyn RemoteWrites)` to bypass
+local command execution entirely; every local backend (JSON, SQLite,
+in-memory) returns `None`, so there's zero behavior change for them.
+
+## Position in the workspace
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain]
+    PER[kanban-persistence]
+    BE[kanban-backend]
+    BEMEM[kanban-backend-memory]
+    BEHTTP[kanban-backend-http]
+    JSON[kanban-persistence-json]
+    SQL[kanban-persistence-sqlite]
+    SVC[kanban-service]
+    CLI[kanban-cli]
+    MCP[kanban-mcp]
+    TUI[kanban-tui]
+    SRV[kanban-server]
+
+    BE --> CORE
+    BE --> DOM
+    BE --> PER
+
+    BEMEM --> BE
+    BEHTTP --> BE
+    JSON --> BE
+    SQL --> BE
+    SVC --> BE
+    CLI --> BE
+    MCP --> BE
+    TUI --> BE
+    SRV --> BE
+```
+
+All edges shown are normal (`[dependencies]`) edges — every crate above
+depends on `kanban-backend` unconditionally, none behind a feature flag. See
+the [root README](../../README.md) for the full workspace dependency graph
+(including the optional/feature edges elsewhere in the graph).
+
+## Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `kanban-core` | `KanbanResult`, `AppConfig`, `HealthChecker` |
+| `kanban-domain` | `DataStore`, `CommandStore` traits this crate's trait is built on |
+| `kanban-persistence` | `PersistenceMetadata` type surfaced by `persistence_metadata()` |
+| `async-trait` | Async trait methods |
+| `uuid` | Instance IDs |
+| `chrono` | Timestamps |

--- a/crates/kanban-backend/README.md
+++ b/crates/kanban-backend/README.md
@@ -10,10 +10,11 @@ registering it from the application, not editing `kanban-service`.
 
 ## Key public exports
 
-From `src/lib.rs`, `src/factory.rs`, `src/remote_writes.rs`:
+From `src/lib.rs`, `src/factory.rs`, `src/remote_writes.rs`, `src/local_persistence.rs`:
 
 ```rust
 pub use factory::{KanbanBackendFactory, KanbanBackendRegistry};
+pub use local_persistence::LocalPersistence;
 pub use remote_writes::RemoteWrites;
 
 #[async_trait]
@@ -24,7 +25,7 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     fn needs_flush(&self) -> bool { false }
     fn needs_save_worker(&self) -> bool { false }
     fn instance_id(&self) -> Uuid { Uuid::nil() }
-    fn persistence_metadata(&self) -> Option<PersistenceMetadata> { None }
+    fn local_persistence(&self) -> Option<&dyn LocalPersistence> { None }
     fn health_checker(&self) -> Option<Box<dyn kanban_core::HealthChecker>> { None }
     fn remote_writes(&self) -> Option<&dyn RemoteWrites> { None }
     fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> { /* default: snapshot + restore on error */ }
@@ -69,6 +70,16 @@ the remote side is authoritative for create/update/delete (i.e. `kanban-backend-
 `KanbanBackend::remote_writes()` returns `Some(&dyn RemoteWrites)` to bypass
 local command execution entirely; every local backend (JSON, SQLite,
 in-memory) returns `None`, so there's zero behavior change for them.
+
+`LocalPersistence` (in `local_persistence.rs`) is the sibling capability for the
+opposite case: backends backed by a durable local file expose format/writer
+metadata through it. `KanbanBackend::local_persistence()` returns
+`Some(&dyn LocalPersistence)` only for the JSON and SQLite backends;
+`kanban-backend-memory` and `kanban-backend-http` inherit the `None` default,
+so they are never asked for a `PersistenceMetadata` they cannot produce. This
+is an Interface Segregation split (KAN-1029): the trait no longer carries a
+blanket `persistence_metadata()` method every backend had to implement. It
+mirrors `RemoteWrites`'s optional-capability shape exactly.
 
 ## Implementing `KanbanBackendFactory`
 
@@ -147,7 +158,7 @@ the [root README](../../README.md) for the full workspace dependency graph
 |-------|---------|
 | [`kanban-core`](../kanban-core/README.md) | `KanbanResult`, `AppConfig`, `HealthChecker` |
 | [`kanban-domain`](../kanban-domain/README.md) | `DataStore`, `CommandStore` traits this crate's trait is built on |
-| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceMetadata` type surfaced by `persistence_metadata()` |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceMetadata` type surfaced by the `LocalPersistence` capability |
 | `async-trait` | Async trait methods |
 | `uuid` | Instance IDs |
 | `chrono` | Timestamps |

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -229,13 +229,48 @@ kanban completions powershell >> $PROFILE
 
 ---
 
+## Position in the workspace
+
+```mermaid
+graph TD
+    PER[kanban-persistence]
+    BE[kanban-backend] --> PER
+    JSON[kanban-persistence-json] --> BE
+    SQL[kanban-persistence-sqlite] --> BE
+    SVC[kanban-service] --> PER
+    SVC --> BE
+    TUI[kanban-tui] --> SVC
+    CLI[kanban-cli] --> PER
+    CLI --> BE
+    CLI --> SVC
+    CLI -.->|feature: json, default-on| JSON
+    CLI -.->|feature: sqlite, default-on| SQL
+    CLI -.->|feature: tui, default-on| TUI
+```
+
+Solid arrows are normal (`[dependencies]`) edges; dotted arrows are
+feature-gated (all three optional features are on by default, so a plain
+`cargo build`/`cargo install kanban-cli` pulls all of them — `--no-default-features
+--features sqlite` builds a JSON-less, TUI-less binary). This is the
+KAN-1027 shape: `kanban-cli`, not `kanban-service`, registers the concrete
+backends (`kanban-persistence-json`, `kanban-persistence-sqlite`) it ships
+with. See the [root README](../../README.md) for the full workspace
+dependency graph.
+
 ## Dependencies
 
 | Crate | Purpose |
 |-------|---------|
 | `kanban-service` | `KanbanContext`, all domain operations |
-| `kanban-tui` | TUI launch |
-| `clap` | CLI argument parsing |
+| `kanban-core` | Shared types, config |
+| `kanban-domain` | Domain models |
+| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
+| `kanban-backend` | `KanbanBackend`, `KanbanBackendRegistry` |
+| `kanban-persistence-json` (optional, feature `json`, default-on) | JSON backend, registered at startup |
+| `kanban-persistence-sqlite` (optional, feature `sqlite`, default-on) | SQLite backend, registered at startup |
+| `kanban-tui` (optional, feature `tui`, default-on) | TUI launch |
+| `clap` + `clap_complete` | CLI argument parsing, shell completions |
 | `tokio` | Async runtime |
-| `serde_json` | JSON output formatting |
-| `tracing` | Structured logging |
+| `serde` + `serde_json` | JSON output formatting |
+| `tracing` + `tracing-subscriber` | Structured logging |
+| `anyhow` + `thiserror` | Error handling |

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -261,16 +261,20 @@ dependency graph.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-service` | `KanbanContext`, all domain operations |
-| `kanban-core` | Shared types, config |
-| `kanban-domain` | Domain models |
-| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
-| `kanban-backend` | `KanbanBackend`, `KanbanBackendRegistry` |
-| `kanban-persistence-json` (optional, feature `json`, default-on) | JSON backend, registered at startup |
-| `kanban-persistence-sqlite` (optional, feature `sqlite`, default-on) | SQLite backend, registered at startup |
-| `kanban-tui` (optional, feature `tui`, default-on) | TUI launch |
+| [`kanban-service`](../kanban-service/README.md) | `KanbanContext`, all domain operations |
+| [`kanban-core`](../kanban-core/README.md) | Shared types, config |
+| [`kanban-domain`](../kanban-domain/README.md) | Domain models |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore`, `StoreRegistry` |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend`, `KanbanBackendRegistry` |
+| [`kanban-persistence-json`](../kanban-persistence-json/README.md) (optional, feature `json`, default-on) | JSON backend, registered at startup |
+| [`kanban-persistence-sqlite`](../kanban-persistence-sqlite/README.md) (optional, feature `sqlite`, default-on) | SQLite backend, registered at startup |
+| [`kanban-tui`](../kanban-tui/README.md) (optional, feature `tui`, default-on) | TUI launch |
 | `clap` + `clap_complete` | CLI argument parsing, shell completions |
 | `tokio` | Async runtime |
 | `serde` + `serde_json` | JSON output formatting |
 | `tracing` + `tracing-subscriber` | Structured logging |
 | `anyhow` + `thiserror` | Error handling |
+
+## Related crates
+
+Used by: none — `kanban-cli` is a binary entry point, not a library dependency of any other workspace crate.

--- a/crates/kanban-core/README.md
+++ b/crates/kanban-core/README.md
@@ -245,6 +245,35 @@ pub trait Loggable {
 
 ---
 
+## Position in the workspace
+
+`kanban-core` is the foundation crate: it has no intra-workspace dependencies,
+and almost every other crate in the workspace depends on it directly (not
+just transitively through `kanban-domain`).
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain] --> CORE
+    API[kanban-api] --> CORE
+    PER[kanban-persistence] --> CORE
+    BE[kanban-backend] --> CORE
+    BEHTTP[kanban-backend-http] --> CORE
+    JSON[kanban-persistence-json] --> CORE
+    SQL[kanban-persistence-sqlite] --> CORE
+    SVC[kanban-service] --> CORE
+    CLI[kanban-cli] --> CORE
+    MCP[kanban-mcp] --> CORE
+    TUI[kanban-tui] --> CORE
+    SRV[kanban-server] --> CORE
+```
+
+All edges shown are normal (`[dependencies]`) edges — none are behind a
+feature flag. `kanban-backend-memory` is the one crate that does *not*
+depend on `kanban-core` directly (it reaches `kanban-core`'s types only
+transitively, through `kanban-domain` / `kanban-backend`). See the
+[root README](../../README.md) for the full workspace dependency graph.
+
 ## Dependencies
 
 | Crate | Purpose |

--- a/crates/kanban-core/README.md
+++ b/crates/kanban-core/README.md
@@ -282,3 +282,7 @@ transitively, through `kanban-domain` / `kanban-backend`). See the
 | `uuid` | `Uuid` type |
 | `thiserror` | Error derivation |
 | `chrono` | Timestamps |
+
+## Related crates
+
+Used by: essentially every crate in the workspace. All other 13 crates depend on `kanban-core` directly or transitively (`kanban-backend-memory` is the sole exception, reaching it only through `kanban-domain` / `kanban-backend`) for `KanbanError`, `KanbanResult`, and the other shared foundation types.

--- a/crates/kanban-domain/README.md
+++ b/crates/kanban-domain/README.md
@@ -399,6 +399,37 @@ KanbanError::is_conflict_detected(&self) -> bool
 
 ---
 
+## Position in the workspace
+
+`kanban-domain` depends only on `kanban-core`, and (aside from
+`kanban-core` itself) is the crate the rest of the workspace depends on most
+broadly — every other crate reaches it directly.
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain] --> CORE
+    API[kanban-api] --> DOM
+    PER[kanban-persistence] --> DOM
+    BE[kanban-backend] --> DOM
+    BEMEM[kanban-backend-memory] --> DOM
+    BEHTTP[kanban-backend-http] --> DOM
+    JSON[kanban-persistence-json] --> DOM
+    SQL[kanban-persistence-sqlite] --> DOM
+    SVC[kanban-service] --> DOM
+    CLI[kanban-cli] --> DOM
+    MCP[kanban-mcp] --> DOM
+    TUI[kanban-tui] --> DOM
+    SRV[kanban-server] --> DOM
+```
+
+All edges shown are normal (`[dependencies]`) edges. Not shown: this crate
+has a `[dev-dependencies]` edge on `kanban-backend-memory` for lightweight
+in-memory test fixtures — a dev-only edge back into a crate that itself
+depends on `kanban-domain` in production, which Cargo permits but which is
+never reachable from a release build. See the [root README](../../README.md)
+for the full workspace dependency graph.
+
 ## Dependencies
 
 | Crate | Purpose |
@@ -408,3 +439,5 @@ KanbanError::is_conflict_detected(&self) -> bool
 | `uuid` | `Uuid` type |
 | `chrono` | Timestamps |
 | `thiserror` | Error derivation |
+| `async-trait` | Async trait methods (e.g. persistence-facing traits defined here) |
+| `tracing` | Structured logging |

--- a/crates/kanban-domain/README.md
+++ b/crates/kanban-domain/README.md
@@ -316,26 +316,6 @@ Both `Add*` and `Remove*` carry per-paradigm flags with `#[serde(default)]` so l
 
 ---
 
-### `HistoryManager`
-
-Undo/redo stack for `KanbanContext`.
-
-```rust
-pub struct HistoryManager { /* private */ }
-```
-
-| Method | Description |
-|--------|-------------|
-| `capture_before_command(snapshot)` | Push snapshot onto undo stack |
-| `pop_undo()` | Pop and return the most recent undo snapshot |
-| `push_redo(snapshot)` | Push snapshot onto redo stack |
-| `suppress()` | Temporarily disable capture (used during undo/redo) |
-| `clear()` | Clear both stacks (called on external reload) |
-
-Both stacks are capped at **100 entries**. The oldest entries are dropped when the cap is exceeded.
-
----
-
 ## Error Types
 
 ### `KanbanError`

--- a/crates/kanban-domain/README.md
+++ b/crates/kanban-domain/README.md
@@ -414,10 +414,14 @@ for the full workspace dependency graph.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-core` | Error types, config, graph |
+| [`kanban-core`](../kanban-core/README.md) | Error types, config, graph |
 | `serde` + `serde_json` | Serialization |
 | `uuid` | `Uuid` type |
 | `chrono` | Timestamps |
 | `thiserror` | Error derivation |
 | `async-trait` | Async trait methods (e.g. persistence-facing traits defined here) |
 | `tracing` | Structured logging |
+
+## Related crates
+
+Used by: essentially every crate in the workspace. All other crates except `kanban-core` depend on `kanban-domain` directly for its domain models (`Board`, `Card`, `Column`, `Sprint`, ...) and the `DataStore` / `CommandStore` traits.

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -232,13 +232,13 @@ dependency graph.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-service` (feature `schemars`) | `KanbanContext`, all domain operations, schema-derived wire DTOs |
-| `kanban-core` | Shared types, config |
-| `kanban-domain` | Domain models |
-| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
-| `kanban-backend` | `KanbanBackend`, `KanbanBackendRegistry` |
-| `kanban-persistence-json` (optional, feature `json`, default-on) | JSON backend, registered at startup |
-| `kanban-persistence-sqlite` (optional, feature `sqlite`, default-on) | SQLite backend, registered at startup |
+| [`kanban-service`](../kanban-service/README.md) (feature `schemars`) | `KanbanContext`, all domain operations, schema-derived wire DTOs |
+| [`kanban-core`](../kanban-core/README.md) | Shared types, config |
+| [`kanban-domain`](../kanban-domain/README.md) | Domain models |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore`, `StoreRegistry` |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend`, `KanbanBackendRegistry` |
+| [`kanban-persistence-json`](../kanban-persistence-json/README.md) (optional, feature `json`, default-on) | JSON backend, registered at startup |
+| [`kanban-persistence-sqlite`](../kanban-persistence-sqlite/README.md) (optional, feature `sqlite`, default-on) | SQLite backend, registered at startup |
 | `rmcp` | MCP server/transport SDK |
 | `schemars` | JSON Schema for tool parameters |
 | `tokio` | Async runtime |
@@ -246,3 +246,7 @@ dependency graph.
 | `clap` | CLI argument parsing (data file path) |
 | `tracing` + `tracing-subscriber` | Structured logging |
 | `anyhow` + `thiserror` | Error handling |
+
+## Related crates
+
+Used by: none — `kanban-mcp` is a binary entry point, not a library dependency of any other workspace crate.

--- a/crates/kanban-mcp/README.md
+++ b/crates/kanban-mcp/README.md
@@ -199,3 +199,50 @@ Undo/redo state is maintained in memory across tool calls within a single server
 | I/O, serialization, internal errors | `INTERNAL_ERROR` |
 
 Domain errors (not found, validation) map to `INVALID_PARAMS`; all other errors map to `INTERNAL_ERROR`.
+
+---
+
+## Position in the workspace
+
+```mermaid
+graph TD
+    PER[kanban-persistence]
+    BE[kanban-backend] --> PER
+    JSON[kanban-persistence-json] --> BE
+    SQL[kanban-persistence-sqlite] --> BE
+    SVC[kanban-service] --> PER
+    SVC --> BE
+    MCP[kanban-mcp] --> PER
+    MCP --> BE
+    MCP --> SVC
+    MCP -.->|feature: json, default-on| JSON
+    MCP -.->|feature: sqlite, default-on| SQL
+```
+
+Solid arrows are normal (`[dependencies]`) edges; dotted arrows are
+feature-gated (both on by default). `kanban-mcp` also enables
+`kanban-service`'s `schemars` feature, so the wire DTOs it re-exports as
+`kanban_service::api` derive `schemars::JsonSchema` for use as `Parameters<T>`
+in `rmcp` tool handlers. As with `kanban-cli`, `kanban-mcp` — not
+`kanban-service` — registers the concrete storage backends it ships with
+(KAN-1027). See the [root README](../../README.md) for the full workspace
+dependency graph.
+
+## Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `kanban-service` (feature `schemars`) | `KanbanContext`, all domain operations, schema-derived wire DTOs |
+| `kanban-core` | Shared types, config |
+| `kanban-domain` | Domain models |
+| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
+| `kanban-backend` | `KanbanBackend`, `KanbanBackendRegistry` |
+| `kanban-persistence-json` (optional, feature `json`, default-on) | JSON backend, registered at startup |
+| `kanban-persistence-sqlite` (optional, feature `sqlite`, default-on) | SQLite backend, registered at startup |
+| `rmcp` | MCP server/transport SDK |
+| `schemars` | JSON Schema for tool parameters |
+| `tokio` | Async runtime |
+| `serde` + `serde_json` | Serialization |
+| `clap` | CLI argument parsing (data file path) |
+| `tracing` + `tracing-subscriber` | Structured logging |
+| `anyhow` + `thiserror` | Error handling |

--- a/crates/kanban-persistence-json/README.md
+++ b/crates/kanban-persistence-json/README.md
@@ -146,12 +146,58 @@ impl StoreFactory for JsonStoreFactory {
 
 ---
 
+## Position in the workspace
+
+`kanban-persistence-json` implements both `kanban-persistence`'s
+`StoreFactory`/`PersistenceStore` traits (the storage-format layer) and, via
+its `kanban-backend` + `kanban-backend-memory` dependencies, the
+`KanbanBackend` layer above it — one crate covers both halves of "JSON
+backend."
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain] --> CORE
+    PER[kanban-persistence] --> CORE
+    PER --> DOM
+    BE[kanban-backend] --> PER
+    BEMEM[kanban-backend-memory] --> BE
+    JSON[kanban-persistence-json] --> CORE
+    JSON --> DOM
+    JSON --> PER
+    JSON --> BE
+    JSON --> BEMEM
+    TUI[kanban-tui] --> JSON
+    SRV[kanban-server] --> JSON
+    CLI[kanban-cli] -.->|feature: json, default-on| JSON
+    MCP[kanban-mcp] -.->|feature: json, default-on| JSON
+```
+
+Solid arrows are normal (`[dependencies]`) edges; dotted arrows are
+feature-gated. Not shown: `kanban-service` dev-depends on this crate (feature
+`test-helpers`) to run the shared contract test suite against the JSON
+backend, and this crate dev-depends back on `kanban-service` — a
+dev-dependency-only cycle, never reachable from a release build. See the
+[root README](../../README.md) for the full workspace dependency graph.
+
+Note the KAN-1027 shift: `kanban-service` no longer has a production
+dependency on this crate (its old `json` feature and `kanban-service ->
+kanban-persistence-json` production edge are both gone) — `kanban-cli`,
+`kanban-mcp`, `kanban-tui`, and `kanban-server` each depend on it directly
+instead.
+
 ## Dependencies
 
 | Crate | Purpose |
 |-------|---------|
 | `kanban-persistence` | `PersistenceStore`, `StoreFactory` traits, `FormatVersion` |
+| `kanban-core` | `KanbanError`, `KanbanResult` |
 | `kanban-domain` | `Snapshot` type |
-| `serde_json` | JSON parsing |
+| `kanban-backend` | `KanbanBackend` trait this backend's `KanbanBackendFactory` produces |
+| `kanban-backend-memory` | Shared in-memory scaffolding this backend's `KanbanBackend` impl builds on |
+| `serde` + `serde_json` | JSON parsing |
 | `tokio` | Async I/O |
+| `async-trait` | Async trait methods |
+| `chrono` | Timestamps |
+| `tracing` | Structured logging |
 | `tempfile` | Temp file for atomic writes |

--- a/crates/kanban-persistence-json/README.md
+++ b/crates/kanban-persistence-json/README.md
@@ -190,14 +190,18 @@ instead.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-persistence` | `PersistenceStore`, `StoreFactory` traits, `FormatVersion` |
-| `kanban-core` | `KanbanError`, `KanbanResult` |
-| `kanban-domain` | `Snapshot` type |
-| `kanban-backend` | `KanbanBackend` trait this backend's `KanbanBackendFactory` produces |
-| `kanban-backend-memory` | Shared in-memory scaffolding this backend's `KanbanBackend` impl builds on |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore`, `StoreFactory` traits, `FormatVersion` |
+| [`kanban-core`](../kanban-core/README.md) | `KanbanError`, `KanbanResult` |
+| [`kanban-domain`](../kanban-domain/README.md) | `Snapshot` type |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend` trait this backend's `KanbanBackendFactory` produces |
+| [`kanban-backend-memory`](../kanban-backend-memory/README.md) | Shared in-memory scaffolding this backend's `KanbanBackend` impl builds on |
 | `serde` + `serde_json` | JSON parsing |
 | `tokio` | Async I/O |
 | `async-trait` | Async trait methods |
 | `chrono` | Timestamps |
 | `tracing` | Structured logging |
 | `tempfile` | Temp file for atomic writes |
+
+## Related crates
+
+Used by: [kanban-cli](../kanban-cli/README.md) (optional feature `json`, default-on), [kanban-mcp](../kanban-mcp/README.md) (optional feature `json`, default-on), [kanban-tui](../kanban-tui/README.md), and [kanban-server](../kanban-server/README.md).

--- a/crates/kanban-persistence-sqlite/README.md
+++ b/crates/kanban-persistence-sqlite/README.md
@@ -114,12 +114,56 @@ Backend selection is content-sniffed, not extension-based. `StoreRegistry` reads
 
 ---
 
+## Position in the workspace
+
+`kanban-persistence-sqlite` mirrors `kanban-persistence-json`'s shape: it
+implements both the storage-format layer (`kanban-persistence`'s
+`StoreFactory`/`PersistenceStore`) and the `KanbanBackend` layer above it.
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain] --> CORE
+    PER[kanban-persistence] --> CORE
+    PER --> DOM
+    BE[kanban-backend] --> PER
+    BEMEM[kanban-backend-memory] --> BE
+    SQL[kanban-persistence-sqlite] --> CORE
+    SQL --> DOM
+    SQL --> PER
+    SQL --> BE
+    SQL --> BEMEM
+    TUI[kanban-tui] --> SQL
+    SRV[kanban-server] --> SQL
+    SVC[kanban-service] -.->|feature: sqlite, default-on| SQL
+    CLI[kanban-cli] -.->|feature: sqlite, default-on| SQL
+    MCP[kanban-mcp] -.->|feature: sqlite, default-on| SQL
+```
+
+Solid arrows are normal (`[dependencies]`) edges; dotted arrows are
+feature-gated. Unlike `kanban-persistence-json`, `kanban-service` keeps an
+*optional* production dependency on this crate, gated behind its own
+`sqlite` feature (default-on) — SQLite is still the crate's default storage
+backend even after KAN-1027 dropped the JSON one. Not shown: this crate
+dev-depends on `kanban-service` (feature `test-helpers`) for the shared
+contract test suite, and `kanban-service` dev-depends back on it — a
+dev-dependency-only cycle, never reachable from a release build. See the
+[root README](../../README.md) for the full workspace dependency graph.
+
 ## Dependencies
 
 | Crate | Purpose |
 |-------|---------|
 | `kanban-persistence` | `PersistenceStore`, `StoreFactory` traits |
+| `kanban-core` | `KanbanError`, `KanbanResult` |
 | `kanban-domain` | `Snapshot` type |
+| `kanban-backend` | `KanbanBackend` trait this backend's `KanbanBackendFactory` produces |
+| `kanban-backend-memory` | Shared in-memory scaffolding this backend's `KanbanBackend` impl builds on |
 | `sqlx` | Async SQLite with connection pooling |
 | `tokio` | Async runtime |
-| `serde_json` | JSON serialisation for the `command_log` table |
+| `serde` + `serde_json` | Serialisation for the `command_log` table |
+| `async-trait` | Async trait methods |
+| `chrono` | Timestamps |
+| `tracing` | Structured logging |
+| `flate2` | Compression for durable pre-migration `VACUUM INTO` backups |
+| `tempfile` | Temp file handling |

--- a/crates/kanban-persistence-sqlite/README.md
+++ b/crates/kanban-persistence-sqlite/README.md
@@ -154,11 +154,11 @@ dev-dependency-only cycle, never reachable from a release build. See the
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-persistence` | `PersistenceStore`, `StoreFactory` traits |
-| `kanban-core` | `KanbanError`, `KanbanResult` |
-| `kanban-domain` | `Snapshot` type |
-| `kanban-backend` | `KanbanBackend` trait this backend's `KanbanBackendFactory` produces |
-| `kanban-backend-memory` | Shared in-memory scaffolding this backend's `KanbanBackend` impl builds on |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore`, `StoreFactory` traits |
+| [`kanban-core`](../kanban-core/README.md) | `KanbanError`, `KanbanResult` |
+| [`kanban-domain`](../kanban-domain/README.md) | `Snapshot` type |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend` trait this backend's `KanbanBackendFactory` produces |
+| [`kanban-backend-memory`](../kanban-backend-memory/README.md) | Shared in-memory scaffolding this backend's `KanbanBackend` impl builds on |
 | `sqlx` | Async SQLite with connection pooling |
 | `tokio` | Async runtime |
 | `serde` + `serde_json` | Serialisation for the `command_log` table |
@@ -167,3 +167,7 @@ dev-dependency-only cycle, never reachable from a release build. See the
 | `tracing` | Structured logging |
 | `flate2` | Compression for durable pre-migration `VACUUM INTO` backups |
 | `tempfile` | Temp file handling |
+
+## Related crates
+
+Used by: [kanban-cli](../kanban-cli/README.md) (optional feature `sqlite`, default-on), [kanban-mcp](../kanban-mcp/README.md) (optional feature `sqlite`, default-on), [kanban-tui](../kanban-tui/README.md), [kanban-server](../kanban-server/README.md), and [kanban-service](../kanban-service/README.md) (optional feature `sqlite`, default-on).

--- a/crates/kanban-persistence/README.md
+++ b/crates/kanban-persistence/README.md
@@ -330,6 +330,30 @@ CliApp::default()
 
 ---
 
+## Position in the workspace
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain] --> CORE
+    PER[kanban-persistence] --> CORE
+    PER --> DOM
+    BE[kanban-backend] --> PER
+    JSON[kanban-persistence-json] --> PER
+    SQL[kanban-persistence-sqlite] --> PER
+    SVC[kanban-service] --> PER
+    CLI[kanban-cli] --> PER
+    MCP[kanban-mcp] --> PER
+    TUI[kanban-tui] --> PER
+    SRV[kanban-server] --> PER
+```
+
+All edges shown are normal (`[dependencies]`) edges. Not shown: this crate
+has a `[dev-dependencies]` edge on `kanban-backend-memory` for test fixtures
+— a dev-only edge into a crate that (via `kanban-backend`) depends on
+`kanban-persistence` in production; never reachable from a release build. See
+the [root README](../../README.md) for the full workspace dependency graph.
+
 ## Dependencies
 
 | Crate | Purpose |
@@ -341,3 +365,7 @@ CliApp::default()
 | `chrono` | Timestamps in metadata |
 | `thiserror` | Error derivation |
 | `uuid` | Instance IDs |
+| `tokio` | Async I/O, file watching |
+| `notify` | File-watching backend for `ChangeDetector` |
+| `tracing` | Structured logging |
+| `tempfile` (optional, feature `test-helpers`) | Test fixture helpers |

--- a/crates/kanban-persistence/README.md
+++ b/crates/kanban-persistence/README.md
@@ -188,8 +188,8 @@ the [root README](../../README.md) for the full workspace dependency graph.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-core` | `KanbanError`, `KanbanResult` |
-| `kanban-domain` | `Snapshot` type |
+| [`kanban-core`](../kanban-core/README.md) | `KanbanError`, `KanbanResult` |
+| [`kanban-domain`](../kanban-domain/README.md) | `Snapshot` type |
 | `serde` + `serde_json` | Serialization |
 | `async-trait` | Async trait methods |
 | `chrono` | Timestamps in metadata |
@@ -199,6 +199,10 @@ the [root README](../../README.md) for the full workspace dependency graph.
 | `notify` | File-watching backend for `ChangeDetector` |
 | `tracing` | Structured logging |
 | `tempfile` (optional, feature `test-helpers`) | Test fixture helpers |
+
+## Related crates
+
+Used by: [kanban-backend](../kanban-backend/README.md), [kanban-persistence-json](../kanban-persistence-json/README.md), [kanban-persistence-sqlite](../kanban-persistence-sqlite/README.md), and [kanban-service](../kanban-service/README.md) (which the application crates `kanban-cli`, `kanban-mcp`, `kanban-tui`, and `kanban-server` in turn depend on directly for `PersistenceStore` / `StoreRegistry` wiring).
 
 ---
 

--- a/crates/kanban-persistence/README.md
+++ b/crates/kanban-persistence/README.md
@@ -160,6 +160,48 @@ Used by backends and the service layer to serialize/deserialize the domain `Snap
 
 ---
 
+## Position in the workspace
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain] --> CORE
+    PER[kanban-persistence] --> CORE
+    PER --> DOM
+    BE[kanban-backend] --> PER
+    JSON[kanban-persistence-json] --> PER
+    SQL[kanban-persistence-sqlite] --> PER
+    SVC[kanban-service] --> PER
+    CLI[kanban-cli] --> PER
+    MCP[kanban-mcp] --> PER
+    TUI[kanban-tui] --> PER
+    SRV[kanban-server] --> PER
+```
+
+All edges shown are normal (`[dependencies]`) edges. Not shown: this crate
+has a `[dev-dependencies]` edge on `kanban-backend-memory` for test fixtures
+— a dev-only edge into a crate that (via `kanban-backend`) depends on
+`kanban-persistence` in production; never reachable from a release build. See
+the [root README](../../README.md) for the full workspace dependency graph.
+
+## Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `kanban-core` | `KanbanError`, `KanbanResult` |
+| `kanban-domain` | `Snapshot` type |
+| `serde` + `serde_json` | Serialization |
+| `async-trait` | Async trait methods |
+| `chrono` | Timestamps in metadata |
+| `thiserror` | Error derivation |
+| `uuid` | Instance IDs |
+| `tokio` | Async I/O, file watching |
+| `notify` | File-watching backend for `ChangeDetector` |
+| `tracing` | Structured logging |
+| `tempfile` (optional, feature `test-helpers`) | Test fixture helpers |
+
+---
+
 ## Writing a Third-Party Backend
 
 This section walks through implementing a custom storage backend and plugging it into the CLI or MCP server without forking the repo.
@@ -327,45 +369,3 @@ CliApp::default()
     .run()
     .await
 ```
-
----
-
-## Position in the workspace
-
-```mermaid
-graph TD
-    CORE[kanban-core]
-    DOM[kanban-domain] --> CORE
-    PER[kanban-persistence] --> CORE
-    PER --> DOM
-    BE[kanban-backend] --> PER
-    JSON[kanban-persistence-json] --> PER
-    SQL[kanban-persistence-sqlite] --> PER
-    SVC[kanban-service] --> PER
-    CLI[kanban-cli] --> PER
-    MCP[kanban-mcp] --> PER
-    TUI[kanban-tui] --> PER
-    SRV[kanban-server] --> PER
-```
-
-All edges shown are normal (`[dependencies]`) edges. Not shown: this crate
-has a `[dev-dependencies]` edge on `kanban-backend-memory` for test fixtures
-— a dev-only edge into a crate that (via `kanban-backend`) depends on
-`kanban-persistence` in production; never reachable from a release build. See
-the [root README](../../README.md) for the full workspace dependency graph.
-
-## Dependencies
-
-| Crate | Purpose |
-|-------|---------|
-| `kanban-core` | `KanbanError`, `KanbanResult` |
-| `kanban-domain` | `Snapshot` type |
-| `serde` + `serde_json` | Serialization |
-| `async-trait` | Async trait methods |
-| `chrono` | Timestamps in metadata |
-| `thiserror` | Error derivation |
-| `uuid` | Instance IDs |
-| `tokio` | Async I/O, file watching |
-| `notify` | File-watching backend for `ChangeDetector` |
-| `tracing` | Structured logging |
-| `tempfile` (optional, feature `test-helpers`) | Test fixture helpers |

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -220,17 +220,21 @@ dependency graph.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-core` | Shared types, config |
-| `kanban-domain` | Domain models |
-| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
-| `kanban-backend` | `KanbanBackend`, `KanbanBackendRegistry` |
-| `kanban-persistence-json` | JSON backend, registered at startup |
-| `kanban-persistence-sqlite` | SQLite backend, registered at startup |
-| `kanban-service` | `KanbanContext`, all domain operations |
-| `kanban-backend-memory` (optional, feature `test-helpers`) | In-memory backend for tests |
+| [`kanban-core`](../kanban-core/README.md) | Shared types, config |
+| [`kanban-domain`](../kanban-domain/README.md) | Domain models |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore`, `StoreRegistry` |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend`, `KanbanBackendRegistry` |
+| [`kanban-persistence-json`](../kanban-persistence-json/README.md) | JSON backend, registered at startup |
+| [`kanban-persistence-sqlite`](../kanban-persistence-sqlite/README.md) | SQLite backend, registered at startup |
+| [`kanban-service`](../kanban-service/README.md) | `KanbanContext`, all domain operations |
+| [`kanban-backend-memory`](../kanban-backend-memory/README.md) (optional, feature `test-helpers`) | In-memory backend for tests |
 | `axum` + `tower` + `tower-http` | HTTP routing/middleware |
 | `tokio` | Async runtime |
 | `serde` | Serialization |
 | `prometheus` | Metrics |
 | `clap` | CLI argument parsing |
 | `tracing` + `tracing-subscriber` | Structured logging |
+
+## Related crates
+
+Used by: none in production — [kanban-backend-http](../kanban-backend-http/README.md) depends on this crate only as a dev-dependency (feature `test-helpers`) to spin up a real server for its own integration tests.

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -181,3 +181,56 @@ Every non-2xx response is a JSON `ApiError`:
 | 500 | `IO_ERROR`, `SERIALIZATION_ERROR`, `DATABASE_ERROR`, `INTERNAL_ERROR` |
 
 Malformed or type-mismatched request bodies (e.g. missing a required field) also come back as `VALIDATION_FAILED` (422) in this same envelope, rather than axum's default plain-text rejection.
+
+---
+
+## Position in the workspace
+
+```mermaid
+graph TD
+    PER[kanban-persistence]
+    BE[kanban-backend] --> PER
+    BEMEM[kanban-backend-memory] --> BE
+    JSON[kanban-persistence-json] --> BE
+    SQL[kanban-persistence-sqlite] --> BE
+    SVC[kanban-service] --> PER
+    SVC --> BE
+    SRV[kanban-server] --> PER
+    SRV --> BE
+    SRV --> JSON
+    SRV --> SQL
+    SRV --> SVC
+    SRV -.->|feature: test-helpers| BEMEM
+    BEHTTP[kanban-backend-http] -.->|dev-dependency, feature: test-helpers| SRV
+```
+
+Solid arrows are normal (`[dependencies]`) edges; the `kanban-backend-memory`
+edge is feature-gated (`test-helpers`, off by default) rather than optional
+in the usual sense — it exists so integration tests can spin up an in-memory
+`AppState` without touching disk. Like `kanban-cli`/`kanban-mcp`/`kanban-tui`,
+`kanban-server` — not `kanban-service` — registers the concrete storage
+backends (`kanban-persistence-json`, `kanban-persistence-sqlite`)
+unconditionally (KAN-1027). The dashed edge from `kanban-backend-http` is a
+`[dev-dependencies]` edge (feature `test-helpers`) used only to spin up a
+real server for that crate's integration tests — not reachable from a
+release build. See the [root README](../../README.md) for the full workspace
+dependency graph.
+
+## Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `kanban-core` | Shared types, config |
+| `kanban-domain` | Domain models |
+| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
+| `kanban-backend` | `KanbanBackend`, `KanbanBackendRegistry` |
+| `kanban-persistence-json` | JSON backend, registered at startup |
+| `kanban-persistence-sqlite` | SQLite backend, registered at startup |
+| `kanban-service` | `KanbanContext`, all domain operations |
+| `kanban-backend-memory` (optional, feature `test-helpers`) | In-memory backend for tests |
+| `axum` + `tower` + `tower-http` | HTTP routing/middleware |
+| `tokio` | Async runtime |
+| `serde` | Serialization |
+| `prometheus` | Metrics |
+| `clap` | CLI argument parsing |
+| `tracing` + `tracing-subscriber` | Structured logging |

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -387,15 +387,19 @@ those dev edges are reachable from a release build. See the
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-core` | `AppConfig`, `AppType`, `KanbanResult` |
-| `kanban-domain` | All domain types, `KanbanOperations`, `DataStore` |
-| `kanban-persistence` | `PersistenceStore`, `StoreRegistry`, `PersistenceMetadata` |
-| `kanban-api` | Re-exported as `kanban_service::api` — wire DTOs for MCP/server consumers |
-| `kanban-backend` | `KanbanBackend`, `RemoteWrites` — the backend abstraction this crate depends on instead of a concrete backend |
-| `kanban-persistence-sqlite` (optional, feature `sqlite`, default-on) | The one concrete storage backend this crate still knows about by name |
+| [`kanban-core`](../kanban-core/README.md) | `AppConfig`, `AppType`, `KanbanResult` |
+| [`kanban-domain`](../kanban-domain/README.md) | All domain types, `KanbanOperations`, `DataStore` |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore`, `StoreRegistry`, `PersistenceMetadata` |
+| [`kanban-api`](../kanban-api/README.md) | Re-exported as `kanban_service::api` — wire DTOs for MCP/server consumers |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend`, `RemoteWrites` — the backend abstraction this crate depends on instead of a concrete backend |
+| [`kanban-persistence-sqlite`](../kanban-persistence-sqlite/README.md) (optional, feature `sqlite`, default-on) | The one concrete storage backend this crate still knows about by name |
 | `tokio` | Async runtime |
 | `serde` + `serde_json` | Serialization |
 | `schemars` (optional, feature `schemars`) | JSON Schema derivation on wire DTOs for MCP tool parameters |
 | `toml`, `dirs`, `dunce` | Config file location/parsing |
 | `chrono`, `uuid` | Timestamps, entity/session IDs |
 | `tracing` | Structured logging |
+
+## Related crates
+
+Used by: [kanban-cli](../kanban-cli/README.md), [kanban-mcp](../kanban-mcp/README.md), [kanban-tui](../kanban-tui/README.md), and [kanban-server](../kanban-server/README.md).

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -236,33 +236,40 @@ pub struct DataSnapshot {
 
 ---
 
-## Utility Functions
+## Store / backend construction — `StoreManager`
+
+Backend and store construction live on **`StoreManager`** (`src/store_manager.rs`),
+which each application builds and hands a `kanban_persistence::StoreRegistry` +
+`kanban_backend::KanbanBackendRegistry` pair at startup. These are **methods on
+`StoreManager`**, not free functions:
 
 ```rust
-// Build the default store registry (SQLite first, JSON as catch-all)
-pub fn default_registry() -> StoreRegistry;
+// Dispatch to the right KanbanBackend by content-sniffing the locator
+// (the KAN-1027 registry path): first factory whose matches_locator accepts it.
+sm.make_backend(locator, config) -> KanbanResult<Arc<dyn KanbanBackend>>
 
-// Detect which backend matches a locator string
-pub fn detect_backend(locator: &str) -> Option<String>;
+// Build a raw PersistenceStore (used by the admin flows below and by callers
+// that need the store directly, e.g. init's empty-file creation)
+sm.make_store(backend, locator) -> KanbanResult<Arc<dyn PersistenceStore + Send + Sync>>
+sm.make_store_with_config(file, config) -> KanbanResult<Arc<dyn PersistenceStore + Send + Sync>>
 
-// Create a store from backend name + locator
-pub fn make_store(backend: &str, locator: &str) -> KanbanResult<Arc<dyn PersistenceStore + Send + Sync>>;
+// Identify / align the backend for a locator
+sm.detect_backend(locator) -> Option<String>
+sm.is_sqlite(locator) -> bool
+sm.sync_backend_with_file(locator, &mut config) -> bool  // returns true if it corrected config
 
-// Create a store from an optional file path + AppConfig
-pub fn make_store_with_config(file: Option<&str>, config: &AppConfig) -> KanbanResult<Arc<dyn PersistenceStore + Send + Sync>>;
-
-// Load and validate a store (returns error if file doesn't exist)
-pub async fn validate_and_load_store(backend: &str, path: &str) -> KanbanResult<Snapshot>;
-
-// Export board selection to a new SQLite file
-pub async fn export_to_sqlite(export: AllBoardsExport, filename: &str) -> KanbanResult<()>;
-
-// Migrate all data from one store to another
-pub async fn migrate_store(source: &str, target: &str) -> KanbanResult<()>;
-
-// Sync config storage_backend field to match the file's actual backend
-pub fn sync_backend_with_file(locator: &str, config: &mut AppConfig) -> bool;
+// Admin flows that talk to SqliteStore directly (unrelated to backend dispatch)
+sm.validate_and_load_store(backend, path) -> KanbanResult<Snapshot>
+sm.export_to_sqlite(export, filename) -> KanbanResult<()>
+sm.migrate_store(from_backend, from_path, to_backend, to_path) -> KanbanResult<()>
 ```
+
+The former free functions `kanban_service::default_registry()` and
+`kanban_service::open_context()` were **removed in KAN-1027** — each application now
+assembles and owns its `StoreRegistry` + `KanbanBackendRegistry` (and, via the
+extended `register_backend`, can add its own), rather than pulling a pre-built
+registry out of `kanban-service`. This is what let the crate drop its production
+dependency on the JSON concretion.
 
 ---
 

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -7,111 +7,135 @@ frontends (`kanban-cli`, `kanban-mcp`, `kanban-tui`, `kanban-server`).
 
 ## Current architecture (post KAN-1024 / KAN-1027)
 
-> **Note:** the rest of this file's detailed `KanbanContext` walkthrough below
-> predates the backend-registry refactor (KAN-1024 onward) and describes an
-> older shape of the struct (a raw `store: Arc<dyn PersistenceStore>` plus
-> `boards`/`columns`/`cards`/... `Vec` fields and a standalone
-> `HistoryManager`). That shape no longer matches the source. The paragraph
-> below is accurate as of KAN-1027; the walkthrough after it is kept for its
-> still-useful method-reference tables (construction/accessor/CRUD method
-> names generally still exist, just not on the struct shape shown) but should
-> not be trusted for the struct's actual fields. A full refresh of this
-> file's body is tracked as a follow-up, not done as part of this change.
->
-> `KanbanContext` now wraps `backend: Arc<dyn kanban_backend::KanbanBackend>`
-> instead of a `PersistenceStore` directly, and undo/redo is driven by
-> `undo_stack::UndoStack` (in `src/undo_stack.rs`) rather than a
-> `HistoryManager`. Every command batch runs through
-> `KanbanBackend::with_transaction`, and `KanbanContext::open`/`open_deferred`
-> take a pre-built `Arc<dyn KanbanBackend>` — constructed by the caller via
-> `StoreManager` (`src/store_manager.rs`), which wraps both a
-> `kanban_persistence::StoreRegistry` (storage-format dispatch) and a
-> `kanban_backend::KanbanBackendRegistry` (backend dispatch). See
-> [Position in the workspace](#position-in-the-workspace) below for the
-> corrected dependency graph — `kanban-service` has no production dependency
-> on `kanban-persistence-json` or `kanban-backend-memory` any more, and no
-> `json` feature.
+`KanbanContext` (`src/context/`, split across `core.rs`, `undo.rs`,
+`persistence.rs`, `boards.rs`, `columns.rs`, `cards.rs`, `cards_batch.rs`,
+`cards_batch_detailed.rs`, `sprints.rs`, `graph.rs`, `filters.rs`) wraps a
+`backend: Arc<dyn kanban_backend::KanbanBackend>` — there is no domain data
+cached on the struct itself; every accessor reads through to the backend on
+each call. Undo/redo is driven by `undo_stack::UndoStack` (`src/undo_stack.rs`),
+not a `HistoryManager`. Every command batch runs through
+`KanbanBackend::with_transaction`, and `KanbanContext::open`/`open_deferred`
+take a pre-built `Arc<dyn KanbanBackend>` — constructed by the caller via
+`StoreManager` (`src/store_manager.rs`), which wraps both a
+`kanban_persistence::StoreRegistry` (storage-format dispatch) and a
+`kanban_backend::KanbanBackendRegistry` (backend dispatch). See
+[Position in the workspace](#position-in-the-workspace) below for the
+dependency graph — `kanban-service` has no production dependency on
+`kanban-persistence-json` or `kanban-backend-memory`, and no `json` feature.
 
 ## `KanbanContext`
 
-The central type. Holds all domain data in memory and delegates to a `PersistenceStore` for load/save operations.
+The central type. Holds a backend handle plus per-session undo/redo and
+dirty/conflict state; all domain reads and writes go through `backend`.
 
 ```rust
 pub struct KanbanContext {
-    // private fields:
-    boards: Vec<Board>,
-    columns: Vec<Column>,
-    cards: Vec<Card>,
-    sprints: Vec<Sprint>,
-    archived_cards: Vec<ArchivedCard>,
-    graph: DependencyGraph,
-    app_config: AppConfig,
-    store: Arc<dyn PersistenceStore + Send + Sync>,
-    history: HistoryManager,
-    dirty: bool,
-    conflict_pending: bool,
+    pub(super) backend: Arc<dyn KanbanBackend>,
+    pub(super) app_config: AppConfig,
+    pub(super) undo_stack: crate::undo_stack::UndoStack,
+    pub(super) dirty: bool,
+    pub(super) conflict_pending: bool,
+    pub(super) session_id: Uuid,
+    pub(super) app_type: AppType,
 }
 ```
-
-**(Stale — see the callout above. The struct now holds `backend: Arc<dyn KanbanBackend>` and `undo_stack: UndoStack`, not the fields shown here.)**
 
 ### Construction
 
 ```rust
-KanbanContext::load(store, config) -> KanbanResult<Self>
-KanbanContext::load_with_defaults(store) -> KanbanResult<Self>
-KanbanContext::empty(store, config) -> Self
+KanbanContext::open_deferred(backend: Arc<dyn KanbanBackend>, config: AppConfig) -> Self
+KanbanContext::open(backend: Arc<dyn KanbanBackend>, config: AppConfig) -> KanbanResult<Self>
+ctx.with_app_type(app_type: AppType) -> Self
 ```
+
+`open_deferred` is zero-I/O — it just wraps `backend`. `open` is async and
+additionally calls `backend.batch_count()` so a lazy backend's load/parse
+errors surface at construction time rather than on first use. `with_app_type`
+is a builder call made right after `open_deferred`/`open` to record which
+surface (CLI, MCP, TUI) owns the context, for command attribution.
 
 ### State Accessors
 
 ```rust
-ctx.boards() -> &[Board]
-ctx.columns() -> &[Column]
-ctx.cards() -> &[Card]
-ctx.sprints() -> &[Sprint]
-ctx.archived_cards() -> &[ArchivedCard]
-ctx.graph() -> &DependencyGraph
 ctx.app_config() -> &AppConfig
+ctx.data_store() -> &dyn DataStore
+ctx.backend() -> Arc<dyn KanbanBackend>
+ctx.persistence_metadata() -> Option<PersistenceMetadata>
+ctx.session_id() -> Uuid
+ctx.boards() -> KanbanResult<Vec<Board>>
+ctx.columns() -> KanbanResult<Vec<Column>>       // live-scoped (excludes archived-board columns)
+ctx.cards() -> KanbanResult<Vec<Card>>
+ctx.sprints() -> KanbanResult<Vec<Sprint>>
+ctx.archived_cards() -> KanbanResult<Vec<ArchivedCard>>
+ctx.graph() -> KanbanResult<DependencyGraph>
+ctx.require_board(id: Uuid) -> KanbanResult<Board>     // NotFound if missing
+ctx.require_column(id: Uuid) -> KanbanResult<Column>   // NotFound if missing
 ctx.is_dirty() -> bool
+ctx.mark_dirty()
+ctx.mark_clean()
 ctx.has_conflict() -> bool
-ctx.set_conflict(bool)
+ctx.set_conflict()
 ctx.clear_conflict()
+ctx.set_conflict_pending(bool)
 ```
+
+Unlike the pre-KAN-1024 shape, there are no cached `Vec` fields to read —
+`boards()`/`columns()`/`cards()`/`sprints()`/`archived_cards()`/`graph()`
+each query the backend fresh and return an owned, `KanbanResult`-wrapped
+`Vec` (or `DependencyGraph`).
 
 ### Persistence
 
 ```rust
-ctx.save() -> KanbanResult<()>
-ctx.reload() -> KanbanResult<()>
-ctx.replace_store(store)
-ctx.snapshot() -> Snapshot
-ctx.apply_snapshot(snapshot)
+ctx.save() -> KanbanResult<()>                 // async; backend.flush().await
+ctx.reload() -> KanbanResult<()>               // async; backend.reload().await, clears undo_stack
+ctx.replace_backend(backend: Arc<dyn KanbanBackend>)  // clears undo_stack, marks clean
+ctx.snapshot() -> KanbanResult<Snapshot>
+ctx.apply_snapshot(snapshot: Snapshot) -> KanbanResult<()>
+ctx.migrate_sprint_logs() -> KanbanResult<usize>  // one-time backfill utility, bypasses undo on purpose
 ```
+
+`save` and `reload` are `async` — `save` delegates to `backend.flush()`
+(a WAL checkpoint for SQLite, a cache flush for JSON); `reload` re-reads
+from durable storage and drops the per-session undo/redo history, since
+entity ids from before the reload may no longer exist.
 
 ### Undo / Redo
 
 ```rust
-ctx.undo() -> bool        // Returns true if there was something to undo
-ctx.redo() -> bool        // Returns true if there was something to redo
+ctx.execute(commands: Vec<Command>) -> KanbanResult<()>
+ctx.undo() -> KanbanResult<bool>   // Ok(false) if there was nothing to undo
+ctx.redo() -> KanbanResult<bool>   // Ok(false) if there was nothing to redo
 ctx.can_undo() -> bool
 ctx.can_redo() -> bool
 ctx.undo_depth() -> usize
 ctx.redo_depth() -> usize
-ctx.clear_history()
+ctx.clear_history() -> KanbanResult<()>
 ```
 
-History is captured before every mutating operation. Stacks are capped at 100 entries.
+Every undoable command captures an inverse at `execute` time; the
+`(forward, inverse)` pair is pushed onto the per-session `UndoStack` — an
+in-memory, unbounded `Vec` with a cursor, never persisted, never capped.
+`undo`/`redo` re-run the captured inverse/forward batch through the same
+command-execute path (no snapshot apply, no replay); the cursor only
+advances once the batch commits, so a failed undo/redo leaves the stack
+ready to retry the same entry. `execute` also appends the forward batch to
+the `CommandStore` audit log via `backend.append_batch` — informational
+only, it records what happened but does not drive undo.
 
 ### Board Operations
 
 | Method | Description |
 |--------|-------------|
 | `create_board(name, card_prefix)` | Create a new board |
-| `list_boards()` | List all boards |
+| `list_boards()` | List live boards (sugar for `list_boards_filtered` with the default `LiveOnly` selector) |
+| `list_boards_filtered(filter)` | List board heads per `BoardListFilter`'s archival selector (live and/or archived) |
 | `get_board(id)` | Get a board by ID |
 | `update_board(id, updates)` | Partially update a board |
-| `delete_board(id)` | Delete board and all its data |
+| `delete_board(id)` | Permanently delete a board and its subtree |
+| `archive_board(id)` | Move a board out of the live set into the archived collection; its subtree stays in place |
+| `restore_board(id)` | Restore an archived board back into the live set |
+| `list_archived_boards()` | List archived boards (ascending by `archived_at`) |
 
 ### Column Operations
 
@@ -129,8 +153,10 @@ History is captured before every mutating operation. Stacks are capped at 100 en
 | Method | Description |
 |--------|-------------|
 | `create_card(board_id, column_id, title, options)` | Create a card |
-| `list_cards(filter)` | List cards with `CardListFilter` |
-| `list_cards_paged(filter, page, page_size)` | Paginated card list |
+| `list_cards(filter)` | List `CardSummary`s with `CardListFilter` (pagination is MCP-layer only — see below) |
+| `list_all_cards()` | Live-scoped, unfiltered `Card`s across all live boards |
+| `list_all_columns()` | Live-scoped, unfiltered columns across all live boards |
+| `list_all_sprints()` | Live-scoped, unfiltered sprints across all live boards |
 | `get_card(id)` | Get full card by ID |
 | `find_cards_by_identifier(s)` | Find card(s) by UUID or `KAN-5` format |
 | `update_card(id, updates)` | Partially update a card |
@@ -139,6 +165,12 @@ History is captured before every mutating operation. Stacks are capped at 100 en
 | `restore_card(id, column_id)` | Restore an archived card |
 | `delete_card(id)` | Permanently delete a card |
 | `list_archived_cards()` | List all archived cards |
+| `list_archived_cards_by_board(board_id)` | Archived cards for one board (first-class `board_id` query) |
+
+Pagination is not part of `KanbanContext`: `list_cards_paged(filter, page,
+page_size)` lives on `kanban_mcp::McpContext` (`crates/kanban-mcp/src/context.rs`),
+which wraps `list_cards` and paginates the result — `KanbanOperations::list_cards`
+itself has no pagination parameters.
 
 ### Card–Sprint Operations
 
@@ -155,6 +187,7 @@ History is captured before every mutating operation. Stacks are capped at 100 en
 |--------|-------------|
 | `archive_cards(ids)` | Archive multiple cards; returns count |
 | `move_cards(ids, column_id)` | Move multiple cards; returns count |
+| `update_cards(updates)` | Per-card updates as one undo unit; auto-syncs the status ↔ completion-column invariant when only one side of a pair is set |
 | `assign_cards_to_sprint(ids, sprint_id)` | Bulk sprint assignment; returns count |
 | `archive_cards_detailed(ids)` | Archive with per-card success/failure report |
 | `move_cards_detailed(ids, column_id)` | Move with per-card success/failure report |
@@ -226,11 +259,21 @@ Returned by the `*_detailed` bulk operation methods.
 
 ---
 
-## `DataSnapshot`
+## `Snapshot`
+
+There is no `kanban-service`-local snapshot type. `KanbanContext::snapshot()` /
+`apply_snapshot()` and `StoreManager`'s export/migrate helpers all operate
+directly on `kanban_domain::Snapshot` (`crates/kanban-domain/src/snapshot.rs`):
 
 ```rust
-pub struct DataSnapshot {
-    // mirrors kanban_domain::Snapshot; used for serialization
+pub struct Snapshot {
+    pub boards: Vec<Board>,
+    pub columns: Vec<Column>,
+    pub cards: Vec<Card>,
+    pub archived_cards: Vec<ArchivedCard>,
+    pub sprints: Vec<Sprint>,
+    pub archived_boards: Vec<ArchivedBoard>,
+    pub graph: DependencyGraph,
 }
 ```
 
@@ -279,18 +322,30 @@ dependency on the JSON concretion.
 caller
   │
   ▼
-KanbanContext::execute(commands: Vec<Box<dyn Command>>)
+KanbanContext::execute(commands: Vec<Command>)
   │
-  ├─ 1. history.capture_before_command(current_snapshot)
+  ├─ 0. if backend.remote_writes().is_some(): return Err(Unsupported)
+  │      (the HTTP backend bypasses this path entirely — see kanban-backend-http)
   │
-  ├─ 2. for each command:
-  │       command.execute(&mut CommandContext)   ← mutates boards/columns/cards/...
-  │       on error: restore from undo snapshot → return Err
+  ├─ 1. backend.with_transaction(|| {
+  │       for each command:
+  │         per_cmd_inverses.push(command.capture_inverse(store))
+  │         command.execute(&CommandContext { store })   ← mutates via DataStore
+  │       backend.append_batch(&batch)                   ← audit log (informational)
+  │     })
+  │
+  ├─ 2. undo_stack.push(UndoEntry { forward: commands, inverse: per_cmd_inverses.rev() })
   │
   ├─ 3. dirty = true
   │
-  └─ (caller calls ctx.save() → store.save(snapshot, metadata))
+  └─ (caller calls ctx.save().await → backend.flush().await)
 ```
+
+`with_transaction` makes the whole batch atomic: if any command's
+`capture_inverse` or `execute` fails partway through, the transaction rolls
+back and nothing is pushed onto the undo stack. The inverse pushed for undo
+is the per-command inverses composed in reverse order, so undoing runs each
+inverse against the state its forward command actually saw.
 
 ---
 

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -1,6 +1,36 @@
 # kanban-service
 
-Service layer for the kanban workspace. Provides `KanbanContext` — the single in-memory state machine for all board data — along with persistence orchestration, undo/redo, and utility functions.
+Shared service layer implementing `KanbanOperations` over a pluggable
+`PersistenceStore` / `KanbanBackend`. Sits between the persistence backends
+(`kanban-backend` and its concrete implementations) and the interactive
+frontends (`kanban-cli`, `kanban-mcp`, `kanban-tui`, `kanban-server`).
+
+## Current architecture (post KAN-1024 / KAN-1027)
+
+> **Note:** the rest of this file's detailed `KanbanContext` walkthrough below
+> predates the backend-registry refactor (KAN-1024 onward) and describes an
+> older shape of the struct (a raw `store: Arc<dyn PersistenceStore>` plus
+> `boards`/`columns`/`cards`/... `Vec` fields and a standalone
+> `HistoryManager`). That shape no longer matches the source. The paragraph
+> below is accurate as of KAN-1027; the walkthrough after it is kept for its
+> still-useful method-reference tables (construction/accessor/CRUD method
+> names generally still exist, just not on the struct shape shown) but should
+> not be trusted for the struct's actual fields. A full refresh of this
+> file's body is tracked as a follow-up, not done as part of this change.
+>
+> `KanbanContext` now wraps `backend: Arc<dyn kanban_backend::KanbanBackend>`
+> instead of a `PersistenceStore` directly, and undo/redo is driven by
+> `undo_stack::UndoStack` (in `src/undo_stack.rs`) rather than a
+> `HistoryManager`. Every command batch runs through
+> `KanbanBackend::with_transaction`, and `KanbanContext::open`/`open_deferred`
+> take a pre-built `Arc<dyn KanbanBackend>` — constructed by the caller via
+> `StoreManager` (`src/store_manager.rs`), which wraps both a
+> `kanban_persistence::StoreRegistry` (storage-format dispatch) and a
+> `kanban_backend::KanbanBackendRegistry` (backend dispatch). See
+> [Position in the workspace](#position-in-the-workspace) below for the
+> corrected dependency graph — `kanban-service` has no production dependency
+> on `kanban-persistence-json` or `kanban-backend-memory` any more, and no
+> `json` feature.
 
 ## `KanbanContext`
 
@@ -22,6 +52,8 @@ pub struct KanbanContext {
     conflict_pending: bool,
 }
 ```
+
+**(Stale — see the callout above. The struct now holds `backend: Arc<dyn KanbanBackend>` and `undo_stack: UndoStack`, not the fields shown here.)**
 
 ### Construction
 
@@ -255,14 +287,53 @@ KanbanContext::execute(commands: Vec<Box<dyn Command>>)
 
 ---
 
+## Position in the workspace
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain] --> CORE
+    API[kanban-api] --> CORE
+    API --> DOM
+    PER[kanban-persistence] --> CORE
+    PER --> DOM
+    BE[kanban-backend] --> PER
+    SQL[kanban-persistence-sqlite] --> BE
+    SVC[kanban-service] --> CORE
+    SVC --> DOM
+    SVC --> PER
+    SVC --> API
+    SVC --> BE
+    SVC -.->|feature: sqlite, default-on| SQL
+    CLI[kanban-cli] --> SVC
+    MCP[kanban-mcp] --> SVC
+    TUI[kanban-tui] --> SVC
+    SRV[kanban-server] --> SVC
+```
+
+Solid arrows are normal (`[dependencies]`) edges; the one dotted arrow is the
+`sqlite` feature (on by default). **This is the KAN-1027 payoff**:
+`kanban-service` depends on the `kanban-backend` abstraction (and, only
+optionally, on the SQLite concretion for its default-on feature) — not on
+`kanban-persistence-json` or `kanban-backend-memory`, both of which are
+`[dev-dependencies]`-only now (used to drive the shared contract test suite,
+along with a dev-only, mutual `kanban-persistence-sqlite` edge). None of
+those dev edges are reachable from a release build. See the
+[root README](../../README.md) for the full workspace dependency graph.
+
 ## Dependencies
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-core` | `AppConfig`, `KanbanResult` |
-| `kanban-domain` | All domain types |
-| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
-| `kanban-persistence-json` | JSON backend (feature `json-storage`) |
-| `kanban-persistence-sqlite` | SQLite backend (feature `sqlite-storage`) |
+| `kanban-core` | `AppConfig`, `AppType`, `KanbanResult` |
+| `kanban-domain` | All domain types, `KanbanOperations`, `DataStore` |
+| `kanban-persistence` | `PersistenceStore`, `StoreRegistry`, `PersistenceMetadata` |
+| `kanban-api` | Re-exported as `kanban_service::api` — wire DTOs for MCP/server consumers |
+| `kanban-backend` | `KanbanBackend`, `RemoteWrites` — the backend abstraction this crate depends on instead of a concrete backend |
+| `kanban-persistence-sqlite` (optional, feature `sqlite`, default-on) | The one concrete storage backend this crate still knows about by name |
 | `tokio` | Async runtime |
-| `serde` | Serialization |
+| `serde` + `serde_json` | Serialization |
+| `schemars` (optional, feature `schemars`) | JSON Schema derivation on wire DTOs for MCP tool parameters |
+| `toml`, `dirs`, `dunce` | Config file location/parsing |
+| `chrono`, `uuid` | Timestamps, entity/session IDs |
+| `tracing` | Structured logging |

--- a/crates/kanban-tui/README.md
+++ b/crates/kanban-tui/README.md
@@ -353,15 +353,19 @@ dependency graph.
 
 | Crate | Purpose |
 |-------|---------|
-| `kanban-service` | `KanbanContext` and all domain operations |
-| `kanban-core` | Shared types, config, pagination |
-| `kanban-domain` | Domain models |
-| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
-| `kanban-backend` | `KanbanBackend`, `KanbanBackendRegistry` |
-| `kanban-backend-memory` | In-memory backend, registered for the no-file launch path |
-| `kanban-persistence-json` | JSON backend, registered at startup |
-| `kanban-persistence-sqlite` | SQLite backend, registered at startup |
+| [`kanban-service`](../kanban-service/README.md) | `KanbanContext` and all domain operations |
+| [`kanban-core`](../kanban-core/README.md) | Shared types, config, pagination |
+| [`kanban-domain`](../kanban-domain/README.md) | Domain models |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore`, `StoreRegistry` |
+| [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend`, `KanbanBackendRegistry` |
+| [`kanban-backend-memory`](../kanban-backend-memory/README.md) | In-memory backend, registered for the no-file launch path |
+| [`kanban-persistence-json`](../kanban-persistence-json/README.md) | JSON backend, registered at startup |
+| [`kanban-persistence-sqlite`](../kanban-persistence-sqlite/README.md) | SQLite backend, registered at startup |
 | `ratatui` | Terminal rendering |
 | `crossterm` | Terminal input/output |
 | `tokio` | Async runtime |
 | `arboard` | Clipboard access |
+
+## Related crates
+
+Used by: [kanban-cli](../kanban-cli/README.md) (optional feature `tui`, default-on).

--- a/crates/kanban-tui/README.md
+++ b/crates/kanban-tui/README.md
@@ -312,11 +312,55 @@ Card descriptions are rendered with basic markdown formatting in the description
 
 ---
 
+## Position in the workspace
+
+Unlike `kanban-cli`/`kanban-mcp`, `kanban-tui` depends on the storage
+backends unconditionally rather than behind Cargo features — there's no
+"minimal TUI without JSON support" build today.
+
+```mermaid
+graph TD
+    CORE[kanban-core]
+    DOM[kanban-domain] --> CORE
+    PER[kanban-persistence] --> CORE
+    PER --> DOM
+    BE[kanban-backend] --> PER
+    BEMEM[kanban-backend-memory] --> BE
+    JSON[kanban-persistence-json] --> BE
+    SQL[kanban-persistence-sqlite] --> BE
+    SVC[kanban-service] --> BE
+    TUI[kanban-tui] --> CORE
+    TUI --> DOM
+    TUI --> PER
+    TUI --> BE
+    TUI --> BEMEM
+    TUI --> JSON
+    TUI --> SQL
+    TUI --> SVC
+    CLI[kanban-cli] -.->|feature: tui, default-on| TUI
+```
+
+All edges shown out of `kanban-tui` are normal (`[dependencies]`) edges — it
+registers all four backends (in-memory, JSON, SQLite, and — via
+`kanban-backend` — the abstraction an HTTP backend would plug into) at
+startup itself, mirroring `kanban-cli`/`kanban-mcp`/`kanban-server` (KAN-1027:
+the app crates, not `kanban-service`, compose the concrete backends). The one
+dotted arrow (`kanban-cli -.-> kanban-tui`) is `kanban-cli`'s `tui` feature,
+default-on. See the [root README](../../README.md) for the full workspace
+dependency graph.
+
 ## Dependencies
 
 | Crate | Purpose |
 |-------|---------|
 | `kanban-service` | `KanbanContext` and all domain operations |
+| `kanban-core` | Shared types, config, pagination |
+| `kanban-domain` | Domain models |
+| `kanban-persistence` | `PersistenceStore`, `StoreRegistry` |
+| `kanban-backend` | `KanbanBackend`, `KanbanBackendRegistry` |
+| `kanban-backend-memory` | In-memory backend, registered for the no-file launch path |
+| `kanban-persistence-json` | JSON backend, registered at startup |
+| `kanban-persistence-sqlite` | SQLite backend, registered at startup |
 | `ratatui` | Terminal rendering |
 | `crossterm` | Terminal input/output |
 | `tokio` | Async runtime |


### PR DESCRIPTION
## Summary

- Adds an architecture section to the root README with a workspace-wide dependency Mermaid diagram (solid = normal deps, dotted = optional/feature-gated), plus a short build/run/test section.
- Adds a per-crate README for every crate under `crates/`: new for `kanban-api`, `kanban-backend`, `kanban-backend-memory`, `kanban-backend-http` (none existed); extends the ten that already had one with a "Position in the workspace" section carrying a scoped Mermaid diagram (this crate's direct intra-workspace deps and dependents only) plus a corrected `Dependencies` table.
- **All diagrams reflect the post-KAN-1027 graph**: `kanban-service` depends on the `kanban-backend`/`kanban-persistence` abstractions and only optionally on `kanban-persistence-sqlite` (feature `sqlite`, default-on) — it no longer has a production dependency on `kanban-persistence-json` or `kanban-backend-memory`, and the old `json` feature is gone. The four application crates (`kanban-cli`, `kanban-mcp`, `kanban-tui`, `kanban-server`) now compose the concrete backends directly instead of going through the service layer.
- Corrects a stale `KanbanContext` struct description in the `kanban-service` README (it wraps `Arc<dyn KanbanBackend>` now, not a raw `PersistenceStore`) and flags the rest of that file's detailed API walkthrough as needing a fuller refresh in a follow-up, since it predates the backend-registry work.
- Dev-only dependency cycles (e.g. `kanban-persistence-json`/`-sqlite` dev-depending on `kanban-service`, and `kanban-domain`/`kanban-persistence` dev-depending on `kanban-backend-memory`) are called out in prose rather than drawn as edges in the main graphs, since they're never reachable from a release build.
- Adds a patch changeset since the CI changeset check requires one on every PR to `develop` regardless of content.

## Test plan

- [x] `cargo metadata --format-version 1 --no-deps` and the raw `Cargo.toml` reads used to build the adjacency list match what's committed (spot-checked; every intra-workspace edge in every diagram traces to a real `Cargo.toml` line)
- [x] All Mermaid code fences are balanced and render correctly on GitHub
- [x] All root README crate links resolve to an existing file
- [x] `CLAUDE.md`'s own architecture diagram is now the stale one (left untouched — flagged as a follow-up, not part of this change)