### PR TITLE
ci(release): publish kanban to winget via winget-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,3 +491,27 @@ jobs:
             "**Next step:** follow [``packaging/chocolatey/RECOVERY.md``]($env:RUNBOOK_URL)."
           )
           $lines | Add-Content -Path $env:GITHUB_STEP_SUMMARY -Encoding utf8
+
+  publish-winget:
+    name: Submit to winget
+    needs: [release, resolve-version, build-windows]
+    # See build-windows: needs-skip-propagation requires always() even though
+    # `release` being skipped is expected on a workflow_dispatch trigger.
+    # Guard build-windows explicitly since always() also bypasses the default
+    # success() check against it.
+    if: always() && needs.resolve-version.outputs.should_run == 'true' && needs.build-windows.result == 'success'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Submit manifest to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: fulsomenko.kanban
+          version: ${{ needs.resolve-version.outputs.version }}
+          release-tag: v${{ needs.resolve-version.outputs.version }}
+          # Default regex only matches exe/msi/msix/appx; the release ships
+          # a zip, so this override is mandatory. Must not match SHA256SUMS.
+          installers-regex: 'kanban-v.*-x86_64-pc-windows-msvc\.zip$'
+          max-versions-to-keep: 5
+          fork-user: fulsomenko
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -502,9 +502,34 @@ jobs:
     if: always() && needs.resolve-version.outputs.should_run == 'true' && needs.build-windows.result == 'success'
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
     steps:
+      - name: Wait for Windows ZIP asset to be ready
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          asset="kanban-v${VERSION}-x86_64-pc-windows-msvc.zip"
+          for i in $(seq 1 30); do
+            state=$(gh release view "v${VERSION}" --repo "$REPO" \
+              --json assets --jq ".assets[] | select(.name == \"$asset\") | .state" 2>/dev/null || true)
+            if [ "$state" = "uploaded" ]; then
+              echo "Found ${asset}: state=uploaded"
+              exit 0
+            fi
+            echo "Attempt ${i}: state='${state:-not-listed}'"
+            sleep 5
+          done
+          echo "Release asset ${asset} never became ready after 30 attempts (~150s)" >&2
+          exit 1
+
       - name: Submit manifest to winget-pkgs
-        uses: vedantmgoyal9/winget-releaser@v2
+        # winget-releaser only UPDATES a package already present in
+        # winget-pkgs; the first-ever version of a new identifier must be
+        # submitted manually. See packaging/winget/README.md.
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: fulsomenko.kanban
           version: ${{ needs.resolve-version.outputs.version }}
@@ -515,3 +540,25 @@ jobs:
           max-versions-to-keep: 5
           fork-user: fulsomenko
           token: ${{ secrets.WINGET_TOKEN }}
