### PR TITLE
KAN-1089 feat(view,domain,tui): board list search/scroll/multi-select parity with the card list

### DIFF
--- a/.changeset/kan-1089.md
+++ b/.changeset/kan-1089.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Board list gains search, ListComponent-backed scroll/selection state (Ctrl+D/Ctrl+U half-page jumps, more-above/below indicators), and real id-keyed multi-select wired into export. Board name search reaches CLI/MCP too via BoardListFilter.search.

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -38,6 +38,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                 },
                 sort: sort.map(|s| s.to_board_sort_field()),
                 sort_order: order.map(|o| o.to_sort_order()),
+                search: None,
             };
             let responses = match project_board_list(ctx, filter) {
                 Ok(r) => r,

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -72,6 +72,9 @@ pub struct BoardListFilter {
     pub sort: Option<BoardSortField>,
     /// Optional sort direction override, resolved alongside `sort`.
     pub sort_order: Option<SortOrder>,
+    /// Case-insensitive substring match against `Board.name`; empty string or
+    /// `None` is a no-op, mirroring `CardListFilter.search`'s semantics.
+    pub search: Option<String>,
 }
 
 fn allowed_column_ids(columns: &[Column], board_id: Option<Uuid>) -> Option<HashSet<Uuid>> {
@@ -215,18 +218,30 @@ pub fn resolve_board_sort(
     }
 }
 
+fn passes_board_search(board: &Board, query: Option<&str>) -> bool {
+    match query {
+        Some(q) if !q.is_empty() => board.name.to_lowercase().contains(&q.to_lowercase()),
+        _ => true,
+    }
+}
+
 /// Single filter + sort entry point for in-memory board slices, mirroring
 /// [`filter_and_sort_cards`]. Boards have no column/sprint predicates (their
 /// archival split is handled upstream at the service tier), so this is
-/// predominantly the sort: it resolves `(field, order)` via
-/// [`resolve_board_sort`] and applies the shared board sort primitive.
+/// predominantly search + sort: it filters by `filter.search` (a no-op when
+/// absent/empty), then resolves `(field, order)` via [`resolve_board_sort`]
+/// and applies the shared board sort primitive.
 pub fn filter_and_sort_boards(
     boards: &[Board],
     filter: &BoardListFilter,
     archived_at: &HashMap<Uuid, DateTime<Utc>>,
     default: Option<(BoardSortField, SortOrder)>,
 ) -> Vec<Board> {
-    let mut result: Vec<Board> = boards.to_vec();
+    let mut result: Vec<Board> = boards
+        .iter()
+        .filter(|b| passes_board_search(b, filter.search.as_deref()))
+        .cloned()
+        .collect();
     if let Some((field, order)) = resolve_board_sort(filter.sort, filter.sort_order, default) {
         sort_boards_in_place(&mut result, field, order, archived_at);
     }

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -446,4 +446,57 @@ mod tests {
         );
         assert_eq!(got, Some((BoardSortField::Position, SortOrder::Descending)));
     }
+
+    #[test]
+    fn test_filter_and_sort_boards_empty_search_returns_all_boards() {
+        let boards = vec![board_named("Alpha", 0), board_named("Beta", 1)];
+        let filter = BoardListFilter {
+            search: Some(String::new()),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_matches_case_insensitive_substring_of_name() {
+        let boards = vec![
+            board_named("Marketing Site", 0),
+            board_named("Backend API", 1),
+        ];
+        let filter = BoardListFilter {
+            search: Some("MARK".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
+        assert_eq!(names(&out), vec!["Marketing Site"]);
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_no_match_returns_empty() {
+        let boards = vec![board_named("Alpha", 0)];
+        let filter = BoardListFilter {
+            search: Some("zzz".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_filter_and_sort_boards_search_and_sort_compose() {
+        let boards = vec![
+            board_named("Zeta Project", 0),
+            board_named("Alpha Project", 1),
+            board_named("Zeta Archive", 2),
+        ];
+        let filter = BoardListFilter {
+            search: Some("zeta".to_string()),
+            sort: Some(BoardSortField::Name),
+            sort_order: Some(SortOrder::Ascending),
+            ..Default::default()
+        };
+        let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
+        assert_eq!(names(&out), vec!["Zeta Archive", "Zeta Project"]);
+    }
 }

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -71,6 +71,7 @@ impl KanbanMcpServer {
                 archived,
                 sort,
                 sort_order,
+                search: None,
             };
             Ok(ctx
                 .list_boards_filtered(filter)

--- a/crates/kanban-tui/src/app/defaults.rs
+++ b/crates/kanban-tui/src/app/defaults.rs
@@ -5,6 +5,7 @@ use super::{
     StorageBackendChoice, UiState, ViewState,
 };
 use kanban_core::InputState;
+use kanban_view::board_list::BoardList;
 use kanban_view::model::Model;
 use std::sync::{Arc, Mutex};
 
@@ -56,6 +57,7 @@ impl App {
             ctx,
             app_config,
             selection: SelectionHub::default(),
+            board_list: BoardList::new(),
             animation: AnimationState::default(),
             filter: FilterState::default(),
             dialog_input: DialogInputState::default(),

--- a/crates/kanban-tui/src/app/export_import.rs
+++ b/crates/kanban-tui/src/app/export_import.rs
@@ -5,12 +5,9 @@ use uuid::Uuid;
 
 impl App {
     pub fn export_board_with_filename(&self) -> io::Result<()> {
-        if let Some(board_idx) = self.selection.board.get() {
-            let board_id = self.displayed_boards().get(board_idx).map(|b| b.id);
-            if let Some(board_id) = board_id {
-                let export = self.build_boards_export(&[board_id])?;
-                BoardExporter::export_to_file(&export, self.input.as_str())?;
-            }
+        if let Some(board_id) = self.board_list.get_selected_board_id() {
+            let export = self.build_boards_export(&[board_id])?;
+            BoardExporter::export_to_file(&export, self.input.as_str())?;
         }
         Ok(())
     }
@@ -85,7 +82,10 @@ impl App {
                 return Ok(());
             }
 
-            self.selection.board.set(Some(first_new_index));
+            self.prepare_frame();
+            self.board_list
+                .inner_mut()
+                .set_selected_index(Some(first_new_index));
             self.switch_view_strategy(kanban_domain::TaskListView::GroupedByColumn);
             return Ok(());
         }
@@ -112,7 +112,10 @@ impl App {
             return Ok(());
         }
 
-        self.selection.board.set(Some(first_new_index));
+        self.prepare_frame();
+        self.board_list
+            .inner_mut()
+            .set_selected_index(Some(first_new_index));
         self.switch_view_strategy(kanban_domain::TaskListView::GroupedByColumn);
 
         Ok(())

--- a/crates/kanban-tui/src/app/file_io.rs
+++ b/crates/kanban-tui/src/app/file_io.rs
@@ -12,8 +12,8 @@ impl App {
         event_handler: &EventHandler,
         field: BoardField,
     ) -> io::Result<()> {
-        if let Some(board_idx) = self.selection.board.get() {
-            let board = self.displayed_boards().get(board_idx).cloned();
+        if let Some(board_id) = self.board_list.get_selected_board_id() {
+            let board = self.model.board_by_id(board_id).cloned();
             if let Some(board) = board {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -179,14 +179,20 @@ impl App {
     /// live one in detail/priority/move/sprint-assign. Terminal-free — edit
     /// (`e`), the only key that launches the external editor, is pre-intercepted
     /// in `handle_key_event` where the terminal is in scope.
-    fn handle_normal_key(&mut self, key_code: crossterm::event::KeyCode) {
+    pub(in crate::app) fn handle_normal_key(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
         match key_code {
             KeyCode::Char('/') => {
                 self.pending_key = None;
-                if self.focus.active == Focus::Cards {
-                    self.filter.search.activate();
-                    self.push_mode(AppMode::Search);
+                match self.focus.active {
+                    Focus::Cards => {
+                        self.filter.search.activate();
+                        self.push_mode(AppMode::Search);
+                    }
+                    Focus::Boards => {
+                        self.filter.board_search.activate();
+                        self.push_mode(AppMode::Search);
+                    }
                 }
             }
             KeyCode::Char('g') => {
@@ -416,18 +422,28 @@ impl App {
 
     pub fn handle_search_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
+        // Exactly one of `search` (cards) / `board_search` (boards) is active
+        // at a time — whichever `/` activated in `handle_normal_key` — so route
+        // input to that one. Keeping them as two independent `SearchState`s
+        // (rather than one shared field) means a board-name query can never
+        // leak into the tasks panel's card search, and vice versa.
+        let active = if self.filter.board_search.is_active {
+            &mut self.filter.board_search
+        } else {
+            &mut self.filter.search
+        };
         match key_code {
             KeyCode::Char(c) => {
-                self.filter.search.input.insert_char(c);
+                active.input.insert_char(c);
             }
             KeyCode::Backspace => {
-                self.filter.search.input.backspace();
+                active.input.backspace();
             }
             KeyCode::Enter => {
                 self.pop_mode();
             }
             KeyCode::Esc => {
-                self.filter.search.deactivate();
+                active.deactivate();
                 self.pop_mode();
             }
             _ => {}

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -558,15 +558,15 @@ impl App {
                 if let Err(e) = self.undo() {
                     self.set_error(format!("Undo failed: {e}"));
                 }
+                // `prepare_frame` resyncs `board_list`, clamping the highlight to
+                // the post-undo board set.
                 self.prepare_frame();
-                self.selection.board.clamp(self.displayed_boards().len());
             }
             KeyCode::Char('U') => {
                 if let Err(e) = self.redo() {
                     self.set_error(format!("Redo failed: {e}"));
                 }
                 self.prepare_frame();
-                self.selection.board.clamp(self.displayed_boards().len());
             }
             _ => {}
         }

--- a/crates/kanban-tui/src/app/input_router_tests.rs
+++ b/crates/kanban-tui/src/app/input_router_tests.rs
@@ -2,6 +2,21 @@ use super::*;
 use ratatui::layout::Rect;
 
 #[test]
+fn test_slash_key_activates_search_when_focus_is_boards() {
+    let mut app = App::test_default();
+    app.focus.active = Focus::Boards;
+
+    app.handle_normal_key(crossterm::event::KeyCode::Char('/'));
+
+    assert_eq!(app.mode, AppMode::Search);
+    assert!(app.filter.board_search.is_active);
+    assert!(
+        !app.filter.search.is_active,
+        "activating board search must not also activate card search"
+    );
+}
+
+#[test]
 fn test_scroll_help_into_view_scrolls_deep_item() {
     let mut app = App::test_default();
     app.view.last_frame_area = Rect {

--- a/crates/kanban-tui/src/app/lifecycle.rs
+++ b/crates/kanban-tui/src/app/lifecycle.rs
@@ -7,6 +7,7 @@ use super::{
 use crate::tui_context::TuiContext;
 use kanban_core::InputState;
 use kanban_service::StoreManager;
+use kanban_view::board_list::BoardList;
 use kanban_view::model::Model;
 use std::sync::{Arc, Mutex};
 
@@ -116,6 +117,7 @@ impl App {
             ctx,
             app_config,
             selection: SelectionHub::default(),
+            board_list: BoardList::new(),
             animation: AnimationState::default(),
             filter: FilterState::default(),
             dialog_input: DialogInputState::default(),

--- a/crates/kanban-tui/src/app/lifecycle_tests.rs
+++ b/crates/kanban-tui/src/app/lifecycle_tests.rs
@@ -1,6 +1,7 @@
 use super::types::default_store_manager;
 use super::*;
 use kanban_core::InputState;
+use kanban_view::board_list::BoardList;
 use kanban_view::model::Model;
 use std::sync::{Arc, Mutex};
 
@@ -70,6 +71,7 @@ async fn test_save_worker_does_not_send_completion_on_conflict() {
         ctx,
         app_config: kanban_core::AppConfig::default(),
         selection: SelectionHub::default(),
+        board_list: BoardList::new(),
         animation: AnimationState::default(),
         filter: FilterState::default(),
         dialog_input: DialogInputState::default(),

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -26,11 +26,10 @@ impl App {
         // Migration is a transparent startup operation, not a user change.
         // mark_clean so the startup flush doesn't trigger the conflict popup.
         self.ctx.mark_clean();
+        // `prepare_frame` resyncs `board_list`, which auto-selects the first
+        // board when none was previously highlighted and boards exist.
         self.prepare_frame();
         self.check_ended_sprints();
-        if self.selection.board.get().is_none() && self.model.live_boards().next().is_some() {
-            self.selection.board.set(Some(0));
-        }
     }
 
     pub async fn run(

--- a/crates/kanban-tui/src/app/multi_select.rs
+++ b/crates/kanban-tui/src/app/multi_select.rs
@@ -5,4 +5,6 @@ use uuid::Uuid;
 pub struct MultiSelectState {
     pub selected_cards: HashSet<Uuid>,
     pub selection_mode_active: bool,
+    pub selected_boards: HashSet<Uuid>,
+    pub board_selection_mode_active: bool,
 }

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -3,7 +3,6 @@ use std::cell::Cell;
 
 #[derive(Default)]
 pub struct SelectionHub {
-    pub board: SelectionState,
     /// The board the user is currently viewing/acting on, tracked by IDENTITY so
     /// it is archival-agnostic: it resolves through `Model::board_by_id`, which
     /// finds the board whether its head is live or archived. `None` while

--- a/crates/kanban-tui/src/app/types.rs
+++ b/crates/kanban-tui/src/app/types.rs
@@ -6,6 +6,7 @@ use crate::app::AppMode;
 use crate::tui_context::TuiContext;
 use kanban_core::{AppConfig, InputState};
 use kanban_service::StoreManager;
+use kanban_view::board_list::BoardList;
 use kanban_view::model::Model;
 use std::sync::{Arc, Mutex};
 
@@ -33,6 +34,7 @@ pub struct App {
     pub ctx: TuiContext,
     pub app_config: AppConfig,
     pub selection: SelectionHub,
+    pub board_list: BoardList,
     pub animation: AnimationState,
     pub filter: FilterState,
     pub dialog_input: DialogInputState,

--- a/crates/kanban-tui/src/app/types.rs
+++ b/crates/kanban-tui/src/app/types.rs
@@ -8,7 +8,9 @@ use kanban_core::{AppConfig, InputState};
 use kanban_service::StoreManager;
 use kanban_view::board_list::BoardList;
 use kanban_view::model::Model;
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
+use uuid::Uuid;
 
 /// Builds a `StoreManager` that mirrors the default CLI registry: SQLite
 /// first (so content-sniffing prefers it) and JSON second as a catch-all
@@ -115,6 +117,7 @@ pub enum ExportFormat {
 
 #[derive(Debug, Clone)]
 pub struct ExportDialogState {
+    pub board_ids: Vec<Uuid>,
     pub board_selections: Vec<bool>,
     pub cursor: usize,
     pub step: ExportStep,
@@ -123,9 +126,26 @@ pub struct ExportDialogState {
 }
 
 impl ExportDialogState {
-    pub fn new(board_count: usize) -> Self {
+    pub fn new(board_ids: Vec<Uuid>) -> Self {
+        Self::from_selection(&board_ids, &HashSet::new())
+    }
+
+    /// Seeds the dialog's checkboxes from `preselected` (the projects panel's
+    /// current multi-selection) when non-empty, else falls back to none
+    /// checked — today's "pick manually" default.
+    pub fn from_selection(all_live_board_ids: &[Uuid], preselected: &HashSet<Uuid>) -> Self {
+        let board_ids = all_live_board_ids.to_vec();
+        let board_selections = if preselected.is_empty() {
+            vec![false; board_ids.len()]
+        } else {
+            board_ids
+                .iter()
+                .map(|id| preselected.contains(id))
+                .collect()
+        };
         Self {
-            board_selections: vec![false; board_count],
+            board_ids,
+            board_selections,
             cursor: 0,
             step: ExportStep::SelectBoards,
             format: ExportFormat::default(),

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -26,14 +26,10 @@ impl App {
     /// projects set. Board-agnostic — resolves live OR archived boards uniformly,
     /// so board detail, sprints, and columns work identically for either.
     pub fn board_in_context(&self) -> Option<&Board> {
-        let id = match self.selection.active_board_id {
-            Some(id) => Some(id),
-            None => self
-                .selection
-                .board
-                .get()
-                .and_then(|idx| self.displayed_boards().get(idx).map(|b| b.id)),
-        }?;
+        let id = self
+            .selection
+            .active_board_id
+            .or_else(|| self.board_list.get_selected_board_id())?;
         self.model.board_by_id(id)
     }
 
@@ -88,12 +84,14 @@ impl App {
         // tasks preview tracks the cursor. The id is extracted and re-resolved by
         // id so the returned borrow is tied to `self.model`, not a temporary.
         let want_archived_boards = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
-        let highlighted_id: Option<Uuid> = self.selection.board.get().and_then(|idx| {
-            self.model
-                .displayed_boards(want_archived_boards)
-                .get(idx)
-                .map(|b| b.id)
-        });
+        let board_ids: Vec<Uuid> = self
+            .model
+            .displayed_boards(want_archived_boards)
+            .iter()
+            .map(|b| b.id)
+            .collect();
+        self.board_list.update_boards(board_ids);
+        let highlighted_id: Option<Uuid> = self.board_list.get_selected_board_id();
         let board_id: Option<Uuid> = self.selection.active_board_id.or(highlighted_id);
         let board: Option<&Board> = board_id.and_then(|id| self.model.board_by_id(id));
 

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -1,7 +1,8 @@
 use super::{App, AppMode};
 use crate::view_strategy::UnifiedViewStrategy;
-use kanban_domain::{Board, Card, KanbanResult};
+use kanban_domain::{filter_and_sort_boards, Board, BoardListFilter, Card, KanbanResult};
 use kanban_view::view_strategy::{ViewRefreshContext, ViewStrategy};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 impl App {
@@ -52,12 +53,23 @@ impl App {
     ///
     /// Stack-aware: the choice keys off `get_base_mode()`, not the raw `mode`, so
     /// a confirm dialog opened over the archived view (mode == Dialog(..)) still
-    /// resolves the archived heads — the underlay-bug fix. Returns a BORROW of
-    /// the partition cached on `load_from_snapshot`, eliminating the per-redraw
-    /// clone the interim owned-Vec form carried.
-    pub fn displayed_boards(&self) -> &[Board] {
+    /// resolves the archived heads — the underlay-bug fix. Applies the projects
+    /// panel's own search query (`filter.board_search`) via the shared domain
+    /// filter engine on top of the cached, already-sorted model partition, so
+    /// callers that mutate the board sort directly (e.g. `apply_board_sort`)
+    /// see it reflected here without needing a `prepare_frame` round-trip —
+    /// matching the pre-search behavior of this accessor. Owned `Vec<Board>`
+    /// rather than a borrow because the search filter must run fresh on every
+    /// call (board counts are small; this mirrors how card search re-filters
+    /// per redraw).
+    pub fn displayed_boards(&self) -> Vec<Board> {
         let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
-        self.model.displayed_boards(want_archived)
+        let boards = self.model.displayed_boards(want_archived);
+        let filter = BoardListFilter {
+            search: self.filter.board_search.active_query().map(str::to_string),
+            ..Default::default()
+        };
+        filter_and_sort_boards(boards, &filter, &HashMap::new(), None)
     }
 
     pub fn prepare_frame(&mut self) {
@@ -83,13 +95,7 @@ impl App {
         // base-mode-selected subset the projects panel indexes into — so the
         // tasks preview tracks the cursor. The id is extracted and re-resolved by
         // id so the returned borrow is tied to `self.model`, not a temporary.
-        let want_archived_boards = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
-        let board_ids: Vec<Uuid> = self
-            .model
-            .displayed_boards(want_archived_boards)
-            .iter()
-            .map(|b| b.id)
-            .collect();
+        let board_ids: Vec<Uuid> = self.displayed_boards().iter().map(|b| b.id).collect();
         self.board_list.update_boards(board_ids);
         let highlighted_id: Option<Uuid> = self.board_list.get_selected_board_id();
         let board_id: Option<Uuid> = self.selection.active_board_id.or(highlighted_id);

--- a/crates/kanban-tui/src/components/footer.rs
+++ b/crates/kanban-tui/src/components/footer.rs
@@ -1,5 +1,6 @@
 use crate::app::{App, AppMode};
 use crate::theme::*;
+use kanban_view::search::SearchState;
 use ratatui::{
     layout::Rect,
     style::{Color, Style},
@@ -8,9 +9,23 @@ use ratatui::{
     Frame,
 };
 
+/// Whichever `SearchState` is actually active — `board_search` (the projects
+/// panel) or `search` (the tasks panel) — mirroring the routing
+/// `handle_search_mode` (`app/input_router.rs`) already uses to decide which
+/// field typed keystrokes go to. At most one of the two is active at a time.
+fn active_search(app: &App) -> Option<&SearchState> {
+    if app.filter.board_search.is_active {
+        Some(&app.filter.board_search)
+    } else if app.filter.search.is_active {
+        Some(&app.filter.search)
+    } else {
+        None
+    }
+}
+
 pub fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
-    if app.filter.search.is_active && app.mode != AppMode::Search {
-        let search_text = format!("/{}", app.filter.search.query());
+    if let Some(search) = active_search(app).filter(|_| app.mode != AppMode::Search) {
+        let search_text = format!("/{}", search.query());
         let help_text = "j/k: navigate | ESC: clear";
 
         let available_width = area.width.saturating_sub(4);
@@ -40,7 +55,8 @@ pub fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
     }
 
     if app.mode == AppMode::Search {
-        let search_text = format!("/{}", app.filter.search.query());
+        let query = active_search(app).map(SearchState::query).unwrap_or("");
+        let search_text = format!("/{query}");
         let help_text = "ESC: clear | Enter: apply";
 
         let available_width = area.width.saturating_sub(4);

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -23,6 +23,36 @@ impl BoardDeleteCounts {
 }
 
 impl App {
+    pub fn handle_board_selection_toggle(&mut self) {
+        if self.focus.active == Focus::Boards {
+            if self.multi_select.board_selection_mode_active {
+                self.multi_select.board_selection_mode_active = false;
+            } else {
+                self.multi_select.board_selection_mode_active = true;
+                if let Some(board_id) = self.board_list.get_selected_board_id() {
+                    self.multi_select.selected_boards.insert(board_id);
+                }
+            }
+        }
+    }
+
+    pub fn handle_clear_board_selection(&mut self) {
+        self.multi_select.selected_boards.clear();
+    }
+
+    pub fn handle_select_all_boards_in_view(&mut self) {
+        if self.focus.active != Focus::Boards {
+            return;
+        }
+
+        for &id in self.board_list.ids() {
+            self.multi_select.selected_boards.insert(id);
+        }
+        if !self.board_list.is_empty() {
+            self.multi_select.board_selection_mode_active = true;
+        }
+    }
+
     pub fn handle_create_board_key(&mut self) {
         if self.focus.active == Focus::Boards {
             self.open_dialog(DialogMode::CreateBoard);

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -33,10 +33,10 @@ impl App {
     pub fn handle_rename_board_key(&mut self) {
         if self.focus.active == Focus::Boards {
             if let Some(name) = self
-                .selection
-                .board
-                .get()
-                .and_then(|idx| self.displayed_boards().get(idx).map(|b| b.name.clone()))
+                .board_list
+                .get_selected_board_id()
+                .and_then(|id| self.model.board_by_id(id))
+                .map(|b| b.name.clone())
             {
                 self.input.set(name);
                 self.open_dialog(DialogMode::RenameBoard);
@@ -49,12 +49,7 @@ impl App {
             // Opening a board's detail makes it THE active board (by id), from
             // the currently displayed set — live or archived alike. Every detail
             // view then resolves it archival-agnostically via `active_board`.
-            if let Some(board_id) = self
-                .selection
-                .board
-                .get()
-                .and_then(|idx| self.displayed_boards().get(idx).map(|b| b.id))
-            {
+            if let Some(board_id) = self.board_list.get_selected_board_id() {
                 self.selection.active_board_id = Some(board_id);
                 self.push_mode(AppMode::BoardDetail);
                 self.focus.board_focus = BoardFocus::Name;
@@ -63,21 +58,20 @@ impl App {
     }
 
     pub fn handle_export_board_key(&mut self) {
-        if self.focus.active == Focus::Boards && self.selection.board.get().is_some() {
-            if let Some(board_idx) = self.selection.board.get() {
-                if let Some(board_name) = self
-                    .displayed_boards()
-                    .get(board_idx)
-                    .map(|b| b.name.clone())
-                {
-                    let filename = format!(
-                        "{}-{}.json",
-                        board_name.replace(" ", "-").to_lowercase(),
-                        chrono::Utc::now().format("%Y%m%d-%H%M%S")
-                    );
-                    self.input.set(filename);
-                    self.open_dialog(DialogMode::ExportBoard);
-                }
+        if self.focus.active == Focus::Boards {
+            if let Some(board_name) = self
+                .board_list
+                .get_selected_board_id()
+                .and_then(|id| self.model.board_by_id(id))
+                .map(|b| b.name.clone())
+            {
+                let filename = format!(
+                    "{}-{}.json",
+                    board_name.replace(" ", "-").to_lowercase(),
+                    chrono::Utc::now().format("%Y%m%d-%H%M%S")
+                );
+                self.input.set(filename);
+                self.open_dialog(DialogMode::ExportBoard);
             }
         }
     }
@@ -105,14 +99,11 @@ impl App {
 
     pub fn handle_delete_board_key(&mut self) {
         if self.focus.active == Focus::Boards {
-            if let Some(idx) = self.selection.board.get() {
-                if let Some(board_id) = self.displayed_boards().get(idx).map(|b| b.id) {
-                    // Snapshot the counts once, here, rather than re-scanning the
-                    // model on every frame the modal is open.
-                    self.dialog_input.board_delete_counts =
-                        Some(self.board_delete_counts(board_id));
-                    self.open_dialog(DialogMode::DeleteBoardConfirm);
-                }
+            if let Some(board_id) = self.board_list.get_selected_board_id() {
+                // Snapshot the counts once, here, rather than re-scanning the
+                // model on every frame the modal is open.
+                self.dialog_input.board_delete_counts = Some(self.board_delete_counts(board_id));
+                self.open_dialog(DialogMode::DeleteBoardConfirm);
             }
         }
     }
@@ -175,12 +166,10 @@ impl App {
     /// deleted. The selection bookkeeping below is identical to a live removal —
     /// the board simply leaves the live list.
     pub fn delete_board(&mut self) {
-        let Some(idx) = self.selection.board.get() else {
+        let Some(board_id) = self.board_list.get_selected_board_id() else {
             return;
         };
-        let Some(board_id) = self.displayed_boards().get(idx).map(|b| b.id) else {
-            return;
-        };
+        let idx = self.board_list.get_selected_index().unwrap_or(0);
         let remaining_after = self.model.live_boards().count().saturating_sub(1);
 
         if let Err(e) = self.ctx.archive_board(board_id) {
@@ -190,11 +179,16 @@ impl App {
         }
         tracing::info!("Archived board {}", board_id);
 
-        // Highlight (selection.board): clamp to the surviving range, or clear.
+        // Highlight: clamp to the surviving range, or clear. Set directly on
+        // `board_list` (rather than relying on the next `prepare_frame` resync,
+        // which preserves by IDENTITY) because archiving must land on the same
+        // POSITION the removed board vacated, not jump to the first board.
         if remaining_after == 0 {
-            self.selection.board.clear();
+            self.board_list.inner_mut().set_selected_index(None);
         } else {
-            self.selection.board.set(Some(idx.min(remaining_after - 1)));
+            self.board_list
+                .inner_mut()
+                .set_selected_index(Some(idx.min(remaining_after - 1)));
         }
 
         // Active/viewed board: tracked by IDENTITY, so it is naturally stable
@@ -263,20 +257,17 @@ impl App {
                 // Toggling the displayed set returns to the projects list; any
                 // board that was open is no longer active.
                 self.selection.active_board_id = None;
+                // `prepare_frame` resyncs `board_list` from the new (archived)
+                // partition; the previously highlighted live board's id is not in
+                // it, so `BoardList::update_boards` falls back to the first
+                // archived board (or `None` if empty) on its own.
                 self.prepare_frame();
-                // Select the first archived board (if any). In ArchivedBoardsView
-                // `displayed_boards()` is the archived subset of the unified
-                // collection.
-                let has_any = !self.displayed_boards().is_empty();
-                self.selection.board.set(has_any.then_some(0));
                 self.needs_redraw = true;
             }
             AppMode::ArchivedBoardsView => {
                 self.mode = AppMode::Normal;
                 self.selection.active_board_id = None;
                 self.prepare_frame();
-                let has_any = self.model.live_boards().next().is_some();
-                self.selection.board.set(has_any.then_some(0));
                 self.needs_redraw = true;
             }
             _ => {}
@@ -313,9 +304,8 @@ impl App {
             return;
         }
         let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
-        let highlighted_id = self.highlighted_board_id();
         self.model.toggle_board_sort_order(want_archived);
-        self.repin_board_selection(highlighted_id);
+        self.repin_board_selection();
         if !want_archived {
             self.persist_board_sort();
         }
@@ -323,38 +313,26 @@ impl App {
     }
 
     /// The archived board currently highlighted in the ArchivedBoardsView.
-    /// Resolves against the archived subset of the unified collection directly
-    /// (not `displayed_boards`, which is transiently the LIVE set while a confirm
-    /// dialog is open on top of the archived view).
+    /// `board_list` is synced against the same archived partition
+    /// `archived_boards_view` reads, so its selection resolves directly by id —
+    /// no index re-lookup.
     fn selected_archived_board_id(&self) -> Option<uuid::Uuid> {
-        let idx = self.selection.board.get()?;
-        self.model.archived_boards_view().nth(idx).map(|b| b.id)
+        self.board_list.get_selected_board_id()
     }
 
-    /// The board currently highlighted in the projects panel, resolved against
-    /// the partition the panel is showing (archived under the archived view,
-    /// live otherwise) via the stack-aware base mode.
-    fn highlighted_board_id(&self) -> Option<uuid::Uuid> {
+    /// Re-sync `board_list` from the current sort order and re-select the
+    /// board it already had highlighted (by id), so render and selection stay
+    /// pinned to the same project across a re-sort; falls back to the first
+    /// entry when that board is no longer present in the resorted set.
+    fn repin_board_selection(&mut self) {
         let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
-        let idx = self.selection.board.get()?;
-        self.model
+        let ids: Vec<uuid::Uuid> = self
+            .model
             .displayed_boards(want_archived)
-            .get(idx)
+            .iter()
             .map(|b| b.id)
-    }
-
-    /// Re-resolve the highlight to the same board's new index after a re-sort, so
-    /// render and selection stay pinned to the same project; clamps to the first
-    /// entry when the previously highlighted board is not present.
-    fn repin_board_selection(&mut self, highlighted_id: Option<uuid::Uuid>) {
-        let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
-        let boards = self.model.displayed_boards(want_archived);
-        let new_idx = highlighted_id.and_then(|id| boards.iter().position(|b| b.id == id));
-        let count = boards.len();
-        self.selection.board.set(match new_idx {
-            Some(idx) => Some(idx),
-            None => (count > 0).then_some(0),
-        });
+            .collect();
+        self.board_list.update_boards(ids);
     }
 
     /// Persist the LIVE board-list sort field/order to AppConfig via
@@ -394,9 +372,8 @@ impl App {
         order: kanban_domain::SortOrder,
     ) {
         let want_archived = matches!(self.get_base_mode(), AppMode::ArchivedBoardsView);
-        let highlighted_id = self.highlighted_board_id();
         self.model.set_board_sort(want_archived, field, order);
-        self.repin_board_selection(highlighted_id);
+        self.repin_board_selection();
         if !want_archived {
             self.persist_board_sort();
         }
@@ -412,6 +389,7 @@ impl App {
         let Some(board_id) = self.selected_archived_board_id() else {
             return;
         };
+        let idx = self.board_list.get_selected_index().unwrap_or(0);
         if let Err(e) = self.ctx.restore_board(board_id) {
             tracing::error!("Failed to restore board: {}", e);
             self.set_error(format!("Failed to restore board: {}", e));
@@ -426,11 +404,12 @@ impl App {
             self.selection.active_board_id = None;
         }
         self.prepare_frame();
-        // Clamp the highlight to the shrunken archived list.
+        // Clamp the highlight to the shrunken archived list, preserving
+        // position (not identity — the removed board no longer exists there).
         let remaining = self.model.archived_boards_view().count();
-        self.selection.board.set(
-            (remaining > 0).then(|| self.selection.board.get().unwrap_or(0).min(remaining - 1)),
-        );
+        self.board_list
+            .inner_mut()
+            .set_selected_index((remaining > 0).then(|| idx.min(remaining - 1)));
         self.needs_redraw = true;
     }
 
@@ -440,6 +419,7 @@ impl App {
         let Some(board_id) = self.selected_archived_board_id() else {
             return;
         };
+        let idx = self.board_list.get_selected_index().unwrap_or(0);
         if let Err(e) = self.ctx.delete_board(board_id) {
             tracing::error!("Failed to delete archived board: {}", e);
             self.set_error(format!("Failed to delete archived board: {}", e));
@@ -448,9 +428,9 @@ impl App {
         tracing::info!("Permanently deleted archived board {}", board_id);
         self.prepare_frame();
         let remaining = self.model.archived_boards_view().count();
-        self.selection.board.set(
-            (remaining > 0).then(|| self.selection.board.get().unwrap_or(0).min(remaining - 1)),
-        );
+        self.board_list
+            .inner_mut()
+            .set_selected_index((remaining > 0).then(|| idx.min(remaining - 1)));
         self.needs_redraw = true;
     }
 
@@ -459,7 +439,6 @@ impl App {
 
         let board_id = uuid::Uuid::new_v4();
         let position = self.model.live_boards().count() as i32;
-        let new_index = position as usize;
 
         let mut commands: Vec<Command> = vec![Command::Board(BoardCommand::Create(CreateBoard {
             id: board_id,
@@ -487,32 +466,33 @@ impl App {
 
         tracing::info!("Created board: {} (id: {})", board_name, board_id);
 
-        self.selection.board.set(Some(new_index));
+        // Resync `board_list` from the store so the new board is present, then
+        // select it by id (known up front — it was generated above).
+        self.prepare_frame();
+        self.board_list.select_board(board_id);
         self.switch_view_strategy(TaskListView::default());
     }
 
     pub fn rename_board(&mut self) {
-        if let Some(idx) = self.selection.board.get() {
-            if let Some(board_id) = self.displayed_boards().get(idx).map(|b| b.id) {
-                let new_name = self.input.as_str().to_string();
+        if let Some(board_id) = self.board_list.get_selected_board_id() {
+            let new_name = self.input.as_str().to_string();
 
-                // Execute UpdateBoard command
-                let cmd = Command::Board(BoardCommand::Update(UpdateBoard {
-                    board_id,
-                    updates: BoardUpdate {
-                        name: Some(new_name.clone()),
-                        ..Default::default()
-                    },
-                }));
+            // Execute UpdateBoard command
+            let cmd = Command::Board(BoardCommand::Update(UpdateBoard {
+                board_id,
+                updates: BoardUpdate {
+                    name: Some(new_name.clone()),
+                    ..Default::default()
+                },
+            }));
 
-                if let Err(e) = self.execute_command(cmd) {
-                    tracing::error!("Failed to rename board: {}", e);
-                    self.set_error(format!("Failed to rename board: {}", e));
-                    return;
-                }
-
-                tracing::info!("Renamed board to: {}", new_name);
+            if let Err(e) = self.execute_command(cmd) {
+                tracing::error!("Failed to rename board: {}", e);
+                self.set_error(format!("Failed to rename board: {}", e));
+                return;
             }
+
+            tracing::info!("Renamed board to: {}", new_name);
         }
     }
 
@@ -545,11 +525,11 @@ mod tests {
         BoardUpdate, CreateCardOptions, KanbanOperations, SortOrder, TaskListView,
     };
 
-    /// Pull the store snapshot into `app.model` so handlers that read
-    /// `self.model` observe prior writes (the event loop does this per frame).
+    /// Pull the store snapshot into `app.model` and resync `app.board_list` so
+    /// handlers that read either observe prior writes (the event loop does
+    /// this per frame via `prepare_frame`).
     fn refresh(app: &mut App) {
-        let snap = app.ctx.snapshot().unwrap();
-        app.model.load_from_snapshot(snap);
+        app.prepare_frame();
     }
 
     fn create_named_board(app: &mut App, name: &str) {
@@ -575,7 +555,7 @@ mod tests {
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         app.handle_delete_board_key();
 
@@ -588,7 +568,7 @@ mod tests {
         create_named_board(&mut app, "Roadmap");
         let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         app.open_dialog(DialogMode::DeleteBoardConfirm);
 
         app.handle_delete_board_confirm_popup(KeyCode::Enter);
@@ -617,7 +597,7 @@ mod tests {
             .unwrap();
         refresh(&mut app);
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         app.delete_board();
 
@@ -697,7 +677,7 @@ mod tests {
             create_named_board(&mut app, "Roadmap");
             let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
             app.focus.active = Focus::Boards;
-            app.selection.board.set(Some(0));
+            app.board_list.inner_mut().set_selected_index(Some(0));
             app.open_dialog(DialogMode::DeleteBoardConfirm);
 
             app.handle_delete_board_confirm_popup(cancel_key);
@@ -732,7 +712,7 @@ mod tests {
             .unwrap();
         refresh(&mut app);
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         app.delete_board();
 
         app.undo().unwrap();
@@ -764,24 +744,28 @@ mod tests {
         create_named_board(&mut app, "B");
         create_named_board(&mut app, "C");
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(2));
+        app.board_list.inner_mut().set_selected_index(Some(2));
 
         app.delete_board();
         refresh(&mut app);
         assert_eq!(
-            app.selection.board.get(),
+            app.board_list.get_selected_index(),
             Some(1),
             "clamped to last survivor"
         );
 
         // Delete the remaining two; selection must clear at zero.
-        app.selection.board.set(Some(1));
+        app.board_list.inner_mut().set_selected_index(Some(1));
         app.delete_board();
         refresh(&mut app);
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         app.delete_board();
         refresh(&mut app);
-        assert_eq!(app.selection.board.get(), None, "selection cleared at zero");
+        assert_eq!(
+            app.board_list.get_selected_index(),
+            None,
+            "selection cleared at zero"
+        );
         assert!(app.ctx.data_store().list_boards().unwrap().is_empty());
     }
 
@@ -862,7 +846,7 @@ mod tests {
         // Viewing A; highlight is on D (index 3).
         app.selection.active_board_id = Some(a_id);
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(3));
+        app.board_list.inner_mut().set_selected_index(Some(3));
 
         app.delete_board();
         refresh(&mut app);
@@ -886,7 +870,7 @@ mod tests {
         let c_id = app.model.boards()[2].id;
         app.selection.active_board_id = Some(c_id); // viewing C
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0)); // highlight A
+        app.board_list.inner_mut().set_selected_index(Some(0)); // highlight A
 
         app.delete_board(); // archive A (before the active one)
         refresh(&mut app);
@@ -907,7 +891,7 @@ mod tests {
         let b_id = app.model.boards()[1].id;
         app.selection.active_board_id = Some(b_id); // viewing B
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(1)); // highlight B (the active board)
+        app.board_list.inner_mut().set_selected_index(Some(1)); // highlight B (the active board)
 
         app.delete_board();
 
@@ -936,7 +920,7 @@ mod tests {
         refresh(&mut app);
         app.selection.active_board_id = Some(a_id); // viewing A
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(1)); // highlight B
+        app.board_list.inner_mut().set_selected_index(Some(1)); // highlight B
 
         app.delete_board(); // delete B; A survives as the viewed board
 
@@ -968,7 +952,7 @@ mod tests {
         refresh(&mut app);
         app.selection.active_board_id = Some(c_id); // viewing C
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0)); // highlight A (before C)
+        app.board_list.inner_mut().set_selected_index(Some(0)); // highlight A (before C)
 
         app.delete_board(); // archive A; C survives, unchanged id
 
@@ -985,7 +969,7 @@ mod tests {
         create_named_board(&mut app, "Solo");
         app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         // Simulate a populated cards panel.
         app.view
             .card_list_component
@@ -1007,7 +991,7 @@ mod tests {
         create_named_board(&mut app, "Roadmap");
         let board_id = app.model.boards()[0].id;
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         app.handle_delete_board_key();
         assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeleteBoardConfirm));
 
@@ -1041,7 +1025,7 @@ mod tests {
             .unwrap();
         refresh(&mut app);
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         assert_eq!(
             app.dialog_input.board_delete_counts, None,
@@ -1107,7 +1091,7 @@ mod tests {
         app.mode = AppMode::ArchivedBoardsView;
         app.prepare_frame();
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         app.handle_selection_activate();
     }
 
@@ -1231,7 +1215,7 @@ mod tests {
         app.mode = AppMode::ArchivedBoardsView;
         app.prepare_frame();
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         // `x` opens the confirm dialog rather than deleting immediately.
         app.handle_archived_boards_view_mode(KeyCode::Char('x'));
@@ -1286,7 +1270,7 @@ mod tests {
         app.mode = AppMode::ArchivedBoardsView;
         app.prepare_frame();
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         app.handle_archived_boards_view_mode(KeyCode::Char('x'));
         app.handle_delete_permanent_board_confirm_popup(KeyCode::Esc);
@@ -1398,7 +1382,7 @@ mod tests {
         // Name preference.
         app.mode = AppMode::ArchivedBoardsView;
         app.prepare_frame();
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
         assert_eq!(
             rendered,
@@ -1407,7 +1391,7 @@ mod tests {
         );
 
         // Toggle order via the shared 's' while viewing the archived list.
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         app.handle_archived_boards_view_mode(KeyCode::Char('s'));
 
         // Recency ASC → oldest (Arch1) first: only the archived partition moved.
@@ -1454,7 +1438,7 @@ mod tests {
         app.focus.active = Focus::Boards;
         app.selection.active_board_id = None;
         app.prepare_frame();
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         let live_before: Vec<String> = app
             .displayed_boards()
             .iter()
@@ -1470,7 +1454,7 @@ mod tests {
         // within the archived view.
         app.mode = AppMode::ArchivedBoardsView;
         app.prepare_frame();
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         app.handle_archived_boards_view_mode(KeyCode::Char('o'));
         let name_idx = popup_index_of_board_sort_field(kanban_domain::BoardSortField::Name);
         app.filter.board_sort_field_selection.set(Some(name_idx));
@@ -1511,7 +1495,7 @@ mod tests {
         app.mode = AppMode::ArchivedBoardsView;
         app.prepare_frame();
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         // Open the picker over the archived view.
         app.handle_archived_boards_view_mode(KeyCode::Char('o'));
@@ -1549,7 +1533,7 @@ mod tests {
         app.mode = AppMode::Normal;
         app.focus.active = Focus::Boards;
         app.selection.active_board_id = None;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         // Open the picker via the live-panel `o` handler.
         app.handle_order_boards_key();
@@ -1619,7 +1603,7 @@ mod tests {
         // Sanity: sort still fires when browsing the list (no active board).
         app.selection.active_board_id = None;
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
         app.handle_toggle_board_sort_order();
         assert_eq!(
             app.model.board_sort(true).1,
@@ -1645,7 +1629,7 @@ mod tests {
         // Drill into an archived board: active id set, focus on the tasks panel.
         app.selection.active_board_id = Some(arch1);
         app.focus.active = Focus::Cards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         let archived_before = app.ctx.list_archived_boards().unwrap().len();
         app.handle_archived_boards_view_mode(KeyCode::Char('x'));
@@ -1684,7 +1668,7 @@ mod tests {
 
         app.selection.active_board_id = Some(arch1);
         app.focus.active = Focus::Cards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         let archived_before = app.ctx.list_archived_boards().unwrap().len();
         app.handle_archived_boards_view_mode(KeyCode::Char('r'));

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -475,17 +475,14 @@ impl App {
                     let current_idx = self.dialog_input.column_selection.get().unwrap_or(0);
                     if current_idx == 0 {
                         let sprint_count = self
-                            .selection
-                            .board
-                            .get()
-                            .and_then(|idx| {
-                                self.displayed_boards().get(idx).map(|board| {
-                                    self.model
-                                        .sprints()
-                                        .iter()
-                                        .filter(|s| s.board_id == board.id)
-                                        .count()
-                                })
+                            .board_list
+                            .get_selected_board_id()
+                            .map(|board_id| {
+                                self.model
+                                    .sprints()
+                                    .iter()
+                                    .filter(|s| s.board_id == board_id)
+                                    .count()
                             })
                             .unwrap_or(0);
                         if sprint_count == 0 {

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -353,7 +353,7 @@ impl App {
     pub fn handle_navigation_down(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                self.selection.board.next(self.displayed_board_count());
+                self.board_list.navigate_down();
                 if self.mode != AppMode::ArchivedBoardsView {
                     self.switch_view_strategy(TaskListView::GroupedByColumn);
                 }
@@ -401,7 +401,7 @@ impl App {
     pub fn handle_navigation_up(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                self.selection.board.prev();
+                self.board_list.navigate_up();
                 if self.mode != AppMode::ArchivedBoardsView {
                     self.switch_view_strategy(TaskListView::GroupedByColumn);
                 }
@@ -452,9 +452,9 @@ impl App {
                 // panel currently displays (live OR archived) — a board is a
                 // board. From here on it is THE active board, tracked by id, and
                 // every view/operation resolves it archival-agnostically.
-                let activated = self.selection.board.get().and_then(|idx| {
-                    self.displayed_boards()
-                        .get(idx)
+                let activated = self.board_list.get_selected_board_id().and_then(|id| {
+                    self.model
+                        .board_by_id(id)
                         .map(|b| (b.id, b.task_list_view, b.task_sort_field, b.task_sort_order))
                 });
 
@@ -533,13 +533,6 @@ impl App {
         false
     }
 
-    /// Number of boards currently shown in the projects panel. Used to bound
-    /// j/k/G navigation. Delegates to `displayed_boards` (the sole consumption
-    /// site that chooses which set the panel shows).
-    fn displayed_board_count(&self) -> usize {
-        self.displayed_boards().len()
-    }
-
     pub fn handle_kanban_column_left(&mut self) {
         if !self.is_kanban_view() || self.focus.active != Focus::Cards {
             return;
@@ -589,7 +582,7 @@ impl App {
     pub fn handle_jump_to_top(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                self.selection.board.jump_to_first();
+                self.board_list.jump_to_top();
                 self.switch_view_strategy(TaskListView::GroupedByColumn);
             }
             Focus::Cards => {
@@ -605,9 +598,7 @@ impl App {
     pub fn handle_jump_to_bottom(&mut self) {
         match self.focus.active {
             Focus::Boards => {
-                self.selection
-                    .board
-                    .jump_to_last(self.displayed_board_count());
+                self.board_list.jump_to_bottom();
                 if self.mode != AppMode::ArchivedBoardsView {
                     self.switch_view_strategy(TaskListView::GroupedByColumn);
                 }
@@ -626,7 +617,47 @@ impl App {
         }
     }
 
+    /// Shared half-viewport (Ctrl+U/Ctrl+D) jump for the boards panel: same
+    /// three-level page navigation as the cards panel, driven by the same
+    /// `calculate_jump_target_up`/`_down` free functions, over `board_list`
+    /// instead of the active task list.
+    fn jump_board_list_half_viewport(
+        &mut self,
+        calc_target: fn(&[PageBoundary], usize, usize) -> usize,
+    ) {
+        let total_items = self.board_list.len();
+        if total_items == 0 {
+            return;
+        }
+
+        let pages = compute_page_boundaries(total_items, self.view.viewport_height);
+        if pages.is_empty() {
+            return;
+        }
+
+        if let Some(current_idx) = self.board_list.get_selected_index() {
+            if let Some(page_idx) = find_current_page(&pages, current_idx) {
+                let target = calc_target(&pages, current_idx, page_idx);
+
+                if let Some(target_page_idx) = find_current_page(&pages, target) {
+                    if target_page_idx != page_idx {
+                        let target_page = pages[target_page_idx];
+                        self.board_list
+                            .inner_mut()
+                            .set_scroll_offset(target_page.start);
+                    }
+                }
+
+                self.board_list.jump_to(target);
+            }
+        }
+    }
+
     pub fn handle_jump_half_viewport_up(&mut self) {
+        if self.focus.active == Focus::Boards {
+            self.jump_board_list_half_viewport(calculate_jump_target_up);
+            return;
+        }
         if self.focus.active == Focus::Cards {
             // Get total items before borrowing mutably
             let total_items = self
@@ -672,6 +703,10 @@ impl App {
     }
 
     pub fn handle_jump_half_viewport_down(&mut self) {
+        if self.focus.active == Focus::Boards {
+            self.jump_board_list_half_viewport(calculate_jump_target_down);
+            return;
+        }
         if self.focus.active == Focus::Cards {
             // Get total items before borrowing mutably
             let total_items = self
@@ -1044,12 +1079,13 @@ mod tests {
         seed_two_archived_boards(&mut app);
         app.mode = AppMode::ArchivedBoardsView;
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.prepare_frame();
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         app.handle_navigation_down();
 
         assert_eq!(
-            app.selection.board.get(),
+            app.board_list.get_selected_index(),
             Some(1),
             "j must move to index 1 in archived view even with no live boards"
         );
@@ -1085,14 +1121,15 @@ mod tests {
         app.model.load_from_snapshot(snap);
         app.mode = AppMode::ArchivedBoardsView;
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.prepare_frame();
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         app.handle_navigation_down();
         app.handle_navigation_down();
         app.handle_navigation_down();
 
         assert_eq!(
-            app.selection.board.get(),
+            app.board_list.get_selected_index(),
             Some(2),
             "after 3 j presses, should clamp at archived_len-1=2, not live_len-1=0"
         );
@@ -1128,12 +1165,13 @@ mod tests {
         app.model.load_from_snapshot(snap);
         app.mode = AppMode::ArchivedBoardsView;
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.prepare_frame();
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         app.handle_jump_to_bottom();
 
         assert_eq!(
-            app.selection.board.get(),
+            app.board_list.get_selected_index(),
             Some(2),
             "G should jump to archived_len-1=2"
         );
@@ -1147,7 +1185,7 @@ mod tests {
         seed_two_archived_boards(&mut app);
         app.mode = AppMode::ArchivedBoardsView;
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         app.switch_view_strategy(kanban_domain::TaskListView::Flat);
 
@@ -1195,14 +1233,15 @@ mod tests {
         app.model.load_from_snapshot(snap);
         app.mode = AppMode::Normal;
         app.focus.active = Focus::Boards;
-        app.selection.board.set(Some(0));
+        app.prepare_frame();
+        app.board_list.inner_mut().set_selected_index(Some(0));
 
         for _ in 0..10 {
             app.handle_navigation_down();
         }
 
         assert_eq!(
-            app.selection.board.get(),
+            app.board_list.get_selected_index(),
             Some(1),
             "live view navigation must clamp at live_count-1=1"
         );

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -1247,6 +1247,55 @@ mod tests {
         );
     }
 
+    // KAN-1090: Ctrl+D/Ctrl+U half-viewport jumps must work on the boards
+    // panel, matching the card list's existing behavior.
+
+    fn seed_boards_for_half_viewport_jump(app: &mut crate::App, count: usize) {
+        use kanban_domain::KanbanOperations;
+        for i in 0..count {
+            app.ctx.create_board(format!("Board{i}"), None).unwrap();
+        }
+        app.prepare_frame();
+        app.mode = AppMode::Normal;
+        app.focus.active = Focus::Boards;
+        // Single-page pagination (6 items comfortably fit under a viewport of
+        // 10), so calculate_jump_target_down/_up's three-level jump (top ->
+        // middle -> bottom) resolves deterministically to page_size / 2 = 3.
+        app.view.viewport_height = 10;
+    }
+
+    #[test]
+    fn test_handle_jump_half_viewport_down_on_boards_focus_jumps_a_half_page() {
+        let mut app = crate::App::test_default();
+        seed_boards_for_half_viewport_jump(&mut app, 6);
+        app.board_list.inner_mut().set_selected_index(Some(0));
+
+        app.handle_jump_half_viewport_down();
+
+        assert_eq!(
+            app.board_list.get_selected_index(),
+            Some(3),
+            "Ctrl+D from the top of a 6-board single page should jump to the \
+             middle (page_size / 2 = 3), not move by one like j"
+        );
+    }
+
+    #[test]
+    fn test_handle_jump_half_viewport_up_on_boards_focus_jumps_a_half_page() {
+        let mut app = crate::App::test_default();
+        seed_boards_for_half_viewport_jump(&mut app, 6);
+        app.board_list.inner_mut().set_selected_index(Some(5));
+
+        app.handle_jump_half_viewport_up();
+
+        assert_eq!(
+            app.board_list.get_selected_index(),
+            Some(3),
+            "Ctrl+U from the bottom of a 6-board single page should jump to \
+             the middle (page_size / 2 = 3), not move by one like k"
+        );
+    }
+
     // KAN-893: is_kanban_view must return false in ArchivedBoardsView
 
     fn make_app_with_columnview_active_board() -> crate::App {

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -517,12 +517,15 @@ impl App {
     }
 
     fn trigger_export(&mut self) -> bool {
-        let board_count = self.model.live_boards().count();
-        if board_count == 0 {
+        let live_ids: Vec<uuid::Uuid> = self.model.live_boards().map(|b| b.id).collect();
+        if live_ids.is_empty() {
             self.set_error("No boards to export".to_string());
             return false;
         }
-        self.export_dialog = Some(ExportDialogState::new(board_count));
+        self.export_dialog = Some(ExportDialogState::from_selection(
+            &live_ids,
+            &self.multi_select.selected_boards,
+        ));
         self.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
         false
     }
@@ -608,24 +611,18 @@ impl App {
         };
 
         let filename = dialog.filename.clone();
-        let selected_indices: Vec<usize> = dialog
-            .board_selections
+        let selected_board_ids: Vec<uuid::Uuid> = dialog
+            .board_ids
             .iter()
-            .enumerate()
+            .zip(dialog.board_selections.iter())
             .filter(|(_, &selected)| selected)
-            .map(|(i, _)| i)
+            .map(|(&id, _)| id)
             .collect();
 
-        if selected_indices.is_empty() || filename.is_empty() {
+        if selected_board_ids.is_empty() || filename.is_empty() {
             self.set_error("No boards selected or filename empty".to_string());
             return;
         }
-
-        let live_board_ids: Vec<_> = self.model.live_boards().map(|b| b.id).collect();
-        let selected_board_ids: Vec<_> = selected_indices
-            .iter()
-            .filter_map(|&i| live_board_ids.get(i).copied())
-            .collect();
 
         // Route through the snapshot so each selected board's archived-card live
         // rows and markers round-trip.
@@ -669,12 +666,15 @@ impl App {
     /// Open the export-all-boards dialog, or set an error if there are no
     /// live boards to export. Matches the direct `x` keypress's guard exactly.
     pub(crate) fn open_export_boards_dialog(&mut self) {
-        let board_count = self.model.live_boards().count();
-        if board_count == 0 {
+        let live_ids: Vec<uuid::Uuid> = self.model.live_boards().map(|b| b.id).collect();
+        if live_ids.is_empty() {
             self.set_error("No boards to export".to_string());
             return;
         }
-        self.export_dialog = Some(ExportDialogState::new(board_count));
+        self.export_dialog = Some(ExportDialogState::from_selection(
+            &live_ids,
+            &self.multi_select.selected_boards,
+        ));
         self.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
     }
 }

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -271,13 +271,8 @@ impl App {
         }
 
         self.selection.active_board_id = self.model.live_boards().next().map(|b| b.id);
-        self.selection
-            .board
-            .set(if self.model.live_boards().next().is_none() {
-                None
-            } else {
-                Some(0)
-            });
+        let live_ids: Vec<uuid::Uuid> = self.model.live_boards().map(|b| b.id).collect();
+        self.board_list.update_boards(live_ids);
         self.selection.active_card_id = None;
         self.selection.card_navigation_history.clear();
 

--- a/crates/kanban-tui/src/ui/dialogs/boards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/boards.rs
@@ -26,11 +26,16 @@ pub(crate) fn render_export_boards_popup(app: &App, frame: &mut Frame) {
                 .constraints([Constraint::Min(0), Constraint::Length(1)])
                 .split(inner);
 
-            let items: Vec<Line> = app
-                .model
-                .live_boards()
+            let items: Vec<Line> = dialog
+                .board_ids
+                .iter()
                 .enumerate()
-                .map(|(i, board)| {
+                .map(|(i, &id)| {
+                    let name = app
+                        .model
+                        .board_by_id(id)
+                        .map(|b| b.name.as_str())
+                        .unwrap_or("?");
                     let checkbox = if dialog.board_selections.get(i).copied().unwrap_or(false) {
                         "[x] "
                     } else {
@@ -43,7 +48,7 @@ pub(crate) fn render_export_boards_popup(app: &App, frame: &mut Frame) {
                     } else {
                         Style::default().fg(Color::White)
                     };
-                    Line::from(Span::styled(format!("{}{}", checkbox, board.name), style))
+                    Line::from(Span::styled(format!("{}{}", checkbox, name), style))
                 })
                 .collect();
 

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -47,14 +47,32 @@ pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
         };
         lines.push(Line::from(Span::styled(empty, label_text())));
     } else {
-        for (idx, board) in boards.iter().enumerate() {
-            let config = ListItemConfig::new()
-                .selected(app.selection.board.get() == Some(idx))
-                .focused(app.focus.active == Focus::Boards)
-                .active(app.selection.active_board_id == Some(board.id));
+        let viewport_height = area.height.saturating_sub(2) as usize;
+        let render_info = app.board_list.get_render_info(viewport_height);
+        let selected_idx = app.board_list.get_selected_index();
 
-            lines.push(styled_list_item(&board.name, &config));
+        lines.extend(crate::scroll_indicators::render_above_indicator(
+            render_info.show_above_indicator,
+            render_info.items_above,
+            "Project",
+        ));
+
+        for idx in &render_info.visible_indices {
+            if let Some(board) = boards.get(*idx) {
+                let config = ListItemConfig::new()
+                    .selected(selected_idx == Some(*idx))
+                    .focused(app.focus.active == Focus::Boards)
+                    .active(app.selection.active_board_id == Some(board.id));
+
+                lines.push(styled_list_item(&board.name, &config));
+            }
         }
+
+        lines.extend(crate::scroll_indicators::render_below_indicator(
+            render_info.show_below_indicator,
+            render_info.items_below,
+            "Project",
+        ));
     }
 
     let panel_config = if archived_view {

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -82,15 +82,23 @@ pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
         ));
     }
 
-    let panel_config = if archived_view {
-        PanelConfig::new("Archived Projects")
-            .with_focus_indicator("Archived Projects [1]")
-            .focused(app.focus.active == Focus::Boards)
+    let base_title = if archived_view {
+        "Archived Projects"
     } else {
-        PanelConfig::new("Projects")
-            .with_focus_indicator("Projects [1]")
-            .focused(app.focus.active == Focus::Boards)
+        "Projects"
     };
+    let search_suffix = app
+        .filter
+        .board_search
+        .active_query()
+        .filter(|q| !q.is_empty())
+        .and_then(|q| format_filter_title_suffix(&[format!("\"{q}\"")]))
+        .unwrap_or_default();
+    let title = format!("{base_title}{search_suffix}");
+    let focus_title = format!("{base_title} [1]{search_suffix}");
+    let panel_config = PanelConfig::new(&title)
+        .with_focus_indicator(&focus_title)
+        .focused(app.focus.active == Focus::Boards);
 
     let content = Paragraph::new(lines);
     render_panel(frame, area, &panel_config, content);

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -48,7 +48,14 @@ pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
         lines.push(Line::from(Span::styled(empty, label_text())));
     } else {
         let viewport_height = area.height.saturating_sub(2) as usize;
-        let render_info = app.board_list.get_render_info(viewport_height);
+        // Reserve room for the indicator rows themselves (mirroring the card
+        // list's render path in `render_strategy.rs`), so a below indicator
+        // doesn't get pushed past the panel's available rows.
+        let adjusted_viewport_height = app
+            .board_list
+            .inner()
+            .get_adjusted_viewport_height(viewport_height);
+        let render_info = app.board_list.get_render_info(adjusted_viewport_height);
         let selected_idx = app.board_list.get_selected_index();
 
         lines.extend(crate::scroll_indicators::render_above_indicator(

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -68,7 +68,7 @@ fn test_restore_from_archived_boards_view_returns_board_to_live() {
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
 
     // `r` restores the highlighted archived board.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('r'));
@@ -100,7 +100,7 @@ fn test_permanent_delete_from_archived_boards_view_removes_board() {
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
 
     // `x` opens the confirm dialog; confirming with Enter permanently deletes.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
@@ -139,7 +139,7 @@ fn test_x_in_archived_view_opens_confirm_not_immediate_delete() {
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
 
     // `x` must open the confirm dialog, NOT delete immediately.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
@@ -167,7 +167,7 @@ fn test_confirm_permanent_delete_removes_board() {
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
 
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
     assert_eq!(
@@ -202,7 +202,7 @@ fn test_cancel_permanent_delete_keeps_board() {
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
 
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));
     assert_eq!(
@@ -239,14 +239,14 @@ fn test_archived_view_g_then_g_jumps_to_first() {
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
     // Start at the bottom.
-    app.selection.board.set(Some(2));
+    app.board_list.inner_mut().set_selected_index(Some(2));
 
     // `g` → pending, second `g` → jump to first.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('g'));
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('g'));
 
     assert_eq!(
-        app.selection.board.get(),
+        app.board_list.get_selected_index(),
         Some(0),
         "gg should jump to the first item in the archived list"
     );
@@ -262,12 +262,12 @@ fn test_archived_view_shift_g_jumps_to_last() {
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
 
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('G'));
 
     assert_eq!(
-        app.selection.board.get(),
+        app.board_list.get_selected_index(),
         Some(2),
         "G should jump to the last item in the archived list"
     );
@@ -281,7 +281,7 @@ fn test_archived_view_u_undoes_permanent_delete() {
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
 
     // Delete the archived board permanently via the confirm dialog.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('x'));

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -55,7 +55,7 @@ fn open_archived_board(app: &mut App) {
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
     app.focus.active = Focus::Boards;
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.handle_selection_activate();
 }
 
@@ -114,7 +114,7 @@ fn test_archived_board_settings_view_reachable() {
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
     app.focus.active = Focus::Boards;
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
 
     // `e` opens board detail through the same handler as for a live board.
     app.handle_edit_board_key();
@@ -135,7 +135,7 @@ fn test_archived_board_sprints_view_reachable() {
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
     app.focus.active = Focus::Boards;
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.handle_edit_board_key();
 
     // The active board's sprints resolve archival-agnostically.
@@ -159,7 +159,7 @@ fn test_archived_board_columns_resolve() {
     app.mode = AppMode::ArchivedBoardsView;
     app.prepare_frame();
     app.focus.active = Focus::Boards;
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.handle_edit_board_key();
 
     let board = app.active_board().expect("archived board resolves");
@@ -216,7 +216,7 @@ fn test_archived_board_kanban_view_honours_board_setting() {
     // Browsing the archived LIST is never kanban (the list must stay visible)...
     app.mode = AppMode::ArchivedBoardsView;
     app.focus.active = Focus::Boards;
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     assert!(
         !app.is_kanban_view(),
         "the boards list itself is not kanban"

--- a/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
@@ -32,7 +32,7 @@ fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
 
 fn activate_board(app: &mut App, board_id: uuid::Uuid) {
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = Some(board_id);
 }
 

--- a/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
+++ b/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
@@ -50,7 +50,7 @@ fn test_board_delete_confirmation_card_count_excludes_archived_cards() {
     let _ = live;
 
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = Some(board.id);
     app.focus.active = Focus::Boards;
 

--- a/crates/kanban-tui/tests/board_multi_select_tests.rs
+++ b/crates/kanban-tui/tests/board_multi_select_tests.rs
@@ -1,0 +1,92 @@
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::App;
+
+fn create_boards(app: &mut App, names: &[&str]) -> Vec<uuid::Uuid> {
+    names
+        .iter()
+        .map(|name| app.ctx.create_board((*name).to_string(), None).unwrap().id)
+        .collect()
+}
+
+#[test]
+fn test_handle_board_selection_toggle_enters_selection_mode_and_selects_current_board() {
+    let mut app = App::test_default();
+    let ids = create_boards(&mut app, &["Alpha", "Beta"]);
+    app.prepare_frame();
+    app.focus.active = Focus::Boards;
+    app.board_list.select_board(ids[0]);
+
+    app.handle_board_selection_toggle();
+
+    assert!(app.multi_select.board_selection_mode_active);
+    assert!(app.multi_select.selected_boards.contains(&ids[0]));
+    assert_eq!(app.multi_select.selected_boards.len(), 1);
+}
+
+#[test]
+fn test_handle_board_selection_toggle_exits_selection_mode_keeps_selections() {
+    let mut app = App::test_default();
+    let ids = create_boards(&mut app, &["Alpha", "Beta"]);
+    app.prepare_frame();
+    app.focus.active = Focus::Boards;
+    app.board_list.select_board(ids[0]);
+
+    app.handle_board_selection_toggle();
+    assert!(app.multi_select.board_selection_mode_active);
+
+    app.handle_board_selection_toggle();
+
+    assert!(!app.multi_select.board_selection_mode_active);
+    assert!(
+        app.multi_select.selected_boards.contains(&ids[0]),
+        "exiting selection mode must not clear prior selections"
+    );
+}
+
+#[test]
+fn test_handle_clear_board_selection_empties_selected_boards() {
+    let mut app = App::test_default();
+    let ids = create_boards(&mut app, &["Alpha", "Beta"]);
+    app.multi_select.selected_boards.insert(ids[0]);
+    app.multi_select.selected_boards.insert(ids[1]);
+
+    app.handle_clear_board_selection();
+
+    assert!(app.multi_select.selected_boards.is_empty());
+}
+
+#[test]
+fn test_handle_select_all_boards_in_view_selects_only_currently_filtered_boards() {
+    let mut app = App::test_default();
+    let ids = create_boards(&mut app, &["Alpha Project", "Beta Project", "Alpha Two"]);
+    app.focus.active = Focus::Boards;
+
+    app.filter.board_search.activate();
+    app.filter.board_search.input.set("Alpha".to_string());
+    app.prepare_frame();
+
+    app.handle_select_all_boards_in_view();
+
+    assert!(app.multi_select.selected_boards.contains(&ids[0]));
+    assert!(app.multi_select.selected_boards.contains(&ids[2]));
+    assert!(
+        !app.multi_select.selected_boards.contains(&ids[1]),
+        "select-all-in-view must not pull in boards excluded by the active search filter"
+    );
+    assert_eq!(app.multi_select.selected_boards.len(), 2);
+    assert!(app.multi_select.board_selection_mode_active);
+}
+
+#[test]
+fn test_handle_select_all_boards_in_view_does_nothing_when_focus_is_not_boards() {
+    let mut app = App::test_default();
+    create_boards(&mut app, &["Alpha", "Beta"]);
+    app.prepare_frame();
+    app.focus.active = Focus::Cards;
+
+    app.handle_select_all_boards_in_view();
+
+    assert!(app.multi_select.selected_boards.is_empty());
+    assert!(!app.multi_select.board_selection_mode_active);
+}

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -12,7 +12,7 @@ fn setup_app_with_board() -> App {
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -37,7 +37,7 @@ fn test_export_single_board() {
             Default::default(),
         )
         .unwrap();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
     app.prepare_frame();
 
@@ -326,7 +326,7 @@ fn test_export_import_sprint_and_card_prefixes() {
         )
         .unwrap();
 
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/footer_tests.rs
+++ b/crates/kanban-tui/tests/footer_tests.rs
@@ -35,6 +35,38 @@ fn test_render_footer_search_active_shows_search_query() {
 }
 
 #[test]
+fn test_footer_shows_board_query_after_commit_when_board_search_active() {
+    let mut app = App::test_default();
+    app.focus.active = Focus::Boards;
+    app.filter.board_search.is_active = true;
+    for c in "alpha".chars() {
+        app.filter.board_search.input.insert_char(c);
+    }
+    let output = render_footer_to_string(&app);
+    assert!(
+        output.contains("/alpha"),
+        "Footer should echo the committed board search query, not render blank"
+    );
+}
+
+#[test]
+fn test_footer_shows_board_query_while_typing_when_board_search_active() {
+    use kanban_tui::app::mode::AppMode;
+    let mut app = App::test_default();
+    app.focus.active = Focus::Boards;
+    app.filter.board_search.activate();
+    for c in "alpha".chars() {
+        app.filter.board_search.input.insert_char(c);
+    }
+    app.push_mode(AppMode::Search);
+    let output = render_footer_to_string(&app);
+    assert!(
+        output.contains("/alpha"),
+        "Footer should echo the board search query while typing, not the empty card search field"
+    );
+}
+
+#[test]
 fn test_render_footer_search_mode_renders_without_panic() {
     use kanban_tui::app::mode::AppMode;
     let mut app = App::test_default();

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -80,12 +80,15 @@ pub fn setup_app_with_export_dialog(board_count: usize) -> App {
     let mut app = App::test_default();
     app.focus.active = Focus::Boards;
     app.push_mode(AppMode::Settings);
-    for i in 0..board_count {
-        app.ctx
-            .create_board(format!("Board{}", i + 1), None)
-            .unwrap();
-    }
-    app.export_dialog = Some(ExportDialogState::new(board_count));
+    let board_ids: Vec<uuid::Uuid> = (0..board_count)
+        .map(|i| {
+            app.ctx
+                .create_board(format!("Board{}", i + 1), None)
+                .unwrap()
+                .id
+        })
+        .collect();
+    app.export_dialog = Some(ExportDialogState::new(board_ids));
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
     app
 }

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -11,7 +11,7 @@ async fn test_load_initial_state_with_boards_selects_first_board() -> KanbanResu
     app.load_initial_state().await;
 
     assert_eq!(
-        app.selection.board.get(),
+        app.board_list.get_selected_index(),
         Some(0),
         "first board should be selected after startup"
     );
@@ -64,7 +64,7 @@ async fn test_load_initial_state_with_no_boards_leaves_selection_none() -> Kanba
     app.load_initial_state().await;
 
     assert_eq!(
-        app.selection.board.get(),
+        app.board_list.get_selected_index(),
         None,
         "selection should remain None when there are no boards"
     );
@@ -77,7 +77,7 @@ async fn test_load_initial_state_with_no_file_leaves_selection_none() -> KanbanR
     app.load_initial_state().await;
 
     assert_eq!(
-        app.selection.board.get(),
+        app.board_list.get_selected_index(),
         None,
         "selection should remain None when no file is provided"
     );
@@ -89,12 +89,18 @@ async fn test_load_initial_state_does_not_clobber_existing_board_selection() -> 
     let dir = tempfile::tempdir()?;
     let path = helpers::create_test_json_file(dir.path(), "test.json", &["Alpha", "Beta"]).await;
     let (mut app, _rx) = kanban_tui::App::new(Some(path)).await?;
-    app.selection.board.set(Some(1));
+    // Establish a real pre-existing selection (by id, via a prior sync) rather
+    // than a speculative raw index into not-yet-loaded data: `board_list` only
+    // accepts an index within its current, already-synced item count.
+    app.load_initial_state().await;
+    let beta_id = app.model.boards()[1].id;
+    app.board_list.select_board(beta_id);
+
     app.load_initial_state().await;
 
     assert_eq!(
-        app.selection.board.get(),
-        Some(1),
+        app.board_list.get_selected_board_id(),
+        Some(beta_id),
         "pre-existing board selection should not be overwritten by load_initial_state"
     );
     Ok(())

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -139,3 +139,68 @@ fn test_model_description_reflects_mutation() {
         "model must reflect the updated description after prepare_frame"
     );
 }
+
+fn type_query(app: &mut App, query: &str) {
+    app.filter.board_search.activate();
+    for c in query.chars() {
+        app.filter.board_search.input.insert_char(c);
+    }
+}
+
+#[test]
+fn test_board_search_query_narrows_projects_panel_to_matching_boards() {
+    let mut app = App::test_default();
+    app.ctx
+        .create_board("Alpha Project".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_board("Beta Project".to_string(), None)
+        .unwrap();
+    app.prepare_frame();
+    assert_eq!(
+        app.displayed_boards().len(),
+        2,
+        "both boards visible before search"
+    );
+
+    type_query(&mut app, "alpha");
+    app.prepare_frame();
+
+    let displayed = app.displayed_boards();
+    assert_eq!(displayed.len(), 1, "search narrows the projects panel");
+    assert_eq!(displayed[0].name, "Alpha Project");
+    assert_eq!(
+        app.board_list.len(),
+        1,
+        "board_list's selectable set stays aligned with the filtered displayed_boards"
+    );
+}
+
+#[test]
+fn test_board_search_cleared_restores_full_board_list() {
+    let mut app = App::test_default();
+    app.ctx
+        .create_board("Alpha Project".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_board("Beta Project".to_string(), None)
+        .unwrap();
+    app.prepare_frame();
+
+    type_query(&mut app, "alpha");
+    app.prepare_frame();
+    assert_eq!(
+        app.displayed_boards().len(),
+        1,
+        "narrowed while search is active"
+    );
+
+    app.filter.board_search.deactivate();
+    app.prepare_frame();
+
+    assert_eq!(
+        app.displayed_boards().len(),
+        2,
+        "clearing the search query restores the full board list"
+    );
+}

--- a/crates/kanban-tui/tests/scroll_board_edit_lists.rs
+++ b/crates/kanban-tui/tests/scroll_board_edit_lists.rs
@@ -36,7 +36,7 @@ fn test_board_sprints_list_scrolls_to_keep_selection_visible() {
             .unwrap();
     }
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -72,7 +72,7 @@ fn test_board_columns_list_scrolls_to_keep_selection_visible() {
             .unwrap();
     }
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -111,7 +111,7 @@ fn test_board_sprints_scroll_offset_is_stable_when_selection_moves_within_viewpo
             .unwrap();
     }
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -153,7 +153,7 @@ fn test_filter_popup_sprints_scrolls_to_keep_selection_visible() {
             .unwrap();
     }
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()

--- a/crates/kanban-tui/tests/scroll_board_edit_lists.rs
+++ b/crates/kanban-tui/tests/scroll_board_edit_lists.rs
@@ -141,6 +141,40 @@ fn test_board_sprints_scroll_offset_is_stable_when_selection_moves_within_viewpo
 }
 
 #[test]
+fn test_render_projects_panel_shows_more_below_indicator_when_boards_exceed_viewport() {
+    let mut app = App::test_default();
+    for i in 0..20 {
+        app.ctx
+            .create_board(format!("ProjMark{:02}", i), None)
+            .unwrap();
+    }
+    app.prepare_frame();
+    app.focus.active = kanban_tui::app::Focus::Boards;
+    // Selection defaults to the first board (index 0), so nothing above it is
+    // scrolled past — only the "below" indicator is expected here.
+    assert_eq!(app.board_list.get_selected_index(), Some(0));
+
+    // A short terminal so the 20-board list can't fit in the projects panel.
+    let output = render_to_string(&mut app, 80, 15);
+
+    assert!(
+        output.contains("below"),
+        "expected a 'below' scroll indicator when boards exceed the viewport, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("ProjMark00"),
+        "first project should still be visible (selection is at the top), got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("ProjMark19"),
+        "last project should have scrolled off-screen, got:\n{}",
+        output
+    );
+}
+
+#[test]
 fn test_filter_popup_sprints_scrolls_to_keep_selection_visible() {
     use kanban_domain::CardFilters;
     use kanban_view::filters::FilterDialogState;

--- a/crates/kanban-tui/tests/settings_config_edit_tests.rs
+++ b/crates/kanban-tui/tests/settings_config_edit_tests.rs
@@ -93,6 +93,7 @@ async fn test_migration_edit_rejected_while_migrating() {
 fn test_export_filename_rejects_path_separator_forward_slash() {
     let mut app = App::test_default();
     app.export_dialog = Some(ExportDialogState {
+        board_ids: vec![uuid::Uuid::new_v4()],
         board_selections: vec![true],
         cursor: 0,
         step: ExportStep::ExportOptions,
@@ -113,6 +114,7 @@ fn test_export_filename_rejects_path_separator_forward_slash() {
 fn test_export_filename_rejects_path_separator_backslash() {
     let mut app = App::test_default();
     app.export_dialog = Some(ExportDialogState {
+        board_ids: vec![uuid::Uuid::new_v4()],
         board_selections: vec![true],
         cursor: 0,
         step: ExportStep::ExportOptions,
@@ -130,6 +132,7 @@ fn test_export_filename_rejects_path_separator_backslash() {
 fn test_export_filename_rejects_null_byte() {
     let mut app = App::test_default();
     app.export_dialog = Some(ExportDialogState {
+        board_ids: vec![uuid::Uuid::new_v4()],
         board_selections: vec![true],
         cursor: 0,
         step: ExportStep::ExportOptions,

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -6,10 +6,18 @@ use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::app::{ExportDialogState, ExportFormat, ExportStep};
 use kanban_tui::keybindings::KeybindingRegistry;
 use kanban_tui::App;
+use std::collections::HashSet;
+use uuid::Uuid;
+
+fn ids(count: usize) -> Vec<Uuid> {
+    (0..count).map(|_| Uuid::new_v4()).collect()
+}
 
 #[test]
 fn test_export_dialog_state_new_defaults_none_selected() {
-    let state = ExportDialogState::new(3);
+    let board_ids = ids(3);
+    let state = ExportDialogState::new(board_ids.clone());
+    assert_eq!(state.board_ids, board_ids);
     assert_eq!(state.board_selections, vec![false, false, false]);
     assert_eq!(state.cursor, 0);
     assert_eq!(state.step, ExportStep::SelectBoards);
@@ -17,7 +25,7 @@ fn test_export_dialog_state_new_defaults_none_selected() {
 
 #[test]
 fn test_export_dialog_state_toggle_board() {
-    let mut state = ExportDialogState::new(3);
+    let mut state = ExportDialogState::new(ids(3));
     assert!(!state.board_selections[1]);
     state.toggle(1);
     assert!(state.board_selections[1]);
@@ -27,7 +35,7 @@ fn test_export_dialog_state_toggle_board() {
 
 #[test]
 fn test_export_dialog_state_select_all() {
-    let mut state = ExportDialogState::new(3);
+    let mut state = ExportDialogState::new(ids(3));
     state.select_all();
     assert!(state.board_selections.iter().all(|&s| s));
     state.select_all();
@@ -36,8 +44,31 @@ fn test_export_dialog_state_select_all() {
 
 #[test]
 fn test_export_dialog_format_default_is_json() {
-    let state = ExportDialogState::new(1);
+    let state = ExportDialogState::new(ids(1));
     assert_eq!(state.format, ExportFormat::Json);
+}
+
+#[test]
+fn test_export_dialog_from_selection_preselects_checkboxes_for_multi_selected_boards() {
+    let board_ids = ids(3);
+    let mut preselected = HashSet::new();
+    preselected.insert(board_ids[0]);
+    preselected.insert(board_ids[2]);
+
+    let state = ExportDialogState::from_selection(&board_ids, &preselected);
+
+    assert_eq!(state.board_ids, board_ids);
+    assert_eq!(state.board_selections, vec![true, false, true]);
+}
+
+#[test]
+fn test_export_dialog_from_selection_falls_back_to_none_selected_when_selection_empty() {
+    let board_ids = ids(2);
+
+    let state = ExportDialogState::from_selection(&board_ids, &HashSet::new());
+
+    assert_eq!(state.board_ids, board_ids);
+    assert_eq!(state.board_selections, vec![false, false]);
 }
 
 #[test]
@@ -129,7 +160,8 @@ fn test_render_export_boards_select_step_shows_board_names() {
         .first()
         .map(|b| b.id);
     app.prepare_frame();
-    app.export_dialog = Some(ExportDialogState::new(1));
+    let board_id = app.selection.active_board_id.unwrap();
+    app.export_dialog = Some(ExportDialogState::new(vec![board_id]));
     app.push_mode(AppMode::Settings);
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
 
@@ -160,8 +192,8 @@ fn test_render_export_boards_options_step_shows_filename() {
     use ratatui::Terminal;
 
     let mut app = App::test_default();
-    app.ctx.create_board("Board1".into(), None).unwrap();
-    let mut dialog = ExportDialogState::new(1);
+    let board = app.ctx.create_board("Board1".into(), None).unwrap();
+    let mut dialog = ExportDialogState::new(vec![board.id]);
     dialog.step = ExportStep::ExportOptions;
     dialog.board_selections[0] = true;
     app.export_dialog = Some(dialog);
@@ -206,7 +238,7 @@ fn test_export_boards_json_creates_file() {
         .unwrap();
 
     app.prepare_frame();
-    app.export_dialog = Some(ExportDialogState::new(1));
+    app.export_dialog = Some(ExportDialogState::new(vec![board.id]));
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
 
     app.handle_export_boards_dialog(KeyCode::Char(' '));
@@ -224,4 +256,55 @@ fn test_export_boards_json_creates_file() {
     let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert!(parsed["boards"].is_array());
     assert!(content.contains("ExportTest"));
+}
+
+#[test]
+fn test_execute_export_uses_explicit_board_ids_not_live_boards_snapshot_at_confirm_time() {
+    use crossterm::event::KeyCode;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let export_path = dir.path().join("test_export.json");
+
+    let mut app = App::test_default();
+    app.focus.active = Focus::Boards;
+    app.push_mode(AppMode::Settings);
+
+    let board_a = app.ctx.create_board("BoardA".into(), None).unwrap();
+    let board_b = app.ctx.create_board("BoardB".into(), None).unwrap();
+    app.prepare_frame();
+
+    let mut preselected = std::collections::HashSet::new();
+    preselected.insert(board_b.id);
+    let live_ids: Vec<Uuid> = vec![board_a.id, board_b.id];
+    app.export_dialog = Some(ExportDialogState::from_selection(&live_ids, &preselected));
+    app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
+
+    // A board is created AFTER the dialog was seeded, changing what
+    // `self.model.live_boards()` would return if `execute_export` re-derived
+    // positions from it at confirm time instead of using the dialog's own
+    // captured `board_ids`.
+    app.ctx.create_board("BoardC".into(), None).unwrap();
+    app.prepare_frame();
+
+    app.handle_export_boards_dialog(KeyCode::Enter);
+    {
+        let dialog = app.export_dialog.as_mut().unwrap();
+        dialog.filename = export_path.to_string_lossy().to_string();
+    }
+    app.handle_export_boards_dialog(KeyCode::Enter);
+
+    assert!(export_path.exists(), "Export file was not created");
+    let content = std::fs::read_to_string(&export_path).unwrap();
+    assert!(
+        content.contains("BoardB"),
+        "the board selected at dialog-seed time must be exported"
+    );
+    assert!(
+        !content.contains("BoardA"),
+        "only the pre-selected board must be exported, not every live board"
+    );
+    assert!(
+        !content.contains("BoardC"),
+        "a board created after the dialog was seeded must not sneak into the export"
+    );
 }

--- a/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
+++ b/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
@@ -110,7 +110,7 @@ fn test_sprint_detail_populate_applies_board_sort_order() {
         )
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -209,7 +209,7 @@ fn test_sprint_detail_status_done_card_is_not_in_uncompleted_panel_after_populat
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -12,7 +12,7 @@ fn setup_app_with_board() -> App {
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -52,7 +52,7 @@ fn test_create_board_selects_new_board() {
     // Create first board via ctx so it's a known baseline
     app.ctx.create_board("First".to_string(), None).unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.focus.active = Focus::Boards;
 
     // Create second board via handler
@@ -63,7 +63,7 @@ fn test_create_board_selects_new_board() {
     let boards = app.model.boards();
     assert_eq!(boards.len(), 2);
 
-    let selected = app.selection.board.get();
+    let selected = app.board_list.get_selected_index();
     assert_eq!(selected, Some(1), "selection should point to the new board");
     assert_eq!(boards[selected.unwrap()].name, "Second");
 }
@@ -140,7 +140,7 @@ fn test_create_card_auto_completes_in_done_column() {
         .create_column(board.id, "Done".to_string(), Some(2))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -228,7 +228,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -285,7 +285,7 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -360,7 +360,7 @@ fn test_move_card_right_selects_moved_card_in_kanban_view() {
         .create_column(board.id, "Done".to_string(), Some(2))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -414,7 +414,7 @@ fn test_move_selected_cards_right_selects_first_moved_card() {
         .create_column(board.id, "Done".to_string(), Some(2))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -473,7 +473,7 @@ fn test_delete_column_adjusts_selection() {
         .create_column(board.id, "Col3".to_string(), Some(2))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -522,7 +522,7 @@ fn test_toggle_card_completion_retains_selection() {
         .create_column(board.id, "Done".to_string(), Some(1))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()
@@ -576,7 +576,7 @@ fn test_toggle_multi_card_completion_retains_selection() {
         .create_column(board.id, "Done".to_string(), Some(1))
         .unwrap();
     app.prepare_frame();
-    app.selection.board.set(Some(0));
+    app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
         .ctx
         .data_store()

--- a/crates/kanban-view/src/board_list.rs
+++ b/crates/kanban-view/src/board_list.rs
@@ -70,6 +70,13 @@ impl BoardList {
         self.list.jump_to(index);
     }
 
+    /// The board ids currently held, in display order — reflects whatever
+    /// subset `update_boards` was last called with (e.g. narrowed by an
+    /// active search filter).
+    pub fn ids(&self) -> &[Uuid] {
+        &self.boards
+    }
+
     pub fn len(&self) -> usize {
         self.boards.len()
     }
@@ -103,6 +110,18 @@ mod tests {
 
     fn ids(count: usize) -> Vec<Uuid> {
         (0..count).map(|_| Uuid::new_v4()).collect()
+    }
+
+    #[test]
+    fn test_board_list_ids_reflects_last_update_boards_call() {
+        let boards = ids(3);
+        let mut list = BoardList::new();
+        list.update_boards(boards.clone());
+        assert_eq!(list.ids(), boards.as_slice());
+
+        let narrowed = vec![boards[1]];
+        list.update_boards(narrowed.clone());
+        assert_eq!(list.ids(), narrowed.as_slice());
     }
 
     #[test]

--- a/crates/kanban-view/src/board_list.rs
+++ b/crates/kanban-view/src/board_list.rs
@@ -1,0 +1,212 @@
+use crate::list_component::{ListComponent, ListRenderInfo};
+use uuid::Uuid;
+
+pub struct BoardList {
+    boards: Vec<Uuid>,
+    list: ListComponent,
+}
+
+impl Default for BoardList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BoardList {
+    pub fn new() -> Self {
+        Self {
+            boards: Vec::new(),
+            list: ListComponent::new(false),
+        }
+    }
+
+    pub fn update_boards(&mut self, boards: Vec<Uuid>) {
+        let current = self.get_selected_board_id();
+        self.boards = boards;
+        self.list.update_item_count(self.boards.len());
+
+        if let Some(id) = current {
+            if !self.select_board(id) {
+                self.list
+                    .set_selected_index((!self.boards.is_empty()).then_some(0));
+            }
+        }
+    }
+
+    pub fn get_selected_board_id(&self) -> Option<Uuid> {
+        self.list
+            .get_selected_index()
+            .and_then(|i| self.boards.get(i).copied())
+    }
+
+    pub fn select_board(&mut self, id: Uuid) -> bool {
+        if let Some(idx) = self.boards.iter().position(|&b| b == id) {
+            self.list.set_selected_index(Some(idx));
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn navigate_up(&mut self) -> bool {
+        self.list.navigate_up()
+    }
+
+    pub fn navigate_down(&mut self) -> bool {
+        self.list.navigate_down()
+    }
+
+    pub fn jump_to_top(&mut self) {
+        self.list.jump_to(0);
+    }
+
+    pub fn jump_to_bottom(&mut self) {
+        if !self.boards.is_empty() {
+            self.list.jump_to(self.boards.len() - 1);
+        }
+    }
+
+    pub fn jump_to(&mut self, index: usize) {
+        self.list.jump_to(index);
+    }
+
+    pub fn len(&self) -> usize {
+        self.boards.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.boards.is_empty()
+    }
+
+    pub fn get_selected_index(&self) -> Option<usize> {
+        self.list.get_selected_index()
+    }
+
+    pub fn get_render_info(&self, viewport_height: usize) -> ListRenderInfo {
+        self.list.get_render_info(viewport_height)
+    }
+
+    /// Exposed for rendering (scroll indicators) and for future callers (board
+    /// search / multi-select) to extend without widening this wrapper's API.
+    pub fn inner(&self) -> &ListComponent {
+        &self.list
+    }
+
+    pub fn inner_mut(&mut self) -> &mut ListComponent {
+        &mut self.list
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(count: usize) -> Vec<Uuid> {
+        (0..count).map(|_| Uuid::new_v4()).collect()
+    }
+
+    #[test]
+    fn test_board_list_update_boards_preserves_selection_by_id_when_still_present() {
+        let boards = ids(3);
+        let mut list = BoardList::new();
+        list.update_boards(boards.clone());
+        list.select_board(boards[2]);
+        assert_eq!(list.get_selected_board_id(), Some(boards[2]));
+
+        // Re-sync with the same board present at a different index (moved to
+        // front).
+        let reordered = vec![boards[2], boards[0], boards[1]];
+        list.update_boards(reordered);
+
+        assert_eq!(list.get_selected_board_id(), Some(boards[2]));
+        assert_eq!(list.get_selected_index(), Some(0));
+    }
+
+    #[test]
+    fn test_board_list_update_boards_clamps_to_first_when_selected_board_removed() {
+        let boards = ids(3);
+        let mut list = BoardList::new();
+        list.update_boards(boards.clone());
+        list.select_board(boards[1]);
+
+        // The selected board (e.g. archived) is gone from the new set.
+        let remaining = vec![boards[0], boards[2]];
+        list.update_boards(remaining.clone());
+
+        assert_eq!(list.get_selected_board_id(), Some(remaining[0]));
+        assert_eq!(list.get_selected_index(), Some(0));
+    }
+
+    #[test]
+    fn test_board_list_update_boards_clamps_to_none_when_all_boards_removed() {
+        let boards = ids(2);
+        let mut list = BoardList::new();
+        list.update_boards(boards.clone());
+        list.select_board(boards[0]);
+
+        list.update_boards(Vec::new());
+
+        assert_eq!(list.get_selected_board_id(), None);
+        assert_eq!(list.get_selected_index(), None);
+    }
+
+    #[test]
+    fn test_board_list_select_board_returns_false_for_unknown_id() {
+        let boards = ids(2);
+        let mut list = BoardList::new();
+        list.update_boards(boards);
+
+        assert!(!list.select_board(Uuid::new_v4()));
+    }
+
+    #[test]
+    fn test_board_list_navigate_up_down_matches_list_component_bounds() {
+        let boards = ids(3);
+        let mut list = BoardList::new();
+        list.update_boards(boards.clone());
+
+        assert_eq!(list.get_selected_index(), Some(0));
+        let was_at_top = list.navigate_up();
+        assert!(was_at_top, "navigate_up at index 0 reports at-top");
+        assert_eq!(list.get_selected_index(), Some(0));
+
+        list.navigate_down();
+        list.navigate_down();
+        assert_eq!(list.get_selected_index(), Some(2));
+        let was_at_bottom = list.navigate_down();
+        assert!(
+            was_at_bottom,
+            "navigate_down at last index reports at-bottom"
+        );
+        assert_eq!(list.get_selected_index(), Some(2));
+    }
+
+    #[test]
+    fn test_board_list_jump_to_top_and_bottom() {
+        let boards = ids(4);
+        let mut list = BoardList::new();
+        list.update_boards(boards);
+        list.jump_to(2);
+        assert_eq!(list.get_selected_index(), Some(2));
+
+        list.jump_to_top();
+        assert_eq!(list.get_selected_index(), Some(0));
+
+        list.jump_to_bottom();
+        assert_eq!(list.get_selected_index(), Some(3));
+    }
+
+    #[test]
+    fn test_board_list_get_render_info_reports_scroll_indicators() {
+        let boards = ids(10);
+        let mut list = BoardList::new();
+        list.update_boards(boards);
+        list.jump_to(9);
+        list.inner_mut().ensure_selected_visible(3);
+
+        let info = list.get_render_info(3);
+        assert!(info.show_above_indicator);
+        assert!(!info.show_below_indicator);
+        assert!(info.visible_indices.contains(&9));
+    }
+}

--- a/crates/kanban-view/src/board_list.rs
+++ b/crates/kanban-view/src/board_list.rs
@@ -93,8 +93,9 @@ impl BoardList {
         self.list.get_render_info(viewport_height)
     }
 
-    /// Exposed for rendering (scroll indicators) and for future callers (board
-    /// search / multi-select) to extend without widening this wrapper's API.
+    /// Escape hatch onto the underlying `ListComponent` for callers that need
+    /// direct access (e.g. test setup seeding a raw selected index) without
+    /// widening this wrapper's own API for every `ListComponent` method.
     pub fn inner(&self) -> &ListComponent {
         &self.list
     }

--- a/crates/kanban-view/src/filter_state.rs
+++ b/crates/kanban-view/src/filter_state.rs
@@ -16,6 +16,10 @@ pub struct FilterState {
     /// board-side analogue of `sort_field_selection`.
     pub board_sort_field_selection: SelectionState,
     pub search: SearchState,
+    /// Independent from `search`: the projects panel's own search state, so a
+    /// board-name query never bleeds into the tasks panel's card search (the
+    /// two panels can carry different active queries at once).
+    pub board_search: SearchState,
     pub dialog_state: Option<FilterDialogState>,
 }
 
@@ -33,5 +37,6 @@ mod tests {
         assert_eq!(state.current_sort_order, None);
         assert!(state.dialog_state.is_none());
         assert!(!state.search.is_active);
+        assert!(!state.board_search.is_active);
     }
 }

--- a/crates/kanban-view/src/lib.rs
+++ b/crates/kanban-view/src/lib.rs
@@ -5,6 +5,7 @@
 //! or any rendering framework — this `Cargo.toml` simply never declares one.
 //! Each consumer (`kanban-tui`, `kanban-web`) brings its own rendering stack.
 
+pub mod board_list;
 pub mod card_list;
 pub mod card_list_component;
 pub mod filter_state;

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, Utc};
 use kanban_core::AppConfig;
 use kanban_domain::{
-    sort_boards_in_place, ArchivedBoard, ArchivedCard, Board, BoardSortField, Card, Column,
-    DependencyGraph, Snapshot, SortOrder, Sprint, DEFAULT_ARCHIVED_BOARD_SORT,
+    filter_and_sort_boards, ArchivedBoard, ArchivedCard, Board, BoardListFilter, BoardSortField,
+    Card, Column, DependencyGraph, Snapshot, SortOrder, Sprint, DEFAULT_ARCHIVED_BOARD_SORT,
     DEFAULT_BOARD_SORT_LIVE,
 };
 use std::collections::{HashMap, HashSet};
@@ -173,17 +173,27 @@ impl Model {
     /// changes, so the rendered lists and the selection resolvers (which read
     /// these partitions) stay consistent.
     fn sort_partitions(&mut self) {
-        sort_boards_in_place(
-            &mut self.displayed_boards_live,
-            self.live_board_sort_field,
-            self.live_board_sort_order,
+        let live_filter = BoardListFilter {
+            sort: Some(self.live_board_sort_field),
+            sort_order: Some(self.live_board_sort_order),
+            ..Default::default()
+        };
+        self.displayed_boards_live = filter_and_sort_boards(
+            &self.displayed_boards_live,
+            &live_filter,
             &self.archived_board_at,
+            None,
         );
-        sort_boards_in_place(
-            &mut self.displayed_boards_archived,
-            self.archived_board_sort_field,
-            self.archived_board_sort_order,
+        let archived_filter = BoardListFilter {
+            sort: Some(self.archived_board_sort_field),
+            sort_order: Some(self.archived_board_sort_order),
+            ..Default::default()
+        };
+        self.displayed_boards_archived = filter_and_sort_boards(
+            &self.displayed_boards_archived,
+            &archived_filter,
             &self.archived_board_at,
+            None,
         );
     }
 }


### PR DESCRIPTION
Delivers KAN-1089 (Board list parity sub-epic of the list-parity root epic, KAN-1085) by shipping its three leaf cards: KAN-1090, KAN-1091, KAN-1092.

Independent of the Foundation sub-epic (KAN-1086, already merged, #547): boards already had a service-tier `BoardListFilter`/`filter_and_sort_boards` mirror of the card query engine, so this work extends that instead of using the Foundation's generic `Searcher<T>`.

## What

- **KAN-1090** — the board list's selection/scroll state moves off a bare `SelectionState` onto a new `BoardList` wrapper (`kanban-view/src/board_list.rs`) around the shared `ListComponent`, mirroring how `CardList` already works. Gains: Ctrl+D/Ctrl+U half-page jumps when `Focus::Boards`, and "more above/below" scroll indicators on the projects panel (previously a flat, unpaginated list).
- **KAN-1091** — board name search. `BoardListFilter` gains a `search: Option<String>` field (mirroring `CardListFilter.search`), wired into `filter_and_sort_boards` in `kanban-domain`. `/` now activates search when `Focus::Boards`, narrowing the projects panel by name (case-insensitive substring), with a live query echo in the footer and panel title. `filter_and_sort_boards` is the same function CLI/MCP route board queries through, so the domain-level plumbing is now search-capable there too, but neither `kanban-cli`'s `board list` command nor the MCP board tool expose a `--search`/search parameter today — both hardcode `search: None` (matching the existing pattern: card search isn't exposed as a CLI flag either). Adding that flag is a small, separate follow-up, not part of this PR.
- **KAN-1092** — real board multi-select. `MultiSelectState` gains an id-keyed `selected_boards: HashSet<Uuid>` (separate mode flag from card selection, since a user can browse boards with cards still multi-selected). The export dialog now seeds from the current multi-selection when non-empty, falling back to "all live boards, none pre-checked" (today's behavior) otherwise, and carries its own explicit `board_ids` list rather than re-deriving positions against the live model at confirm time.

## How this was built

Each card was first executed end-to-end in a throwaway spike worktree, stacked in dependency order (1090 -> 1091 -> 1092, since 1091 needs `BoardList` and 1092 needs both), each independently reviewed by a second agent with no shared context. Two rework cycles happened during spiking and are reflected in the final commits, not left as follow-up debt:

- KAN-1090: a duplicate `#[test]` attribute and 3 missing named tests were found and fixed. The missing render-indicator test caught a real bug — the "more below" scroll indicator silently didn't render when boards exactly filled the viewport (fixed by routing through `ListComponent::get_adjusted_viewport_height`, matching the card list's own render path).
- KAN-1091: the footer never echoed an active board-search query (both while typing and after committing), making the feature functionally invisible despite the underlying filtering working correctly. Fixed with an `active_search(app)` helper mirroring the existing keystroke-routing logic, plus regression tests.
- KAN-1092: clean PASS on first review, no rework needed.

Notable design decisions verified correct by the independent reviews:
- Board search uses a **second** `FilterState.board_search: SearchState` field rather than reusing the card-search field, because `prepare_frame`'s card-search application has no `Focus::Cards` guard — reuse would have leaked a board-name query into filtering the (unrelated) tasks panel.
- `App::displayed_boards()` stays a live, uncached per-call computation (not cached on `App`) because several sort handlers mutate `Model` and read it back without an intervening `prepare_frame()` call. This does mean the accessor's signature changed from a borrow (`&[Board]`) to an owned clone (`Vec<Board>`) — a real, accepted cost, called from the render path. **Tracked as a dedicated follow-up: KAN-1113**, rather than left only as an in-code comment.
- Board multi-select deliberately does NOT build on `ListComponent`'s existing index-keyed `multi_selected: HashSet<usize>` (dead code, and fragile under an active search filter) — it mirrors the proven id-keyed `MultiSelectState` pattern already used for cards instead.

## Review follow-ups applied

A PR review pass found two more things, both addressed in this branch (not deferred):
- `BoardList::inner()`'s doc comment referenced board search/multi-select as "future" work — both landed in this same PR, so the comment was stale on arrival. Fixed to describe what the accessor is actually used for.
- The `displayed_boards()` perf trade-off above is now tracked as KAN-1113 instead of being invisible outside a code comment.

## Testing

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean, whole workspace
- `cargo test`: full workspace green
- Named tests across all three cards (21 new + regression coverage for pre-existing board/card/export/footer suites), including explicit filter-respecting regression tests (`test_handle_select_all_boards_in_view_selects_only_currently_filtered_boards`) and a confirm-time-drift regression test (`test_execute_export_uses_explicit_board_ids_not_live_boards_snapshot_at_confirm_time`)