### PR TITLE
KAN-1135 feat(domain): column default_status and the column-move promotion rule

### DIFF
--- a/.changeset/kan-1135-column-default-status.md
+++ b/.changeset/kan-1135-column-default-status.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+per-column default card status (domain)

--- a/crates/kanban-api/src/v1/columns/conversions.rs
+++ b/crates/kanban-api/src/v1/columns/conversions.rs
@@ -27,6 +27,7 @@ impl TryFrom<UpdateColumnRequest> for ColumnUpdate {
             name,
             position,
             wip_limit: wip_limit.into(),
+            default_status: None,
         })
     }
 }
@@ -52,6 +53,7 @@ impl CreateColumnRequest {
             board_id,
             name,
             wip_limit,
+            default_status: None,
         };
         Ok((id, spec))
     }
@@ -80,6 +82,7 @@ impl ReplaceColumnRequest {
             board_id,
             name,
             wip_limit,
+            default_status: None,
         };
         Ok((spec, position))
     }
@@ -158,6 +161,7 @@ mod tests {
                 board_id,
                 name: "Doing".to_string(),
                 wip_limit: Some(3),
+                default_status: None,
             }
         );
     }
@@ -209,6 +213,7 @@ mod tests {
             board_id: _,
             name: _,
             wip_limit: _,
+            default_status: _,
         } = spec;
     }
 
@@ -227,6 +232,7 @@ mod tests {
                 board_id,
                 name: "Doing".to_string(),
                 wip_limit: Some(2),
+                default_status: None,
             }
         );
         assert_eq!(position, 3);

--- a/crates/kanban-cli/src/handlers/column.rs
+++ b/crates/kanban-cli/src/handlers/column.rs
@@ -91,6 +91,7 @@ async fn handle_update(
                 .map(FieldUpdate::Set)
                 .unwrap_or(FieldUpdate::NoChange)
         },
+        default_status: None,
     };
     let column = ctx.update_column(uuid, updates)?;
     ctx.save().await?;

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -845,6 +845,84 @@ mod tests {
         assert_eq!(status, None);
     }
 
