### PR TITLE
KAN-1105 feat(service,persistence-sqlite): storage adapter for cross-format moves using atomic reads and transactional writes

### DIFF
--- a/.changeset/kan-1105.md
+++ b/.changeset/kan-1105.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: cross-format storage moves now go through a store adapter that reads and writes per entity instead of round-tripping a whole-store snapshot. SQLite-to-SQLite migration previously serialised the entire source database to JSON and parsed it straight back for no reason; it now reads atomically into a single transaction. JSON-to-SQLite writes inside one transaction too, so a failure partway leaves no half-written destination.

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -35,6 +35,13 @@ impl SqliteBackend {
             last_metadata: std::sync::RwLock::new(initial),
         })
     }
+
+    /// Closes the underlying pool. Callers that may delete the database file
+    /// afterwards must await this first: Windows refuses to unlink a file with
+    /// live handles.
+    pub async fn close(&self) {
+        self.db.close().await;
+    }
 }
 
 // ─── DataStore ───────────────────────────────────────────────────────────────

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -18,6 +18,7 @@ mod cascade;
 pub mod config;
 mod context;
 mod path;
+mod store_adapter;
 mod store_manager;
 pub mod undo_stack;
 pub use config::AppConfigDto;

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -10,8 +10,17 @@ use uuid::Uuid;
 /// individually through the unfiltered `get_board`. Archived cards are likewise
 /// absent from `list_all_cards` and are fetched by id.
 pub(crate) fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot> {
+    // Flat, per-collection reads rather than a walk down boards -> columns ->
+    // cards. Cards carry no foreign key on `column_id` or `board_id`, so a card
+    // can outlive its column; a hierarchical read could only reach cards through
+    // a column and would drop those rows. FK repair re-homes them downstream,
+    // but only if they are carried across at all.
     let archived_boards = store.list_archived_boards()?;
+    let archived_cards = store.list_archived_cards()?;
 
+    // `list_boards` is live-scoped, so an archived board's head has to be
+    // recovered individually through the unfiltered `get_board`; without it the
+    // whole archived subtree lands headless.
     let mut boards = store.list_boards()?;
     let live_board_ids: HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
     for ab in &archived_boards {
@@ -22,27 +31,9 @@ pub(crate) fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot
         }
     }
 
