### PR TITLE
KAN-1037 feat(tui): show a card's git commits in card detail (MVP)

### DIFF
--- a/.changeset/kan-1037-git-commits-in-card-detail.md
+++ b/.changeset/kan-1037-git-commits-in-card-detail.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Show a card's linked git commits in the TUI card-detail view (grep commit messages for the card's KAN-N identifier; read-only, fetched once on open, degrades gracefully when no repo is configured)

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -614,6 +614,86 @@ mod tests {
     }
 
     #[test]
+    fn test_identifier_uses_sprint_prefix_when_set() {
+        use crate::sprint::{Sprint, SprintStatus};
+
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("Test Board", Some("KAN"));
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
+
+        let sprint_with_prefix = Sprint {
+            id: uuid::Uuid::new_v4(),
+            board_id: board.id,
+            sprint_number: 1,
+            name_index: None,
+            prefix: None,
+            card_prefix: Some("SPR".to_string()),
+            status: SprintStatus::Planning,
+            start_date: None,
+            end_date: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let mut card_with_sprint = card.clone();
+        card_with_sprint.sprint_id = Some(sprint_with_prefix.id);
+        let sprints = vec![sprint_with_prefix];
+
+        assert_eq!(
+            card_with_sprint.identifier(&board, &sprints, "task"),
+            "SPR-1"
+        );
+    }
+
+    #[test]
+    fn test_identifier_falls_back_to_board_prefix() {
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("Test Board", Some("KAN"));
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
+        let sprint = crate::sprint::Sprint::new(board.id, 1, None, None::<String>);
+        let mut card_with_sprint = card.clone();
+        card_with_sprint.sprint_id = Some(sprint.id);
+        let sprints = vec![sprint];
+
+        assert_eq!(
+            card_with_sprint.identifier(&board, &sprints, "task"),
+            "KAN-1"
+        );
+    }
+
+    #[test]
+    fn test_identifier_uses_default_when_no_board_prefix() {
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("Test Board", None::<String>);
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
+        let sprints = vec![];
+
+        assert_eq!(card.identifier(&board, &sprints, "task"), "task-1");
+    }
+
+    #[test]
+    fn test_identifier_formats_number_without_padding() {
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("Test Board", Some("KAN"));
+        let _card1 = Card::new(&mut board, column_id, "First", 0);
+        let _card2 = Card::new(&mut board, column_id, "Second", 0);
+        let card3 = Card::new(&mut board, column_id, "Third", 0);
+
+        assert_eq!(card3.identifier(&board, &[], "task"), "KAN-3");
+    }
+
+    #[test]
+    fn test_branch_name_still_prefixes_with_identifier() {
+        let column_id = uuid::Uuid::new_v4();
+        let mut board = Board::new("Test Board", Some("KAN"));
+        let card = Card::new(&mut board, column_id, "Test Card", 0);
+
+        assert_eq!(card.branch_name(&board, &[], "task"), "KAN-1/test-card");
+        assert!(card
+            .branch_name(&board, &[], "task")
+            .starts_with(&format!("{}/", card.identifier(&board, &[], "task"))));
+    }
+
+    #[test]
     fn test_sprint_logging() {
         let column_id = uuid::Uuid::new_v4();
         let mut board = Board::new("Test Board", None::<String>);

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -203,9 +203,9 @@ impl Card {
         self.updated_at = Utc::now();
     }
 
-    /// Resolve the branch name prefix using two-level hierarchy:
-    /// sprint.card_prefix → board.card_prefix → default_prefix
-    pub fn branch_name(&self, board: &Board, sprints: &[Sprint], default_prefix: &str) -> String {
+    /// Resolve the card's stable tag `PREFIX-NUMBER` using the two-level
+    /// hierarchy: sprint.card_prefix → board.card_prefix → default_prefix.
+    pub fn identifier(&self, board: &Board, sprints: &[Sprint], default_prefix: &str) -> String {
         let prefix = if let Some(sprint_id) = self.sprint_id {
             sprints
                 .iter()
@@ -215,8 +215,13 @@ impl Card {
         } else {
             board.effective_card_prefix(default_prefix)
         };
+        format!("{}-{}", prefix, self.card_number)
+    }
+
+    pub fn branch_name(&self, board: &Board, sprints: &[Sprint], default_prefix: &str) -> String {
+        let identifier = self.identifier(board, sprints, default_prefix);
         let kebab_title = Self::to_kebab_case(&self.title);
-        let branch = format!("{}-{}/{}", prefix, self.card_number, kebab_title);
+        let branch = format!("{}/{}", identifier, kebab_title);
         Self::truncate_branch_name(branch)
     }
 

--- a/crates/kanban-service/src/git/config.rs
+++ b/crates/kanban-service/src/git/config.rs
@@ -1,3 +1,52 @@
+use std::path::{Path, PathBuf};
+
+/// Env var naming the local checkout to read git history from.
+pub const REPO_PATH_ENV: &str = "KANBAN_REPO";
+
+/// Resolves which local git checkout the client should read, by precedence:
+/// 1. `explicit` — an explicitly configured path (CLI flag / config field).
+/// 2. `env_repo` — the `KANBAN_REPO` override.
+/// 3. the first ancestor of `start_dir` (inclusive) that contains a `.git` entry.
+/// 4. `None` — nothing configured and no enclosing repository.
+///
+/// Pure: `env_repo` and `start_dir` are injected so callers can unit-test every
+/// branch without touching the process environment or the real cwd.
+pub fn resolve_repo_path(
+    explicit: Option<PathBuf>,
+    env_repo: Option<PathBuf>,
+    start_dir: &Path,
+) -> Option<PathBuf> {
+    if let Some(path) = explicit {
+        return Some(path);
+    }
+    if let Some(path) = env_repo {
+        return Some(path);
+    }
+    find_enclosing_repo(start_dir)
+}
+
+/// Walks `start_dir` and its ancestors, returning the first directory that
+/// contains a `.git` entry. `.git` may be a directory (normal clone) or a file
+/// (worktree/submodule gitlink), so existence — not directory-ness — is the test.
+fn find_enclosing_repo(start_dir: &Path) -> Option<PathBuf> {
+    start_dir
+        .ancestors()
+        .find(|dir| dir.join(".git").exists())
+        .map(Path::to_path_buf)
+}
+
+/// Impure entry point mirroring `path::validate_path`: reads `KANBAN_REPO` and
+/// the process cwd, then delegates to the pure [`resolve_repo_path`]. Returns
+/// `None` if the cwd cannot be read and no explicit/env path is set.
+pub fn resolve_repo_path_from_env(explicit: Option<PathBuf>) -> Option<PathBuf> {
+    let env_repo = std::env::var_os(REPO_PATH_ENV).map(PathBuf::from);
+    if explicit.is_some() || env_repo.is_some() {
+        return resolve_repo_path(explicit, env_repo, Path::new(""));
+    }
+    let cwd = std::env::current_dir().ok()?;
+    resolve_repo_path(None, None, &cwd)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-service/src/git/config.rs
+++ b/crates/kanban-service/src/git/config.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn test_resolve_prefers_explicit_over_env() {
+        let result = resolve_repo_path(
+            Some(PathBuf::from("/explicit")),
+            Some(PathBuf::from("/from-env")),
+            Path::new("/cwd"),
+        );
+        assert_eq!(result, Some(PathBuf::from("/explicit")));
+    }
+
+    #[test]
+    fn test_resolve_uses_env_when_no_explicit() {
+        let result = resolve_repo_path(
+            None,
+            Some(PathBuf::from("/from-env")),
+            Path::new("/some/dir"),
+        );
+        assert_eq!(result, Some(PathBuf::from("/from-env")));
+    }
+
+    #[test]
+    fn test_resolve_walks_up_to_git_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        let deep = root.join("a").join("b").join("c");
+        std::fs::create_dir_all(&deep).unwrap();
+
+        let found = resolve_repo_path(None, None, &deep);
+
+        assert_eq!(found.as_deref(), Some(root));
+    }
+
+    #[test]
+    fn test_resolve_returns_none_when_nothing_found() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(tmp.path().ancestors().all(|d| !d.join(".git").exists()));
+
+        assert!(resolve_repo_path(None, None, tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_resolve_walk_matches_git_file_not_just_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join(".git"), "gitdir: /elsewhere").unwrap();
+        let deep = root.join("nested");
+        std::fs::create_dir_all(&deep).unwrap();
+
+        let found = resolve_repo_path(None, None, &deep);
+
+        assert_eq!(found.as_deref(), Some(root));
+    }
+}

--- a/crates/kanban-service/src/git/mod.rs
+++ b/crates/kanban-service/src/git/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 mod provider;
 mod shell;
 

--- a/crates/kanban-service/src/git/mod.rs
+++ b/crates/kanban-service/src/git/mod.rs
@@ -1,0 +1,5 @@
+mod provider;
+mod shell;
+
+pub use provider::{CommitRef, GitProvider};
+pub use shell::ShellGitProvider;

--- a/crates/kanban-service/src/git/provider.rs
+++ b/crates/kanban-service/src/git/provider.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use kanban_domain::KanbanResult;
+
+/// A single git commit that references a card's identifier.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommitRef {
+    pub short_hash: String,
+    pub subject: String,
+    pub author: String,
+    pub committed_at: DateTime<Utc>,
+}
+
+/// Read-only access to the git commits that implement a card.
+///
+/// Synchronous: implementations shell out to a blocking `git log`, called
+/// once when card detail opens, never per render frame.
+pub trait GitProvider {
+    fn commits_for_tag(&self, tag: &str) -> KanbanResult<Vec<CommitRef>>;
+}

--- a/crates/kanban-service/src/git/shell.rs
+++ b/crates/kanban-service/src/git/shell.rs
@@ -38,8 +38,37 @@ impl GitProvider for ShellGitProvider {
         };
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        Ok(stdout.lines().filter_map(parse_line).collect())
+        Ok(stdout
+            .lines()
+            .filter_map(parse_line)
+            .filter(|c| subject_has_tag_token(&c.subject, tag))
+            .collect())
     }
+}
+
+/// `--grep` is a substring match, so a coarse `git log --grep=KAN-5` also
+/// returns KAN-50/KAN-512/etc. Re-check the match as a bounded token: neither
+/// side of the matched substring may be alphanumeric, so `KAN-5` only matches
+/// `KAN-5` itself, not a longer number sharing the same prefix.
+fn subject_has_tag_token(subject: &str, tag: &str) -> bool {
+    let mut search_from = 0;
+    while let Some(offset) = subject[search_from..].find(tag) {
+        let start = search_from + offset;
+        let end = start + tag.len();
+        let before_ok = subject[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_ascii_alphanumeric());
+        let after_ok = subject[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_ascii_alphanumeric());
+        if before_ok && after_ok {
+            return true;
+        }
+        search_from = start + 1;
+    }
+    false
 }
 
 fn parse_line(line: &str) -> Option<CommitRef> {

--- a/crates/kanban-service/src/git/shell.rs
+++ b/crates/kanban-service/src/git/shell.rs
@@ -150,6 +150,24 @@ mod tests {
     }
 
     #[test]
+    fn test_commits_for_tag_excludes_numeric_prefix_collisions() {
+        let repo = init_repo();
+        commit(repo.path(), "KAN-5 the real card five");
+        commit(repo.path(), "KAN-50 a different card");
+        commit(repo.path(), "KAN-512 another one");
+        let provider = ShellGitProvider::new(repo.path().to_path_buf());
+
+        let commits = provider.commits_for_tag("KAN-5").expect("ok");
+
+        assert_eq!(
+            commits.len(),
+            1,
+            "KAN-5 must not match KAN-50/KAN-512 by substring: got {commits:?}"
+        );
+        assert_eq!(commits[0].subject, "KAN-5 the real card five");
+    }
+
+    #[test]
     fn test_commit_fields_parsed() {
         let repo = init_repo();
         commit(repo.path(), "KAN-8 all fields");

--- a/crates/kanban-service/src/git/shell.rs
+++ b/crates/kanban-service/src/git/shell.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+
+use kanban_domain::KanbanResult;
+
+use super::provider::{CommitRef, GitProvider};
+
+/// `GitProvider` that shells out to a local `git` binary against a checkout.
+pub struct ShellGitProvider {
+    #[allow(dead_code)]
+    repo_path: PathBuf,
+}
+
+impl ShellGitProvider {
+    pub fn new(repo_path: PathBuf) -> Self {
+        Self { repo_path }
+    }
+}
+
+impl GitProvider for ShellGitProvider {
+    fn commits_for_tag(&self, _tag: &str) -> KanbanResult<Vec<CommitRef>> {
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .status()
+            .expect("git must be on PATH for git-module tests");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        run_git(dir.path(), &["init", "--quiet"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Test User"]);
+        dir
+    }
+
+    fn commit(dir: &Path, subject: &str) {
+        run_git(
+            dir,
+            &[
+                "commit",
+                "--allow-empty",
+                "--quiet",
+                "--author=Test User <test@example.com>",
+                "-m",
+                subject,
+            ],
+        );
+    }
+
+    #[test]
+    fn test_commits_for_tag_returns_matching_commit() {
+        let repo = init_repo();
+        commit(repo.path(), "KAN-5 do a thing");
+        let provider = ShellGitProvider::new(repo.path().to_path_buf());
+
+        let commits = provider.commits_for_tag("KAN-5").expect("ok");
+
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].subject, "KAN-5 do a thing");
+    }
+
+    #[test]
+    fn test_commits_for_tag_returns_empty_when_no_match() {
+        let repo = init_repo();
+        commit(repo.path(), "KAN-5 do a thing");
+        let provider = ShellGitProvider::new(repo.path().to_path_buf());
+
+        let commits = provider.commits_for_tag("KAN-999").expect("ok");
+
+        assert!(commits.is_empty());
+    }
+
+    #[test]
+    fn test_commits_for_tag_returns_empty_for_non_repo() {
+        let dir = TempDir::new().expect("tempdir");
+        let provider = ShellGitProvider::new(dir.path().to_path_buf());
+
+        let commits = provider.commits_for_tag("KAN-5").expect("graceful");
+
+        assert!(commits.is_empty());
+    }
+
+    #[test]
+    fn test_parses_multiple_commits_newest_first() {
+        let repo = init_repo();
+        commit(repo.path(), "KAN-7 first");
+        commit(repo.path(), "KAN-7 second");
+        let provider = ShellGitProvider::new(repo.path().to_path_buf());
+
+        let commits = provider.commits_for_tag("KAN-7").expect("ok");
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].subject, "KAN-7 second");
+        assert_eq!(commits[1].subject, "KAN-7 first");
+    }
+
+    #[test]
+    fn test_commit_fields_parsed() {
+        let repo = init_repo();
+        commit(repo.path(), "KAN-8 all fields");
+        let provider = ShellGitProvider::new(repo.path().to_path_buf());
+
+        let commits = provider.commits_for_tag("KAN-8").expect("ok");
+        let c = &commits[0];
+
+        assert_eq!(c.short_hash.len(), 7);
+        assert!(c.short_hash.chars().all(|ch| ch.is_ascii_hexdigit()));
+        assert_eq!(c.subject, "KAN-8 all fields");
+        assert_eq!(c.author, "Test User");
+        assert!(c.committed_at <= Utc::now());
+    }
+}

