### PR TITLE
chore(flake): bump rust-overlay to unblock rustc 1.95+ MSRV crates

### DIFF
--- a/.changeset/bump-rust-overlay-clippy-1-97.md
+++ b/.changeset/bump-rust-overlay-clippy-1-97.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Internal maintenance with no user-visible effect: bumps the `rust-overlay` flake input so `nix develop` resolves stable Rust 1.97.1 instead of 1.93.1 (needed by an in-flight branch depending on a crate with a newer MSRV). The newer clippy this pulls in flags a handful of pre-existing patterns (`manual_checked_ops`, `unnecessary_sort_by`, `collapsible_match`) across `kanban-core`, `kanban-domain`, `kanban-backend-memory`, and `kanban-tui`; all are fixed mechanically with no behavior change.

--- a/crates/kanban-backend-memory/src/in_memory_store/archived_boards.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/archived_boards.rs
@@ -18,7 +18,7 @@ impl InMemoryStore {
         let mut boards: Vec<ArchivedBoard> = state.archived_boards.values().cloned().collect();
         // Ascending by archived_at, matching `list_archived_cards` and the
         // snapshot order (presentation order is the UI layer's concern).
-        boards.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
+        boards.sort_by_key(|b| b.metadata.archived_at);
         Ok(boards)
     }
 

--- a/crates/kanban-backend-memory/src/in_memory_store/archived_cards.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/archived_cards.rs
@@ -19,7 +19,7 @@ impl InMemoryStore {
     pub(super) fn list_archived_cards_impl(&self) -> KanbanResult<Vec<ArchivedCard>> {
         let state = self.read_state()?;
         let mut acs: Vec<ArchivedCard> = state.archived_cards.values().copied().collect();
-        acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
+        acs.sort_by_key(|ac| ac.metadata.archived_at);
         Ok(acs)
     }
 
@@ -43,7 +43,7 @@ impl InMemoryStore {
             .filter(|ac| ac.context.board_id == board_id)
             .copied()
             .collect();
-        acs.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
+        acs.sort_by_key(|ac| ac.metadata.archived_at);
         Ok(acs)
     }
 

--- a/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
@@ -21,13 +21,13 @@ impl InMemoryStore {
 
         let mut archived_cards: Vec<kanban_domain::ArchivedCard> =
             state.archived_cards.values().copied().collect();
-        archived_cards.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
+        archived_cards.sort_by_key(|ac| ac.metadata.archived_at);
 
         let mut sprints: Vec<_> = state.sprints.values().cloned().collect();
         sprints.sort_by_key(|s| s.sprint_number);
 
         let mut archived_boards: Vec<_> = state.archived_boards.values().cloned().collect();
-        archived_boards.sort_by(|a, b| a.metadata.archived_at.cmp(&b.metadata.archived_at));
+        archived_boards.sort_by_key(|ab| ab.metadata.archived_at);
 
         let mut snap = Snapshot::from_data(
             boards,

--- a/crates/kanban-core/src/pagination.rs
+++ b/crates/kanban-core/src/pagination.rs
@@ -147,11 +147,7 @@ impl Page {
         } else {
             0
         };
-        let current_page = if viewport_height > 0 {
-            self.scroll_offset / viewport_height
-        } else {
-            0
-        };
+        let current_page = self.scroll_offset.checked_div(viewport_height).unwrap_or(0);
 
         PageInfo {
             visible_indices,

--- a/crates/kanban-domain/src/sprint.rs
+++ b/crates/kanban-domain/src/sprint.rs
@@ -179,8 +179,8 @@ impl Sprint {
                 SprintStatus::Completed => ended.push(s),
             }
         }
-        active.sort_by(|a, b| b.sprint_number.cmp(&a.sprint_number));
-        ended.sort_by(|a, b| b.sprint_number.cmp(&a.sprint_number));
+        active.sort_by_key(|s| std::cmp::Reverse(s.sprint_number));
+        ended.sort_by_key(|s| std::cmp::Reverse(s.sprint_number));
         (active, ended)
     }
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -536,15 +536,13 @@ impl App {
                     }
                 }
             }
