### PR TITLE
KAN-1134 feat(core): -V reports unstable for non-release builds

### DIFF
--- a/.changeset/kan-1134-unstable-version.md
+++ b/.changeset/kan-1134-unstable-version.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+-V reports unstable for non-release builds

--- a/crates/kanban-core/Cargo.toml
+++ b/crates/kanban-core/Cargo.toml
@@ -20,3 +20,7 @@ async-trait.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[[test]]
+name = "build_support"
+path = "build_support.rs"

--- a/crates/kanban-core/build.rs
+++ b/crates/kanban-core/build.rs
@@ -1,44 +1,58 @@
 use std::process::Command;
 
+include!("build_support.rs");
+
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(has_git_commit)");
-    println!("cargo::rustc-check-cfg=cfg(is_release_build)");
+    println!("cargo::rustc-check-cfg=cfg(is_unstable_build)");
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs/heads/");
     println!("cargo::rerun-if-changed=../../.git/refs/tags/");
     println!("cargo::rerun-if-env-changed=GIT_COMMIT_HASH");
 
-    let commit_hash = std::env::var("GIT_COMMIT_HASH")
+    let env_hash = std::env::var("GIT_COMMIT_HASH")
         .ok()
-        .filter(|s| !s.is_empty() && s != "unknown")
-        .or_else(|| {
-            Command::new("git")
-                .args(["rev-parse", "HEAD"])
-                .output()
-                .ok()
-                .and_then(|output| {
-                    if output.status.success() {
-                        String::from_utf8(output.stdout).ok()
-                    } else {
-                        None
-                    }
-                })
-                .map(|s| s.trim().to_string())
-        })
-        .unwrap_or_else(|| "unknown".to_string());
+        .filter(|s| !s.is_empty() && s != "unknown");
+
+    let (commit_hash, hash_source) = match env_hash {
+        Some(hash) => (hash, HashSource::Env),
+        None => match git_rev_parse_head() {
+            Some(hash) => (hash, HashSource::GitRevParse),
+            None => ("unknown".to_string(), HashSource::Unknown),
+        },
+    };
 
     println!("cargo::rustc-env=GIT_COMMIT_HASH={}", commit_hash);
     if commit_hash != "unknown" {
         println!("cargo::rustc-cfg=has_git_commit");
     }
 
-    let is_release = Command::new("git")
+    let is_release = git_describe_exact_tag();
+
+    if is_unstable_build(hash_source, is_release) {
+        println!("cargo::rustc-cfg=is_unstable_build");
+    }
+}
+
+fn git_rev_parse_head() -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+}
+
+fn git_describe_exact_tag() -> bool {
+    Command::new("git")
         .args(["describe", "--tags", "--exact-match", "HEAD"])
         .output()
         .map(|o| o.status.success())
-        .unwrap_or(false);
-
-    if is_release {
-        println!("cargo::rustc-cfg=is_release_build");
-    }
+        .unwrap_or(false)
 }

--- a/crates/kanban-core/build.rs
+++ b/crates/kanban-core/build.rs
@@ -2,8 +2,10 @@ use std::process::Command;
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(has_git_commit)");
+    println!("cargo::rustc-check-cfg=cfg(is_release_build)");
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs/heads/");
+    println!("cargo::rerun-if-changed=../../.git/refs/tags/");
     println!("cargo::rerun-if-env-changed=GIT_COMMIT_HASH");
 
     let commit_hash = std::env::var("GIT_COMMIT_HASH")