+    // --- target_status_for_column_move with column default_status (promotion rule) ---
+
+    fn board_with_default_status_column() -> (Board, Vec<Column>) {
+        let mut board = test_board();
+        let mut cols = add_columns(&board, &["TODO", "Doing", "Complete"]);
+        cols[1].default_status = Some(CardStatus::InProgress);
+        board.update_completion_column_ids(vec![cols[2].id]);
+        (board, cols)
+    }
+
+    #[test]
+    fn test_move_to_column_with_default_status_promotes_todo_card() {
+        let (board, cols) = board_with_default_status_column();
+        let mut card = test_card(&mut board.clone(), &cols[0], "Task", 0);
+        card.status = CardStatus::Todo;
+
+        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        assert_eq!(status, Some(CardStatus::InProgress));
+    }
+
+    #[test]
+    fn test_move_to_completion_column_sets_done_ignoring_default_status() {
+        let mut board = test_board();
+        let mut cols = add_columns(&board, &["TODO", "Doing"]);
+        cols[1].default_status = Some(CardStatus::InProgress);
+        board.update_completion_column_ids(vec![cols[1].id]);
+        let mut card = test_card(&mut board.clone(), &cols[0], "Task", 0);
+        card.status = CardStatus::Todo;
+
+        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        assert_eq!(
+            status,
+            Some(CardStatus::Done),
+            "completion-column membership must win over default_status"
+        );
+    }
+
+    #[test]
+    fn test_move_out_of_completion_to_default_status_column_promotes_through_todo() {
+        let (board, cols) = board_with_default_status_column();
+        let mut card = test_card(&mut board.clone(), &cols[2], "Task", 0);
+        card.status = CardStatus::Done;
+
+        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        assert_eq!(status, Some(CardStatus::InProgress));
+    }
+
+    #[test]
+    fn test_move_to_default_status_column_does_not_clobber_blocked_card() {
+        let (board, cols) = board_with_default_status_column();
+        let mut card = test_card(&mut board.clone(), &cols[0], "Task", 0);
+        card.status = CardStatus::Blocked;
+
+        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        assert_eq!(status, None);
+    }
+
+    #[test]
+    fn test_move_out_of_default_status_column_leaves_status_unchanged() {
+        let (board, cols) = board_with_default_status_column();
+        let mut card = test_card(&mut board.clone(), &cols[1], "Task", 0);
+        card.status = CardStatus::InProgress;
+
+        let status = target_status_for_column_move(&card, cols[0].id, &board, &cols);
+        assert_eq!(status, None);
+    }
+
+    #[test]
+    fn test_move_to_column_without_default_status_returns_none() {
+        let mut board = test_board();
+        let cols = add_columns(&board, &["TODO", "Doing"]);
+        let mut card = test_card(&mut board, &cols[0], "Task", 0);
+        card.status = CardStatus::Todo;
+
+        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        assert_eq!(status, None);
+    }
+
     // --- uncomplete_target_column ---
 
     #[test]

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -225,18 +225,45 @@ pub fn target_status_for_column_move(
     card: &Card,
     new_column_id: Uuid,
     board: &Board,
-    _columns: &[Column],
+    columns: &[Column],
 ) -> Option<CardStatus> {
     let moving_to_completion = board.is_completion_column(new_column_id);
     let was_in_completion = board.is_completion_column(card.column_id);
 
-    if moving_to_completion && card.status != CardStatus::Done {
-        Some(CardStatus::Done)
-    } else if !moving_to_completion && was_in_completion && card.status == CardStatus::Done {
-        Some(CardStatus::Todo)
-    } else {
-        None
+    if moving_to_completion {
+        return (card.status != CardStatus::Done).then_some(CardStatus::Done);
     }
+
+    let after_completion_rules = if was_in_completion && card.status == CardStatus::Done {
+        CardStatus::Todo
+    } else {
+        card.status
+    };
+
+    let promoted = promoted_status(columns, new_column_id, after_completion_rules);
+
+    match promoted {
+        Some(s) if s != card.status => Some(s),
+        _ => (after_completion_rules != card.status).then_some(after_completion_rules),
+    }
+}
+
+/// The status a card would take from the destination column's
+/// `default_status`, given its status after the completion rules have
+/// already been applied. Promotion only fires when that status is `Todo`.
+fn promoted_status(
+    columns: &[Column],
+    new_column_id: Uuid,
+    after_completion_rules: CardStatus,
+) -> Option<CardStatus> {
+    (after_completion_rules == CardStatus::Todo)
+        .then(|| {
+            columns
+                .iter()
+                .find(|c| c.id == new_column_id)
+                .and_then(|c| c.default_status)
+        })
+        .flatten()
 }
 
 /// Compact card positions in a column to be sequential (0, 1, 2, ...).

--- a/crates/kanban-domain/src/column.rs
+++ b/crates/kanban-domain/src/column.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::board::BoardId;
+use crate::card::CardStatus;
 use crate::field_update::FieldUpdate;
 
 pub type ColumnId = Uuid;
@@ -14,6 +15,9 @@ pub struct Column {
     pub name: String,
     pub position: i32,
     pub wip_limit: Option<i32>,
+    /// Status a card takes when it lands here, unless the column is also a
+    /// completion column (that wins) or the card's status is not `Todo`.
+    pub default_status: Option<CardStatus>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -27,6 +31,7 @@ impl Column {
             name: name.into(),
             position,
             wip_limit: None,
+            default_status: None,
             created_at: now,
             updated_at: now,
         }
@@ -56,6 +61,9 @@ impl Column {
             self.position = position;
         }
         updates.wip_limit.apply_to(&mut self.wip_limit);
+        if let Some(default_status) = updates.default_status {
+            self.default_status = default_status;
+        }
         self.updated_at = Utc::now();
     }
 }
@@ -89,4 +97,7 @@ pub struct ColumnUpdate {
     pub name: Option<String>,
     pub position: Option<i32>,
     pub wip_limit: FieldUpdate<i32>,
+    /// `None` = field absent from this update (leave unchanged). `Some(None)`
+    /// clears `default_status`; `Some(Some(s))` sets it.
+    pub default_status: Option<Option<CardStatus>>,
 }

--- a/crates/kanban-domain/src/column_factory.rs
+++ b/crates/kanban-domain/src/column_factory.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 
 use crate::board::BoardId;
+use crate::card::CardStatus;
 use crate::column::{Column, ColumnId};
 use crate::error::{KanbanError, KanbanResult};
 