+
+      - name: Surface winget failure
+        if: failure()
+        continue-on-error: true
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          echo "::warning title=winget submission failed::v${VERSION} was not submitted to winget-pkgs. See packaging/winget/README.md."
+          {
+            echo "## winget submission failed for v${VERSION}"
+            echo ""
+            echo "The \`publish-winget\` job exited non-zero. The rest of the"
+            echo "release (crates.io, GitHub Release, AUR, Homebrew, Chocolatey)"
+            echo "is unaffected because this job is \`continue-on-error: true\`."
+            echo ""
+            echo "**Most common cause:** the first-ever submission of a new package"
+            echo "identifier must be made manually; \`winget-releaser\` only updates"
+            echo "packages already present in winget-pkgs. See \`packaging/winget/README.md\`."
+            echo ""
+            echo "**Workflow run:** ${RUN_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -711,6 +711,13 @@ To enable automated publishing and releases, configure these secrets in GitHub r
 - Add public key (deploy_key.pub) to GitHub: Settings → Deploy keys → Add (with write access)
 - Add private key (deploy_key) to GitHub: Settings → Secrets → Actions → New repository secret
 
+**WINGET_TOKEN**
+- Required for: Submitting the winget manifest PR to `microsoft/winget-pkgs` via `winget-releaser`
+- How to obtain:
+  1. Create a **classic** GitHub PAT with `public_repo` scope (fine-grained tokens are not supported by the action)
+  2. Add to GitHub: Settings → Secrets → Actions → New repository secret
+- Also requires a fork of `microsoft/winget-pkgs` at `fulsomenko/winget-pkgs` — the action pushes its submission branch there before opening the upstream PR
+
 ### CI/CD Workflows
 
 **ci.yml** - Runs on all pushes and PRs
@@ -731,6 +738,17 @@ To enable automated publishing and releases, configure these secrets in GitHub r
 `validate-release`, both defined in `scripts/`:
 - `check-crate-list-sync.sh` — fails if `validate-release.sh`/`publish-crates.sh` hardcode a `crates/...` array instead of calling `list-crates`, or if `list-crates`'s output disagrees with the crates actually on disk under `crates/`
 - `check-factory-compile-lock.sh` — fails if a `..` rest pattern or `Default::default()` shows up in the `*_factory.rs` record types (`kanban-domain/src/*_factory.rs`) or the DTO conversion modules (`kanban-api/src/v1/**/conversions.rs`, `.../response.rs`), since those are deliberately kept exhaustive so a new field becomes a compile error instead of a silent drop
+
+### Packaging
+
+`release.yml` also publishes the built binaries to several package
+managers once `build-windows`/the crates.io release succeed. The
+`packaging/` directory holds the source or reference files each of
+these jobs consumes:
+
+- `packaging/aur/` — AUR `PKGBUILD`, updated and pushed by the `release` job
+- `packaging/chocolatey/` — Chocolatey nuspec/tools, packed and pushed by `publish-chocolatey`
+- `packaging/winget/` — a reference/fallback copy of the winget manifest (for `winget validate` and manual submission); the real per-version manifest is generated and submitted to `microsoft/winget-pkgs` by the `publish-winget` job via `winget-releaser`, using the `WINGET_TOKEN` secret and the `fulsomenko/winget-pkgs` fork (see [Required Secrets](#required-secrets))
 
 ### Workflow Architecture
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ yay -S kanban
 choco install kanban
 ```
 
+### winget
+```powershell
+winget install fulsomenko.kanban
+```
+
 ### Linux Clipboard Support
 
 For `y`/`Y` clipboard operations to persist after the app exits, you need a clipboard manager:

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,30 @@
+# winget manifest reference set
+
+This directory holds a reference/fallback copy of the `fulsomenko.kanban`
+winget manifest. It is **not** the canonical source: winget manifests
+cannot live in this repo the way the AUR `PKGBUILD` or the Chocolatey
+nuspec do — the single source of truth for a real release is the
+per-version manifest folder merged into `microsoft/winget-pkgs`.
+
+The `publish-winget` job in `.github/workflows/release.yml` generates
+and submits that real manifest on every release, via
+[`vedantmgoyal9/winget-releaser`](https://github.com/vedantmgoyal9/winget-releaser)
+(`komac` under the hood). It downloads the release's Windows zip,
+computes the SHA256, and opens a PR against `microsoft/winget-pkgs`
+from the `fulsomenko/winget-pkgs` fork.
+
+The files under `manifests/f/fulsomenko/kanban/0.0.0/` exist so that:
+
+- `winget validate` can be run against a well-formed example locally
+  or in CI, independent of any real release.
+- A maintainer has a manual fallback to hand-submit with
+  `wingetcreate`/`komac` if the automated job is ever unavailable.
+
+`0.0.0` and the installer's SHA256 are placeholders — they are never
+published as-is. Do not bump this version by hand; the action
+generates the real per-version manifest directly in the upstream PR.
+
+Both binaries the Windows release zip ships (`kanban.exe` and
+`kanban-mcp.exe`, staged flat at the zip root — see `build-windows` in
+`.github/workflows/release.yml`) are declared as portable nested
+installer files so both land on `PATH` after `winget install`.

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -13,6 +13,31 @@ and submits that real manifest on every release, via
 computes the SHA256, and opens a PR against `microsoft/winget-pkgs`
 from the `fulsomenko/winget-pkgs` fork.
 
+## First submission is manual (one time)
+
+`winget-releaser` only **updates** a package that already has at least
+one version in `microsoft/winget-pkgs` — it bases each new version on
+the previous manifest. It cannot create a brand-new package identifier.
+So the very first `fulsomenko.kanban` submission must be made by hand;
+until it lands, the `publish-winget` job will fail on every release
+(harmlessly, since the job is `continue-on-error: true`).
+
+Bootstrap the first version once, from a machine with the winget CLI
+(Windows) or `komac`, using the shape captured in this directory. For
+an already-published GitHub release `vX.Y.Z`:
+
+```powershell
+winget install wingetcreate
+wingetcreate new `
+  https://github.com/fulsomenko/kanban/releases/download/vX.Y.Z/kanban-vX.Y.Z-x86_64-pc-windows-msvc.zip `
+  --submit
+```
+
+When prompted, match this directory: `InstallerType: zip`,
+`NestedInstallerType: portable`, and both `kanban.exe` -> `kanban` and
+`kanban-mcp.exe` -> `kanban-mcp`. Once that PR merges upstream, every
+subsequent release is fully automated by the `publish-winget` job.
+
 The files under `manifests/f/fulsomenko/kanban/0.0.0/` exist so that:
 
 - `winget validate` can be run against a well-formed example locally

--- a/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.installer.yaml
+++ b/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: fulsomenko.kanban
+PackageVersion: 0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: kanban.exe
+    PortableCommandAlias: kanban
+  - RelativeFilePath: kanban-mcp.exe
+    PortableCommandAlias: kanban-mcp
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fulsomenko/kanban/releases/download/v0.0.0/kanban-v0.0.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.locale.en-US.yaml
+++ b/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: fulsomenko.kanban
+PackageVersion: 0.0.0
+PackageLocale: en-US
+Publisher: Fulsomenko
+PublisherUrl: https://github.com/fulsomenko
+PublisherSupportUrl: https://github.com/fulsomenko/kanban/issues
+Author: Max Blomstervall
+PackageName: kanban
+PackageUrl: https://github.com/fulsomenko/kanban
+License: Apache-2.0
+LicenseUrl: https://github.com/fulsomenko/kanban/blob/master/LICENSE.md
+ShortDescription: Terminal-based kanban board inspired by lazygit
+Moniker: kanban
+Tags:
+  - kanban
+  - tui
+  - terminal
+  - productivity
+  - rust
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.yaml
+++ b/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: fulsomenko.kanban
+PackageVersion: 0.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## What

Adds a fourth automated packaging channel: publish `kanban` to winget (the Windows Package Manager), so Windows users can run `winget install fulsomenko.kanban`. Tracks kanban card KAN-1045 (Task 3 of the packaging epic).

## Changes

- **`packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/`** — a committed reference manifest set (version, defaultLocale, installer). The installer manifest uses `InstallerType: zip` with `NestedInstallerType: portable` and aliases both binaries shipped in the release zip: `kanban.exe` to `kanban` and `kanban-mcp.exe` to `kanban-mcp`. This directory is a reference and manual fallback only; the live per-version manifest is generated by the action at release time (see `packaging/winget/README.md`).
- **`.github/workflows/release.yml`** — new `publish-winget` job appended after `publish-chocolatey`, using `vedantmgoyal9/winget-releaser@v2`. It mirrors the Chocolatey job's gating exactly: `needs: [release, resolve-version, build-windows]` and `if: always() && needs.resolve-version.outputs.should_run == 'true' && needs.build-windows.result == 'success'`, version sourced from `resolve-version`. The action's default installer regex only matches exe/msi/msix/appx, so `installers-regex` is overridden to match the Windows zip and not `SHA256SUMS`.
- **`README.md`, `CONTRIBUTING.md`** — document the winget install path, a new Packaging subsection, and the `WINGET_TOKEN` secret plus `fulsomenko/winget-pkgs` fork requirement.

## How it works

`winget-releaser` cannot push to `microsoft/winget-pkgs` directly, so it pushes the generated manifest to a branch on the `fulsomenko/winget-pkgs` fork and opens a PR upstream from there. The `WINGET_TOKEN` secret (classic PAT, `public_repo`) grants write access to that fork. Both the fork and the secret are already set up.

## Test plan

Verified on Linux:
- `actionlint .github/workflows/release.yml` clean; the new job adds zero findings (one pre-existing unrelated SC2016 in the `.SRCINFO` step, present on `develop` too).
- All three manifests and the workflow parse as valid YAML.
- Installer regex matches `kanban-v1.2.3-x86_64-pc-windows-msvc.zip` and does not match `SHA256SUMS`.
- No Rust sources touched; build and test unaffected.

Requires a Windows/CI run (cannot run on Linux):
- `winget validate` on the manifest directory.
- `winget install fulsomenko.kanban` end to end.
- The upstream `microsoft/winget-pkgs` PR opening and merging, which only happens on a real release.