-            KeyCode::Char('p') => {
-                if self.focus.board_focus == BoardFocus::Settings {
-                    if let Some(current_prefix) = self
-                        .active_board()
-                        .map(|b| b.sprint_prefix.clone().unwrap_or_default())
-                    {
-                        self.input.set(current_prefix);
-                        self.open_dialog(DialogMode::SetBranchPrefix);
-                    }
+            KeyCode::Char('p') if self.focus.board_focus == BoardFocus::Settings => {
+                if let Some(current_prefix) = self
+                    .active_board()
+                    .map(|b| b.sprint_prefix.clone().unwrap_or_default())
+                {
+                    self.input.set(current_prefix);
+                    self.open_dialog(DialogMode::SetBranchPrefix);
                 }
             }
             _ => {}

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -58,12 +58,8 @@ impl App {
                     }
                 },
                 KeyCode::Char('k') | KeyCode::Up => match dialog_state.current_section {
-                    FilterDialogSection::Sprints => {
-                        if dialog_state.item_selection > 0 {
-                            dialog_state.item_selection -= 1;
-                        } else {
-                            dialog_state.prev_section();
-                        }
+                    FilterDialogSection::Sprints if dialog_state.item_selection > 0 => {
+                        dialog_state.item_selection -= 1;
                     }
                     _ => {
                         dialog_state.prev_section();

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -430,12 +430,12 @@ impl App {
                         .auto_select_first_if_empty(true);
                 }
             }
-            KeyCode::Enter => {
+            KeyCode::Enter
                 if self.focus.settings_focus == SettingsFocus::Storage
-                    && self.selection.settings_storage.get() == Some(EXPORT_BUTTON_STORAGE_INDEX)
-                {
-                    return self.trigger_export();
-                }
+                    && self.selection.settings_storage.get()
+                        == Some(EXPORT_BUTTON_STORAGE_INDEX) =>
+            {
+                return self.trigger_export();
             }
             _ => {}
         }

--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1771642886,
-        "narHash": "sha256-4zOvSi0WkS2WAaoJtM28wECtS9S+L38CPYbhF+wINDA=",
+        "lastModified": 1785562362,
+        "narHash": "sha256-J15aBa3d6B1SUUAQydQ06wFjPzrrcVceb6jkdfwfGls=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "85078369717bdbe1f266c9eaad5e66956fb6feea",
+        "rev": "5f29c219a7655519f8a9f8c6968064b82c17cc93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the pinned `rust-overlay` flake input so `nix develop` resolves stable Rust 1.97.1 instead of 1.93.1, and fixes the clippy fallout.

- Bump `rust-overlay` to the 2026-08-01 revision (stable resolves to 1.97.1)
- Fix `clippy::manual_checked_ops` in `kanban-core/pagination.rs`
- Fix `clippy::unnecessary_sort_by` in `kanban-domain/sprint.rs` and three `kanban-backend-memory` files
- Fix `clippy::collapsible_match` in three `kanban-tui/handlers` files

**What**: Toolchain bump plus the mechanical fixes the newer clippy requires.

**Why**: An in-flight branch (`max/kan-1039`, a Topcoat-based web-client prototype) depends on a crate with MSRV 1.95, which the previously-pinned `rust-overlay` revision couldn't satisfy. Splitting this out as its own PR keeps the toolchain/lint-debt change reviewable independently of the feature work that motivated it, per plan.

**How**: `nix flake update rust-overlay`, then fixed every lint the new clippy version (1.97) surfaced across the workspace — all pre-existing code, none related to the motivating branch's own changes.

**Testing**: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, `cargo build --workspace`, and `cargo test --workspace` are all clean on this branch.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`