### PR TITLE
fix(release): always() guard for build-windows/publish-chocolatey skip-propagation

### DIFF
--- a/.changeset/release-workflow-skip-propagation.md
+++ b/.changeset/release-workflow-skip-propagation.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Fixed `build-windows`/`publish-chocolatey` still being skipped on a manual
+`workflow_dispatch` recovery run even when their own `if` condition was
+true. GitHub Actions auto-skips a job when *any* of its `needs` jobs was
+skipped, overriding a custom `if` unless that condition includes
+`always()` — `release` is legitimately skipped on `workflow_dispatch`
+(it only runs on a merged-PR trigger), which was silently defeating the
+recovery path added in the previous changeset.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,10 @@ jobs:
   build-windows:
     name: Build Windows release archive
     needs: [release, resolve-version]
-    if: needs.resolve-version.outputs.should_run == 'true'
+    # `release` is legitimately skipped on a workflow_dispatch trigger; without
+    # always() here, GitHub Actions auto-skips this job whenever ANY needs job
+    # is skipped, regardless of this condition (a known runner quirk).
+    if: always() && needs.resolve-version.outputs.should_run == 'true'
     runs-on: windows-latest
     permissions:
       contents: write
@@ -334,7 +337,11 @@ jobs:
   publish-chocolatey:
     name: Publish to Chocolatey
     needs: [release, resolve-version, build-windows]
-    if: needs.resolve-version.outputs.should_run == 'true'
+    # See build-windows: needs-skip-propagation requires always() even though
+    # `release` being skipped is expected on a workflow_dispatch trigger.
+    # Guard build-windows explicitly since always() also bypasses the default
+    # success() check against it.
+    if: always() && needs.resolve-version.outputs.should_run == 'true' && needs.build-windows.result == 'success'
     runs-on: windows-latest
     continue-on-error: true
     permissions:


### PR DESCRIPTION
Follow-up to #527. That PR added a `workflow_dispatch` recovery path for `build-windows`/`publish-chocolatey`, gated on a new `resolve-version` job's `should_run` output.

Dispatching it for v0.8.0 (run https://github.com/fulsomenko/kanban/actions/runs/30759221204) showed `resolve-version` correctly computing `version=0.8.0`, `should_run=true` — but both downstream jobs still skipped themselves anyway.

Root cause: GitHub Actions auto-skips a job when *any* of its `needs` jobs was itself skipped, **regardless of that job's own `if` condition**, unless the condition explicitly includes `always()`. `release` is legitimately skipped on a `workflow_dispatch` trigger (it only runs on a merged-PR event) — that skip was silently propagating through `needs: [release, resolve-version]` and defeating the recovery path.

Fix: add `always()` to both jobs' `if`. `publish-chocolatey` additionally gets an explicit `needs.build-windows.result == 'success'` guard, since `always()` also bypasses the default implicit success-check against `build-windows`.