### PR TITLE
KAN-1029 refactor(backend): replace persistence_metadata() with a LocalPersistence capability accessor

### DIFF
--- a/.changeset/kan-1029-local-persistence-capability-accessor.md
+++ b/.changeset/kan-1029-local-persistence-capability-accessor.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+Internal groundwork with no user-visible effect: `KanbanBackend::persistence_metadata()` is
+replaced by a `local_persistence()` capability accessor returning `Option<&dyn
+LocalPersistence>`, mirroring the existing `remote_writes()` pattern. Only the JSON and SQLite
+backends implement `LocalPersistence`; the in-memory and HTTP backends simply have no
+capability to return, instead of being forced to answer a question they cannot meaningfully
+answer. The TUI's F12 diagnostics panel still shows the writer stamp exactly as before;
+behaviour, storage formats, and commands are unchanged.
+
+Completes the KAN-1021 epic.

--- a/crates/kanban-backend-memory/src/lib.rs
+++ b/crates/kanban-backend-memory/src/lib.rs
@@ -55,10 +55,10 @@ mod tests {
     }
 
     #[test]
-    fn test_in_memory_backend_returns_none_persistence_metadata() {
+    fn test_in_memory_backend_returns_none_local_persistence() {
         let store = InMemoryStore::new();
         let backend: &dyn KanbanBackend = &store;
-        assert!(backend.persistence_metadata().is_none());
+        assert!(backend.local_persistence().is_none());
     }
 
     #[test]

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -100,3 +100,150 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::command_batch::CommandBatch;
+    use kanban_domain::*;
+
+    struct StubBackend;
+
+    impl DataStore for StubBackend {
+        fn get_board(&self, _id: Uuid) -> KanbanResult<Option<Board>> {
+            unimplemented!()
+        }
+        fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+            unimplemented!()
+        }
+        fn upsert_board(&self, _board: Board) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn delete_board(&self, _id: Uuid) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn get_column(&self, _id: Uuid) -> KanbanResult<Option<Column>> {
+            unimplemented!()
+        }
+        fn list_columns_by_board(&self, _board_id: Uuid) -> KanbanResult<Vec<Column>> {
+            unimplemented!()
+        }
+        fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+            unimplemented!()
+        }
+        fn upsert_column(&self, _column: Column) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn delete_column(&self, _id: Uuid) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn delete_columns_by_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn get_card(&self, _id: Uuid) -> KanbanResult<Option<Card>> {
+            unimplemented!()
+        }
+        fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+            unimplemented!()
+        }
+        fn list_cards_by_column(&self, _column_id: Uuid) -> KanbanResult<Vec<Card>> {
+            unimplemented!()
+        }
+        fn list_cards_by_sprint(&self, _sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+            unimplemented!()
+        }
+        fn count_cards_in_column(&self, _column_id: Uuid) -> KanbanResult<usize> {
+            unimplemented!()
+        }
+        fn count_cards_in_column_excluding(
+            &self,
+            _column_id: Uuid,
+            _exclude: &[Uuid],
+        ) -> KanbanResult<usize> {
+            unimplemented!()
+        }
+        fn upsert_card(&self, _card: Card) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn delete_card(&self, _id: Uuid) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn delete_cards_by_columns(&self, _column_ids: &[Uuid]) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn clear_sprint_from_cards(
+            &self,
+            _sprint_id: Uuid,
+            _timestamp: chrono::DateTime<chrono::Utc>,
+        ) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn get_archived_card(&self, _card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+            unimplemented!()
+        }
+        fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+            unimplemented!()
+        }
+        fn insert_archived_card(&self, _ac: ArchivedCard) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn delete_archived_card(&self, _card_id: Uuid) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn get_sprint(&self, _id: Uuid) -> KanbanResult<Option<Sprint>> {
+            unimplemented!()
+        }
+        fn list_sprints_by_board(&self, _board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+            unimplemented!()
+        }
+        fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+            unimplemented!()
+        }
+        fn upsert_sprint(&self, _sprint: Sprint) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn delete_sprint(&self, _id: Uuid) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn delete_sprints_by_board(&self, _board_id: Uuid) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+            unimplemented!()
+        }
+        fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn snapshot(&self) -> KanbanResult<Snapshot> {
+            unimplemented!()
+        }
+        fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
+            unimplemented!()
+        }
+    }
+
+    impl CommandStore for StubBackend {
+        fn append_batch(&self, _batch: &CommandBatch) -> KanbanResult<u64> {
+            unimplemented!()
+        }
+        fn batch_count(&self) -> KanbanResult<u64> {
+            unimplemented!()
+        }
+        fn load_batches(&self, _offset: u64, _limit: u64) -> KanbanResult<Vec<CommandBatch>> {
+            unimplemented!()
+        }
+    }
+
+    impl KanbanBackend for StubBackend {
+        fn as_data_store(&self) -> &dyn DataStore {
+            self
+        }
+    }
+
+    #[test]
+    fn test_backend_without_local_persistence_returns_none() {
+        let backend = StubBackend;
+        let backend: &dyn KanbanBackend = &backend;
+        assert!(backend.local_persistence().is_none());
+    }
+}

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{KanbanError, KanbanResult};
-use kanban_persistence::PersistenceMetadata;
 use uuid::Uuid;
 
 /// Combines the entity-level CRUD interface (`DataStore`) with the command
