### PR TITLE
fix: v0.8.0 release-readiness fix-up

### DIFF
--- a/crates/kanban-api/src/v1/sprints/requests.rs
+++ b/crates/kanban-api/src/v1/sprints/requests.rs
@@ -36,6 +36,10 @@ pub struct CreateSprintRequest {
 /// endpoints, not PATCH.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateSprintRequest {
+    /// Deliberately `Option<String>`, not `Patch<String>`: a sprint name has
+    /// no "clear" state (it resolves through the board's name pool, mirroring
+    /// `kanban-domain`'s `SprintUpdate.name`) — only rename (`Some`) or
+    /// no-op (`None`) are meaningful.
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Patch::is_no_change")]

--- a/crates/kanban-domain/tests/cascade_commands.rs
+++ b/crates/kanban-domain/tests/cascade_commands.rs
@@ -89,8 +89,8 @@ fn test_delete_archived_cards_removes_only_listed_ids_ignoring_columns() {
     // Board-scoped id list must delete archived records even when their
     // `original_column_id` dangles (column already gone).
     let tc = TestContext::new();
-    let board_id = Uuid::new_v4();
     let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board_id = board.id;
     let dangling_col = Uuid::new_v4();
     let live_col = kanban_domain::Column::new(board_id, "Live", 0);
     let card1 = kanban_domain::Card::new(&mut board, dangling_col, "1", 0);

--- a/crates/kanban-domain/tests/sprint_commands.rs
+++ b/crates/kanban-domain/tests/sprint_commands.rs
@@ -293,23 +293,19 @@ fn test_delete_sprint_clears_sprint_from_cards_with_command_timestamp() {
     use chrono::{TimeZone, Utc};
 
     let tc = TestContext::new();
-    let board = kanban_domain::Board::new("B", Some("KAN"));
+    let mut board = kanban_domain::Board::new("B", Some("KAN"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "Col", 0);
     let sprint = kanban_domain::Sprint::new(board_id, 1, None, None::<String>);
     let sprint_id = sprint.id;
+
+    let mut card = kanban_domain::Card::new(&mut board, col.id, "C", 0);
+    card.sprint_id = Some(sprint_id);
+    let card_id = card.id;
+
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col.clone()).unwrap();
     tc.store.upsert_sprint(sprint).unwrap();
-
-    let mut card = kanban_domain::Card::new(
-        &mut kanban_domain::Board::new("B", Some("KAN")),
-        col.id,
-        "C",
-        0,
-    );
-    card.sprint_id = Some(sprint_id);
-    let card_id = card.id;
     tc.store.upsert_card(card).unwrap();
 
     let fixed_time = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();

--- a/crates/kanban-persistence-json/src/migration/v9_to_v10_archival_refs.rs
+++ b/crates/kanban-persistence-json/src/migration/v9_to_v10_archival_refs.rs
@@ -362,6 +362,30 @@ mod tests {
     }
 
     #[test]
+    fn test_errors_on_embedded_entity_with_non_string_id() {
+        // A malformed embed whose `id` is a JSON number: to_marker() would
+        // happily stash the raw number as `entity_id`, but the lift-into-live
+        // step only recognizes a string id, so the entity would be silently
+        // dropped from `cards` while the marker still claims it by a
+        // non-string, non-UUID entity_id. That divergence must be a hard
+        // migration error, matching the sibling "no embed, no entity_id"
+        // corrupt-entry branch, not a silent partial success.
+        let mut env = v9_env(json!({
+            "cards": [],
+            "archived_cards": [{
+                "card": { "id": 12345, "title": "T" },
+                "archived_at": "2024-01-01T00:00:00Z",
+                "board_id": BOARD
+            }]
+        }));
+        let err = transform_v9_to_v10_value(&mut env).unwrap_err();
+        assert!(
+            matches!(err, PersistenceError::Serialization(_)),
+            "a non-string embedded id must error, got {err:?}"
+        );
+    }
+
+    #[test]
     fn test_bumps_version_when_no_archived_arrays() {
         let mut env = v9_env(json!({ "boards": [], "cards": [] }));
         assert!(transform_v9_to_v10_value(&mut env).unwrap());

--- a/crates/kanban-persistence-json/src/migration/v9_to_v10_archival_refs.rs
+++ b/crates/kanban-persistence-json/src/migration/v9_to_v10_archival_refs.rs
@@ -68,20 +68,16 @@ fn lift_archived_cards(data: &mut serde_json::Map<String, Value>) -> Persistence
         "archived_cards",
         "cards",
         &["entity", "card"],
-        |embedded, entry| {
-            let id = embedded
-                .get("id")
-                .cloned()
-                .ok_or("archived card entity has no `id`")?;
+        |id, entry| {
             let mut marker = serde_json::Map::new();
-            marker.insert("entity_id".to_string(), id);
+            marker.insert("entity_id".to_string(), Value::String(id.to_string()));
             if let Some(at) = entry.get("archived_at") {
                 marker.insert("archived_at".to_string(), at.clone());
             }
             if let Some(board_id) = entry.get("board_id") {
                 marker.insert("board_id".to_string(), board_id.clone());
             }
-            Ok(Value::Object(marker))
+            Value::Object(marker)
         },
     )
 }
@@ -94,31 +90,29 @@ fn lift_archived_boards(data: &mut serde_json::Map<String, Value>) -> Persistenc
         "archived_boards",
         "boards",
         &["entity", "board"],
-        |embedded, entry| {
-            let id = embedded
-                .get("id")
-                .cloned()
-                .ok_or("archived board entity has no `id`")?;
+        |id, entry| {
             let mut marker = serde_json::Map::new();
-            marker.insert("entity_id".to_string(), id);
+            marker.insert("entity_id".to_string(), Value::String(id.to_string()));
             if let Some(at) = entry.get("archived_at") {
                 marker.insert("archived_at".to_string(), at.clone());
             }
-            Ok(Value::Object(marker))
+            Value::Object(marker)
         },
     )
 }
 
 /// Generic lift: for each entry in `archived_key`, if it embeds an entity under
 /// any `embed_keys`, MOVE the entity into `live_key` (dedup by id — live copy
-/// wins) and replace the entry with the marker built by `to_marker`. Entries
-/// already in marker shape (no embed) require an `entity_id` and pass through.
+/// wins) and replace the entry with the marker built by `to_marker` (given the
+/// embedded entity's already-validated string id and the entry itself, for
+/// `archived_at`/`board_id`). Entries already in marker shape (no embed)
+/// require an `entity_id` and pass through.
 fn lift(
     data: &mut serde_json::Map<String, Value>,
     archived_key: &str,
     live_key: &str,
     embed_keys: &[&str],
-    to_marker: impl Fn(&Value, &Value) -> Result<Value, &'static str>,
+    to_marker: impl Fn(&str, &Value) -> Value,
 ) -> PersistenceResult<()> {
     let Some(mut archived) = data
         .get_mut(archived_key)
@@ -147,9 +141,7 @@ fn lift(
                          whose `id` is missing or not a string"
                     )));
                 };