--- a/crates/kanban-service/src/git/shell.rs
+++ b/crates/kanban-service/src/git/shell.rs
@@ -1,12 +1,16 @@
 use std::path::PathBuf;
+use std::process::Command;
 
+use chrono::{DateTime, Utc};
 use kanban_domain::KanbanResult;
 
 use super::provider::{CommitRef, GitProvider};
 
+const FIELD_SEP: char = '\u{1f}';
+const LOG_FORMAT: &str = "--format=%h%x1f%s%x1f%an%x1f%cI";
+
 /// `GitProvider` that shells out to a local `git` binary against a checkout.
 pub struct ShellGitProvider {
-    #[allow(dead_code)]
     repo_path: PathBuf,
 }
 
@@ -17,9 +21,45 @@ impl ShellGitProvider {
 }
 
 impl GitProvider for ShellGitProvider {
-    fn commits_for_tag(&self, _tag: &str) -> KanbanResult<Vec<CommitRef>> {
-        Ok(Vec::new())
+    fn commits_for_tag(&self, tag: &str) -> KanbanResult<Vec<CommitRef>> {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&self.repo_path)
+            .args(["log", "--all", "--fixed-strings"])
+            .arg(format!("--grep={tag}"))
+            .arg(LOG_FORMAT)
+            .output();
+
+        let output = match output {
+            Ok(output) if output.status.success() => output,
+            // git missing (spawn error) or non-zero exit (not a repo / bad
+            // invocation): the card-detail view degrades to "No linked commits".
+            _ => return Ok(Vec::new()),
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(stdout.lines().filter_map(parse_line).collect())
     }
+}
+
+fn parse_line(line: &str) -> Option<CommitRef> {
+    let mut fields = line.split(FIELD_SEP);
+    let short_hash = fields.next()?;
+    let subject = fields.next()?;
+    let author = fields.next()?;
+    let committed_at = fields.next()?;
+    if fields.next().is_some() {
+        return None;
+    }
+    let committed_at = DateTime::parse_from_rfc3339(committed_at)
+        .ok()?
+        .with_timezone(&Utc);
+    Some(CommitRef {
+        short_hash: short_hash.to_string(),
+        subject: subject.to_string(),
+        author: author.to_string(),
+        committed_at,
+    })
 }
 
 #[cfg(test)]

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -17,6 +17,7 @@ mod backend_test_support;
 mod cascade;
 pub mod config;
 mod context;
+pub mod git;
 mod path;
 mod store_manager;
 pub mod undo_stack;
@@ -25,6 +26,7 @@ pub use context::{
     BatchOperationFailure, BatchOperationResult, BoardCreateOutcome, BoardRelations,
     CardCreateOutcome, ColumnCreateOutcome, KanbanContext, SprintCreateOutcome,
 };
+pub use git::{CommitRef, GitProvider, ShellGitProvider};
 pub use kanban_backend::KanbanBackend;
 pub use kanban_backend::RemoteWrites;
 pub use path::validate_path;

--- a/crates/kanban-tui/src/app/card_commits.rs
+++ b/crates/kanban-tui/src/app/card_commits.rs
@@ -1,0 +1,52 @@
+use super::App;
+use kanban_service::git::CommitRef;
+
+/// Cached result of the one-shot git-log lookup for the card currently open
+/// in card detail. Populated on detail open / active-card change; rendered
+/// from cache every frame (never re-shelled per frame).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum CommitsPanel {
+    #[default]
+    NotLoaded,
+    Loaded(Vec<CommitRef>),
+    Unavailable,
+}
+
+impl App {
+    #[doc(hidden)]
+    pub fn set_git_provider(
+        &mut self,
+        provider: Option<Box<dyn kanban_service::git::GitProvider>>,
+    ) {
+        self.git_provider = provider;
+    }
+
+    /// Recompute `commits_panel` for the card currently open in card detail.
+    /// Invoked only on detail open / active-card change, never per render frame.
+    /// `None` provider or a provider error → Unavailable.
+    #[doc(hidden)]
+    pub fn refresh_card_commits(&mut self) {
+        self.commits_panel = self.compute_card_commits();
+    }
+
+    fn compute_card_commits(&self) -> CommitsPanel {
+        let Some(provider) = self.git_provider.as_ref() else {
+            return CommitsPanel::Unavailable;
+        };
+        let Some(card) = self.get_card_for_detail_view() else {
+            return CommitsPanel::NotLoaded;
+        };
+        let Some(board) = self.active_board() else {
+            return CommitsPanel::NotLoaded;
+        };
+        let tag = card.identifier(
+            board,
+            self.model.sprints(),
+            self.app_config.effective_default_card_prefix(),
+        );
+        match provider.commits_for_tag(&tag) {
+            Ok(commits) => CommitsPanel::Loaded(commits),
+            Err(_) => CommitsPanel::Unavailable,
+        }
+    }
+}