@@ -57,14 +56,6 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     /// Stable instance UUID used for own-write detection in file watchers.
     fn instance_id(&self) -> Uuid {
         Uuid::nil()
-    }
-
-    /// Metadata about the underlying persistence store (file format version,
-    /// writer kanban version, writer commit, last save time). Returns `None`
-    /// for in-memory backends or when no metadata has been observed yet.
-    /// Surfaced by the TUI's F12 diagnostics panel.
-    fn persistence_metadata(&self) -> Option<PersistenceMetadata> {
-        None
     }
 
     /// Some(...) when this backend can report format version, writer kanban

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod factory;
+pub mod local_persistence;
 pub mod remote_writes;
 pub use factory::{KanbanBackendFactory, KanbanBackendRegistry};
+pub use local_persistence::LocalPersistence;
 pub use remote_writes::RemoteWrites;
 
 use async_trait::async_trait;
@@ -62,6 +64,14 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     /// for in-memory backends or when no metadata has been observed yet.
     /// Surfaced by the TUI's F12 diagnostics panel.
     fn persistence_metadata(&self) -> Option<PersistenceMetadata> {
+        None
+    }
+
+    /// Some(...) when this backend can report format version, writer kanban
+    /// version, writer commit, and last save time (JSON, SQLite). `None`
+    /// (the default) for backends with no durable local store (InMemory,
+    /// Http) or that don't track it (MockBackend).
+    fn local_persistence(&self) -> Option<&dyn crate::LocalPersistence> {
         None
     }
 

--- a/crates/kanban-backend/src/local_persistence.rs
+++ b/crates/kanban-backend/src/local_persistence.rs
@@ -1,0 +1,11 @@
+use kanban_persistence::PersistenceMetadata;
+
+/// Optional backend capability: expose metadata about the underlying
+/// persistence store (format version, writer kanban version, writer commit,
+/// last save time). JSON and SQLite are the only real implementors; local
+/// backends without durable storage (InMemory) and remote backends (Http)
+/// never override `KanbanBackend::local_persistence()`, so callers must
+/// treat the capability as optional rather than assuming every backend has it.
+pub trait LocalPersistence: Send + Sync {
+    fn persistence_metadata(&self) -> Option<PersistenceMetadata>;
+}

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -389,6 +389,12 @@ impl KanbanBackend for JsonDataStore {
         self.file_store.instance_id()
     }
 
