### PR TITLE
chore: address remaining non-blocking release-review findings

### DIFF
--- a/.changeset/import-board-transaction-audit-log.md
+++ b/.changeset/import-board-transaction-audit-log.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+`kanban-service`: `import_board_impl` now runs transactionally and appends an
+audit-log entry, matching every other mutation's guarantee. Previously a
+successful board import left no audit-log record and had no rollback
+guarantee on partial failure. Import still clears undo history afterward
+(unchanged) — it remains intentionally not undoable via the normal undo stack.

--- a/crates/kanban-backend-memory/src/in_memory_store/archived_boards.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/archived_boards.rs
@@ -1,7 +1,6 @@
 use uuid::Uuid;
 
 use super::InMemoryStore;
-use kanban_domain::archival::ArchivedEntity;
 use kanban_domain::{ArchivedBoard, KanbanResult};
 
 impl InMemoryStore {
@@ -24,7 +23,7 @@ impl InMemoryStore {
 
     pub(super) fn insert_archived_board_impl(&self, ab: ArchivedBoard) -> KanbanResult<()> {
         let mut state = self.write_state()?;
-        state.archived_boards.insert(ab.entity_id(), ab);
+        state.archived_boards.insert(ab.entity_id, ab);
         Ok(())
     }
 

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -357,13 +357,31 @@ impl KanbanContext {
             graph: Some(imported.graph),
         }))];
 
