### PR TITLE
KAN-1132 feat(cli): board create --with-default-columns seeds columns and completion

### DIFF
--- a/.changeset/kan-1132-default-columns-flag.md
+++ b/.changeset/kan-1132-default-columns-flag.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+board create --with-default-columns

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Press `?` at any time to see context-sensitive help.
 ```bash
 export KANBAN_FILE=boards.json   # or pass the path as the first argument
 
-kanban board create --name "My Project"
+kanban board create --name "My Project" --with-default-columns  # seeds TODO/Doing/Complete, Complete = completion column
 kanban board list
 kanban card create --board "My Project" --column TODO --title "Fix the bug" --priority high
 kanban card list --board "My Project"
@@ -157,6 +157,7 @@ VS Code is known not to work in the current implementation.
 - Card relations: parent/child (Spawns), blocking (with severity), and undirected relates (with sub-kind) — each with cycle / self-reference detection and dedicated `kanban relation` CLI + MCP tools
 - Archive and restore cards
 - Configurable completion columns per board: `board update <board> --completion-columns Done,Decision` — status=done files cards under the first entry; `''` disables the status/column sync
+- `board create --with-default-columns` seeds TODO/Doing/Complete and sets Complete as the completion column in one step; a board created without the flag has no columns and no completion column until you run `column create` and `board update --completion-columns` yourself
 - Archive and restore whole boards: `board archive` / `board restore` / `board delete-archived`, an archived-boards TUI view you can drill into like a live board, `board list --archived` / `--include-archived`, a three-state MCP `archived` filter (`exclude` / `only` / `include`), and matching MCP archive/restore/delete-archived tools
 
 ### Sprint Planning

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -61,6 +61,9 @@ pub enum BoardAction {
         name: String,
         #[arg(long)]
         card_prefix: Option<String>,
+        /// Also create TODO/Doing/Complete and set Complete as the completion column.
+        #[arg(long)]
+        with_default_columns: bool,
     },
     /// List boards (live by default; use --archived / --include-archived).
     List {

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -195,7 +195,8 @@ fn seed_default_columns(
         completion_column_ids: complete_column_id.map(|id| vec![id]),
         ..Default::default()
     };
-    Ok(ctx.update_board(board_id, updates)?)
+    ctx.update_board(board_id, updates)
+        .map_err(anyhow::Error::from)
 }
 
 async fn handle_update(

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -7,10 +7,19 @@ use kanban_service::api::BoardResponse;
 
 pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result<()> {
     match action {
-        BoardAction::Create { name, card_prefix } => {
+        BoardAction::Create {
+            name,
+            card_prefix,
+            with_default_columns,
+        } => {
             // Funnels through the Board factory via the name/card_prefix shim
             // (KAN-792); the JSON edge projects the domain Board via BoardResponse.
             let board = ctx.create_board(name, card_prefix)?;
+            let board = if with_default_columns {
+                seed_default_columns(ctx, board.id)?
+            } else {
+                board
+            };
             ctx.save().await?;
             output::output_success(BoardResponse::from(&board));
         }
@@ -167,6 +176,26 @@ fn resolve_archived_board(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, Str
         [] => Err(format!("No archived board named: {}", raw)),
         _ => Err(format!("Ambiguous archived board name: {}", raw)),
     }
+}
+
+const DEFAULT_TEMPLATE_COLUMNS: [&str; 3] = ["TODO", "Doing", "Complete"];
+
+fn seed_default_columns(
+    ctx: &mut CliContext,
+    board_id: uuid::Uuid,
+) -> anyhow::Result<kanban_domain::Board> {
+    let mut complete_column_id = None;
+    for name in DEFAULT_TEMPLATE_COLUMNS {
+        let column = ctx.create_column(board_id, name.to_string(), None)?;
+        if name == "Complete" {
+            complete_column_id = Some(column.id);
+        }
+    }
+    let updates = BoardUpdate {
+        completion_column_ids: complete_column_id.map(|id| vec![id]),
+        ..Default::default()
+    };
+    Ok(ctx.update_board(board_id, updates)?)
 }
 
 async fn handle_update(

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5714,9 +5714,7 @@ mod default_columns_tests {
             .get_output()
             .stdout
             .clone();
-        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(
-            &create_output,
-        )));
+        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
 
         let list_output = kanban()
             .args([
@@ -5772,9 +5770,7 @@ mod default_columns_tests {
             .get_output()
             .stdout
             .clone();
-        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(
-            &create_output,
-        )));
+        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
 
         let list_output = kanban()
             .args([
@@ -5791,10 +5787,7 @@ mod default_columns_tests {
             .clone();
         let json = parse_json_output(&String::from_utf8_lossy(&list_output));
         let items = json["data"]["items"].as_array().unwrap();
-        let complete_id = items
-            .iter()
-            .find(|c| c["name"] == "Complete")
-            .unwrap()["id"]
+        let complete_id = items.iter().find(|c| c["name"] == "Complete").unwrap()["id"]
             .as_str()
             .unwrap()
             .to_string();
@@ -5820,21 +5813,13 @@ mod default_columns_tests {
         kanban().args([file.to_str().unwrap()]).assert().success();
 
         let create_output = kanban()
-            .args([
-                file.to_str().unwrap(),
-                "board",
-                "create",
-                "--name",
-                "Board",
-            ])
+            .args([file.to_str().unwrap(), "board", "create", "--name", "Board"])
             .assert()
             .success()
             .get_output()
             .stdout
             .clone();
-        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(
-            &create_output,
-        )));
+        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
 
         let list_output = kanban()
             .args([

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5690,3 +5690,179 @@ mod completion_columns_tests {
         );
     }
 }
+
+mod default_columns_tests {
+    use super::*;
+
+    #[test]
+    fn test_board_create_with_default_columns_creates_three_columns_in_order() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "create",
+                "--name",
+                "Board",
+                "--with-default-columns",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(
+            &create_output,
+        )));
+
+        let list_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "list",
+                "--board",
+                &board_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&list_output));
+        let items = json["data"]["items"].as_array().unwrap();
+        let names_and_positions: Vec<(String, i64)> = items
+            .iter()
+            .map(|c| {
+                (
+                    c["name"].as_str().unwrap().to_string(),
+                    c["position"].as_i64().unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            names_and_positions,
+            vec![
+                ("TODO".to_string(), 0),
+                ("Doing".to_string(), 1),
+                ("Complete".to_string(), 2),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_board_create_with_default_columns_sets_completion_to_complete_column() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "create",
+                "--name",
+                "Board",
+                "--with-default-columns",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(
+            &create_output,
+        )));
+
+        let list_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "list",
+                "--board",
+                &board_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&list_output));
+        let items = json["data"]["items"].as_array().unwrap();
+        let complete_id = items
+            .iter()
+            .find(|c| c["name"] == "Complete")
+            .unwrap()["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let get_output = kanban()
+            .args([file.to_str().unwrap(), "board", "get", &board_id])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let board_json = parse_json_output(&String::from_utf8_lossy(&get_output));
+        assert_eq!(
+            board_json["data"]["completion_column_ids"],
+            serde_json::json!([complete_id])
+        );
+    }
+
+    #[test]
+    fn test_board_create_without_flag_leaves_board_with_no_columns() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "create",
+                "--name",
+                "Board",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(
+            &create_output,
+        )));
+
+        let list_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "list",
+                "--board",
+                &board_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&list_output));
+        assert_eq!(json["data"]["total"], 0);
+
+        let get_output = kanban()
+            .args([file.to_str().unwrap(), "board", "get", &board_id])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let board_json = parse_json_output(&String::from_utf8_lossy(&get_output));
+        assert_eq!(
+            board_json["data"]["completion_column_ids"],
+            serde_json::json!([])
+        );
+    }
+}

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -365,6 +365,23 @@ mod tests {
     }
 
     #[test]
+    fn test_card_move_to_last_column_without_completion_config_leaves_status_unchanged() {
+        let board = test_board();
+        let cols = add_columns(&board, &["TODO", "Doing", "Complete"]);
+        let last = &cols[2];
+        let mut card = test_card(&mut board.clone(), &cols[0], "C", 0);
+        card.status = CardStatus::Todo;
+        card.column_id = last.id;
+
+        assert_eq!(
+            target_status_for_column_move(&card, last.id, &board, &cols),
+            None,
+            "a board with no completion_column_ids configured must not infer \
+             completion from column position"
+        );
+    }
+
+    #[test]
     fn test_empty_completion_column_ids_disables_auto_sync_entirely() {
         let mut board = test_board();
         let cols = add_columns(&board, &["TODO", "Doing", "Done"]);


### PR DESCRIPTION
Adds an opt-in template flag to `board create`, closing the completion-column gap for CLI-created boards.

- Add `--with-default-columns` to `kanban board create`
- Seed TODO/Doing/Complete and set Complete as the board's completion column
- Pin the unconfigured-board behaviour with a domain regression test
- Document the flag and the manual alternative in README

**What**: `kanban board create --name X --with-default-columns` now creates the three template columns and wires `completion_column_ids` to Complete, matching what the TUI already does on board creation.

**Why**: Found while debugging issue #565. KAN-1115 replaced the positional completion heuristic with an explicit `Board.completion_column_ids` list, which is the right model. The TUI sets that list when it seeds its template columns, but no other creation path does, and `create_board` deliberately rejects the field because a new board has no columns to point at. The result was that a board created through the CLI, MCP or REST silently lost auto-completion: moving a card into the last column left it `todo`, with nothing to indicate that `board update --completion-columns` was needed. On v0.8.1 the same sequence worked, via the heuristic that has since been removed.

**How**: Opt-in flag rather than a seeded default. Seeding on first column creation would make TODO the completion column, and always seeding would change `board create` from "no columns" to "three columns" for every existing script. The flag keeps the default path byte-identical and gives CLI users the one-step path the TUI already has. The heuristic is deliberately not reintroduced; a regression test pins that.

**Testing**: Three CLI integration tests cover column names and order, the completion binding, and the unchanged no-flag path. One domain test pins that a board with an empty completion list leaves card status untouched on a move. Full workspace suite, clippy with warnings as errors, fmt and the factory compile-lock script all green. Also verified end to end against a temp file: with the flag, a card moved into Complete comes back `done`; without it, the board still has zero columns.

Closes part of #565.