@@ -28,5 +30,15 @@ fn main() {
     println!("cargo::rustc-env=GIT_COMMIT_HASH={}", commit_hash);
     if commit_hash != "unknown" {
         println!("cargo::rustc-cfg=has_git_commit");
+    }
+
+    let is_release = Command::new("git")
+        .args(["describe", "--tags", "--exact-match", "HEAD"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    if is_release {
+        println!("cargo::rustc-cfg=is_release_build");
     }
 }

--- a/crates/kanban-core/build_support.rs
+++ b/crates/kanban-core/build_support.rs
@@ -1,3 +1,14 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashSource {
+    Env,
+    GitRevParse,
+    Unknown,
+}
+
+pub fn is_unstable_build(hash_source: HashSource, is_release: bool) -> bool {
+    hash_source == HashSource::GitRevParse && !is_release
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-core/build_support.rs
+++ b/crates/kanban-core/build_support.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_git_rev_parse_hash_without_release_tag_is_unstable() {
+        assert!(is_unstable_build(HashSource::GitRevParse, false));
+    }
+
+    #[test]
+    fn test_git_rev_parse_hash_with_release_tag_is_stable() {
+        assert!(!is_unstable_build(HashSource::GitRevParse, true));
+    }
+
+    #[test]
+    fn test_env_injected_hash_is_never_unstable() {
+        assert!(!is_unstable_build(HashSource::Env, false));
+        assert!(!is_unstable_build(HashSource::Env, true));
+    }
+
+    #[test]
+    fn test_unknown_hash_is_never_unstable() {
+        assert!(!is_unstable_build(HashSource::Unknown, false));
+    }
+
+    #[test]
+    fn test_injected_commit_hash_without_git_does_not_report_unstable() {
+        assert!(!is_unstable_build(HashSource::Env, false));
+    }
+}

--- a/crates/kanban-core/src/version.rs
+++ b/crates/kanban-core/src/version.rs
@@ -25,14 +25,14 @@ pub const KANBAN_COMMIT: &str = env!("GIT_COMMIT_HASH");
 /// {KANBAN_COMMIT}"` for a git checkout with no exact tag, and bare
 /// `KANBAN_VERSION` when no git commit is available at all (crates.io/AUR
 /// tarball builds).
-#[cfg(all(has_git_commit, is_release_build))]
+#[cfg(all(has_git_commit, not(is_unstable_build)))]
 pub const CLI_VERSION_DISPLAY: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     "\ncommit: ",
     env!("GIT_COMMIT_HASH")
 );
 
-#[cfg(all(has_git_commit, not(is_release_build)))]
+#[cfg(all(has_git_commit, is_unstable_build))]
 pub const CLI_VERSION_DISPLAY: &str = concat!("unstable\ncommit: ", env!("GIT_COMMIT_HASH"));
 
 #[cfg(not(has_git_commit))]

--- a/crates/kanban-core/src/version.rs
+++ b/crates/kanban-core/src/version.rs
@@ -20,15 +20,20 @@ pub const KANBAN_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const KANBAN_COMMIT: &str = env!("GIT_COMMIT_HASH");
 
 /// Multi-line display string passed to clap's `version = ...` attribute on the
-/// `kanban` and `kanban-mcp` binaries. Renders as
-/// `"{KANBAN_VERSION}\ncommit: {KANBAN_COMMIT}"` when a git commit is
-/// available, falling back to bare `KANBAN_VERSION` otherwise.
-#[cfg(has_git_commit)]
+/// `kanban` and `kanban-mcp` binaries. Renders `"{KANBAN_VERSION}\ncommit:
+/// {KANBAN_COMMIT}"` for an exact-tag build, `"unstable\ncommit:
+/// {KANBAN_COMMIT}"` for a git checkout with no exact tag, and bare
+/// `KANBAN_VERSION` when no git commit is available at all (crates.io/AUR
+/// tarball builds).
+#[cfg(all(has_git_commit, is_release_build))]
 pub const CLI_VERSION_DISPLAY: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     "\ncommit: ",
     env!("GIT_COMMIT_HASH")
 );
+
+#[cfg(all(has_git_commit, not(is_release_build)))]
+pub const CLI_VERSION_DISPLAY: &str = concat!("unstable\ncommit: ", env!("GIT_COMMIT_HASH"));
 
 #[cfg(not(has_git_commit))]
 pub const CLI_VERSION_DISPLAY: &str = env!("CARGO_PKG_VERSION");

--- a/crates/kanban-server/tests/cli_version.rs
+++ b/crates/kanban-server/tests/cli_version.rs
@@ -6,8 +6,12 @@ fn kanban_server() -> Command {
     assert_cmd::cargo_bin_cmd!("kanban-server")
 }
 
