### PR TITLE
fix(api): enable schemars chrono04 feature for JsonSchema derives

### DIFF
--- a/.changeset/fix-kanban-api-schemars-chrono.md
+++ b/.changeset/fix-kanban-api-schemars-chrono.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+api: enable schemars chrono04 feature so JsonSchema derives compile for DateTime fields under --all-features (fixes CI clippy break)

--- a/crates/kanban-api/Cargo.toml
+++ b/crates/kanban-api/Cargo.toml
@@ -23,4 +23,4 @@ serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 chrono.workspace = true
-schemars = { version = "1.0", optional = true, features = ["uuid1"] }
+schemars = { version = "1.0", optional = true, features = ["uuid1", "chrono04"] }


### PR DESCRIPTION
## What

Adds the `chrono04` feature to the optional `schemars` dependency in `kanban-api`.

## Why

CI Lint (`cargo clippy --all-targets --all-features -- -D warnings`) fails to compile `kanban-api` on `develop`:

```
error[E0277]: the trait bound `chrono::DateTime<chrono::Utc>: schemars::JsonSchema` is not satisfied
  --> crates/kanban-api/src/v1/cards/requests.rs:27:19
```

`CreateCardRequest` derives `schemars::JsonSchema` (gated behind the crate's `schemars` feature) and has a `due_date: Option<DateTime<Utc>>` field. The `schemars` dependency enabled only `uuid1`, so `DateTime<Utc>: JsonSchema` was never provided. The break only surfaces under `--all-features`, which is why normal per-crate builds stayed green while the workspace-wide lint gate went red.

This is pre-existing on `develop` (reproduces on an unmodified checkout), independent of any feature work. It currently blocks the Lint check on every open PR.

## How

`crates/kanban-api/Cargo.toml`:

```diff
-schemars = { version = "1.0", optional = true, features = ["uuid1"] }
+schemars = { version = "1.0", optional = true, features = ["uuid1", "chrono04"] }
```

`chrono04` is schemars 1.x's feature that provides `JsonSchema` impls for chrono 0.4 types, matching the existing `uuid1` convention.

## Testing

- Before: `cargo clippy --all-targets --all-features -- -D warnings` fails compiling `kanban-api` (reproduced on clean `develop`).
- After: the same command finishes clean across the whole workspace.