@@ -14,6 +15,7 @@ pub struct NewColumn {
     pub board_id: BoardId,
     pub name: String,
     pub wip_limit: Option<i32>,
+    pub default_status: Option<CardStatus>,
 }
 
 /// COMPLETE field set. The ONLY Column type deriving `Serialize`/`Deserialize`
@@ -26,6 +28,11 @@ pub struct ColumnRecord {
     pub name: String,
     pub position: i32,
     pub wip_limit: Option<i32>,
+    // TEMPORARY: removed by the JSON persistence child card when it bumps the
+    // envelope to V13. Needed now so pre-existing envelopes without this key
+    // keep deserializing.
+    #[serde(default)]
+    pub default_status: Option<CardStatus>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -45,6 +52,7 @@ impl Column {
             board_id,
             name,
             wip_limit,
+            default_status,
         } = spec;
         if name.trim().is_empty() {
             return Err(KanbanError::validation("column name must not be blank"));
@@ -67,6 +75,7 @@ impl Column {
             name,
             position,
             wip_limit,
+            default_status,
             created_at: now,
             updated_at: now,
         })
@@ -81,6 +90,7 @@ impl Column {
             name,
             position,
             wip_limit,
+            default_status,
             created_at,
             updated_at,
         } = record;
@@ -98,6 +108,7 @@ impl Column {
             name,
             position,
             wip_limit,
+            default_status,
             created_at,
             updated_at,
         })
@@ -112,6 +123,7 @@ impl From<&Column> for ColumnRecord {
             name,
             position,
             wip_limit,
+            default_status,
             created_at,
             updated_at,
         } = column;
@@ -121,6 +133,7 @@ impl From<&Column> for ColumnRecord {
             name: name.clone(),
             position: *position,
             wip_limit: *wip_limit,
+            default_status: *default_status,
             created_at: *created_at,
             updated_at: *updated_at,
         }
@@ -188,6 +201,7 @@ mod factory_tests {
             board_id: Uuid::new_v4(),
             name: "To Do".to_string(),
             wip_limit,
+            default_status: None,
         }
     }
 
@@ -201,6 +215,7 @@ mod factory_tests {
                 board_id,
                 name: "To Do".to_string(),
                 wip_limit: None,
+                default_status: None,
             },
             id,
             0,
@@ -242,6 +257,7 @@ mod factory_tests {
                 board_id: Uuid::new_v4(),
                 name: "To Do".to_string(),
                 wip_limit: Some(-1),
+                default_status: None,
             },
             Uuid::new_v4(),
             0,
@@ -258,6 +274,7 @@ mod factory_tests {
                 board_id: Uuid::new_v4(),
                 name: "   ".to_string(),
                 wip_limit: None,
+                default_status: None,
             },
             Uuid::new_v4(),
             0,
@@ -295,6 +312,7 @@ mod factory_tests {
             name: "In Progress".to_string(),
             position: 2,
             wip_limit: Some(5),
+            default_status: None,
             created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
             updated_at: "2024-02-02T00:00:00Z".parse().unwrap(),
         }