+fn version_or_unstable() -> predicates::str::RegexPredicate {
+    predicate::str::is_match(concat!("(", env!("CARGO_PKG_VERSION"), "|unstable)")).unwrap()
+}
+
 #[test]
-fn test_dash_capital_v_prints_version_and_exits_zero() {
+fn test_dash_capital_v_prints_version_or_unstable_and_exits_zero() {
     let dir = tempdir().unwrap();
 
     kanban_server()
@@ -16,11 +20,11 @@ fn test_dash_capital_v_prints_version_and_exits_zero() {
         .arg("-V")
         .assert()
         .success()
-        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+        .stdout(version_or_unstable());
 }
 
 #[test]
-fn test_dash_dash_version_prints_version_and_exits_zero() {
+fn test_dash_dash_version_prints_version_or_unstable_and_exits_zero() {
     let dir = tempdir().unwrap();
 
     kanban_server()
@@ -29,7 +33,44 @@ fn test_dash_dash_version_prints_version_and_exits_zero() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+        .stdout(version_or_unstable());
+}
+
+#[test]
+fn test_unstable_output_always_carries_a_commit_line() {
+    let dir = tempdir().unwrap();
+
+    let output = kanban_server()
+        .current_dir(dir.path())
+        .env_remove("KANBAN_FILE")
+        .arg("-V")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    if stdout.starts_with("unstable") {
+        assert!(
+            stdout.contains("commit: "),
+            "unstable output must carry a commit line, got: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn test_kanban_version_const_remains_semver_parseable() {
+    let parts: Vec<&str> = kanban_core::version::KANBAN_VERSION.split('.').collect();
+    assert_eq!(
+        parts.len(),
+        3,
+        "KANBAN_VERSION must stay MAJOR.MINOR.PATCH, got: {}",
+        kanban_core::version::KANBAN_VERSION
+    );
+    for part in parts {
+        assert!(
+            part.parse::<u64>().is_ok(),
+            "KANBAN_VERSION component {part:?} must be numeric"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Makes `-V` distinguish a tagged release from a development build.

- Probe for an exact tag in `build.rs` and expose it as a cfg
- `CLI_VERSION_DISPLAY` renders `unstable` plus the commit for non-release builds
- Extract the provenance decision into a pure, unit-tested helper
- Rewrite the two `cli_version` assertions that hardcoded the package version

**What**: A binary built from a non-tag commit now reports `unstable` with its commit hash instead of the last released version number. Tagged builds are unchanged.

**Why**: Asking a bug reporter for `kanban -V` currently yields a version that cannot be trusted. Every one of the commits on develop past `v0.8.1` prints the identical string a real v0.8.1 binary prints, so the version identifies a tag the binary is not actually built from. Since a develop build can only come from a git checkout, the commit is always available exactly when the version is ambiguous, and its absence can be made to mean "tagged release".

**How**: Three cases, keyed on the provenance of the commit hash rather than on a branch name. `unstable` requires positive evidence of a checkout at a non-tag commit, meaning the hash came from `git rev-parse HEAD` and `git describe --tags --exact-match HEAD` failed. A hash injected via `GIT_COMMIT_HASH` (the Nix packaging path) or no hash at all both fall back to the packaged version. That distinction is load-bearing: without it, tagged Nix builds and crates.io tarball installs would wrongly report `unstable`.

Scope is deliberately limited to `CLI_VERSION_DISPLAY`. `KANBAN_VERSION` stays a parseable semver because it is stamped into persistence metadata, command batches and sprint logs, and is compared by `version_is_newer_than_self`; a test pins that.

**Testing**: Pure unit tests over the provenance helper, plus the rewritten `cli_version` integration tests. Verified against real builds in all three cases: exact tag prints `0.8.1` + commit; git unavailable with an injected hash prints `0.8.1` + commit; a plain checkout prints `unstable` + commit. Full workspace suite, clippy with warnings as errors, and fmt all green.
