### PR TITLE
fix(release): add workflow_dispatch recovery path for build-windows/publish-chocolatey

### DIFF
--- a/.changeset/release-workflow-manual-dispatch.md
+++ b/.changeset/release-workflow-manual-dispatch.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+---
+
+Added a `workflow_dispatch` entry point to the release workflow so
+`build-windows` and `publish-chocolatey` can be re-run for an
+already-published version. Previously they were gated on the changesets
+found during the original PR-merge run; once that run consumed and
+committed the changesets, no rerun could satisfy the gate again, leaving
+no recovery path if either job was skipped by an earlier job's failure
+(as happened during the v0.8.0 release, where AUR's own maintenance
+outage caused these two jobs to be skipped).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
       - master
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Already-published version to (re)run the Windows build and Chocolatey publish for, e.g. 0.8.0. Use this to recover build-windows/publish-chocolatey after a partial release run (they are otherwise gated on the changesets found in the original PR-merge run, which are consumed and unavailable on rerun).'
+        required: true
+        type: string
 
 concurrency:
   group: release
@@ -240,17 +246,36 @@ jobs:
           fi
           git push origin develop
 
+  resolve-version:
+    name: Resolve release version
+    needs: [release]
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      should_run: ${{ steps.resolve.outputs.should_run }}
+    steps:
+      - id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ needs.release.outputs.new }}" >> "$GITHUB_OUTPUT"
+            echo "should_run=${{ needs.release.outputs.has_changesets }}" >> "$GITHUB_OUTPUT"
+          fi
+
   build-windows:
     name: Build Windows release archive
-    needs: [release]
-    if: needs.release.outputs.has_changesets == 'true'
+    needs: [release, resolve-version]
+    if: needs.resolve-version.outputs.should_run == 'true'
     runs-on: windows-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v${{ needs.release.outputs.new }}
+          ref: v${{ needs.resolve-version.outputs.version }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -269,7 +294,7 @@ jobs:
       - name: Stage archive contents
         shell: pwsh
         env:
-          VERSION: ${{ needs.release.outputs.new }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
           $stage = "stage/kanban-v$env:VERSION-x86_64-pc-windows-msvc"
           New-Item -ItemType Directory -Path $stage -Force | Out-Null
@@ -283,7 +308,7 @@ jobs:
       - name: Compress archive
         shell: pwsh
         env:
-          VERSION: ${{ needs.release.outputs.new }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
           $name = "kanban-v$env:VERSION-x86_64-pc-windows-msvc"
           Compress-Archive -Path "stage/$name/*" -DestinationPath "$name.zip" -Force
@@ -291,7 +316,7 @@ jobs:
       - name: Write SHA256SUMS
         shell: pwsh
         env:
-          VERSION: ${{ needs.release.outputs.new }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
           $name = "kanban-v$env:VERSION-x86_64-pc-windows-msvc.zip"
           $sha  = (Get-FileHash -Algorithm SHA256 $name).Hash.ToLower()
@@ -300,16 +325,16 @@ jobs:
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ needs.release.outputs.new }}
+          tag_name: v${{ needs.resolve-version.outputs.version }}
           files: |
-            kanban-v${{ needs.release.outputs.new }}-x86_64-pc-windows-msvc.zip
+            kanban-v${{ needs.resolve-version.outputs.version }}-x86_64-pc-windows-msvc.zip
             SHA256SUMS
           fail_on_unmatched_files: true
 
   publish-chocolatey:
     name: Publish to Chocolatey
-    needs: [release, build-windows]
-    if: needs.release.outputs.has_changesets == 'true'
+    needs: [release, resolve-version, build-windows]
+    if: needs.resolve-version.outputs.should_run == 'true'
     runs-on: windows-latest
     continue-on-error: true
     permissions:
@@ -317,13 +342,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v${{ needs.release.outputs.new }}
+          ref: v${{ needs.resolve-version.outputs.version }}
 
       - name: Read Windows ZIP digest from GitHub Release
         id: sha
         shell: pwsh
         env:
-          VERSION: ${{ needs.release.outputs.new }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
@@ -355,7 +380,7 @@ jobs:
       - name: Stage Chocolatey package with substitutions
         shell: pwsh
         env:
-          VERSION: ${{ needs.release.outputs.new }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
           SHA: ${{ steps.sha.outputs.sha }}
         run: |
           $build = "build/chocolatey"
@@ -390,7 +415,7 @@ jobs:
         working-directory: build/chocolatey
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-          VERSION: ${{ needs.release.outputs.new }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
           # Pre-check: if this version is already published and approved,
           # treat as success. This makes the job safe to re-run after a
@@ -428,7 +453,7 @@ jobs:
       - name: Note moderation expectations
         shell: pwsh
         env:
-          VERSION: ${{ needs.release.outputs.new }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
           Write-Output "==="
           Write-Output "Pushed kanban v$env:VERSION to community.chocolatey.org."
@@ -442,9 +467,9 @@ jobs:
         continue-on-error: true
         shell: pwsh
         env:
-          VERSION: ${{ needs.release.outputs.new }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          RUNBOOK_URL: ${{ github.server_url }}/${{ github.repository }}/blob/v${{ needs.release.outputs.new }}/packaging/chocolatey/RECOVERY.md
+          RUNBOOK_URL: ${{ github.server_url }}/${{ github.repository }}/blob/v${{ needs.resolve-version.outputs.version }}/packaging/chocolatey/RECOVERY.md
         run: |
           Write-Output "::warning title=Chocolatey publish failed::v$env:VERSION did not publish to Chocolatey. See packaging/chocolatey/RECOVERY.md for recovery steps."
           $lines = @(


### PR DESCRIPTION
During the v0.8.0 release, AUR's own maintenance outage caused `Deploy to AUR` to fail, which skipped every step after it in the same job (Homebrew bump, sync-develop) plus the separate `build-windows` and `publish-chocolatey` jobs entirely (they're gated on `needs.release.outputs.has_changesets`).

Re-running the failed job worked for crates.io/tag/GitHub-release, but once that rerun's "Bump version from changesets" step found no changesets left (they were consumed and committed by the first attempt), `has_changesets` evaluated false on every subsequent rerun — permanently skipping `build-windows` and `publish-chocolatey` for this release, with no built-in way to retry them.

This adds a `workflow_dispatch` trigger with a `version` input, and a new `resolve-version` job that sources the target version from either the original release job's output (PR-merge trigger) or the manual input (workflow_dispatch trigger). `build-windows`/`publish-chocolatey` now depend on `resolve-version` instead of `release` directly, so they can be re-run standalone for an already-published version.

No change to the normal PR-merge release path — this only adds a recovery entry point.