### PR TITLE
docs: make CLAUDE.md dependency graph and version accurate to develop

### DIFF
--- a/.changeset/docs-claude-md-accuracy.md
+++ b/.changeset/docs-claude-md-accuracy.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Correct the CLAUDE.md architecture reference: the dependency graph now shows the JSON and SQLite persistence crates depending on kanban-backend and kanban-backend-memory (they currently host their KanbanBackend adapters), both crate descriptions note that adapter placement, and the JSON envelope version is updated from V10 to the current V11.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,11 @@ graph LR
     MEM --> BE
     BE --> PER
     JSON --> PER
+    JSON --> BE
+    JSON --> MEM
     SQL --> PER
+    SQL --> BE
+    SQL --> MEM
     PER --> DOM[kanban-domain]
     API --> DOM
     DOM --> CORE[kanban-core]
@@ -164,8 +168,9 @@ cargo tarpaulin        # Code coverage
 
 - `JsonFileStore` - `PersistenceStore` impl with atomic writes (temp file + rename)
 - `JsonStoreFactory` - `matches_content` sniffs the first non-whitespace byte (`{` or `[`); no extension matching
-- Envelope: `{ version, metadata, data }`, current version V10; reader accepts V1..V10
-- Migration chain V1 → V2 → V3 → (V4/V5 are shape-stable bumps) → V6 (split-graph) → V7 (spawns-bucket rename) → V8 (archived-card board_id backfill) → V9 (archived-board-capable marker) → V10 (archival wrapper collapsed to a pure reference marker); legacy steps write `.v{N}.backup` on the way forward, including `.v9.backup` on the V9→V10 step
+- Also hosts the `KanbanBackend` adapter over that store: `JsonDataStore` (`impl KanbanBackend`/`LocalPersistence`, wraps the format store with an `InMemoryStore` command-log mirror) + `JsonBackendFactory` (`impl KanbanBackendFactory`). This is why the crate also depends on `kanban-backend`/`kanban-backend-memory` (an interim placement from KAN-1025 — see the `kanban-backend-json` extraction follow-up).
+- Envelope: `{ version, metadata, data }`, current version V11; reader accepts V1..V11
+- Migration chain V1 → V2 → V3 → (V4/V5 are shape-stable bumps) → V6 (split-graph) → V7 (spawns-bucket rename) → V8 (archived-card board_id backfill) → V9 (archived-board-capable marker) → V10 (archival wrapper collapsed to a pure reference marker) → V11 (historical `cards.board_id` backfill); legacy steps write `.v{N}.backup` on the way forward, including `.v10.backup` on the V10→V11 step
 - Debounced saving (500ms minimum interval)
 
 ### kanban-persistence-sqlite
@@ -173,6 +178,7 @@ cargo tarpaulin        # Code coverage
 
 - `SqliteStore` - `PersistenceStore` impl with WAL mode, foreign keys, max 2 connections
 - `SqliteStoreFactory` - `matches_content` sniffs the SQLite magic bytes (`SQLite format 3\0`); no extension matching
