### PR TITLE
refactor(cli): create empty storage files through make_backend instead of PersistenceStore::save

### DIFF
--- a/.changeset/kan-1107.md
+++ b/.changeset/kan-1107.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+kanban init now creates empty storage files through the backend registry instead of the PersistenceStore save path, so a .db locator produces a real SQLite file rather than JSON written to a .db extension.

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -120,15 +120,19 @@ async fn create_empty_storage_file(
     file: &str,
     config: &AppConfig,
 ) -> anyhow::Result<()> {
-    use kanban_domain::Snapshot;
-    use kanban_persistence::{snapshot_to_json_bytes, PersistenceMetadata, StoreSnapshot};
-    let store = store_manager.make_store_with_config(Some(file), config)?;
-    let data = snapshot_to_json_bytes(&Snapshot::new()).map_err(|e| anyhow::anyhow!("{e}"))?;
-    let metadata = PersistenceMetadata::new(uuid::Uuid::new_v4());
-    store
-        .save(StoreSnapshot { data, metadata })
+    let backend = store_manager
+        .make_backend(file, config)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
+    // `flush()` alone is a no-op here: a never-mutated backend's dirty flag
+    // starts false, so nothing would land on disk without seeding a write.
+    if backend.needs_save_worker() {
+        backend
+            .as_data_store()
+            .apply_snapshot(kanban_domain::Snapshot::new())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    backend.flush().await.map_err(|e| anyhow::anyhow!("{e}"))?;
     Ok(())
 }
 

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -4631,6 +4631,55 @@ mod init_tests {
             .assert()
             .failure();
     }
+
+    #[test]
+    fn test_init_creates_loadable_json_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("boards.json");
+
+        kanban()
+            .args([file.to_str().unwrap(), "init"])
+            .assert()
+            .success();
+
+        assert!(file.exists());
+
+        let list = kanban()
+            .args([file.to_str().unwrap(), "board", "list"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let listed = parse_json_output(&String::from_utf8_lossy(&list));
+        assert_eq!(listed["data"]["total"].as_u64().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_init_creates_loadable_sqlite_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("boards.db");
+
+        kanban()
+            .args([file.to_str().unwrap(), "init"])
+            .assert()
+            .success();
+
+        assert!(file.exists());
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let boards = rt.block_on(async {
+            let backend = kanban_persistence_sqlite::SqliteBackend::open(file.to_str().unwrap())
+                .await
+                .expect("SqliteBackend::open should succeed on an initialised file");
+            kanban_domain::DataStore::list_boards(&backend)
+                .expect("list_boards should succeed on an initialised schema")
+        });
+        assert_eq!(boards.len(), 0);
+    }
 }
 
 mod relation_tests {

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -4644,15 +4644,27 @@ mod init_tests {
 
         assert!(file.exists());
 
-        let list = kanban()
-            .args([file.to_str().unwrap(), "board", "list"])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        let listed = parse_json_output(&String::from_utf8_lossy(&list));
-        assert_eq!(listed["data"]["total"].as_u64().unwrap(), 0);
+        // Pin the file TYPE, not just readability. Going through the CLI would
+        // content-sniff and happily accept a SQLite file at a .json path, so
+        // open the JSON backend directly the way the sqlite test does.
+        let head = std::fs::read(&file).unwrap();
+        assert_eq!(
+            head.iter().find(|b| !b.is_ascii_whitespace()),
+            Some(&b'{'),
+            "init must write a JSON envelope, not another format, to a .json locator"
+        );
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let boards = rt.block_on(async {
+            let store = std::sync::Arc::new(kanban_persistence_json::JsonFileStore::new(&file));
+            let backend = kanban_persistence_json::JsonDataStore::new(store);
+            kanban_domain::DataStore::list_boards(&backend)
+                .expect("list_boards should succeed on an initialised JSON envelope")
+        });
+        assert_eq!(boards.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Part of the Snapshot-removal epic (KAN-1065). `kanban init` created empty storage files through `PersistenceStore::save`, one of the paths this epic removes. It also produced the wrong kind of file: for a `.db` locator, `detect_backend`'s content sniff sits behind a `path.exists()` guard, so a new path returned `None` and fell back to the configured backend, writing JSON into a file named `.db`.

Routing creation through `make_backend` fixes both. `matches_locator` does honour `.db`/`.sqlite` when the header is empty, which `detect_backend` never reached.

## The seeding subtlety

`flush()` alone is a no-op on a freshly constructed backend. `JsonDataStore::flush` short-circuits on a `dirty` flag that starts false and is never set by the create path, so nothing reaches disk. `do_flush`'s `inner.is_none()` guard is a second net that is never even consulted.

The fix gates on `needs_save_worker()`, which defaults to false and is overridden to true only by `JsonDataStore`. So the JSON leg gets an `apply_snapshot(Snapshot::new())` seed to mark it dirty, and SQLite takes the bare `flush()` (stamp_writer plus checkpoint, no whole-store write).

## Sequencing decision, recorded

The card asked the implementer to state which of two options they took, since the seed uses `DataStore::apply_snapshot` and KAN-1079 removes that method.

This uses `DataStore::apply_snapshot`, not `PersistenceStore::apply_snapshot_async`. Those are different methods on different traits, and only the latter is deleted by the `PersistenceStore` work in KAN-1109. `DataStore::apply_snapshot` does go away in KAN-1079, so **this card must land before KAN-1079**, which is already the recorded sequencing. When KAN-1079 lands, this seed becomes an atomic no-op write instead.

## Tests

Two integration tests assert `init` produces a file a fresh backend can actually load, on both backends.

Being straight about their status: only the SQLite one is genuinely Red. The old code produced a loadable JSON file for a `.json` locator, so the JSON test would have passed before this change too. It is regression cover rather than a failing test, and the commit message says so.

`cargo test -p kanban-cli` green (144 + 10 + 1 doctest), clippy `--all-targets -D warnings` clean, fmt clean.

## Note on a related quirk

Before this change, an existing `.db` file written as JSON still worked in practice: `SqliteBackendFactory::matches_locator` declines it and `JsonBackendFactory` claims it. So the observable bug was narrower than "corrupt file", and this change fixes the file type at creation rather than repairing anything already on disk.