--- a/crates/kanban-tui/src/app/defaults.rs
+++ b/crates/kanban-tui/src/app/defaults.rs
@@ -46,6 +46,8 @@ impl App {
             model: super::model::Model::default(),
             relationship: RelationshipState::default(),
             save_error: None,
+            commits_panel: super::CommitsPanel::NotLoaded,
+            git_provider: None,
             pending_key: None,
             has_data_file: true,
             cli_file_provided: false,

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -105,6 +105,7 @@ impl App {
                 .children_list
                 .update_item_count(children.len());
             self.push_mode(AppMode::CardDetail);
+            self.refresh_card_commits();
             self.focus.card_focus = crate::app::CardFocus::Title;
         }
     }

--- a/crates/kanban-tui/src/app/lifecycle.rs
+++ b/crates/kanban-tui/src/app/lifecycle.rs
@@ -92,6 +92,10 @@ impl App {
         // `prepare_frame`/`load_from_snapshot`, which re-sorts using this state.
         let mut model = super::model::Model::default();
         model.set_board_sort_from_config(&app_config);
+        let git_provider = kanban_service::git::config::resolve_repo_path_from_env(None).map(|p| {
+            Box::new(kanban_service::git::ShellGitProvider::new(p))
+                as Box<dyn kanban_service::git::GitProvider>
+        });
         let app = Self {
             store_manager,
             should_quit: false,
@@ -115,6 +119,8 @@ impl App {
             model,
             relationship: RelationshipState::default(),
             save_error: None,
+            commits_panel: crate::app::CommitsPanel::NotLoaded,
+            git_provider,
             pending_key: None,
             has_data_file: has_explicit_file,
             cli_file_provided: save_file.is_some(),

--- a/crates/kanban-tui/src/app/lifecycle_tests.rs
+++ b/crates/kanban-tui/src/app/lifecycle_tests.rs
@@ -81,6 +81,8 @@ async fn test_save_worker_does_not_send_completion_on_conflict() {
         model: model::Model::default(),
         relationship: RelationshipState::default(),
         save_error: None,
+        commits_panel: crate::app::CommitsPanel::NotLoaded,
+        git_provider: None,
         pending_key: None,
         has_data_file: true,
         cli_file_provided: false,

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -43,6 +43,8 @@ pub use types::{
 };
 
 mod animation_tick;
+mod card_commits;
+pub use card_commits::CommitsPanel;
 mod card_selection;
 mod clipboard;
 mod command_execution;

--- a/crates/kanban-tui/src/app/types.rs
+++ b/crates/kanban-tui/src/app/types.rs
@@ -44,6 +44,8 @@ pub struct App {
     pub model: super::model::Model,
     pub relationship: RelationshipState,
     pub save_error: Option<String>,
+    pub commits_panel: super::CommitsPanel,
+    pub(crate) git_provider: Option<Box<dyn kanban_service::git::GitProvider>>,
     pub pending_key: Option<char>,
     pub has_data_file: bool,
     pub cli_file_provided: bool,

--- a/crates/kanban-tui/src/components/card_detail_sections.rs
+++ b/crates/kanban-tui/src/components/card_detail_sections.rs
@@ -1,3 +1,4 @@
+use crate::app::CommitsPanel;
 use crate::components::metadata_line_multi;
 use crate::theme::*;
 use kanban_core::AppConfig;
@@ -6,6 +7,46 @@ use ratatui::{
     style::{Color, Style},
     text::{Line, Span},
 };
+
+const MAX_VISIBLE_COMMITS: usize = 4;
+
+pub fn build_commits_lines(panel: &CommitsPanel) -> Vec<Line<'static>> {
+    match panel {
+        CommitsPanel::NotLoaded => {
+            vec![Line::from(Span::styled("Loading commits…", label_text()))]
+        }
+        CommitsPanel::Unavailable => {
+            vec![Line::from(Span::styled(
+                "Commits unavailable",
+                label_text(),
+            ))]
+        }
+        CommitsPanel::Loaded(commits) if commits.is_empty() => {
+            vec![Line::from(Span::styled("No linked commits", label_text()))]
+        }
+        CommitsPanel::Loaded(commits) => commits
+            .iter()
+            .take(MAX_VISIBLE_COMMITS)
+            .map(commit_line)
+            .collect(),
+    }
+}
+
+fn commit_line(commit: &kanban_service::git::CommitRef) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{} ", commit.short_hash),
+            Style::default().fg(Color::Yellow),
+        ),
+        Span::styled("· ", label_text()),
+        Span::styled(commit.subject.clone(), normal_text()),
+        Span::raw("  "),
+        Span::styled(
+            commit.committed_at.format("%Y-%m-%d").to_string(),
+            label_text(),
+        ),
+    ])
+}
 
 pub fn build_title_lines(card: &Card) -> String {
     card.title.clone()

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -817,6 +817,7 @@ impl App {
                                     .children_list
                                     .update_item_count(children.len());
                                 self.push_mode(AppMode::CardDetail);
+                                self.refresh_card_commits();
                                 self.focus.card_focus = CardFocus::Title;
                             }
                         }
