### PR TITLE
KAN-1093 feat(view,tui): column list search/scroll parity with the card list

### DIFF
--- a/.changeset/kan-1093.md
+++ b/.changeset/kan-1093.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Column list gains live incremental name search (case-insensitive substring, filters without resorting) and ListComponent-backed scroll/selection state (more-above/below indicators). Manual reorder is deliberately disabled while a column search is active.

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -1,7 +1,7 @@
 use crate::components::sprint_picker::{SprintFilter, SprintPicker};
 use crate::handlers::board_handlers::BoardDeleteCounts;
 use kanban_core::SelectionState;
-use std::cell::Cell;
+use kanban_view::ListComponent;
 use uuid::Uuid;
 
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
@@ -15,8 +15,7 @@ pub struct DialogInputState {
     pub import_files: Vec<String>,
     pub import_selection: SelectionState,
     pub priority_selection: SelectionState,
-    pub column_selection: SelectionState,
-    pub column_scroll: Cell<usize>,
+    pub column_list: ListComponent,
     pub sprint_assign_selection: SelectionState,
     pub task_list_view_selection: SelectionState,
     pub carry_over_sprint_selection: SelectionState,
@@ -40,8 +39,7 @@ impl Default for DialogInputState {
             import_files: Vec::new(),
             import_selection: SelectionState::default(),
             priority_selection: SelectionState::default(),
-            column_selection: SelectionState::default(),
-            column_scroll: Cell::new(0),
+            column_list: ListComponent::new(false),
             sprint_assign_selection: SelectionState::default(),
             task_list_view_selection: SelectionState::default(),
             carry_over_sprint_selection: SelectionState::default(),

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -422,13 +422,17 @@ impl App {
 
     pub fn handle_search_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
-        // Exactly one of `search` (cards) / `board_search` (boards) is active
-        // at a time — whichever `/` activated in `handle_normal_key` — so route
-        // input to that one. Keeping them as two independent `SearchState`s
-        // (rather than one shared field) means a board-name query can never
-        // leak into the tasks panel's card search, and vice versa.
+        // Exactly one of `search` (cards) / `board_search` (boards) /
+        // `column_search` (board detail's column list) is active at a time —
+        // whichever `/` activated in `handle_normal_key` or
+        // `handle_board_detail_navigation_key` — so route input to that one.
+        // Keeping them as three independent `SearchState`s (rather than one
+        // shared field) means a query typed for one panel can never leak
+        // into another panel's search.
         let active = if self.filter.board_search.is_active {
             &mut self.filter.board_search
+        } else if self.filter.column_search.is_active {
+            &mut self.filter.column_search
         } else {
             &mut self.filter.search
         };

--- a/crates/kanban-tui/src/components/footer.rs
+++ b/crates/kanban-tui/src/components/footer.rs
@@ -10,12 +10,15 @@ use ratatui::{
 };
 
 /// Whichever `SearchState` is actually active — `board_search` (the projects
-/// panel) or `search` (the tasks panel) — mirroring the routing
-/// `handle_search_mode` (`app/input_router.rs`) already uses to decide which
-/// field typed keystrokes go to. At most one of the two is active at a time.
+/// panel), `column_search` (the board detail column list), or `search` (the
+/// tasks panel) — mirroring the routing `handle_search_mode`
+/// (`app/input_router.rs`) already uses to decide which field typed
+/// keystrokes go to. At most one of the three is active at a time.
 fn active_search(app: &App) -> Option<&SearchState> {
     if app.filter.board_search.is_active {
         Some(&app.filter.board_search)
+    } else if app.filter.column_search.is_active {
+        Some(&app.filter.column_search)
     } else if app.filter.search.is_active {
         Some(&app.filter.search)
     } else {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -491,25 +491,26 @@ impl App {
                 }
             }
             if self.is_kanban_view() {
-                if let Some(current_col_idx) = self.dialog_input.column_selection.get() {
+                let columns = self.model.columns();
+                let num_cols = self
+                    .active_board()
+                    .map(|b| columns.iter().filter(|c| c.board_id == b.id).count())
+                    .unwrap_or(0);
+                self.dialog_input.column_list.update_item_count(num_cols);
+                if let Some(current_col_idx) = self.dialog_input.column_list.get_selected_index() {
                     match direction {
                         kanban_domain::card_lifecycle::MoveDirection::Left => {
                             if current_col_idx > 0 {
                                 self.dialog_input
-                                    .column_selection
-                                    .set(Some(current_col_idx - 1));
+                                    .column_list
+                                    .set_selected_index(Some(current_col_idx - 1));
                             }
                         }
                         kanban_domain::card_lifecycle::MoveDirection::Right => {
-                            let columns = self.model.columns();
-                            let num_cols = self
-                                .active_board()
-                                .map(|b| columns.iter().filter(|c| c.board_id == b.id).count())
-                                .unwrap_or(0);
                             if current_col_idx < num_cols - 1 {
                                 self.dialog_input
-                                    .column_selection
-                                    .set(Some(current_col_idx + 1));
+                                    .column_list
+                                    .set_selected_index(Some(current_col_idx + 1));
                             }
                         }
                     }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -491,10 +491,9 @@ impl App {
                 }
             }
             if self.is_kanban_view() {
-                let columns = self.model.columns();
                 let num_cols = self
                     .active_board()
-                    .map(|b| columns.iter().filter(|c| c.board_id == b.id).count())
+                    .map(|b| self.visible_board_columns(b.id).len())
                     .unwrap_or(0);
                 self.dialog_input.column_list.update_item_count(num_cols);
                 if let Some(current_col_idx) = self.dialog_input.column_list.get_selected_index() {

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -259,14 +259,11 @@ impl App {
             // Collect column ID before mutable borrow
             let column_info = {
                 if let Some(board) = self.active_board() {
+                    let board_id = board.id;
                     if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
-                        let columns = self.model.columns();
-                        let board_columns: Vec<_> = columns
-                            .iter()
-                            .filter(|col| col.board_id == board.id)
-                            .collect();
-
-                        board_columns.get(column_idx).map(|col| col.id)
+                        self.visible_board_columns(board_id)
+                            .get(column_idx)
+                            .map(|col| col.id)
                     } else {
                         None
                     }
@@ -772,6 +769,73 @@ mod tests {
     }
 
     #[test]
+    fn test_rename_column_dialog_confirm_resolves_correct_column_regardless_of_model_iteration_order(
+    ) {
+        use kanban_domain::KanbanOperations;
+
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Roadmap");
+        let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
+
+        let doing_id = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap()
+            .iter()
+            .find(|c| c.name == "Doing")
+            .unwrap()
+            .id;
+        let new_col = app
+            .ctx
+            .create_column(board_id, "New".to_string(), Some(1))
+            .unwrap();
+
+        let mut snapshot = app.ctx.snapshot().unwrap();
+        let doing_idx = snapshot
+            .columns
+            .iter()
+            .position(|c| c.id == doing_id)
+            .unwrap();
+        let new_idx = snapshot
+            .columns
+            .iter()
+            .position(|c| c.id == new_col.id)
+            .unwrap();
+        snapshot.columns.swap(doing_idx, new_idx);
+        app.model.load_from_snapshot(snapshot);
+        app.selection.active_board_id = Some(board_id);
+
+        // Canonical index 2 is "New" (Doing was created first, tied at
+        // position 1). Confirming a rename at index 2 must persist against
+        // "New", not "Doing", regardless of the scrambled model order --
+        // pins the same "resolve against the sorted/filtered list, not raw
+        // model iteration order" contract, but for actual persistence
+        // rather than just the dialog's pre-populated display text.
+        app.focus.board_focus = BoardFocus::Columns;
+        app.dialog_input.column_list.update_item_count(4);
+        app.dialog_input.column_list.set_selected_index(Some(2));
+        app.handle_rename_column_key();
+        assert_eq!(app.input.as_str(), "New");
+
+        app.input.set("Renamed".to_string());
+        app.handle_rename_column_dialog(KeyCode::Enter);
+
+        let doing = app.ctx.data_store().get_column(doing_id).unwrap().unwrap();
+        let new_col_after = app
+            .ctx
+            .data_store()
+            .get_column(new_col.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(doing.name, "Doing", "Doing must be untouched");
+        assert_eq!(
+            new_col_after.name, "Renamed",
+            "New (canonical index 2) must be the one actually renamed, regardless of scrambled model order"
+        );
+    }
+
+    #[test]
     fn test_move_column_down_noop_while_column_search_active() {
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
@@ -855,7 +919,11 @@ mod tests {
                 .create_column(board.id, name.to_string(), Some(position))
                 .unwrap();
         }
-        let board_columns = app.ctx.data_store().list_columns_by_board(board.id).unwrap();
+        let board_columns = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board.id)
+            .unwrap();
         let in_progress_id = board_columns
             .iter()
             .find(|c| c.name == "In Progress")

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -21,13 +21,13 @@ impl App {
 
     pub fn handle_rename_column_key(&mut self) {
         if self.focus.board_focus == BoardFocus::Columns
-            && self.dialog_input.column_selection.get().is_some()
+            && self.dialog_input.column_list.get_selected_index().is_some()
         {
             {
                 if let Some(board) = self.active_board() {
                     let board_columns = sorted_board_columns(board.id, self.model.columns());
 
-                    if let Some(column_idx) = self.dialog_input.column_selection.get() {
+                    if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
                         if let Some(column) = board_columns.get(column_idx) {
                             self.input.set(column.name.clone());
                             self.open_dialog(DialogMode::RenameColumn);
@@ -40,7 +40,7 @@ impl App {
 
     pub fn handle_delete_column_key(&mut self) {
         if self.focus.board_focus == BoardFocus::Columns
-            && self.dialog_input.column_selection.get().is_some()
+            && self.dialog_input.column_list.get_selected_index().is_some()
         {
             {
                 if let Some(board) = self.active_board() {
@@ -63,7 +63,7 @@ impl App {
 
     pub fn handle_move_column_up(&mut self) {
         if self.focus.board_focus == BoardFocus::Columns
-            && self.dialog_input.column_selection.get().is_some()
+            && self.dialog_input.column_list.get_selected_index().is_some()
         {
             {
                 if let Some(board) = self.active_board() {
@@ -73,7 +73,7 @@ impl App {
                             .map(|col| (col.id, col.position))
                             .collect();
 
-                    if let Some(selected_idx) = self.dialog_input.column_selection.get() {
+                    if let Some(selected_idx) = self.dialog_input.column_list.get_selected_index() {
                         if selected_idx > 0 && selected_idx < board_columns.len() {
                             let prev_col_id = board_columns[selected_idx - 1].0;
                             let curr_col_id = board_columns[selected_idx].0;
@@ -103,7 +103,12 @@ impl App {
                                 return;
                             }
 
-                            self.dialog_input.column_selection.prev();
+                            self.dialog_input
+                                .column_list
+                                .update_item_count(board_columns.len());
+                            self.dialog_input
+                                .column_list
+                                .set_selected_index(Some(selected_idx - 1));
                             tracing::info!("Moved column up");
                         }
                     }
@@ -114,7 +119,7 @@ impl App {
 
     pub fn handle_move_column_down(&mut self) {
         if self.focus.board_focus == BoardFocus::Columns
-            && self.dialog_input.column_selection.get().is_some()
+            && self.dialog_input.column_list.get_selected_index().is_some()
         {
             {
                 if let Some(board) = self.active_board() {
@@ -124,7 +129,7 @@ impl App {
                             .map(|col| (col.id, col.position))
                             .collect();
 
-                    if let Some(selected_idx) = self.dialog_input.column_selection.get() {
+                    if let Some(selected_idx) = self.dialog_input.column_list.get_selected_index() {
                         if selected_idx < board_columns.len() - 1 {
                             let curr_col_id = board_columns[selected_idx].0;
                             let next_col_id = board_columns[selected_idx + 1].0;
@@ -155,7 +160,12 @@ impl App {
                             }
 
                             let column_count = board_columns.len();
-                            self.dialog_input.column_selection.next(column_count);
+                            self.dialog_input
+                                .column_list
+                                .update_item_count(column_count);
+                            self.dialog_input
+                                .column_list
+                                .set_selected_index(Some(selected_idx + 1));
                             tracing::info!("Moved column down");
                         }
                     }
@@ -228,8 +238,11 @@ impl App {
                 tracing::info!("Created column: {} (position: {})", column_name, position);
 
                 self.dialog_input
-                    .column_selection
-                    .set(Some(prior_column_count));
+                    .column_list
+                    .update_item_count(prior_column_count + 1);
+                self.dialog_input
+                    .column_list
+                    .set_selected_index(Some(prior_column_count));
             }
         }
     }
@@ -239,7 +252,7 @@ impl App {
             // Collect column ID before mutable borrow
             let column_info = {
                 if let Some(board) = self.active_board() {
-                    if let Some(column_idx) = self.dialog_input.column_selection.get() {
+                    if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
                         let columns = self.model.columns();
                         let board_columns: Vec<_> = columns
                             .iter()
@@ -287,7 +300,7 @@ impl App {
             // Collect all necessary data before mutating
             let delete_info = {
                 if let Some(board) = self.active_board() {
-                    if let Some(column_idx) = self.dialog_input.column_selection.get() {
+                    if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
                         let board_columns: Vec<(uuid::Uuid, String)> =
                             sorted_board_columns(board.id, self.model.columns())
                                 .into_iter()
@@ -372,16 +385,21 @@ impl App {
 
                 tracing::info!("Deleted column: {}", column_name);
 
+                self.dialog_input
+                    .column_list
+                    .update_item_count(remaining_after_delete);
                 if remaining_after_delete > 0 {
                     if column_idx >= remaining_after_delete {
                         self.dialog_input
-                            .column_selection
-                            .set(Some(remaining_after_delete - 1));
+                            .column_list
+                            .set_selected_index(Some(remaining_after_delete - 1));
                     } else {
-                        self.dialog_input.column_selection.set(Some(column_idx));
+                        self.dialog_input
+                            .column_list
+                            .set_selected_index(Some(column_idx));
                     }
                 } else {
-                    self.dialog_input.column_selection.clear();
+                    self.dialog_input.column_list.set_selected_index(None);
                 }
             }
         }
@@ -658,7 +676,8 @@ mod tests {
         // with "New" (its canonical predecessor, the later-created of the
         // tied pair) -- not "Doing", regardless of the scrambled model order.
         app.focus.board_focus = BoardFocus::Columns;
-        app.dialog_input.column_selection.set(Some(3));
+        app.dialog_input.column_list.update_item_count(4);
+        app.dialog_input.column_list.set_selected_index(Some(3));
         app.handle_move_column_up();
 
         let doing = app.ctx.data_store().get_column(doing_id).unwrap().unwrap();
@@ -730,7 +749,8 @@ mod tests {
         // index 2 and opening rename must populate "New"'s name, not
         // "Doing"'s, regardless of the scrambled model order.
         app.focus.board_focus = BoardFocus::Columns;
-        app.dialog_input.column_selection.set(Some(2));
+        app.dialog_input.column_list.update_item_count(4);
+        app.dialog_input.column_list.set_selected_index(Some(2));
         app.handle_rename_column_key();
 
         assert_eq!(app.input.as_str(), "New");

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -25,7 +25,8 @@ impl App {
         {
             {
                 if let Some(board) = self.active_board() {
-                    let board_columns = sorted_board_columns(board.id, self.model.columns());
+                    let board_id = board.id;
+                    let board_columns = self.visible_board_columns(board_id);
 
                     if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
                         if let Some(column) = board_columns.get(column_idx) {
@@ -62,6 +63,9 @@ impl App {
     }
 
     pub fn handle_move_column_up(&mut self) {
+        if self.filter.column_search.is_active {
+            return;
+        }
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_list.get_selected_index().is_some()
         {
@@ -118,6 +122,9 @@ impl App {
     }
 
     pub fn handle_move_column_down(&mut self) {
+        if self.filter.column_search.is_active {
+            return;
+        }
         if self.focus.board_focus == BoardFocus::Columns
             && self.dialog_input.column_list.get_selected_index().is_some()
         {
@@ -300,19 +307,26 @@ impl App {
             // Collect all necessary data before mutating
             let delete_info = {
                 if let Some(board) = self.active_board() {
+                    let board_id = board.id;
                     if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
-                        let board_columns: Vec<(uuid::Uuid, String)> =
-                            sorted_board_columns(board.id, self.model.columns())
+                        let all_columns: Vec<(uuid::Uuid, String)> =
+                            sorted_board_columns(board_id, self.model.columns())
                                 .into_iter()
                                 .map(|col| (col.id, col.name.clone()))
                                 .collect();
 
-                        if board_columns.len() <= 1 {
+                        if all_columns.len() <= 1 {
                             return;
                         }
 
-                        let column_to_delete = board_columns.get(column_idx).cloned();
-                        let first_column_id = board_columns.first().map(|(id, _)| *id);
+                        // Resolved against the filtered list the confirm
+                        // dialog was opened from, not `all_columns`, so a
+                        // narrowed search doesn't delete the wrong column.
+                        let column_to_delete = self
+                            .visible_board_columns(board_id)
+                            .get(column_idx)
+                            .map(|col| (col.id, col.name.clone()));
+                        let first_column_id = all_columns.first().map(|(id, _)| *id);
 
                         if let Some((column_id, column_name)) = column_to_delete {
                             let cards_to_move: Vec<(uuid::Uuid, i32)> = self
@@ -758,8 +772,6 @@ mod tests {
 
     #[test]
     fn test_move_column_down_noop_while_column_search_active() {
-        use kanban_domain::KanbanOperations;
-
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
         let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
@@ -794,8 +806,6 @@ mod tests {
 
     #[test]
     fn test_move_column_up_noop_while_column_search_active() {
-        use kanban_domain::KanbanOperations;
-
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
         let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -755,4 +755,76 @@ mod tests {
 
         assert_eq!(app.input.as_str(), "New");
     }
+
+    #[test]
+    fn test_move_column_down_noop_while_column_search_active() {
+        use kanban_domain::KanbanOperations;
+
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Roadmap");
+        let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
+        app.focus.board_focus = BoardFocus::Columns;
+        app.dialog_input.column_list.update_item_count(3);
+        app.dialog_input.column_list.set_selected_index(Some(0));
+        let before: Vec<(uuid::Uuid, i32)> = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap()
+            .iter()
+            .map(|c| (c.id, c.position))
+            .collect();
+        app.filter.column_search.activate();
+
+        app.handle_move_column_down();
+
+        let after: Vec<(uuid::Uuid, i32)> = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap()
+            .iter()
+            .map(|c| (c.id, c.position))
+            .collect();
+        assert_eq!(
+            before, after,
+            "reorder must not touch positions while column search is active"
+        );
+    }
+
+    #[test]
+    fn test_move_column_up_noop_while_column_search_active() {
+        use kanban_domain::KanbanOperations;
+
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Roadmap");
+        let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
+        app.focus.board_focus = BoardFocus::Columns;
+        app.dialog_input.column_list.update_item_count(3);
+        app.dialog_input.column_list.set_selected_index(Some(1));
+        let before: Vec<(uuid::Uuid, i32)> = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap()
+            .iter()
+            .map(|c| (c.id, c.position))
+            .collect();
+        app.filter.column_search.activate();
+
+        app.handle_move_column_up();
+
+        let after: Vec<(uuid::Uuid, i32)> = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap()
+            .iter()
+            .map(|c| (c.id, c.position))
+            .collect();
+        assert_eq!(
+            before, after,
+            "reorder must not touch positions while column search is active"
+        );
+    }
 }

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -555,6 +555,7 @@ impl App {
 mod tests {
     use crate::app::BoardFocus;
     use crate::App;
+    use crossterm::event::KeyCode;
 
     /// Refresh the TUI model from the store so the create handlers (which read
     /// `self.model`) see prior writes. The event loop does this each frame via
@@ -835,6 +836,81 @@ mod tests {
         assert_eq!(
             before, after,
             "reorder must not touch positions while column search is active"
+        );
+    }
+
+    #[test]
+    fn test_rename_column_dialog_confirm_renames_filtered_selection_not_unfiltered_index() {
+        use kanban_domain::KanbanOperations;
+
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        for (name, position) in [
+            ("Todo", 0),
+            ("In Progress", 1),
+            ("TODO Later", 2),
+            ("Done", 3),
+        ] {
+            app.ctx
+                .create_column(board.id, name.to_string(), Some(position))
+                .unwrap();
+        }
+        let board_columns = app.ctx.data_store().list_columns_by_board(board.id).unwrap();
+        let in_progress_id = board_columns
+            .iter()
+            .find(|c| c.name == "In Progress")
+            .unwrap()
+            .id;
+        let todo_later_id = board_columns
+            .iter()
+            .find(|c| c.name == "TODO Later")
+            .unwrap()
+            .id;
+
+        app.selection.active_board_id = Some(board.id);
+        app.prepare_frame();
+        app.focus.board_focus = BoardFocus::Columns;
+
+        // Filtered to [Todo, TODO Later] -- selecting filtered index 1 must
+        // resolve to "TODO Later", not the unfiltered board's index 1
+        // ("In Progress").
+        app.filter.column_search.activate();
+        for c in "todo".chars() {
+            app.filter.column_search.input.insert_char(c);
+        }
+        app.dialog_input.column_list.update_item_count(2);
+        app.dialog_input.column_list.set_selected_index(Some(1));
+
+        app.handle_rename_column_key();
+        assert_eq!(
+            app.input.as_str(),
+            "TODO Later",
+            "the rename dialog must pre-populate with the filtered selection's name"
+        );
+
+        app.input.set("Renamed".to_string());
+        app.handle_rename_column_dialog(KeyCode::Enter);
+
+        let in_progress = app
+            .ctx
+            .data_store()
+            .get_column(in_progress_id)
+            .unwrap()
+            .unwrap();
+        let todo_later = app
+            .ctx
+            .data_store()
+            .get_column(todo_later_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            in_progress.name, "In Progress",
+            "unfiltered index 1 (\"In Progress\") must not be touched by a filtered rename"
+        );
+        assert_eq!(
+            todo_later.name, "Renamed",
+            "the actually-selected filtered item (\"TODO Later\") must be the one renamed"
         );
     }
 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1300,6 +1300,23 @@ mod tests {
         board.id
     }
 
+    /// Seeds a board with columns at explicit `(name, position)` pairs (via
+    /// `create_column`, not the TUI's default-seeding `create_board`
+    /// handler) and opens it in Board Detail with the Columns panel focused.
+    fn seed_board_with_named_columns(app: &mut App, columns: &[(&str, i32)]) -> uuid::Uuid {
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        for (name, position) in columns {
+            app.ctx
+                .create_column(board.id, (*name).to_string(), Some(*position))
+                .unwrap();
+        }
+        app.selection.active_board_id = Some(board.id);
+        app.prepare_frame();
+        app.push_mode(AppMode::BoardDetail);
+        app.focus.board_focus = BoardFocus::Columns;
+        board.id
+    }
+
     fn reload_snapshot(app: &mut App) {
         let snap = Snapshot {
             archived_boards: Vec::new(),
@@ -1994,6 +2011,145 @@ mod tests {
         assert_eq!(
             positions[1].0, "Column01",
             "Column01 must have swapped back into position 1"
+        );
+    }
+
+    #[test]
+    fn test_column_search_filters_to_matching_names_case_insensitively() {
+        let mut app = App::test_default();
+        let board_id = seed_board_with_named_columns(
+            &mut app,
+            &[
+                ("Todo", 0),
+                ("In Progress", 1),
+                ("TODO Later", 2),
+                ("Done", 3),
+            ],
+        );
+        app.filter.column_search.activate();
+        for c in "todo".chars() {
+            app.filter.column_search.input.insert_char(c);
+        }
+
+        let visible = app.visible_board_columns(board_id);
+
+        assert_eq!(
+            visible.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Todo", "TODO Later"],
+            "column search must match case-insensitively on a name substring"
+        );
+    }
+
+    #[test]
+    fn test_column_search_empty_query_shows_all_columns_in_position_order() {
+        let mut app = App::test_default();
+        let board_id = seed_board_with_named_columns(
+            &mut app,
+            &[
+                ("Todo", 0),
+                ("In Progress", 1),
+                ("TODO Later", 2),
+                ("Done", 3),
+            ],
+        );
+        app.filter.column_search.activate();
+
+        let visible = app.visible_board_columns(board_id);
+
+        assert_eq!(
+            visible.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Todo", "In Progress", "TODO Later", "Done"],
+            "an empty query must show every column, in position order"
+        );
+    }
+
+    #[test]
+    fn test_column_search_preserves_position_order_not_alphabetical() {
+        let mut app = App::test_default();
+        let board_id = seed_board_with_named_columns(&mut app, &[("Zeta", 0), ("Alpha", 1)]);
+        app.filter.column_search.activate();
+        app.filter.column_search.input.insert_char('a');
+
+        let visible = app.visible_board_columns(board_id);
+
+        assert_eq!(
+            visible.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Zeta", "Alpha"],
+            "search must filter without resorting -- position order must win over alphabetical"
+        );
+    }
+
+    #[test]
+    fn test_column_search_does_not_affect_card_search_state() {
+        let mut app = App::test_default();
+        seed_board_with_named_columns(&mut app, &[("Todo", 0)]);
+
+        app.filter.search.activate();
+        for c in "card query".chars() {
+            app.filter.search.input.insert_char(c);
+        }
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('/'));
+        for c in "col query".chars() {
+            app.filter.column_search.input.insert_char(c);
+        }
+
+        assert_eq!(app.filter.search.query(), "card query");
+        assert_eq!(app.filter.column_search.query(), "col query");
+        assert!(
+            app.filter.column_search.is_active,
+            "activating column search via '/' on the Columns panel must set is_active"
+        );
+    }
+
+    #[test]
+    fn test_slash_key_in_columns_focus_activates_column_search() {
+        let mut app = App::test_default();
+        seed_board_with_named_columns(&mut app, &[("Todo", 0), ("Doing", 1)]);
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('/'));
+
+        assert!(app.filter.column_search.is_active);
+        assert_eq!(app.mode, AppMode::Search);
+    }
+
+    #[test]
+    fn test_slash_key_outside_columns_focus_does_not_activate_column_search() {
+        let mut app = App::test_default();
+        seed_board_with_named_columns(&mut app, &[("Todo", 0)]);
+        app.focus.board_focus = BoardFocus::Name;
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('/'));
+
+        assert!(!app.filter.column_search.is_active);
+        assert_eq!(app.mode, AppMode::BoardDetail);
+    }
+
+    #[test]
+    fn test_rename_column_key_resolves_correct_column_when_search_filters_list() {
+        let mut app = App::test_default();
+        seed_board_with_named_columns(
+            &mut app,
+            &[
+                ("Todo", 0),
+                ("In Progress", 1),
+                ("TODO Later", 2),
+                ("Done", 3),
+            ],
+        );
+        app.filter.column_search.activate();
+        for c in "todo".chars() {
+            app.filter.column_search.input.insert_char(c);
+        }
+        app.dialog_input.column_list.update_item_count(2);
+        app.dialog_input.column_list.set_selected_index(Some(1));
+
+        app.handle_rename_column_key();
+
+        assert_eq!(
+            app.input.as_str(),
+            "TODO Later",
+            "renaming while filtered must resolve the filtered list's index, not the unfiltered board order"
         );
     }
 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -19,6 +19,24 @@ pub(crate) enum RelationSide {
 }
 
 impl App {
+    fn column_count_for_board(&self, board_id: uuid::Uuid) -> usize {
+        self.model
+            .columns()
+            .iter()
+            .filter(|col| col.board_id == board_id)
+            .count()
+    }
+
+    fn enter_column_focus_at_top(&mut self, board_id: uuid::Uuid) {
+        let column_count = self.column_count_for_board(board_id);
+        self.dialog_input
+            .column_list
+            .update_item_count(column_count);
+        self.dialog_input
+            .column_list
+            .set_selected_index((column_count > 0).then_some(0));
+    }
+
     pub fn handle_card_detail_key(
         &mut self,
         key_code: KeyCode,
@@ -286,7 +304,97 @@ impl App {
         terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
         event_handler: &EventHandler,
     ) -> bool {
+        if let KeyCode::Char('e') = key_code {
+            return self.handle_board_detail_edit_key(terminal, event_handler);
+        }
+        self.handle_board_detail_navigation_key(key_code)
+    }
+
+    fn handle_board_detail_edit_key(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
         let mut should_restart = false;
+        match self.focus.board_focus {
+            BoardFocus::Name => {
+                if let Err(e) = self.edit_board_field(terminal, event_handler, BoardField::Name) {
+                    tracing::error!("Failed to edit board name: {}", e);
+                    self.set_error(format!("Failed to edit board name: {}", e));
+                }
+                should_restart = true;
+            }
+            BoardFocus::Description => {
+                if let Err(e) =
+                    self.edit_board_field(terminal, event_handler, BoardField::Description)
+                {
+                    tracing::error!("Failed to edit board description: {}", e);
+                    self.set_error(format!("Failed to edit board description: {}", e));
+                }
+                should_restart = true;
+            }
+            BoardFocus::Settings => {
+                if let Some(board) = self.active_board() {
+                    {
+                        let board_id = board.id;
+                        let dto = BoardSettingsDto::from_entity(board);
+                        let json =
+                            serde_json::to_string_pretty(&dto).unwrap_or_else(|_| "{}".to_string());
+                        let temp_file = std::env::temp_dir()
+                            .join(format!("kanban-board-{}-settings.json", board_id));
+                        match edit_in_external_editor(terminal, event_handler, temp_file, &json) {
+                            Ok(Some(new_content)) => {
+                                match serde_json::from_str::<BoardSettingsDto>(&new_content) {
+                                    Ok(new_dto) => {
+                                        let cmd = kanban_domain::commands::Command::Board(
+                                            kanban_domain::commands::BoardCommand::ApplySettings(
+                                                kanban_domain::commands::ApplyBoardSettings {
+                                                    board_id,
+                                                    dto: new_dto,
+                                                },
+                                            ),
+                                        );
+                                        if let Err(e) = self.ctx.execute_command(cmd) {
+                                            tracing::error!(
+                                                "Failed to apply board settings: {}",
+                                                e
+                                            );
+                                            self.set_error(format!(
+                                                "Failed to apply board settings: {}",
+                                                e
+                                            ));
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to parse board settings JSON: {}",
+                                            e
+                                        );
+                                        self.set_error(format!(
+                                            "Failed to parse board settings JSON: {}",
+                                            e
+                                        ));
+                                    }
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                tracing::error!("Failed to edit board settings: {}", e);
+                                self.set_error(format!("Failed to edit board settings: {}", e));
+                            }
+                        }
+                        should_restart = true;
+                    }
+                }
+            }
+            BoardFocus::Sprints => {}
+            BoardFocus::Columns => {}
+        }
+        should_restart
+    }
+
+    fn handle_board_detail_navigation_key(&mut self, key_code: KeyCode) -> bool {
+        let should_restart = false;
         match key_code {
             KeyCode::Esc => {
                 self.pop_mode();
@@ -307,80 +415,6 @@ impl App {
             KeyCode::Char('5') => {
                 self.focus.board_focus = BoardFocus::Columns;
             }
-            KeyCode::Char('e') => match self.focus.board_focus {
-                BoardFocus::Name => {
-                    if let Err(e) = self.edit_board_field(terminal, event_handler, BoardField::Name)
-                    {
-                        tracing::error!("Failed to edit board name: {}", e);
-                        self.set_error(format!("Failed to edit board name: {}", e));
-                    }
-                    should_restart = true;
-                }
-                BoardFocus::Description => {
-                    if let Err(e) =
-                        self.edit_board_field(terminal, event_handler, BoardField::Description)
-                    {
-                        tracing::error!("Failed to edit board description: {}", e);
-                        self.set_error(format!("Failed to edit board description: {}", e));
-                    }
-                    should_restart = true;
-                }
-                BoardFocus::Settings => {
-                    if let Some(board) = self.active_board() {
-                        {
-                            let board_id = board.id;
-                            let dto = BoardSettingsDto::from_entity(board);
-                            let json = serde_json::to_string_pretty(&dto)
-                                .unwrap_or_else(|_| "{}".to_string());
-                            let temp_file = std::env::temp_dir()
-                                .join(format!("kanban-board-{}-settings.json", board_id));
-                            match edit_in_external_editor(terminal, event_handler, temp_file, &json)
-                            {
-                                Ok(Some(new_content)) => {
-                                    match serde_json::from_str::<BoardSettingsDto>(&new_content) {
-                                        Ok(new_dto) => {
-                                            let cmd = kanban_domain::commands::Command::Board(
-                                                kanban_domain::commands::BoardCommand::ApplySettings(kanban_domain::commands::ApplyBoardSettings {
-                                                    board_id,
-                                                    dto: new_dto,
-                                                }),
-                                            );
-                                            if let Err(e) = self.ctx.execute_command(cmd) {
-                                                tracing::error!(
-                                                    "Failed to apply board settings: {}",
-                                                    e
-                                                );
-                                                self.set_error(format!(
-                                                    "Failed to apply board settings: {}",
-                                                    e
-                                                ));
-                                            }
-                                        }
-                                        Err(e) => {
-                                            tracing::error!(
-                                                "Failed to parse board settings JSON: {}",
-                                                e
-                                            );
-                                            self.set_error(format!(
-                                                "Failed to parse board settings JSON: {}",
-                                                e
-                                            ));
-                                        }
-                                    }
-                                }
-                                Ok(None) => {}
-                                Err(e) => {
-                                    tracing::error!("Failed to edit board settings: {}", e);
-                                    self.set_error(format!("Failed to edit board settings: {}", e));
-                                }
-                            }
-                            should_restart = true;
-                        }
-                    }
-                }
-                BoardFocus::Sprints => {}
-                BoardFocus::Columns => {}
-            },
             KeyCode::Char('n') => {
                 if self.focus.board_focus == BoardFocus::Sprints {
                     self.handle_create_sprint_key();
@@ -410,18 +444,18 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => match self.focus.board_focus {
                 BoardFocus::Sprints => {
-                    if let Some(board) = self.active_board() {
+                    if let Some(board_id) = self.active_board().map(|board| board.id) {
                         {
                             let sprint_count = self
                                 .model
                                 .sprints()
                                 .iter()
-                                .filter(|s| s.board_id == board.id)
+                                .filter(|s| s.board_id == board_id)
                                 .count();
                             let current_idx = self.selection.sprint.get().unwrap_or(0);
                             if sprint_count == 0 || current_idx >= sprint_count - 1 {
                                 self.focus.board_focus = BoardFocus::Columns;
-                                self.dialog_input.column_selection.set(Some(0));
+                                self.enter_column_focus_at_top(board_id);
                             } else {
                                 self.selection.sprint.next(sprint_count);
                             }
@@ -431,18 +465,20 @@ impl App {
                 BoardFocus::Columns => {
                     if let Some(board) = self.active_board() {
                         {
-                            let column_count = self
-                                .model
-                                .columns()
-                                .iter()
-                                .filter(|col| col.board_id == board.id)
-                                .count();
-                            let current_idx = self.dialog_input.column_selection.get().unwrap_or(0);
+                            let column_count = self.column_count_for_board(board.id);
+                            self.dialog_input
+                                .column_list
+                                .update_item_count(column_count);
+                            let current_idx = self
+                                .dialog_input
+                                .column_list
+                                .get_selected_index()
+                                .unwrap_or(0);
                             if column_count > 0 && current_idx >= column_count - 1 {
                                 self.focus.board_focus = BoardFocus::Name;
                                 self.selection.sprint.set(Some(0));
                             } else {
-                                self.dialog_input.column_selection.next(column_count);
+                                self.dialog_input.column_list.navigate_down();
                             }
                         }
                     }
@@ -458,7 +494,9 @@ impl App {
                     if self.focus.board_focus == BoardFocus::Sprints {
                         self.selection.sprint.set(Some(0));
                     } else if self.focus.board_focus == BoardFocus::Columns {
-                        self.dialog_input.column_selection.set(Some(0));
+                        if let Some(board) = self.active_board() {
+                            self.enter_column_focus_at_top(board.id);
+                        }
                     }
                 }
             },
@@ -472,8 +510,16 @@ impl App {
                     }
                 }
                 BoardFocus::Columns => {
-                    let current_idx = self.dialog_input.column_selection.get().unwrap_or(0);
-                    if current_idx == 0 {
+                    let column_count = self
+                        .board_list
+                        .get_selected_board_id()
+                        .map(|board_id| self.column_count_for_board(board_id))
+                        .unwrap_or(0);
+                    self.dialog_input
+                        .column_list
+                        .update_item_count(column_count);
+                    let was_at_top = self.dialog_input.column_list.navigate_up();
+                    if was_at_top {
                         let sprint_count = self
                             .board_list
                             .get_selected_board_id()
@@ -491,8 +537,6 @@ impl App {
                             self.focus.board_focus = BoardFocus::Sprints;
                             self.selection.sprint.set(Some(sprint_count - 1));
                         }
-                    } else {
-                        self.dialog_input.column_selection.prev();
                     }
                 }
                 _ => {
@@ -504,7 +548,9 @@ impl App {
                         BoardFocus::Columns => BoardFocus::Sprints,
                     };
                     if self.focus.board_focus == BoardFocus::Columns {
-                        self.dialog_input.column_selection.set(Some(0));
+                        if let Some(board) = self.active_board() {
+                            self.enter_column_focus_at_top(board.id);
+                        }
                     }
                 }
             },

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -5,7 +5,8 @@ use crate::editor::edit_in_external_editor;
 use crate::events::EventHandler;
 use crossterm::event::KeyCode;
 use kanban_core::Editable;
-use kanban_domain::{BoardSettingsDto, CardMetadataDto};
+use kanban_domain::card_lifecycle::sorted_board_columns;
+use kanban_domain::{BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, Searcher};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -19,12 +20,29 @@ pub(crate) enum RelationSide {
 }
 
 impl App {
+    /// The columns a user actually sees on the board detail Columns panel:
+    /// board-scoped, position-ordered, and narrowed by `filter.column_search`
+    /// when it holds a query (an inactive/empty search matches everything,
+    /// per `FieldSearcher`'s empty-query contract). This is the single
+    /// source of truth for both rendering (`ui::board_detail`) and index
+    /// resolution in the column handlers, so a filtered list and an
+    /// unfiltered handler can never disagree on what index N means.
+    pub(crate) fn visible_board_columns(&self, board_id: uuid::Uuid) -> Vec<Column> {
+        let ordered = sorted_board_columns(board_id, self.model.columns());
+        let query = self.filter.column_search.active_query().unwrap_or("");
+        let searcher = FieldSearcher::new(query, |c: &&Column| c.name.as_str());
+        kanban_view::list_query::search_and_sort(
+            ordered,
+            |c| searcher.matches(c),
+            |a, b| a.position.cmp(&b.position),
+        )
+        .into_iter()
+        .cloned()
+        .collect()
+    }
+
     fn column_count_for_board(&self, board_id: uuid::Uuid) -> usize {
-        self.model
-            .columns()
-            .iter()
-            .filter(|col| col.board_id == board_id)
-            .count()
+        self.visible_board_columns(board_id).len()
     }
 
     fn enter_column_focus_at_top(&mut self, board_id: uuid::Uuid) {
@@ -399,6 +417,12 @@ impl App {
             KeyCode::Esc => {
                 self.pop_mode();
                 self.focus.board_focus = BoardFocus::Name;
+            }
+            KeyCode::Char('/') => {
+                if self.focus.board_focus == BoardFocus::Columns {
+                    self.filter.column_search.activate();
+                    self.push_mode(AppMode::Search);
+                }
             }
             KeyCode::Char('1') => {
                 self.focus.board_focus = BoardFocus::Name;

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1275,10 +1275,30 @@ impl App {
 #[cfg(test)]
 mod tests {
     use crate::app::sprint_view::SprintTaskPanel;
-    use crate::app::CardFocus;
+    use crate::app::{AppMode, BoardFocus, CardFocus};
     use crate::App;
     use crossterm::event::KeyCode;
     use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, Snapshot};
+
+    /// Seeds a board with exactly `total_columns` columns (via `create_column`,
+    /// not the TUI's default-seeding `create_board` handler) and opens it in
+    /// Board Detail with the Columns panel focused.
+    fn seed_board_with_columns(app: &mut App, total_columns: usize) -> uuid::Uuid {
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        for i in 0..total_columns {
+            app.ctx
+                .create_column(board.id, format!("Column{i:02}"), None)
+                .unwrap();
+        }
+        app.selection.active_board_id = Some(board.id);
+        // Populates `board_list` (and auto-selects the sole board), which the
+        // Columns-focus up-navigation resolves the board through, mirroring
+        // the main loop's per-action refresh.
+        app.prepare_frame();
+        app.push_mode(AppMode::BoardDetail);
+        app.focus.board_focus = BoardFocus::Columns;
+        board.id
+    }
 
     fn reload_snapshot(app: &mut App) {
         let snap = Snapshot {
@@ -1812,6 +1832,168 @@ mod tests {
         assert_eq!(
             card.id, fx.a_id,
             "get_card_for_detail_view must return the originally selected card (A) by id, not the card now at A's stale index"
+        );
+    }
+
+    #[test]
+    fn test_column_list_navigate_down_advances_selection_and_clamps_at_last_column() {
+        let mut app = App::test_default();
+        seed_board_with_columns(&mut app, 3);
+        app.dialog_input.column_list.update_item_count(3);
+        app.dialog_input.column_list.set_selected_index(Some(0));
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('j'));
+        assert_eq!(app.dialog_input.column_list.get_selected_index(), Some(1));
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('j'));
+        assert_eq!(
+            app.dialog_input.column_list.get_selected_index(),
+            Some(2),
+            "should advance to the last column"
+        );
+        assert_eq!(
+            app.focus.board_focus,
+            BoardFocus::Columns,
+            "focus stays on Columns while there is still a next column"
+        );
+
+        // One more 'j' at the last column exits Columns focus forward,
+        // matching the pre-migration cross-panel cycling behavior; the
+        // selection itself must not have advanced past the last column.
+        app.handle_board_detail_navigation_key(KeyCode::Char('j'));
+        assert_eq!(
+            app.dialog_input.column_list.get_selected_index(),
+            Some(2),
+            "selection must not overshoot the last column"
+        );
+        assert_eq!(app.focus.board_focus, BoardFocus::Name);
+    }
+
+    #[test]
+    fn test_column_list_navigate_up_at_first_column_exits_to_sprints_focus() {
+        let mut app = App::test_default();
+        let board_id = seed_board_with_columns(&mut app, 3);
+        app.ctx.create_sprint(board_id, None, None).unwrap();
+        app.ctx.create_sprint(board_id, None, None).unwrap();
+        app.prepare_frame();
+
+        app.dialog_input.column_list.update_item_count(3);
+        app.dialog_input.column_list.set_selected_index(Some(0));
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('k'));
+
+        assert_eq!(
+            app.focus.board_focus,
+            BoardFocus::Sprints,
+            "up at the first column must exit to the Sprints panel, not stay on Columns"
+        );
+        assert_eq!(
+            app.selection.sprint.get(),
+            Some(1),
+            "focus-exit must land on the last sprint (count - 1)"
+        );
+    }
+
+    #[test]
+    fn test_column_list_scroll_offset_keeps_selected_column_visible_after_migration() {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let mut app = App::test_default();
+        seed_board_with_columns(&mut app, 10);
+        app.dialog_input.column_list.update_item_count(10);
+        app.dialog_input.column_list.set_selected_index(Some(0));
+
+        for _ in 0..9 {
+            app.handle_board_detail_navigation_key(KeyCode::Char('j'));
+        }
+        assert_eq!(app.dialog_input.column_list.get_selected_index(), Some(9));
+
+        let backend = TestBackend::new(80, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(&mut app, frame))
+            .unwrap();
+
+        let buffer = terminal.backend().buffer().clone();
+        let mut rendered = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                rendered.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+            }
+            rendered.push('\n');
+        }
+
+        assert!(
+            rendered.contains("Column09"),
+            "the selected last column must be visible after scrolling, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("Column00"),
+            "the first column should have scrolled off-screen, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn test_move_column_up_and_down_still_operate_after_migration() {
+        let mut app = App::test_default();
+        let board_id = seed_board_with_columns(&mut app, 3);
+        app.dialog_input.column_list.update_item_count(3);
+        app.dialog_input.column_list.set_selected_index(Some(0));
+
+        app.handle_move_column_down();
+        assert_eq!(
+            app.dialog_input.column_list.get_selected_index(),
+            Some(1),
+            "moving a column down should follow it with the selection"
+        );
+
+        let columns_after_down = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap();
+        let mut positions: Vec<_> = columns_after_down
+            .iter()
+            .map(|c| (c.name.clone(), c.position))
+            .collect();
+        positions.sort_by_key(|(_, pos)| *pos);
+        assert_eq!(
+            positions[0].0, "Column01",
+            "Column01 must have swapped into position 0"
+        );
+        assert_eq!(
+            positions[1].0, "Column00",
+            "Column00 must have swapped into position 1"
+        );
+
+        // Mirrors the main loop's per-keypress refresh: the model is a
+        // snapshot, so the next handler must see the just-executed swap.
+        app.prepare_frame();
+
+        app.handle_move_column_up();
+        assert_eq!(
+            app.dialog_input.column_list.get_selected_index(),
+            Some(0),
+            "moving the column back up should follow it with the selection"
+        );
+
+        let columns_after_up = app
+            .ctx
+            .data_store()
+            .list_columns_by_board(board_id)
+            .unwrap();
+        let mut positions: Vec<_> = columns_after_up
+            .iter()
+            .map(|c| (c.name.clone(), c.position))
+            .collect();
+        positions.sort_by_key(|(_, pos)| *pos);
+        assert_eq!(
+            positions[0].0, "Column00",
+            "Column00 must have swapped back into position 0"
+        );
+        assert_eq!(
+            positions[1].0, "Column01",
+            "Column01 must have swapped back into position 1"
         );
     }
 }

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -246,13 +246,14 @@ fn render_board_columns_list(
         .with_focus_indicator("Columns [5]")
         .focused(app.focus.board_focus == BoardFocus::Columns);
 
-    let board_columns = sorted_board_columns(board.id, app.model.columns());
+    let total_columns = sorted_board_columns(board.id, app.model.columns()).len();
+    let board_columns = app.visible_board_columns(board.id);
 
     let mut column_lines = vec![];
 
     if board_columns.is_empty() {
         column_lines.push(Line::from(Span::styled(
-            "  No columns yet. Press 'n' to create one!",
+            columns_empty_state_message(total_columns),
             label_text(),
         )));
     } else {
@@ -303,6 +304,14 @@ fn render_board_columns_list(
 
     let columns = Paragraph::new(column_lines).block(columns_config.block());
     frame.render_widget(columns, area);
+}
+
+fn columns_empty_state_message(total_columns: usize) -> &'static str {
+    if total_columns == 0 {
+        "  No columns yet. Press 'n' to create one!"
+    } else {
+        "  No columns match search"
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -12,10 +12,11 @@ use ratatui::{
     Frame,
 };
 
-pub(super) fn render_board_detail_view(app: &App, frame: &mut Frame, area: Rect) {
+pub(super) fn render_board_detail_view(app: &mut App, frame: &mut Frame, area: Rect) {
     // Resolve the board by identity so board detail works for a live OR archived
-    // board without branching — a board is a board.
-    if let Some(board) = app.board_in_context() {
+    // board without branching — a board is a board. Cloned so the borrow of
+    // `app` doesn't outlive the `&mut App` the columns list needs below.
+    if let Some(board) = app.board_in_context().cloned() {
         {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -28,11 +29,11 @@ pub(super) fn render_board_detail_view(app: &App, frame: &mut Frame, area: Rect)
                 ])
                 .split(area);
 
-            render_board_name_field(app, board, frame, chunks[0]);
-            render_board_description_field(app, board, frame, chunks[1]);
-            render_board_settings_section(app, board, frame, chunks[2]);
-            render_board_sprints_list(app, board, frame, chunks[3]);
-            render_board_columns_list(app, board, frame, chunks[4]);
+            render_board_name_field(app, &board, frame, chunks[0]);
+            render_board_description_field(app, &board, frame, chunks[1]);
+            render_board_settings_section(app, &board, frame, chunks[2]);
+            render_board_sprints_list(app, &board, frame, chunks[3]);
+            render_board_columns_list(app, &board, frame, chunks[4]);
         }
     }
 }
@@ -234,7 +235,7 @@ fn render_board_sprints_list(
 }
 
 fn render_board_columns_list(
-    app: &App,
+    app: &mut App,
     board: &kanban_domain::Board,
     frame: &mut Frame,
     area: Rect,
@@ -256,9 +257,29 @@ fn render_board_columns_list(
         )));
     } else {
         let all_cards = app.model.live_cards();
-        for (column_idx, column) in board_columns.iter().enumerate() {
-            let is_selected = app.dialog_input.column_selection.get() == Some(column_idx);
-            let is_focused = app.focus.board_focus == BoardFocus::Columns;
+        let is_focused = app.focus.board_focus == BoardFocus::Columns;
+        let viewport_height = area.height.saturating_sub(2) as usize;
+
+        // Refreshed here rather than relying on a handler having run first:
+        // jumping straight to the Columns panel (key '5') sets focus without
+        // touching the list.
+        app.dialog_input
+            .column_list
+            .update_item_count(board_columns.len());
+        app.dialog_input
+            .column_list
+            .ensure_selected_visible(viewport_height);
+        let render_info = app
+            .dialog_input
+            .column_list
+            .get_render_info(viewport_height);
+        let selected_idx = app.dialog_input.column_list.get_selected_index();
+
+        for &column_idx in &render_info.visible_indices {
+            let Some(column) = board_columns.get(column_idx) else {
+                continue;
+            };
+            let is_selected = selected_idx == Some(column_idx);
 
             let card_count = all_cards
                 .iter()
@@ -280,16 +301,6 @@ fn render_board_columns_list(
         }
     }
 
-    let selected_idx = app.dialog_input.column_selection.get().unwrap_or(0);
-    let viewport_height = area.height.saturating_sub(2) as usize;
-    let scroll = scroll_offset_to_keep_visible(
-        app.dialog_input.column_scroll.get(),
-        selected_idx,
-        viewport_height,
-    );
-    app.dialog_input.column_scroll.set(scroll);
-    let columns = Paragraph::new(column_lines)
-        .block(columns_config.block())
-        .scroll((scroll as u16, 0));
+    let columns = Paragraph::new(column_lines).block(columns_config.block());
     frame.render_widget(columns, area);
 }

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -304,3 +304,21 @@ fn render_board_columns_list(
     let columns = Paragraph::new(column_lines).block(columns_config.block());
     frame.render_widget(columns, area);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_columns_empty_state_message_when_board_has_no_columns() {
+        assert_eq!(
+            columns_empty_state_message(0),
+            "  No columns yet. Press 'n' to create one!"
+        );
+    }
+
+    #[test]
+    fn test_columns_empty_state_message_when_search_matches_nothing() {
+        assert_eq!(columns_empty_state_message(3), "  No columns match search");
+    }
+}

--- a/crates/kanban-tui/tests/footer_tests.rs
+++ b/crates/kanban-tui/tests/footer_tests.rs
@@ -67,6 +67,36 @@ fn test_footer_shows_board_query_while_typing_when_board_search_active() {
 }
 
 #[test]
+fn test_footer_shows_column_query_after_commit_when_column_search_active() {
+    let mut app = App::test_default();
+    app.filter.column_search.is_active = true;
+    for c in "todo".chars() {
+        app.filter.column_search.input.insert_char(c);
+    }
+    let output = render_footer_to_string(&app);
+    assert!(
+        output.contains("/todo"),
+        "Footer should echo the committed column search query, not render blank"
+    );
+}
+
+#[test]
+fn test_footer_shows_column_query_while_typing_when_column_search_active() {
+    use kanban_tui::app::mode::AppMode;
+    let mut app = App::test_default();
+    app.filter.column_search.activate();
+    for c in "todo".chars() {
+        app.filter.column_search.input.insert_char(c);
+    }
+    app.push_mode(AppMode::Search);
+    let output = render_footer_to_string(&app);
+    assert!(
+        output.contains("/todo"),
+        "Footer should echo the column search query while typing"
+    );
+}
+
+#[test]
 fn test_render_footer_search_mode_renders_without_panic() {
     use kanban_tui::app::mode::AppMode;
     let mut app = App::test_default();

--- a/crates/kanban-tui/tests/scroll_board_edit_lists.rs
+++ b/crates/kanban-tui/tests/scroll_board_edit_lists.rs
@@ -82,7 +82,8 @@ fn test_board_columns_list_scrolls_to_keep_selection_visible() {
         .map(|b| b.id);
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Columns;
-    app.dialog_input.column_selection.set(Some(19));
+    app.dialog_input.column_list.update_item_count(20);
+    app.dialog_input.column_list.set_selected_index(Some(19));
 
     let output = render_to_string(&mut app, 80, 30);
 

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -627,3 +627,76 @@ fn test_toggle_multi_card_completion_retains_selection() {
         selected_after
     );
 }
+
+#[test]
+fn test_move_card_right_syncs_column_list_count_to_filtered_columns_not_raw_board_count() {
+    // KAN-1093 follow-up: handle_move_card's cosmetic column_list bookkeeping
+    // used to derive its item count from the raw, unfiltered board column
+    // count, disagreeing with visible_board_columns (which every other
+    // column call site resolves indices against once a column search is
+    // active). Not reachable from Kanban view today (column search only
+    // activates from the board-detail Columns panel), but a stale
+    // column_search left active is still real synced state, so this pins the
+    // count to agree with visible_board_columns regardless.
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let _todo = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let _doing = app
+        .ctx
+        .create_column(board.id, "Doing".to_string(), Some(1))
+        .unwrap();
+    let _done = app
+        .ctx
+        .create_column(board.id, "Done".to_string(), Some(2))
+        .unwrap();
+    app.prepare_frame();
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
+    // `is_kanban_view()` reads the board's persisted `task_list_view`, not
+    // the app's local view strategy — both must be set for
+    // `handle_move_card`'s column_list tracking block to actually run.
+    app.execute_command(kanban_domain::commands::Command::Board(
+        kanban_domain::commands::BoardCommand::SetTaskListView(
+            kanban_domain::commands::SetBoardTaskListView {
+                board_id: board.id,
+                view: kanban_domain::TaskListView::ColumnView,
+            },
+        ),
+    ))
+    .unwrap();
+    app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.prepare_frame();
+    app.focus.active = Focus::Cards;
+
+    app.input.set("Mover".to_string());
+    app.create_card();
+    app.prepare_frame();
+
+    // Narrow the column list to a single match — if the cosmetic tracking
+    // used the raw 3-column count instead, this would silently disagree with
+    // ListComponent's own bounds (which are set from the filtered count
+    // everywhere else in this board's column handling).
+    app.filter.column_search.activate();
+    for c in "todo".chars() {
+        app.filter.column_search.input.insert_char(c);
+    }
+
+    app.handle_move_card_right();
+    app.prepare_frame();
+
+    assert_eq!(
+        app.dialog_input.column_list.len(),
+        1,
+        "column_list's item count after a card move must match visible_board_columns \
+         (filtered to 1 by the active column search), not the raw 3-column board count"
+    );
+}

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -211,7 +211,7 @@ fn test_create_column_selects_new_column() {
     app.create_column();
     app.prepare_frame();
 
-    let selected = app.dialog_input.column_selection.get();
+    let selected = app.dialog_input.column_list.get_selected_index();
     assert_eq!(
         selected,
         Some(columns_before),
@@ -485,7 +485,8 @@ fn test_delete_column_adjusts_selection() {
     app.focus.board_focus = BoardFocus::Columns;
 
     // Select the last column (index 2) and delete it
-    app.dialog_input.column_selection.set(Some(2));
+    app.dialog_input.column_list.update_item_count(3);
+    app.dialog_input.column_list.set_selected_index(Some(2));
     app.delete_column();
     app.prepare_frame();
 
@@ -497,7 +498,7 @@ fn test_delete_column_adjusts_selection() {
         .count();
     assert_eq!(remaining, 2, "should have 2 columns remaining");
 
-    let selected = app.dialog_input.column_selection.get();
+    let selected = app.dialog_input.column_list.get_selected_index();
     assert_eq!(
         selected,
         Some(1),

--- a/crates/kanban-view/src/filter_state.rs
+++ b/crates/kanban-view/src/filter_state.rs
@@ -20,6 +20,10 @@ pub struct FilterState {
     /// board-name query never bleeds into the tasks panel's card search (the
     /// two panels can carry different active queries at once).
     pub board_search: SearchState,
+    /// Independent from both `search` and `board_search`: the board detail
+    /// view's column-list search, so a column-name query never bleeds into
+    /// the other two panels' searches.
+    pub column_search: SearchState,
     pub dialog_state: Option<FilterDialogState>,
 }
 

--- a/crates/kanban-view/src/filter_state.rs
+++ b/crates/kanban-view/src/filter_state.rs
@@ -38,5 +38,6 @@ mod tests {
         assert!(state.dialog_state.is_none());
         assert!(!state.search.is_active);
         assert!(!state.board_search.is_active);
+        assert!(!state.column_search.is_active);
     }
 }


### PR DESCRIPTION
Delivers KAN-1093 (Column list parity sub-epic of the list-parity root epic, KAN-1085) by shipping its two leaf cards: KAN-1094, KAN-1095.

Depends on the Foundation sub-epic (KAN-1086, merged, #547) and follows KAN-1089 (Board list parity, merged, #549) as the third parity epic shipped.

## What

- **KAN-1094** — the column list's selection/scroll state moves off a raw `SelectionState` + `Cell<usize>` pair onto a `ListComponent` field directly on `DialogInputState` (`column_list: ListComponent`), replacing hand-rolled scroll math with the shared primitive every other migrated list surface already uses. Pure state-representation refactor, no user-visible behavior change: same keys, same empty-state text, same row content, same cross-panel focus-exit behavior when navigating up from the first column.
- **KAN-1095** — live incremental column name search. `/` activates a new, independently-scoped `column_search: SearchState` field on `FilterState` when the Columns panel is focused (mirroring KAN-1091's `board_search` precedent exactly), filtering the rendered list by name (case-insensitive substring) without resorting — column order stays position-based, since it mirrors board layout. This is the first production consumer of the Foundation's `Searcher<T>`/`FieldSearcher<T, F>`/`search_and_sort` (the card list's own search predates Foundation and uses a separate, older mechanism). Manual reorder (Shift+J/K) is deliberately disabled while a search is active, since reordering within a filtered subset would silently corrupt column position in a way that's easy to miss.

## How this was built

Each card was first executed end-to-end in a throwaway spike worktree, stacked (1094 -> 1095, since 1095 filters on top of 1094's `ListComponent` migration), each independently reviewed by a second agent with no shared context.

- KAN-1094: clean PASS, one non-blocking process nit (a test/impl commit-ordering slip, no functional issue). The real complexity here was invisible in the card: the pre-migration render path used `Cell<usize>` interior mutability to self-correct scroll state every frame regardless of handler ordering (so jumping straight to the Columns panel with no prior navigation still rendered correctly). `ListComponent` has no such interior mutability, so the render function had to move from `&App` to `&mut App` (matching existing precedent elsewhere in the crate) and call `update_item_count`/`ensure_selected_visible` directly every frame to reproduce the same guarantee.
- KAN-1095: **initial FAIL on a real, reproducible data-corruption bug.** With a column search active narrowing the list, the rename dialog correctly *displayed* the right column's name, but confirming the rename silently mutated a *different* column — the dialog's selected index lived in the filtered list's index space, but the actual rename-execution code resolved it against an unsorted, unfiltered snapshot. Root cause: the first-round regression test only asserted on what got displayed in the dialog, not what got persisted, so the bug passed review invisibly. Fixed by resolving the mutation the same way `delete_column()`/the dialog-population step already did (against `visible_board_columns`), with a new test that drives the full rename to actual persistence and asserts on stored state. As a side effect, this also fixed a **pre-existing, search-independent bug**: renaming after a manual reorder could already target the wrong column, since the buggy code used raw unsorted model iteration order — same root cause, same fix, confirmed with a dedicated regression test.

## Testing

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean, whole workspace
- `cargo test`: full workspace green, 174 `test result: ok` blocks, 0 failed
- Named tests across both cards, including the safety-critical regression tests: `test_column_list_navigate_up_at_first_column_exits_to_sprints_focus` (cross-panel focus-exit preserved), `test_column_search_preserves_position_order_not_alphabetical` (filter, don't resort), `test_move_column_up_noop_while_column_search_active` / `..._down_...` (reorder disabled under an active filter, asserted via real before/after position checks, not just early-return), `test_rename_column_dialog_confirm_renames_filtered_selection_not_unfiltered_index` (the data-corruption fix, drives to actual persistence) and `test_rename_column_dialog_confirm_resolves_correct_column_regardless_of_model_iteration_order` (the pre-existing bug, fixed as a side effect)

## Review follow-up applied

A PR review pass found one more thing, addressed in this branch: `handle_move_card`'s cosmetic column_list bookkeeping (which column shows highlighted next time board detail opens, for moving a card left/right in Kanban view) derived its item count from the raw, unfiltered board column count instead of `visible_board_columns` — the same index-space-mismatch class of bug fixed for `rename_column` above, just in a call site the original spike review didn't check. Not a data-loss risk (this block never drives the card's actual destination column, only a cosmetic highlight), but fixed for consistency with every other column call site in this PR, with a genuine Red-then-Green regression test.
