### PR TITLE
KAN-1067 feat(persistence-sqlite): ambient BEGIN/COMMIT/ROLLBACK transaction for SqliteBackend::with_transaction

### DIFF
--- a/.changeset/kan-1067.md
+++ b/.changeset/kan-1067.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+persistence-sqlite: `SqliteBackend::with_transaction` now runs a real `BEGIN`/`COMMIT`/`ROLLBACK` database transaction instead of the generic snapshot-and-restore default, so SQLite command execution, undo, and redo no longer pay a full-database read-everything-then-possibly-delete-and-reinsert-everything cost on every failure path. Every `SqliteStore` read and write now resolves its connection through a shared ambient-transaction-aware primitive, so a read inside a batch correctly observes a sibling write from earlier in the same batch before it commits.

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -259,6 +259,19 @@ impl kanban_backend::KanbanBackend for SqliteBackend {
     fn local_persistence(&self) -> Option<&dyn kanban_backend::LocalPersistence> {
         Some(self)
     }
+
+    /// Real `BEGIN`/`COMMIT`/`ROLLBACK` transaction instead of the trait
+    /// default's snapshot()/apply_snapshot() rollback — see KAN-1067.
+    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
+        self.db.begin_write_transaction()?;
+        match f() {
+            Ok(()) => self.db.commit_write_transaction(),
+            Err(e) => {
+                self.db.rollback_write_transaction();
+                Err(e)
+            }
+        }
+    }
 }
 
 impl kanban_backend::LocalPersistence for SqliteBackend {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -17,34 +17,37 @@ impl DataStore for SqliteStore {
     // Board
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
-        run(async {
-            let id_str = id.to_string();
-            // Reference-marker model: `get_board` is UNFILTERED — it returns the
-            // head whether the board is live OR archived (an `archived_board`
-            // marker hides it only from the LIVE `list_boards`). Callers
-            // discriminate archived-ness via `get_archived_board`.
-            let row = sqlx::query(
-                "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
-                        task_sort_order, sprint_duration_days, sprint_name_used_count,
-                        next_sprint_number, active_sprint_id, task_list_view,
-                        COALESCE(card_counter, 1) as card_counter,
-                        position, created_at, updated_at
-                 FROM boards
-                 WHERE id = ?",
-            )
-            .bind(&id_str)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(db_err)?;
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let id_str = id.to_string();
+                // Reference-marker model: `get_board` is UNFILTERED — it returns the
+                // head whether the board is live OR archived (an `archived_board`
+                // marker hides it only from the LIVE `list_boards`). Callers
+                // discriminate archived-ness via `get_archived_board`.
+                let row = sqlx::query(
+                    "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
+                            task_sort_order, sprint_duration_days, sprint_name_used_count,
+                            next_sprint_number, active_sprint_id, task_list_view,
+                            COALESCE(card_counter, 1) as card_counter,
+                            position, created_at, updated_at
+                     FROM boards
+                     WHERE id = ?",
+                )
+                .bind(&id_str)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(db_err)?;
 
-            match row {
-                Some(row) => {
-                    let (names, counters, completion) = self.fetch_board_aux(&id_str).await?;
-                    Ok(Some(row_to_board(&row, names, counters, completion)?))
+                match row {
+                    Some(row) => {
+                        let (names, counters, completion) =
+                            SqliteStore::fetch_board_aux_with_conn(conn, &id_str).await?;
+                        Ok(Some(row_to_board(&row, names, counters, completion)?))
+                    }
+                    None => Ok(None),
                 }
-                None => Ok(None),
-            }
-        })
+            })
+        }))
     }
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
@@ -56,49 +59,55 @@ impl DataStore for SqliteStore {
     }
 
     fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
-        run(async {
-            sqlx::query(
-                "DELETE FROM boards
-                 WHERE id = ?
-                   AND NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)",
-            )
-            .bind(id.to_string())
-            .execute(&self.pool)
-            .await
-            .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                sqlx::query(
+                    "DELETE FROM boards
+                     WHERE id = ?
+                       AND NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)",
+                )
+                .bind(id.to_string())
+                .execute(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     // Column
 
     fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
-        run(async {
-            let row = sqlx::query(
-                "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
-                 FROM columns WHERE id = ?",
-            )
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(db_err)?;
-            row.as_ref().map(row_to_column).transpose()
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let row = sqlx::query(
+                    "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
+                     FROM columns WHERE id = ?",
+                )
+                .bind(id.to_string())
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                row.as_ref().map(row_to_column).transpose()
+            })
+        }))
     }
 
     fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
-        run(async {
-            let rows = sqlx::query(
-                "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
-                 FROM columns WHERE board_id = ?
-                 ORDER BY position ASC, created_at ASC, id ASC",
-            )
-            .bind(board_id.to_string())
-            .fetch_all(&self.pool)
-            .await
-            .map_err(db_err)?;
-            rows.iter().map(row_to_column).collect()
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let rows = sqlx::query(
+                    "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
+                     FROM columns WHERE board_id = ?
+                     ORDER BY position ASC, created_at ASC, id ASC",
+                )
+                .bind(board_id.to_string())
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                rows.iter().map(row_to_column).collect()
+            })
+        }))
     }
 
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
@@ -110,63 +119,70 @@ impl DataStore for SqliteStore {
     }
 
     fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
-        run(async {
-            sqlx::query("DELETE FROM columns WHERE id = ?")
-                .bind(id.to_string())
-                .execute(&self.pool)
-                .await
-                .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                sqlx::query("DELETE FROM columns WHERE id = ?")
+                    .bind(id.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
-        run(async {
-            sqlx::query("DELETE FROM columns WHERE board_id = ?")
-                .bind(board_id.to_string())
-                .execute(&self.pool)
-                .await
-                .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                sqlx::query("DELETE FROM columns WHERE board_id = ?")
+                    .bind(board_id.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     // Card
 
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
-        run(async {
-            let id_str = id.to_string();
-            // F1 (KAN-870): get_card is UNFILTERED — an archived card stays in
-            // `cards` behind a marker and is reachable by id (it is an ordinary,
-            // editable card). The archived/live distinction is a LIST-level filter.
-            let row = sqlx::query(
-                "SELECT id, column_id, board_id, title, description, priority, status, position,
-                        due_date, points, card_number, sprint_id, created_at, updated_at,
-                        completed_at
-                 FROM cards
-                 WHERE id = ?",
-            )
-            .bind(&id_str)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(db_err)?;
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let id_str = id.to_string();
+                // F1 (KAN-870): get_card is UNFILTERED — an archived card stays in
+                // `cards` behind a marker and is reachable by id (it is an ordinary,
+                // editable card). The archived/live distinction is a LIST-level filter.
+                let row = sqlx::query(
+                    "SELECT id, column_id, board_id, title, description, priority, status, position,
+                            due_date, points, card_number, sprint_id, created_at, updated_at,
+                            completed_at
+                     FROM cards
+                     WHERE id = ?",
+                )
+                .bind(&id_str)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(db_err)?;
 
-            match row {
-                Some(row) => {
-                    let logs = self.fetch_sprint_logs_for_card(&id_str).await?;
-                    Ok(Some(row_to_card(&row, logs)?))
+                match row {
+                    Some(row) => {
+                        let logs = SqliteStore::fetch_sprint_logs_for_card_with_conn(conn, &id_str)
+                            .await?;
+                        Ok(Some(row_to_card(&row, logs)?))
+                    }
+                    None => Ok(None),
                 }
-                None => Ok(None),
-            }
-        })
+            })
+        }))
     }
 
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
-        run(self.fetch_cards_with_filter("", &[]))
+        run(self.fetch_cards_with_filter("", vec![]))
     }
 
     fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
-        run(self.fetch_cards_with_filter("AND column_id = ?", &[column_id.to_string()]))
+        run(self.fetch_cards_with_filter("AND column_id = ?", vec![column_id.to_string()]))
     }
 
     fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
@@ -176,11 +192,11 @@ impl DataStore for SqliteStore {
         let placeholders = column_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let where_clause = format!("AND column_id IN ({placeholders})");
         let binds: Vec<String> = column_ids.iter().map(|id| id.to_string()).collect();
-        run(self.fetch_cards_with_filter(&where_clause, &binds))
+        run(self.fetch_cards_with_filter(where_clause, binds))
     }
 
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
-        run(self.fetch_cards_with_filter("AND sprint_id = ?", &[sprint_id.to_string()]))
+        run(self.fetch_cards_with_filter("AND sprint_id = ?", vec![sprint_id.to_string()]))
     }
 
     /// 3-state archived-aware column read. Overrides the loud-floor default so
@@ -195,17 +211,12 @@ impl DataStore for SqliteStore {
     }
 
     fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
-        run(async {
-            let row = sqlx::query(
-                "SELECT COUNT(*) as cnt FROM cards
-                 WHERE column_id = ? AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
-            )
-            .bind(column_id.to_string())
-            .fetch_one(&self.pool)
-            .await
-            .map_err(db_err)?;
-            Ok(row.try_get::<i32, _>("cnt").map_err(db_err)? as usize)
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let column_id = column_id.to_string();
+                SqliteStore::count_cards_in_column_with_conn(conn, &column_id).await
+            })
+        }))
     }
 
     /// 3-state archived-aware column count. Mirrors