@@ -832,6 +833,7 @@ impl App {
                                     .children_list
                                     .update_item_count(children.len());
                                 self.push_mode(AppMode::CardDetail);
+                                self.refresh_card_commits();
                                 self.focus.card_focus = CardFocus::Title;
                             }
                         }
@@ -1130,6 +1132,7 @@ impl App {
         self.relationship
             .children_list
             .update_item_count(children.len());
+        self.refresh_card_commits();
     }
 
     fn related_card_ids(&self, side: RelationSide) -> Vec<uuid::Uuid> {

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -493,6 +493,7 @@ impl App {
                         .children_list
                         .update_item_count(children.len());
                     self.push_mode(AppMode::CardDetail);
+                    self.refresh_card_commits();
                 }
             }
         }

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -10,6 +10,14 @@ use uuid::Uuid;
 
 const RELATIONSHIP_BOX_HEIGHT: u16 = 7;
 const RELATIONSHIP_VIEWPORT_BORDER_HEIGHT: usize = 2;
+const COMMITS_BOX_HEIGHT: u16 = 6;
+
+fn render_commits_section(app: &App, frame: &mut Frame, area: Rect) {
+    let commits_config = FieldSectionConfig::new("Commits");
+    let commits =
+        Paragraph::new(build_commits_lines(&app.commits_panel)).block(commits_config.block());
+    frame.render_widget(commits, area);
+}
 
 pub(super) fn render_relationship_boxes(
     app: &App,
@@ -76,10 +84,11 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                 let child_count = children.len();
 
                 let constraints = vec![
-                    Constraint::Length(5),                       // Title
-                    Constraint::Length(6),                       // Metadata
-                    Constraint::Min(5),                          // Description
-                    Constraint::Length(RELATIONSHIP_BOX_HEIGHT), // Relationships
+                    Constraint::Length(5),                       // Title       -> chunks[0]
+                    Constraint::Length(6),                       // Metadata    -> chunks[1]
+                    Constraint::Min(5),                          // Description -> chunks[2]
+                    Constraint::Length(COMMITS_BOX_HEIGHT),      // Commits     -> chunks[3]
+                    Constraint::Length(RELATIONSHIP_BOX_HEIGHT), // Relations   -> chunks[4]
                 ];
 
                 let chunks = Layout::default()
@@ -126,11 +135,13 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                     let desc = Paragraph::new(desc_lines).block(desc_config.block());
                     frame.render_widget(desc, chunks[2]);
 
+                    render_commits_section(app, frame, chunks[3]);
+
                     // Render relationship boxes
                     render_relationship_boxes(
                         app,
                         frame,
-                        chunks[3],
+                        chunks[4],
                         &parents,
                         &children,
                         child_count,
@@ -153,11 +164,13 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                     let desc = Paragraph::new(desc_lines).block(desc_config.block());
                     frame.render_widget(desc, chunks[2]);
 
+                    render_commits_section(app, frame, chunks[3]);
+
                     // Render relationship boxes
                     render_relationship_boxes(
                         app,
                         frame,
-                        chunks[3],
+                        chunks[4],
                         &parents,
                         &children,
                         child_count,

--- a/crates/kanban-tui/tests/card_commits_tests.rs
+++ b/crates/kanban-tui/tests/card_commits_tests.rs
@@ -1,0 +1,160 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use kanban_domain::{Board, Card, Column, Snapshot};
+use kanban_service::git::{CommitRef, GitProvider};
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::app::CommitsPanel;
+
+struct FakeGitProvider {
+    commits: Vec<CommitRef>,
+    calls: Arc<AtomicUsize>,
+}
+impl GitProvider for FakeGitProvider {
+    fn commits_for_tag(&self, _tag: &str) -> kanban_domain::KanbanResult<Vec<CommitRef>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self.commits.clone())
+    }
+}
+
+struct ErrGitProvider;
+impl GitProvider for ErrGitProvider {
+    fn commits_for_tag(&self, _tag: &str) -> kanban_domain::KanbanResult<Vec<CommitRef>> {
+        Err(kanban_domain::KanbanError::Internal("boom".to_string()))
+    }
+}
+
+fn commit(hash: &str, subject: &str) -> CommitRef {
+    CommitRef {
+        short_hash: hash.into(),
+        subject: subject.into(),
+        author: "Dev".into(),
+        committed_at: chrono::Utc::now(),
+    }
+}
+
+fn setup_app_in_detail() -> kanban_tui::App {
+    let mut app = kanban_tui::App::test_default();
+
+    let mut board = Board::new("TestBoard", Some("KAN"));
+    let col = Column::new(board.id, "Backlog", 0);
+    let card = Card::new(&mut board, col.id, "Card Alpha", 0);
+    let board_id = board.id;
+    let card_id = card.id;
+
+    app.model.load_from_snapshot(Snapshot {
+        archived_boards: Vec::new(),
+        boards: vec![board],
+        columns: vec![col],
+        cards: vec![card],
+        ..Default::default()
+    });
+
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_card_id = Some(card_id);
+    app.mode = AppMode::CardDetail;
+    app
+}
+
+fn render_to_string(app: &mut kanban_tui::App) -> String {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| kanban_tui::ui::render(app, frame))
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
+}
+
+#[test]
+fn test_card_detail_renders_commits_from_provider() {
+    let mut app = setup_app_in_detail();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let seeded = vec![
+        commit("abc1234", "KAN-1 first"),
+        commit("def5678", "KAN-1 second"),
+    ];
+    app.set_git_provider(Some(Box::new(FakeGitProvider {
+        commits: seeded.clone(),
+        calls: calls.clone(),
+    })));
+
+    app.refresh_card_commits();
+    let rendered = render_to_string(&mut app);
+
+    assert_eq!(app.commits_panel, CommitsPanel::Loaded(seeded));
+    assert!(rendered.contains("abc1234"), "buffer missing first hash");
+    assert!(
+        rendered.contains("KAN-1 first"),
+        "buffer missing first subject"
+    );
+    assert!(rendered.contains("def5678"), "buffer missing second hash");
+    assert!(
+        rendered.contains("KAN-1 second"),
+        "buffer missing second subject"
+    );
+}
+
+#[test]
+fn test_card_detail_shows_no_commits_message_when_empty() {
+    let mut app = setup_app_in_detail();
+    let calls = Arc::new(AtomicUsize::new(0));
+    app.set_git_provider(Some(Box::new(FakeGitProvider {
+        commits: vec![],
+        calls,
+    })));
+
+    app.refresh_card_commits();
+    let rendered = render_to_string(&mut app);
+
+    assert_eq!(app.commits_panel, CommitsPanel::Loaded(vec![]));
+    assert!(rendered.contains("No linked commits"));
+}
+
+#[test]
+fn test_card_detail_shows_unavailable_when_no_repo() {
+    let mut app = setup_app_in_detail();
+    // No provider set -> git_provider None.
+
+    app.refresh_card_commits();
+    let rendered = render_to_string(&mut app);
+
+    assert_eq!(app.commits_panel, CommitsPanel::Unavailable);
+    assert!(rendered.contains("Commits unavailable"));
+}
+
+#[test]
+fn test_card_detail_shows_unavailable_when_provider_errors() {
+    let mut app = setup_app_in_detail();
+    app.set_git_provider(Some(Box::new(ErrGitProvider)));
+
+    app.refresh_card_commits();
+
+    assert_eq!(app.commits_panel, CommitsPanel::Unavailable);
+}
+
+#[test]
+fn test_commits_fetched_once_on_open_not_per_render() {
+    let mut app = setup_app_in_detail();
+    let calls = Arc::new(AtomicUsize::new(0));
+    app.set_git_provider(Some(Box::new(FakeGitProvider {
+        commits: vec![commit("abc1234", "KAN-1 x")],
+        calls: calls.clone(),
+    })));
+
+    app.refresh_card_commits();
+    let _ = render_to_string(&mut app);
+    let _ = render_to_string(&mut app);
+    let _ = render_to_string(&mut app);
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}

