### PR TITLE
KAN-1046 feat(server): configurable bind address via --addr, KANBAN_ADDR, and server_addr

### DIFF
--- a/.changeset/feat-kan-1046-configurable-bind-addr.md
+++ b/.changeset/feat-kan-1046-configurable-bind-addr.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+server: configurable bind address via --addr flag, KANBAN_ADDR env var, and server_addr config key (default 127.0.0.1:0 preserves existing ephemeral-loopback behavior)

--- a/crates/kanban-core/src/config.rs
+++ b/crates/kanban-core/src/config.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_STORAGE_BACKEND: &str = "json";
 pub const DEFAULT_JSON_FILENAME: &str = "boards.json";
 pub const DEFAULT_SQLITE_FILENAME: &str = "boards.sqlite";
+pub const DEFAULT_SERVER_ADDR: &str = "127.0.0.1:0";
 
 pub fn validate_branch_prefix(prefix: &str) -> bool {
     if prefix.is_empty() {
@@ -49,6 +50,8 @@ pub struct AppConfig {
     pub board_sort_field: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub board_sort_order: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_addr: Option<String>,
 }
 
 impl AppConfig {
@@ -82,6 +85,10 @@ impl AppConfig {
             }
             .to_string()
         })
+    }
+
+    pub fn effective_server_addr(&self) -> &str {
+        self.server_addr.as_deref().unwrap_or(DEFAULT_SERVER_ADDR)
     }
 
     pub fn validate_values(&self) -> CoreResult<()> {
@@ -121,6 +128,14 @@ impl AppConfig {
             if !validate_branch_prefix(v) {
                 return Err(crate::CoreError::Validation(format!(
                     "Invalid default_sprint_prefix '{}': must be non-empty, alphanumeric with hyphens/underscores, no leading/trailing hyphens",
+                    v
+                )));
+            }
+        }
+        if let Some(ref v) = self.server_addr {
+            if v.parse::<std::net::SocketAddr>().is_err() {
+                return Err(crate::CoreError::Validation(format!(
+                    "Invalid server_addr '{}': must be host:port (e.g. 0.0.0.0:5175)",
                     v
                 )));
             }
@@ -391,5 +406,55 @@ mod tests {
             let err = config.validate_values().unwrap_err();
             assert!(err.to_string().contains("default_sprint_prefix"));
         }
+    }
+
+    #[test]
+    fn test_effective_server_addr_defaults_to_loopback_ephemeral() {
+        let config = AppConfig::default();
+        assert_eq!(config.effective_server_addr(), "127.0.0.1:0");
+    }
+
+    #[test]
+    fn test_effective_server_addr_returns_configured_value() {
+        let config = AppConfig {
+            server_addr: Some("0.0.0.0:5175".into()),
+            ..Default::default()
+        };
+        assert_eq!(config.effective_server_addr(), "0.0.0.0:5175");
+    }
+
+    #[test]
+    fn test_validate_values_accepts_valid_server_addr() {
+        for addr in &["127.0.0.1:8080", "0.0.0.0:5175", "127.0.0.1:9999", "[::1]:8080"] {
+            let config = AppConfig {
+                server_addr: Some(addr.to_string()),
+                ..Default::default()
+            };
+            config.validate_values().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_validate_values_rejects_unparseable_server_addr() {
+        let config = AppConfig {
+            server_addr: Some("not-an-addr".into()),
+            ..Default::default()
+        };
+        let err = config.validate_values().unwrap_err();
+        assert!(err.to_string().contains("server_addr"));
+        assert!(err.to_string().contains("not-an-addr"));
+    }
+
+    #[test]
+    fn test_server_addr_round_trips_through_json() {
+        let config = AppConfig {
+            server_addr: Some("0.0.0.0:5175".into()),
+            ..Default::default()
+        };
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(serialized.contains("server_addr"));
+        assert!(serialized.contains("0.0.0.0:5175"));
+        let deserialized: AppConfig = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.server_addr, Some("0.0.0.0:5175".into()));
     }
 }

--- a/crates/kanban-core/src/config.rs
+++ b/crates/kanban-core/src/config.rs
@@ -425,7 +425,12 @@ mod tests {
 
     #[test]
     fn test_validate_values_accepts_valid_server_addr() {
-        for addr in &["127.0.0.1:8080", "0.0.0.0:5175", "127.0.0.1:9999", "[::1]:8080"] {
+        for addr in &[
+            "127.0.0.1:8080",
+            "0.0.0.0:5175",
+            "127.0.0.1:9999",
+            "[::1]:8080",
+        ] {
             let config = AppConfig {
                 server_addr: Some(addr.to_string()),
                 ..Default::default()

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -18,8 +18,8 @@ pub mod traits;
 pub mod version;
 
 pub use config::{
-    validate_branch_prefix, AppConfig, DEFAULT_JSON_FILENAME, DEFAULT_SQLITE_FILENAME,
-    DEFAULT_STORAGE_BACKEND, DEFAULT_SERVER_ADDR,
+    validate_branch_prefix, AppConfig, DEFAULT_JSON_FILENAME, DEFAULT_SERVER_ADDR,
+    DEFAULT_SQLITE_FILENAME, DEFAULT_STORAGE_BACKEND,
 };
 pub use datetime_input::parse_datetime_input;
 pub use error::{CoreError, CoreResult};

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod version;
 
 pub use config::{
     validate_branch_prefix, AppConfig, DEFAULT_JSON_FILENAME, DEFAULT_SQLITE_FILENAME,
-    DEFAULT_STORAGE_BACKEND,
+    DEFAULT_STORAGE_BACKEND, DEFAULT_SERVER_ADDR,
 };
 pub use datetime_input::parse_datetime_input;
 pub use error::{CoreError, CoreResult};

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -46,7 +46,7 @@ On startup the server opens (or creates) the board file, binds the configured ad
 | Env var | Default | Purpose |
 |---|---|---|
 | `KANBAN_FILE` | `kanban.json` (in the working directory) | Storage locator, resolved through the same backend registry as the CLI/TUI/MCP server — a `.json` path uses the JSON backend, a `.sqlite`/`.db` path (or existing SQLite file) uses the SQLite backend. |
-| `KANBAN_ADDR` | `127.0.0.1:0` (ephemeral loopback) | Address the HTTP server binds, as `host:port`. Resolved with the same layered precedence as `KANBAN_FILE`: the `--addr` flag wins, then `KANBAN_ADDR`, then the `server_addr` key in the config file, then the default. Set `0.0.0.0:<port>` to accept non-loopback connections (e.g. behind a reverse proxy). |
+| `KANBAN_ADDR` | `127.0.0.1:0` (ephemeral loopback) | Address the HTTP server binds, as `host:port` where host is an IP literal (`127.0.0.1`, `0.0.0.0`, `[::1]`); hostnames such as `localhost` are not resolved. Resolved with the same layered precedence as `KANBAN_FILE`: the `--addr` flag wins, then `KANBAN_ADDR`, then the `server_addr` key in the config file, then the default. Set `0.0.0.0:<port>` to accept non-loopback connections (e.g. behind a reverse proxy). |
 | `RUST_LOG` | unset (⇒ `error` only) | Standard `tracing-subscriber` env filter. Set to `info` to see the startup log line; there is no per-request access logging. |
 
 The bind address can also be set with the `--addr` flag or the `server_addr` key in the kanban config file (`~/.config/kanban/config.toml`); the resolution order is `--addr` > `KANBAN_ADDR` > `server_addr` > the `127.0.0.1:0` default.

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -2,7 +2,7 @@
 
 HTTP API server for kanban project management. Wraps `kanban-service` behind a REST interface so non-Rust clients (web UIs, scripts, other services) can read and write boards without going through the TUI, CLI, or MCP server.
 
-**Status: early / minimal.** Only boards and column reads are wired up so far — see [Endpoints](#endpoints). The binding address and logging are not yet configurable; treat this as a local development server, not a production deployment.
+**Status: early / minimal.** Only boards and column reads are wired up so far — see [Endpoints](#endpoints). The bind address is configurable (see [Configuration](#configuration)); per-request logging is not. Still best treated as a development server rather than a hardened production deployment.
 
 ## Architecture
 
@@ -39,16 +39,17 @@ cargo install --path crates/kanban-server
 kanban-server
 ```
 
-On startup the server opens (or creates) the board file, binds to `127.0.0.1` on an OS-assigned ephemeral port, and serves until killed. There is currently no way to pin the port or host — the process must be introspected (e.g. via its log line, or `lsof -p <pid>`) to find where it's listening.
+On startup the server opens (or creates) the board file, binds the configured address (default `127.0.0.1` on an OS-assigned ephemeral port), and serves until killed. Pin a fixed host/port with the `--addr` flag, the `KANBAN_ADDR` env var, or the `server_addr` config key (see [Configuration](#configuration)). When left on the default ephemeral port, read the bound address from the startup log line (`RUST_LOG=info`) or `lsof -p <pid>`.
 
 ### Configuration
 
 | Env var | Default | Purpose |
 |---|---|---|
 | `KANBAN_FILE` | `kanban.json` (in the working directory) | Storage locator, resolved through the same backend registry as the CLI/TUI/MCP server — a `.json` path uses the JSON backend, a `.sqlite`/`.db` path (or existing SQLite file) uses the SQLite backend. |
+| `KANBAN_ADDR` | `127.0.0.1:0` (ephemeral loopback) | Address the HTTP server binds, as `host:port`. Resolved with the same layered precedence as `KANBAN_FILE`: the `--addr` flag wins, then `KANBAN_ADDR`, then the `server_addr` key in the config file, then the default. Set `0.0.0.0:<port>` to accept non-loopback connections (e.g. behind a reverse proxy). |
 | `RUST_LOG` | unset (⇒ `error` only) | Standard `tracing-subscriber` env filter. Set to `info` to see the startup log line; there is no per-request access logging. |
 
-There are no other flags or config files. The bind address (`127.0.0.1:0`) is hardcoded in `src/main.rs`.
+The bind address can also be set with the `--addr` flag or the `server_addr` key in the kanban config file (`~/.config/kanban/config.toml`); the resolution order is `--addr` > `KANBAN_ADDR` > `server_addr` > the `127.0.0.1:0` default.
 
 ### Example
 

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -13,6 +13,11 @@ struct Args {
     /// Path to kanban data file (or set KANBAN_FILE env var)
     #[arg(value_name = "FILE", env = "KANBAN_FILE")]
     file: Option<String>,
+
+    /// Address to bind as host:port (or set KANBAN_ADDR). Falls back to the
+    /// `server_addr` config value, then 127.0.0.1:0.
+    #[arg(long, env = "KANBAN_ADDR")]
+    addr: Option<String>,
 }
 
 #[tokio::main]
@@ -24,9 +29,12 @@ async fn main() {
     let locator = args
         .file
         .unwrap_or_else(|| config::resolve_storage_location(&config));
+    let addr = args
+        .addr
+        .unwrap_or_else(|| config::resolve_server_addr(&config));
 
-    if let Err(e) = run(&locator, config).await {
-        eprintln!("Error: failed to start kanban-server with data file '{locator}': {e}");
+    if let Err(e) = run(&locator, config, &addr).await {
+        eprintln!("Error: failed to start kanban-server on '{addr}' with data file '{locator}': {e}");
         std::process::exit(1);
     }
 }
@@ -34,6 +42,7 @@ async fn main() {
 async fn run(
     locator: &str,
     config: kanban_service::AppConfig,
+    addr: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
@@ -50,8 +59,33 @@ async fn run(
 
     kanban_server::watch::watch_for_external_changes(state.clone(), locator).await?;
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!(addr = %listener.local_addr()?, "kanban-server listening");
     axum::serve(listener, app::router(state)).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_addr_defaults_to_none_without_flag_or_env() {
+        let args = Args::parse_from(&["kanban-server"]);
+        assert!(args.addr.is_none());
+    }
+
+    #[test]
+    fn test_addr_long_flag_sets_value() {
+        let args = Args::parse_from(&["kanban-server", "--addr", "0.0.0.0:5175"]);
+        assert_eq!(args.addr, Some("0.0.0.0:5175".into()));
+    }
+
+    #[test]
+    fn test_file_and_addr_parse_together() {
+        let args =
+            Args::parse_from(&["kanban-server", "board.json", "--addr", "127.0.0.1:9999"]);
+        assert_eq!(args.file, Some("board.json".into()));
+        assert_eq!(args.addr, Some("127.0.0.1:9999".into()));
+    }
 }

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -34,7 +34,9 @@ async fn main() {
         .unwrap_or_else(|| config::resolve_server_addr(&config));
 
     if let Err(e) = run(&locator, config, &addr).await {
-        eprintln!("Error: failed to start kanban-server on '{addr}' with data file '{locator}': {e}");
+        eprintln!(
+            "Error: failed to start kanban-server on '{addr}' with data file '{locator}': {e}"
+        );
         std::process::exit(1);
     }
 }
@@ -83,8 +85,7 @@ mod tests {
 
     #[test]
     fn test_file_and_addr_parse_together() {
-        let args =
-            Args::parse_from(&["kanban-server", "board.json", "--addr", "127.0.0.1:9999"]);
+        let args = Args::parse_from(&["kanban-server", "board.json", "--addr", "127.0.0.1:9999"]);
         assert_eq!(args.file, Some("board.json".into()));
         assert_eq!(args.addr, Some("127.0.0.1:9999".into()));
     }

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -61,7 +61,13 @@ async fn run(
 
     kanban_server::watch::watch_for_external_changes(state.clone(), locator).await?;
 
-    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let socket_addr: std::net::SocketAddr = addr.parse().map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid bind address '{addr}': expected an IP literal host:port, e.g. 0.0.0.0:5175 (hostnames like 'localhost' are not resolved)"),
+        )
+    })?;
+    let listener = tokio::net::TcpListener::bind(socket_addr).await?;
     tracing::info!(addr = %listener.local_addr()?, "kanban-server listening");
     axum::serve(listener, app::router(state)).await?;
     Ok(())
@@ -73,19 +79,19 @@ mod tests {
 
     #[test]
     fn test_addr_defaults_to_none_without_flag_or_env() {
-        let args = Args::parse_from(&["kanban-server"]);
+        let args = Args::parse_from(["kanban-server"]);
         assert!(args.addr.is_none());
     }
 
     #[test]
     fn test_addr_long_flag_sets_value() {
-        let args = Args::parse_from(&["kanban-server", "--addr", "0.0.0.0:5175"]);
+        let args = Args::parse_from(["kanban-server", "--addr", "0.0.0.0:5175"]);
         assert_eq!(args.addr, Some("0.0.0.0:5175".into()));
     }
 
     #[test]
     fn test_file_and_addr_parse_together() {
-        let args = Args::parse_from(&["kanban-server", "board.json", "--addr", "127.0.0.1:9999"]);
+        let args = Args::parse_from(["kanban-server", "board.json", "--addr", "127.0.0.1:9999"]);
         assert_eq!(args.file, Some("board.json".into()));
         assert_eq!(args.addr, Some("127.0.0.1:9999".into()));
     }

--- a/crates/kanban-server/tests/bind_addr.rs
+++ b/crates/kanban-server/tests/bind_addr.rs
@@ -23,6 +23,7 @@ fn spawn_and_wait_for_port(dir: &Path, env: &[(&str, &str)], args: &[&str]) -> (
     cmd.current_dir(dir)
         .env_remove("KANBAN_FILE")
         .env_remove("KANBAN_ADDR")
+        .env_remove("KANBAN_CONFIG")
         .env("NO_COLOR", "1")
         .env("RUST_LOG", "info")
         .args(args)
@@ -47,7 +48,7 @@ fn spawn_and_wait_for_port(dir: &Path, env: &[(&str, &str)], args: &[&str]) -> (
                     // Look for "addr=" in the log line (e.g. "addr=127.0.0.1:12345")
                     if let Some(idx) = line.find("addr=") {
                         let rest = &line[idx + "addr=".len()..];
-                        if let Some(end) = rest.find(|c: char| c == ' ' || c == '\n') {
+                        if let Some(end) = rest.find([' ', '\n']) {
                             let addr_str = &rest[..end];
                             if let Some(colon_idx) = addr_str.rfind(':') {
                                 if let Ok(port) = addr_str[colon_idx + 1..].parse::<u16>() {
@@ -76,6 +77,21 @@ fn get_free_port() -> u16 {
         .local_addr()
         .expect("failed to get local addr")
         .port()
+}
+
+/// Returns `n` distinct free loopback ports. All listeners are held open at
+/// once so the OS hands out different ports, then dropped together. The usual
+/// bind-time race still applies, but the returned ports are guaranteed
+/// distinct from one another -- which matters for precedence tests that must
+/// tell two candidate addresses apart.
+fn get_free_ports(n: usize) -> Vec<u16> {
+    let listeners: Vec<TcpListener> = (0..n)
+        .map(|_| TcpListener::bind("127.0.0.1:0").expect("failed to bind to free port"))
+        .collect();
+    listeners
+        .iter()
+        .map(|l| l.local_addr().expect("failed to get local addr").port())
+        .collect()
 }
 
 #[test]
@@ -112,8 +128,8 @@ fn test_kanban_addr_env_binds_requested_port() {
 fn test_addr_precedence_flag_over_env() {
     let dir = tempdir().unwrap();
     let data_file = dir.path().join("test_data.json");
-    let env_port = get_free_port();
-    let flag_port = get_free_port();
+    let ports = get_free_ports(2);
+    let (env_port, flag_port) = (ports[0], ports[1]);
 
     let (mut child, actual_port) = spawn_and_wait_for_port(
         dir.path(),
@@ -128,6 +144,64 @@ fn test_addr_precedence_flag_over_env() {
     assert_eq!(
         actual_port, flag_port,
         "--addr flag should take precedence over KANBAN_ADDR env"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn test_config_server_addr_binds_when_no_flag_or_env() {
+    let dir = tempdir().unwrap();
+    let data_file = dir.path().join("test_data.json");
+    let cfg_port = get_free_port();
+    let cfg_path = dir.path().join("config.toml");
+    std::fs::write(
+        &cfg_path,
+        format!("server_addr = \"127.0.0.1:{}\"\n", cfg_port),
+    )
+    .unwrap();
+
+    let (mut child, actual_port) = spawn_and_wait_for_port(
+        dir.path(),
+        &[("KANBAN_CONFIG", cfg_path.to_str().unwrap())],
+        &[data_file.to_str().unwrap()],
+    );
+
+    assert_eq!(
+        actual_port, cfg_port,
+        "server should bind server_addr from the config file when no flag or env is set"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn test_env_addr_overrides_config_server_addr() {
+    let dir = tempdir().unwrap();
+    let data_file = dir.path().join("test_data.json");
+    let ports = get_free_ports(2);
+    let (cfg_port, env_port) = (ports[0], ports[1]);
+    let cfg_path = dir.path().join("config.toml");
+    std::fs::write(
+        &cfg_path,
+        format!("server_addr = \"127.0.0.1:{}\"\n", cfg_port),
+    )
+    .unwrap();
+
+    let (mut child, actual_port) = spawn_and_wait_for_port(
+        dir.path(),
+        &[
+            ("KANBAN_CONFIG", cfg_path.to_str().unwrap()),
+            ("KANBAN_ADDR", &format!("127.0.0.1:{}", env_port)),
+        ],
+        &[data_file.to_str().unwrap()],
+    );
+
+    assert_eq!(
+        actual_port, env_port,
+        "KANBAN_ADDR should take precedence over the config file's server_addr"
     );
 
     let _ = child.kill();

--- a/crates/kanban-server/tests/bind_addr.rs
+++ b/crates/kanban-server/tests/bind_addr.rs
@@ -1,0 +1,149 @@
+//! Integration tests for configurable server bind address.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::{BufRead, BufReader};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Child, Command as StdCommand, Stdio};
+use std::time::Duration;
+use tempfile::tempdir;
+
+fn kanban_server() -> Command {
+    assert_cmd::cargo_bin_cmd!("kanban-server")
+}
+
+/// Spawns `kanban-server` with the given env vars and CLI args, waits for it
+/// to log its bound address on stdout, and returns the child (for cleanup)
+/// plus the actual port it bound to.
+fn spawn_and_wait_for_port(dir: &Path, env: &[(&str, &str)], args: &[&str]) -> (Child, u16) {
+    let bin_path = assert_cmd::cargo_bin!("kanban-server");
+
+    let mut cmd = StdCommand::new(bin_path);
+    cmd.current_dir(dir)
+        .env_remove("KANBAN_FILE")
+        .env_remove("KANBAN_ADDR")
+        .env("NO_COLOR", "1")
+        .env("RUST_LOG", "info")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd.spawn().expect("failed to spawn kanban-server");
+    let stdout = child.stdout.take().expect("stdout must be piped");
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    // Look for "addr=" in the log line (e.g. "addr=127.0.0.1:12345")
+                    if let Some(idx) = line.find("addr=") {
+                        let rest = &line[idx + "addr=".len()..];
+                        if let Some(end) = rest.find(|c: char| c == ' ' || c == '\n') {
+                            let addr_str = &rest[..end];
+                            if let Some(colon_idx) = addr_str.rfind(':') {
+                                if let Ok(port) = addr_str[colon_idx + 1..].parse::<u16>() {
+                                    let _ = tx.send(port);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let port = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("server did not report its bound port within 5s");
+    (child, port)
+}
+
+/// Helper to find a free port by binding to 127.0.0.1:0 and reading the port.
+fn get_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind to free port");
+    listener
+        .local_addr()
+        .expect("failed to get local addr")
+        .port()
+}
+
+#[test]
+fn test_kanban_addr_env_binds_requested_port() {
+    let dir = tempdir().unwrap();
+    let data_file = dir.path().join("test_data.json");
+    let requested_port = get_free_port();
+
+    let (mut child, actual_port) = spawn_and_wait_for_port(
+        dir.path(),
+        &[("KANBAN_ADDR", &format!("127.0.0.1:{}", requested_port))],
+        &[data_file.to_str().unwrap()],
+    );
+
+    assert_eq!(
+        actual_port, requested_port,
+        "server should bind to the requested port from KANBAN_ADDR"
+    );
+
+    // Try to hit /health on the bound port to confirm it's listening
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .get(format!("http://127.0.0.1:{}/health", actual_port))
+        .timeout(Duration::from_secs(2))
+        .send()
+        .expect("failed to GET /health");
+    assert!(resp.status().is_success(), "/health must return 200");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn test_addr_precedence_flag_over_env() {
+    let dir = tempdir().unwrap();
+    let data_file = dir.path().join("test_data.json");
+    let env_port = get_free_port();
+    let flag_port = get_free_port();
+
+    let (mut child, actual_port) = spawn_and_wait_for_port(
+        dir.path(),
+        &[("KANBAN_ADDR", &format!("127.0.0.1:{}", env_port))],
+        &[
+            "--addr",
+            &format!("127.0.0.1:{}", flag_port),
+            data_file.to_str().unwrap(),
+        ],
+    );
+
+    assert_eq!(
+        actual_port, flag_port,
+        "--addr flag should take precedence over KANBAN_ADDR env"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn test_invalid_addr_exits_nonzero() {
+    let dir = tempdir().unwrap();
+    let data_file = dir.path().join("test_data.json");
+
+    kanban_server()
+        .current_dir(dir.path())
+        .env("KANBAN_ADDR", "not-an-addr")
+        .arg(data_file.to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error").or(predicate::str::contains("failed")));
+}

--- a/crates/kanban-service/src/config.rs
+++ b/crates/kanban-service/src/config.rs
@@ -1,6 +1,6 @@
 use kanban_core::{
-    AppConfig, CoreResult, Editable, DEFAULT_JSON_FILENAME, DEFAULT_SQLITE_FILENAME,
-    DEFAULT_STORAGE_BACKEND, DEFAULT_SERVER_ADDR,
+    AppConfig, CoreResult, Editable, DEFAULT_JSON_FILENAME, DEFAULT_SERVER_ADDR,
+    DEFAULT_SQLITE_FILENAME, DEFAULT_STORAGE_BACKEND,
 };
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -251,7 +251,10 @@ fn is_all_defaults(config: &AppConfig) -> bool {
         })
         && config.board_sort_field.is_none()
         && config.board_sort_order.is_none()
-        && config.server_addr.as_deref().is_none_or(|v| v == DEFAULT_SERVER_ADDR)
+        && config
+            .server_addr
+            .as_deref()
+            .is_none_or(|v| v == DEFAULT_SERVER_ADDR)
 }
 
 /// Removes fields whose values are equal to the compile-time defaults so that
@@ -559,6 +562,7 @@ mod tests {
             editing_format: Some("json".into()),
             configuration_format: Some("toml".into()),
             configuration_location: Some("/tmp/test.toml".into()),
+            server_addr: Some("0.0.0.0:5175".into()),
             ..Default::default()
         };
         save_to(&config, &path).unwrap();
@@ -573,6 +577,7 @@ mod tests {
             loaded.configuration_location.as_deref(),
             Some("/tmp/test.toml")
         );
+        assert_eq!(loaded.server_addr.as_deref(), Some("0.0.0.0:5175"));
     }
 
     #[test]

--- a/crates/kanban-service/src/config.rs
+++ b/crates/kanban-service/src/config.rs
@@ -1,6 +1,6 @@
 use kanban_core::{
     AppConfig, CoreResult, Editable, DEFAULT_JSON_FILENAME, DEFAULT_SQLITE_FILENAME,
-    DEFAULT_STORAGE_BACKEND,
+    DEFAULT_STORAGE_BACKEND, DEFAULT_SERVER_ADDR,
 };
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -145,6 +145,12 @@ pub fn resolve_storage_location(config: &AppConfig) -> String {
     }
 }
 
+/// The address kanban-server binds. Returns the configured value or the
+/// compile-time default; unlike storage_location there is no cwd join.
+pub fn resolve_server_addr(config: &AppConfig) -> String {
+    config.effective_server_addr().to_string()
+}
+
 pub fn validate(config: &AppConfig) -> CoreResult<()> {
     config.validate_values()?;
     if let Some(ref v) = config.storage_location {
@@ -205,7 +211,8 @@ fn is_all_defaults(config: &AppConfig) -> bool {
         && config.configuration_location.is_none()
         && config.storage_location.is_none()
         && config.board_sort_field.is_none()
-        && config.board_sort_order.is_none();
+        && config.board_sort_order.is_none()
+        && config.server_addr.is_none();
 
     if all_none {
         return true;
@@ -244,6 +251,7 @@ fn is_all_defaults(config: &AppConfig) -> bool {
         })
         && config.board_sort_field.is_none()
         && config.board_sort_order.is_none()
+        && config.server_addr.as_deref().is_none_or(|v| v == DEFAULT_SERVER_ADDR)
 }
 
 /// Removes fields whose values are equal to the compile-time defaults so that
@@ -287,6 +295,9 @@ pub fn strip_defaults(config: &mut AppConfig) {
                 config.storage_location = None;
             }
         }
+    }
+    if config.server_addr.as_deref() == Some(DEFAULT_SERVER_ADDR) {
+        config.server_addr = None;
     }
 }
 
@@ -1173,6 +1184,72 @@ mod tests {
             all_files.is_empty(),
             "no leftover files should remain after successful write, found: {:?}",
             all_files.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_resolve_server_addr_falls_back_to_default() {
+        let config = AppConfig::default();
+        assert_eq!(resolve_server_addr(&config), "127.0.0.1:0");
+    }
+
+    #[test]
+    fn test_resolve_server_addr_returns_configured() {
+        let config = AppConfig {
+            server_addr: Some("0.0.0.0:5175".into()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_server_addr(&config), "0.0.0.0:5175");
+    }
+
+    #[test]
+    fn test_is_all_defaults_false_when_only_server_addr_set() {
+        let config = AppConfig {
+            server_addr: Some("0.0.0.0:5175".into()),
+            ..Default::default()
+        };
+        assert!(
+            !is_all_defaults(&config),
+            "a config with only server_addr set should not be all defaults"
+        );
+    }
+
+    #[test]
+    fn test_is_all_defaults_true_when_server_addr_is_default() {
+        let config = AppConfig {
+            server_addr: Some("127.0.0.1:0".into()),
+            ..Default::default()
+        };
+        assert!(
+            is_all_defaults(&config),
+            "a config with server_addr set to the default value should be all defaults"
+        );
+    }
+
+    #[test]
+    fn test_strip_defaults_strips_default_server_addr() {
+        let mut config = AppConfig {
+            server_addr: Some("127.0.0.1:0".into()),
+            ..Default::default()
+        };
+        strip_defaults(&mut config);
+        assert!(
+            config.server_addr.is_none(),
+            "default server_addr should be stripped"
+        );
+    }
+
+    #[test]
+    fn test_strip_defaults_preserves_non_default_server_addr() {
+        let mut config = AppConfig {
+            server_addr: Some("0.0.0.0:5175".into()),
+            ..Default::default()
+        };
+        strip_defaults(&mut config);
+        assert_eq!(
+            config.server_addr.as_deref(),
+            Some("0.0.0.0:5175"),
+            "non-default server_addr should be preserved"
         );
     }
 }


### PR DESCRIPTION
## What

Makes the `kanban-server` bind address configurable instead of hardcoded to `127.0.0.1:0`. The address resolves through the same layered precedence already used for the data file:

`--addr` flag > `KANBAN_ADDR` env var > `server_addr` config key > `127.0.0.1:0` default

## Why

The server bound to loopback on an OS-assigned random port with no way to pin it, so it could not be reverse-proxied or reached from another host, which blocked hosting it as a real service. Modelling the address on the existing `file` / `KANBAN_FILE` / `storage_location` resolution keeps configuration consistent and makes the address settable from the kanban config file, not only the environment.

## How

- `kanban-core`: new `DEFAULT_SERVER_ADDR` const, `server_addr` field on `AppConfig`, `effective_server_addr()` accessor, and `SocketAddr` validation in `validate_values()`. Follows the existing `storage_backend` / `effective_storage_backend` pattern.
- `kanban-service`: new `resolve_server_addr()` helper, plus `server_addr` wired into `is_all_defaults` / `strip_defaults` so config minimization stays correct.
- `kanban-server`: `Args.addr: Option<String>` with `env = "KANBAN_ADDR"` and no clap default (the default comes from the config layer), threaded through `main` into `run`, which binds the resolved address. Error message now names the address.
- Docs: `crates/kanban-server/README.md` updated to document the new option and drop the now-inaccurate "hardcoded / not configurable" notes.

Backward compatible: with nothing set anywhere, `effective_server_addr()` returns `127.0.0.1:0`, so the TUI, CLI, and test harness keep their existing ephemeral-loopback behavior. `test_helpers.rs` is unchanged.

## Testing

- New unit tests in `kanban-core` (effective accessor, valid/invalid address validation, serde round-trip) and `kanban-service` (resolver, `is_all_defaults` / `strip_defaults` handling, TOML round-trip).
- New `crates/kanban-server/tests/bind_addr.rs` integration tests: env-binds-requested-port, flag-over-env-over-config precedence, invalid-address-exits-nonzero.
- Inline `main.rs` arg-parsing tests.
- Manual end-to-end smoke against the running binary: `KANBAN_ADDR` and a `config.toml` `server_addr` each bound the requested port and served `/health` 200; with all three set the `--addr` value won and the other two ports were not bound; an invalid address exited non-zero with a clean message; the default still bound an ephemeral loopback port.
- `cargo fmt --all --check` clean; build / test / clippy `-D warnings` green for `kanban-core`, `kanban-service`, `kanban-server`.

Card: KAN-1046