-                let marker = to_marker(&embedded, entry).map_err(|e| {
-                    PersistenceError::Serialization(format!("V9→V10 migration: {e}"))
-                })?;
+                let marker = to_marker(id, entry);
                 if live_ids.insert(id.to_string()) {
                     lifted.push(embedded.clone());
                 }
@@ -366,20 +358,36 @@ mod tests {
     }
 
     #[test]
-    fn test_errors_on_embedded_entity_with_non_string_id() {
-        // A malformed embed whose `id` is a JSON number: to_marker() would
-        // happily stash the raw number as `entity_id`, but the lift-into-live
-        // step only recognizes a string id, so the entity would be silently
-        // dropped from `cards` while the marker still claims it by a
-        // non-string, non-UUID entity_id. That divergence must be a hard
-        // migration error, matching the sibling "no embed, no entity_id"
-        // corrupt-entry branch, not a silent partial success.
+    fn test_errors_on_embedded_card_entity_with_non_string_id() {
+        // A malformed embed whose `id` is a JSON number: lift() would have
+        // silently dropped the entity from `cards` while the marker still
+        // claimed it by a non-string, non-UUID entity_id. That divergence
+        // must be a hard migration error, matching the sibling "no embed, no
+        // entity_id" corrupt-entry branch, not a silent partial success.
         let mut env = v9_env(json!({
             "cards": [],
             "archived_cards": [{
                 "card": { "id": 12345, "title": "T" },
                 "archived_at": "2024-01-01T00:00:00Z",
                 "board_id": BOARD
+            }]
+        }));
+        let err = transform_v9_to_v10_value(&mut env).unwrap_err();
+        assert!(
+            matches!(err, PersistenceError::Serialization(_)),
+            "a non-string embedded id must error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_errors_on_embedded_board_entity_with_non_string_id() {
+        // Symmetric to the card case: `lift_archived_boards` shares the same
+        // generic `lift()`, so the guard must fire here too.
+        let mut env = v9_env(json!({
+            "boards": [],
+            "archived_boards": [{
+                "board": { "id": 12345, "name": "B" },
+                "archived_at": "2024-02-02T00:00:00Z"
             }]
         }));
         let err = transform_v9_to_v10_value(&mut env).unwrap_err();

--- a/crates/kanban-persistence-json/src/migration/v9_to_v10_archival_refs.rs
+++ b/crates/kanban-persistence-json/src/migration/v9_to_v10_archival_refs.rs
@@ -141,13 +141,17 @@ fn lift(
     for entry in archived.iter_mut() {
         match embed_keys.iter().find_map(|k| entry.get(*k)).cloned() {
             Some(embedded) => {
+                let Some(id) = embedded.get("id").and_then(Value::as_str) else {
+                    return Err(PersistenceError::Serialization(format!(
+                        "V9→V10 migration: {archived_key} entry has an embedded entity \
+                         whose `id` is missing or not a string"
+                    )));
+                };
                 let marker = to_marker(&embedded, entry).map_err(|e| {
                     PersistenceError::Serialization(format!("V9→V10 migration: {e}"))
                 })?;
-                if let Some(id) = embedded.get("id").and_then(Value::as_str) {
-                    if live_ids.insert(id.to_string()) {
-                        lifted.push(embedded.clone());
-                    }
+                if live_ids.insert(id.to_string()) {
+                    lifted.push(embedded.clone());
                 }
                 *entry = marker;
             }

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -111,9 +111,7 @@ pub fn fully_populated_snapshot() -> Snapshot {
     };
     let archived_card = kanban_domain::Archived::with_context(
         archived_card_inner_id,
-        kanban_domain::CardRestoreContext {
-            board_id: Uuid::nil(),
-        },
+        kanban_domain::CardRestoreContext { board_id },
         kanban_domain::ArchiveMetadata::at(now),
     );
 

--- a/crates/kanban-server/Cargo.toml
+++ b/crates/kanban-server/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "HTTP API server exposing the kanban project management tool over REST"
 
 [lib]
 name = "kanban_server"

--- a/crates/kanban-service/src/context/cards_batch.rs
+++ b/crates/kanban-service/src/context/cards_batch.rs
@@ -175,6 +175,7 @@ impl KanbanContext {
         ids: Vec<Uuid>,
         column_id: Uuid,
     ) -> KanbanResult<usize> {
+        let ids = kanban_domain::card_lifecycle::dedup_preserving_order(&ids);
         let before = self.backend.list_cards_by_column(column_id)?.len();
 
         let chained_status_updates = self.chained_status_updates_for_batch_move(&ids, column_id)?;

--- a/crates/kanban-service/src/context/filters.rs
+++ b/crates/kanban-service/src/context/filters.rs
@@ -59,16 +59,16 @@ impl KanbanContext {
         // downstream filter so filter_and_sort_cards does not re-apply column-
         // membership restriction, which would drop archived cards with deleted columns.
         let effective_filter;
-        let filter_ref =
-            if filter.archived != ArchivedFilter::LiveOnly && filter.board_id.is_some() {
-                effective_filter = CardListFilter {
-                    board_id: None,
-                    ..filter.clone()
-                };
-                &effective_filter
-            } else {
-                filter
+        let filter_ref = if filter.archived != ArchivedFilter::LiveOnly && filter.board_id.is_some()
+        {
+            effective_filter = CardListFilter {
+                board_id: None,
+                ..filter.clone()
             };
+            &effective_filter
+        } else {
+            filter
+        };
         Ok(kanban_domain::filter_and_sort_cards(
             &cards,
             &columns,

--- a/crates/kanban-service/src/context/filters.rs
+++ b/crates/kanban-service/src/context/filters.rs
@@ -53,13 +53,14 @@ impl KanbanContext {
             (Some(b), Some(q)) if !q.is_empty() => self.backend.list_sprints_by_board(b.id)?,
             _ => Vec::new(),
         };
-        // For ArchivedOnly with a board scope, the cards are already pre-scoped by
-        // marker board_id (see gather_board_cards_for_selector). Clear board_id from
-        // the downstream filter so filter_and_sort_cards does not re-apply column-
+        // For ArchivedOnly and Include with a board scope, the cards are already
+        // pre-scoped by marker board_id (see gather_board_cards_for_selector, which
+        // gathers by marker board_id for both selectors). Clear board_id from the
+        // downstream filter so filter_and_sort_cards does not re-apply column-
         // membership restriction, which would drop archived cards with deleted columns.
         let effective_filter;
         let filter_ref =
-            if filter.archived == ArchivedFilter::ArchivedOnly && filter.board_id.is_some() {
+            if filter.archived != ArchivedFilter::LiveOnly && filter.board_id.is_some() {
                 effective_filter = CardListFilter {
                     board_id: None,
                     ..filter.clone()

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -37,7 +37,7 @@ impl StoreManager {
 
     /// Returns `true` if at least one backend factory is registered.
     pub fn has_backends(&self) -> bool {
-        !self.registry.is_empty()
+        !self.backends.is_empty()
     }
 
     /// Returns the names of all registered factories in registration order.

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -850,6 +850,69 @@ pub async fn test_list_cards_archived_only_keeps_card_with_deleted_column(
     assert_eq!(archived[0].id, card.id);
 }
 
+/// Include must, like ArchivedOnly, keep an archived card whose original
+/// column was deleted — and it must ALSO still return the board's live
+/// cards. The board_id scope is cleared for BOTH selectors that pre-scope by
+/// marker board_id (ArchivedOnly and Include), not just ArchivedOnly, so
+/// column-membership re-filtering doesn't drop the archived card.
+pub async fn test_list_cards_include_keeps_archived_card_with_deleted_column(
+    factory: &BackendFactory,
+) {
+    use kanban_domain::ArchivedFilter;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let archived_card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let live_card = ctx
+        .create_card(board.id, col.id, "Live".into(), CreateCardOptions::default())
+        .unwrap();
+    ctx.archive_card(archived_card.id).unwrap();
+    // Delete the column AFTER archival — the archived card's live row still
+    // references it; the live card gets recreated in a fresh column so it
+    // survives the delete.
+    let col2 = ctx.create_column(board.id, "Col2".into(), None).unwrap();
+    ctx.move_card(live_card.id, col2.id, None).unwrap();
+    ctx.delete_column(col.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let cards = ctx
+        .list_cards(CardListFilter {
+            board_id: Some(board.id),
+            archived: ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(
+        cards.len(),
+        2,
+        "Include with a board scope must return both the live card and the \
+         archived card with a deleted original column"
+    );
+    assert!(
+        cards.iter().any(|c| c.id == archived_card.id),
+        "archived card with deleted original column must still appear in Include list"
+    );
+    assert!(
+        cards.iter().any(|c| c.id == live_card.id),
+        "live card must still appear in Include list"
+    );
+}
+
 /// KAN-901: board default sort is honoured by list_cards(ArchivedOnly).
 pub async fn test_list_cards_archived_only_board_default_sort(factory: &BackendFactory) {
     use kanban_domain::{ArchivedFilter, BoardUpdate, CardPriority, SortField, SortOrder};

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -877,7 +877,12 @@ pub async fn test_list_cards_include_keeps_archived_card_with_deleted_column(
         )
         .unwrap();
     let live_card = ctx
-        .create_card(board.id, col.id, "Live".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
     ctx.archive_card(archived_card.id).unwrap();
     // Delete the column AFTER archival — the archived card's live row still

--- a/crates/kanban-service/src/test_helpers/contract/mod.rs
+++ b/crates/kanban-service/src/test_helpers/contract/mod.rs
@@ -14,6 +14,7 @@ pub mod sprint_log;
 pub fn assert_card_eq(a: &kanban_domain::Card, b: &kanban_domain::Card) {
     assert_eq!(a.id, b.id, "card id");
     assert_eq!(a.column_id, b.column_id, "card column_id");
+    assert_eq!(a.board_id, b.board_id, "card board_id");
     assert_eq!(a.title, b.title, "card title");
     assert_eq!(a.description, b.description, "card description");
     assert_eq!(a.priority, b.priority, "card priority");

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -147,6 +147,10 @@ macro_rules! context_contract_tests {
             $crate::test_helpers::contract::archive::test_list_cards_archived_only_keeps_card_with_deleted_column(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_cards_include_keeps_archived_card_with_deleted_column() {
+            $crate::test_helpers::contract::archive::test_list_cards_include_keeps_archived_card_with_deleted_column(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
         async fn test_list_cards_archived_only_board_default_sort() {
             $crate::test_helpers::contract::archive::test_list_cards_archived_only_board_default_sort(&$factory_fn()).await;
         }

--- a/crates/kanban-service/tests/move_cards.rs
+++ b/crates/kanban-service/tests/move_cards.rs
@@ -4,6 +4,7 @@
 //! backend-specific divergence. Position-computation logic is unit-tested in
 //! `kanban_domain::card_lifecycle::tests::compute_move_positions_*`.
 
+use kanban_domain::commands::{CardCommand, Command};
 use kanban_domain::{Board, Card, Column};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
@@ -308,6 +309,50 @@ macro_rules! move_cards_tests {
 
                 let moved = backend.get_card(card_a.id).unwrap().unwrap();
                 assert_eq!(moved.column_id, dst_col.id);
+            }
+
+            // move_cards_impl must dedup ids before computing chained status
+            // updates, mirroring the dedup compute_move_positions already does
+            // for MoveCard commands. Moving a duplicated id into the board's
+            // completion column must emit exactly ONE chained UpdateCard
+            // (status -> Done) for that card, not one per occurrence.
+            #[tokio::test(flavor = "multi_thread")]
+            async fn test_move_cards_with_duplicate_ids_emits_one_chained_status_update() {
+                let (mut ctx, _dir) = $open_ctx.await;
+                let backend = ctx.backend();
+
+                let board = ctx.create_board("B".into(), Some("TST".into())).unwrap();
+                let src_col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+                // Last column by position is the completion-column fallback.
+                let dst_col = ctx.create_column(board.id, "Done".into(), None).unwrap();
+                let card = ctx
+                    .create_card(board.id, src_col.id, "C".into(), Default::default())
+                    .unwrap();
+
+                let baseline = backend.batch_count().unwrap();
+                ctx.move_cards(vec![card.id, card.id], dst_col.id).unwrap();
+
+                let batches = backend.load_batches(baseline, baseline + 1).unwrap();
+                assert_eq!(batches.len(), 1, "move_cards executes as one batch");
+                let status_updates = batches[0]
+                    .commands
+                    .iter()
+                    .filter(|c| {
+                        matches!(
+                            c,
+                            Command::Card(CardCommand::Update(u))
+                                if u.card_id == card.id && u.updates.status.is_some()
+                        )
+                    })
+                    .count();
+                assert_eq!(
+                    status_updates, 1,
+                    "duplicate input ids must not emit duplicate chained status-update commands"
+                );
+
+                let moved = backend.get_card(card.id).unwrap().unwrap();
+                assert_eq!(moved.column_id, dst_col.id);
+                assert_eq!(moved.status, kanban_domain::CardStatus::Done);
             }
 
             // KAN-428 followup: move_cards_detailed.succeeded must report the

--- a/crates/kanban-service/tests/store_manager_injection.rs
+++ b/crates/kanban-service/tests/store_manager_injection.rs
@@ -7,7 +7,7 @@
 
 use kanban_backend::KanbanBackendRegistry;
 use kanban_persistence::StoreRegistry;
-use kanban_persistence_json::JsonStoreFactory;
+use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
 use kanban_service::StoreManager;
 use std::sync::Arc;
 
@@ -51,7 +51,9 @@ fn test_store_manager_has_backends_returns_false_when_empty() {
 fn test_store_manager_has_backends_returns_true_after_registration() {
     let mut registry = StoreRegistry::new();
     registry.register(Box::new(JsonStoreFactory));
-    let manager = StoreManager::new(registry, KanbanBackendRegistry::new());
+    let mut backends = KanbanBackendRegistry::new();
+    backends.register(Box::new(JsonBackendFactory));
+    let manager = StoreManager::new(registry, backends);
     assert!(
         manager.has_backends(),
         "registry with one factory must report has_backends"
@@ -65,8 +67,28 @@ fn test_store_manager_has_backends_reflects_registration_count() {
 
     let mut registry = StoreRegistry::new();
     registry.register(Box::new(JsonStoreFactory));
-    let full_manager = StoreManager::new(registry, KanbanBackendRegistry::new());
+    let mut backends = KanbanBackendRegistry::new();
+    backends.register(Box::new(JsonBackendFactory));
+    let full_manager = StoreManager::new(registry, backends);
     assert!(full_manager.has_backends());
+}
+
+/// `has_backends()` must reflect the `KanbanBackendRegistry` (what
+/// `make_backend` actually dispatches through), not the `StoreRegistry` —
+/// they are two independent registries `StoreManager::new` accepts as two
+/// separate parameters, and nothing enforces they stay in sync. This is the
+/// divergent case `register_backend()`'s paired-factory contract prevents at
+/// its own call sites, but `StoreManager::new` itself does not.
+#[test]
+fn test_store_manager_has_backends_true_when_only_backend_registry_populated() {
+    let mut backends = KanbanBackendRegistry::new();
+    backends.register(Box::new(JsonBackendFactory));
+    let manager = StoreManager::new(StoreRegistry::new(), backends);
+    assert!(
+        manager.has_backends(),
+        "a populated KanbanBackendRegistry alone must report has_backends, \
+         even with an empty StoreRegistry"
+    );
 }
 
 #[test]
@@ -75,7 +97,9 @@ fn test_store_manager_clone_shares_registry() {
     // stores — the underlying Arc<StoreRegistry> is shared, not copied.
     let mut registry = StoreRegistry::new();
     registry.register(Box::new(JsonStoreFactory));
-    let original = StoreManager::new(registry, KanbanBackendRegistry::new());
+    let mut backends = KanbanBackendRegistry::new();
+    backends.register(Box::new(JsonBackendFactory));
+    let original = StoreManager::new(registry, backends);
     let cloned = original.clone();
 
     // Both handles must see the same backends.

--- a/crates/kanban-tui/tests/footer_panel_hints_tests.rs
+++ b/crates/kanban-tui/tests/footer_panel_hints_tests.rs
@@ -23,7 +23,7 @@ fn test_footer_omits_panel_switch_hints_on_cards_panel() {
     let footer = render_footer_text(&app);
 
     assert!(
-        !footer.contains("panel 1") && !footer.contains("panel 2"),
+        (1..=5).all(|n| !footer.contains(&format!("panel {n}"))),
         "footer must not advertise `panel N` hints, got: {footer}"
     );
 }
@@ -54,7 +54,7 @@ fn test_footer_omits_panel_switch_hints_on_card_detail() {
     let footer = render_footer_text(&app);
 
     assert!(
-        !footer.contains("panel 1") && !footer.contains("panel 3") && !footer.contains("panel 5"),
+        (1..=5).all(|n| !footer.contains(&format!("panel {n}"))),
         "card detail footer must not advertise `panel N` hints, got: {footer}"
     );
 }

--- a/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
+++ b/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
@@ -12,7 +12,7 @@ use kanban_tui::App;
 
 fn sync_model_from_store(app: &mut App) {
     let snapshot = Snapshot {
-        archived_boards: Vec::new(),
+        archived_boards: app.ctx.data_store().list_archived_boards().unwrap(),
         boards: app.ctx.data_store().list_boards().unwrap(),
         columns: app.ctx.data_store().list_all_columns().unwrap(),
         cards: app.ctx.data_store().list_all_cards().unwrap(),


### PR DESCRIPTION
## Summary

A multi-agent release-readiness review of the v0.7.2..develop diff (release candidate for v0.8.0: 164 commits, 575 files, +73134/-22532) came back NO_GO as staged. This fixes the one real release-pipeline blocker plus every confirmed code bug the review turned up, each via TDD (red test, then green fix) where production behavior changes.

**Blocker**
- `kanban-server`'s `Cargo.toml` was the only crate in the workspace missing `description`/`repository`/`homepage`. crates.io hard-rejects uploads without a description, and this crate publishes second-to-last in the release script's order — as staged, a real release would have published ~12 sibling crates and then failed here, with no tag, no GitHub release, and no way to un-publish what already went out.

**Confirmed bugs**
- `filter_cards`'s `Include` selector silently dropped archived cards whose original column was deleted (only `ArchivedOnly` cleared the re-applied board scope, not `Include`, even though both selectors pre-scope by marker board_id).
- `move_cards_impl` didn't dedup input ids before computing chained status updates, so duplicate ids in a batch produced duplicate chained status-update commands (the `MoveCard` commands were already deduped downstream, masking this).
- `StoreManager::has_backends()` checked `self.registry` (the `StoreFactory` registry) instead of `self.backends` (the `KanbanBackendFactory` registry `make_backend` actually dispatches through). Not observably wrong at either production call site today since both always populate the two registries in lockstep, but `StoreManager::new` takes them as two independent parameters with no invariant enforced, and `register_backend` is a documented third-party extension point.
- The JSON V9→V10 archival-reference migration silently dropped an embedded entity with a non-string id from the live collection while its marker still referenced it, instead of erroring like the sibling malformed-entry branch.

**Test/fixture fixes**
- Two `kanban-domain` test fixtures had internally-inconsistent board_id setup (a standalone random board_id unrelated to the actual `Board` constructed; a card built via a throwaway temporary `Board` instead of the real one).
- A shared `kanban-persistence` test fixture used `Uuid::nil()` for one entity's board_id while every sibling entity in the same fixture used the real value.
- A `kanban-tui` test helper hardcoded an empty `archived_boards` list instead of reading it from the store, unlike every other field in the same snapshot construction.
- Strengthened two footer panel-hint tests to check all 5 panel hints instead of 2-3 (per the file's own doc comment, all 5 should be gone) — still green, confirming the render code already does the full job.
- Doc comment clarifying an intentional API asymmetry (`UpdateSprintRequest.name` vs `Patch<String>`).

## Test plan

- [x] `cargo build --workspace --locked`
- [x] `cargo test --workspace --locked` — every test binary reports 0 failed, including all new red→green tests on every backend they touch
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check`
- [x] `cargo metadata` confirms `kanban-server`'s description/repository/homepage are now populated
- [x] `cargo build -p kanban-cli --no-default-features --features sqlite` and `--features json` both build
- [x] Changeset bump levels checked: 11 `minor` / 87 `patch` / 0 `major` across all 99 pending changesets, confirming `0.8.0` is the correct target