### PR TITLE
KAN-1086 feat(domain,view): foundation for list search/filter/sort parity

### DIFF
--- a/.changeset/kan-1086.md
+++ b/.changeset/kan-1086.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Add generic Searcher<T>/FieldSearcher<T,F> (kanban-domain) and a search_and_sort composition helper (kanban-view), the foundation for the KAN-1086 list-parity effort. No observable behavior change yet.

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -67,7 +67,8 @@ pub use query::{
 pub use search::{
     find_boards_by_name, find_cards_by_identifier, find_columns_by_name,
     find_sprints_by_query_global, find_sprints_by_query_on_board, format_ambiguous_matches,
-    BranchNameSearcher, CardSearcher, CompositeSearcher, SearchBy, TitleSearcher,
+    BranchNameSearcher, CardSearcher, CompositeSearcher, FieldSearcher, SearchBy, Searcher,
+    TitleSearcher,
 };
 pub use snapshot::Snapshot;
 pub use sort::{

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -376,6 +376,49 @@ impl CardSearcher for CompositeSearcher {
     }
 }
 
+// ---- Generic, context-free searcher for TUI-only in-memory list surfaces ----
+//
+// Unlike `CardSearcher`, which needs `&Board`/`&[Sprint]` context to resolve
+// branch names and identifiers, these searchers only need the item itself.
+// For entities backed by a service-tier query/filter type (e.g. boards, via
+// `BoardListFilter`), search belongs there instead of here.
+
+/// Generic substring search over a single entity, independent of any
+/// card-specific context (board/sprints). For entities whose search is a
+/// plain "does this field contain the query" check.
+pub trait Searcher<T> {
+    /// Returns true if `item` matches the search criteria.
+    fn matches(&self, item: &T) -> bool;
+}
+
+/// A `Searcher<T>` that matches a case-insensitive substring against a field
+/// extracted by a closure.
+pub struct FieldSearcher<T, F: Fn(&T) -> &str> {
+    query: String,
+    field: F,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T, F: Fn(&T) -> &str> FieldSearcher<T, F> {
+    /// Create a new field searcher with the given query and field extractor.
+    pub fn new(query: impl Into<String>, field: F) -> Self {
+        Self {
+            query: query.into().to_lowercase(),
+            field,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, F: Fn(&T) -> &str> Searcher<T> for FieldSearcher<T, F> {
+    fn matches(&self, item: &T) -> bool {
+        if self.query.is_empty() {
+            return true;
+        }
+        (self.field)(item).to_lowercase().contains(&self.query)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -376,7 +376,7 @@ impl CardSearcher for CompositeSearcher {
     }
 }
 
-// ---- Generic, context-free searcher for TUI-only in-memory list surfaces ----
+// ---- Generic, context-free searcher for ephemeral view-layer list surfaces ----
 //
 // Unlike `CardSearcher`, which needs `&Board`/`&[Sprint]` context to resolve
 // branch names and identifiers, these searchers only need the item itself.

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -376,23 +376,13 @@ impl CardSearcher for CompositeSearcher {
     }
 }
 
-// ---- Generic, context-free searcher for ephemeral view-layer list surfaces ----
-//
-// Unlike `CardSearcher`, which needs `&Board`/`&[Sprint]` context to resolve
-// branch names and identifiers, these searchers only need the item itself.
-// For entities backed by a service-tier query/filter type (e.g. boards, via
-// `BoardListFilter`), search belongs there instead of here.
-
-/// Generic substring search over a single entity, independent of any
-/// card-specific context (board/sprints). For entities whose search is a
-/// plain "does this field contain the query" check.
+/// Trait for context-free substring search over a single entity.
 pub trait Searcher<T> {
     /// Returns true if `item` matches the search criteria.
     fn matches(&self, item: &T) -> bool;
 }
 
-/// A `Searcher<T>` that matches a case-insensitive substring against a field
-/// extracted by a closure.
+/// Matches a case-insensitive substring against a field extracted by a closure.
 pub struct FieldSearcher<T, F: Fn(&T) -> &str> {
     query: String,
     field: F,
@@ -400,7 +390,6 @@ pub struct FieldSearcher<T, F: Fn(&T) -> &str> {
 }
 
 impl<T, F: Fn(&T) -> &str> FieldSearcher<T, F> {
-    /// Create a new field searcher with the given query and field extractor.
     pub fn new(query: impl Into<String>, field: F) -> Self {
         Self {
             query: query.into().to_lowercase(),

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -994,4 +994,52 @@ mod tests {
         let result = find_sprints_by_query_on_board("13", &sprints, &board_a);
         assert!(result.is_empty());
     }
+
+    // ---- FieldSearcher<T, F> tests ----
+
+    struct Widget {
+        name: String,
+    }
+
+    #[test]
+    fn test_field_searcher_matches_case_insensitive_substring() {
+        let widget = Widget {
+            name: "In Progress".to_string(),
+        };
+        let searcher = FieldSearcher::new("progress", |w: &Widget| w.name.as_str());
+        assert!(searcher.matches(&widget));
+
+        let searcher = FieldSearcher::new("PROGRESS", |w: &Widget| w.name.as_str());
+        assert!(searcher.matches(&widget));
+    }
+
+    #[test]
+    fn test_field_searcher_empty_query_matches_everything() {
+        let widget = Widget {
+            name: "Anything".to_string(),
+        };
+        let searcher = FieldSearcher::new("", |w: &Widget| w.name.as_str());
+        assert!(searcher.matches(&widget));
+    }
+
+    #[test]
+    fn test_field_searcher_no_match_returns_false() {
+        let widget = Widget {
+            name: "Done".to_string(),
+        };
+        let searcher = FieldSearcher::new("todo", |w: &Widget| w.name.as_str());
+        assert!(!searcher.matches(&widget));
+    }
+
+    #[test]
+    fn test_field_searcher_matches_substring_anywhere_in_field() {
+        let widget = Widget {
+            name: "Code Review".to_string(),
+        };
+        let searcher = FieldSearcher::new("review", |w: &Widget| w.name.as_str());
+        assert!(searcher.matches(&widget));
+
+        let searcher = FieldSearcher::new("de rev", |w: &Widget| w.name.as_str());
+        assert!(searcher.matches(&widget));
+    }
 }

--- a/crates/kanban-view/src/lib.rs
+++ b/crates/kanban-view/src/lib.rs
@@ -12,6 +12,7 @@ pub mod filters;
 pub mod layout_strategy;
 pub mod list_component;
 pub mod list_nav;
+pub mod list_query;
 pub mod model;
 pub mod panel_titles;
 pub mod scroll_indicators;

--- a/crates/kanban-view/src/list_query.rs
+++ b/crates/kanban-view/src/list_query.rs
@@ -1,8 +1,3 @@
-/// Applies a search predicate then a sort comparator to a list of items,
-/// returning the filtered+ordered result. For ephemeral list surfaces with
-/// no service-tier query type behind them (column list, sprint
-/// browser/picker, relationship-picker candidates). Not for boards or
-/// cards, which have their own service-tier query pipelines.
 pub fn search_and_sort<T>(
     items: Vec<T>,
     matches: impl Fn(&T) -> bool,

--- a/crates/kanban-view/src/list_query.rs
+++ b/crates/kanban-view/src/list_query.rs
@@ -1,0 +1,57 @@
+/// Applies a search predicate then a sort comparator to a list of items,
+/// returning the filtered+ordered result. For ephemeral list surfaces with
+/// no service-tier query type behind them (column list, sprint
+/// browser/picker, relationship-picker candidates). Not for boards or
+/// cards, which have their own service-tier query pipelines.
+pub fn search_and_sort<T>(
+    items: Vec<T>,
+    matches: impl Fn(&T) -> bool,
+    compare: impl Fn(&T, &T) -> std::cmp::Ordering,
+) -> Vec<T> {
+    todo!("KAN-1088: implement search_and_sort")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Item {
+        name: &'static str,
+    }
+
+    fn item(name: &'static str) -> Item {
+        Item { name }
+    }
+
+    #[test]
+    fn test_search_and_sort_filters_non_matching_items() {
+        let items = vec![item("apple"), item("banana"), item("apricot")];
+
+        let result = search_and_sort(
+            items,
+            |i| i.name.starts_with('a'),
+            |a, b| a.name.cmp(b.name),
+        );
+
+        assert_eq!(result, vec![item("apple"), item("apricot")]);
+    }
+
+    #[test]
+    fn test_search_and_sort_orders_by_comparator() {
+        let items = vec![item("banana"), item("apple"), item("cherry")];
+
+        let result = search_and_sort(items, |_| true, |a, b| a.name.cmp(b.name));
+
+        assert_eq!(result, vec![item("apple"), item("banana"), item("cherry")]);
+    }
+
+    #[test]
+    fn test_search_and_sort_empty_input_returns_empty_output() {
+        let items: Vec<Item> = vec![];
+
+        let result = search_and_sort(items, |_| true, |a, b| a.name.cmp(b.name));
+
+        assert!(result.is_empty());
+    }
+}

--- a/crates/kanban-view/src/list_query.rs
+++ b/crates/kanban-view/src/list_query.rs
@@ -8,7 +8,9 @@ pub fn search_and_sort<T>(
     matches: impl Fn(&T) -> bool,
     compare: impl Fn(&T, &T) -> std::cmp::Ordering,
 ) -> Vec<T> {
-    todo!("KAN-1088: implement search_and_sort")
+    let mut filtered: Vec<T> = items.into_iter().filter(matches).collect();
+    filtered.sort_by(compare);
+    filtered
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Delivers KAN-1086 (Foundation sub-epic of the list-parity effort, KAN-1085) by shipping its two leaf cards: KAN-1087 and KAN-1088.

## What

- `kanban-domain`: a generic `Searcher<T>` trait plus `FieldSearcher<T, F>` (a case-insensitive substring searcher over a caller-supplied field), added alongside (not replacing) the existing `Card`-specific `CardSearcher`/`CompositeSearcher`. Both are re-exported from the crate root alongside their siblings.
- `kanban-view`: a `search_and_sort` composition helper in a new `list_query.rs` module.

Both are strictly additive infrastructure with no wiring into any UI surface yet, so there is no observable behavior change in this PR.

## Why

Several list surfaces in the TUI (board list, column list, sprint lists, relationship picker) need search/filter/sort parity with the card list, but have no shared, entity-agnostic primitive to build on. `Searcher<T>`/`FieldSearcher<T, F>` and `search_and_sort` are that primitive for the surfaces that have no service-tier query type behind them (column list, sprint lists, relationship-picker candidates). Board list search does not use this, it extends its own existing `BoardListFilter`/`filter_and_sort_boards` domain mirror directly (a separate, already-shared-with-CLI/MCP pattern), covered by a different card in the tree.

## How

- `kanban-domain/src/search/mod.rs`: `Searcher<T>` trait + `FieldSearcher<T, F: Fn(&T) -> &str>` impl, plus a crate-root re-export fix so it's reachable the same way every sibling searcher type already is. Zero lines removed from the file; `CardSearcher` and its four existing implementations (`TitleSearcher`, `BranchNameSearcher`, `CardIdentifierSearcher`, `CompositeSearcher`) are untouched.
- `kanban-view/src/list_query.rs` (new module): `search_and_sort<T>(items, matches, compare) -> Vec<T>`, a small filter-then-sort composition function.

This branch was originally authored against `kanban-tui` before rebasing onto latest `develop`, where KAN-1044 (#546 and preceding) extracted a renderer-agnostic `kanban-view` crate out of `kanban-tui` ("which cards belong in which list, in what order" per its README) in the meantime. `search_and_sort` is exactly the kind of code that crate now owns, so it moved there during the rebase rather than landing in `kanban-tui` and needing a follow-up move later.

Both pieces were first executed end-to-end in throwaway spike worktrees (one per card), each independently reviewed by a second agent with no shared context, and both passed with no rework needed before being reproduced here for the real PR. Two review findings from a subsequent PR review were folded in before this push: the missing crate-root re-export (above), and a redundant test in `list_query.rs` (`test_search_and_sort_empty_query_predicate_returns_all_items_sorted` was an exact duplicate of `test_search_and_sort_orders_by_comparator`, since `search_and_sort` has no concept of a "query" itself; consolidated down to 3 tests).

## Testing

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean, whole workspace
- `cargo test`: full workspace green, 173 `test result: ok` blocks, 0 failed
- Named tests: `test_field_searcher_matches_case_insensitive_substring`, `test_field_searcher_empty_query_matches_everything`, `test_field_searcher_no_match_returns_false`, `test_field_searcher_matches_substring_anywhere_in_field`, `test_search_and_sort_filters_non_matching_items`, `test_search_and_sort_orders_by_comparator`, `test_search_and_sort_empty_input_returns_empty_output`