### PR TITLE
fix(server): cross-scope ownership guards on card/column/sprint write handlers

### DIFF
--- a/.changeset/server-cards-columns-sprints-cross-scope-guard.md
+++ b/.changeset/server-cards-columns-sprints-cross-scope-guard.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+`kanban-server`: fixes a write-path scoping hole across the card, column, and
+sprint create-or-replace handlers. Each honours a client-supplied id for
+idempotent create, but only the column PUT handler already guarded against
+that id belonging to a different parent. A `PUT`/`POST` targeting an id that
+already exists under a *different* column/board now returns 404 instead of
+silently relocating a card or column, or silently editing a sprint that
+belongs to a different board.

--- a/crates/kanban-server/src/handlers/cards.rs
+++ b/crates/kanban-server/src/handlers/cards.rs
@@ -1,23 +1,24 @@
 //! Typed card-create seam for the HTTP server.
 //!
-//! The server itself is still a stub (no router/transport yet), but the
-//! create-from-spec wiring is real and tested here: this is the single funnel a
-//! future `POST /v1/columns/:column_id/cards` + `PUT /v1/cards/:id` handler
-//! binds to. The shared [`CreateCardRequest`] is split via
-//! `into_new_card(column_id)` (the column FK is path-supplied on the nested
-//! route; the owning board is derived from the column server-side), runs the
-//! idempotent PUT-create (`create_or_replace_card`), and the resulting domain
-//! `Card` is projected onto the wire [`CardResponse`]. The `created` flag lets
-//! the eventual HTTP layer answer 201 (created) vs 200 (replaced).
+//! This is the funnel `POST /v1/columns/:column_id/cards` +
+//! `PUT /v1/columns/:column_id/cards/:id` bind to. The shared
+//! [`CreateCardRequest`] is split via `into_new_card(column_id)` (the column
+//! FK is path-supplied on the nested route; the owning board is derived from
+//! the column server-side), runs the idempotent PUT-create
+//! (`create_or_replace_card`), and the resulting domain `Card` is projected
+//! onto the wire [`CardResponse`]. The `created` flag lets the HTTP layer
+//! answer 201 (created) vs 200 (replaced).
 
 use kanban_service::api::{ApiError, CardResponse, CreateCardRequest};
