### PR TITLE
KAN-1110 refactor(backend): make with_transaction a required method and override it per backend

### DIFF
--- a/.changeset/kan-1110.md
+++ b/.changeset/kan-1110.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+KanbanBackend::with_transaction loses its generic default and becomes a required method, so each backend states its own transaction strategy instead of inheriting one that suited only in-memory stores. HttpBackend now reports with_transaction as unsupported directly rather than failing through an inherited snapshot call, and InMemoryStore keeps the snapshot and restore approach that is cheap for a hashmap.

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -24,6 +24,13 @@ impl kanban_backend::KanbanBackend for HttpBackend {
     fn instance_id(&self) -> uuid::Uuid {
         self.instance_id
     }
+
+    fn with_transaction(
+        &self,
+        _f: &mut dyn FnMut() -> kanban_domain::KanbanResult<()>,
+    ) -> kanban_domain::KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("with_transaction"))
+    }
 }
 
 impl HttpBackend {

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -133,4 +133,21 @@ mod tests {
         assert_eq!(backend_ref.instance_id(), backend.instance_id);
         Ok(())
     }
+
+    #[test]
+    fn test_http_backend_with_transaction_returns_unsupported() -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        let backend_ref: &dyn kanban_backend::KanbanBackend = &backend;
+        let err = backend_ref
+            .with_transaction(&mut || Ok(()))
+            .unwrap_err();
+        assert!(err.is_unsupported());
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("with_transaction"),
+            "error must name with_transaction itself, not a helper it happens to call \
+             through a fallback (got: {msg:?})"
+        );
+        Ok(())
+    }
 }

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -145,9 +145,7 @@ mod tests {
     fn test_http_backend_with_transaction_returns_unsupported() -> kanban_domain::KanbanResult<()> {
         let backend = HttpBackend::new("http://example.com")?;
         let backend_ref: &dyn kanban_backend::KanbanBackend = &backend;
-        let err = backend_ref
-            .with_transaction(&mut || Ok(()))
-            .unwrap_err();
+        let err = backend_ref.with_transaction(&mut || Ok(())).unwrap_err();
         assert!(err.is_unsupported());
         let msg = format!("{err}");
         assert!(

--- a/crates/kanban-backend-memory/src/lib.rs
+++ b/crates/kanban-backend-memory/src/lib.rs
@@ -4,6 +4,7 @@ pub use in_memory_store::InMemoryStore;
 
 use kanban_backend::KanbanBackend;
 use kanban_domain::data_store::DataStore;
+use kanban_domain::{KanbanError, KanbanResult};
 
 impl KanbanBackend for InMemoryStore {
     fn as_data_store(&self) -> &dyn DataStore {
@@ -11,6 +12,21 @@ impl KanbanBackend for InMemoryStore {
     }
     // All lifecycle defaults are correct for in-memory: flush=noop, reload=noop,
     // needs_flush=false, needs_save_worker=false.
+
+    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
+        let before = self.snapshot_impl()?;
+        match f() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                if let Err(rollback_err) = self.apply_snapshot_impl(before) {
+                    return Err(KanbanError::Internal(format!(
+                        "Batch failed ({e}) and rollback also failed ({rollback_err}). State may be inconsistent."
+                    )));
+                }
+                Err(e)
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -8,7 +8,7 @@ pub use remote_writes::RemoteWrites;
 use async_trait::async_trait;
 use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::DataStore;
-use kanban_domain::{KanbanError, KanbanResult};
+use kanban_domain::KanbanResult;
 use uuid::Uuid;
 
 /// Combines the entity-level CRUD interface (`DataStore`) with the command
@@ -82,24 +82,21 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     }
 
     /// Run `f` as an atomic batch: every mutation commits or rolls
-    /// back together. The default impl snapshots state before `f`
-    /// runs and restores it on failure — cheap for in-memory backends,
-    /// expensive on disk. Disk-backed backends should override with a
-    /// native transaction.
-    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
-        let before = self.snapshot()?;
-        match f() {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                if let Err(rollback_err) = self.apply_snapshot(before) {
-                    return Err(KanbanError::Internal(format!(
-                        "Batch failed ({e}) and rollback also failed ({rollback_err}). State may be inconsistent."
-                    )));
-                }
-                Err(e)
-            }
-        }
-    }
+    /// back together. Every implementor supplies its own strategy: a
+    /// native transaction where the backend has one, a whole-state
+    /// snapshot/restore where that is cheap (in-memory), or an
+    /// `unsupported` error where neither applies (over-the-wire backends
+    /// with no local state to roll back).
+    ///
+    /// `f` is called exactly once per `with_transaction` call, never
+    /// retried. The parameter is `&mut dyn FnMut()` rather than
+    /// `FnOnce`/`Box<dyn FnOnce()>` to keep the trait object-safe without
+    /// forcing every caller to heap-allocate the closure. Moving an owned
+    /// value into the closure body therefore needs the `Option::take()`
+    /// dance (wrap the value in an `Option`, `.take()` it inside the
+    /// closure) rather than a bare `move ||`, since the compiler cannot
+    /// prove a single call from the `FnMut` bound alone.
+    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()>;
 }
 
 #[cfg(test)]
@@ -238,6 +235,10 @@ mod tests {
     impl KanbanBackend for StubBackend {
         fn as_data_store(&self) -> &dyn DataStore {
             self
+        }
+
+        fn with_transaction(&self, _f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
+            unimplemented!()
         }
     }
 

--- a/crates/kanban-service/src/backend_test_support.rs
+++ b/crates/kanban-service/src/backend_test_support.rs
@@ -213,4 +213,8 @@ impl KanbanBackend for MockBackend {
     fn remote_writes(&self) -> Option<&dyn RemoteWrites> {
         Some(&self.mock)
     }
+
+    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
+        self.inner.with_transaction(f)
+    }
 }

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -3,7 +3,7 @@
 
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::data_store::DataStore;
-use kanban_domain::{Board, KanbanError, KanbanResult};
+use kanban_domain::{Board, Card, Column, KanbanError, KanbanResult, Sprint};
 use kanban_service::backend::KanbanBackend;
 use std::sync::Arc;
 
@@ -109,5 +109,78 @@ async fn test_execute_partial_batch_failure_rolls_back_via_transaction() -> Kanb
         0,
         "rollback must remove the board that was created before the failure"
     );