@@ -345,6 +363,7 @@ mod factory_tests {
             board_id: Uuid::new_v4(),
             name: "Done".to_string(),
             wip_limit: Some(0),
+            default_status: None,
         };
         assert_eq!(new_column.name, "Done");
         let record = ColumnRecord {
@@ -353,6 +372,7 @@ mod factory_tests {
             name: "Done".to_string(),
             position: 0,
             wip_limit: Some(0),
+            default_status: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/crates/kanban-domain/src/column_factory.rs
+++ b/crates/kanban-domain/src/column_factory.rs
@@ -326,6 +326,17 @@ mod factory_tests {
     }
 
     #[test]
+    fn test_column_record_round_trips_default_status() -> KanbanResult<()> {
+        let mut rec = populated_record();
+        rec.default_status = Some(crate::CardStatus::InProgress);
+        let column = Column::reconstitute(rec)?;
+        assert_eq!(column.default_status, Some(crate::CardStatus::InProgress));
+        let record = ColumnRecord::from(&column);
+        assert_eq!(record.default_status, Some(crate::CardStatus::InProgress));
+        Ok(())
+    }
+
+    #[test]
     fn test_new_column_is_default_free() {
         // Compile-lock: constructing NewColumn/ColumnRecord requires naming every
         // field (no `Default`, no `..`). If a Default impl crept in, this would

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -89,6 +89,7 @@ impl UpdateColumn {
                     None => FieldUpdate::Clear,
                 },
             },
+            default_status: self.updates.default_status.map(|_| column.default_status),
         };
 
         Ok(vec![Command::Column(ColumnCommand::Update(UpdateColumn {
@@ -118,6 +119,7 @@ impl CreateColumn {
             board_id: self.board_id,
             name: self.name.clone(),
             wip_limit: None,
+            default_status: None,
         };
         let column = crate::Column::create(spec, self.id, self.position, Utc::now())?;
         context.store.upsert_column(column)?;

--- a/crates/kanban-domain/src/field_update.rs
+++ b/crates/kanban-domain/src/field_update.rs
@@ -161,6 +161,7 @@ mod tests {
             name: Some("Col".to_string()),
             position: Some(1),
             wip_limit: FieldUpdate::Set(5),
+            default_status: None,
         };
         let json = serde_json::to_string(&update).unwrap();
         let back: crate::ColumnUpdate = serde_json::from_str(&json).unwrap();

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -267,6 +267,7 @@ mod tests {
                 name: format!("Col {position}"),
                 position,
                 wip_limit,
+                default_status: None,
                 created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
                 updated_at: "2024-02-02T00:00:00Z".parse().unwrap(),
             })
@@ -601,6 +602,7 @@ mod tests {
                 board_id: Uuid::new_v4(),
                 name: "Done".to_string(),
                 wip_limit: Some(5),
+                default_status: None,
             },
             Uuid::new_v4(),
             1,

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -88,6 +88,7 @@ impl KanbanMcpServer {
                     .map(|w| FieldUpdate::Set(w as i32))
                     .unwrap_or(FieldUpdate::NoChange)
             },
+            default_status: None,
         };
         let column = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_column_global(&req.column)?;

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -164,6 +164,7 @@ async fn column_create_list_update() {
                 name: Some("Done".into()),
                 position: None,
                 wip_limit: kanban_domain::FieldUpdate::NoChange,
+                default_status: None,
             },
         )
         .unwrap();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -65,6 +65,7 @@ pub(crate) fn row_to_column(row: &SqliteRow) -> KanbanResult<Column> {
         name: row.try_get("name").map_err(db_err)?,
         position: row.try_get("position").map_err(db_err)?,
         wip_limit: row.try_get("wip_limit").map_err(db_err)?,
+        default_status: None,
         created_at: p_dt(&created_at_str)?,
         updated_at: p_dt(&updated_at_str)?,
     };

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/archived_cards.rs
@@ -20,6 +20,7 @@ fn seed_board_and_column(store: &SqliteStore, board_name: &str) -> (Uuid, Uuid) 
         name: "Todo".to_string(),
         position: 0,
         wip_limit: None,
+        default_status: None,
         created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
         updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
     })

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
@@ -62,6 +62,7 @@ fn seed_column(store: &SqliteStore) -> Uuid {
         name: "In Progress".to_string(),
         position: 0,
         wip_limit: None,
+        default_status: None,
         created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
         updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
     })

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/columns.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/columns.rs
@@ -15,6 +15,7 @@ fn record_for(board_id: Uuid, wip_limit: Option<i32>) -> ColumnRecord {
         name: "In Progress".to_string(),
         position: 3,
         wip_limit,
+        default_status: None,
         created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
         updated_at: "2024-02-02T00:00:00Z".parse().unwrap(),
     }
@@ -101,6 +102,7 @@ fn test_column_create_store_load_equal_sqlite() {
                 board_id,
                 name: "Done".to_string(),
                 wip_limit: Some(5),
+                default_status: None,
             },
             Uuid::new_v4(),
             1,

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/filtered_reads.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/filtered_reads.rs
@@ -20,6 +20,7 @@ fn seed_board_and_column(store: &SqliteStore) -> Uuid {
         name: "Todo".to_string(),
         position: 0,
         wip_limit: None,
+        default_status: None,
         created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
         updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
     })
