### PR TITLE
KAN-1100 feat(tui): relationship picker search + scroll parity with the card list

### DIFF
--- a/.changeset/kan-1100.md
+++ b/.changeset/kan-1100.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Relationship picker (manage parents/children) search now matches branch name and card identifier, not just title, via the same CompositeSearcher the main card list uses. Its list also gains ListComponent-backed scroll and more-above/below indicators, matching the card list's UX.

--- a/crates/kanban-tui/src/app/relationship.rs
+++ b/crates/kanban-tui/src/app/relationship.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 pub struct RelationshipState {
     pub card_ids: Vec<Uuid>,
+    pub board_id: Option<Uuid>,
     pub selected: HashSet<Uuid>,
     pub selection: SelectionState,
     pub search: String,
@@ -17,6 +18,7 @@ impl Default for RelationshipState {
     fn default() -> Self {
         Self {
             card_ids: Vec::new(),
+            board_id: None,
             selected: HashSet::new(),
             selection: SelectionState::new(),
             search: String::new(),

--- a/crates/kanban-tui/src/app/relationship.rs
+++ b/crates/kanban-tui/src/app/relationship.rs
@@ -1,4 +1,3 @@
-use kanban_core::SelectionState;
 use kanban_view::ListComponent;
 use std::collections::HashSet;
 use uuid::Uuid;
@@ -7,7 +6,7 @@ pub struct RelationshipState {
     pub card_ids: Vec<Uuid>,
     pub board_id: Option<Uuid>,
     pub selected: HashSet<Uuid>,
-    pub selection: SelectionState,
+    pub picker_list: ListComponent,
     pub search: String,
     pub search_active: bool,
     pub parents_list: ListComponent,
@@ -20,7 +19,7 @@ impl Default for RelationshipState {
             card_ids: Vec::new(),
             board_id: None,
             selected: HashSet::new(),
-            selection: SelectionState::new(),
+            picker_list: ListComponent::new(false),
             search: String::new(),
             search_active: false,
             parents_list: ListComponent::new(false),

--- a/crates/kanban-tui/src/components/relationship_popup.rs
+++ b/crates/kanban-tui/src/components/relationship_popup.rs
@@ -1,7 +1,7 @@
 use crate::app::App;
 use crate::components::centered_rect;
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
@@ -16,6 +16,29 @@ pub fn render_manage_children_popup(app: &App, frame: &mut Frame) {
     render_relationship_popup(app, frame, "Set Children");
 }
 
+fn relationship_popup_layout(frame_area: Rect) -> std::rc::Rc<[Rect]> {
+    let area = centered_rect(60, 70, frame_area);
+    let block = Block::default().borders(Borders::ALL);
+    let inner = block.inner(area);
+
+    Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(inner)
+}
+
+/// The card list's viewport height, computed from the current frame area.
+/// Mirrors `render_relationship_popup`'s layout math so key handlers can
+/// scroll the list into view without needing a live `Frame`.
+pub fn relationship_popup_viewport_height(frame_area: Rect) -> usize {
+    relationship_popup_layout(frame_area)[1].height as usize
+}
+
 fn render_relationship_popup(app: &App, frame: &mut Frame, title: &str) {
     let area = centered_rect(60, 70, frame.area());
     frame.render_widget(Clear, area);
@@ -25,18 +48,9 @@ fn render_relationship_popup(app: &App, frame: &mut Frame, title: &str) {
         .borders(Borders::ALL)
         .style(Style::default().bg(Color::Black));
 
-    let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(1)
-        .constraints([
-            Constraint::Length(3),
-            Constraint::Min(0),
-            Constraint::Length(1),
-        ])
-        .split(inner);
+    let chunks = relationship_popup_layout(frame.area());
 
     render_relationship_search_box(app, frame, chunks[0]);
     render_relationship_card_list(app, frame, chunks[1]);
@@ -75,37 +89,62 @@ fn render_relationship_search_box(app: &App, frame: &mut Frame, area: ratatui::l
     frame.render_widget(search, area);
 }
 
-fn render_relationship_card_list(app: &App, frame: &mut Frame, area: ratatui::layout::Rect) {
+fn render_relationship_card_list(app: &App, frame: &mut Frame, area: Rect) {
     let filtered_cards = app.relationship_filtered_cards();
 
     let mut lines = vec![];
-    for (idx, card_id) in filtered_cards.iter().enumerate() {
-        if let Some(card) = app.model.card_by_id(*card_id) {
-            let is_selected = app.relationship.selection.get() == Some(idx);
-            let is_checked = app.relationship.selected.contains(card_id);
 
-            let checkbox = if is_checked { "[✓]" } else { "[ ]" };
-
-            let style = if is_selected {
-                Style::default().fg(Color::White).bg(Color::Blue)
-            } else if is_checked {
-                Style::default().fg(Color::Green)
-            } else {
-                Style::default().fg(Color::White)
-            };
-
-            lines.push(Line::from(Span::styled(
-                format!("{} {}", checkbox, card.title),
-                style,
-            )));
-        }
-    }
-
-    if lines.is_empty() {
+    if filtered_cards.is_empty() {
         lines.push(Line::from(Span::styled(
             "No eligible cards found",
             Style::default().fg(Color::DarkGray),
         )));
+    } else {
+        // Built from `filtered_cards.len()` rather than
+        // `picker_list.get_render_info` directly: the picker's item count
+        // changes on every search keystroke, and rendering must reflect the
+        // current filtered set even if a caller mutated `search`/`card_ids`
+        // without also calling `picker_list.update_item_count`.
+        let mut page = kanban_core::Page::new(filtered_cards.len());
+        page.set_scroll_offset(app.relationship.picker_list.get_scroll_offset());
+        let adjusted_height = page.get_adjusted_viewport_height(area.height as usize);
+        let page_info = page.get_page_info(adjusted_height);
+
+        lines.extend(crate::scroll_indicators::render_above_indicator(
+            page_info.show_above_indicator,
+            page_info.items_above,
+            "card",
+        ));
+
+        for &idx in &page_info.visible_indices {
+            if let Some(card_id) = filtered_cards.get(idx) {
+                if let Some(card) = app.model.card_by_id(*card_id) {
+                    let is_selected = app.relationship.picker_list.selection.get() == Some(idx);
+                    let is_checked = app.relationship.selected.contains(card_id);
+
+                    let checkbox = if is_checked { "[✓]" } else { "[ ]" };
+
+                    let style = if is_selected {
+                        Style::default().fg(Color::White).bg(Color::Blue)
+                    } else if is_checked {
+                        Style::default().fg(Color::Green)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+
+                    lines.push(Line::from(Span::styled(
+                        format!("{} {}", checkbox, card.title),
+                        style,
+                    )));
+                }
+            }
+        }
+
+        lines.extend(crate::scroll_indicators::render_below_indicator(
+            page_info.show_below_indicator,
+            page_info.items_below,
+            "card",
+        ));
     }
 
     let list = Paragraph::new(lines);

--- a/crates/kanban-tui/src/components/relationship_popup.rs
+++ b/crates/kanban-tui/src/components/relationship_popup.rs
@@ -57,7 +57,7 @@ fn render_relationship_popup(app: &App, frame: &mut Frame, title: &str) {
     render_relationship_instructions(app, frame, chunks[2]);
 }
 
-fn render_relationship_search_box(app: &App, frame: &mut Frame, area: ratatui::layout::Rect) {
+fn render_relationship_search_box(app: &App, frame: &mut Frame, area: Rect) {
     let search_border_style = if app.relationship.search_active {
         Style::default().fg(Color::Yellow)
     } else {
@@ -151,7 +151,7 @@ fn render_relationship_card_list(app: &App, frame: &mut Frame, area: Rect) {
     frame.render_widget(list, area);
 }
 
-fn render_relationship_instructions(app: &App, frame: &mut Frame, area: ratatui::layout::Rect) {
+fn render_relationship_instructions(app: &App, frame: &mut Frame, area: Rect) {
     let instructions_text = if app.relationship.search_active {
         "Type to search | Enter/Esc: exit search"
     } else {

--- a/crates/kanban-tui/src/components/relationship_popup.rs
+++ b/crates/kanban-tui/src/components/relationship_popup.rs
@@ -76,22 +76,7 @@ fn render_relationship_search_box(app: &App, frame: &mut Frame, area: ratatui::l
 }
 
 fn render_relationship_card_list(app: &App, frame: &mut Frame, area: ratatui::layout::Rect) {
-    let filtered_cards: Vec<_> = if app.relationship.search.is_empty() {
-        app.relationship.card_ids.clone()
-    } else {
-        let search_lower = app.relationship.search.to_lowercase();
-        app.relationship
-            .card_ids
-            .iter()
-            .filter(|card_id| {
-                app.model
-                    .card_by_id(**card_id)
-                    .map(|c| c.title.to_lowercase().contains(&search_lower))
-                    .unwrap_or(false)
-            })
-            .copied()
-            .collect()
-    };
+    let filtered_cards = app.relationship_filtered_cards();
 
     let mut lines = vec![];
     for (idx, card_id) in filtered_cards.iter().enumerate() {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -863,7 +863,9 @@ impl App {
         // Set up dialog state
         self.relationship.card_ids = eligible_cards;
         self.relationship.selected = current_children;
-        self.relationship.selection.set(Some(0));
+        self.relationship
+            .picker_list
+            .update_item_count(self.relationship.card_ids.len());
         self.relationship.search.clear();
 
         self.open_dialog(DialogMode::ManageChildren);

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1104,7 +1104,9 @@ impl App {
                     self.relationship.card_ids = eligible_cards;
                     self.relationship.board_id = Some(board_id);
                     self.relationship.selected = current_parents;
-                    self.relationship.selection.set(Some(0));
+                    self.relationship
+                        .picker_list
+                        .update_item_count(self.relationship.card_ids.len());
                     self.relationship.search.clear();
 
                     self.open_dialog(DialogMode::ManageParents);
@@ -1163,7 +1165,9 @@ impl App {
                     self.relationship.card_ids = eligible_cards;
                     self.relationship.board_id = Some(board_id);
                     self.relationship.selected = current_children;
-                    self.relationship.selection.set(Some(0));
+                    self.relationship
+                        .picker_list
+                        .update_item_count(self.relationship.card_ids.len());
                     self.relationship.search.clear();
 
                     self.open_dialog(DialogMode::ManageChildren);

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1102,6 +1102,7 @@ impl App {
 
                     // Set up dialog state
                     self.relationship.card_ids = eligible_cards;
+                    self.relationship.board_id = Some(board_id);
                     self.relationship.selected = current_parents;
                     self.relationship.selection.set(Some(0));
                     self.relationship.search.clear();
@@ -1160,6 +1161,7 @@ impl App {
 
                     // Set up dialog state
                     self.relationship.card_ids = eligible_cards;
+                    self.relationship.board_id = Some(board_id);
                     self.relationship.selected = current_children;
                     self.relationship.selection.set(Some(0));
                     self.relationship.search.clear();

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -592,7 +592,7 @@ impl App {
                 self.pop_mode();
                 self.relationship.card_ids.clear();
                 self.relationship.selected.clear();
-                self.relationship.selection.clear();
+                self.relationship.picker_list.reset();
                 self.relationship.search.clear();
                 self.relationship.search_active = false;
             }
@@ -601,14 +601,18 @@ impl App {
                 self.relationship.search_active = true;
             }
             KeyCode::Char('j') | KeyCode::Down => {
-                self.relationship.selection.next(list_len);
+                self.relationship.picker_list.update_item_count(list_len);
+                self.relationship.picker_list.navigate_down();
+                self.scroll_relationship_picker_into_view();
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.relationship.selection.prev();
+                self.relationship.picker_list.update_item_count(list_len);
+                self.relationship.picker_list.navigate_up();
+                self.scroll_relationship_picker_into_view();
             }
             KeyCode::Char(' ') | KeyCode::Enter => {
                 // Toggle relationship
-                if let Some(idx) = self.relationship.selection.get() {
+                if let Some(idx) = self.relationship.picker_list.selection.get() {
                     if let Some(selected_card_id) = filtered_cards.get(idx).copied() {
                         if let Some(active_id) = self.selection.active_card_id {
                             if let Some(current_card) = self.model.card_by_id(active_id) {
@@ -655,12 +659,34 @@ impl App {
 
     fn update_relationship_selection_after_search(&mut self) {
         let filtered_count = self.relationship_filtered_cards().len();
+        self.relationship
+            .picker_list
+            .update_item_count(filtered_count);
 
         if filtered_count > 0 {
-            self.relationship.selection.set(Some(0));
+            self.relationship.picker_list.jump_to(0);
         } else {
-            self.relationship.selection.clear();
+            self.relationship.picker_list.set_selected_index(None);
         }
+    }
+
+    /// Scroll the relationship picker's card list so the current selection
+    /// is visible. `navigate_down`/`navigate_up` only move the cursor; they
+    /// don't know about the popup's viewport, so this reads the last known
+    /// frame area to compute it, mirroring `scroll_help_into_view`'s use of
+    /// `self.view.last_frame_area` for the help popup.
+    fn scroll_relationship_picker_into_view(&mut self) {
+        let raw = crate::components::relationship_popup_viewport_height(self.view.last_frame_area);
+        if raw == 0 {
+            return;
+        }
+        let adjusted = self
+            .relationship
+            .picker_list
+            .get_adjusted_viewport_height(raw);
+        self.relationship
+            .picker_list
+            .ensure_selected_visible(adjusted);
     }
 }
 
@@ -962,7 +988,7 @@ mod tests {
 
         app.relationship.card_ids = vec![fx.p_id, fx.b_id, fx.c_id];
         app.relationship.selected = HashSet::from_iter(vec![fx.p_id]);
-        app.relationship.selection.set(Some(1));
+        app.relationship.picker_list.selection.set(Some(1));
 
         app.handle_manage_parents_popup(KeyCode::Enter);
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,10 +1,39 @@
 use crate::app::{App, AppMode};
 use crossterm::event::KeyCode;
-use kanban_domain::{GraphOperations, KanbanOperations, SortOrder};
+use kanban_domain::{
+    CardSearcher, CompositeSearcher, GraphOperations, KanbanOperations, SortOrder,
+};
+use uuid::Uuid;
 
 const PRIORITY_COUNT: usize = 4;
 
 impl App {
+    pub(crate) fn relationship_filtered_cards(&self) -> Vec<Uuid> {
+        let Some(board) = self
+            .relationship
+            .board_id
+            .and_then(|id| self.model.board_by_id(id))
+        else {
+            return self.relationship.card_ids.clone();
+        };
+        let searcher = CompositeSearcher::all(self.relationship.search.clone());
+        let sprints = self.model.sprints();
+        let cards: Vec<_> = self
+            .relationship
+            .card_ids
+            .iter()
+            .filter_map(|id| self.model.card_by_id(*id).cloned())
+            .collect();
+        kanban_view::list_query::search_and_sort(
+            cards,
+            |card| searcher.matches(card, board, sprints),
+            |_, _| std::cmp::Ordering::Equal,
+        )
+        .into_iter()
+        .map(|c| c.id)
+        .collect()
+    }
+
     pub fn handle_import_board_popup(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {
@@ -529,25 +558,7 @@ impl App {
     }
 
     fn handle_relationship_popup(&mut self, key_code: KeyCode, is_parent_mode: bool) {
-        // Filter cards by search
-        let filtered_cards: Vec<_> = if self.relationship.search.is_empty() {
-            self.relationship.card_ids.clone()
-        } else {
-            let search_lower = self.relationship.search.to_lowercase();
-            self.relationship
-                .card_ids
-                .iter()
-                .filter(|card_id| {
-                    self.model
-                        .all_cards()
-                        .iter()
-                        .find(|c| c.id == **card_id)
-                        .map(|c| c.title.to_lowercase().contains(&search_lower))
-                        .unwrap_or(false)
-                })
-                .copied()
-                .collect()
-        };
+        let filtered_cards = self.relationship_filtered_cards();
 
         let list_len = filtered_cards.len();
 
@@ -643,23 +654,7 @@ impl App {
     }
 
     fn update_relationship_selection_after_search(&mut self) {
-        let filtered_count = if self.relationship.search.is_empty() {
-            self.relationship.card_ids.len()
-        } else {
-            let search_lower = self.relationship.search.to_lowercase();
-            self.relationship
-                .card_ids
-                .iter()
-                .filter(|card_id| {
-                    self.model
-                        .all_cards()
-                        .iter()
-                        .find(|c| c.id == **card_id)
-                        .map(|c| c.title.to_lowercase().contains(&search_lower))
-                        .unwrap_or(false)
-                })
-                .count()
-        };
+        let filtered_count = self.relationship_filtered_cards().len();
 
         if filtered_count > 0 {
             self.relationship.selection.set(Some(0));
@@ -693,18 +688,31 @@ mod tests {
     #[test]
     fn test_relationship_picker_search_matches_by_card_identifier() {
         let mut app = App::test_default();
-        let board = app.ctx.create_board("Board".into(), Some("KAN".into())).unwrap();
+        let board = app
+            .ctx
+            .create_board("Board".into(), Some("KAN".into()))
+            .unwrap();
         let column = app
             .ctx
             .create_column(board.id, "TODO".into(), None)
             .unwrap();
         let first = app
             .ctx
-            .create_card(board.id, column.id, "Unrelated title".into(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Unrelated title".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         let second = app
             .ctx
-            .create_card(board.id, column.id, "Also unrelated".into(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Also unrelated".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         load_snapshot(&mut app);
 
@@ -731,11 +739,21 @@ mod tests {
             .unwrap();
         let matching = app
             .ctx
-            .create_card(board.id, column.id, "Widget task".into(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Widget task".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         let other = app
             .ctx
-            .create_card(board.id, column.id, "Gadget task".into(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Gadget task".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         load_snapshot(&mut app);
 
@@ -766,11 +784,21 @@ mod tests {
             .unwrap();
         let matching = app
             .ctx
-            .create_card(board.id, column.id, "Fix authentication bug".into(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Fix authentication bug".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         let other = app
             .ctx
-            .create_card(board.id, column.id, "Improve docs".into(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Improve docs".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         load_snapshot(&mut app);
 
@@ -793,11 +821,21 @@ mod tests {
             .unwrap();
         let a = app
             .ctx
-            .create_card(board.id, column.id, "A".into(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                column.id,
+                "A".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         let b = app
             .ctx
-            .create_card(board.id, column.id, "B".into(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                column.id,
+                "B".into(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         load_snapshot(&mut app);
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -849,6 +849,50 @@ mod tests {
     }
 
     #[test]
+    fn test_relationship_picker_none_board_id_falls_back_to_unfiltered_cards() {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "TODO".into(), None)
+            .unwrap();
+        let a = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Alpha".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        let b = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Bravo".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        load_snapshot(&mut app);
+
+        app.relationship.card_ids = vec![a.id, b.id];
+        app.relationship.board_id = None;
+        // Neither title contains this query, so if filtering were
+        // (wrongly) applied against an absent board, the result would be
+        // empty rather than the full unfiltered set.
+        app.relationship.search = "nonmatching-query".to_string();
+
+        let filtered = app.relationship_filtered_cards();
+
+        assert_eq!(
+            filtered,
+            vec![a.id, b.id],
+            "a None board_id must fall back to the unfiltered card_ids set, not silently match nothing"
+        );
+    }
+
+    #[test]
     fn test_handle_set_card_priority_popup_after_reload_resort_updates_originally_selected_card_priority(
     ) {
         let mut app = App::test_default();

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -674,8 +674,141 @@ mod tests {
     use crate::test_helpers::{load_with_card_order, setup_reload_resort_fixture};
     use crate::App;
     use crossterm::event::KeyCode;
-    use kanban_domain::{CardPriority, KanbanOperations};
+    use kanban_domain::{CardPriority, CreateCardOptions, KanbanOperations, Snapshot};
     use std::collections::HashSet;
+
+    fn load_snapshot(app: &mut App) {
+        let snapshot = Snapshot {
+            archived_boards: Vec::new(),
+            boards: app.ctx.data_store().list_boards().unwrap(),
+            columns: app.ctx.data_store().list_all_columns().unwrap(),
+            cards: app.ctx.data_store().list_all_cards().unwrap(),
+            archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+            sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+            graph: app.ctx.data_store().get_graph().unwrap(),
+        };
+        app.model.load_from_snapshot(snapshot);
+    }
+
+    #[test]
+    fn test_relationship_picker_search_matches_by_card_identifier() {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), Some("KAN".into())).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "TODO".into(), None)
+            .unwrap();
+        let first = app
+            .ctx
+            .create_card(board.id, column.id, "Unrelated title".into(), CreateCardOptions::default())
+            .unwrap();
+        let second = app
+            .ctx
+            .create_card(board.id, column.id, "Also unrelated".into(), CreateCardOptions::default())
+            .unwrap();
+        load_snapshot(&mut app);
+
+        app.relationship.card_ids = vec![first.id, second.id];
+        app.relationship.board_id = Some(board.id);
+        app.relationship.search = "kan-2".to_string();
+
+        let filtered = app.relationship_filtered_cards();
+
+        assert_eq!(
+            filtered,
+            vec![second.id],
+            "search by card identifier must match the card whose resolved identifier is KAN-2, not by title"
+        );
+    }
+
+    #[test]
+    fn test_relationship_picker_search_matches_by_branch_name_fragment() {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "TODO".into(), None)
+            .unwrap();
+        let matching = app
+            .ctx
+            .create_card(board.id, column.id, "Widget task".into(), CreateCardOptions::default())
+            .unwrap();
+        let other = app
+            .ctx
+            .create_card(board.id, column.id, "Gadget task".into(), CreateCardOptions::default())
+            .unwrap();
+        load_snapshot(&mut app);
+
+        app.relationship.card_ids = vec![matching.id, other.id];
+        app.relationship.board_id = Some(board.id);
+        // Neither title contains "feature", but the generated branch name
+        // for every card on this board (no sprint_prefix configured) is
+        // prefixed "feature<N>-...", so this only narrows via the branch
+        // searcher, not the title searcher.
+        app.relationship.search = format!("feature{}", matching.card_number);
+
+        let filtered = app.relationship_filtered_cards();
+
+        assert_eq!(
+            filtered,
+            vec![matching.id],
+            "search must match by generated branch name fragment"
+        );
+    }
+
+    #[test]
+    fn test_relationship_picker_search_still_matches_by_title() {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "TODO".into(), None)
+            .unwrap();
+        let matching = app
+            .ctx
+            .create_card(board.id, column.id, "Fix authentication bug".into(), CreateCardOptions::default())
+            .unwrap();
+        let other = app
+            .ctx
+            .create_card(board.id, column.id, "Improve docs".into(), CreateCardOptions::default())
+            .unwrap();
+        load_snapshot(&mut app);
+
+        app.relationship.card_ids = vec![matching.id, other.id];
+        app.relationship.board_id = Some(board.id);
+        app.relationship.search = "auth".to_string();
+
+        let filtered = app.relationship_filtered_cards();
+
+        assert_eq!(filtered, vec![matching.id]);
+    }
+
+    #[test]
+    fn test_relationship_picker_search_empty_query_returns_all_eligible_cards() {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "TODO".into(), None)
+            .unwrap();
+        let a = app
+            .ctx
+            .create_card(board.id, column.id, "A".into(), CreateCardOptions::default())
+            .unwrap();
+        let b = app
+            .ctx
+            .create_card(board.id, column.id, "B".into(), CreateCardOptions::default())
+            .unwrap();
+        load_snapshot(&mut app);
+
+        app.relationship.card_ids = vec![a.id, b.id];
+        app.relationship.board_id = Some(board.id);
+        app.relationship.search = String::new();
+
+        let filtered = app.relationship_filtered_cards();
+
+        assert_eq!(filtered, vec![a.id, b.id]);
+    }
 
     #[test]
     fn test_handle_set_card_priority_popup_after_reload_resort_updates_originally_selected_card_priority(

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -235,3 +235,71 @@ fn test_manage_parents_popup_cycle_surfaces_error_banner_to_user() {
         "failed attach_child must not toggle the popup selection"
     );
 }
+
+/// End-to-end proof that the render path, not just the unit-level
+/// filter helper, benefits from `CompositeSearcher`: a card whose title
+/// does not contain the search query must still render because its
+/// resolved card identifier does.
+#[test]
+fn test_relationship_popup_render_shows_card_found_only_by_identifier() {
+    use kanban_domain::{CreateCardOptions, KanbanOperations, Snapshot};
+    use kanban_tui::app::mode::{AppMode, DialogMode};
+
+    let mut app = App::test_default();
+
+    let board = app
+        .ctx
+        .create_board("Board".into(), Some("KAN".into()))
+        .unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "TODO".into(), None)
+        .unwrap();
+    let first = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Unrelated title".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let second = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Also unrelated".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let snapshot = Snapshot {
+        archived_boards: Vec::new(),
+        boards: app.ctx.data_store().list_boards().unwrap(),
+        columns: app.ctx.data_store().list_all_columns().unwrap(),
+        cards: app.ctx.data_store().list_all_cards().unwrap(),
+        archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+        sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+        graph: app.ctx.data_store().get_graph().unwrap(),
+    };
+    app.model.load_from_snapshot(snapshot);
+
+    app.push_mode(AppMode::Dialog(DialogMode::ManageParents));
+    app.relationship.card_ids = vec![first.id, second.id];
+    app.relationship.board_id = Some(board.id);
+    app.relationship.search = "kan-2".to_string();
+
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::components::render_manage_parents_popup(&app, frame);
+    });
+
+    assert!(
+        output.contains("Also unrelated"),
+        "card KAN-2 must render even though neither title contains 'kan-2'; got:\n{output}"
+    );
+    assert!(
+        !output.contains("Unrelated title"),
+        "card KAN-1 must be filtered out; got:\n{output}"
+    );
+}

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -110,7 +110,7 @@ fn test_manage_parents_popup_enter_creates_parent_edge() {
     // and select it.
     app.push_mode(AppMode::Dialog(DialogMode::ManageParents));
     app.relationship.card_ids = vec![parent.id];
-    app.relationship.selection.set(Some(0));
+    app.relationship.picker_list.selection.set(Some(0));
 
     app.handle_manage_parents_popup(KeyCode::Enter);
 
@@ -198,7 +198,7 @@ fn test_manage_parents_popup_cycle_surfaces_error_banner_to_user() {
 
     app.push_mode(AppMode::Dialog(DialogMode::ManageParents));
     app.relationship.card_ids = vec![c.id];
-    app.relationship.selection.set(Some(0));
+    app.relationship.picker_list.selection.set(Some(0));
 
     // Sanity: no banner before the failed attempt.
     assert!(

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -303,3 +303,260 @@ fn test_relationship_popup_render_shows_card_found_only_by_identifier() {
         "card KAN-1 must be filtered out; got:\n{output}"
     );
 }
+
+/// The relationship picker's card list overflows a small popup silently
+/// today (KAN-1102): every eligible card is pushed into the `Paragraph`
+/// regardless of the popup's height. Once the list is migrated onto
+/// `ListComponent`, a popup with more eligible cards than fit the viewport
+/// must show a "below" scroll indicator, matching `render_relationship_section`'s
+/// existing pattern for the read-only parents/children display.
+#[test]
+fn test_relationship_picker_list_shows_below_indicator_when_eligible_cards_exceed_viewport() {
+    use kanban_domain::{CreateCardOptions, KanbanOperations, Snapshot};
+    use kanban_tui::app::mode::{AppMode, DialogMode};
+
+    let mut app = App::test_default();
+
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "TODO".into(), None)
+        .unwrap();
+
+    let mut card_ids = Vec::new();
+    for i in 0..30 {
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                format!("Card {i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        card_ids.push(card.id);
+    }
+
+    let snapshot = Snapshot {
+        archived_boards: Vec::new(),
+        boards: app.ctx.data_store().list_boards().unwrap(),
+        columns: app.ctx.data_store().list_all_columns().unwrap(),
+        cards: app.ctx.data_store().list_all_cards().unwrap(),
+        archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+        sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+        graph: app.ctx.data_store().get_graph().unwrap(),
+    };
+    app.model.load_from_snapshot(snapshot);
+
+    app.push_mode(AppMode::Dialog(DialogMode::ManageParents));
+    app.relationship.card_ids = card_ids;
+    app.relationship.board_id = Some(board.id);
+    app.relationship.picker_list.update_item_count(30);
+
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::components::render_manage_parents_popup(&app, frame);
+    });
+
+    assert!(
+        output.contains("below"),
+        "30 eligible cards in a small popup must show a below-scroll indicator; got:\n{output}"
+    );
+}
+
+/// `navigate_down` alone only moves the cursor; without an explicit
+/// scroll-into-view call the scroll offset never advances, so a user
+/// pressing `j` past the initial viewport would be stuck staring at cards
+/// that never appear. This proves the migrated key handler actually scrolls,
+/// not just that the render call renders once.
+#[test]
+fn test_relationship_picker_navigate_down_past_viewport_scrolls_list() {
+    use crossterm::event::KeyCode;
+    use kanban_domain::{CreateCardOptions, KanbanOperations, Snapshot};
+    use kanban_tui::app::mode::{AppMode, DialogMode};
+    use ratatui::layout::Rect;
+
+    let mut app = App::test_default();
+    app.view.last_frame_area = Rect {
+        x: 0,
+        y: 0,
+        width: 120,
+        height: 40,
+    };
+
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "TODO".into(), None)
+        .unwrap();
+
+    let mut card_ids = Vec::new();
+    for i in 0..30 {
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                format!("Card {i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        card_ids.push(card.id);
+    }
+
+    let snapshot = Snapshot {
+        archived_boards: Vec::new(),
+        boards: app.ctx.data_store().list_boards().unwrap(),
+        columns: app.ctx.data_store().list_all_columns().unwrap(),
+        cards: app.ctx.data_store().list_all_cards().unwrap(),
+        archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+        sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+        graph: app.ctx.data_store().get_graph().unwrap(),
+    };
+    app.model.load_from_snapshot(snapshot);
+
+    app.push_mode(AppMode::Dialog(DialogMode::ManageParents));
+    app.relationship.card_ids = card_ids;
+    app.relationship.board_id = Some(board.id);
+    app.relationship.picker_list.update_item_count(30);
+
+    for _ in 0..29 {
+        app.handle_manage_parents_popup(KeyCode::Char('j'));
+    }
+
+    assert!(
+        app.relationship.picker_list.get_scroll_offset() > 0,
+        "navigating down past the initial viewport must scroll the list"
+    );
+}
+
+/// Regression for the existing cursor-reset-after-search behavior, now
+/// expressed through `picker_list` instead of the old `selection` field:
+/// narrowing the search must reset the cursor to the top of the new
+/// (smaller) result set rather than leaving it at a stale index.
+#[test]
+fn test_relationship_picker_search_narrowing_resets_out_of_range_selection() {
+    use crossterm::event::KeyCode;
+    use kanban_domain::{CreateCardOptions, KanbanOperations, Snapshot};
+    use kanban_tui::app::mode::{AppMode, DialogMode};
+
+    let mut app = App::test_default();
+
+    let board = app
+        .ctx
+        .create_board("Board".into(), Some("KAN".into()))
+        .unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "TODO".into(), None)
+        .unwrap();
+    let mut card_ids = Vec::new();
+    for i in 0..5 {
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                format!("Card {i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        card_ids.push(card.id);
+    }
+
+    let snapshot = Snapshot {
+        archived_boards: Vec::new(),
+        boards: app.ctx.data_store().list_boards().unwrap(),
+        columns: app.ctx.data_store().list_all_columns().unwrap(),
+        cards: app.ctx.data_store().list_all_cards().unwrap(),
+        archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+        sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+        graph: app.ctx.data_store().get_graph().unwrap(),
+    };
+    app.model.load_from_snapshot(snapshot);
+
+    app.push_mode(AppMode::Dialog(DialogMode::ManageParents));
+    app.relationship.card_ids = card_ids;
+    app.relationship.board_id = Some(board.id);
+    app.relationship.picker_list.update_item_count(5);
+    app.relationship.picker_list.jump_to(4);
+
+    app.handle_manage_parents_popup(KeyCode::Char('/'));
+    app.handle_manage_parents_popup(KeyCode::Char('C'));
+    app.handle_manage_parents_popup(KeyCode::Char('a'));
+    app.handle_manage_parents_popup(KeyCode::Char('r'));
+    app.handle_manage_parents_popup(KeyCode::Char('d'));
+    app.handle_manage_parents_popup(KeyCode::Char(' '));
+    app.handle_manage_parents_popup(KeyCode::Char('0'));
+
+    assert_eq!(
+        app.relationship.picker_list.selection.get(),
+        Some(0),
+        "narrowing the search to a single match must reset the cursor to the top"
+    );
+}
+
+/// The picker's checkbox membership tracking (`selected: HashSet<Uuid>`) is
+/// independent of `ListComponent`'s own navigation/scroll state — this must
+/// not regress when the cursor migrates onto `picker_list`.
+#[test]
+fn test_relationship_picker_checkbox_toggle_still_works_after_migration() {
+    use crossterm::event::KeyCode;
+    use kanban_domain::{CreateCardOptions, KanbanOperations, Snapshot};
+    use kanban_tui::app::mode::{AppMode, DialogMode};
+
+    let mut app = App::test_default();
+
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "TODO".into(), None)
+        .unwrap();
+    let parent = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Parent".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let child = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Child".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let snapshot = Snapshot {
+        archived_boards: Vec::new(),
+        boards: app.ctx.data_store().list_boards().unwrap(),
+        columns: app.ctx.data_store().list_all_columns().unwrap(),
+        cards: app.ctx.data_store().list_all_cards().unwrap(),
+        archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+        sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+        graph: app.ctx.data_store().get_graph().unwrap(),
+    };
+    app.model.load_from_snapshot(snapshot);
+    app.selection.active_card_id = Some(child.id);
+
+    app.push_mode(AppMode::Dialog(DialogMode::ManageParents));
+    app.relationship.card_ids = vec![parent.id];
+    app.relationship.picker_list.update_item_count(1);
+
+    app.handle_manage_parents_popup(KeyCode::Char(' '));
+
+    assert!(
+        app.relationship.selected.contains(&parent.id),
+        "Space on the selected candidate must toggle its checkbox membership"
+    );
+
+    app.handle_manage_parents_popup(KeyCode::Char(' '));
+
+    assert!(
+        !app.relationship.selected.contains(&parent.id),
+        "Space again must untoggle the checkbox membership"
+    );
+}


### PR DESCRIPTION
Delivers KAN-1100 (Relationship picker parity sub-epic of the list-parity root epic, KAN-1085) by shipping its two leaf cards: KAN-1101, KAN-1102.

## What

- **KAN-1101** — the relationship picker's search box (used when managing a card's parent/child links) matched only `card.title`, hand-written via `.to_lowercase().contains(...)` and duplicated in three places (render, the navigable-list computation, and the post-keystroke selection-cursor recompute). Now it goes through `kanban_domain::search::CompositeSearcher`, the exact same searcher the main card list uses, so it also matches generated branch name and card identifier (e.g. "KAN-5"). One shared `App::relationship_filtered_cards` helper replaces all three duplicated call sites. `RelationshipState` gains a `board_id: Option<Uuid>` field (`CompositeSearcher` needs `&Board` for prefix resolution); if it's ever unexpectedly `None`, the helper falls back to the unfiltered list rather than silently matching nothing.
- **KAN-1102** — the picker's cursor/scroll moves off a bare `SelectionState` onto the shared `ListComponent` (`RelationshipState.picker_list`), gaining scroll and above/below indicators, matching how the read-only parents/children display (`relationship_section.rs`) already renders. `ListComponent::new(false)` — the picker's checkbox membership tracking (`selected: HashSet<Uuid>`) stays entirely separate from `ListComponent`'s own multi-select feature.

## How this was built

Each card was first executed end-to-end in a throwaway spike worktree, stacked (1101 -> 1102, since 1102's render loop is written against 1101's `relationship_filtered_cards`), each independently reviewed by a second agent with no shared context.

- KAN-1101: one review finding — the card's own highest-flagged risk (the `None`-`board_id` fallback, "a search box that goes blank... is a worse failure mode than a search box that stops filtering") had zero test coverage despite being correctly implemented. Added a regression test, confirmed as genuine (not trivially true) by both the engineer and the independent reviewer, each by temporarily breaking the fallback and confirming the test catches it.
- KAN-1102: clean PASS on first review. The engineer went beyond the card's literal text and found (all independently confirmed real by the reviewer): a third un-migrated call site the card's own audit missed (`card_handlers.rs`'s `handle_manage_children_from_list`); that the card's literal j/k wiring snippet would leave `j` never advancing the scroll offset (`navigate_down` alone doesn't scroll); and a stale-cached-count render bug, fixed by building the render-time page from the live filtered count rather than trusting a component that isn't always kept in sync.

**One finding tracked as a separate follow-up, not bundled into this PR:** the engineer found, and the reviewer independently confirmed by tracing `kanban-core/src/pagination.rs`, a latent bug in the reference pattern this card was told to copy (`relationship_section.rs`) — calling `get_render_info` with the raw (unadjusted) viewport height silently drops the below-scroll-indicator when item count exactly equals that height. This affects `relationship_section.rs` and, separately, `board_detail.rs`/`sprint_detail.rs` too — none of which this PR's cards own. Filed as KAN-1124. This PR's own new render code calls `get_adjusted_viewport_height` correctly and does not have the bug.

## Testing

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean, whole workspace
- `cargo test`: full workspace green, 174 `test result: ok` blocks, 0 failed
- Named tests across both cards, including the safety-critical regression coverage: `test_relationship_picker_search_matches_by_card_identifier`/`..._branch_name_fragment` (the core gap this PR closes), `test_relationship_picker_none_board_id_falls_back_to_unfiltered_cards` (the fallback the card flagged as highest-risk), `test_relationship_picker_navigate_down_past_viewport_scrolls_list` (proves scroll offset actually moves, not just that indicators render once), and `test_relationship_picker_checkbox_toggle_still_works_after_migration` (multi-select untouched by the cursor migration)