### PR TITLE
KAN-1106 refactor(service): narrow validate_and_load_store to validate_store_readable with a cheap backend probe

### DIFF
--- a/.changeset/kan-1106.md
+++ b/.changeset/kan-1106.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+StoreManager::validate_and_load_store becomes validate_store_readable and probes the backend with a cheap indexed read instead of deserialising the whole store, so validating a storage location no longer pays a full snapshot. The settings migration channel narrows to Result<bool, String> accordingly.

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -302,7 +302,7 @@ sm.is_sqlite(locator) -> bool
 sm.sync_backend_with_file(locator, &mut config) -> bool  // returns true if it corrected config
 
 // Admin flows that talk to SqliteStore directly (unrelated to backend dispatch)
-sm.validate_and_load_store(backend, path) -> KanbanResult<Snapshot>
+sm.validate_store_readable(backend, path) -> KanbanResult<()>
 sm.export_to_sqlite(export, filename) -> KanbanResult<()>
 sm.migrate_store(from_backend, from_path, to_backend, to_path) -> KanbanResult<()>
 ```

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -142,6 +142,16 @@ impl StoreManager {
         self.make_store(&backend, &locator)
     }
 
+    /// Verifies `path` is a readable, valid store for `backend` without
+    /// returning its contents.
+    pub async fn validate_store_readable(
+        &self,
+        _backend: &str,
+        _path: &str,
+    ) -> Result<(), KanbanError> {
+        todo!()
+    }
+
     /// Creates a store for `path`, verifies the file exists, then loads and
     /// deserializes the snapshot. Returns an error if the file is missing or
     /// the data cannot be parsed.

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -144,25 +144,20 @@ impl StoreManager {
 
     /// Verifies `path` is a readable, valid store for `backend` without
     /// returning its contents.
-    pub async fn validate_store_readable(
-        &self,
-        _backend: &str,
-        _path: &str,
-    ) -> Result<(), KanbanError> {
-        todo!()
-    }
-
-    /// Creates a store for `path`, verifies the file exists, then loads and
-    /// deserializes the snapshot. Returns an error if the file is missing or
-    /// the data cannot be parsed.
     ///
-    /// For `.sqlite`/`.db` files, bypasses the registry and uses `SqliteStore`
-    /// directly.
-    pub async fn validate_and_load_store(
+    /// For `.sqlite`/`.db` files, opens through `SqliteBackend` and issues one
+    /// cheap real read (`list_boards`) rather than a full-database dump:
+    /// opening already runs schema migration and fails loudly on a corrupt or
+    /// future-version file (side effects — see the comment below — are
+    /// pre-existing and intentional), so a full table scan on top of that
+    /// buys nothing. Non-SQLite backends keep a full parse: for JSON the
+    /// envelope IS the file, so "readable" means "the whole file parses";
+    /// a partial read could miss corruption in an untouched region.
+    pub async fn validate_store_readable(
         &self,
         backend: &str,
         path: &str,
-    ) -> Result<kanban_domain::Snapshot, KanbanError> {
+    ) -> Result<(), KanbanError> {
         if matches!(backend, "sqlite" | "sqlite3" | "db") {
             #[cfg(feature = "sqlite")]
             {
@@ -173,8 +168,12 @@ impl StoreManager {
                     )
                     .into());
                 }
-                let store = kanban_persistence_sqlite::SqliteStore::open(path).await?;
-                return store.snapshot();
+                // Opening runs schema migration and writes a `.v{N}.backup`;
+                // pre-existing and intentional — a validate that cannot open
+                // the file is not a validate.
+                let sqlite_backend = kanban_persistence_sqlite::SqliteBackend::open(path).await?;
+                sqlite_backend.list_boards()?;
+                return Ok(());
             }
             #[cfg(not(feature = "sqlite"))]
             return Err(KanbanError::validation("sqlite feature not compiled in"));
@@ -188,8 +187,8 @@ impl StoreManager {
             .into());
         }
         let (snapshot, _metadata) = store.load().await?;
-        let data = snapshot_from_json_bytes(&snapshot.data)?;
-        Ok(data)
+        snapshot_from_json_bytes(&snapshot.data)?;
+        Ok(())
     }
 
     /// Exports a board selection to a new SQLite file via `SqliteStore`.

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -145,14 +145,15 @@ impl StoreManager {
     /// Verifies `path` is a readable, valid store for `backend` without
     /// returning its contents.
     ///
-    /// For `.sqlite`/`.db` files, opens through `SqliteBackend` and issues one
-    /// cheap real read (`list_boards`) rather than a full-database dump:
-    /// opening already runs schema migration and fails loudly on a corrupt or
-    /// future-version file (side effects — see the comment below — are
-    /// pre-existing and intentional), so a full table scan on top of that
-    /// buys nothing. Non-SQLite backends keep a full parse: for JSON the
-    /// envelope IS the file, so "readable" means "the whole file parses";
-    /// a partial read could miss corruption in an untouched region.
+    /// For `.sqlite`/`.db` files, opens through `SqliteBackend` and issues a
+    /// cheap real read (`list_boards`) that proves the store is openable and
+    /// queryable, rather than deserialising the whole store: opening already
+    /// runs schema migration and fails loudly on a corrupt or future-version
+    /// file (side effects — see the comment below — are pre-existing and
+    /// intentional), so a full table scan on top of that buys nothing.
+    /// Non-SQLite backends keep a full parse: for JSON the envelope IS the
+    /// file, so "readable" means "the whole file parses"; a partial read
+    /// could miss corruption in an untouched region.
     pub async fn validate_store_readable(
         &self,
         backend: &str,

--- a/crates/kanban-service/tests/validate_and_load.rs
+++ b/crates/kanban-service/tests/validate_and_load.rs
@@ -141,6 +141,7 @@ fn test_storage_location_with_nested_dotdot_fails_validation() {
 }
 
 async fn create_test_sqlite(dir: &std::path::Path, name: &str, boards: &[&str]) -> String {
+    use kanban_persistence::PersistenceStore;
     use kanban_persistence_sqlite::SqliteStore;
 
     let path = dir.join(name);
@@ -152,6 +153,12 @@ async fn create_test_sqlite(dir: &std::path::Path, name: &str, boards: &[&str]) 
             .upsert_board(kanban_domain::Board::new(name.to_string(), None::<String>))
             .unwrap();
     }
+    // Checkpoint (WAL -> base file, truncating the WAL) and close the pool so
+    // a later on-disk corruption of the base file is actually observed by
+    // the next open, instead of being masked by a live WAL or a pool
+    // connection still holding valid cached pages.
+    store.checkpoint().await.unwrap();
+    store.close().await;
 
     path_str
 }
@@ -174,10 +181,10 @@ async fn test_validate_store_readable_corrupt_sqlite_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     let path = create_test_sqlite(dir.path(), "board.sqlite", &["Board1"]).await;
 
-    // Truncate the file to a handful of bytes: the SQLite header is intact
-    // enough to open, but every table read fails.
-    let bytes = std::fs::read(&path).unwrap();
-    std::fs::write(&path, &bytes[..bytes.len().min(32)]).unwrap();
+    // Overwrite the whole file (including the 16-byte "SQLite format 3\0"
+    // magic) with garbage.
+    let len = std::fs::metadata(&path).unwrap().len() as usize;
+    std::fs::write(&path, vec![0xFFu8; len.max(200)]).unwrap();
 
     let err = manager()
         .validate_store_readable("sqlite", &path)

--- a/crates/kanban-service/tests/validate_and_load.rs
+++ b/crates/kanban-service/tests/validate_and_load.rs
@@ -37,24 +37,23 @@ fn create_test_json(dir: &std::path::Path, name: &str, boards: &[&str]) -> Strin
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_validate_and_load_valid_json_returns_snapshot() {
+async fn test_validate_store_readable_valid_json_returns_ok() {
     let dir = tempfile::tempdir().unwrap();
     let path = create_test_json(dir.path(), "board.json", &["Board1"]);
 
-    let snapshot = manager()
-        .validate_and_load_store("json", &path)
+    manager()
+        .validate_store_readable("json", &path)
         .await
         .unwrap();
-    assert_eq!(snapshot.boards.len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_validate_and_load_nonexistent_file_returns_error() {
+async fn test_validate_store_readable_nonexistent_file_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("nonexistent.json");
 
     let err = manager()
-        .validate_and_load_store("json", path.to_str().unwrap())
+        .validate_store_readable("json", path.to_str().unwrap())
         .await
         .unwrap_err();
     assert!(
@@ -65,13 +64,13 @@ async fn test_validate_and_load_nonexistent_file_returns_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_validate_and_load_invalid_json_content_returns_error() {
+async fn test_validate_store_readable_invalid_json_content_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("bad.json");
     std::fs::write(&path, "hello world").unwrap();
 
     let err = manager()
-        .validate_and_load_store("json", path.to_str().unwrap())
+        .validate_store_readable("json", path.to_str().unwrap())
         .await
         .unwrap_err();
     let msg = err.to_string();
@@ -83,29 +82,16 @@ async fn test_validate_and_load_invalid_json_content_returns_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_validate_and_load_empty_file_returns_error() {
+async fn test_validate_store_readable_empty_file_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("empty.json");
     std::fs::write(&path, "").unwrap();
 
     let err = manager()
-        .validate_and_load_store("json", path.to_str().unwrap())
+        .validate_store_readable("json", path.to_str().unwrap())
         .await
         .unwrap_err();
     assert!(!err.to_string().is_empty(), "expected error, got: {}", err);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_validate_and_load_preserves_board_data() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = create_test_json(dir.path(), "board.json", &["MyBoard"]);
-
-    let snapshot = manager()
-        .validate_and_load_store("json", &path)
-        .await
-        .unwrap();
-    assert_eq!(snapshot.boards.len(), 1);
-    assert_eq!(snapshot.boards[0].name, "MyBoard");
 }
 
 #[test]
@@ -161,47 +147,41 @@ async fn create_test_sqlite(dir: &std::path::Path, name: &str, boards: &[&str]) 
     let path_str = path.to_str().unwrap().to_string();
     let store = SqliteStore::open(&path_str).await.unwrap();
 
-    let domain_boards: Vec<kanban_domain::Board> = boards
-        .iter()
-        .map(|name| kanban_domain::Board::new(name.to_string(), None::<String>))
-        .collect();
-    let snapshot = kanban_domain::Snapshot {
-        archived_boards: Vec::new(),
-        boards: domain_boards,
-        columns: vec![],
-        cards: vec![],
-        archived_cards: vec![],
-        sprints: vec![],
-        graph: Default::default(),
-    };
-    store.apply_snapshot(snapshot).unwrap();
+    for name in boards {
+        store
+            .upsert_board(kanban_domain::Board::new(name.to_string(), None::<String>))
+            .unwrap();
+    }
 
     path_str
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
 #[tokio::test(flavor = "multi_thread")]
-async fn test_validate_and_load_valid_sqlite_returns_snapshot() {
+async fn test_validate_store_readable_valid_sqlite_returns_ok() {
     let dir = tempfile::tempdir().unwrap();
     let path = create_test_sqlite(dir.path(), "board.sqlite", &["Board1"]).await;
 
-    let snapshot = manager()
-        .validate_and_load_store("sqlite", &path)
+    manager()
+        .validate_store_readable("sqlite", &path)
         .await
         .unwrap();
-    assert_eq!(snapshot.boards.len(), 1);
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
 #[tokio::test(flavor = "multi_thread")]
-async fn test_validate_and_load_sqlite_preserves_board_data() {
+async fn test_validate_store_readable_corrupt_sqlite_returns_error() {
     let dir = tempfile::tempdir().unwrap();
-    let path = create_test_sqlite(dir.path(), "board.sqlite", &["SQLiteBoard"]).await;
+    let path = create_test_sqlite(dir.path(), "board.sqlite", &["Board1"]).await;
 
-    let snapshot = manager()
-        .validate_and_load_store("sqlite", &path)
+    // Truncate the file to a handful of bytes: the SQLite header is intact
+    // enough to open, but every table read fails.
+    let bytes = std::fs::read(&path).unwrap();
+    std::fs::write(&path, &bytes[..bytes.len().min(32)]).unwrap();
+
+    let err = manager()
+        .validate_store_readable("sqlite", &path)
         .await
-        .unwrap();
-    assert_eq!(snapshot.boards.len(), 1);
-    assert_eq!(snapshot.boards[0].name, "SQLiteBoard");
+        .unwrap_err();
+    assert!(!err.to_string().is_empty(), "expected error, got: {}", err);
 }

--- a/crates/kanban-tui/src/app/types.rs
+++ b/crates/kanban-tui/src/app/types.rs
@@ -178,7 +178,7 @@ pub enum MigrationState {
         // and the `Idle` variant carries nothing (clippy::large_enum_variant).
         old_config: Box<AppConfig>,
         old_storage_location: String,
-        result_rx: tokio::sync::oneshot::Receiver<Result<(kanban_domain::Snapshot, bool), String>>,
+        result_rx: tokio::sync::oneshot::Receiver<Result<bool, String>>,
     },
 }
 

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -191,7 +191,7 @@ impl App {
         let store_manager = self.store_manager.clone();
         tokio::spawn(async move {
             let file_existed = std::path::Path::new(&new_storage_clone).exists();
-            let result: Result<(kanban_domain::Snapshot, bool), String> = async {
+            let result: Result<bool, String> = async {
                 if !file_existed && old_path_exists {
                     store_manager
                         .migrate_store(
@@ -204,11 +204,11 @@ impl App {
                         .map_err(|e| format!("Migration failed: {}", e))?;
                 }
 
-                let snapshot = store_manager
-                    .validate_and_load_store(&new_backend_clone, &new_storage_clone)
+                store_manager
+                    .validate_store_readable(&new_backend_clone, &new_storage_clone)
                     .await
                     .map_err(|e| format!("Invalid storage file: {}", e))?;
-                Ok((snapshot, file_existed))
+                Ok(file_existed)
             }
             .await;
 
@@ -226,13 +226,13 @@ impl App {
     pub async fn handle_migration_complete(
         &mut self,
         old_config: kanban_core::AppConfig,
-        result: Result<(kanban_domain::Snapshot, bool), String>,
+        result: Result<bool, String>,
     ) {
         self.migration_state = crate::app::MigrationState::Idle;
         self.quit_with_migration = false;
 
-        let (snapshot, file_existed) = match result {
-            Ok(s) => s,
+        let file_existed = match result {
+            Ok(existed) => existed,
             Err(e) => {
                 self.app_config = old_config;
                 self.set_error(e);
@@ -262,6 +262,7 @@ impl App {
         }
         let (save_rx, completion_rx) = self.ctx.save_coordinator.reset_save_channels();
         use crate::state::snapshot::TuiSnapshot;
+        let snapshot = kanban_domain::Snapshot::from_app(self);
         if let Err(e) = snapshot.apply_to_app(self) {
             tracing::error!("Failed to apply snapshot: {}", e);
         }


### PR DESCRIPTION
Part of the Snapshot-removal epic (KAN-1065). `StoreManager::validate_and_load_store` deserialised the entire store just to answer "is this location readable", then threw the result away on the SQLite path. It becomes `validate_store_readable` and probes with a cheap indexed read instead.

`SqliteBackend::list_boards()` resolves to one indexed `SELECT ... FROM boards WHERE NOT EXISTS (...) ORDER BY ...` via `sqlite_store/lists.rs:9`, so validating a location no longer costs a full snapshot.

## The migration channel narrows too

This was not optional. Once the method stops returning a `Snapshot`, `handle_migration_complete` stops compiling, so `MigrationState::Migrating`'s payload narrows from `Result<(Snapshot, bool), String>` to `Result<bool, String>` (`app/types.rs:181`) and the handler builds its post-swap `Snapshot` synchronously via the existing `TuiSnapshot::from_app(self)` after `replace_backend`, rather than receiving one over the channel.

An earlier version of the card assumed this could be deferred to KAN-1077 and that the TUI change would be "a pure method rename". It cannot and it is not. KAN-1077's remaining job is to delete `TuiSnapshot` and swap that interim call for `reload_model()`.

## Tests

Genuinely red. All six renamed tests panicked on the `todo!()` stub in the Red commit with `not yet implemented` at `store_manager.rs:152`, because the API did not exist yet.

One of them, `test_validate_store_readable_corrupt_sqlite_returns_error`, is worth calling out because it passed twice while the database was not actually corrupt. WAL mode keeps live data in a `-wal` sidecar that an open pool serves from, and the seeding store's pool was never closed, so lingering connections kept serving valid cached pages. Root-caused with an external `sqlite3` call confirming on-disk corruption while the in-process reopen still succeeded. The test now checkpoints and closes the pool before corrupting, and overwrites the whole file including the `SQLite format 3\0` header rather than a byte range. Verified deterministic over repeated runs.

`cargo test -p kanban-service --features test-helpers` and `cargo test -p kanban-tui` green, clippy `--all-targets -D warnings` clean on both, fmt clean.

## Removed tests

`validate_and_load.rs` loses `test_validate_and_load_preserves_board_data` and `test_validate_and_load_sqlite_preserves_board_data` with no direct replacement. Both asserted that the returned `Snapshot` still had the right board data, and that assertion has nowhere to live now that the method returns `()` instead of a `Snapshot`. The underlying behaviour they were pinning is still covered where it actually lives:

- JSON deserialisation round-trips: `test_snapshot_roundtrip` (`crates/kanban-persistence/src/snapshot_serde.rs:18`) and `test_save_and_load` (`crates/kanban-persistence-json/src/json_file_store.rs:558`)
- SQLite persistence through `list_boards()`: `test_list_boards_ties_break_by_created_at_then_id` (`crates/kanban-persistence-sqlite/src/sqlite_store/tests/boards.rs:107`), and `test_migration_boards_case_preserves_multiple_board_subtrees` (`crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs:217`), which closes and reopens the store before reading back both boards' subtrees

## Also updated

`crates/kanban-service/README.md:305` referenced the old method name.

## Sequencing

Blocks KAN-1079 and KAN-1108. Independent of KAN-1077, which now inherits a narrower job.