@@ -64,6 +65,7 @@ fn seed_two_live_two_archived(store: &SqliteStore) -> (Uuid, Vec<Uuid>, Vec<Uuid
         name: "Todo".to_string(),
         position: 0,
         wip_limit: None,
+        default_status: None,
         created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
         updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
     })

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -45,6 +45,7 @@ pub fn fully_populated_snapshot() -> Snapshot {
         name: "Full Col".into(),
         position: 0,
         wip_limit: Some(5),
+        default_status: None,
         created_at: now,
         updated_at: now,
     };

--- a/crates/kanban-service/src/context/columns.rs
+++ b/crates/kanban-service/src/context/columns.rs
@@ -114,6 +114,7 @@ impl KanbanContext {
                     board_id,
                     name,
                     wip_limit: None,
+                    default_status: None,
                 },
             ),
         }
@@ -157,6 +158,7 @@ impl KanbanContext {
             name: None,
             position: Some(new_position),
             wip_limit: FieldUpdate::NoChange,
+            default_status: None,
         };
         self.update_column_impl(id, updates)
     }
@@ -173,6 +175,7 @@ fn replace_update_from_spec(spec: NewColumn, position: Option<i32>) -> ColumnUpd
         board_id: _,
         name,
         wip_limit,
+        default_status,
     } = spec;
     ColumnUpdate {
         name: Some(name),
@@ -181,5 +184,6 @@ fn replace_update_from_spec(spec: NewColumn, position: Option<i32>) -> ColumnUpd
             Some(limit) => FieldUpdate::Set(limit),
             None => FieldUpdate::Clear,
         },
+        default_status: Some(default_status),
     }
 }

--- a/crates/kanban-service/src/test_helpers/contract/column.rs
+++ b/crates/kanban-service/src/test_helpers/contract/column.rs
@@ -20,6 +20,7 @@ pub async fn test_column_all_fields_roundtrip(factory: &BackendFactory) {
             name: Some("In Progress".into()),
             position: Some(3),
             wip_limit: FieldUpdate::Set(5),
+            default_status: None,
         },
     )
     .unwrap();

--- a/crates/kanban-service/tests/create_column_from_spec.rs
+++ b/crates/kanban-service/tests/create_column_from_spec.rs
@@ -36,6 +36,7 @@ fn spec(board_id: Uuid, name: &str, wip_limit: Option<i32>) -> NewColumn {
         board_id,
         name: name.to_string(),
         wip_limit,
+        default_status: None,
     }
 }
 

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -110,6 +110,7 @@ async fn test_inverse_update_column_restores_prior_fields() -> KanbanResult<()> 
             name: Some("Renamed".into()),
             position: Some(99),
             wip_limit: FieldUpdate::NoChange,
+            default_status: None,
         },
     }))])?;
     let after = &ctx.columns()?[0];


### PR DESCRIPTION
First of six children implementing per-column default card status. Domain model and transition rule only; nothing is durably persisted yet.

- Add `default_status` to `Column`, `NewColumn`, `ColumnRecord` and `ColumnUpdate`
- Implement the column-move promotion rule
- Apply the field in `Column::update` and capture it in the undo inverse

**What**: A column can now carry an optional status that a card takes on when it lands there. Moving a card into such a column promotes it, so a TODO card dragged to "Doing" becomes `in_progress` instead of staying `todo`.

**Why**: From issue #565. Two of the four `CardStatus` variants were unreachable from any board interaction — only completion columns changed status, so `InProgress` and `Blocked` required a manual `card update --status` every time. A board's workflow was only half expressible.

**How**: Three rules, taken from the epic's design decisions. Completion-column membership wins over `default_status`. Promotion applies only when the card would otherwise settle at `Todo`, so a deliberate `Blocked` is never silently cleared by dragging a card. Moving out of a column consults nothing — only the destination's rule matters. The un-complete path composes with promotion: a `Done` card leaving a completion column settles at `Todo` and is then eligible for the destination's promotion.

This change is deliberately additive. `ColumnRecord.default_status` carries a temporary `#[serde(default)]` so existing data files keep deserializing; the JSON child removes it when it bumps the envelope to V13. The JSON and SQLite conversion sites pass `None` for now, and the persistence children replace those placeholders.

**Testing**: One test per row of the epic's worked-example table, plus a record round-trip. Verified an existing data file containing no `default_status` key still loads, with the field reading back as null. Full workspace suite, clippy with warnings as errors, fmt, and the factory compile-lock script all green.