-    let mut columns = Vec::new();
-    let mut cards = Vec::new();
-    let mut archived_cards = Vec::new();
-    let mut sprints = Vec::new();
-
-    for board in &boards {
-        let board_columns = store.list_columns_by_board(board.id)?;
-        let board_archived = store.list_archived_cards_by_board(board.id)?;
-
-        for column in &board_columns {
-            cards.extend(store.list_cards_by_column(column.id)?);
-        }
-        columns.extend(board_columns);
-
-        sprints.extend(store.list_sprints_by_board(board.id)?);
-        archived_cards.extend(board_archived);
-    }
-
-    // `list_cards_by_column` is live-only under the marker model, so an archived
-    // card's row is missing above. Fetch it unfiltered, or the marker imports
-    // orphaned.
+    // Likewise `list_all_cards` hides archived rows under the marker model, so
+    // fetch those by id or the markers import orphaned.
+    let mut cards = store.list_all_cards()?;
     let live_card_ids: HashSet<Uuid> = cards.iter().map(|c| c.id).collect();
     for ac in &archived_cards {
         if !live_card_ids.contains(&ac.entity_id) {
@@ -54,11 +45,11 @@ pub(crate) fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot
 
     Ok(Snapshot {
         boards,
-        columns,
+        columns: store.list_all_columns()?,
         cards,
         archived_cards,
         archived_boards,
-        sprints,
+        sprints: store.list_all_sprints()?,
         graph: store.get_graph()?,
     })
 }

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -1,0 +1,469 @@
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{KanbanResult, Snapshot};
+use std::collections::HashSet;
+use uuid::Uuid;
+
+/// Reads a whole workspace through per-entity `DataStore` calls rather than
+/// `DataStore::snapshot`.
+///
+/// Archived boards are absent from `list_boards`, so their heads are recovered
+/// individually through the unfiltered `get_board`. Archived cards are likewise
+/// absent from `list_all_cards` and are fetched by id.
+pub(crate) fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot> {
+    let archived_boards = store.list_archived_boards()?;
+
+    let mut boards = store.list_boards()?;
+    let live_board_ids: HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
+    for ab in &archived_boards {
+        if !live_board_ids.contains(&ab.entity_id) {
+            if let Some(board) = store.get_board(ab.entity_id)? {
+                boards.push(board);
+            }
+        }
+    }
+
+    let mut columns = Vec::new();
+    let mut cards = Vec::new();
+    let mut archived_cards = Vec::new();
+    let mut sprints = Vec::new();
+
+    for board in &boards {
+        let board_columns = store.list_columns_by_board(board.id)?;
+        let board_archived = store.list_archived_cards_by_board(board.id)?;
+
+        for column in &board_columns {
+            cards.extend(store.list_cards_by_column(column.id)?);
+        }
+        columns.extend(board_columns);
+
+        sprints.extend(store.list_sprints_by_board(board.id)?);
+        archived_cards.extend(board_archived);
+    }
+
+    // `list_cards_by_column` is live-only under the marker model, so an archived
+    // card's row is missing above. Fetch it unfiltered, or the marker imports
+    // orphaned.
+    let live_card_ids: HashSet<Uuid> = cards.iter().map(|c| c.id).collect();
+    for ac in &archived_cards {
+        if !live_card_ids.contains(&ac.entity_id) {
+            if let Some(card) = store.get_card(ac.entity_id)? {
+                cards.push(card);
+            }
+        }
+    }
+
+    Ok(Snapshot {
+        boards,
+        columns,
+        cards,
+        archived_cards,
+        archived_boards,
+        sprints,
+        graph: store.get_graph()?,
+    })
+}
+
+/// Writes a whole workspace through per-entity `DataStore` calls rather than
+/// `DataStore::apply_snapshot`. The caller supplies the transaction.
+pub(crate) fn write_full_snapshot(store: &dyn DataStore, snapshot: Snapshot) -> KanbanResult<()> {
+    for board in snapshot.boards {
+        store.upsert_board(board)?;
+    }
+    for column in snapshot.columns {
+        store.upsert_column(column)?;
+    }
+    for card in snapshot.cards {
+        store.upsert_card(card)?;
+    }
+    for sprint in snapshot.sprints {
+        store.upsert_sprint(sprint)?;
+    }
+    for ac in snapshot.archived_cards {
+        store.insert_archived_card(ac)?;
+    }
+    for ab in snapshot.archived_boards {
+        store.insert_archived_board(ab)?;
+    }
+    store.set_graph(snapshot.graph)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_backend_memory::InMemoryStore;
+    use kanban_domain::{Archived, ArchivedCard, Board, Card, Column, DependencyGraph, Sprint};
+    use uuid::Uuid;
+
+    /// Delegates everything to an inner store but refuses the two whole-store
+    /// trait methods this card exists to stop using. Any accidental fallback to
+    /// them fails the test loudly instead of silently producing a correct-looking
+    /// result.
+    struct NoWholeStoreReads(InMemoryStore);
+
+    impl DataStore for NoWholeStoreReads {
+        fn snapshot(&self) -> KanbanResult<Snapshot> {
+            panic!("read_full_snapshot must compose per-entity reads, not call snapshot()")
+        }
+        fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
+            panic!("write_full_snapshot must compose per-entity writes, not call apply_snapshot()")
+        }
+
+        fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+            self.0.get_board(id)
+        }
+        fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+            self.0.list_boards()
+        }
+        fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+            self.0.upsert_board(board)
+        }
+        fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+            self.0.delete_board(id)
+        }
+        fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+            self.0.get_column(id)
+        }
+        fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+            self.0.list_columns_by_board(board_id)
+        }
+        fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+            self.0.list_all_columns()
+        }
+        fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+            self.0.upsert_column(column)
+        }
+        fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+            self.0.delete_column(id)
+        }
+        fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.0.delete_columns_by_board(board_id)
+        }
+        fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+            self.0.get_card(id)
+        }
+        fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+            self.0.list_all_cards()
+        }
+        fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+            self.0.list_cards_by_column(column_id)
+        }
+        fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+            self.0.list_cards_by_sprint(sprint_id)
+        }
+        fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+            self.0.count_cards_in_column(column_id)
+        }
+        fn count_cards_in_column_excluding(
+            &self,
+            column_id: Uuid,
+            exclude: &[Uuid],
+        ) -> KanbanResult<usize> {
+            self.0.count_cards_in_column_excluding(column_id, exclude)
+        }
+        fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+            self.0.upsert_card(card)
+        }
+        fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+            self.0.delete_card(id)
+        }
+        fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+            self.0.delete_cards_by_columns(column_ids)
+        }
+        fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+            self.0.list_archived_cards()
+        }
+        fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+            self.0.list_archived_cards_by_board(board_id)
+        }
+        fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+            self.0.insert_archived_card(ac)
+        }
+        fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+            self.0.get_archived_card(card_id)
+        }
+        fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+            self.0.delete_archived_card(card_id)
+        }
+        fn get_archived_board(
+            &self,
+            board_id: Uuid,
+        ) -> KanbanResult<Option<kanban_domain::ArchivedBoard>> {
+            self.0.get_archived_board(board_id)
+        }
+        fn list_archived_boards(&self) -> KanbanResult<Vec<kanban_domain::ArchivedBoard>> {
+            self.0.list_archived_boards()
+        }
+        fn insert_archived_board(&self, ab: kanban_domain::ArchivedBoard) -> KanbanResult<()> {
+            self.0.insert_archived_board(ab)
+        }
+        fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.0.delete_archived_board(board_id)
+        }
+        fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+            self.0.get_sprint(id)
+        }
+        fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+            self.0.list_sprints_by_board(board_id)
+        }
+        fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+            self.0.list_all_sprints()
+        }
+        fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+            self.0.upsert_sprint(sprint)
+        }
+        fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+            self.0.delete_sprint(id)
+        }
+        fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.0.delete_sprints_by_board(board_id)
+        }
+        fn clear_sprint_from_cards(
+            &self,
+            sprint_id: Uuid,
+            timestamp: chrono::DateTime<chrono::Utc>,
+        ) -> KanbanResult<()> {
+            self.0.clear_sprint_from_cards(sprint_id, timestamp)
+        }
+        fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+            self.0.get_graph()
+        }
+        fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+            self.0.set_graph(graph)
+        }
+    }
+
+    struct Seeded {
+        live_board: Uuid,
+        live_column: Uuid,
+        blocker: Uuid,
+        blocked: Uuid,
+        archived_card: Uuid,
+        live_sprint: Uuid,
+        archived_board: Uuid,
+        archived_board_column: Uuid,
+        archived_board_card: Uuid,
+        archived_board_sprint: Uuid,
+    }
+
+    /// A live board with a column, two linked cards, a sprint and an archived
+    /// card, PLUS a separately archived board carrying its own whole subtree.
+    fn seed(store: &InMemoryStore) -> KanbanResult<Seeded> {
+        let mut live = Board::new("Live", None::<String>);
+        let live_column = Column::new(live.id, "Todo", 0);
+        let blocker = Card::new(&mut live, live_column.id, "Blocker", 0);
+        let blocked = Card::new(&mut live, live_column.id, "Blocked", 1);
+        let archived_card = Card::new(&mut live, live_column.id, "Archived card", 2);
+        let live_sprint = Sprint::new(live.id, 1, None, None::<String>);
+
+        let mut arch = Board::new("Archived board", None::<String>);
+        let arch_column = Column::new(arch.id, "Done", 0);
+        let arch_card = Card::new(&mut arch, arch_column.id, "Card on archived board", 0);
+        let arch_sprint = Sprint::new(arch.id, 1, None, None::<String>);
+
+        let ids = Seeded {
+            live_board: live.id,
+            live_column: live_column.id,
+            blocker: blocker.id,
+            blocked: blocked.id,
+            archived_card: archived_card.id,
+            live_sprint: live_sprint.id,
+            archived_board: arch.id,
+            archived_board_column: arch_column.id,
+            archived_board_card: arch_card.id,
+            archived_board_sprint: arch_sprint.id,
+        };
+
+        store.upsert_board(live)?;
+        store.upsert_column(live_column)?;
+        store.upsert_card(blocker)?;
+        store.upsert_card(blocked)?;
+        store.upsert_card(archived_card)?;
+        store.upsert_sprint(live_sprint)?;
+        store.insert_archived_card(ArchivedCard::new(ids.archived_card, ids.live_board))?;
+
+        store.upsert_board(arch)?;
+        store.upsert_column(arch_column)?;
+        store.upsert_card(arch_card)?;
+        store.upsert_sprint(arch_sprint)?;
+        store.insert_archived_board(Archived::now(ids.archived_board))?;
+
+        store.modify_graph(Box::new({
+            let (a, b) = (ids.blocker, ids.blocked);
+            move |g| g.set_block(a, b)
+        }))?;
+
+        Ok(ids)
+    }
+
+    #[test]
+    fn test_read_full_snapshot_includes_archived_board_subtree() -> KanbanResult<()> {
+        let inner = InMemoryStore::new();
+        let ids = seed(&inner)?;
+        let store = NoWholeStoreReads(inner);
+
+        let snap = read_full_snapshot(&store)?;
+
+        assert!(
+            snap.boards.iter().any(|b| b.id == ids.archived_board),
+            "an archived board is absent from list_boards, so its head must be \
+             recovered through the unfiltered get_board; missing this silently \
+             drops the whole subtree"
+        );
+        assert!(
+            snap.columns
+                .iter()
+                .any(|c| c.id == ids.archived_board_column),
+            "the archived board's column must survive"
+        );
+        assert!(
+            snap.cards.iter().any(|c| c.id == ids.archived_board_card),
+            "the archived board's card must survive"
+        );
+        assert!(
+            snap.sprints
+                .iter()
+                .any(|s| s.id == ids.archived_board_sprint),
+            "the archived board's sprint must survive"
+        );
+        assert!(
+            snap.archived_boards
+                .iter()
+                .any(|ab| ab.entity_id == ids.archived_board),
+            "the archival marker itself must survive"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_full_snapshot_carries_archived_cards_and_their_live_rows() -> KanbanResult<()> {
+        let inner = InMemoryStore::new();
+        let ids = seed(&inner)?;
+        let store = NoWholeStoreReads(inner);
+
+        let snap = read_full_snapshot(&store)?;
+
+        assert!(
+            snap.archived_cards
+                .iter()
+                .any(|ac| ac.entity_id == ids.archived_card),
+            "the archived-card marker must survive"
+        );
+        assert!(
+            snap.cards.iter().any(|c| c.id == ids.archived_card),
+            "list_all_cards is live-only under the marker model, so the archived \
+             card's row must be fetched by id or the marker lands orphaned"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_full_snapshot_carries_the_live_graph() -> KanbanResult<()> {
+        let inner = InMemoryStore::new();
+        let ids = seed(&inner)?;
+        let store = NoWholeStoreReads(inner);
+
+        let snap = read_full_snapshot(&store)?;
+
+        assert_eq!(
+            snap.graph.blockers(ids.blocked),
+            vec![ids.blocker],
+            "the dependency edge lives in the workspace-global graph and must be \
+             carried across"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_full_snapshot_restores_the_whole_graph() -> KanbanResult<()> {
+        let source = InMemoryStore::new();
+        let ids = seed(&source)?;
+        let snap = read_full_snapshot(&NoWholeStoreReads(source))?;
+
+        let dest_inner = InMemoryStore::new();
+        let dest = NoWholeStoreReads(dest_inner);
+        write_full_snapshot(&dest, snap)?;
+
+        assert!(dest.get_board(ids.live_board)?.is_some(), "live board");
+        assert!(
+            dest.get_board(ids.archived_board)?.is_some(),
+            "archived board head"
+        );
+        assert!(dest.get_column(ids.live_column)?.is_some(), "live column");
+        assert!(
+            dest.get_column(ids.archived_board_column)?.is_some(),
+            "archived board's column"
+        );
+        assert!(dest.get_card(ids.blocker)?.is_some(), "blocker card");
+        assert!(dest.get_card(ids.blocked)?.is_some(), "blocked card");
+        assert!(
+            dest.get_card(ids.archived_card)?.is_some(),
+            "archived card's live row"
+        );
+        assert!(
+            dest.get_card(ids.archived_board_card)?.is_some(),
+            "archived board's card"
+        );
+        assert!(dest.get_sprint(ids.live_sprint)?.is_some(), "live sprint");
+        assert!(
+            dest.get_sprint(ids.archived_board_sprint)?.is_some(),
+            "archived board's sprint"
+        );
+        assert!(
+            dest.get_archived_card(ids.archived_card)?.is_some(),
+            "archived-card marker"
+        );
+        assert!(
+            dest.get_archived_board(ids.archived_board)?.is_some(),
+            "archived-board marker"
+        );
+        assert_eq!(
+            dest.get_graph()?.blockers(ids.blocked),
+            vec![ids.blocker],
+            "dependency edge"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_then_write_then_read_is_the_identity() -> KanbanResult<()> {
+        let source = InMemoryStore::new();
+        seed(&source)?;
+        let first = read_full_snapshot(&NoWholeStoreReads(source))?;
+
+        let dest = NoWholeStoreReads(InMemoryStore::new());
+        write_full_snapshot(&dest, first.clone())?;
+        let second = read_full_snapshot(&dest)?;
+
+        // Compared as sorted id sets: neither read nor write promises an ordering,
+        // so a Vec comparison would fail on a permutation that loses nothing.
+        fn ids<T, F: Fn(&T) -> Uuid>(v: &[T], f: F) -> Vec<Uuid> {
+            let mut out: Vec<Uuid> = v.iter().map(f).collect();
+            out.sort();
+            out
+        }
+
+        assert_eq!(ids(&first.boards, |b| b.id), ids(&second.boards, |b| b.id));
+        assert_eq!(
+            ids(&first.columns, |c| c.id),
+            ids(&second.columns, |c| c.id)
+        );
+        assert_eq!(ids(&first.cards, |c| c.id), ids(&second.cards, |c| c.id));
+        assert_eq!(
+            ids(&first.sprints, |s| s.id),
+            ids(&second.sprints, |s| s.id)
+        );
+        assert_eq!(
+            ids(&first.archived_cards, |a| a.entity_id),
+            ids(&second.archived_cards, |a| a.entity_id)
+        );
+        assert_eq!(
+            ids(&first.archived_boards, |a| a.entity_id),
+            ids(&second.archived_boards, |a| a.entity_id)
+        );
+        assert_eq!(
+            first.graph, second.graph,
+            "the dependency graph must survive"
+        );
+        Ok(())
+    }
+}

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -65,6 +65,11 @@ pub(crate) fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot
 
 /// Writes a whole workspace through per-entity `DataStore` calls rather than
 /// `DataStore::apply_snapshot`. The caller supplies the transaction.
+///
+/// Order is load-bearing on a relational backend, which checks foreign keys as
+/// each row lands: sprints precede cards because `cards.sprint_id` references
+/// them, and both follow boards. Archival markers reference the rows they mark,
+/// so they come last.
 pub(crate) fn write_full_snapshot(store: &dyn DataStore, snapshot: Snapshot) -> KanbanResult<()> {
     for board in snapshot.boards {
         store.upsert_board(board)?;
@@ -72,11 +77,11 @@ pub(crate) fn write_full_snapshot(store: &dyn DataStore, snapshot: Snapshot) -> 
     for column in snapshot.columns {
         store.upsert_column(column)?;
     }
-    for card in snapshot.cards {
-        store.upsert_card(card)?;
-    }
     for sprint in snapshot.sprints {
         store.upsert_sprint(sprint)?;
+    }
+    for card in snapshot.cards {
+        store.upsert_card(card)?;
     }
     for ac in snapshot.archived_cards {
         store.insert_archived_card(ac)?;

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -270,8 +270,9 @@ impl StoreManager {
         );
 
         // SQLite -> SQLite never touches JSON: atomic reads feed transactional
-        // writes directly. FK ordering is not a correctness concern here because
-        // the write runs inside one transaction with deferred foreign keys.
+        // writes directly. Foreign keys are checked as each row lands, so
+        // write_full_snapshot's ordering carries the correctness here, not the
+        // transaction.
         if !leg.round_trips_through_json() {
             #[cfg(feature = "sqlite")]
             {
@@ -345,8 +346,13 @@ impl StoreManager {
         snapshot
     }
 
-    /// Writes a whole workspace into a fresh SQLite destination inside one
-    /// transaction, cleaning up the partial file if anything fails.
+    /// Writes a whole workspace into a SQLite destination inside one
+    /// transaction, cleaning up on failure.
+    ///
+    /// Cleanup only removes a file this call brought into existence. `migrate_store`
+    /// rejects an existing destination up front, so its behaviour is unchanged;
+    /// `export_to_sqlite` has no such guard, and deleting a database the caller
+    /// already had would turn a failed export into data loss.
     ///
     /// `close()` runs before the cleanup because Windows refuses to unlink a
     /// file that still has live handles.
@@ -358,6 +364,8 @@ impl StoreManager {
     ) -> Result<(), KanbanError> {
         use kanban_backend::KanbanBackend;
 
+        let created_here = !std::path::Path::new(to_path).exists();
+
         let backend = kanban_persistence_sqlite::SqliteBackend::open(to_path).await?;
         let outcome = backend.with_transaction(Box::new(|| {
             crate::store_adapter::write_full_snapshot(backend.as_data_store(), snapshot)
@@ -365,7 +373,9 @@ impl StoreManager {
         backend.close().await;
         drop(backend);
         if let Err(e) = outcome {
-            cleanup_destination_files(to_path).await;
+            if created_here {
+                cleanup_destination_files(to_path).await;
+            }
             return Err(e);
         }
         Ok(())
@@ -435,8 +445,9 @@ impl MigrationLeg {
     }
 
     /// Whether this leg serialises through JSON bytes. Only `SqliteToSqlite`
-    /// does not, and that is the leg FK repair therefore cannot run on — the
-    /// transaction's deferred foreign keys cover it instead.
+    /// does not, and that is therefore the one leg FK repair cannot run on. It
+    /// does not need it: its source is a relational database that already
+    /// enforced those keys on the way in.
     pub(crate) fn round_trips_through_json(self) -> bool {
         !matches!(self, Self::SqliteToSqlite)
     }

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -192,7 +192,7 @@ impl StoreManager {
         Ok(())
     }
 
-    /// Exports a board selection to a new SQLite file via `SqliteStore`.
+    /// Exports a board selection to a new SQLite file.
     ///
     /// **Note:** The dependency graph is not part of the `AllBoardsExport` format
     /// and will not be present in the exported file.
@@ -216,9 +216,7 @@ impl StoreManager {
                 sprints: entities.sprints,
                 graph: DependencyGraph::default(),
             };
-            let store = kanban_persistence_sqlite::SqliteStore::open(filename).await?;
-            store.apply_snapshot(snapshot)?;
-            Ok(())
+            self.write_sqlite_destination(filename, snapshot).await
         }
         #[cfg(not(feature = "sqlite"))]
         {
@@ -261,69 +259,114 @@ impl StoreManager {
             .into());
         }
 
-        // Load snapshot from source into a StoreSnapshot (JSON bytes) for FK repair.
-        let mut store_snapshot: StoreSnapshot = match from_backend {
-            "sqlite" | "sqlite3" | "db" => {
-                #[cfg(feature = "sqlite")]
-                {
-                    use kanban_persistence::PersistenceMetadata;
-                    // KAN-845: opening a SQLite source below SUPPORTED_SCHEMA_VERSION
-                    // runs the same in-place schema upgrade (+ durable
-                    // `.v{N}.backup` snapshot) that any other kanban binary
-                    // would run against this file. That's intentional, not a
-                    // migrate_store-specific side effect: reading a
-                    // schema-current snapshot below requires the upgrade to
-                    // have already run, and the source file gets exactly the
-                    // same treatment `SqliteStore::open` gives it anywhere
-                    // else it's opened directly.
-                    let store = kanban_persistence_sqlite::SqliteStore::open(from_path).await?;
-                    let snapshot = store.snapshot()?;
-                    let data = kanban_persistence::snapshot_to_json_bytes(&snapshot)?;
-                    StoreSnapshot {
-                        data,
-                        metadata: PersistenceMetadata::new(uuid::Uuid::new_v4()),
-                    }
+        let leg = MigrationLeg::of(from_backend, to_backend);
+        let source_is_sqlite = matches!(
+            leg,
+            MigrationLeg::SqliteToSqlite | MigrationLeg::SqliteToJson
+        );
+        let dest_is_sqlite = matches!(
+            leg,
+            MigrationLeg::SqliteToSqlite | MigrationLeg::JsonToSqlite
+        );
+
+        // SQLite -> SQLite never touches JSON: atomic reads feed transactional
+        // writes directly. FK ordering is not a correctness concern here because
+        // the write runs inside one transaction with deferred foreign keys.
+        if !leg.round_trips_through_json() {
+            #[cfg(feature = "sqlite")]
+            {
+                let snapshot = self.read_sqlite_source(from_path).await?;
+                return self.write_sqlite_destination(to_path, snapshot).await;
+            }
+            #[cfg(not(feature = "sqlite"))]
+            return Err(KanbanError::validation("sqlite feature not compiled in"));
+        }
+
+        // Every other leg has JSON on one end, so a StoreSnapshot exists and FK
+        // repair applies to it.
+        let mut store_snapshot: StoreSnapshot = if source_is_sqlite {
+            #[cfg(feature = "sqlite")]
+            {
+                use kanban_persistence::PersistenceMetadata;
+                let snapshot = self.read_sqlite_source(from_path).await?;
+                StoreSnapshot {
+                    data: kanban_persistence::snapshot_to_json_bytes(&snapshot)?,
+                    metadata: PersistenceMetadata::new(uuid::Uuid::new_v4()),
                 }
-                #[cfg(not(feature = "sqlite"))]
-                return Err(KanbanError::validation("sqlite feature not compiled in"));
             }
-            _ => {
-                let source = self.make_store(from_backend, from_path)?;
-                let (snap, _) = source.load().await?;
-                snap
-            }
+            #[cfg(not(feature = "sqlite"))]
+            return Err(KanbanError::validation("sqlite feature not compiled in"));
+        } else {
+            let source = self.make_store(from_backend, from_path)?;
+            let (snap, _) = source.load().await?;
+            snap
         };
 
         repair_snapshot_fks(&mut store_snapshot)?;
 
-        // Save to destination
-        match to_backend {
-            "sqlite" | "sqlite3" | "db" => {
-                #[cfg(feature = "sqlite")]
-                {
-                    let repaired = snapshot_from_json_bytes(&store_snapshot.data)?;
-                    let store = kanban_persistence_sqlite::SqliteStore::open(to_path).await?;
-                    let outcome = store.apply_snapshot(repaired.clone());
-                    store.close().await;
-                    drop(store);
-                    if let Err(e) = outcome {
-                        cleanup_destination_files(to_path).await;
-                        return Err(e);
-                    }
-                }
-                #[cfg(not(feature = "sqlite"))]
-                return Err(KanbanError::validation("sqlite feature not compiled in"));
+        if dest_is_sqlite {
+            #[cfg(feature = "sqlite")]
+            {
+                let repaired = snapshot_from_json_bytes(&store_snapshot.data)?;
+                return self.write_sqlite_destination(to_path, repaired).await;
             }
-            _ => {
-                let target = self.make_store(to_backend, to_path)?;
-                let outcome = target.save(store_snapshot).await;
-                target.close().await;
-                drop(target);
-                if let Err(e) = outcome {
-                    cleanup_destination_files(to_path).await;
-                    return Err(e.into());
-                }
-            }
+            #[cfg(not(feature = "sqlite"))]
+            return Err(KanbanError::validation("sqlite feature not compiled in"));
+        }
+
+        let target = self.make_store(to_backend, to_path)?;
+        let outcome = target.save(store_snapshot).await;
+        target.close().await;
+        drop(target);
+        if let Err(e) = outcome {
+            cleanup_destination_files(to_path).await;
+            return Err(e.into());
+        }
+        Ok(())
+    }
+
+    /// Reads a SQLite source into a `Snapshot` through per-entity `DataStore`
+    /// calls.
+    ///
+    /// Opening a source below `SUPPORTED_SCHEMA_VERSION` runs the same in-place
+    /// schema upgrade (and durable `.v{N}.backup`) that any kanban binary runs
+    /// against that file — reading a schema-current workspace requires it.
+    #[cfg(feature = "sqlite")]
+    async fn read_sqlite_source(
+        &self,
+        from_path: &str,
+    ) -> Result<kanban_domain::Snapshot, KanbanError> {
+        use kanban_backend::KanbanBackend;
+
+        let backend = kanban_persistence_sqlite::SqliteBackend::open(from_path).await?;
+        let snapshot = crate::store_adapter::read_full_snapshot(backend.as_data_store());
+        backend.close().await;
+        drop(backend);
+        snapshot
+    }
+
+    /// Writes a whole workspace into a fresh SQLite destination inside one
+    /// transaction, cleaning up the partial file if anything fails.
+    ///
+    /// `close()` runs before the cleanup because Windows refuses to unlink a
+    /// file that still has live handles.
+    #[cfg(feature = "sqlite")]
+    async fn write_sqlite_destination(
+        &self,
+        to_path: &str,
+        snapshot: kanban_domain::Snapshot,
+    ) -> Result<(), KanbanError> {
+        use kanban_backend::KanbanBackend;
+
+        let backend = kanban_persistence_sqlite::SqliteBackend::open(to_path).await?;
+        let outcome = backend.with_transaction(Box::new(|| {
+            crate::store_adapter::write_full_snapshot(backend.as_data_store(), snapshot)
+        }));
+        backend.close().await;
+        drop(backend);
+        if let Err(e) = outcome {
+            cleanup_destination_files(to_path).await;
+            return Err(e);
         }
         Ok(())
     }
@@ -364,6 +407,41 @@ async fn remove_file_with_windows_retry(path: &std::path::Path) {
 /// The sidecars are named `<path>-wal` and `<path>-shm` regardless of the
 /// main file's extension, so they're constructed by appending to the raw
 /// path string rather than via `Path::with_extension`.
+fn is_sqlite_backend(name: &str) -> bool {
+    matches!(name, "sqlite" | "sqlite3" | "db")
+}
+
+/// Which of the four source/destination combinations a migration takes.
+/// `SqliteToSqlite` is the one leg that carries no JSON at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MigrationLeg {
+    SqliteToSqlite,
+    SqliteToJson,
+    JsonToSqlite,
+    JsonToJson,
+}
+
+impl MigrationLeg {
+    pub(crate) fn of(from_backend: &str, to_backend: &str) -> Self {
+        match (
+            is_sqlite_backend(from_backend),
+            is_sqlite_backend(to_backend),
+        ) {
+            (true, true) => Self::SqliteToSqlite,
+            (true, false) => Self::SqliteToJson,
+            (false, true) => Self::JsonToSqlite,
+            (false, false) => Self::JsonToJson,
+        }
+    }
+
+    /// Whether this leg serialises through JSON bytes. Only `SqliteToSqlite`
+    /// does not, and that is the leg FK repair therefore cannot run on — the
+    /// transaction's deferred foreign keys cover it instead.
+    pub(crate) fn round_trips_through_json(self) -> bool {
+        !matches!(self, Self::SqliteToSqlite)
+    }
+}
+
 async fn cleanup_destination_files(to_path: &str) {
     remove_file_with_windows_retry(std::path::Path::new(to_path)).await;
     let wal = format!("{}-wal", to_path);
@@ -508,6 +586,39 @@ mod tests {
     use kanban_persistence::{PersistenceMetadata, StoreRegistry};
     use tempfile::tempdir;
     use uuid::Uuid;
+
+    #[test]
+    fn test_sqlite_to_sqlite_leg_does_not_round_trip_through_json() {
+        // The whole point of the adapter: a SQLite-to-SQLite move reads
+        // atomically straight into transactional writes, with no intermediate
+        // serialisation. Asserted on the routing decision so it cannot regress
+        // into a JSON round trip unnoticed.
+        for (from, to) in [("sqlite", "sqlite"), ("sqlite3", "db"), ("db", "sqlite3")] {
+            let leg = MigrationLeg::of(from, to);
+            assert_eq!(leg, MigrationLeg::SqliteToSqlite, "{from} -> {to}");
+            assert!(
+                !leg.round_trips_through_json(),
+                "{from} -> {to} must not serialise through JSON"
+            );
+        }
+    }
+
+    #[test]
+    fn test_every_leg_with_json_on_one_end_round_trips_through_json() {
+        // FK repair operates on JSON bytes, so it can only run where they exist.
+        for (from, to, expected) in [
+            ("sqlite", "json", MigrationLeg::SqliteToJson),
+            ("json", "sqlite", MigrationLeg::JsonToSqlite),
+            ("json", "json", MigrationLeg::JsonToJson),
+        ] {
+            let leg = MigrationLeg::of(from, to);
+            assert_eq!(leg, expected, "{from} -> {to}");
+            assert!(
+                leg.round_trips_through_json(),
+                "{from} -> {to} carries a StoreSnapshot, so FK repair applies"
+            );
+        }
+    }
 
     fn make_snapshot_with_json(data: serde_json::Value) -> StoreSnapshot {
         StoreSnapshot {

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -206,6 +206,21 @@ impl StoreManager {
             use kanban_domain::export::BoardImporter;
             use kanban_domain::{DependencyGraph, Snapshot};
 
+            // Mirrors migrate_store. The path this replaced wiped the
+            // destination's tables before inserting, so exporting onto an
+            // existing database silently replaced it; writing per entity would
+            // instead merge the export on top of whatever was there. Refusing
+            // an existing file makes the caller choose rather than either.
+            if std::path::Path::new(filename).exists() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!(
+                        "Destination already exists: {filename}. Remove it first or use a different path."
+                    ),
+                )
+                .into());
+            }
+
             let entities = BoardImporter::extract_entities(export);
             let snapshot = Snapshot {
                 archived_boards: entities.archived_boards,

--- a/crates/kanban-service/tests/export_to_sqlite_tests.rs
+++ b/crates/kanban-service/tests/export_to_sqlite_tests.rs
@@ -166,12 +166,13 @@ async fn test_export_to_sqlite_preserves_full_archival_graph() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_failed_export_does_not_delete_a_pre_existing_database() {
-    // export_to_sqlite has no "destination must not exist" guard, unlike
-    // migrate_store. A failure must therefore never remove a database the
-    // caller already had.
+async fn test_export_to_sqlite_rejects_an_existing_destination() {
+    // The path this replaced wiped the destination's tables before inserting,
+    // so an export onto an existing database silently replaced it. Writing per
+    // entity would merge instead, leaving unrelated boards behind. Refusing the
+    // write keeps the caller's data intact and makes them choose.
     use kanban_domain::export::BoardExporter;
-    use kanban_domain::{Board, Card, Column, Sprint};
+    use kanban_domain::{Board, Column};
 
     let dir = tempfile::tempdir().unwrap();
     let target = dir
@@ -186,42 +187,30 @@ async fn test_failed_export_does_not_delete_a_pre_existing_database() {
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     let sm = StoreManager::new(stores, backends);
 
-    // Pre-existing database with real content.
     let mut config = AppConfig::default();
     sm.sync_backend_with_file(&target, &mut config);
     let existing = sm.make_backend(&target, &config).await.unwrap();
-    let keep = Board::new("Do not lose me", None::<String>);
+    let keep = Board::new("Already here", None::<String>);
     let keep_id = keep.id;
     existing.upsert_board(keep).unwrap();
     drop(existing);
 
-    // An export whose card points at a sprint the export does not carry: the
-    // cards.sprint_id foreign key rejects it, so the write fails.
-    let mut board = Board::new("Export", None::<String>);
+    let board = Board::new("Exported", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let mut card = Card::new(&mut board, column.id, "Card", 0);
-    card.sprint_id = Some(Sprint::new(board.id, 9, None, None::<String>).id);
-    let export = BoardExporter::export_all_boards(
-        &[board],
-        &[column],
-        &[card],
-        &[],
-        &[],
-        &[], // sprint deliberately absent
-    );
-    let result = sm.export_to_sqlite(export, &target).await;
+    let export = BoardExporter::export_all_boards(&[board], &[column], &[], &[], &[], &[]);
+
+    let err = sm
+        .export_to_sqlite(export, &target)
+        .await
+        .expect_err("exporting onto an existing database must be refused");
     assert!(
-        result.is_err(),
-        "the dangling sprint reference must be rejected"
+        err.to_string().contains("already exists"),
+        "the error must say why (got: {err})"
     );
 
-    assert!(
-        std::path::Path::new(&target).exists(),
-        "a failed export must not delete a database the caller already had"
-    );
     let reopened = sm.make_backend(&target, &config).await.unwrap();
     assert!(
         reopened.get_board(keep_id).unwrap().is_some(),
-        "the pre-existing board must still be there"
+        "the caller's existing data must be untouched"
     );
 }

--- a/crates/kanban-service/tests/export_to_sqlite_tests.rs
+++ b/crates/kanban-service/tests/export_to_sqlite_tests.rs
@@ -164,3 +164,64 @@ async fn test_export_to_sqlite_preserves_full_archival_graph() {
         "archived-board marker"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_failed_export_does_not_delete_a_pre_existing_database() {
+    // export_to_sqlite has no "destination must not exist" guard, unlike
+    // migrate_store. A failure must therefore never remove a database the
+    // caller already had.
+    use kanban_domain::export::BoardExporter;
+    use kanban_domain::{Board, Card, Column, Sprint};
+
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir
+        .path()
+        .join("existing.sqlite")
+        .to_string_lossy()
+        .to_string();
+
+    let mut stores = StoreRegistry::new();
+    let mut backends = kanban_backend::KanbanBackendRegistry::new();
+    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
+    backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+    let sm = StoreManager::new(stores, backends);
+
+    // Pre-existing database with real content.
+    let mut config = AppConfig::default();
+    sm.sync_backend_with_file(&target, &mut config);
+    let existing = sm.make_backend(&target, &config).await.unwrap();
+    let keep = Board::new("Do not lose me", None::<String>);
+    let keep_id = keep.id;
+    existing.upsert_board(keep).unwrap();
+    drop(existing);
+
+    // An export whose card points at a sprint the export does not carry: the
+    // cards.sprint_id foreign key rejects it, so the write fails.
+    let mut board = Board::new("Export", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let mut card = Card::new(&mut board, column.id, "Card", 0);
+    card.sprint_id = Some(Sprint::new(board.id, 9, None, None::<String>).id);
+    let export = BoardExporter::export_all_boards(
+        &[board],
+        &[column],
+        &[card],
+        &[],
+        &[],
+        &[], // sprint deliberately absent
+    );
+    let result = sm.export_to_sqlite(export, &target).await;
+    assert!(
+        result.is_err(),
+        "the dangling sprint reference must be rejected"
+    );
+
+    assert!(
+        std::path::Path::new(&target).exists(),
+        "a failed export must not delete a database the caller already had"
+    );
+    let reopened = sm.make_backend(&target, &config).await.unwrap();
+    assert!(
+        reopened.get_board(keep_id).unwrap().is_some(),
+        "the pre-existing board must still be there"
+    );
+}

--- a/crates/kanban-service/tests/export_to_sqlite_tests.rs
+++ b/crates/kanban-service/tests/export_to_sqlite_tests.rs
@@ -57,3 +57,110 @@ async fn test_export_to_sqlite_result_is_readable_via_open_sqlite() {
         .expect("open_context must succeed on exported file");
     assert_eq!(ctx.boards().unwrap().len(), 0);
 }
+
+// ─── KAN-1105: export writes through the store adapter ───────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_to_sqlite_preserves_full_archival_graph() {
+    use kanban_domain::export::BoardExporter;
+    use kanban_domain::{Archived, ArchivedCard, Board, Card, Column, Sprint};
+
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("source.json").to_string_lossy().to_string();
+
+    let mut stores = StoreRegistry::new();
+    let mut backends = kanban_backend::KanbanBackendRegistry::new();
+    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
+    backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+    stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+    backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+    let sm = StoreManager::new(stores, backends);
+
+    let mut config = AppConfig::default();
+    sm.sync_backend_with_file(&source, &mut config);
+    let src = sm.make_backend(&source, &config).await.unwrap();
+
+    // A live board with a column, cards, a sprint and an archived card, plus a
+    // separately archived board carrying its own subtree.
+    let mut live = Board::new("Live", None::<String>);
+    let live_col = Column::new(live.id, "Todo", 0);
+    let card = Card::new(&mut live, live_col.id, "Card", 0);
+    let archived_card = Card::new(&mut live, live_col.id, "Archived", 1);
+    let sprint = Sprint::new(live.id, 1, None, None::<String>);
+    let mut arch = Board::new("Archived board", None::<String>);
+    let arch_col = Column::new(arch.id, "Done", 0);
+    let arch_card = Card::new(&mut arch, arch_col.id, "On archived board", 0);
+
+    let (live_id, live_col_id, card_id, archived_card_id, sprint_id) =
+        (live.id, live_col.id, card.id, archived_card.id, sprint.id);
+    let (arch_id, arch_col_id, arch_card_id) = (arch.id, arch_col.id, arch_card.id);
+
+    src.upsert_board(live).unwrap();
+    src.upsert_column(live_col).unwrap();
+    src.upsert_card(card).unwrap();
+    src.upsert_card(archived_card).unwrap();
+    src.upsert_sprint(sprint).unwrap();
+    src.insert_archived_card(ArchivedCard::new(archived_card_id, live_id))
+        .unwrap();
+    src.upsert_board(arch).unwrap();
+    src.upsert_column(arch_col).unwrap();
+    src.upsert_card(arch_card).unwrap();
+    src.insert_archived_board(Archived::now(arch_id)).unwrap();
+
+    let export = BoardExporter::export_all_boards(
+        &[
+            src.get_board(live_id).unwrap().unwrap(),
+            src.get_board(arch_id).unwrap().unwrap(),
+        ],
+        &src.list_all_columns().unwrap(),
+        &[
+            src.get_card(card_id).unwrap().unwrap(),
+            src.get_card(archived_card_id).unwrap().unwrap(),
+            src.get_card(arch_card_id).unwrap().unwrap(),
+        ],
+        &src.list_archived_cards().unwrap(),
+        &src.list_archived_boards().unwrap(),
+        &src.list_all_sprints().unwrap(),
+    );
+
+    let output = dir.path().join("out.sqlite").to_string_lossy().to_string();
+    sm.export_to_sqlite(export, &output)
+        .await
+        .expect("export must succeed");
+
+    let mut out_config = AppConfig::default();
+    sm.sync_backend_with_file(&output, &mut out_config);
+    let dest = sm.make_backend(&output, &out_config).await.unwrap();
+
+    assert!(dest.get_board(live_id).unwrap().is_some(), "live board");
+    assert!(
+        dest.get_board(arch_id).unwrap().is_some(),
+        "archived board head"
+    );
+    assert!(
+        dest.get_column(live_col_id).unwrap().is_some(),
+        "live column"
+    );
+    assert!(
+        dest.get_column(arch_col_id).unwrap().is_some(),
+        "archived board's column"
+    );
+    assert!(dest.get_card(card_id).unwrap().is_some(), "live card");
+    assert!(
+        dest.get_card(archived_card_id).unwrap().is_some(),
+        "archived card's live row"
+    );
+    assert!(
+        dest.get_card(arch_card_id).unwrap().is_some(),
+        "archived board's card"
+    );
+    assert!(dest.get_sprint(sprint_id).unwrap().is_some(), "sprint");
+    assert!(
+        dest.get_archived_card(archived_card_id).unwrap().is_some(),
+        "archived-card marker"
+    );
+    assert!(
+        dest.get_archived_board(arch_id).unwrap().is_some(),
+        "archived-board marker"
+    );
+}

--- a/crates/kanban-service/tests/migrate.rs
+++ b/crates/kanban-service/tests/migrate.rs
@@ -559,3 +559,39 @@ async fn test_migrate_json_to_sqlite_writes_in_one_transaction() {
         );
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_preserves_a_card_assigned_to_a_sprint() {
+    // cards.sprint_id carries a foreign key to sprints(id), so a card that
+    // belongs to a sprint constrains the order the destination is written in.
+    let dir = tempfile::tempdir().unwrap();
+    let from = dir.path().join("source.json");
+    let to = dir.path().join("target.sqlite");
+    let (from, to) = (from.to_str().unwrap(), to.to_str().unwrap());
+
+    let backend = open_backend(from).await;
+    let mut board = Board::new("B", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+    let mut card = Card::new(&mut board, column.id, "In a sprint", 0);
+    card.sprint_id = Some(sprint.id);
+    let (card_id, sprint_id) = (card.id, sprint.id);
+
+    backend.upsert_board(board).unwrap();
+    backend.upsert_column(column).unwrap();
+    backend.upsert_sprint(sprint).unwrap();
+    backend.upsert_card(card).unwrap();
+    backend.flush().await.unwrap();
+
+    full_manager()
+        .migrate_store("json", from, "sqlite", to)
+        .await
+        .expect("a card assigned to a sprint must migrate");
+
+    let dest = open_backend(to).await;
+    assert_eq!(
+        dest.get_card(card_id).unwrap().unwrap().sprint_id,
+        Some(sprint_id),
+        "the card must still belong to its sprint"
+    );
+}

--- a/crates/kanban-service/tests/migrate.rs
+++ b/crates/kanban-service/tests/migrate.rs
@@ -595,3 +595,46 @@ async fn test_migrate_preserves_a_card_assigned_to_a_sprint() {
         "the card must still belong to its sprint"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_preserves_a_card_whose_column_is_gone() {
+    // cards carry no foreign key on column_id, so a card can outlive its column.
+    // The whole-store read this replaced was flat and returned such a row
+    // regardless; a read that walks boards -> columns -> cards can only reach a
+    // card through a column, and would drop it silently.
+    let dir = tempfile::tempdir().unwrap();
+    let from = dir.path().join("source.sqlite");
+    let to = dir.path().join("target.json");
+    let (from, to) = (from.to_str().unwrap(), to.to_str().unwrap());
+
+    let backend = open_backend(from).await;
+    let mut board = Board::new("B", None::<String>);
+    let survivor = Column::new(board.id, "Survivor", 0);
+    let doomed = Column::new(board.id, "Doomed", 1);
+    let card = Card::new(&mut board, doomed.id, "Outlives its column", 0);
+    let (doomed_id, card_id) = (doomed.id, card.id);
+
+    backend.upsert_board(board).unwrap();
+    backend.upsert_column(survivor).unwrap();
+    backend.upsert_column(doomed).unwrap();
+    backend.upsert_card(card).unwrap();
+    backend.delete_column(doomed_id).unwrap();
+    backend.flush().await.unwrap();
+
+    assert!(
+        backend.get_card(card_id).unwrap().is_some(),
+        "precondition: the card must still be in the source after its column went"
+    );
+
+    full_manager()
+        .migrate_store("sqlite", from, "json", to)
+        .await
+        .unwrap();
+
+    let dest = open_backend(to).await;
+    assert!(
+        dest.get_card(card_id).unwrap().is_some(),
+        "a card whose column was deleted must survive the migration; FK repair \
+         re-homes it, but only if the read carried it across at all"
+    );
+}

--- a/crates/kanban-service/tests/migrate.rs
+++ b/crates/kanban-service/tests/migrate.rs
@@ -291,3 +291,271 @@ async fn test_migrate_store_repairs_dangling_completion_column_id() {
         "a dangling completion id must be pruned so the SQLite FK accepts the import; live ids keep their order"
     );
 }
+
+// ─── KAN-1105: cross-format moves through the store adapter ──────────────────
+
+use kanban_backend::KanbanBackend;
+use kanban_domain::{Archived, ArchivedCard, Board, Card, Column, Sprint};
+use std::sync::Arc;
+use uuid::Uuid;
+
+fn full_manager() -> StoreManager {
+    let mut stores = StoreRegistry::new();
+    let mut backends = kanban_backend::KanbanBackendRegistry::new();
+    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
+    backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+    stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+    backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+    StoreManager::new(stores, backends)
+}
+
+async fn open_backend(locator: &str) -> Arc<dyn KanbanBackend> {
+    let mut config = AppConfig::default();
+    let sm = full_manager();
+    sm.sync_backend_with_file(locator, &mut config);
+    sm.make_backend(locator, &config).await.unwrap()
+}
+
+struct Graph {
+    live_board: Uuid,
+    live_column: Uuid,
+    blocker: Uuid,
+    blocked: Uuid,
+    archived_card: Uuid,
+    live_sprint: Uuid,
+    archived_board: Uuid,
+    archived_board_column: Uuid,
+    archived_board_card: Uuid,
+    archived_board_sprint: Uuid,
+}
+
+/// A live board with a column, two linked cards, a sprint and an archived card,
+/// PLUS a separately archived board carrying its own whole subtree. Anything
+/// less cannot catch a migration that drops archived subtrees.
+async fn seed_graph(locator: &str) -> Graph {
+    let backend = open_backend(locator).await;
+
+    let mut live = Board::new("Live", None::<String>);
+    let live_column = Column::new(live.id, "Todo", 0);
+    let blocker = Card::new(&mut live, live_column.id, "Blocker", 0);
+    let blocked = Card::new(&mut live, live_column.id, "Blocked", 1);
+    let archived_card = Card::new(&mut live, live_column.id, "Archived", 2);
+    let live_sprint = Sprint::new(live.id, 1, None, None::<String>);
+
+    let mut arch = Board::new("Archived board", None::<String>);
+    let arch_column = Column::new(arch.id, "Done", 0);
+    let arch_card = Card::new(&mut arch, arch_column.id, "On archived board", 0);
+    let arch_sprint = Sprint::new(arch.id, 1, None, None::<String>);
+
+    let g = Graph {
+        live_board: live.id,
+        live_column: live_column.id,
+        blocker: blocker.id,
+        blocked: blocked.id,
+        archived_card: archived_card.id,
+        live_sprint: live_sprint.id,
+        archived_board: arch.id,
+        archived_board_column: arch_column.id,
+        archived_board_card: arch_card.id,
+        archived_board_sprint: arch_sprint.id,
+    };
+
+    backend.upsert_board(live).unwrap();
+    backend.upsert_column(live_column).unwrap();
+    backend.upsert_card(blocker).unwrap();
+    backend.upsert_card(blocked).unwrap();
+    backend.upsert_card(archived_card).unwrap();
+    backend.upsert_sprint(live_sprint).unwrap();
+    backend
+        .insert_archived_card(ArchivedCard::new(g.archived_card, g.live_board))
+        .unwrap();
+
+    backend.upsert_board(arch).unwrap();
+    backend.upsert_column(arch_column).unwrap();
+    backend.upsert_card(arch_card).unwrap();
+    backend.upsert_sprint(arch_sprint).unwrap();
+    backend
+        .insert_archived_board(Archived::now(g.archived_board))
+        .unwrap();
+
+    backend
+        .modify_graph(Box::new({
+            let (a, b) = (g.blocker, g.blocked);
+            move |gr| gr.set_block(a, b)
+        }))
+        .unwrap();
+
+    backend.flush().await.unwrap();
+    g
+}
+
+/// Reloads `locator` from disk and asserts every seeded entity survived. Uses
+/// the unfiltered `get_card`, because an archived card is absent from the
+/// live-only listings under the marker model.
+async fn assert_graph_survived(locator: &str, g: &Graph, ctx: &str) {
+    let backend = open_backend(locator).await;
+
+    assert!(
+        backend.get_board(g.live_board).unwrap().is_some(),
+        "{ctx}: live board"
+    );
+    assert!(
+        backend.get_board(g.archived_board).unwrap().is_some(),
+        "{ctx}: archived board head — absent from list_boards, so a migration \
+         that reads only live boards drops this whole subtree"
+    );
+    assert!(
+        backend.get_column(g.live_column).unwrap().is_some(),
+        "{ctx}: live column"
+    );
+    assert!(
+        backend
+            .get_column(g.archived_board_column)
+            .unwrap()
+            .is_some(),
+        "{ctx}: archived board's column"
+    );
+    assert!(
+        backend.get_card(g.blocker).unwrap().is_some(),
+        "{ctx}: blocker card"
+    );
+    assert!(
+        backend.get_card(g.blocked).unwrap().is_some(),
+        "{ctx}: blocked card"
+    );
+    assert!(
+        backend.get_card(g.archived_card).unwrap().is_some(),
+        "{ctx}: archived card's live row"
+    );
+    assert!(
+        backend.get_card(g.archived_board_card).unwrap().is_some(),
+        "{ctx}: archived board's card"
+    );
+    assert!(
+        backend.get_sprint(g.live_sprint).unwrap().is_some(),
+        "{ctx}: live sprint"
+    );
+    assert!(
+        backend
+            .get_sprint(g.archived_board_sprint)
+            .unwrap()
+            .is_some(),
+        "{ctx}: archived board's sprint"
+    );
+    assert!(
+        backend
+            .get_archived_card(g.archived_card)
+            .unwrap()
+            .is_some(),
+        "{ctx}: archived-card marker"
+    );
+    assert!(
+        backend
+            .get_archived_board(g.archived_board)
+            .unwrap()
+            .is_some(),
+        "{ctx}: archived-board marker"
+    );
+    assert_eq!(
+        backend.get_graph().unwrap().blockers(g.blocked),
+        vec![g.blocker],
+        "{ctx}: dependency edge, which lives in the workspace-global graph"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_sqlite_to_json_preserves_full_archival_graph() {
+    let dir = tempfile::tempdir().unwrap();
+    let from = dir.path().join("source.sqlite");
+    let to = dir.path().join("target.json");
+    let (from, to) = (from.to_str().unwrap(), to.to_str().unwrap());
+
+    let g = seed_graph(from).await;
+    full_manager()
+        .migrate_store("sqlite", from, "json", to)
+        .await
+        .unwrap();
+
+    assert_graph_survived(to, &g, "sqlite -> json").await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_json_to_sqlite_preserves_full_archival_graph() {
+    let dir = tempfile::tempdir().unwrap();
+    let from = dir.path().join("source.json");
+    let to = dir.path().join("target.sqlite");
+    let (from, to) = (from.to_str().unwrap(), to.to_str().unwrap());
+
+    let g = seed_graph(from).await;
+    full_manager()
+        .migrate_store("json", from, "sqlite", to)
+        .await
+        .unwrap();
+
+    assert_graph_survived(to, &g, "json -> sqlite").await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_sqlite_to_sqlite_preserves_full_archival_graph() {
+    let dir = tempfile::tempdir().unwrap();
+    let from = dir.path().join("source.sqlite");
+    let to = dir.path().join("target.sqlite");
+    let (from, to) = (from.to_str().unwrap(), to.to_str().unwrap());
+
+    let g = seed_graph(from).await;
+    full_manager()
+        .migrate_store("sqlite", from, "sqlite", to)
+        .await
+        .unwrap();
+
+    // This leg reads atomically straight into transactional writes, with no
+    // JSON serialisation anywhere. The routing decision that guarantees that is
+    // asserted in store_manager's unit tests; this proves the data survives it.
+    assert_graph_survived(to, &g, "sqlite -> sqlite").await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_json_to_sqlite_writes_in_one_transaction() {
+    // A column whose board_id names no board is a foreign-key violation SQLite
+    // rejects, and FK repair does not rewrite column ownership, so the write
+    // fails partway. The destination must not survive half-written.
+    let dir = tempfile::tempdir().unwrap();
+    let good_board = Uuid::new_v4();
+    let from = write_json(
+        dir.path(),
+        "source.json",
+        serde_json::json!({
+            "boards": [{
+                "id": good_board, "name": "Live", "position": 0,
+                "created_at": now(), "updated_at": now()
+            }],
+            "columns": [
+                { "id": Uuid::new_v4(), "board_id": good_board, "name": "Todo",
+                  "position": 0, "created_at": now(), "updated_at": now() },
+                { "id": Uuid::new_v4(), "board_id": Uuid::new_v4(), "name": "Orphan",
+                  "position": 1, "created_at": now(), "updated_at": now() }
+            ],
+            "cards": [], "archived_cards": [], "sprints": [],
+            "graph": { "cards": { "edges": [] } }
+        }),
+    );
+    let to = dir.path().join("target.sqlite");
+    let to_str = to.to_str().unwrap();
+
+    let result = full_manager()
+        .migrate_store("json", &from, "sqlite", to_str)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a foreign-key violation partway through the write must surface"
+    );
+    if to.exists() {
+        let backend = open_backend(to_str).await;
+        assert!(
+            backend.list_boards().unwrap().is_empty(),
+            "the transaction must roll back entirely: the board written before \
+             the failing column must not survive"
+        );
+    }
+}


### PR DESCRIPTION
Closes KAN-1105. The keystone of the KAN-1065 epic ("Snapshot is a file format, not a backend operation"): this is the card that stops cross-format moves depending on whole-store snapshot operations.

## Why

Every move between storage formats round-tripped through a whole-store `Snapshot`, which is what keeps `snapshot_async`/`apply_snapshot_async` alive on the SQLite leg.

It also carried a plain inefficiency: **SQLite → SQLite serialised the entire source database to JSON bytes and parsed them straight back**, for no reason. No file, no user, nothing ever saw that JSON.

## What changed

`store_adapter` composes per-entity `DataStore` calls instead:

- `read_full_snapshot` — flat, per-collection reads
- `write_full_snapshot` — per-entity writes; the caller supplies the transaction

`migrate_store` becomes four explicit legs, and `export_to_sqlite` a thin caller:

| leg | how |
|---|---|
| SQLite → SQLite | atomic reads into transactional writes. **No JSON at all** |
| SQLite → JSON | atomic reads → `Snapshot` → JSON file |
| JSON → SQLite | JSON file → `Snapshot` → per-entity writes in ONE transaction |
| JSON → JSON | unchanged |

FK repair operates on JSON bytes, so it still runs on every leg with JSON at one end. SQLite → SQLite has none and does not need it: its source is a relational database that already enforced those keys on the way in.

`SqliteBackend` gains a `close()` delegate — its `db` field is private, and a destination cannot be cleaned up after a failure without closing the pool first, because Windows refuses to unlink files with live handles.

### Write order is load-bearing

The destination is written inside one transaction, but foreign keys are checked **as each row lands** — nothing defers them. (`PRAGMA defer_foreign_keys` belongs to the `apply_snapshot` path being replaced, not to KAN-1067's ambient transaction.) The order is therefore part of the contract:

```
boards → columns → sprints → cards → archived_cards → archived_boards → graph
```

Sprints precede cards because `cards.sprint_id` references `sprints(id)`; archival markers follow the rows they mark.

### Reads are flat, not hierarchical

`read_full_snapshot` reads each collection whole rather than walking boards → columns → cards. Cards carry **no** foreign key on `column_id` or `board_id`, so a card can outlive its column, and a hierarchical walk can only reach cards through a column. Two unions remain because those listings are live-scoped: archived board heads via the unfiltered `get_board`, and archived cards' rows via `get_card`.

## Making the invariant testable rather than inspectable

The card asks that "SQLite → SQLite performs no JSON serialisation" be asserted *in a test, not by inspection*. Absence is awkward to observe, so the routing decision is a `MigrationLeg` enum with `round_trips_through_json()` on it, and **production branches on the same predicate the tests assert**. The claim and the code path are one expression and cannot drift.

## Tests

The spike found the card's six named integration tests are not red — they pass against the old code too, because the behaviour they assert was already satisfied a layer down. The genuine Red is in the internal composition, so that is where it was written.

**Adapter unit tests** (verified failing against `todo!()` stubs first). These run against a `DataStore` wrapper that **panics** on `snapshot()`/`apply_snapshot()`, so an accidental whole-store fallback fails loudly rather than quietly producing a correct-looking result:

- `test_read_full_snapshot_includes_archived_board_subtree`
- `test_read_full_snapshot_carries_archived_cards_and_their_live_rows`
- `test_read_full_snapshot_carries_the_live_graph`
- `test_write_full_snapshot_restores_the_whole_graph`
- `test_read_then_write_then_read_is_the_identity`

**Routing**: `test_sqlite_to_sqlite_leg_does_not_round_trip_through_json`, `test_every_leg_with_json_on_one_end_round_trips_through_json`

**Integration**, closing a real gap — every pre-existing migration test started from a JSON file, so the two legs that read from a database had no coverage with real files, and those are exactly the legs this rewrites. The adapter's unit tests use an in-memory store, which has no foreign keys and no cascading deletes, so per the repo's testing rule it is necessary but never sufficient:

- `test_migrate_sqlite_to_json_preserves_full_archival_graph`
- `test_migrate_json_to_sqlite_preserves_full_archival_graph`
- `test_migrate_sqlite_to_sqlite_preserves_full_archival_graph`
- `test_migrate_json_to_sqlite_writes_in_one_transaction`
- `test_export_to_sqlite_preserves_full_archival_graph`
- `test_migrate_preserves_a_card_assigned_to_a_sprint` — from review
- `test_migrate_preserves_a_card_whose_column_is_gone` — from review
- `test_export_to_sqlite_rejects_an_existing_destination` — from review

Each archival test seeds a live board with a column, linked cards, a sprint and an archived card, PLUS a separately archived board with its own subtree, then reloads the destination from disk and asserts every entity and the dependency edge survived.

**`test_migrate_preserves_fk_repair_behaviour` was deliberately not added.** `test_migrate_store_repairs_dangling_sprint_id` already covers that behaviour on the same leg with the same shape; a second test under the card's name would only restate it.

## Four defects found in review, all fixed here

All four are one class, now recorded as **defect class 4 on KAN-1065**: replacing an implementation without auditing what the old one did that the new one does not. Two were data-destroying.

**1 — A card assigned to a sprint could not migrate at all.** `write_full_snapshot` wrote cards before sprints, violating `cards.sprint_id`'s foreign key: `FOREIGN KEY constraint failed (code: 787)`. That is the normal case in real use. Fixed in `d6d5c7f8`. An earlier revision of this description claimed the write ran with deferred foreign keys; it does not, and that mistaken belief is what let the ordering through.

**2 — A failed export could delete a database the caller already had.** Routing `export_to_sqlite` through the shared destination helper handed it `migrate_store`'s cleanup-on-failure, but `migrate_store` rejects an existing destination up front and export had no such guard. Cleanup is now limited to a file the call itself created. Fixed in `d6d5c7f8`.

**3 — The hierarchical read dropped orphaned cards.** Silent data loss: a card whose column had been deleted exists in the source and vanished from the destination. Fixed by reading flat, in `09b67387`.

**4 — Export onto an existing database silently changed semantics.** The path it replaced deleted every table before inserting, so an export *replaced* the destination; writing per entity *merges*, leaving unrelated boards behind. It now refuses, as `migrate_store` already did, making the caller choose rather than silently doing either. Fixed in `09b67387`.

Each fix is mutation-verified: reverting any one fails its test.

The test gap that let 1 and 3 through is worth naming — every fixture was built with `Card::new`, which never assigns a sprint, and every card was reachable from a column because the fixtures built the hierarchy top-down. Fixtures inherit their constructors' defaults and their builder's shape; the states worth seeding are the ones the *old implementation tolerated*.

## One acceptance criterion interpreted, not met literally

The card says `Snapshot` should appear "only where JSON is on one end", and its Target is blunter: SQLite → SQLite is "No `Snapshot`, no JSON round trip".

The JSON round trip is gone, but the `Snapshot` *type* is still the in-memory carrier on that leg. The stricter reading would mean streaming board by board so the workspace is never materialised — a memory optimisation that also complicates the workspace-global pieces (dependency graph, archival markers) belonging to no single board.

Decision recorded on the card: the invariant carrying the epic's intent is **no `DataStore::snapshot` call and no JSON serialisation**, and that is what is enforced and tested. If a workspace grows enough for materialisation to matter, the adapter's two functions are the only place that would change.

## Verification

- `cargo test --workspace` exit 0, 177 test binaries
- `cargo test -p kanban-service --features test-helpers` green
- `cargo clippy --workspace --all-targets -- -D warnings` zero diagnostics
- `cargo fmt --check` clean
- All 10 pre-existing migrate/export tests pass unmodified — the rewrite is behaviour-preserving

## Note

The batch closure moves an owned `Snapshot` into `with_transaction`, which KAN-1110's `FnOnce` signature makes possible without an `Option::take()` dance. KAN-1067's consumer-validation notes predicted that friction and deferred it to KAN-1110; that card settled it, and this one collects the benefit.