@@ -224,24 +235,32 @@ impl DataStore for SqliteStore {
         column_id: Uuid,
         exclude: &[Uuid],
     ) -> KanbanResult<usize> {
-        run(async {
-            if exclude.is_empty() {
-                return self.count_cards_in_column(column_id);
-            }
-            let placeholders = exclude.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-            let sql = format!(
-                "SELECT COUNT(*) as cnt FROM cards
-                 WHERE column_id = ?
-                   AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)
-                   AND id NOT IN ({placeholders})"
-            );
-            let mut query = sqlx::query(&sql).bind(column_id.to_string());
-            for id in exclude {
-                query = query.bind(id.to_string());
-            }
-            let row = query.fetch_one(&self.pool).await.map_err(db_err)?;
-            Ok(row.try_get::<i32, _>("cnt").map_err(db_err)? as usize)
-        })
+        let exclude: Vec<Uuid> = exclude.to_vec();
+        run(self.db_conn(move |conn| {
+            Box::pin(async move {
+                let column_id_str = column_id.to_string();
+                if exclude.is_empty() {
+                    // Associated fn on the already-held conn — calling
+                    // `self.count_cards_in_column` here would capture `self`
+                    // and violate db_conn's CAPTURE RULE.
+                    return SqliteStore::count_cards_in_column_with_conn(conn, &column_id_str)
+                        .await;
+                }
+                let placeholders = exclude.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+                let sql = format!(
+                    "SELECT COUNT(*) as cnt FROM cards
+                     WHERE column_id = ?
+                       AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)
+                       AND id NOT IN ({placeholders})"
+                );
+                let mut query = sqlx::query(&sql).bind(&column_id_str);
+                for id in &exclude {
+                    query = query.bind(id.to_string());
+                }
+                let row = query.fetch_one(&mut *conn).await.map_err(db_err)?;
+                Ok(row.try_get::<i32, _>("cnt").map_err(db_err)? as usize)
+            })
+        }))
     }
 
     fn upsert_card(&self, card: Card) -> KanbanResult<()> {
@@ -249,37 +268,42 @@ impl DataStore for SqliteStore {
     }
 
     fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
-        run(async {
-            sqlx::query(
-                "DELETE FROM cards
-                 WHERE id = ? AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
-            )
-            .bind(id.to_string())
-            .execute(&self.pool)
-            .await
-            .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                sqlx::query(
+                    "DELETE FROM cards
+                     WHERE id = ? AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
+                )
+                .bind(id.to_string())
+                .execute(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
-        run(async {
-            if column_ids.is_empty() {
-                return Ok(());
-            }
-            let placeholders = column_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-            let sql = format!(
-                "DELETE FROM cards
-                 WHERE column_id IN ({placeholders})
-                   AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)"
-            );
-            let mut query = sqlx::query(&sql);
-            for id in column_ids {
-                query = query.bind(id.to_string());
-            }
-            query.execute(&self.pool).await.map_err(db_err)?;
-            Ok(())
-        })
+        let column_ids: Vec<Uuid> = column_ids.to_vec();
+        run(self.db_conn(move |conn| {
+            Box::pin(async move {
+                if column_ids.is_empty() {
+                    return Ok(());
+                }
+                let placeholders = column_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+                let sql = format!(
+                    "DELETE FROM cards
+                     WHERE column_id IN ({placeholders})
+                       AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)"
+                );
+                let mut query = sqlx::query(&sql);
+                for id in &column_ids {
+                    query = query.bind(id.to_string());
+                }
+                query.execute(&mut *conn).await.map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     fn clear_sprint_from_cards(
@@ -287,44 +311,48 @@ impl DataStore for SqliteStore {
         sprint_id: Uuid,
         timestamp: DateTime<Utc>,
     ) -> KanbanResult<()> {
-        run(async {
-            let now = fmt_dt(&timestamp);
-            sqlx::query(
-                "UPDATE cards SET sprint_id = NULL, updated_at = ?
-                 WHERE sprint_id = ?
-                   AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
-            )
-            .bind(&now)
-            .bind(sprint_id.to_string())
-            .execute(&self.pool)
-            .await
-            .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(move |conn| {
+            Box::pin(async move {
+                let now = fmt_dt(&timestamp);
+                sqlx::query(
+                    "UPDATE cards SET sprint_id = NULL, updated_at = ?
+                     WHERE sprint_id = ?
+                       AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
+                )
+                .bind(&now)
+                .bind(sprint_id.to_string())
+                .execute(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     // Archived card
 
     fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
-        run(async {
-            let id_str = card_id.to_string();
-            // Reference-marker model: a marker needs only card id, board scope, and
-            // archive time. No card JOIN required.
-            let row = sqlx::query(
-                "SELECT card_id AS id, board_id, archived_at
-                 FROM archived_cards
-                 WHERE card_id = ?",
-            )
-            .bind(&id_str)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(db_err)?;
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let id_str = card_id.to_string();
+                // Reference-marker model: a marker needs only card id, board scope, and
+                // archive time. No card JOIN required.
+                let row = sqlx::query(
+                    "SELECT card_id AS id, board_id, archived_at
+                     FROM archived_cards
+                     WHERE card_id = ?",
+                )
+                .bind(&id_str)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(db_err)?;
 
-            match row {
-                Some(row) => Ok(Some(row_to_archived_card(&row)?)),
-                None => Ok(None),
-            }
-        })
+                match row {
+                    Some(row) => Ok(Some(row_to_archived_card(&row)?)),
+                    None => Ok(None),
+                }
+            })
+        }))
     }
 
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
@@ -336,93 +364,102 @@ impl DataStore for SqliteStore {
     }
 
     fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
-        run(async {
-            let mut tx = self.pool.begin().await.map_err(db_err)?;
-            sqlx::query("DELETE FROM archived_cards WHERE card_id = ?")
-                .bind(card_id.to_string())
-                .execute(&mut *tx)
-                .await
-                .map_err(db_err)?;
-            sqlx::query("DELETE FROM cards WHERE id = ?")
-                .bind(card_id.to_string())
-                .execute(&mut *tx)
-                .await
-                .map_err(db_err)?;
-            tx.commit().await.map_err(db_err)
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                sqlx::query("DELETE FROM archived_cards WHERE card_id = ?")
+                    .bind(card_id.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_err)?;
+                sqlx::query("DELETE FROM cards WHERE id = ?")
+                    .bind(card_id.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     // Archived board (C5): board row stays in `boards`; a `board_archival` marker
     // row marks it out of the live set. Reconstitute Archived<Board> by join.
 
     fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
-        run(async {
-            let id_str = board_id.to_string();
-            // Reference-marker model: the marker carries only the board id + archive
-            // time. The board row stays live in `boards`.
-            let row =
-                sqlx::query("SELECT board_id, archived_at FROM board_archival WHERE board_id = ?")
-                    .bind(&id_str)
-                    .fetch_optional(&self.pool)
-                    .await
-                    .map_err(db_err)?;
-            match row {
-                Some(row) => {
-                    let at: String = row.try_get("archived_at").map_err(db_err)?;
-                    Ok(Some(Archived::at(board_id, p_dt(&at)?)))
+        run(self.db_conn(move |conn| {
+            Box::pin(async move {
+                let id_str = board_id.to_string();
+                // Reference-marker model: the marker carries only the board id + archive
+                // time. The board row stays live in `boards`.
+                let row = sqlx::query(
+                    "SELECT board_id, archived_at FROM board_archival WHERE board_id = ?",
+                )
+                .bind(&id_str)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                match row {
+                    Some(row) => {
+                        let at: String = row.try_get("archived_at").map_err(db_err)?;
+                        Ok(Some(Archived::at(board_id, p_dt(&at)?)))
+                    }
+                    None => Ok(None),
                 }
-                None => Ok(None),
-            }
-        })
+            })
+        }))
     }
 
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
-        run(self.list_archived_boards_async())
+        run(self.db_conn(|conn| {
+            Box::pin(async move { SqliteStore::list_archived_boards_with_conn(conn).await })
+        }))
     }
 
     fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
-        run(async {
-            // Reference-marker model: the board row must already be live in
-            // `boards` (archive keeps the head in place). Only record the marker.
-            sqlx::query(
-                "INSERT INTO board_archival (board_id, archived_at) VALUES (?, ?)
-                 ON CONFLICT(board_id) DO UPDATE SET archived_at = excluded.archived_at",
-            )
-            .bind(ab.entity_id.to_string())
-            .bind(fmt_dt(&ab.metadata.archived_at))
-            .execute(&self.pool)
-            .await
-            .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(move |conn| {
+            Box::pin(async move {
+                // Reference-marker model: the board row must already be live in
+                // `boards` (archive keeps the head in place). Only record the marker.
+                sqlx::query(
+                    "INSERT INTO board_archival (board_id, archived_at) VALUES (?, ?)
+                     ON CONFLICT(board_id) DO UPDATE SET archived_at = excluded.archived_at",
+                )
+                .bind(ab.entity_id.to_string())
+                .bind(fmt_dt(&ab.metadata.archived_at))
+                .execute(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
-        run(async {
-            let id_str = board_id.to_string();
-            let mut tx = self.pool.begin().await.map_err(db_err)?;
-            // Only remove the board row if it is actually archived — parity with
-            // the in-memory store, whose delete_archived_board touches only the
-            // archived collection and no-ops on a live board. Guarded delete runs
-            // FIRST (the marker still exists to satisfy the EXISTS check); the
-            // board_archival FK (ON DELETE CASCADE) drops the marker with the row,
-            // and the explicit marker delete below is belt-and-suspenders.
-            sqlx::query(
-                "DELETE FROM boards
-                 WHERE id = ?
-                   AND EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)",
-            )
-            .bind(&id_str)
-            .execute(&mut *tx)
-            .await
-            .map_err(db_err)?;
-            sqlx::query("DELETE FROM board_archival WHERE board_id = ?")
+        run(self.db_conn(move |conn| {
+            Box::pin(async move {
+                let id_str = board_id.to_string();
+                // Only remove the board row if it is actually archived — parity with
+                // the in-memory store, whose delete_archived_board touches only the
+                // archived collection and no-ops on a live board. Guarded delete runs
+                // FIRST (the marker still exists to satisfy the EXISTS check); the
+                // board_archival FK (ON DELETE CASCADE) drops the marker with the row,
+                // and the explicit marker delete below is belt-and-suspenders.
+                sqlx::query(
+                    "DELETE FROM boards
+                     WHERE id = ?
+                       AND EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)",
+                )
                 .bind(&id_str)
-                .execute(&mut *tx)
+                .execute(&mut *conn)
                 .await
                 .map_err(db_err)?;
-            tx.commit().await.map_err(db_err)
-        })
+                sqlx::query("DELETE FROM board_archival WHERE board_id = ?")
+                    .bind(&id_str)
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     /// RESTORE path: drop only the archived MARKER, leaving the shared board row
@@ -430,36 +467,40 @@ impl DataStore for SqliteStore {
     /// (cascading the subtree) which is right for permanent delete but would
     /// destroy the subtree on restore (KAN-863). No-op on a live board.
     fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
-        run(async {
-            sqlx::query("DELETE FROM board_archival WHERE board_id = ?")
-                .bind(board_id.to_string())
-                .execute(&self.pool)
-                .await
-                .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                sqlx::query("DELETE FROM board_archival WHERE board_id = ?")
+                    .bind(board_id.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     /// Board-scoped archived cards. Overrides the trait default (which filters
     /// the full list) with a direct `WHERE board_id = ?` on the extension table,
     /// so board scoping is a single indexed query.
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
-        run(async {
-            // Reference-marker model: markers only, scoped by the first-class
-            // `board_id`. Single indexed query, no card JOIN.
-            let rows = sqlx::query(
-                "SELECT card_id AS id, board_id, archived_at
-                 FROM archived_cards
-                 WHERE board_id = ?
-                 ORDER BY archived_at",
-            )
-            .bind(board_id.to_string())
-            .fetch_all(&self.pool)
-            .await
-            .map_err(db_err)?;
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                // Reference-marker model: markers only, scoped by the first-class
+                // `board_id`. Single indexed query, no card JOIN.
+                let rows = sqlx::query(
+                    "SELECT card_id AS id, board_id, archived_at
+                     FROM archived_cards
+                     WHERE board_id = ?
+                     ORDER BY archived_at",
+                )
+                .bind(board_id.to_string())
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
 
-            rows.iter().map(row_to_archived_card).collect()
-        })
+                rows.iter().map(row_to_archived_card).collect()
+            })
+        }))
     }
 
     fn clear_sprint_from_archived_cards(
@@ -467,52 +508,58 @@ impl DataStore for SqliteStore {
         sprint_id: Uuid,
         timestamp: DateTime<Utc>,
     ) -> KanbanResult<()> {
-        run(async {
-            let now = fmt_dt(&timestamp);
-            sqlx::query(
-                "UPDATE cards SET sprint_id = NULL, updated_at = ?
-                 WHERE sprint_id = ?
-                   AND EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
-            )
-            .bind(&now)
-            .bind(sprint_id.to_string())
-            .execute(&self.pool)
-            .await
-            .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(move |conn| {
+            Box::pin(async move {
+                let now = fmt_dt(&timestamp);
+                sqlx::query(
+                    "UPDATE cards SET sprint_id = NULL, updated_at = ?
+                     WHERE sprint_id = ?
+                       AND EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
+                )
+                .bind(&now)
+                .bind(sprint_id.to_string())
+                .execute(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     // Sprint
 
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
-        run(async {
-            let row = sqlx::query(
-                "SELECT id, board_id, sprint_number, name_index, prefix, card_prefix,
-                        status, start_date, end_date, created_at, updated_at
-                 FROM sprints WHERE id = ?",
-            )
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(db_err)?;
-            row.as_ref().map(row_to_sprint).transpose()
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let row = sqlx::query(
+                    "SELECT id, board_id, sprint_number, name_index, prefix, card_prefix,
+                            status, start_date, end_date, created_at, updated_at
+                     FROM sprints WHERE id = ?",
+                )
+                .bind(id.to_string())
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                row.as_ref().map(row_to_sprint).transpose()
+            })
+        }))
     }
 
     fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
-        run(async {
-            let rows = sqlx::query(
-                "SELECT id, board_id, sprint_number, name_index, prefix, card_prefix,
-                        status, start_date, end_date, created_at, updated_at
-                 FROM sprints WHERE board_id = ? ORDER BY sprint_number",
-            )
-            .bind(board_id.to_string())
-            .fetch_all(&self.pool)
-            .await
-            .map_err(db_err)?;
-            rows.iter().map(row_to_sprint).collect()
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let rows = sqlx::query(
+                    "SELECT id, board_id, sprint_number, name_index, prefix, card_prefix,
+                            status, start_date, end_date, created_at, updated_at
+                     FROM sprints WHERE board_id = ? ORDER BY sprint_number",
+                )
+                .bind(board_id.to_string())
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                rows.iter().map(row_to_sprint).collect()
+            })
+        }))
     }
 
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
@@ -524,25 +571,29 @@ impl DataStore for SqliteStore {
     }
 
     fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
-        run(async {
-            sqlx::query("DELETE FROM sprints WHERE id = ?")
-                .bind(id.to_string())
-                .execute(&self.pool)
-                .await
-                .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                sqlx::query("DELETE FROM sprints WHERE id = ?")
+                    .bind(id.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
-        run(async {
-            sqlx::query("DELETE FROM sprints WHERE board_id = ?")
-                .bind(board_id.to_string())
-                .execute(&self.pool)
-                .await
-                .map_err(db_err)?;
-            Ok(())
-        })
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                sqlx::query("DELETE FROM sprints WHERE board_id = ?")
+                    .bind(board_id.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_err)?;
+                Ok(())
+            })
+        }))
     }
 
     // Graph

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/archived_card.rs
@@ -31,9 +31,10 @@ impl SqliteStore {
     }
 
     pub(crate) async fn write_archived_card_async(&self, ac: &ArchivedCard) -> KanbanResult<()> {
-        let mut tx = self.pool.begin().await.map_err(db_err)?;
-        Self::write_archived_card_with_conn(&mut tx, ac).await?;
-        tx.commit().await.map_err(db_err)?;
-        Ok(())
+        let ac = *ac;
+        self.db_conn(|conn| {
+            Box::pin(async move { Self::write_archived_card_with_conn(conn, &ac).await })
+        })
+        .await
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/board.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/board.rs
@@ -8,14 +8,14 @@ use crate::sqlite_store::helpers::{db_err, fmt_dt, p_uuid, required_str};
 use crate::sqlite_store::SqliteStore;
 
 impl SqliteStore {
-    pub(crate) async fn fetch_board_aux(
-        &self,
+    pub(crate) async fn fetch_board_aux_with_conn(
+        conn: &mut sqlx::SqliteConnection,
         board_id: &str,
     ) -> KanbanResult<(Vec<String>, HashMap<String, u32>, Vec<Uuid>)> {
         let name_rows =
             sqlx::query("SELECT name FROM board_sprint_names WHERE board_id = ? ORDER BY position")
                 .bind(board_id)
-                .fetch_all(&self.pool)
+                .fetch_all(&mut *conn)
                 .await
                 .map_err(db_err)?;
         let sprint_names: Vec<String> = name_rows
@@ -26,7 +26,7 @@ impl SqliteStore {
         let counter_rows =
             sqlx::query("SELECT prefix, counter FROM board_sprint_counters WHERE board_id = ?")
                 .bind(board_id)
-                .fetch_all(&self.pool)
+                .fetch_all(&mut *conn)
                 .await
                 .map_err(db_err)?;
         let mut sprint_counters = HashMap::new();
@@ -40,7 +40,7 @@ impl SqliteStore {
             "SELECT column_id FROM board_completion_columns WHERE board_id = ? ORDER BY position",
         )
         .bind(board_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(db_err)?;
         let completion_column_ids: Vec<Uuid> = completion_rows
@@ -156,14 +156,15 @@ impl SqliteStore {
     }
 
     pub(crate) async fn write_board_async(&self, board: &Board) -> KanbanResult<()> {
-        let mut tx = self.pool.begin().await.map_err(db_err)?;
-        Self::write_board_with_conn(&mut tx, board).await?;
-        tx.commit().await.map_err(db_err)?;
-        Ok(())
+        let board = board.clone();
+        self.db_conn(|conn| {
+            Box::pin(async move { Self::write_board_with_conn(conn, &board).await })
+        })
+        .await
     }
 
-    pub(crate) async fn fetch_all_board_aux(
-        &self,
+    pub(crate) async fn fetch_all_board_aux_with_conn(
+        conn: &mut sqlx::SqliteConnection,
     ) -> KanbanResult<(
         HashMap<String, Vec<String>>,
         HashMap<String, HashMap<String, u32>>,
@@ -172,7 +173,7 @@ impl SqliteStore {
         let name_rows = sqlx::query(
             "SELECT board_id, name FROM board_sprint_names ORDER BY board_id, position",
         )
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(db_err)?;
         let mut names_map: HashMap<String, Vec<String>> = HashMap::new();
@@ -184,7 +185,7 @@ impl SqliteStore {
 
         let counter_rows =
             sqlx::query("SELECT board_id, prefix, counter FROM board_sprint_counters")
-                .fetch_all(&self.pool)
+                .fetch_all(&mut *conn)
                 .await
                 .map_err(db_err)?;
         let mut counters_map: HashMap<String, HashMap<String, u32>> = HashMap::new();
@@ -201,7 +202,7 @@ impl SqliteStore {
         let completion_rows = sqlx::query(
             "SELECT board_id, column_id FROM board_completion_columns ORDER BY board_id, position",
         )
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(db_err)?;
         let mut completion_map: HashMap<String, Vec<Uuid>> = HashMap::new();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
@@ -8,8 +8,8 @@ use crate::sqlite_store::helpers::{db_err, fmt_dt, opt_dt, required_str};
 use crate::sqlite_store::SqliteStore;
 
 impl SqliteStore {
-    pub(crate) async fn fetch_sprint_logs_for_card(
-        &self,
+    pub(crate) async fn fetch_sprint_logs_for_card_with_conn(
+        conn: &mut sqlx::SqliteConnection,
         card_id: &str,
     ) -> KanbanResult<Vec<SprintLog>> {
         let rows = sqlx::query(
@@ -17,7 +17,7 @@ impl SqliteStore {
              FROM sprint_logs WHERE card_id = ? ORDER BY id",
         )
         .bind(card_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(db_err)?;
         rows.iter().map(row_to_sprint_log).collect()
@@ -88,14 +88,13 @@ impl SqliteStore {
     }
 
     pub(crate) async fn write_card_async(&self, card: &Card) -> KanbanResult<()> {
-        let mut tx = self.pool.begin().await.map_err(db_err)?;
-        Self::write_card_with_conn(&mut tx, card).await?;
-        tx.commit().await.map_err(db_err)?;
-        Ok(())
+        let card = card.clone();
+        self.db_conn(|conn| Box::pin(async move { Self::write_card_with_conn(conn, &card).await }))
+            .await
     }
 
-    pub(crate) async fn fetch_sprint_logs_batch(
-        &self,
+    pub(crate) async fn fetch_sprint_logs_batch_with_conn(
+        conn: &mut sqlx::SqliteConnection,
         card_ids: &[String],
     ) -> KanbanResult<HashMap<String, Vec<SprintLog>>> {
         if card_ids.is_empty() {
@@ -110,7 +109,7 @@ impl SqliteStore {
         for id in card_ids {
             query = query.bind(id);
         }
-        let rows = query.fetch_all(&self.pool).await.map_err(db_err)?;
+        let rows = query.fetch_all(&mut *conn).await.map_err(db_err)?;
         let mut map: HashMap<String, Vec<SprintLog>> = HashMap::new();
         for row in &rows {
             let card_id: String = row.try_get("card_id").map_err(db_err)?;
@@ -122,14 +121,21 @@ impl SqliteStore {
 
     pub(crate) async fn fetch_cards_with_filter(
         &self,
-        where_clause: &str,
-        binds: &[String],
+        where_clause: impl Into<String>,
+        binds: Vec<String>,
     ) -> KanbanResult<Vec<Card>> {
         // LIVE-scoped reads exclude archived cards (they stay live behind a marker
         // but are hidden from the live list). Snapshot/export fidelity uses
         // `fetch_all_cards_unfiltered` instead.
-        let filter = "WHERE NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)";
-        self.fetch_cards_query(filter, where_clause, binds).await
+        let filter = "WHERE NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)"
+            .to_string();
+        let where_clause = where_clause.into();
+        self.db_conn(move |conn| {
+            Box::pin(async move {
+                Self::fetch_cards_query_with_conn(conn, &filter, &where_clause, &binds).await
+            })
+        })
+        .await
     }
 
     /// The `WHERE`-prefixed archived predicate for an [`ArchivedFilter`]. Empty
@@ -170,13 +176,14 @@ impl SqliteStore {
         column_id: &str,
         archived: kanban_domain::ArchivedFilter,
     ) -> KanbanResult<Vec<Card>> {
-        let base = Self::archived_base_clause(archived);
-        let column_clause = format!("{} column_id = ?", Self::connector_for(base));
-        self.fetch_cards_query(
-            base,
-            &column_clause,
-            std::slice::from_ref(&column_id.to_string()),
-        )
+        let base = Self::archived_base_clause(archived).to_string();
+        let column_clause = format!("{} column_id = ?", Self::connector_for(&base));
+        let column_id = column_id.to_string();
+        self.db_conn(move |conn| {
+            Box::pin(async move {
+                Self::fetch_cards_query_with_conn(conn, &base, &column_clause, &[column_id]).await
+            })
+        })
         .await
     }
 
@@ -184,6 +191,21 @@ impl SqliteStore {
     /// base-clause / connector logic as [`fetch_cards_in_column_filtered`].
     pub(crate) async fn count_cards_in_column_filtered_impl(
         &self,
+        column_id: &str,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        let column_id = column_id.to_string();
+        self.db_conn(move |conn| {
+            Box::pin(async move {
+                Self::count_cards_in_column_filtered_impl_with_conn(conn, &column_id, archived)
+                    .await
+            })
+        })
+        .await
+    }
+
+    pub(crate) async fn count_cards_in_column_filtered_impl_with_conn(
+        conn: &mut sqlx::SqliteConnection,
         column_id: &str,
         archived: kanban_domain::ArchivedFilter,
     ) -> KanbanResult<usize> {
@@ -195,9 +217,28 @@ impl SqliteStore {
         );
         let row = sqlx::query(&sql)
             .bind(column_id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await
             .map_err(db_err)?;
+        Ok(row.try_get::<i32, _>("cnt").map_err(db_err)? as usize)
+    }
+
+    /// Associated fn taking an already-held connection, so
+    /// `count_cards_in_column_excluding`'s empty-`exclude` fast path can call
+    /// it without re-entering `db_conn` through a `self` capture (would
+    /// violate the CAPTURE RULE — see `data_store.rs`).
+    pub(crate) async fn count_cards_in_column_with_conn(
+        conn: &mut sqlx::SqliteConnection,
+        column_id: &str,
+    ) -> KanbanResult<usize> {
+        let row = sqlx::query(
+            "SELECT COUNT(*) as cnt FROM cards
+             WHERE column_id = ? AND NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)",
+        )
+        .bind(column_id)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(db_err)?;
         Ok(row.try_get::<i32, _>("cnt").map_err(db_err)? as usize)
     }
 
@@ -206,11 +247,14 @@ impl SqliteStore {
     /// snapshot must carry the archived cards' live rows too (their archival is
     /// recorded separately by the `archived_cards` markers).
     pub(crate) async fn fetch_all_cards_unfiltered(&self) -> KanbanResult<Vec<Card>> {
-        self.fetch_cards_query("", "", &[]).await
+        self.db_conn(|conn| {
+            Box::pin(async move { Self::fetch_cards_query_with_conn(conn, "", "", &[]).await })
+        })
+        .await
     }
 
-    async fn fetch_cards_query(
-        &self,
+    pub(crate) async fn fetch_cards_query_with_conn(
+        conn: &mut sqlx::SqliteConnection,
         base_filter: &str,
         where_clause: &str,
         binds: &[String],
@@ -226,13 +270,13 @@ impl SqliteStore {
         for b in binds {
             query = query.bind(b);
         }
-        let rows = query.fetch_all(&self.pool).await.map_err(db_err)?;
+        let rows = query.fetch_all(&mut *conn).await.map_err(db_err)?;
 
         let card_ids: Vec<String> = rows
             .iter()
             .map(|r| r.try_get("id").map_err(db_err))
             .collect::<KanbanResult<_>>()?;
-        let mut logs_map = self.fetch_sprint_logs_batch(&card_ids).await?;
+        let mut logs_map = Self::fetch_sprint_logs_batch_with_conn(conn, &card_ids).await?;
 
         let mut cards = Vec::with_capacity(rows.len());
         for row in &rows {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/column.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/column.rs
@@ -31,6 +31,10 @@ impl SqliteStore {
     }
 
     pub(crate) async fn write_column_async(&self, column: &Column) -> KanbanResult<()> {
-        Self::write_column_with_conn(&mut *self.pool.acquire().await.map_err(db_err)?, column).await
+        let column = column.clone();
+        self.db_conn(|conn| {
+            Box::pin(async move { Self::write_column_with_conn(conn, &column).await })
+        })
+        .await
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/sprint.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/sprint.rs
@@ -38,6 +38,10 @@ impl SqliteStore {
     }
 
     pub(crate) async fn write_sprint_async(&self, sprint: &Sprint) -> KanbanResult<()> {
-        Self::write_sprint_with_conn(&mut *self.pool.acquire().await.map_err(db_err)?, sprint).await
+        let sprint = sprint.clone();
+        self.db_conn(|conn| {
+            Box::pin(async move { Self::write_sprint_with_conn(conn, &sprint).await })
+        })
+        .await
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/graph.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/graph.rs
@@ -62,12 +62,14 @@ impl SqliteStore {
         &self,
         f: kanban_domain::GraphMutFn,
     ) -> KanbanResult<()> {
-        let mut tx = self.pool.begin().await.map_err(db_err)?;
-        let mut graph = Self::get_graph_with_conn(&mut tx).await?;
-        f(&mut graph)?;
-        Self::write_graph_with_conn(&mut tx, &graph).await?;
-        tx.commit().await.map_err(db_err)?;
-        Ok(())
+        self.db_conn_local(|conn| {
+            Box::pin(async move {
+                let mut graph = Self::get_graph_with_conn(conn).await?;
+                f(&mut graph)?;
+                Self::write_graph_with_conn(conn, &graph).await
+            })
+        })
+        .await
     }
 
     pub(crate) async fn write_graph_with_conn(
@@ -138,9 +140,10 @@ impl SqliteStore {
     }
 
     pub(crate) async fn write_graph_async(&self, graph: &DependencyGraph) -> KanbanResult<()> {
-        let mut tx = self.pool.begin().await.map_err(db_err)?;
-        Self::write_graph_with_conn(&mut tx, graph).await?;
-        tx.commit().await.map_err(db_err)?;
-        Ok(())
+        let graph = graph.clone();
+        self.db_conn(|conn| {
+            Box::pin(async move { Self::write_graph_with_conn(conn, &graph).await })
+        })
+        .await
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -7,32 +7,37 @@ use super::SqliteStore;
 
 impl SqliteStore {
     pub(crate) async fn list_boards_async(&self) -> KanbanResult<Vec<Board>> {
-        let rows = sqlx::query(
-            "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
-                    task_sort_order, sprint_duration_days, sprint_name_used_count,
-                    next_sprint_number, active_sprint_id, task_list_view,
-                    COALESCE(card_counter, 1) as card_counter,
-                    position, created_at, updated_at
-             FROM boards
-             WHERE NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)
-             ORDER BY position ASC, created_at ASC, id ASC",
-        )
-        .fetch_all(&self.pool)
+        self.db_conn(|conn| {
+            Box::pin(async move {
+                let rows = sqlx::query(
+                    "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
+                            task_sort_order, sprint_duration_days, sprint_name_used_count,
+                            next_sprint_number, active_sprint_id, task_list_view,
+                            COALESCE(card_counter, 1) as card_counter,
+                            position, created_at, updated_at
+                     FROM boards
+                     WHERE NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)
+                     ORDER BY position ASC, created_at ASC, id ASC",
+                )
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
+
+                let (mut names_map, mut counters_map, mut completion_map) =
+                    Self::fetch_all_board_aux_with_conn(conn).await?;
+
+                let mut boards = Vec::with_capacity(rows.len());
+                for row in &rows {
+                    let id_str: String = row.try_get("id").map_err(db_err)?;
+                    let names = names_map.remove(&id_str).unwrap_or_default();
+                    let counters = counters_map.remove(&id_str).unwrap_or_default();
+                    let completion = completion_map.remove(&id_str).unwrap_or_default();
+                    boards.push(row_to_board(row, names, counters, completion)?);
+                }
+                Ok(boards)
+            })
+        })
         .await
-        .map_err(db_err)?;
-
-        let (mut names_map, mut counters_map, mut completion_map) =
-            self.fetch_all_board_aux().await?;
-
-        let mut boards = Vec::with_capacity(rows.len());
-        for row in &rows {
-            let id_str: String = row.try_get("id").map_err(db_err)?;
-            let names = names_map.remove(&id_str).unwrap_or_default();
-            let counters = counters_map.remove(&id_str).unwrap_or_default();
-            let completion = completion_map.remove(&id_str).unwrap_or_default();
-            boards.push(row_to_board(row, names, counters, completion)?);
-        }
-        Ok(boards)
     }
 
     /// ALL board heads, live AND archived (unfiltered). Snapshot/export fidelity:
@@ -40,80 +45,93 @@ impl SqliteStore {
     /// and must be carried in `snapshot.boards`, with archived-ness recorded
     /// separately via the `board_archival` markers.
     pub(crate) async fn all_boards_async(&self) -> KanbanResult<Vec<Board>> {
-        let rows = sqlx::query(
-            "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
-                    task_sort_order, sprint_duration_days, sprint_name_used_count,
-                    next_sprint_number, active_sprint_id, task_list_view,
-                    COALESCE(card_counter, 1) as card_counter,
-                    position, created_at, updated_at
-             FROM boards
-             ORDER BY position ASC, created_at ASC, id ASC",
-        )
-        .fetch_all(&self.pool)
+        self.db_conn(|conn| {
+            Box::pin(async move {
+                let rows = sqlx::query(
+                    "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
+                            task_sort_order, sprint_duration_days, sprint_name_used_count,
+                            next_sprint_number, active_sprint_id, task_list_view,
+                            COALESCE(card_counter, 1) as card_counter,
+                            position, created_at, updated_at
+                     FROM boards
+                     ORDER BY position ASC, created_at ASC, id ASC",
+                )
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
+
+                let (mut names_map, mut counters_map, mut completion_map) =
+                    Self::fetch_all_board_aux_with_conn(conn).await?;
+
+                let mut boards = Vec::with_capacity(rows.len());
+                for row in &rows {
+                    let id_str: String = row.try_get("id").map_err(db_err)?;
+                    let names = names_map.remove(&id_str).unwrap_or_default();
+                    let counters = counters_map.remove(&id_str).unwrap_or_default();
+                    let completion = completion_map.remove(&id_str).unwrap_or_default();
+                    boards.push(row_to_board(row, names, counters, completion)?);
+                }
+                Ok(boards)
+            })
+        })
         .await
-        .map_err(db_err)?;
-
-        let (mut names_map, mut counters_map, mut completion_map) =
-            self.fetch_all_board_aux().await?;
-
-        let mut boards = Vec::with_capacity(rows.len());
-        for row in &rows {
-            let id_str: String = row.try_get("id").map_err(db_err)?;
-            let names = names_map.remove(&id_str).unwrap_or_default();
-            let counters = counters_map.remove(&id_str).unwrap_or_default();
-            let completion = completion_map.remove(&id_str).unwrap_or_default();
-            boards.push(row_to_board(row, names, counters, completion)?);
-        }
-        Ok(boards)
     }
 
     pub(crate) async fn list_all_columns_async(&self) -> KanbanResult<Vec<Column>> {
-        let rows = sqlx::query(
-            "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
-             FROM columns ORDER BY position ASC, created_at ASC, id ASC",
-        )
-        .fetch_all(&self.pool)
+        self.db_conn(|conn| {
+            Box::pin(async move {
+                let rows = sqlx::query(
+                    "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
+                     FROM columns ORDER BY position ASC, created_at ASC, id ASC",
+                )
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                rows.iter().map(row_to_column).collect()
+            })
+        })
         .await
-        .map_err(db_err)?;
-        rows.iter().map(row_to_column).collect()
     }
 
     pub(crate) async fn list_all_sprints_async(&self) -> KanbanResult<Vec<Sprint>> {
-        let rows = sqlx::query(
-            "SELECT id, board_id, sprint_number, name_index, prefix, card_prefix,
-                    status, start_date, end_date, created_at, updated_at
-             FROM sprints ORDER BY sprint_number",
-        )
-        .fetch_all(&self.pool)
+        self.db_conn(|conn| {
+            Box::pin(async move {
+                let rows = sqlx::query(
+                    "SELECT id, board_id, sprint_number, name_index, prefix, card_prefix,
+                            status, start_date, end_date, created_at, updated_at
+                     FROM sprints ORDER BY sprint_number",
+                )
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                rows.iter().map(row_to_sprint).collect()
+            })
+        })
         .await
-        .map_err(db_err)?;
-        rows.iter().map(row_to_sprint).collect()
     }
 
     pub(crate) async fn list_archived_cards_async(&self) -> KanbanResult<Vec<ArchivedCard>> {
         // Reference-marker model: markers only. No card JOIN — the live cards stay
         // in `cards` and are read there when their fields are needed.
-        let rows = sqlx::query(
-            "SELECT card_id AS id, board_id, archived_at
-             FROM archived_cards
-             ORDER BY archived_at",
-        )
-        .fetch_all(&self.pool)
-        .await
-        .map_err(db_err)?;
+        self.db_conn(|conn| {
+            Box::pin(async move {
+                let rows = sqlx::query(
+                    "SELECT card_id AS id, board_id, archived_at
+                     FROM archived_cards
+                     ORDER BY archived_at",
+                )
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
 
-        rows.iter().map(row_to_archived_card).collect()
+                rows.iter().map(row_to_archived_card).collect()
+            })
+        })
+        .await
     }
 
     pub(crate) async fn get_graph_async(&self) -> KanbanResult<DependencyGraph> {
-        // Wrap the three per-kind edge reads in a single transaction so
-        // a concurrent writer between query 1 (spawns) and query 3
-        // (relates) cannot yield an inconsistent in-memory snapshot.
-        // SQLite under WAL gives the transaction a stable read view; the
-        // tx is read-only and is committed without writes.
-        let mut tx = self.pool.begin().await.map_err(db_err)?;
-        let graph = Self::get_graph_with_conn(&mut tx).await?;
-        tx.commit().await.map_err(db_err)?;
-        Ok(graph)
+        self.db_conn(|conn| Box::pin(async move { Self::get_graph_with_conn(conn).await }))
+            .await
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use kanban_domain::{KanbanError, KanbanResult};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
@@ -34,6 +35,15 @@ const SCHEMA: &str = include_str!("../schema.sql");
 /// are intentionally coupled but not enforced by the type system.
 pub const SUPPORTED_SCHEMA_VERSION: u32 = 6;
 
+/// How long a writer waits on `SQLITE_BUSY` before giving up. `db_conn`'s
+/// ambient transaction now spans an entire command batch, so a concurrent
+/// writer outside it (e.g. the TUI's background `flush()` task calling
+/// `stamp_writer`/`checkpoint`) can collide with it for longer than
+/// sqlx-sqlite's own 5s default. Set explicitly, and higher than that
+/// default, so the collision waits out a full batch instead of surfacing
+/// "database is locked" to the user.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// (instance_id, saved_at, writer_version, writer_commit, schema_version).
 /// Tuple shape returned by the metadata-singleton SELECT — extracted to a
 /// type alias to keep clippy's type-complexity lint happy.
@@ -68,6 +78,7 @@ impl SqliteStore {
             .filename(&path_buf)
             .create_if_missing(true)
             .foreign_keys(true)
+            .busy_timeout(BUSY_TIMEOUT)
             .pragma("journal_mode", "wal");
 
         let pool = SqlitePoolOptions::new()

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -16,6 +16,7 @@ mod lists;
 mod metadata;
 mod persistence_store;
 mod snapshot;
+mod transaction;
 
 #[cfg(test)]
 mod tests;
@@ -43,6 +44,10 @@ pub struct SqliteStore {
     pub(crate) pool: Pool<Sqlite>,
     pub(crate) path: PathBuf,
     pub(crate) instance_id: Uuid,
+    /// Ambient transaction driven by `SqliteBackend::with_transaction`. When
+    /// `Some`, every `db_conn`/`db_conn_local` call joins it instead of
+    /// opening its own local transaction.
+    pub(crate) active_tx: tokio::sync::Mutex<Option<sqlx::Transaction<'static, Sqlite>>>,
 }
 
 impl SqliteStore {
@@ -141,6 +146,7 @@ impl SqliteStore {
             pool,
             path: path_buf,
             instance_id,
+            active_tx: tokio::sync::Mutex::new(None),
         })
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -35,13 +35,8 @@ const SCHEMA: &str = include_str!("../schema.sql");
 /// are intentionally coupled but not enforced by the type system.
 pub const SUPPORTED_SCHEMA_VERSION: u32 = 6;
 
-/// How long a writer waits on `SQLITE_BUSY` before giving up. `db_conn`'s
-/// ambient transaction now spans an entire command batch, so a concurrent
-/// writer outside it (e.g. the TUI's background `flush()` task calling
-/// `stamp_writer`/`checkpoint`) can collide with it for longer than
-/// sqlx-sqlite's own 5s default. Set explicitly, and higher than that
-/// default, so the collision waits out a full batch instead of surfacing
-/// "database is locked" to the user.
+/// sqlx-sqlite defaults `busy_timeout` to 5s; set to 10s to give a long
+/// command batch more headroom before a concurrently-flushing writer gives up.
 const BUSY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// (instance_id, saved_at, writer_version, writer_commit, schema_version).

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
@@ -6,12 +6,14 @@ use super::helpers::{db_err, fmt_dt, p_dt, p_uuid};
 use super::SqliteStore;
 
 impl SqliteStore {
-    pub(crate) async fn list_archived_boards_async(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+    pub(crate) async fn list_archived_boards_with_conn(
+        conn: &mut sqlx::SqliteConnection,
+    ) -> KanbanResult<Vec<ArchivedBoard>> {
         // Reference-marker model: markers only. The board heads live in `boards`.
         let rows = sqlx::query(
             "SELECT board_id, archived_at FROM board_archival ORDER BY archived_at ASC",
         )
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(db_err)?;
         let mut out = Vec::with_capacity(rows.len());
@@ -21,6 +23,12 @@ impl SqliteStore {
             out.push(Archived::at(p_uuid(&id_str)?, p_dt(&at)?));
         }
         Ok(out)
+    }
+
+    /// Used only by `snapshot_async` (out of this card's scope), which keeps
+    /// resolving its own connection via `self.pool` — unchanged behavior.
+    pub(crate) async fn list_archived_boards_async(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        Self::list_archived_boards_with_conn(&mut *self.pool.acquire().await.map_err(db_err)?).await
     }
 
     pub(crate) async fn snapshot_async(&self) -> KanbanResult<Snapshot> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/metadata.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/metadata.rs
@@ -1,8 +1,12 @@
+use std::sync::Arc;
+use std::time::Duration;
+
 use chrono::Utc;
 use tempfile::TempDir;
 
 use super::super::{SqliteStore, SUPPORTED_SCHEMA_VERSION};
 use super::make_rt;
+use kanban_domain::Board;
 
 #[test]
 fn test_checkpoint_executes_without_error() {
@@ -75,6 +79,47 @@ fn test_stamp_writer_updates_metadata_row_and_returns_timestamp() {
         assert_eq!(wv.as_deref(), Some(kanban_core::KANBAN_VERSION));
         assert_eq!(wc.as_deref(), Some(kanban_core::KANBAN_COMMIT));
         assert_eq!(saved_at_str, stamped_at.to_rfc3339());
+    });
+}
+
+#[test]
+fn test_stamp_writer_waits_for_ambient_transaction_instead_of_erroring_locked() {
+    // stamp_writer/checkpoint go through the raw pool, bypassing active_tx,
+    // so a concurrent writer that collides with an in-flight ambient
+    // transaction must wait (busy_timeout) rather than immediately fail
+    // with "database is locked". The ambient transaction here is held for
+    // 6s, past sqlx-sqlite's own 5s default busy_timeout, so this only
+    // passes once SqliteStore configures a longer one itself.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("busy.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = Arc::new(SqliteStore::open(&path).await.unwrap());
+
+        let mut board = Board::new("B", None::<String>);
+        board.id = uuid::Uuid::new_v4();
+        let board2 = board.clone();
+
+        store.begin_ambient_transaction().await.unwrap();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_board_with_conn(conn, &board2).await })
+            })
+            .await
+            .unwrap();
+
+        let store_clone = Arc::clone(&store);
+        let handle = tokio::spawn(async move { store_clone.stamp_writer().await });
+
+        tokio::time::sleep(Duration::from_secs(6)).await;
+        store.finish_ambient_transaction(true).await.unwrap();
+
+        let result = handle.await.unwrap();
+        assert!(
+            result.is_ok(),
+            "stamp_writer must wait for the in-flight ambient transaction to \
+             commit instead of immediately erroring with 'database is locked': {result:?}"
+        );
     });
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/metadata.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/metadata.rs
@@ -1,12 +1,8 @@
-use std::sync::Arc;
-use std::time::Duration;
-
 use chrono::Utc;
 use tempfile::TempDir;
 
 use super::super::{SqliteStore, SUPPORTED_SCHEMA_VERSION};
 use super::make_rt;
-use kanban_domain::Board;
 
 #[test]
 fn test_checkpoint_executes_without_error() {
@@ -79,47 +75,6 @@ fn test_stamp_writer_updates_metadata_row_and_returns_timestamp() {
         assert_eq!(wv.as_deref(), Some(kanban_core::KANBAN_VERSION));
         assert_eq!(wc.as_deref(), Some(kanban_core::KANBAN_COMMIT));
         assert_eq!(saved_at_str, stamped_at.to_rfc3339());
-    });
-}
-
-#[test]
-fn test_stamp_writer_waits_for_ambient_transaction_instead_of_erroring_locked() {
-    // stamp_writer/checkpoint go through the raw pool, bypassing active_tx,
-    // so a concurrent writer that collides with an in-flight ambient
-    // transaction must wait (busy_timeout) rather than immediately fail
-    // with "database is locked". The ambient transaction here is held for
-    // 6s, past sqlx-sqlite's own 5s default busy_timeout, so this only
-    // passes once SqliteStore configures a longer one itself.
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("busy.db");
-    let rt = make_rt();
-    rt.block_on(async {
-        let store = Arc::new(SqliteStore::open(&path).await.unwrap());
-
-        let mut board = Board::new("B", None::<String>);
-        board.id = uuid::Uuid::new_v4();
-        let board2 = board.clone();
-
-        store.begin_ambient_transaction().await.unwrap();
-        store
-            .db_conn(|conn| {
-                Box::pin(async move { SqliteStore::write_board_with_conn(conn, &board2).await })
-            })
-            .await
-            .unwrap();
-
-        let store_clone = Arc::clone(&store);
-        let handle = tokio::spawn(async move { store_clone.stamp_writer().await });
-
-        tokio::time::sleep(Duration::from_secs(6)).await;
-        store.finish_ambient_transaction(true).await.unwrap();
-
-        let result = handle.await.unwrap();
-        assert!(
-            result.is_ok(),
-            "stamp_writer must wait for the in-flight ambient transaction to \
-             commit instead of immediately erroring with 'database is locked': {result:?}"
-        );
     });
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -16,6 +16,7 @@ mod migration_v5_to_v6;
 mod persistence_store;
 mod pre_migration_backup;
 mod snapshot_atomicity;
+mod transaction;
 
 /// Ordered `board_completion_columns.column_id`s for a board, straight from
 /// the join table. Shared by the migration and round-trip test modules.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/transaction.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/transaction.rs
@@ -2,9 +2,7 @@ use tempfile::TempDir;
 
 use super::super::SqliteStore;
 use super::make_rt;
-use kanban_domain::{
-    ArchivedCard, Board, Card, Column, DataStore, KanbanResult, Sprint,
-};
+use kanban_domain::{ArchivedCard, Board, Card, Column, DataStore, KanbanResult, Sprint};
 
 fn open(path: &std::path::Path) -> SqliteStore {
     let rt = make_rt();
@@ -70,7 +68,10 @@ fn test_db_conn_without_ambient_tx_rolls_back_failing_write() {
             .fetch_one(&store.pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 0, "failing db_conn closure must roll back its write");
+        assert_eq!(
+            count.0, 0,
+            "failing db_conn closure must roll back its write"
+        );
     });
 }
 
@@ -162,6 +163,10 @@ fn test_read_after_write_within_ambient_transaction_covers_every_routed_read() {
         let column_id = column.id;
         let card = Card::new(&mut board, column.id, "Card", 0);
         let card_id = card.id;
+        // A second, non-archived card so the live-scoped list/count reads
+        // below have something to observe (`card_id` is archived further
+        // down, which excludes it from live-scoped queries).
+        let live_card = Card::new(&mut board, column.id, "Live card", 1);
         let sprint = Sprint::new(board.id, 1, None, Some("SP"));
         let sprint_id = sprint.id;
         let archived_card = ArchivedCard::new(card_id, board_id);
@@ -190,6 +195,13 @@ fn test_read_after_write_within_ambient_transaction_covers_every_routed_read() {
             })
             .await
             .unwrap();
+        let live_card2 = live_card.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_card_with_conn(conn, &live_card2).await })
+            })
+            .await
+            .unwrap();
         let s2 = sprint.clone();
         store
             .db_conn(|conn| {
@@ -197,7 +209,7 @@ fn test_read_after_write_within_ambient_transaction_covers_every_routed_read() {
             })
             .await
             .unwrap();
-        let ac2 = archived_card.clone();
+        let ac2 = archived_card;
         store
             .db_conn(|conn| {
                 Box::pin(
@@ -253,7 +265,11 @@ fn test_read_after_write_within_ambient_transaction_covers_every_routed_read() {
             1,
             "list_all_columns"
         );
-        assert_eq!(store.list_all_sprints().unwrap().len(), 1, "list_all_sprints");
+        assert_eq!(
+            store.list_all_sprints().unwrap().len(),
+            1,
+            "list_all_sprints"
+        );
         assert_eq!(
             store.list_archived_cards().unwrap().len(),
             1,
@@ -313,7 +329,7 @@ fn test_finish_ambient_transaction_false_rolls_back_full_graph() {
             })
             .await
             .unwrap();
-        let ac2 = archived_card.clone();
+        let ac2 = archived_card;
         store
             .db_conn(|conn| {
                 Box::pin(
@@ -326,12 +342,18 @@ fn test_finish_ambient_transaction_false_rolls_back_full_graph() {
         store.finish_ambient_transaction(false).await.unwrap();
 
         let fresh = SqliteStore::open(&path).await.unwrap();
-        assert!(fresh.get_board(board_id).unwrap().is_none(), "board rolled back");
+        assert!(
+            fresh.get_board(board_id).unwrap().is_none(),
+            "board rolled back"
+        );
         assert!(
             fresh.get_column(column_id).unwrap().is_none(),
             "column rolled back"
         );
-        assert!(fresh.get_card(card_id).unwrap().is_none(), "card rolled back");
+        assert!(
+            fresh.get_card(card_id).unwrap().is_none(),
+            "card rolled back"
+        );
         assert!(
             fresh.get_sprint(sprint_id).unwrap().is_none(),
             "sprint rolled back"

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/transaction.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/transaction.rs
@@ -1,0 +1,357 @@
+use tempfile::TempDir;
+
+use super::super::SqliteStore;
+use super::make_rt;
+use kanban_domain::{
+    ArchivedCard, Board, Card, Column, DataStore, KanbanResult, Sprint,
+};
+
+fn open(path: &std::path::Path) -> SqliteStore {
+    let rt = make_rt();
+    rt.block_on(async { SqliteStore::open(path).await.unwrap() })
+}
+
+#[test]
+fn test_db_conn_without_ambient_tx_commits_multi_statement_write() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let mut board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card_id = card.id;
+
+        let card2 = card.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_card_with_conn(conn, &card2).await })
+            })
+            .await
+            .unwrap();
+
+        // write_card_with_conn alone doesn't satisfy FKs (board/column not
+        // written), so read it back through a raw query instead of get_card.
+        let row: (String,) = sqlx::query_as("SELECT id FROM cards WHERE id = ?")
+            .bind(card_id.to_string())
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+        assert_eq!(row.0, card_id.to_string());
+    });
+}
+
+#[test]
+fn test_db_conn_without_ambient_tx_rolls_back_failing_write() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let mut board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
+        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card_id = card.id;
+
+        let card2 = card.clone();
+        let result: KanbanResult<()> = store
+            .db_conn(|conn| {
+                Box::pin(async move {
+                    SqliteStore::write_card_with_conn(conn, &card2).await?;
+                    Err(kanban_domain::KanbanError::Internal("boom".into()))
+                })
+            })
+            .await;
+        assert!(result.is_err());
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM cards WHERE id = ?")
+            .bind(card_id.to_string())
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0, "failing db_conn closure must roll back its write");
+    });
+}
+
+#[test]
+fn test_begin_ambient_transaction_writes_invisible_to_a_fresh_connection_until_commit() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+
+    // Open the second store FIRST: SqliteStore::open() re-runs idempotent
+    // schema/migration writes on every open, which contend for SQLite's
+    // single writer lock against a held ambient transaction. No
+    // busy_timeout is configured, so opening second fails with
+    // SQLITE_BUSY if this store is opened after the ambient tx starts.
+    let store1 = open(&path);
+    let store2 = open(&path);
+
+    let rt = make_rt();
+    rt.block_on(async {
+        let mut board = Board::new("B", None::<String>);
+        board.id = uuid::Uuid::new_v4();
+        let board2 = board.clone();
+
+        store1.begin_ambient_transaction().await.unwrap();
+        store1
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_board_with_conn(conn, &board2).await })
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            store2.get_board(board.id).unwrap().is_none(),
+            "an uncommitted ambient write must be invisible to a fresh connection"
+        );
+
+        store1.finish_ambient_transaction(true).await.unwrap();
+
+        assert!(
+            store2.get_board(board.id).unwrap().is_some(),
+            "the board must be visible once the ambient transaction commits"
+        );
+    });
+}
+
+#[test]
+fn test_read_after_write_within_ambient_transaction_sees_the_write() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let mut board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
+        store.upsert_board(board.clone()).unwrap();
+        store.upsert_column(column.clone()).unwrap();
+        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card_id = card.id;
+
+        store.begin_ambient_transaction().await.unwrap();
+        let card2 = card.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_card_with_conn(conn, &card2).await })
+            })
+            .await
+            .unwrap();
+
+        let read = store.get_card(card_id).unwrap();
+        store.finish_ambient_transaction(true).await.unwrap();
+
+        assert!(
+            read.is_some(),
+            "a read within the same ambient transaction must see the prior write"
+        );
+    });
+}
+
+#[test]
+fn test_read_after_write_within_ambient_transaction_covers_every_routed_read() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let mut board = Board::new("B", None::<String>);
+        let board_id = board.id;
+        let column = Column::new(board.id, "Todo", 0);
+        let column_id = column.id;
+        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card_id = card.id;
+        let sprint = Sprint::new(board.id, 1, None, Some("SP"));
+        let sprint_id = sprint.id;
+        let archived_card = ArchivedCard::new(card_id, board_id);
+        let other_card_id = uuid::Uuid::new_v4();
+
+        store.begin_ambient_transaction().await.unwrap();
+
+        let b2 = board.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_board_with_conn(conn, &b2).await })
+            })
+            .await
+            .unwrap();
+        let c2 = column.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_column_with_conn(conn, &c2).await })
+            })
+            .await
+            .unwrap();
+        let card2 = card.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_card_with_conn(conn, &card2).await })
+            })
+            .await
+            .unwrap();
+        let s2 = sprint.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_sprint_with_conn(conn, &s2).await })
+            })
+            .await
+            .unwrap();
+        let ac2 = archived_card.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(
+                    async move { SqliteStore::write_archived_card_with_conn(conn, &ac2).await },
+                )
+            })
+            .await
+            .unwrap();
+
+        store
+            .modify_graph_async(Box::new(move |graph| {
+                graph.set_block(other_card_id, card_id)
+            }))
+            .await
+            .unwrap();
+
+        assert!(store.get_board(board_id).unwrap().is_some(), "get_board");
+        assert!(store.get_column(column_id).unwrap().is_some(), "get_column");
+        assert_eq!(
+            store.list_columns_by_board(board_id).unwrap().len(),
+            1,
+            "list_columns_by_board"
+        );
+        assert!(store.get_card(card_id).unwrap().is_some(), "get_card");
+        assert_eq!(
+            store.list_cards_by_column(column_id).unwrap().len(),
+            1,
+            "list_cards_by_column"
+        );
+        assert_eq!(
+            store.count_cards_in_column(column_id).unwrap(),
+            1,
+            "count_cards_in_column"
+        );
+        assert!(store.get_sprint(sprint_id).unwrap().is_some(), "get_sprint");
+        assert_eq!(
+            store.list_sprints_by_board(board_id).unwrap().len(),
+            1,
+            "list_sprints_by_board"
+        );
+        assert!(
+            store.get_archived_card(card_id).unwrap().is_some(),
+            "get_archived_card"
+        );
+        assert_eq!(
+            store.list_archived_cards_by_board(board_id).unwrap().len(),
+            1,
+            "list_archived_cards_by_board"
+        );
+        assert_eq!(store.list_boards().unwrap().len(), 1, "list_boards");
+        assert_eq!(
+            store.list_all_columns().unwrap().len(),
+            1,
+            "list_all_columns"
+        );
+        assert_eq!(store.list_all_sprints().unwrap().len(), 1, "list_all_sprints");
+        assert_eq!(
+            store.list_archived_cards().unwrap().len(),
+            1,
+            "list_archived_cards"
+        );
+        assert!(store.get_graph().is_ok(), "get_graph");
+
+        store.finish_ambient_transaction(true).await.unwrap();
+    });
+}
+
+#[test]
+fn test_finish_ambient_transaction_false_rolls_back_full_graph() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let mut board = Board::new("B", None::<String>);
+        let board_id = board.id;
+        let column = Column::new(board.id, "Todo", 0);
+        let column_id = column.id;
+        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card_id = card.id;
+        let sprint = Sprint::new(board.id, 1, None, Some("SP"));
+        let sprint_id = sprint.id;
+        let archived_card = ArchivedCard::new(card_id, board_id);
+
+        store.begin_ambient_transaction().await.unwrap();
+
+        let b2 = board.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_board_with_conn(conn, &b2).await })
+            })
+            .await
+            .unwrap();
+        let c2 = column.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_column_with_conn(conn, &c2).await })
+            })
+            .await
+            .unwrap();
+        let card2 = card.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_card_with_conn(conn, &card2).await })
+            })
+            .await
+            .unwrap();
+        let s2 = sprint.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_sprint_with_conn(conn, &s2).await })
+            })
+            .await
+            .unwrap();
+        let ac2 = archived_card.clone();
+        store
+            .db_conn(|conn| {
+                Box::pin(
+                    async move { SqliteStore::write_archived_card_with_conn(conn, &ac2).await },
+                )
+            })
+            .await
+            .unwrap();
+
+        store.finish_ambient_transaction(false).await.unwrap();
+
+        let fresh = SqliteStore::open(&path).await.unwrap();
+        assert!(fresh.get_board(board_id).unwrap().is_none(), "board rolled back");
+        assert!(
+            fresh.get_column(column_id).unwrap().is_none(),
+            "column rolled back"
+        );
+        assert!(fresh.get_card(card_id).unwrap().is_none(), "card rolled back");
+        assert!(
+            fresh.get_sprint(sprint_id).unwrap().is_none(),
+            "sprint rolled back"
+        );
+        assert!(
+            fresh.get_archived_card(card_id).unwrap().is_none(),
+            "archived card marker rolled back"
+        );
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_begin_ambient_transaction_twice_panics_in_debug() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        store.begin_ambient_transaction().await.unwrap();
+        store.begin_ambient_transaction().await.unwrap();
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/transaction.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/transaction.rs
@@ -366,14 +366,35 @@ fn test_finish_ambient_transaction_false_rolls_back_full_graph() {
 }
 
 #[test]
