### PR TITLE
KAN-1110 refactor(backend): delete with_transaction's generic default and override it per backend

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -24,6 +24,8 @@ Brief description of changes for the changelog
 - `minor` - New features, backwards compatible (0.1.0 → 0.2.0)
 - `major` - Breaking changes (0.1.0 → 1.0.0)
 
+On merge to master, changesets are aggregated and the highest bump type determines the version increment.
+
 ### While the project is pre-1.0
 
 Use `minor` for breaking changes, not `major`. Under Cargo's semver rules a
@@ -38,5 +40,3 @@ even though nothing in this workspace notices).
 
 Every crate in `crates/` publishes to crates.io, so "downstream" means real
 external users, not just this repository.
-
-On merge to master, changesets are aggregated and the highest bump type determines the version increment.

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -24,4 +24,19 @@ Brief description of changes for the changelog
 - `minor` - New features, backwards compatible (0.1.0 → 0.2.0)
 - `major` - Breaking changes (0.1.0 → 1.0.0)
 
+### While the project is pre-1.0
+
+Use `minor` for breaking changes, not `major`. Under Cargo's semver rules a
+`0.x` minor bump already breaks callers pinned to `^0.x`, so `minor` is the
+strongest signal available without declaring the API stable. Reserve `major`
+for the deliberate 1.0.0 release.
+
+This applies to anything that breaks a downstream crate: removing or renaming a
+public item, changing a public function or trait method signature, and removing
+a trait's default implementation (which breaks every out-of-tree implementor,
+even though nothing in this workspace notices).
+
+Every crate in `crates/` publishes to crates.io, so "downstream" means real
+external users, not just this repository.
+
 On merge to master, changesets are aggregated and the highest bump type determines the version increment.

--- a/.changeset/kan-1110.md
+++ b/.changeset/kan-1110.md
@@ -4,4 +4,4 @@ bump: patch
 
 backend: `KanbanBackend::with_transaction` loses its generic default and becomes a required trait method, so every backend answers for its own rollback rather than silently inheriting a whole-store snapshot-and-restore that is cheap in memory and ruinous on disk. SQLite and JSON already had native overrides; in-memory now rolls back through its own single-lock snapshot, and the HTTP backend declines with an unsupported error because the remote server owns the state. A backend that forgets the method is now a compile error.
 
-The closure changes from `&mut dyn FnMut()` to a boxed `FnOnce` (`TransactionFn`), matching the fact that the batch runs exactly once. Callers can move owned values into the closure instead of laundering them through an `Option::take()`.
+The closure changes from `&mut dyn FnMut()` to a boxed `FnOnce` (`TransactionFn`), matching the fact that the batch never runs twice. Callers can move owned values into the closure instead of laundering them through an `Option::take()`.

--- a/.changeset/kan-1110.md
+++ b/.changeset/kan-1110.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+backend: `KanbanBackend::with_transaction` loses its generic default and becomes a required trait method, so every backend answers for its own rollback rather than silently inheriting a whole-store snapshot-and-restore that is cheap in memory and ruinous on disk. SQLite and JSON already had native overrides; in-memory now rolls back through its own single-lock snapshot, and the HTTP backend declines with an unsupported error because the remote server owns the state. A backend that forgets the method is now a compile error.
+
+The closure changes from `&mut dyn FnMut()` to a boxed `FnOnce` (`TransactionFn`), matching the fact that the batch runs exactly once. Callers can move owned values into the closure instead of laundering them through an `Option::take()`.

--- a/.changeset/kan-1110.md
+++ b/.changeset/kan-1110.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 backend: `KanbanBackend::with_transaction` loses its generic default and becomes a required trait method, so every backend answers for its own rollback rather than silently inheriting a whole-store snapshot-and-restore that is cheap in memory and ruinous on disk. SQLite and JSON already had native overrides; in-memory now rolls back through its own single-lock snapshot, and the HTTP backend declines with an unsupported error because the remote server owns the state. A backend that forgets the method is now a compile error.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -669,6 +669,16 @@ Description of changes
    - `minor` - New features, backwards compatible (0.1.0 → 0.2.0)
    - `major` - Breaking changes (0.1.0 → 1.0.0)
 
+   **Pre-1.0 exception**: while the project is on `0.x`, file breaking changes
+   as `minor`, not `major`. A `0.x` minor bump already breaks callers pinned to
+   `^0.x`, so it is the strongest signal available short of declaring the API
+   stable; `major` is reserved for the deliberate 1.0.0 release. Breaking here
+   means anything that breaks a downstream crate, including removing or
+   renaming a public item, changing a public function or trait method
+   signature, and removing a trait's default implementation. Every crate in
+   `crates/` publishes to crates.io, so this covers external users rather than
+   only this workspace.
+
 3. On merge to master:
    - Version automatically bumps based on changeset
    - CHANGELOG.md updates with your description

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -24,6 +24,16 @@ impl kanban_backend::KanbanBackend for HttpBackend {
     fn instance_id(&self) -> uuid::Uuid {
         self.instance_id
     }
+
+    /// Declines without running the closure. The remote server owns the state,
+    /// so there is nothing local to roll back and no way to make the batch
+    /// atomic from this side.
+    fn with_transaction(
+        &self,
+        _f: kanban_backend::TransactionFn<'_>,
+    ) -> kanban_domain::KanbanResult<()> {
+        Err(kanban_domain::KanbanError::unsupported("with_transaction"))
+    }
 }
 
 impl HttpBackend {
@@ -123,6 +133,42 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.is_unsupported());
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_with_transaction_returns_unsupported() -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        let backend_ref: &dyn kanban_backend::KanbanBackend = &backend;
+
+        let result = backend_ref.with_transaction(Box::new(|| Ok(())));
+
+        let err = result.unwrap_err();
+        assert!(
+            err.is_unsupported(),
+            "an HTTP backend has no local state to roll back, so it must decline \
+             rather than silently run the closure unprotected (got: {err:?})"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_with_transaction_does_not_run_the_closure(
+    ) -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        let backend_ref: &dyn kanban_backend::KanbanBackend = &backend;
+        let ran = std::cell::Cell::new(false);
+
+        let _ = backend_ref.with_transaction(Box::new(|| {
+            ran.set(true);
+            Ok(())
+        }));
+
+        assert!(
+            !ran.get(),
+            "declining must happen before the closure runs; running it would apply \
+             mutations with no transaction around them"
+        );
         Ok(())
     }
 