+    fn local_persistence(&self) -> Option<&dyn kanban_backend::LocalPersistence> {
+        Some(self)
+    }
+}
+
+impl kanban_backend::LocalPersistence for JsonDataStore {
     fn persistence_metadata(&self) -> Option<PersistenceMetadata> {
         // Surface what we've observed; do NOT trigger a load here — the
         // backend may be queried before any DataStore call (e.g. when the TUI

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_json_backend_exposes_metadata_after_flush() {
+    async fn test_json_backend_exposes_local_persistence() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("md.json");
         let jds = make_store(&path);
@@ -419,6 +419,8 @@ mod tests {
         jds.upsert_board(Board::new("B", None::<String>)).unwrap();
         jds.flush().await.unwrap();
         let meta = jds
+            .local_persistence()
+            .expect("JSON backend must expose a LocalPersistence capability")
             .persistence_metadata()
             .expect("flushed JSON backend must expose metadata");
         assert_eq!(
@@ -437,7 +439,11 @@ mod tests {
         let path = dir.path().join("untouched.json");
         let jds = make_store(&path);
         // No DataStore call yet → ensure_loaded never ran → cache empty.
-        assert!(jds.persistence_metadata().is_none());
+        assert!(jds
+            .local_persistence()
+            .expect("JSON backend must expose a LocalPersistence capability")
+            .persistence_metadata()
+            .is_none());
     }
 
     /// Verifies that `ensure_loaded` no longer relies on `block_in_place`, so

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_sqlite_backend_exposes_metadata_after_flush() {
+    async fn test_sqlite_backend_exposes_local_persistence() {
         use super::SqliteBackend;
         use kanban_backend::KanbanBackend;
 
@@ -300,6 +300,8 @@ mod tests {
         let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
         backend.flush().await.unwrap();
         let meta = backend
+            .local_persistence()
+            .expect("sqlite backend must expose a LocalPersistence capability")
             .persistence_metadata()
             .expect("flushed sqlite backend must expose metadata");
         assert_eq!(

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -256,6 +256,12 @@ impl kanban_backend::KanbanBackend for SqliteBackend {
         <SqliteStore as PersistenceStore>::instance_id(&self.db)
     }
 
+    fn local_persistence(&self) -> Option<&dyn kanban_backend::LocalPersistence> {
+        Some(self)
+    }
+}
+
+impl kanban_backend::LocalPersistence for SqliteBackend {
     fn persistence_metadata(&self) -> Option<PersistenceMetadata> {
         self.last_metadata.read().ok().and_then(|g| g.clone())
     }

--- a/crates/kanban-service/src/context/core.rs
+++ b/crates/kanban-service/src/context/core.rs
@@ -64,7 +64,7 @@ impl KanbanContext {
     /// in-memory backends or before the underlying file has been loaded.
     /// Surfaced by the TUI F12 diagnostics panel.
     pub fn persistence_metadata(&self) -> Option<kanban_persistence::PersistenceMetadata> {
-        self.backend.persistence_metadata()
+        self.backend.local_persistence()?.persistence_metadata()
     }
 
     /// Replace the active backend, discarding all undo/redo history.


### PR DESCRIPTION
## Summary

Replaces the blanket `KanbanBackend::persistence_metadata() -> Option<PersistenceMetadata>` method with a `LocalPersistence` capability accessor, mirroring the existing `remote_writes()`/`RemoteWrites` pattern. Only the JSON and SQLite backends can meaningfully answer "what's your persistence metadata"; the in-memory, HTTP, and mock backends were previously forced to inherit a `None` default for a question they cannot answer at all. This was an ISP violation fixed the same way `remote_writes()` already handles the analogous "can this backend bypass local command execution" question.

- New `LocalPersistence` trait in `crates/kanban-backend/src/local_persistence.rs`, re-exported from `kanban-backend`'s `lib.rs`, exactly mirroring `RemoteWrites`'s placement.
- `KanbanBackend` gains `local_persistence(&self) -> Option<&dyn LocalPersistence>` (default `None`); the old `persistence_metadata()` trait method and its JSON/SQLite overrides are removed once every caller is rerouted.
- `JsonDataStore` and `SqliteBackend` each implement `LocalPersistence`, with the cached `RwLock<Option<PersistenceMetadata>>` read moved verbatim from their old `KanbanBackend::persistence_metadata()` bodies. No new I/O or lock acquisition on the render path.
- `KanbanContext::persistence_metadata()` keeps its exact signature and now delegates through `self.backend.local_persistence()?.persistence_metadata()`. The TUI (`tui_context.rs`, `error_log.rs`, the F12 diagnostics popup) needed zero changes.

Completes the KAN-1021 epic.

## Dependency-edge decision

`kanban-backend`'s `kanban-persistence` dependency (`Cargo.toml:19`) is **retained**, not dropped. `PersistenceMetadata` stays defined in `kanban-persistence` because it is load-bearing there in its own right, independent of this refactor: `NullStore`'s `PersistenceStore::save`/`load` return it directly (`null_store.rs`), `ConflictResolver`'s interface and unit tests are built around comparing two `PersistenceMetadata` values (`conflict/resolver.rs`), and the registry's own contract-test mock implements `PersistenceStore` against it (`registry.rs`). There is no smaller crate to move it to without also relocating `PersistenceStore`, `ConflictResolver`, and `NullStore` themselves, which is out of scope here. `LocalPersistence` itself lives in `kanban-backend`, exactly where `RemoteWrites` lives despite importing `kanban_domain` types without those types moving.

## Commits

Split by type, test and implementation separate, in Red -> Green -> Refactor order:

1. `test(backend): add LocalPersistence capability contract test` - in-crate `StubBackend`, fails to compile until `local_persistence()`/`LocalPersistence` exist.
2. `feat(backend): add LocalPersistence trait and accessor` - the trait, module, and `KanbanBackend::local_persistence()` default; old `persistence_metadata()` kept in place so nothing downstream breaks yet.
3. `test(persistence-json): reroute persistence_metadata tests through LocalPersistence` - renames `test_json_backend_exposes_metadata_after_flush` to `test_json_backend_exposes_local_persistence` and reroutes `test_json_backend_metadata_is_none_before_any_load_or_save`, both through `local_persistence()`. Fails at runtime (not compile) since `JsonDataStore` hasn't overridden `local_persistence()` yet.
4. `test(persistence-sqlite): reroute persistence_metadata test through LocalPersistence` - same rename/reroute for `test_sqlite_backend_exposes_metadata_after_flush` -> `test_sqlite_backend_exposes_local_persistence`.
5. `feat(persistence-json): implement LocalPersistence for JsonDataStore` and `feat(persistence-sqlite): implement LocalPersistence for SqliteBackend` - move each backend's `persistence_metadata()` body verbatim into a new `LocalPersistence` impl.
6. `refactor(service): route KanbanContext::persistence_metadata through LocalPersistence` - `test_context_persistence_metadata_returns_writer_stamp_after_save` passes unmodified.
7. `test(backend-memory): rename persistence_metadata test to local_persistence` - done ahead of the trait removal (rather than after, as originally sequenced) so `kanban-backend-memory` stays compiling at every commit; it was the last remaining direct call on a concrete backend struct.
8. `refactor(backend): remove persistence_metadata from KanbanBackend` - drops the now-dead trait method and its unused import. No `Cargo.toml` change, per the dependency-edge decision above.
9. `chore: add changeset for LocalPersistence capability accessor`

## Verification

- Each of the 5 touched crates individually, without `--all-features` for `kanban-service` (dodging the known pre-existing KAN-1022 `DateTime<Utc>: JsonSchema` failure): `cargo check -p <crate> --all-targets` and `cargo test -p <crate>` both green with 0 failed, checked one crate at a time (not a combined `-p a -p b -p c`, which would mask a later failure).
- `test_context_persistence_metadata_returns_writer_stamp_after_save` (`context_open.rs:111`) passes unmodified.
- `cargo test --workspace --all-features`: **3296 passed, 0 failed** (baseline on develop was 3295; the only true net-new test is `test_backend_without_local_persistence_returns_none`, the rest of the delta is renames).
- `cargo check --workspace --all-targets`: clean.
- `rg -n '\.persistence_metadata\(\)' crates/`: only hits inside `LocalPersistence` impls/trait definition, `KanbanContext::persistence_metadata`, and the unchanged TUI passthrough (`tui_context.rs`, `error_log.rs`) remain. No orphan direct calls on a concrete backend struct.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `bash scripts/validate-release.sh`, `bash scripts/check-crate-list-sync.sh`: clean.

## Test plan

- [x] `cargo test --workspace --all-features` - 3296 passed, 0 failed
- [x] `cargo check --workspace --all-targets` - clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - clean
- [x] `cargo fmt --all --check` - clean
- [x] `scripts/validate-release.sh`, `scripts/check-crate-list-sync.sh` - clean
- [x] F12 diagnostics panel still surfaces the writer stamp (verified by inspection: `KanbanContext::persistence_metadata()` signature unchanged, TUI call sites untouched)