+- Also hosts the `KanbanBackend` adapter over that store: `SqliteBackend` (`impl KanbanBackend`/`LocalPersistence`) + `SqliteBackendFactory` (`impl KanbanBackendFactory`). Hence the crate's dependency on `kanban-backend`/`kanban-backend-memory` (interim placement from KAN-1026 — see the `kanban-backend-sqlite` extraction follow-up).
 - Relational schema, 14 tables: metadata, boards, board_sprint_names, board_sprint_counters, columns, sprints, cards, sprint_logs, archived_cards, spawns_edges, blocks_edges, relates_edges, board_archival, command_log
 - `SUPPORTED_SCHEMA_VERSION = 5` (active migrations upgrade older databases on open, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`); legacy-table drops on open for pre-KAN-405 `command_log`, the retired `undo_state`, and the pre-KAN-504 single `card_edges` table
 - Auto-creates database file on first use

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ cargo tarpaulin        # Code coverage
 
 - `JsonFileStore` - `PersistenceStore` impl with atomic writes (temp file + rename)
 - `JsonStoreFactory` - `matches_content` sniffs the first non-whitespace byte (`{` or `[`); no extension matching
-- Also hosts the `KanbanBackend` adapter over that store: `JsonDataStore` (`impl KanbanBackend`/`LocalPersistence`, wraps the format store with an `InMemoryStore` command-log mirror) + `JsonBackendFactory` (`impl KanbanBackendFactory`). This is why the crate also depends on `kanban-backend`/`kanban-backend-memory` (an interim placement from KAN-1025 — see the `kanban-backend-json` extraction follow-up).
+- Also hosts the `KanbanBackend` adapter over that store: `JsonDataStore` (in `json_backend.rs`, `impl KanbanBackend`/`LocalPersistence`, wrapping the format store with an `InMemoryStore` command-log mirror) and `JsonBackendFactory` (in `backend_factory.rs`, `impl KanbanBackendFactory`). This is why the crate depends on `kanban-backend` and `kanban-backend-memory`.
 - Envelope: `{ version, metadata, data }`, current version V11; reader accepts V1..V11
 - Migration chain V1 → V2 → V3 → (V4/V5 are shape-stable bumps) → V6 (split-graph) → V7 (spawns-bucket rename) → V8 (archived-card board_id backfill) → V9 (archived-board-capable marker) → V10 (archival wrapper collapsed to a pure reference marker) → V11 (historical `cards.board_id` backfill); legacy steps write `.v{N}.backup` on the way forward, including `.v10.backup` on the V10→V11 step
 - Debounced saving (500ms minimum interval)
@@ -178,7 +178,7 @@ cargo tarpaulin        # Code coverage
 
 - `SqliteStore` - `PersistenceStore` impl with WAL mode, foreign keys, max 2 connections
 - `SqliteStoreFactory` - `matches_content` sniffs the SQLite magic bytes (`SQLite format 3\0`); no extension matching
-- Also hosts the `KanbanBackend` adapter over that store: `SqliteBackend` (`impl KanbanBackend`/`LocalPersistence`) + `SqliteBackendFactory` (`impl KanbanBackendFactory`). Hence the crate's dependency on `kanban-backend`/`kanban-backend-memory` (interim placement from KAN-1026 — see the `kanban-backend-sqlite` extraction follow-up).
+- Also hosts the `KanbanBackend` adapter over that store: `SqliteBackend` (in `sqlite_backend.rs`, `impl KanbanBackend`/`LocalPersistence`) and `SqliteBackendFactory` (in `backend_factory.rs`, `impl KanbanBackendFactory`). This is why the crate depends on `kanban-backend` and `kanban-backend-memory`.
 - Relational schema, 14 tables: metadata, boards, board_sprint_names, board_sprint_counters, columns, sprints, cards, sprint_logs, archived_cards, spawns_edges, blocks_edges, relates_edges, board_archival, command_log
 - `SUPPORTED_SCHEMA_VERSION = 5` (active migrations upgrade older databases on open, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`); legacy-table drops on open for pre-KAN-405 `command_log`, the retired `undo_state`, and the pre-KAN-504 single `card_edges` table
 - Auto-creates database file on first use


### PR DESCRIPTION
Follows up #517 (merged): brings CLAUDE.md into agreement with the code on develop.

## What
- Dependency mermaid: add the `JSON --> BE`/`JSON --> MEM` and `SQL --> BE`/`SQL --> MEM` edges the graph was missing. The persistence crates currently host their `KanbanBackend` adapters, so they really do depend on `kanban-backend` and `kanban-backend-memory`; the graph now matches the per-crate READMEs and the real Cargo.toml edges.
- Note the adapter placement in both persistence-crate descriptions (interim from KAN-1025/1026; there is a follow-up to extract dedicated `kanban-backend-json`/`kanban-backend-sqlite` crates).
- JSON envelope V10 to V11 (`FormatVersion::MAX`), migration chain extended with the V10 to V11 cards.board_id backfill.

## Why
The previous graph was drawn as if the adapters did not live in the persistence crates, which is not the current state. This makes the source-of-truth doc match reality.

## Verification
- `SUPPORTED_SCHEMA_VERSION = 5` (already correct in develop) unchanged.
- No code changes; docs only.