--- a/crates/kanban-tui/tests/card_commits_tests.rs
+++ b/crates/kanban-tui/tests/card_commits_tests.rs
@@ -1,8 +1,9 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use kanban_domain::{Board, Card, Column, Snapshot};
+use kanban_domain::{Board, Card, Column, CreateCardOptions, KanbanOperations, Snapshot};
 use kanban_service::git::{CommitRef, GitProvider};
+use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::app::CommitsPanel;
 
@@ -140,6 +141,74 @@ fn test_card_detail_shows_unavailable_when_provider_errors() {
     app.refresh_card_commits();
 
     assert_eq!(app.commits_panel, CommitsPanel::Unavailable);
+}
+
+/// Drives the REAL open path (Focus::Boards -> activate -> Focus::Cards ->
+/// activate) that a keypress would take, rather than poking `app.mode` and
+/// calling `refresh_card_commits()` directly. Proves the hook wired into
+/// `handle_selection_activate` (navigation_handlers.rs) actually fires.
+#[test]
+fn test_opening_card_detail_via_real_handler_fetches_commits() {
+    let mut app = kanban_tui::App::test_default();
+    let board = app
+        .ctx
+        .create_board("TestBoard".to_string(), Some("KAN".to_string()))
+        .unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Backlog".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card Alpha".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let expected = vec![commit("abc1234", "KAN-1 x")];
+    app.set_git_provider(Some(Box::new(FakeGitProvider {
+        commits: expected.clone(),
+        calls: calls.clone(),
+    })));
+
+    app.prepare_frame();
+    assert_eq!(
+        app.focus.active,
+        Focus::Boards,
+        "starts on the boards panel"
+    );
+    app.selection.board.set(Some(0));
+    app.handle_selection_activate();
+    assert_eq!(
+        app.focus.active,
+        Focus::Cards,
+        "board activation moves focus to cards"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "opening a BOARD must not fetch commits"
+    );
+
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+    app.handle_selection_activate();
+
+    assert_eq!(
+        app.mode,
+        AppMode::CardDetail,
+        "card activation opens detail"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "opening the card via the real handler must trigger exactly one git fetch"
+    );
+    assert_eq!(app.commits_panel, CommitsPanel::Loaded(expected));
 }
 
 #[test]