--- a/crates/kanban-backend-memory/src/lib.rs
+++ b/crates/kanban-backend-memory/src/lib.rs
@@ -35,6 +35,41 @@ mod tests {
         let _: &dyn KanbanBackend = &store;
     }
 
+    /// Poisons the state lock from inside the batch. `modify_graph_impl` holds
+    /// the write guard across its closure, so panicking there leaves the lock
+    /// poisoned and the rollback's `apply_snapshot_impl` cannot reacquire it.
+    fn poison_state_lock(store: &InMemoryStore) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = store.modify_graph(Box::new(|_| panic!("poison the state lock")));
+        }));
+    }
+
+    #[test]
+    fn test_with_transaction_surfaces_both_errors_when_the_rollback_also_fails() {
+        let store = InMemoryStore::new();
+
+        let result = store.with_transaction(Box::new(|| {
+            poison_state_lock(&store);
+            Err(kanban_domain::KanbanError::Internal("batch boom".into()))
+        }));
+
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("batch boom"),
+            "the batch's own error must survive (got: {msg:?})"
+        );
+        assert!(
+            msg.contains("poisoned"),
+            "the rollback failure must be reported too, not swallowed in favour \
+             of the batch error (got: {msg:?})"
+        );
+        assert!(
+            msg.contains("State may be inconsistent"),
+            "a rollback that failed leaves the store in an unknown state and \
+             must say so (got: {msg:?})"
+        );
+    }
+
     #[test]
     fn test_as_data_store_returns_data_store_ref() {
         let store = InMemoryStore::new();

--- a/crates/kanban-backend-memory/src/lib.rs
+++ b/crates/kanban-backend-memory/src/lib.rs
@@ -2,9 +2,9 @@ mod in_memory_store;
 
 pub use in_memory_store::InMemoryStore;
 
-use kanban_backend::{KanbanBackend, TransactionFn};
+use kanban_backend::{rollback_failed, KanbanBackend, TransactionFn};
 use kanban_domain::data_store::DataStore;
-use kanban_domain::{KanbanError, KanbanResult};
+use kanban_domain::KanbanResult;
 
 impl KanbanBackend for InMemoryStore {
     fn as_data_store(&self) -> &dyn DataStore {
@@ -17,14 +17,10 @@ impl KanbanBackend for InMemoryStore {
         let before = self.snapshot_impl()?;
         match f() {
             Ok(()) => Ok(()),
-            Err(e) => {
-                if let Err(rollback_err) = self.apply_snapshot_impl(before) {
-                    return Err(KanbanError::Internal(format!(
-                        "Batch failed ({e}) and rollback also failed ({rollback_err}). State may be inconsistent."
-                    )));
-                }
-                Err(e)
-            }
+            Err(e) => match self.apply_snapshot_impl(before) {
+                Err(rollback_err) => Err(rollback_failed(e, rollback_err)),
+                Ok(()) => Err(e),
+            },
         }
     }
 }

--- a/crates/kanban-backend-memory/src/lib.rs
+++ b/crates/kanban-backend-memory/src/lib.rs
@@ -2,8 +2,9 @@ mod in_memory_store;
 
 pub use in_memory_store::InMemoryStore;
 
-use kanban_backend::KanbanBackend;
+use kanban_backend::{KanbanBackend, TransactionFn};
 use kanban_domain::data_store::DataStore;
+use kanban_domain::{KanbanError, KanbanResult};
 
 impl KanbanBackend for InMemoryStore {
     fn as_data_store(&self) -> &dyn DataStore {
@@ -11,6 +12,21 @@ impl KanbanBackend for InMemoryStore {
     }
     // All lifecycle defaults are correct for in-memory: flush=noop, reload=noop,
     // needs_flush=false, needs_save_worker=false.
+
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
+        let before = self.snapshot_impl()?;
+        match f() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                if let Err(rollback_err) = self.apply_snapshot_impl(before) {
+                    return Err(KanbanError::Internal(format!(
+                        "Batch failed ({e}) and rollback also failed ({rollback_err}). State may be inconsistent."
+                    )));
+                }
+                Err(e)
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-backend/README.md
+++ b/crates/kanban-backend/README.md
@@ -46,9 +46,11 @@ internal snapshot under a single lock, and the HTTP backend declines because the
 remote server owns the state. Requiring the method also turns a new backend that
 forgets it into a compile error.
 
-The closure is `FnOnce` because the batch runs exactly once, which lets callers
+The closure is `FnOnce` because the batch never runs twice, which lets callers
 move owned values in; it is boxed so the method stays callable on
-`dyn KanbanBackend`.
+`dyn KanbanBackend`. It may run zero times: a backend that declines does so
+before invoking it, so a caller must not assume a side effect inside the
+closure happened unless `with_transaction` returned `Ok`.
 
 Snapshot-restoring implementations assume a single writer: they cannot tell the
 batch's writes from anyone else's, so a mutation committed by another task

--- a/crates/kanban-backend/README.md
+++ b/crates/kanban-backend/README.md
@@ -28,15 +28,33 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     fn local_persistence(&self) -> Option<&dyn LocalPersistence> { None }
     fn health_checker(&self) -> Option<Box<dyn kanban_core::HealthChecker>> { None }
     fn remote_writes(&self) -> Option<&dyn RemoteWrites> { None }
-    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> { /* default: snapshot + restore on error */ }
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()>; // required
 }
+
+pub type TransactionFn<'f> = Box<dyn FnOnce() -> KanbanResult<()> + 'f>;
 ```
 
 `KanbanBackend` combines `kanban_domain::DataStore` (entity CRUD) with
 `kanban_domain::CommandStore` (the audit/command log) plus the lifecycle hooks
-above. `with_transaction`'s default implementation snapshots state before
-running `f` and restores it on failure (cheap in-memory, expensive on disk);
-disk-backed backends override it with a native transaction.
+above.
+
+`with_transaction` is the one method with no default. A generic default could
+only roll back by snapshotting the whole store and restoring it, which is cheap
+in memory and ruinous on disk, so each backend supplies its own mechanism:
+SQLite issues a real `BEGIN`/`COMMIT`/`ROLLBACK`, JSON and in-memory restore an
+internal snapshot under a single lock, and the HTTP backend declines because the
+remote server owns the state. Requiring the method also turns a new backend that
+forgets it into a compile error.
+
+The closure is `FnOnce` because the batch runs exactly once, which lets callers
+move owned values in; it is boxed so the method stays callable on
+`dyn KanbanBackend`.
+
+Snapshot-restoring implementations assume a single writer: they cannot tell the
+batch's writes from anyone else's, so a mutation committed by another task
+mid-batch would be rolled back with it. Every consumer serialises today
+(`kanban-server` and `kanban-mcp` behind `Arc<Mutex<KanbanContext>>`, the TUI on
+its main loop).
 
 ```rust
 #[async_trait::async_trait]

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -85,11 +85,13 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     /// together.
     ///
     /// `f` runs at most once — never twice, so it may consume what it
-    /// captures, and possibly not at all: a backend that cannot offer a
-    /// transaction (`HttpBackend`, where the remote server owns the state)
-    /// declines with an unsupported error *before* invoking it, rather than
-    /// running the mutations unprotected. Do not rely on a side effect inside
-    /// `f` having happened unless this returned `Ok`.
+    /// captures, and possibly not at all. Anything that stops a batch from
+    /// being atomic fails *before* `f` is invoked rather than running the
+    /// mutations unprotected: a backend that cannot offer a transaction at all
+    /// (`HttpBackend`, where the remote server owns the state) declines with an
+    /// unsupported error, and one that can will still bail if it fails to open
+    /// the transaction. Do not rely on a side effect inside `f` having happened
+    /// unless this returned `Ok`.
     ///
     /// There is deliberately no default implementation. A generic one can only
     /// roll back by snapshotting the whole store and restoring it, which is

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -8,7 +8,7 @@ pub use remote_writes::RemoteWrites;
 use async_trait::async_trait;
 use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::DataStore;
-use kanban_domain::{KanbanError, KanbanResult};
+use kanban_domain::KanbanResult;
 use uuid::Uuid;
 
 /// Combines the entity-level CRUD interface (`DataStore`) with the command
@@ -81,26 +81,34 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
         None
     }
 
-    /// Run `f` as an atomic batch: every mutation commits or rolls
-    /// back together. The default impl snapshots state before `f`
-    /// runs and restores it on failure — cheap for in-memory backends,
-    /// expensive on disk. Disk-backed backends should override with a
-    /// native transaction.
-    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
-        let before = self.snapshot()?;
-        match f() {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                if let Err(rollback_err) = self.apply_snapshot(before) {
-                    return Err(KanbanError::Internal(format!(
-                        "Batch failed ({e}) and rollback also failed ({rollback_err}). State may be inconsistent."
-                    )));
-                }
-                Err(e)
-            }
-        }
-    }
+    /// Run `f` as an atomic batch: every mutation commits or rolls back
+    /// together. `f` runs exactly once.
+    ///
+    /// There is deliberately no default implementation. A generic one can only
+    /// roll back by snapshotting the whole store and restoring it, which is
+    /// cheap in memory and ruinous on disk; making the method required forces
+    /// each backend to answer with its own native mechanism, and turns a new
+    /// backend that forgot to into a compile error rather than a silent
+    /// whole-store copy.
+    ///
+    /// # Single-writer requirement
+    ///
+    /// Implementations that roll back by restoring a whole-store snapshot
+    /// cannot tell the batch's own writes apart from anyone else's, so a
+    /// mutation committed by another task between the capture and the failure
+    /// is reverted along with the batch. Every consumer today serialises its
+    /// mutations (`kanban-server` and `kanban-mcp` behind
+    /// `Arc<Mutex<KanbanContext>>`, the TUI on its main loop), which is what
+    /// makes this sound. Any new concurrent access to a shared backend must
+    /// serialise too, and must revisit `SqliteStore::db_conn`, whose ambient
+    /// transaction fails the same way but worse.
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()>;
 }
