### PR TITLE
fix(packaging): add required schema header to winget reference manifests

### DIFF
--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -49,6 +49,11 @@ The files under `manifests/f/fulsomenko/kanban/0.0.0/` exist so that:
 published as-is. Do not bump this version by hand; the action
 generates the real per-version manifest directly in the upstream PR.
 
+Each file starts with a `# yaml-language-server: $schema=...` header.
+The winget-pkgs validation pipeline rejects manifests without it
+(`SchemaHeaderNotFound`), so keep the header when copying these as a
+starting point for a manual submission.
+
 Both binaries the Windows release zip ships (`kanban.exe` and
 `kanban-mcp.exe`, staged flat at the zip root — see `build-windows` in
 `.github/workflows/release.yml`) are declared as portable nested

--- a/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.installer.yaml
+++ b/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: fulsomenko.kanban
 PackageVersion: 0.0.0
 InstallerType: zip

--- a/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.locale.en-US.yaml
+++ b/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: fulsomenko.kanban
 PackageVersion: 0.0.0
 PackageLocale: en-US

--- a/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.yaml
+++ b/packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/fulsomenko.kanban.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: fulsomenko.kanban
 PackageVersion: 0.0.0
 DefaultLocale: en-US


### PR DESCRIPTION
## What

Adds the required `# yaml-language-server: $schema=...` header to the three winget reference manifests under `packaging/winget/manifests/f/fulsomenko/kanban/0.0.0/`, and documents the requirement in `packaging/winget/README.md`.

## Why

The winget-pkgs validation pipeline rejects manifests without this header (`SchemaHeaderNotFound`). The reference set committed in #530 omitted it. This surfaced for real on the first live submission (`microsoft/winget-pkgs` PR for fulsomenko.kanban 0.8.0), which failed validation with three `SchemaHeaderNotFound` errors until the header was added.

The automated `publish-winget` job is unaffected either way (winget-releaser generates its own headered manifests), but the committed reference/fallback copy should be valid so `winget validate` and a manual `wingetcreate`/`komac` submission work from it.

## Change

- Prepend the version/defaultLocale/installer schema header (1.12.0) to each of the three files. No other content change.
- One short note in the README explaining the header is mandatory.