### PR DESCRIPTION
## What
Adds a read-only "Commits" section to the TUI card-detail view listing the git commits that implement the card, found by grepping commit messages for the card's KAN-N identifier.

Spans three crates (one leaf card each, under epic KAN-1037):
- KAN-1047 feat(domain): add `Card::identifier()` and refactor `branch_name` to reuse it
- KAN-1048 feat(service): `GitProvider` trait, `CommitRef`, `ShellGitProvider` (local `git log --grep`)
- KAN-1049 feat(service): client-side `repo_path` resolution (explicit, `KANBAN_REPO` env, cwd walk to `.git`)
- KAN-1050 feat(tui): the card-detail Commits section, fetched once on open

## Why
The tool already emits the KAN-N identifier into branch names but never reads it back. This closes the loop so a card shows the commits that implement it (the read direction of the existing branch-name feature). Read-only and additive, no board writes.

## How
- Card and git are linked only by the KAN-N string (no stored foreign key); linking greps that identifier.
- `ShellGitProvider` shells out to `git log` (std::process, no new deps), returns typed `CommitRef` values, and degrades to `Ok(empty)` on any absence (no repo, git missing, no match).
- The TUI caches the result in a `CommitsPanel` enum (NotLoaded / Loaded / Unavailable), fetched once when detail opens or the active card changes, never per render frame.
- Git stays out of `KanbanContext`; it is a sibling module composed at the app edge.

## Testing
- TDD throughout: 20 new tests across the three crates (domain identifier precedence; `ShellGitProvider` against a real temp git repo; `repo_path` resolution; TUI render and fetch-once with a hand-written fake provider).
- `cargo test` / `clippy -D warnings` / `fmt` green per crate.
- Validated end to end in a throwaway worktree spike before this PR: graceful absence, the fetch-once invariant (provider called once across three renders), and the three panel states, all confirmed by running the tests.

Out of scope (follow-ups tracked under KAN-1037): forge/remote providers, merged-status and git-to-column sync, CLI and MCP surfaces.
