### PR TITLE
ci(release): silence false-positive SC2016 in .SRCINFO step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Generate .SRCINFO
         if: steps.check.outputs.has_changesets == 'true'
         run: |
+          # Single quotes are required: the expansions run in the inner pacman
+          # shell where makepkg is on PATH, not the runner shell.
+          # shellcheck disable=SC2016
           nix shell nixpkgs#pacman -c sh -c '
             PACMAN_ROOT="$(dirname "$(dirname "$(command -v makepkg)")")"
             export MAKEPKG_CONF="$PACMAN_ROOT/etc/makepkg.conf"


### PR DESCRIPTION
## What

Silences the one remaining `actionlint` finding in `release.yml`: an info-level `SC2016` in the `Generate .SRCINFO` step.

## Why it is a false positive

```sh
nix shell nixpkgs#pacman -c sh -c '
  PACMAN_ROOT="$(dirname "$(dirname "$(command -v makepkg)")")"
  export MAKEPKG_CONF="$PACMAN_ROOT/etc/makepkg.conf"
  cd packaging/aur && makepkg --printsrcinfo > .SRCINFO
'
```

The single quotes are required. The `$(...)` and `$PACMAN_ROOT` must expand inside the inner `sh -c`, which runs in the `nix shell nixpkgs#pacman` environment where `makepkg` is on PATH. Switching to double quotes (what SC2016 suggests) would evaluate them in the outer runner shell, where `makepkg` does not exist, and break the step. So the code is correct; only the lint needs suppressing.

## Change

A `# shellcheck disable=SC2016` directive with a one-line rationale, immediately above the command. No behavior change. `actionlint .github/workflows/release.yml` now exits 0.