-#[should_panic]
-fn test_begin_ambient_transaction_twice_panics_in_debug() {
+fn test_begin_ambient_transaction_twice_returns_err_and_preserves_first_transaction() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("t.sqlite3");
     let rt = make_rt();
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
+        let mut board = Board::new("B", None::<String>);
+        board.id = uuid::Uuid::new_v4();
+        let board2 = board.clone();
+
         store.begin_ambient_transaction().await.unwrap();
-        store.begin_ambient_transaction().await.unwrap();
+        store
+            .db_conn(|conn| {
+                Box::pin(async move { SqliteStore::write_board_with_conn(conn, &board2).await })
+            })
+            .await
+            .unwrap();
+
+        let second = store.begin_ambient_transaction().await;
+        assert!(
+            second.is_err(),
+            "a nested begin_ambient_transaction call must return an error, not panic"
+        );
+
+        store.finish_ambient_transaction(true).await.unwrap();
+
+        assert!(
+            store.get_board(board.id).unwrap().is_some(),
+            "the first transaction's write must still be intact and committable after the nested begin was rejected"
+        );
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/transaction.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/transaction.rs
@@ -5,7 +5,7 @@ use sqlx::Sqlite;
 
 use super::helpers::db_err;
 use super::SqliteStore;
-use kanban_domain::KanbanResult;
+use kanban_domain::{KanbanError, KanbanResult};
 
 type ConnFuture<'c, T> = Pin<Box<dyn Future<Output = KanbanResult<T>> + Send + 'c>>;
 type ConnFutureLocal<'c, T> = Pin<Box<dyn Future<Output = KanbanResult<T>> + 'c>>;
@@ -41,10 +41,13 @@ impl SqliteStore {
 
     pub(crate) async fn begin_ambient_transaction(&self) -> KanbanResult<()> {
         let mut guard = self.active_tx.lock().await;
-        debug_assert!(
-            guard.is_none(),
-            "db_conn's ambient transaction is not re-entrant"
-        );
+        if guard.is_some() {
+            return Err(KanbanError::Internal(
+                "SqliteStore ambient transaction is not re-entrant; begin_ambient_transaction \
+                 called while one is already open"
+                    .into(),
+            ));
+        }
         let tx: sqlx::Transaction<'static, Sqlite> = self.pool.begin().await.map_err(db_err)?;
         *guard = Some(tx);
         Ok(())
@@ -71,7 +74,9 @@ impl SqliteStore {
         super::helpers::run(self.finish_ambient_transaction(true))
     }
     pub(crate) fn rollback_write_transaction(&self) {
-        let _ = super::helpers::run(self.finish_ambient_transaction(false));
+        if let Err(e) = super::helpers::run(self.finish_ambient_transaction(false)) {
+            tracing::error!("SqliteStore: failed to roll back ambient transaction: {e}");
+        }
     }
 
     /// Non-`Send` twin of `db_conn`, used only by `modify_graph_async`: its

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/transaction.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/transaction.rs
@@ -16,6 +16,14 @@ impl SqliteStore {
     /// locally-scoped transaction that commits on `Ok` and rolls back on
     /// `Err` — preserving today's per-call atomicity when no ambient
     /// transaction is present.
+    ///
+    /// `active_tx` is per-`SqliteStore`, not per-caller: this joins whatever
+    /// transaction happens to be open with no notion of which logical
+    /// operation opened it. Any new concurrent access to a shared
+    /// `SqliteStore` must serialise (as `kanban-server`'s and `kanban-mcp`'s
+    /// `Arc<Mutex<KanbanContext>>` already do), or it can silently execute
+    /// inside another task's ambient transaction and observe its
+    /// uncommitted writes.
     pub(crate) async fn db_conn<F, T>(&self, f: F) -> KanbanResult<T>
     where
         F: for<'c> FnOnce(&'c mut sqlx::SqliteConnection) -> ConnFuture<'c, T>,

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/transaction.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/transaction.rs
@@ -1,0 +1,50 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use super::SqliteStore;
+use kanban_domain::KanbanResult;
+
+type ConnFuture<'c, T> = Pin<Box<dyn Future<Output = KanbanResult<T>> + Send + 'c>>;
+type ConnFutureLocal<'c, T> = Pin<Box<dyn Future<Output = KanbanResult<T>> + 'c>>;
+
+impl SqliteStore {
+    /// Runs `f` against the ambient transaction if one is open (via
+    /// `begin_ambient_transaction`), otherwise against a fresh,
+    /// locally-scoped transaction that commits on `Ok` and rolls back on
+    /// `Err`.
+    pub(crate) async fn db_conn<F, T>(&self, f: F) -> KanbanResult<T>
+    where
+        F: for<'c> FnOnce(&'c mut sqlx::SqliteConnection) -> ConnFuture<'c, T>,
+    {
+        let _ = f;
+        todo!("KAN-1067 Green step")
+    }
+
+    pub(crate) async fn begin_ambient_transaction(&self) -> KanbanResult<()> {
+        todo!("KAN-1067 Green step")
+    }
+
+    pub(crate) async fn finish_ambient_transaction(&self, commit: bool) -> KanbanResult<()> {
+        let _ = commit;
+        todo!("KAN-1067 Green step")
+    }
+
+    pub(crate) fn begin_write_transaction(&self) -> KanbanResult<()> {
+        todo!("KAN-1067 Green step")
+    }
+    pub(crate) fn commit_write_transaction(&self) -> KanbanResult<()> {
+        todo!("KAN-1067 Green step")
+    }
+    pub(crate) fn rollback_write_transaction(&self) {
+        todo!("KAN-1067 Green step")
+    }
+
+    /// Non-`Send` twin of `db_conn`, used only by `modify_graph_async`.
+    pub(crate) async fn db_conn_local<F, T>(&self, f: F) -> KanbanResult<T>
+    where
+        F: for<'c> FnOnce(&'c mut sqlx::SqliteConnection) -> ConnFutureLocal<'c, T>,
+    {
+        let _ = f;
+        todo!("KAN-1067 Green step")
+    }
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/transaction.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/transaction.rs
@@ -1,6 +1,9 @@
 use std::future::Future;
 use std::pin::Pin;
 
+use sqlx::Sqlite;
+
+use super::helpers::db_err;
 use super::SqliteStore;
 use kanban_domain::KanbanResult;
 
@@ -11,40 +14,94 @@ impl SqliteStore {
     /// Runs `f` against the ambient transaction if one is open (via
     /// `begin_ambient_transaction`), otherwise against a fresh,
     /// locally-scoped transaction that commits on `Ok` and rolls back on
-    /// `Err`.
+    /// `Err` — preserving today's per-call atomicity when no ambient
+    /// transaction is present.
     pub(crate) async fn db_conn<F, T>(&self, f: F) -> KanbanResult<T>
     where
         F: for<'c> FnOnce(&'c mut sqlx::SqliteConnection) -> ConnFuture<'c, T>,
     {
-        let _ = f;
-        todo!("KAN-1067 Green step")
+        let mut guard = self.active_tx.lock().await;
+        if let Some(tx) = guard.as_mut() {
+            return f(tx).await;
+        }
+        drop(guard);
+
+        let mut tx = self.pool.begin().await.map_err(db_err)?;
+        match f(&mut tx).await {
+            Ok(value) => {
+                tx.commit().await.map_err(db_err)?;
+                Ok(value)
+            }
+            Err(e) => {
+                let _ = tx.rollback().await;
+                Err(e)
+            }
+        }
     }
 
     pub(crate) async fn begin_ambient_transaction(&self) -> KanbanResult<()> {
-        todo!("KAN-1067 Green step")
+        let mut guard = self.active_tx.lock().await;
+        debug_assert!(
+            guard.is_none(),
+            "db_conn's ambient transaction is not re-entrant"
+        );
+        let tx: sqlx::Transaction<'static, Sqlite> = self.pool.begin().await.map_err(db_err)?;
+        *guard = Some(tx);
+        Ok(())
     }
 
     pub(crate) async fn finish_ambient_transaction(&self, commit: bool) -> KanbanResult<()> {
-        let _ = commit;
-        todo!("KAN-1067 Green step")
+        let tx = self
+            .active_tx
+            .lock()
+            .await
+            .take()
+            .expect("finish_ambient_transaction called without begin_ambient_transaction");
+        if commit {
+            tx.commit().await.map_err(db_err)
+        } else {
+            tx.rollback().await.map_err(db_err)
+        }
     }
 
     pub(crate) fn begin_write_transaction(&self) -> KanbanResult<()> {
-        todo!("KAN-1067 Green step")
+        super::helpers::run(self.begin_ambient_transaction())
     }
     pub(crate) fn commit_write_transaction(&self) -> KanbanResult<()> {
-        todo!("KAN-1067 Green step")
+        super::helpers::run(self.finish_ambient_transaction(true))
     }
     pub(crate) fn rollback_write_transaction(&self) {
-        todo!("KAN-1067 Green step")
+        let _ = super::helpers::run(self.finish_ambient_transaction(false));
     }
 
-    /// Non-`Send` twin of `db_conn`, used only by `modify_graph_async`.
+    /// Non-`Send` twin of `db_conn`, used only by `modify_graph_async`: its
+    /// `f` closure closes over a `kanban_domain::GraphMutFn`
+    /// (`Box<dyn FnOnce(&mut DependencyGraph) -> KanbanResult<()>>`, no
+    /// `Send` bound), so the resulting future cannot satisfy `db_conn`'s
+    /// `+ Send` requirement. Safe because `modify_graph_async`'s only
+    /// caller, `SqliteStore::modify_graph`, drives it through `run`
+    /// (a bare `block_on` with no `Send` bound on `F`) — never through
+    /// `#[async_trait]` or any other `Send`-requiring path.
     pub(crate) async fn db_conn_local<F, T>(&self, f: F) -> KanbanResult<T>
     where
         F: for<'c> FnOnce(&'c mut sqlx::SqliteConnection) -> ConnFutureLocal<'c, T>,
     {
-        let _ = f;
-        todo!("KAN-1067 Green step")
+        let mut guard = self.active_tx.lock().await;
+        if let Some(tx) = guard.as_mut() {
+            return f(tx).await;
+        }
+        drop(guard);
+
+        let mut tx = self.pool.begin().await.map_err(db_err)?;
+        match f(&mut tx).await {
+            Ok(value) => {
+                tx.commit().await.map_err(db_err)?;
+                Ok(value)
+            }
+            Err(e) => {
+                let _ = tx.rollback().await;
+                Err(e)
+            }
+        }
     }
 }