-use kanban_service::KanbanContext;
+use kanban_service::{KanbanContext, KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 /// `POST /v1/columns/:column_id/cards`: append-create a card under the
 /// path-supplied column. The body id is honoured when present (idempotent), else
 /// minted. Returns the wire projection plus whether the card was created
-/// (`true`) or replaced an existing id (`false`).
+/// (`true`) or replaced an existing id (`false`). If the body id already
+/// exists under a *different* column, this 404s rather than silently
+/// relocating it — see [`create_or_replace_card`].
 pub fn create_card(
     ctx: &mut KanbanContext,
     column_id: Uuid,
@@ -27,6 +28,7 @@ pub fn create_card(
         .into_new_card(column_id)
         .map_err(|e| ApiError::from(&e))?;
     let id = maybe_id.unwrap_or_else(Uuid::new_v4);
+    require_card_in_column_if_present(ctx, id, column_id)?;
     let outcome = ctx
         .create_or_replace_card(id, spec)
         .map_err(|e| ApiError::from(&e))?;
@@ -37,13 +39,18 @@ pub fn create_card(
 /// card keyed on the path `id`. The column FK is path-supplied; the
 /// server-managed `card_number`/`position` stay stable across the replace arm.
 /// Returns the wire projection plus whether the card was created (`true`) or
-/// replaced (`false`).
+/// replaced (`false`). If `id` already exists under a *different* column,
+/// this 404s rather than silently relocating it — mirrors the column route's
+/// cross-board guard (`handlers::columns::create_or_replace_column`) since
+/// `create_or_replace_card`'s replace arm never checks the existing card's
+/// column on its own.
 pub fn create_or_replace_card(
     ctx: &mut KanbanContext,
     column_id: Uuid,
     id: Uuid,
     req: CreateCardRequest,
 ) -> Result<(CardResponse, bool), ApiError> {
+    require_card_in_column_if_present(ctx, id, column_id)?;
     let (_body_id, spec) = req
         .into_new_card(column_id)
         .map_err(|e| ApiError::from(&e))?;
@@ -51,4 +58,19 @@ pub fn create_or_replace_card(
         .create_or_replace_card(id, spec)
         .map_err(|e| ApiError::from(&e))?;
     Ok((CardResponse::from(&outcome.card), outcome.created))
+}
+
+/// 404s when `id` already refers to a card outside `column_id`. A no-op when
+/// `id` doesn't exist yet (the create arm) or already belongs to `column_id`.
+fn require_card_in_column_if_present(
+    ctx: &KanbanContext,
+    id: Uuid,
+    column_id: Uuid,
+) -> Result<(), ApiError> {
+    if let Some(existing) = ctx.get_card(id).map_err(|e| ApiError::from(&e))? {
+        if existing.column_id != column_id {
+            return Err(ApiError::from(&KanbanError::not_found("Card", id)));
+        }
+    }
+    Ok(())
 }

--- a/crates/kanban-server/src/handlers/columns.rs
+++ b/crates/kanban-server/src/handlers/columns.rs
@@ -1,13 +1,12 @@
 //! Typed column-create/replace seam for the HTTP server.
 //!
-//! The server itself is still a stub (no router/transport yet), but the
-//! create-from-spec and replace-from-spec wiring is real and tested here: this
-//! is the funnel `POST /v1/boards/:id/columns` + `PUT /v1/boards/:id/columns/:id`
-//! handlers bind to. The shared DTOs are split via `into_new_column` (board id
-//! is path-supplied on the nested route), runs the idempotent PUT-create
-//! (`create_or_replace_column`), and the resulting domain `Column` is projected
-//! onto the wire [`ColumnResponse`]. The `created` flag lets the HTTP layer
-//! answer 201 (created) vs 200 (replaced).
+//! This is the funnel `POST /v1/boards/:id/columns` +
+//! `PUT /v1/boards/:id/columns/:id` handlers bind to. The shared DTOs are
+//! split via `into_new_column` (board id is path-supplied on the nested
+//! route), runs the idempotent PUT-create (`create_or_replace_column`), and
+//! the resulting domain `Column` is projected onto the wire
+//! [`ColumnResponse`]. The `created` flag lets the HTTP layer answer 201
+//! (created) vs 200 (replaced).
 
 use kanban_service::api::{ApiError, ColumnResponse, CreateColumnRequest, ReplaceColumnRequest};
 use kanban_service::{KanbanContext, KanbanError, KanbanOperations};
@@ -16,7 +15,9 @@ use uuid::Uuid;
 /// `POST /v1/boards/:board_id/columns`: append-create a column under the
 /// path-supplied board. The body id is honoured when present (idempotent), else
 /// minted. Returns the wire projection plus whether the column was created
-/// (`true`) or replaced an existing id (`false`).
+/// (`true`) or replaced an existing id (`false`). If the body id already
+/// exists under a *different* board, this 404s rather than silently
+/// relocating it — see [`create_or_replace_column`].
 pub fn create_column(
     ctx: &mut KanbanContext,
     board_id: Uuid,
@@ -26,6 +27,7 @@ pub fn create_column(
         .into_new_column(board_id)
         .map_err(|e| ApiError::from(&e))?;
     let id = maybe_id.unwrap_or_else(Uuid::new_v4);
+    require_column_in_board_if_present(ctx, id, board_id)?;
     let outcome = ctx
         .create_or_replace_column(id, spec, None)
         .map_err(|e| ApiError::from(&e))?;
@@ -46,11 +48,7 @@ pub fn create_or_replace_column(
     id: Uuid,
     req: ReplaceColumnRequest,
 ) -> Result<(ColumnResponse, bool), ApiError> {
-    if let Some(existing) = ctx.get_column(id).map_err(|e| ApiError::from(&e))? {
-        if existing.board_id != board_id {
-            return Err(ApiError::from(&KanbanError::not_found("Column", id)));
-        }
-    }
+    require_column_in_board_if_present(ctx, id, board_id)?;
     let (spec, position) = req
         .into_new_column(board_id)
         .map_err(|e| ApiError::from(&e))?;
@@ -58,4 +56,20 @@ pub fn create_or_replace_column(
         .create_or_replace_column(id, spec, Some(position))
         .map_err(|e| ApiError::from(&e))?;
     Ok((ColumnResponse::from(&outcome.column), outcome.created))
+}
+
+/// 404s when `id` already refers to a column outside `board_id`. A no-op
+/// when `id` doesn't exist yet (the create arm) or already belongs to
+/// `board_id`.
+fn require_column_in_board_if_present(
+    ctx: &KanbanContext,
+    id: Uuid,
+    board_id: Uuid,
+) -> Result<(), ApiError> {
+    if let Some(existing) = ctx.get_column(id).map_err(|e| ApiError::from(&e))? {
+        if existing.board_id != board_id {
+            return Err(ApiError::from(&KanbanError::not_found("Column", id)));
+        }
+    }
+    Ok(())
 }

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -14,7 +14,7 @@
 //! [`SprintResponse`], whose `name` is resolved against the owning board.
 
 use kanban_service::api::{ApiError, CreateSprintRequest, ReplaceSprintRequest, SprintResponse};
-use kanban_service::{KanbanContext, KanbanOperations};
+use kanban_service::{KanbanContext, KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 /// `POST /v1/boards/:board_id/sprints`: create a sprint under the path-supplied
@@ -57,9 +57,7 @@ pub fn create_or_replace_sprint(
 ) -> Result<(SprintResponse, bool), ApiError> {
     if let Some(existing) = ctx.get_sprint(id).map_err(|e| ApiError::from(&e))? {
         if existing.board_id != board_id {
-            return Err(ApiError::from(&kanban_service::KanbanError::not_found(
-                "Sprint", id,
-            )));
+            return Err(ApiError::from(&KanbanError::not_found("Sprint", id)));
         }
     }
     let ReplaceSprintRequest {
@@ -83,11 +81,6 @@ fn project(
     let board = ctx
         .get_board(sprint.board_id)
         .map_err(|e| ApiError::from(&e))?
-        .ok_or_else(|| {
-            ApiError::from(&kanban_service::KanbanError::not_found(
-                "Board",
-                sprint.board_id,
-            ))
-        })?;
+        .ok_or_else(|| ApiError::from(&KanbanError::not_found("Board", sprint.board_id)))?;
     Ok((SprintResponse::from_sprint(&sprint, &board), created))
 }

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -1,9 +1,8 @@
 //! Typed sprint-create seam for the HTTP server.
 //!
-//! The server itself is still a stub (no router/transport yet), but the
-//! create-from-spec wiring is real and tested here: this is the single funnel a
-//! future `POST /v1/boards/:board_id/sprints` + `PUT /v1/sprints/:id` handler
-//! binds to. The board FK is path-supplied on the nested route. The shared
+//! This is the funnel `POST /v1/boards/:board_id/sprints` +
+//! `PUT /v1/boards/:board_id/sprints/:id` handlers bind to. The board FK is
+//! path-supplied on the nested route. The shared
 //! [`CreateSprintRequest`]/[`ReplaceSprintRequest`] carry the client-settable
 //! create/replace fields; the service mints `sprint_number` + `name_index`
 //! against the owning board (the create DTO carries a `name` STRING, not the
@@ -45,13 +44,24 @@ pub fn create_sprint(
 /// id maps to the create arm with that exact path id, a present id maps to a
 /// content replace of the client-settable `name`/`prefix`. Returns the wire
 /// projection plus whether the sprint was created (`true`) or replaced
-/// (`false`).
+/// (`false`). If `id` already exists under a *different* board, this 404s
+/// rather than silently editing it — mirrors the cross-board guard on
+/// `handlers::columns::create_or_replace_column`, since
+/// `KanbanContext::create_or_replace_sprint`'s replace arm never checks the
+/// existing sprint's board on its own.
 pub fn create_or_replace_sprint(
     ctx: &mut KanbanContext,
     board_id: Uuid,
     id: Uuid,
     req: ReplaceSprintRequest,
 ) -> Result<(SprintResponse, bool), ApiError> {
+    if let Some(existing) = ctx.get_sprint(id).map_err(|e| ApiError::from(&e))? {
+        if existing.board_id != board_id {
+            return Err(ApiError::from(&kanban_service::KanbanError::not_found(
+                "Sprint", id,
+            )));
+        }
+    }
     let ReplaceSprintRequest {
         name,
         prefix,

--- a/crates/kanban-server/tests/cards_write.rs
+++ b/crates/kanban-server/tests/cards_write.rs
@@ -83,6 +83,51 @@ async fn test_post_card_unknown_column_returns_404() {
     assert_eq!(json_of(response).await["code"], "NOT_FOUND");
 }
 
+// POST honours a client-supplied id for idempotent create (into_new_card),
+// so without a guard it hits the same relocation hole as PUT: a body id
+// matching a card that already exists under a DIFFERENT column must 404,
+// not silently move it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_card_wrong_column_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, column_a, card_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col_a = ctx
+            .create_column(board_id, "Column A".to_string(), None)
+            .unwrap();
+        let card = ctx
+            .create_card(board_id, col_a.id, "Task".to_string(), Default::default())
+            .unwrap();
+        (board_id, col_a.id, card.id)
+    };
+    let column_b = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_column(board_id, "Column B".to_string(), None)
+            .unwrap()
+            .id
+    };
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/columns/{column_b}/cards"),
+        Some(&json!({"id": card_id, "title": "Hijacked"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let ctx = state.ctx.lock().await;
+    let card = ctx.get_card(card_id).unwrap().unwrap();
+    assert_eq!(card.column_id, column_a);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_put_card_creates_when_absent_returns_201() {
     let dir = tempdir().unwrap();
@@ -103,6 +148,52 @@ async fn test_put_card_creates_when_absent_returns_201() {
     let json = json_of(response).await;
     assert_eq!(json["id"], card_id.to_string());
     assert_eq!(json["title"], "New Task");
+}
+
+// Mirrors test_put_column_wrong_board_returns_404 (columns_write.rs): PUT is
+// idempotent create-or-replace keyed on the path id, so without a guard a
+// client could PUT an id that already exists under a DIFFERENT column and
+// silently relocate it into the path's column instead of getting a 404.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_card_wrong_column_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, column_a, card_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col_a = ctx
+            .create_column(board_id, "Column A".to_string(), None)
+            .unwrap();
+        let card = ctx
+            .create_card(board_id, col_a.id, "Task".to_string(), Default::default())
+            .unwrap();
+        (board_id, col_a.id, card.id)
+    };
+    let column_b = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_column(board_id, "Column B".to_string(), None)
+            .unwrap()
+            .id
+    };
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/columns/{column_b}/cards/{card_id}"),
+        Some(&json!({"title": "Hijacked"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // The card must not have been relocated into column_b.
+    let ctx = state.ctx.lock().await;
+    let card = ctx.get_card(card_id).unwrap().unwrap();
+    assert_eq!(card.column_id, column_a);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/columns_write.rs
+++ b/crates/kanban-server/tests/columns_write.rs
@@ -89,6 +89,33 @@ async fn test_post_column_unknown_board_returns_404() {
     assert_eq!(json_of(response).await["code"], "NOT_FOUND");
 }
 
+// POST honours a client-supplied id for idempotent create (into_new_column),
+// so it hits the same relocation hole as PUT: a body id matching a column
+// that already exists under a DIFFERENT board must 404, not silently move
+// it. Mirrors test_put_column_replace_wrong_board_returns_404.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_column_wrong_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_a, column_id) = seed_board_and_column(&state, "Column A").await;
+    let board_b = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_b}/columns"),
+        Some(&json!({"id": column_id, "name": "Hijacked"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let ctx = state.ctx.lock().await;
+    let column = ctx.get_column(column_id).unwrap().unwrap();
+    assert_eq!(column.board_id, board_a);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_post_column_negative_wip_limit_returns_422() {
     let dir = tempdir().unwrap();

--- a/crates/kanban-server/tests/sprint_create_seam.rs
+++ b/crates/kanban-server/tests/sprint_create_seam.rs
@@ -132,8 +132,13 @@ async fn test_put_sprint_wrong_board_returns_404() {
     let board_b = seed_board(&mut ctx);
     let id = Uuid::new_v4();
 
-    create_or_replace_sprint(&mut ctx, board_a, id, replace_req(Some("Alpha"), Some("SPR")))
-        .unwrap();
+    create_or_replace_sprint(
+        &mut ctx,
+        board_a,
+        id,
+        replace_req(Some("Alpha"), Some("SPR")),
+    )
+    .unwrap();
 
     let err = create_or_replace_sprint(&mut ctx, board_b, id, replace_req(Some("Hijacked"), None))
         .unwrap_err();

--- a/crates/kanban-server/tests/sprint_create_seam.rs
+++ b/crates/kanban-server/tests/sprint_create_seam.rs
@@ -118,6 +118,35 @@ async fn test_put_sprint_create_or_replace_is_idempotent() {
     );
 }
 
+// create_or_replace_sprint's replace arm never checked that the existing
+// sprint (fetched by id alone) actually belongs to the path board_id.
+// SprintUpdate has no board_id field, so this wasn't a relocation hole like
+// cards/columns — it was worse: a PUT scoped to the WRONG board could
+// silently edit a sprint's name/prefix that board doesn't own. Mirrors the
+// cross-board guard already on create_or_replace_column.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_sprint_wrong_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let mut ctx = make_ctx(&dir.path().join("s.json"));
+    let board_a = seed_board(&mut ctx);
+    let board_b = seed_board(&mut ctx);
+    let id = Uuid::new_v4();
+
+    create_or_replace_sprint(&mut ctx, board_a, id, replace_req(Some("Alpha"), Some("SPR")))
+        .unwrap();
+
+    let err = create_or_replace_sprint(&mut ctx, board_b, id, replace_req(Some("Hijacked"), None))
+        .unwrap_err();
+    assert_eq!(err.code, ErrorCode::NotFound);
+    assert_eq!(err.code.http_status(), 404);
+
+    // The sprint under board_a must be untouched — still owned by board_a
+    // with its original prefix, not cleared by the rejected hijack attempt.
+    let sprint = ctx.get_sprint(id).unwrap().unwrap();
+    assert_eq!(sprint.board_id, board_a);
+    assert_eq!(sprint.prefix, Some("SPR".to_string()));
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_put_sprint_replace_preserves_server_managed_number() {
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

A second-pass release-readiness review of `develop` (after merging #523) came back GO_WITH_FOLLOWUPS with one confirmed finding: `kanban-server/src/handlers/cards.rs` was missing a cross-column ownership guard on card create/replace, unlike the sibling column handler. Verifying that finding turned up two more instances of the exact same bug class in the same file family, so this PR fixes all three consistently.

**The pattern**: each nested-resource write handler (cards under columns, columns under boards, sprints under boards) accepts a client-supplied id for idempotent create-or-replace. Only `handlers::columns::create_or_replace_column` (PUT) already guarded against that id belonging to a *different* parent before dispatching. The other four call sites did not:

- `handlers::cards::create_card` (POST) and `create_or_replace_card` (PUT) — a client could PUT/POST an id belonging to a card in a *different column* and silently relocate it instead of getting a 404.
- `handlers::columns::create_column` (POST) — same relocation hole, one level up (board instead of column).
- `handlers::sprints::create_or_replace_sprint` (PUT) — worse than a relocation hole: `SprintUpdate` has no `board_id` field, so a PUT scoped to the *wrong* board would silently edit a sprint's `name`/`prefix` in place rather than move it.

Also corrects three handler module doc comments that still claimed "the server itself is still a stub (no router/transport yet)" — false; all three are wired into `write_router()`.

Each fix follows this repo's TDD workflow: a red test confirming the gap, then the guard mirroring the existing `create_or_replace_column` pattern.

## Test plan

- [x] `cargo build --workspace --locked`
- [x] `cargo test --workspace --locked` — 0 failed, including 4 new red→green tests (`test_put_card_wrong_column_returns_404`, `test_post_card_wrong_column_returns_404`, `test_post_column_wrong_board_returns_404`, `test_put_sprint_wrong_board_returns_404`), each confirmed failing before the corresponding fix
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check`
- [x] Changeset added (`patch`)