+
+/// Closure passed to [`KanbanBackend::with_transaction`], boxed so the method
+/// stays callable on `dyn KanbanBackend`. `FnOnce` because the batch runs
+/// exactly once and closures need to move owned values in.
+pub type TransactionFn<'f> = Box<dyn FnOnce() -> KanbanResult<()> + 'f>;
 
 #[cfg(test)]
 mod tests {
@@ -238,6 +246,9 @@ mod tests {
     impl KanbanBackend for StubBackend {
         fn as_data_store(&self) -> &dyn DataStore {
             self
+        }
+        fn with_transaction(&self, _f: TransactionFn<'_>) -> KanbanResult<()> {
+            unimplemented!()
         }
     }
 

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -8,7 +8,7 @@ pub use remote_writes::RemoteWrites;
 use async_trait::async_trait;
 use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::DataStore;
-use kanban_domain::KanbanResult;
+use kanban_domain::{KanbanError, KanbanResult};
 use uuid::Uuid;
 
 /// Combines the entity-level CRUD interface (`DataStore`) with the command
@@ -82,7 +82,14 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     }
 
     /// Run `f` as an atomic batch: every mutation commits or rolls back
-    /// together. `f` runs exactly once.
+    /// together.
+    ///
+    /// `f` runs at most once — never twice, so it may consume what it
+    /// captures, and possibly not at all: a backend that cannot offer a
+    /// transaction (`HttpBackend`, where the remote server owns the state)
+    /// declines with an unsupported error *before* invoking it, rather than
+    /// running the mutations unprotected. Do not rely on a side effect inside
+    /// `f` having happened unless this returned `Ok`.
     ///
     /// There is deliberately no default implementation. A generic one can only
     /// roll back by snapshotting the whole store and restoring it, which is
@@ -106,15 +113,47 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
 }
 
 /// Closure passed to [`KanbanBackend::with_transaction`], boxed so the method