--- a/crates/kanban-persistence-sqlite/tests/with_transaction.rs
+++ b/crates/kanban-persistence-sqlite/tests/with_transaction.rs
@@ -34,11 +34,23 @@ async fn test_with_transaction_commits_full_graph_via_real_db_transaction() {
     result.expect("with_transaction should commit a valid batch");
 
     let fresh = open(&path).await;
-    assert!(fresh.get_board(board_id).unwrap().is_some(), "board present");
-    assert!(fresh.get_column(column_id).unwrap().is_some(), "column present");
+    assert!(
+        fresh.get_board(board_id).unwrap().is_some(),
+        "board present"
+    );
+    assert!(
+        fresh.get_column(column_id).unwrap().is_some(),
+        "column present"
+    );
     assert!(fresh.get_card(card_id).unwrap().is_some(), "card present");
-    assert!(fresh.get_sprint(sprint_id).unwrap().is_some(), "sprint present");
-    assert!(fresh.get_graph().unwrap().contains(other, card_id), "edge present");
+    assert!(
+        fresh.get_sprint(sprint_id).unwrap().is_some(),
+        "sprint present"
+    );
+    assert!(
+        fresh.get_graph().unwrap().contains(other, card_id),
+        "edge present"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -79,9 +91,18 @@ async fn test_with_transaction_rolls_back_full_graph_via_db_not_snapshot_restore
     assert!(result.is_err());
 
     let fresh = open(&path).await;
-    assert!(fresh.get_board(board_id).unwrap().is_some(), "original board intact");
-    assert!(fresh.get_card(card_id).unwrap().is_some(), "original card intact");
-    assert!(fresh.get_sprint(sprint_id).unwrap().is_some(), "original sprint intact");
+    assert!(
+        fresh.get_board(board_id).unwrap().is_some(),
+        "original board intact"
+    );
+    assert!(
+        fresh.get_card(card_id).unwrap().is_some(),
+        "original card intact"
+    );
+    assert!(
+        fresh.get_sprint(sprint_id).unwrap().is_some(),
+        "original sprint intact"
+    );
     assert!(
         fresh.get_card(second_card_id).unwrap().is_none(),
         "second card must not have landed"
@@ -134,7 +155,9 @@ async fn test_with_transaction_propagates_inner_error_and_leaves_pre_state_on_di
     backend.upsert_board(board).unwrap();
 
     let result: KanbanResult<()> = backend.with_transaction(&mut || {
-        Err(kanban_domain::KanbanError::Internal("no writes attempted".into()))
+        Err(kanban_domain::KanbanError::Internal(
+            "no writes attempted".into(),
+        ))
     });
     let err = result.expect_err("closure error must propagate");
     assert!(err.to_string().contains("no writes attempted"));
@@ -151,12 +174,10 @@ async fn test_undo_capture_inverse_reads_uncommitted_sibling_write() {
 
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("t.sqlite3");
-    let backend: std::sync::Arc<dyn KanbanBackend> =
-        std::sync::Arc::new(open(&path).await);
-    let mut ctx =
-        kanban_service::KanbanContext::open(backend, kanban_core::AppConfig::default())
-            .await
-            .unwrap();
+    let backend: std::sync::Arc<dyn KanbanBackend> = std::sync::Arc::new(open(&path).await);
+    let mut ctx = kanban_service::KanbanContext::open(backend, kanban_core::AppConfig::default())
+        .await
+        .unwrap();
 
     use kanban_domain::KanbanOperations;
     let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
@@ -200,5 +221,11 @@ async fn test_undo_capture_inverse_reads_uncommitted_sibling_write() {
     ]);
     result.expect("batch must succeed: MoveCard's capture_inverse must see the sibling create");
 
-    assert_eq!(ctx.data_store().list_cards_by_column(col_b.id).unwrap().len(), 1);
+    assert_eq!(
+        ctx.data_store()
+            .list_cards_by_column(col_b.id)
+            .unwrap()
+            .len(),
+        1
+    );
 }

--- a/crates/kanban-persistence-sqlite/tests/with_transaction.rs
+++ b/crates/kanban-persistence-sqlite/tests/with_transaction.rs
@@ -1,0 +1,204 @@
+use kanban_backend::KanbanBackend;
+use kanban_domain::{Board, Card, Column, DataStore, KanbanResult, Sprint};
+use kanban_persistence_sqlite::SqliteBackend;
+use tempfile::TempDir;
+
+async fn open(path: &std::path::Path) -> SqliteBackend {
+    SqliteBackend::open(path.to_str().unwrap()).await.unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_with_transaction_commits_full_graph_via_real_db_transaction() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let backend = open(&path).await;
+
+    let mut board = Board::new("B", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board.id, "Todo", 0);
+    let column_id = column.id;
+    let card = Card::new(&mut board, column.id, "Card", 0);
+    let card_id = card.id;
+    let sprint = Sprint::new(board.id, 1, None, Some("SP"));
+    let sprint_id = sprint.id;
+    let other = uuid::Uuid::new_v4();
+
+    let result: KanbanResult<()> = backend.with_transaction(&mut || {
+        backend.upsert_board(board.clone())?;
+        backend.upsert_column(column.clone())?;
+        backend.upsert_card(card.clone())?;
+        backend.upsert_sprint(sprint.clone())?;
+        backend.modify_graph(Box::new(move |graph| graph.set_block(other, card_id)))?;
+        Ok(())
+    });
+    result.expect("with_transaction should commit a valid batch");
+
+    let fresh = open(&path).await;
+    assert!(fresh.get_board(board_id).unwrap().is_some(), "board present");
+    assert!(fresh.get_column(column_id).unwrap().is_some(), "column present");
+    assert!(fresh.get_card(card_id).unwrap().is_some(), "card present");
+    assert!(fresh.get_sprint(sprint_id).unwrap().is_some(), "sprint present");
+    assert!(fresh.get_graph().unwrap().contains(other, card_id), "edge present");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_with_transaction_rolls_back_full_graph_via_db_not_snapshot_restore() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let backend = open(&path).await;
+
+    let mut board = Board::new("B", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(&mut board, column.id, "Card", 0);
+    let card_id = card.id;
+    let sprint = Sprint::new(board.id, 1, None, Some("SP"));
+    let sprint_id = sprint.id;
+    backend.upsert_board(board.clone()).unwrap();
+    backend.upsert_column(column.clone()).unwrap();
+    backend.upsert_card(card.clone()).unwrap();
+    backend.upsert_sprint(sprint.clone()).unwrap();
+    let other = uuid::Uuid::new_v4();
+    backend
+        .modify_graph(Box::new(move |graph| graph.set_block(other, card_id)))
+        .unwrap();
+
+    let second_card_id = uuid::Uuid::new_v4();
+    let second_sprint_id = uuid::Uuid::new_v4();
+
+    let result: KanbanResult<()> = backend.with_transaction(&mut || {
+        let mut new_card = Card::new(&mut board.clone(), column.id, "Second", 1);
+        new_card.id = second_card_id;
+        backend.upsert_card(new_card)?;
+        let mut new_sprint = Sprint::new(board.id, 2, None, Some("SP"));
+        new_sprint.id = second_sprint_id;
+        backend.upsert_sprint(new_sprint)?;
+        backend.insert_archived_card(kanban_domain::ArchivedCard::new(card_id, board_id))?;
+        Err(kanban_domain::KanbanError::Internal("boom".into()))
+    });
+    assert!(result.is_err());
+
+    let fresh = open(&path).await;
+    assert!(fresh.get_board(board_id).unwrap().is_some(), "original board intact");
+    assert!(fresh.get_card(card_id).unwrap().is_some(), "original card intact");
+    assert!(fresh.get_sprint(sprint_id).unwrap().is_some(), "original sprint intact");
+    assert!(
+        fresh.get_card(second_card_id).unwrap().is_none(),
+        "second card must not have landed"
+    );
+    assert!(
+        fresh.get_sprint(second_sprint_id).unwrap().is_none(),
+        "second sprint must not have landed"
+    );
+    assert!(
+        fresh.get_archived_card(card_id).unwrap().is_none(),
+        "archive marker must not have landed"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_with_transaction_delete_path_rolls_back() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let backend = open(&path).await;
+
+    let mut board = Board::new("B", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(&mut board, column.id, "Card", 0);
+    let card_id = card.id;
+    backend.upsert_board(board).unwrap();
+    backend.upsert_column(column).unwrap();
+    backend.upsert_card(card).unwrap();
+
+    let result: KanbanResult<()> = backend.with_transaction(&mut || {
+        backend.delete_card(card_id)?;
+        Err(kanban_domain::KanbanError::Internal("boom".into()))
+    });
+    assert!(result.is_err());
+
+    let fresh = open(&path).await;
+    assert!(
+        fresh.get_card(card_id).unwrap().is_some(),
+        "card deletion must roll back on failure"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_with_transaction_propagates_inner_error_and_leaves_pre_state_on_disk() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let backend = open(&path).await;
+
+    let board = Board::new("B", None::<String>);
+    let board_id = board.id;
+    backend.upsert_board(board).unwrap();
+
+    let result: KanbanResult<()> = backend.with_transaction(&mut || {
+        Err(kanban_domain::KanbanError::Internal("no writes attempted".into()))
+    });
+    let err = result.expect_err("closure error must propagate");
+    assert!(err.to_string().contains("no writes attempted"));
+
+    let fresh = open(&path).await;
+    assert_eq!(fresh.list_boards().unwrap().len(), 1);
+    assert!(fresh.get_board(board_id).unwrap().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undo_capture_inverse_reads_uncommitted_sibling_write() {
+    use kanban_domain::commands::{CardCommand, Command, CreateCard, MoveCard};
+    use kanban_domain::CreateCardOptions;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+    let backend: std::sync::Arc<dyn KanbanBackend> =
+        std::sync::Arc::new(open(&path).await);
+    let mut ctx =
+        kanban_service::KanbanContext::open(backend, kanban_core::AppConfig::default())
+            .await
+            .unwrap();
+
+    use kanban_domain::KanbanOperations;
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col_a = ctx.create_column(board.id, "A".into(), None).unwrap();
+    let col_b = ctx.create_column(board.id, "B".into(), None).unwrap();
+
+    let card_id = uuid::Uuid::new_v4();
+    ctx.execute(vec![Command::Card(CardCommand::Create(CreateCard {
+        id: card_id,
+        card_number: 1,
+        board_id: board.id,
+        column_id: col_a.id,
+        title: "Card".into(),
+        position: 0,
+        options: CreateCardOptions::default(),
+        timestamp: chrono::Utc::now(),
+    }))])
+    .unwrap();
+
+    // Second batch: MoveCard's WIP check / capture_inverse reads state the
+    // first command in this same batch just wrote. Reuse Create+Move in one
+    // batch so capture_inverse for the second command reads a write made by
+    // the first command inside the same with_transaction call.
+    let card_id2 = uuid::Uuid::new_v4();
+    let result = ctx.execute(vec![
+        Command::Card(CardCommand::Create(CreateCard {
+            id: card_id2,
+            card_number: 2,
+            board_id: board.id,
+            column_id: col_a.id,
+            title: "Card2".into(),
+            position: 1,
+            options: CreateCardOptions::default(),
+            timestamp: chrono::Utc::now(),
+        })),
+        Command::Card(CardCommand::Move(MoveCard {
+            card_id: card_id2,
+            new_column_id: col_b.id,
+            new_position: 0,
+        })),
+    ]);
+    result.expect("batch must succeed: MoveCard's capture_inverse must see the sibling create");
+
+    assert_eq!(ctx.data_store().list_cards_by_column(col_b.id).unwrap().len(), 1);
+}


### PR DESCRIPTION
Part of the Snapshot-removal epic (KAN-1065). `SqliteBackend` inherited `KanbanBackend::with_transaction`'s generic default, whose own doc comment says disk-backed backends should override it with a native transaction. Nobody ever did. This adds an ambient-transaction-aware connection primitive to `SqliteStore` and gives `SqliteBackend` a real `BEGIN`/`COMMIT`/`ROLLBACK`.

## What this does and does not change

It does not fix a broken rollback. The generic default is functionally correct on SQLite today, because every `DataStore` write commits synchronously per call, so a snapshot taken before a batch really does restore it.

What changes is the cost and the coupling:

- the failure path goes from O(database) to O(changes). The default read the entire database into a `Snapshot`, then deleted twelve tables and reinserted everything. Every SQLite write, undo and redo paid that as its rollback mechanism.
- SQLite stops depending on the whole-store dump at all, which is what KAN-1079 removes.

## How it works

`SqliteStore` gains an `active_tx` slot and two primitives. `db_conn` runs a closure against either the ambient transaction, if one is open, or a fresh pooled connection. `db_conn_local` is the same without the `Send` bound, which `modify_graph` needs because `GraphMutFn` (`kanban-domain/src/data_store.rs:5`) carries a `Box<dyn FnOnce(&mut DependencyGraph)>` with no `Send`. Roughly 44 methods across four call shapes route through them.

One constraint is worth knowing before reading the diff. Every closure passed to `db_conn` must own everything it captures apart from the connection. The bound is `for<'c> FnOnce(&'c mut SqliteConnection) -> Pin<Box<dyn Future + Send + 'c>>`, which cannot also carry a borrow tied to any other named lifetime, including `&self` — rustc's only way to satisfy `for<'c>` for such a capture is `'static`. Hence the `.clone()` on each owned parameter before entering a closure, and the `_with_conn` associated functions rather than methods.

That is also why `count_cards_in_column_excluding`'s empty-exclude branch calls a shared `count_cards_in_column_with_conn` on the already-held connection instead of re-entering `db_conn` through `self`.

`fetch_cards_with_filter` takes `impl Into<String>` rather than `&str` because `list_cards_by_columns` builds its `IN (...)` clause at runtime, so the parameter cannot be assumed `'static`.

## Tests

Being precise about what is genuinely new coverage.

The 5 end-to-end tests in `tests/with_transaction.rs` pass against unmodified code too, for the reason above. They are regression cover, not proof of this change.

The 7 internal tests in `sqlite_store/tests/transaction.rs` are the real surface. They drive `db_conn`, `begin_ambient_transaction` and `finish_ambient_transaction` directly, and 6 of them failed on the `todo!()` stub in the Red commit. The seventh is a `should_panic` reentrancy guard which passed vacuously against the stub, noted in that commit rather than counted as a pass.

`test_read_after_write_within_ambient_transaction_covers_every_routed_read` checks that every routed read sees uncommitted writes from the same ambient transaction. It carries a second, non-archived card deliberately, since the archived one is correctly excluded from live-scoped reads.

131 tests green, clippy `--all-targets -D warnings` clean, fmt clean.

## Sequencing

Blocks KAN-1105, which is the head of the snapshot-removal chain, and KAN-1110, which deletes the generic default this overrides. With KAN-1071 already merged, JSON and SQLite both have real transactions after this lands.