-        {
-            let store: &dyn DataStore = self.backend.as_data_store();
+        // Mirrors KanbanContext::execute()'s transaction + audit-log-append
+        // structure (context/undo.rs) so a failing import can't leave partial
+        // state and a successful one is visible in the audit log — but does
+        // NOT push an undo entry: import intentionally clears undo history
+        // (below) rather than being undoable via the normal command stack.
+        let backend = std::sync::Arc::clone(&self.backend);
+        let cmds = &commands;
+        backend.with_transaction(&mut || {
+            let store: &dyn DataStore = backend.as_data_store();
             let ctx = CommandContext { store };
-            for cmd in &commands {
+            for cmd in cmds.iter() {
                 cmd.execute(&ctx)?;
             }
-        }
+            let batch = kanban_domain::CommandBatch {
+                commands: cmds.clone(),
+                correlation_id: Uuid::new_v4(),
+                issued_by: kanban_core::ClientId::nil(),
+                timestamp: chrono::Utc::now(),
+                app_type: self.app_type,
+                app_version: kanban_core::KANBAN_VERSION.to_string(),
+                session_id: self.session_id,
+            };
+            backend.append_batch(&batch)?;
+            Ok(())
+        })?;
 
         self.undo_stack.clear();
         self.dirty = true;

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -1,4 +1,5 @@
 use super::KanbanContext;
+use kanban_core::{ClientId, KANBAN_VERSION};
 use kanban_domain::commands::{Command, SprintCommand};
 use kanban_domain::{
     Board, DataStore, FieldUpdate, KanbanError, KanbanResult, Snapshot, Sprint, SprintUpdate,
@@ -373,10 +374,10 @@ impl KanbanContext {
             let batch = kanban_domain::CommandBatch {
                 commands: cmds.clone(),
                 correlation_id: Uuid::new_v4(),
-                issued_by: kanban_core::ClientId::nil(),
+                issued_by: ClientId::nil(),
                 timestamp: chrono::Utc::now(),
                 app_type: self.app_type,
-                app_version: kanban_core::KANBAN_VERSION.to_string(),
+                app_version: KANBAN_VERSION.to_string(),
                 session_id: self.session_id,
             };
             backend.append_batch(&batch)?;

--- a/crates/kanban-service/tests/create_card_from_spec.rs
+++ b/crates/kanban-service/tests/create_card_from_spec.rs
@@ -6,8 +6,7 @@
 //! board counter (bumping it), and dispatches through `Card::create` via the
 //! frozen `CreateCard` command.
 use kanban_domain::{
-    CardPriority, CardStatus, CreateCardOptions, KanbanError, KanbanOperations, KanbanResult,
-    NewCard,
+    CardPriority, CardStatus, CreateCardOptions, KanbanOperations, KanbanResult, NewCard,
 };
 use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
@@ -347,5 +346,4 @@ async fn test_create_card_shim_delegates_to_spec_path() {
     assert_eq!(card.description, Some("via shim".to_string()));
     assert_eq!(card.priority, CardPriority::Low);
     assert_eq!(card.status, CardStatus::Todo);
-    let _ = KanbanError::not_found("x", Uuid::nil());
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -258,6 +258,32 @@ async fn test_import_board_clears_history() -> KanbanResult<()> {
     Ok(())
 }
 
+// import_board_impl runs its single ImportEntities command directly against
+// a bare CommandContext, bypassing the transaction wrap AND the audit-log
+// append that every other mutation gets via KanbanContext::execute(). This
+// pins the audit-log half of that gap: a successful import must append
+// exactly one batch, like every other mutation does.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_board_appends_one_audit_log_batch() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("Export".into(), None)?;
+    let _col = ctx.create_column(board.id, "C".into(), None)?;
+    let json = ctx.export_board(Some(board.id))?;
+
+    let mut ctx2 = make_ctx().await;
+    let backend = ctx2.backend();
+    let baseline = backend.batch_count()?;
+
+    ctx2.import_board(&json)?;
+
+    assert_eq!(
+        backend.batch_count()?,
+        baseline + 1,
+        "import must append exactly one audit-log batch, like every other mutation"
+    );
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_import_board_includes_archived_cards() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -67,7 +67,27 @@ cargo check --workspace --all-features --quiet
 echo "✓ Workspace check passed"
 
 echo ""
-echo "Step 5: Validating individual crate manifests (offline)..."
+echo "Step 5: Checking required crates.io publish metadata..."
+# crates.io hard-rejects an upload with no description, and Step 6 below
+# can't catch this (it's a documented near-no-op — see its comment). This
+# is a real, offline-checkable guard against exactly the class of bug that
+# blocked the v0.8.0 cut (a crate missing `description`): every crate's
+# [package] section must carry a non-empty description, repository, and
+# homepage, either as a literal value or `.workspace = true`.
+for crate in "${CRATES[@]}"; do
+  pkg_section=$(awk '/^\[package\]/{flag=1; next} /^\[/{flag=0} flag' "$crate/Cargo.toml")
+  for field in description repository homepage; do
+    if ! echo "$pkg_section" | grep -Eq "^${field}([[:space:]]*\.workspace[[:space:]]*=[[:space:]]*true|[[:space:]]*=[[:space:]]*\".+\")"; then
+      echo "❌ Error: $crate/Cargo.toml is missing a non-empty '$field' (needed for crates.io publish)"
+      echo "   Use: $field.workspace = true, or $field = \"...\""
+      exit 1
+    fi
+  done
+done
+echo "✓ All crates have required publish metadata"
+
+echo ""
+echo "Step 6: Validating individual crate manifests (offline)..."
 # This step is intentionally weak — it runs cargo publish --dry-run in
 # offline mode and trusts a failure to mean "offline blocked us" rather
 # than a real defect. Stronger validation is blocked by a chicken-and-egg
@@ -75,8 +95,8 @@ echo "Step 5: Validating individual crate manifests (offline)..."
 # 0.7.0) but no sibling crate has been published yet, so cargo package
 # fails to resolve `kanban-core = "^0.7"` for any non-leaf crate. The
 # only crate that can be packaged this way is kanban-core (the leaf).
-# KAN-670 tracks a real fix; for now this step is a no-op and Step 4
-# (cargo check --workspace) carries the validation weight.
+# KAN-670 tracks a real fix; Step 4 (cargo check --workspace) and Step 5
+# above carry the real validation weight this step can't provide.
 for crate in "${CRATES[@]}"; do
   echo "  Validating $crate..."
   cd "$crate"


### PR DESCRIPTION
## Summary

The 2nd release-readiness review pass (see #524) came back GO_WITH_FOLLOWUPS with a handful of non-blocking concerns explicitly marked "track as a follow-up, don't gate the tag." Rather than defer them, this PR addresses every one of them now:

**Fixed:**
- `kanban-backend-memory/src/in_memory_store/archived_boards.rs`: `insert_archived_board_impl` used `.entity_id()` (trait method) where every sibling call site uses `.entity_id` (field access) — style-only, made consistent.
- `kanban-service/tests/create_card_from_spec.rs`: removed a leftover no-op `let _ = KanbanError::not_found(...)` line at the end of a test.
- `kanban-service/src/context/sprints.rs`: `import_board_impl` ran its `ImportEntities` command directly against a bare `CommandContext`, bypassing both the transaction wrap and the audit-log append that `KanbanContext::execute()` gives every other mutation — a successful import left **no audit-log entry**. Now mirrors `execute()`'s structure (transaction + `append_batch`) while deliberately still clearing undo history afterward (import remains intentionally non-undoable, unchanged from before).
- `scripts/validate-release.sh`: added a real, offline-checkable Step 5 that verifies every crate's `Cargo.toml` has a non-empty `description`/`repository`/`homepage`. This directly hardens against the exact class of bug that blocked the v0.8.0 cut (`kanban-server` missing `description`, fixed in #523), independent of the KAN-670 offline/unpublished-siblings limitation the existing dry-run step can't work around.

**Investigated, confirmed clean, no action needed:**
- `json_backend.rs` / `sqlite_backend.rs`: full line-by-line read against the actual `develop` content — no correctness bugs found.
- The `sqlite_store.rs` → `sqlite_store/` module split (KAN-762): diffed function-by-function against the pre-split monolith — confirmed byte-for-byte behaviorally equivalent.
- `CardRestoreContext.board_id` test coverage: confirmed dedicated non-nil coverage already exists via the archival contract suite across all three backends.
- `kanban-backend`'s `with_transaction` default-impl concern: confirmed no backend overrides it anywhere in the workspace — the default is used universally and is exactly what `execute()` (and now `import_board_impl`) rely on.
- `^0.7` version pins / un-bumped crate versions: confirmed `scripts/bump-version.sh` already handles this automatically at release-cut time.

**Explicitly out of scope (by design, not deferral):** implementing `KanbanBackend::reload_if_changed()` for kanban-mcp's undo-history-wiping tradeoff. This is a genuine multi-crate feature (trait + JSON mtime-diffing + SQLite has no natural "changed" signal), not a bug fix, and the code already documents it as tracked future work. Will be logged as a kanban board card separately.

## Test plan

- [x] `cargo build --workspace --locked`
- [x] `cargo test --workspace --locked` — 0 failed, including a new red→green test (`test_import_board_appends_one_audit_log_batch`), confirmed failing before the fix
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check`
- [x] `validate-release.sh`'s new Step 5 manually verified both directions: passes on the real tree, fails with a clear error when a required field is removed from a scratch copy
- [x] Changeset added (`patch`) for the `import_board_impl` behavior change