+    Ok(())
+}
+
+// NOTE: this test already passes against the pre-KAN-1110 default
+// `with_transaction` body, because that default's snapshot/restore already
+// covers the whole `InMemoryStore` state (via `snapshot_impl`/
+// `apply_snapshot_impl`). It is regression cover pinning the override's
+// full-graph behaviour, not a Red test for this card; the card's genuine Red
+// surface is the compile-level gate (every `KanbanBackend` impl must supply
+// `with_transaction` once the default is deleted).
+#[test]
+fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
+    let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
+
+    let mut board = Board::new("Board", None::<String>);
+    let col = Column::new(board.id, "Col", 0);
+    let card_a = Card::new(&mut board, col.id, "A", 0);
+    let card_b = Card::new(&mut board, col.id, "B", 1);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+
+    backend.upsert_board(board.clone())?;
+    backend.upsert_column(col.clone())?;
+    backend.upsert_card(card_a.clone())?;
+    backend.upsert_card(card_b.clone())?;
+    backend.upsert_sprint(sprint.clone())?;
+
+    let mut graph = backend.get_graph()?;
+    graph.set_block(card_a.id, card_b.id)?;
+    backend.set_graph(graph)?;
+
+    let before = backend.snapshot()?;
+
+    let backend_for_closure = Arc::clone(&backend);
+    let result = backend.with_transaction(&mut || {
+        let store: &dyn DataStore = backend_for_closure.as_data_store();
+        store.upsert_board(Board::new("Injected", None::<String>))?;
+        store.delete_card(card_a.id)?;
+        store.delete_sprint(sprint.id)?;
+        Err(KanbanError::validation("forced batch failure"))
+    });
+
+    assert!(result.is_err(), "the batch's own error must propagate");
+
+    let after = backend.snapshot()?;
+    assert_eq!(
+        after, before,
+        "entire graph must be restored byte-identical after a failed batch"
+    );
+
+    assert!(
+        !backend
+            .list_boards()?
+            .iter()
+            .any(|b| b.name == "Injected"),
+        "the injected board from the failed batch must not survive"
+    );
+    assert!(
+        backend.get_card(card_a.id)?.is_some(),
+        "deleted card must be restored"
+    );
+    assert!(
+        backend.get_sprint(sprint.id)?.is_some(),
+        "deleted sprint must be restored"
+    );
+    let restored_graph = backend.get_graph()?;
+    assert!(
+        restored_graph
+            .blocks_edges()
+            .iter()
+            .any(|e| e.base.source == card_a.id && e.base.target == card_b.id),
+        "the block edge must survive rollback"
+    );
+
     Ok(())
 }

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -159,10 +159,7 @@ fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
     );
 
     assert!(
-        !backend
-            .list_boards()?
-            .iter()
-            .any(|b| b.name == "Injected"),
+        !backend.list_boards()?.iter().any(|b| b.name == "Injected"),
         "the injected board from the failed batch must not survive"
     );
     assert!(


### PR DESCRIPTION
Completes the transaction work started by KAN-1067 and KAN-1071. `KanbanBackend::with_transaction` loses its generic default and becomes a required method, so every backend states its own strategy instead of inheriting one.

## Why the default had to go

```rust
fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
    let before = self.snapshot()?;
    match f() { ... self.apply_snapshot(before) ... }
}
```

Two problems. It calls `DataStore::snapshot`/`apply_snapshot`, which KAN-1079 removes, so it stops compiling regardless. And it gives a silently wrong answer for backends it does not suit: `HttpBackend` talks to a REST API and cannot roll back, but it inherited this default and failed through `snapshot()`, which returns unsupported. It failed by accident rather than by decision.

Deleting the default turns "you might not have thought about transactions" into a compile error.

## What each backend now says

- SQLite: native BEGIN/COMMIT/ROLLBACK (KAN-1067, already merged)
- JSON: single-lock snapshot and restore via the inherent methods (KAN-1071, already merged)
- InMemoryStore: snapshot and restore, which is genuinely cheap for a hashmap. Uses the `snapshot_impl`/`apply_snapshot_impl` pair KAN-1071 widened to `pub`
- HttpBackend: `unsupported("with_transaction")`, naming itself
- StubBackend and MockBackend: matching their siblings

## FnMut rather than FnOnce

This card rewrites every impl, so it is the cheapest point to settle a question KAN-1105's spike raised: moving an owned value into the closure needs an `Option::take()` dance, because a bare `move ||` will not compile as `FnMut` even though the trait calls it exactly once.

Kept `FnMut`. Calling an `FnOnce` requires ownership of the callee, so it cannot be called through `&mut dyn`. The alternative is `Box<dyn FnOnce()>`, which forces a heap allocation at every call site across five crates to avoid one working idiom in one place. The trait now documents the idiom instead.

## Tests

`test_http_backend_with_transaction_returns_unsupported` is genuinely red before this change. Its captured failure names the exact bug:

```
error must name with_transaction itself, not a helper it happens to call
through a fallback (got: "operation not supported by this backend: snapshot")
```

`test_in_memory_with_transaction_rolls_back_full_graph` (board, column, card, sprint, dependency edge) passes before and after, because the old default already handled in-memory correctly. It is regression cover, recorded as such rather than presented as red.

The rest of the red surface is the compile gate: `cargo test --workspace --no-run` fails for any implementor that does not supply an override. That gate passes here, which is what proves none was missed.

`cargo test --workspace --no-run` clean, backend crate tests and the 5 service `with_transaction` tests green, clippy `--all-targets --all-features -D warnings` clean across the four touched crates plus `kanban-server`, fmt clean.