-/// stays callable on `dyn KanbanBackend`. `FnOnce` because the batch runs
-/// exactly once and closures need to move owned values in.
+/// stays callable on `dyn KanbanBackend`. `FnOnce` because the batch never runs
+/// twice and closures need to move owned values in.
 pub type TransactionFn<'f> = Box<dyn FnOnce() -> KanbanResult<()> + 'f>;
+
+/// Combines a batch failure with a failure to roll it back. Shared by the
+/// snapshot-restoring backends so the wording of the one message a user sees
+/// when the store is left in an unknown state cannot drift between them.
+pub fn rollback_failed(batch_err: KanbanError, rollback_err: KanbanError) -> KanbanError {
+    KanbanError::Internal(format!(
+        "Batch failed ({batch_err}) and rollback also failed ({rollback_err}). State may be inconsistent."
+    ))
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use kanban_domain::command_batch::CommandBatch;
     use kanban_domain::*;
+
+    #[test]
+    fn test_rollback_failed_names_both_the_batch_and_the_rollback_error() {
+        let err = rollback_failed(
+            KanbanError::Internal("batch boom".into()),
+            KanbanError::Internal("restore boom".into()),
+        );
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("batch boom"),
+            "batch error lost (got: {msg:?})"
+        );
+        assert!(
+            msg.contains("restore boom"),
+            "rollback error lost (got: {msg:?})"
+        );
+        assert!(
+            msg.contains("State may be inconsistent"),
+            "a failed rollback must say the store is left in an unknown state \
+             (got: {msg:?})"
+        );
+    }
 
     struct StubBackend;
 

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -428,6 +428,40 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_with_transaction_surfaces_both_errors_when_the_rollback_also_fails() {
+        let dir = tempdir().unwrap();
+        let jds = make_store(&dir.path().join("t.json"));
+        jds.upsert_board(Board::new("Seeded", None::<String>))
+            .unwrap();
+
+        let result = jds.with_transaction(Box::new(|| {
+            // The inner InMemoryStore holds its write guard across
+            // modify_graph's closure, so panicking there poisons the lock the
+            // rollback needs.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = jds.modify_graph(Box::new(|_| panic!("poison the state lock")));
+            }));
+            Err(KanbanError::Internal("batch boom".into()))
+        }));
+
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("batch boom"),
+            "the batch's own error must survive (got: {msg:?})"
+        );
+        assert!(
+            msg.contains("poisoned"),
+            "the rollback failure must be reported too, not swallowed in favour \
+             of the batch error (got: {msg:?})"
+        );
+        assert!(
+            msg.contains("State may be inconsistent"),
+            "a rollback that failed leaves the store in an unknown state and \
+             must say so (got: {msg:?})"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_json_backend_exposes_local_persistence() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("md.json");

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -393,7 +393,7 @@ impl KanbanBackend for JsonDataStore {
         Some(self)
     }
 
-    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
+    fn with_transaction(&self, f: kanban_backend::TransactionFn<'_>) -> KanbanResult<()> {
         let before = self.with_read(|s| s.snapshot_impl())?;
         match f() {
             Ok(()) => Ok(()),
@@ -791,8 +791,10 @@ mod tests {
         jds.flush().await.unwrap();
         assert!(!jds.needs_flush(), "clean after flush");
 
-        jds.with_transaction(&mut || jds.upsert_board(Board::new("Committed", None::<String>)))
-            .unwrap();
+        jds.with_transaction(Box::new(|| {
+            jds.upsert_board(Board::new("Committed", None::<String>))
+        }))
+        .unwrap();
 
         assert!(
             jds.needs_flush(),
@@ -843,12 +845,12 @@ mod tests {
 
         let before = jds.snapshot().unwrap();
 
-        let result = jds.with_transaction(&mut || {
+        let result = jds.with_transaction(Box::new(|| {
             jds.upsert_board(Board::new("Injected", None::<String>))?;
             jds.delete_card(card_a.id)?;
             jds.delete_sprint(sprint.id)?;
             Err(KanbanError::validation("forced batch failure"))
-        });
+        }));
 
         assert!(result.is_err(), "the batch's own error must propagate");
 

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -397,14 +397,10 @@ impl KanbanBackend for JsonDataStore {
         let before = self.with_read(|s| s.snapshot_impl())?;
         match f() {
             Ok(()) => Ok(()),
-            Err(e) => {
-                if let Err(rollback_err) = self.with_mutate(|s| s.apply_snapshot_impl(before)) {
-                    return Err(KanbanError::Internal(format!(
-                        "Batch failed ({e}) and rollback also failed ({rollback_err}). State may be inconsistent."
-                    )));
-                }
-                Err(e)
-            }
+            Err(e) => match self.with_mutate(|s| s.apply_snapshot_impl(before)) {
+                Err(rollback_err) => Err(kanban_backend::rollback_failed(e, rollback_err)),
+                Ok(()) => Err(e),
+            },
         }
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -260,9 +260,9 @@ impl kanban_backend::KanbanBackend for SqliteBackend {
         Some(self)
     }
 
-    /// Real `BEGIN`/`COMMIT`/`ROLLBACK` transaction instead of the trait
-    /// default's snapshot()/apply_snapshot() rollback — see KAN-1067.
-    fn with_transaction(&self, f: &mut dyn FnMut() -> KanbanResult<()>) -> KanbanResult<()> {
+    /// Real `BEGIN`/`COMMIT`/`ROLLBACK` transaction rather than a
+    /// snapshot-and-restore rollback.
+    fn with_transaction(&self, f: kanban_backend::TransactionFn<'_>) -> KanbanResult<()> {
         self.db.begin_write_transaction()?;
         match f() {
             Ok(()) => self.db.commit_write_transaction(),

--- a/crates/kanban-persistence-sqlite/tests/with_transaction.rs
+++ b/crates/kanban-persistence-sqlite/tests/with_transaction.rs
@@ -23,14 +23,14 @@ async fn test_with_transaction_commits_full_graph_via_real_db_transaction() {
     let sprint_id = sprint.id;
     let other = uuid::Uuid::new_v4();
 
-    let result: KanbanResult<()> = backend.with_transaction(&mut || {
+    let result: KanbanResult<()> = backend.with_transaction(Box::new(|| {
         backend.upsert_board(board.clone())?;
         backend.upsert_column(column.clone())?;
         backend.upsert_card(card.clone())?;
         backend.upsert_sprint(sprint.clone())?;
         backend.modify_graph(Box::new(move |graph| graph.set_block(other, card_id)))?;
         Ok(())
-    });
+    }));
     result.expect("with_transaction should commit a valid batch");
 
     let fresh = open(&path).await;
@@ -78,7 +78,7 @@ async fn test_with_transaction_rolls_back_full_graph_via_db_not_snapshot_restore
     let second_card_id = uuid::Uuid::new_v4();
     let second_sprint_id = uuid::Uuid::new_v4();
 
-    let result: KanbanResult<()> = backend.with_transaction(&mut || {
+    let result: KanbanResult<()> = backend.with_transaction(Box::new(|| {
         let mut new_card = Card::new(&mut board.clone(), column.id, "Second", 1);
         new_card.id = second_card_id;
         backend.upsert_card(new_card)?;
@@ -87,7 +87,7 @@ async fn test_with_transaction_rolls_back_full_graph_via_db_not_snapshot_restore
         backend.upsert_sprint(new_sprint)?;
         backend.insert_archived_card(kanban_domain::ArchivedCard::new(card_id, board_id))?;
         Err(kanban_domain::KanbanError::Internal("boom".into()))
-    });
+    }));
     assert!(result.is_err());
 
     let fresh = open(&path).await;
@@ -131,10 +131,10 @@ async fn test_with_transaction_delete_path_rolls_back() {
     backend.upsert_column(column).unwrap();
     backend.upsert_card(card).unwrap();
 
-    let result: KanbanResult<()> = backend.with_transaction(&mut || {
+    let result: KanbanResult<()> = backend.with_transaction(Box::new(|| {
         backend.delete_card(card_id)?;
         Err(kanban_domain::KanbanError::Internal("boom".into()))
-    });
+    }));
     assert!(result.is_err());
 
     let fresh = open(&path).await;
@@ -154,11 +154,11 @@ async fn test_with_transaction_propagates_inner_error_and_leaves_pre_state_on_di
     let board_id = board.id;
     backend.upsert_board(board).unwrap();
 
-    let result: KanbanResult<()> = backend.with_transaction(&mut || {
+    let result: KanbanResult<()> = backend.with_transaction(Box::new(|| {
         Err(kanban_domain::KanbanError::Internal(
             "no writes attempted".into(),
         ))
-    });
+    }));
     let err = result.expect_err("closure error must propagate");
     assert!(err.to_string().contains("no writes attempted"));
 

--- a/crates/kanban-service/src/backend_test_support.rs
+++ b/crates/kanban-service/src/backend_test_support.rs
@@ -1,4 +1,4 @@
-use kanban_backend::{KanbanBackend, RemoteWrites};
+use kanban_backend::{KanbanBackend, RemoteWrites, TransactionFn};
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
     Board, BoardUpdate, Card, CardUpdate, Column, ColumnUpdate, CommandBatch, CommandStore,
@@ -212,5 +212,9 @@ impl KanbanBackend for MockBackend {
 
     fn remote_writes(&self) -> Option<&dyn RemoteWrites> {
         Some(&self.mock)
+    }
+
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
+        self.inner.with_transaction(f)
     }
 }

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -365,7 +365,7 @@ impl KanbanContext {
         // (below) rather than being undoable via the normal command stack.
         let backend = std::sync::Arc::clone(&self.backend);
         let cmds = &commands;
-        backend.with_transaction(&mut || {
+        backend.with_transaction(Box::new(|| {
             let store: &dyn DataStore = backend.as_data_store();
             let ctx = CommandContext { store };
             for cmd in cmds.iter() {
@@ -382,7 +382,7 @@ impl KanbanContext {
             };
             backend.append_batch(&batch)?;
             Ok(())
-        })?;
+        }))?;
 
         self.undo_stack.clear();
         self.dirty = true;

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -23,7 +23,7 @@ impl KanbanContext {
         let backend = Arc::clone(&self.backend);
         let cmds = &commands;
         let mut per_cmd_inverses: Vec<Vec<Command>> = Vec::new();
-        self.backend.with_transaction(&mut || {
+        self.backend.with_transaction(Box::new(|| {
             let store: &dyn DataStore = backend.as_data_store();
             let ctx = CommandContext { store };
             for cmd in cmds.iter() {
@@ -42,7 +42,7 @@ impl KanbanContext {
             };
             backend.append_batch(&batch)?;
             Ok(())
-        })?;
+        }))?;
         let inverses: Vec<Command> = per_cmd_inverses.into_iter().rev().flatten().collect();
 
         self.undo_stack.push(crate::undo_stack::UndoEntry {
@@ -63,12 +63,11 @@ impl KanbanContext {
             None => return Ok(false),
         };
         let backend = Arc::clone(&self.backend);
-        let inv = &inverse;
-        self.backend.with_transaction(&mut || {
+        self.backend.with_transaction(Box::new(move || {
             let store: &dyn DataStore = backend.as_data_store();
             let ctx = CommandContext { store };
-            inv.iter().try_for_each(|cmd| cmd.execute(&ctx))
-        })?;
+            inverse.iter().try_for_each(|cmd| cmd.execute(&ctx))
+        }))?;
         self.undo_stack.commit_undo();
         self.dirty = true;
         Ok(true)
@@ -83,12 +82,11 @@ impl KanbanContext {
             None => return Ok(false),
         };
         let backend = Arc::clone(&self.backend);
-        let fwd = &forward;
-        self.backend.with_transaction(&mut || {
+        self.backend.with_transaction(Box::new(move || {
             let store: &dyn DataStore = backend.as_data_store();
             let ctx = CommandContext { store };
-            fwd.iter().try_for_each(|cmd| cmd.execute(&ctx))
-        })?;
+            forward.iter().try_for_each(|cmd| cmd.execute(&ctx))
+        }))?;
         self.undo_stack.commit_redo();
         self.dirty = true;
         Ok(true)

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -27,6 +27,7 @@ pub use context::{
 };
 pub use kanban_backend::KanbanBackend;
 pub use kanban_backend::RemoteWrites;
+pub use kanban_backend::TransactionFn;
 pub use path::validate_path;
 pub use store_manager::StoreManager;
 

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -99,9 +99,14 @@ fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
         graph.set_block(blocker_id, blocked_id)
     }))?;
 
+    let before = backend.snapshot()?;
+
     let backend_for_closure = Arc::clone(&backend);
     let result = backend.with_transaction(Box::new(move || {
         let store: &dyn DataStore = backend_for_closure.as_data_store();
+        // Both directions: the batch adds as well as deletes, so rollback has
+        // to discard the addition and restore the deletions.
+        store.upsert_board(Board::new("Injected", None::<String>))?;
         store.delete_card(blocked_id)?;
         store.delete_sprint(sprint_id)?;
         store.modify_graph(Box::new(move |graph| {
@@ -115,6 +120,18 @@ fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
     assert!(
         result.is_err(),
         "transaction must propagate the inner error"
+    );
+
+    assert_eq!(
+        backend.snapshot()?,
+        before,
+        "the whole store must come back identical, not merely the entities \
+         this test thought to enumerate below"
+    );
+    assert!(
+        !backend.list_boards()?.iter().any(|b| b.name == "Injected"),
+        "rollback must discard what the failed batch added, not just restore \
+         what it deleted"
     );
 
     assert!(

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -122,18 +122,11 @@ fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
         "transaction must propagate the inner error"
     );
 
-    assert_eq!(
-        backend.snapshot()?,
-        before,
-        "the whole store must come back identical, not merely the entities \
-         this test thought to enumerate below"
-    );
     assert!(
         !backend.list_boards()?.iter().any(|b| b.name == "Injected"),
         "rollback must discard what the failed batch added, not just restore \
          what it deleted"
     );
-
     assert!(
         backend.get_board(board_id)?.is_some(),
         "rollback must restore the board"
@@ -155,6 +148,15 @@ fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
         vec![blocker_id],
         "rollback must restore the dependency edge, which lives in the \
          workspace-global graph rather than being owned by the board"
+    );
+
+    // Backstop, deliberately last: catches anything the assertions above did
+    // not think to enumerate. Its failure output is a whole-Snapshot diff, so
+    // running it first would bury the readable diagnosis.
+    assert_eq!(
+        backend.snapshot()?,
+        before,
+        "the whole store must come back identical"
     );
     Ok(())
 }

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -76,7 +76,8 @@ fn test_with_transaction_propagates_inner_error() -> KanbanResult<()> {
 fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
     // `test_with_transaction_rolls_back_on_failure` only checks a board count.
     // Rollback has to restore every entity the store owns plus the workspace
-    // graph, so seed a non-trivial graph and assert all of it comes back.
+    // graph, and discard whatever the batch added, so seed a non-trivial graph
+    // and drive a batch that both adds and deletes.
     use kanban_domain::{Card, Column, Sprint};
 
     let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -14,10 +14,10 @@ fn test_with_transaction_commits_on_success() -> KanbanResult<()> {
     let board_id = board.id;
 
     let backend_for_closure = Arc::clone(&backend);
-    backend.with_transaction(&mut || {
+    backend.with_transaction(Box::new(|| {
         let store: &dyn DataStore = backend_for_closure.as_data_store();
         store.upsert_board(board.clone())
-    })?;
+    }))?;
 
     let boards = backend.list_boards()?;
     assert_eq!(boards.len(), 1);
@@ -34,11 +34,11 @@ fn test_with_transaction_rolls_back_on_failure() -> KanbanResult<()> {
     let pre_count = backend.list_boards()?.len();
 
     let backend_for_closure = Arc::clone(&backend);
-    let result = backend.with_transaction(&mut || {
+    let result = backend.with_transaction(Box::new(|| {
         let store: &dyn DataStore = backend_for_closure.as_data_store();
         store.upsert_board(Board::new("Will be rolled back", None::<String>))?;
         Err(KanbanError::Internal("simulated failure".into()))
-    });
+    }));
 
     assert!(
         result.is_err(),
@@ -58,16 +58,107 @@ fn test_with_transaction_propagates_inner_error() -> KanbanResult<()> {
 
     let backend_for_closure = Arc::clone(&backend);
     let err = backend
-        .with_transaction(&mut || {
+        .with_transaction(Box::new(|| {
             let _store: &dyn DataStore = backend_for_closure.as_data_store();
             Err(KanbanError::Internal("inner error message".into()))
-        })
+        }))
         .unwrap_err();
 
     let msg = format!("{err}");
     assert!(
         msg.contains("inner error message"),
         "the original error message must be preserved (got: {msg:?})"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
+    // `test_with_transaction_rolls_back_on_failure` only checks a board count.
+    // Rollback has to restore every entity the store owns plus the workspace
+    // graph, so seed a non-trivial graph and assert all of it comes back.
+    use kanban_domain::{Card, Column, Sprint};
+
+    let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
+
+    let mut board = Board::new("Seeded", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let blocker = Card::new(&mut board, column.id, "Blocker", 0);
+    let blocked = Card::new(&mut board, column.id, "Blocked", 1);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+
+    let (board_id, column_id) = (board.id, column.id);
+    let (blocker_id, blocked_id, sprint_id) = (blocker.id, blocked.id, sprint.id);
+
+    backend.upsert_board(board)?;
+    backend.upsert_column(column)?;
+    backend.upsert_card(blocker)?;
+    backend.upsert_card(blocked)?;
+    backend.upsert_sprint(sprint)?;
+    backend.modify_graph(Box::new(move |graph| {
+        graph.set_block(blocker_id, blocked_id)
+    }))?;
+
+    let backend_for_closure = Arc::clone(&backend);
+    let result = backend.with_transaction(Box::new(move || {
+        let store: &dyn DataStore = backend_for_closure.as_data_store();
+        store.delete_card(blocked_id)?;
+        store.delete_sprint(sprint_id)?;
+        store.modify_graph(Box::new(move |graph| {
+            graph.unblock(blocker_id, blocked_id)?;
+            Ok(())
+        }))?;
+        store.delete_column(column_id)?;
+        store.delete_board(board_id)?;
+        Err(KanbanError::Internal("simulated failure".into()))
+    }));
+    assert!(
+        result.is_err(),
+        "transaction must propagate the inner error"
+    );
+
+    assert!(
+        backend.get_board(board_id)?.is_some(),
+        "rollback must restore the board"
+    );
+    assert!(
+        backend.get_column(column_id)?.is_some(),
+        "rollback must restore the column"
+    );
+    assert!(
+        backend.get_card(blocker_id)?.is_some() && backend.get_card(blocked_id)?.is_some(),
+        "rollback must restore both cards"
+    );
+    assert!(
+        backend.get_sprint(sprint_id)?.is_some(),
+        "rollback must restore the sprint"
+    );
+    assert_eq!(
+        backend.get_graph()?.blockers(blocked_id),
+        vec![blocker_id],
+        "rollback must restore the dependency edge, which lives in the \
+         workspace-global graph rather than being owned by the board"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_with_transaction_accepts_a_closure_that_consumes_captured_state() -> KanbanResult<()> {
+    // Pins the FnOnce contract: a closure may move an owned value out of its
+    // captures. Under `&mut dyn FnMut` this does not compile and callers have
+    // to launder the value through an `Option::take()`.
+    let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
+    let board = Board::new("Moved in", None::<String>);
+    let board_id = board.id;
+
+    let backend_for_closure = Arc::clone(&backend);
+    backend.with_transaction(Box::new(move || {
+        backend_for_closure.as_data_store().upsert_board(board)
+    }))?;
+
+    assert!(
+        backend.get_board(board_id)?.is_some(),
+        "the moved-in board must have been committed"
     );
     Ok(())
 }


### PR DESCRIPTION
Closes KAN-1110. Part of the KAN-1065 epic ("Snapshot is a file format, not a backend operation").

## Why

`KanbanBackend::with_transaction` had a generic default that rolled back by snapshotting the whole store and restoring it on failure. That is cheap for an in-memory backend and ruinous for a disk-backed one, and because it was a default, a backend could inherit it silently rather than answering for its own rollback.

Deleting the default makes the method required. Each backend now supplies its own mechanism, and a new backend that forgets one is a compile error rather than an accidental whole-store copy. This is also the last piece before KAN-1079 can remove `snapshot`/`apply_snapshot` from `DataStore`, since nothing routes through them any more.

## What changed

Six implementors, no default:

| Backend | Mechanism |
|---|---|
| `SqliteBackend` | real `BEGIN`/`COMMIT`/`ROLLBACK` (already present, signature only) |
| `JsonDataStore` | single-lock snapshot restore (already present, signature only) |
| `InMemoryStore` | its own `snapshot_impl`/`apply_snapshot_impl`, one lock each |
| `HttpBackend` | declines with an unsupported error, before running the closure |
| `MockBackend` | delegates to its inner `InMemoryStore` |
| `StubBackend` | `unimplemented!()`, like its siblings |

The closure changes from `&mut dyn FnMut() -> KanbanResult<()>` to a boxed `FnOnce`:

```rust
pub type TransactionFn<'f> = Box<dyn FnOnce() -> KanbanResult<()> + 'f>;

fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()>;
```

The batch never runs twice, so `FnMut` was promising something no implementation wanted. Under `FnMut` a caller with an owned value had to launder it through an `Option::take().expect(...)`, a runtime assertion of something the trait already guarantees statically. Boxed rather than generic because the method has to stay callable on `dyn KanbanBackend`; this mirrors `DataStore::modify_graph`'s existing `GraphMutFn`.

The documented contract is **at most once**, not exactly once: `f` never runs twice, and may not run at all. Anything that stops a batch being atomic fails *before* `f` is invoked rather than running the mutations unprotected — a backend with no transaction to offer declines, and one that has them still bails if it cannot open it, as `SqliteBackend` does on `begin_write_transaction`.

`FnOnce` paid off immediately beyond the case that prompted it. `undo()` and `redo()` were each keeping a borrow alias that existed only to satisfy `FnMut`:

```rust
-        let inv = &inverse;
-        self.backend.with_transaction(&mut || {
+        self.backend.with_transaction(Box::new(move || {
             let store: &dyn DataStore = backend.as_data_store();
             let ctx = CommandContext { store };
-            inv.iter().try_for_each(|cmd| cmd.execute(&ctx))
-        })?;
+            inverse.iter().try_for_each(|cmd| cmd.execute(&ctx))
+        }))?;
```

Both snapshot-restoring backends now build their combined error through one shared `kanban_backend::rollback_failed(batch_err, rollback_err)`, so the single message a user sees when the store is left in an unknown state cannot drift between them.

## The rollback race, investigated rather than assumed

The card flagged a flaw inherited by every snapshot-restoring implementation: a mutation committed by another task between the capture and the failure is reverted along with the batch, because a whole-store restore cannot tell whose writes are whose. Reachability was marked UNVERIFIED, and the options ranged from building change tracking to just documenting it.

It is not reachable. Every consumer serialises its mutations:

- `kanban-server` behind `Arc<Mutex<KanbanContext>>` (`state.rs:15`) — all axum handlers
- `kanban-mcp` behind `Arc<Mutex<McpContext>>` (`lib.rs:52`) — all tool calls via `locked_read`/`locked_write`
- the TUI on its main loop; the only spawned task holding the live backend is the save worker, which calls `flush()`, and `flush` drains a dirty flag and writes bytes without touching the entity graph. External-change reloads are dispatched from the main loop itself, not the watcher task.

So no machinery, just a documented requirement on the trait. Worth noting the same invariant is already load-bearing for `SqliteStore::db_conn`'s ambient transaction, which was documented independently by KAN-1067 and fails worse: it would silently observe another task's uncommitted writes. Any future consumer that mutates one backend from two tasks must revisit both.

This limitation is not new and not a regression from #550 — it was identical in the default being replaced.

## Tests

Red first, then the implementation:

- `test_in_memory_with_transaction_rolls_back_full_graph` — the existing rollback test only checked a board count. This seeds a board, column, two cards, a sprint and a `blocks` edge, then fails a batch that both adds and deletes, so rollback is checked in both directions: deletions restored, the addition discarded. The edge matters: it lives in the workspace-global dependency graph keyed on card id rather than being owned by the board, so a count-only assertion would not catch losing it.

  The enumerated assertions run first for a readable failure, then a whole-snapshot `assert_eq!` runs last as a backstop for anything they did not think to enumerate — that ordering matters, because the backstop's failure output is a full `Snapshot` diff and running it first would bury the diagnosis.
- `test_with_transaction_accepts_a_closure_that_consumes_captured_state` — pins the `FnOnce` contract; does not compile under `FnMut`.
- `test_http_backend_with_transaction_returns_unsupported` and `..._does_not_run_the_closure` — declining has to happen *before* the closure runs, or mutations get applied with no transaction around them.
- `test_rollback_failed_names_both_the_batch_and_the_rollback_error` — the shared helper keeps both errors and the "State may be inconsistent" warning.
- `test_with_transaction_surfaces_both_errors_when_the_rollback_also_fails`, on **both** the in-memory and JSON backends — the rollback-failure path had no coverage at either backend, so swapping an override's error arm for `Err(e)`, silently discarding the rollback failure, left the whole suite green while the user lost the only message telling them the store may be inconsistent.

  These reach a genuinely awkward state without mocks: `modify_graph_impl` holds its write guard across the closure, so panicking inside it (caught with `catch_unwind`) poisons the state lock from *within* the batch. The snapshot is taken before the closure runs, so it still succeeds and only the rollback fails. Both tests were verified to fail against that `Err(e)` mutation before landing.

The four pre-existing tests in `kanban-service/tests/with_transaction.rs` stay green. Their bodies and assertions are untouched; only the `&mut || {` → `Box::new(|| {` wrapper changed, which the signature decision forces.

## Verification

- `cargo check --workspace --all-targets` clean
- `cargo test --workspace` exit 0, 177 test binaries
- `cargo clippy --workspace --all-targets -- -D warnings` zero diagnostics
- `cargo fmt --check` clean
- Key invariant: no `with_transaction` implementation routes through `DataStore::snapshot`/`apply_snapshot`

## Notes for review

- **Versioning.** The changeset is `minor`, not `patch`. Removing a trait default and changing a published method's signature breaks any out-of-tree implementor, and every crate in `crates/` publishes to crates.io. The bump tables in `.changeset/README.md` and `CONTRIBUTING.md` said breaking changes are `major`, which on `0.x` means 1.0.0 and is never the intent — so this PR also writes down the pre-1.0 rule (breaking ⇒ `minor`) and spells out what counts as breaking, including removing a trait default. That doc change is tangential to the card; happy to split it out if preferred.
- `crates/kanban-backend/README.md` documented the old default verbatim and was not in the card's acceptance criteria; updated here.
- The card's criterion that the four existing tests stay "unmodified" could not hold once the signature changed. They are mechanically rewrapped, nothing else.
- `kanban-service` now re-exports `TransactionFn` alongside `KanbanBackend` and `RemoteWrites`, so implementing the trait through that path does not require reaching into a second crate for the argument type.
- Removing a trait default is breaking for any out-of-tree implementor. There are none in this workspace.



---

Supersedes #562, which was a parallel attempt at the same card and is now closed. That branch kept `&mut dyn FnMut` and documented the `Option::take()` dance; this one takes the `FnOnce` route the card asked to have settled. Nothing from it was lost — both of its tests exist here by the same names, and the two respects in which its full-graph test was stronger (whole-snapshot equality, and a batch that adds as well as deletes) are carried across in 20d413a6.
