### PR TITLE
KAN-1137 feat(persistence-sqlite): schema v7 adds columns.default_status

### DIFF
--- a/.changeset/kan-1137-sqlite-v7.md
+++ b/.changeset/kan-1137-sqlite-v7.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+SQLite schema v7 for column default_status

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -1,4 +1,6 @@
 -- SQLite schema for kanban persistence
+-- Version: 7 (columns.default_status added — see
+-- init.rs::migrate_v6_to_v7_column_default_status)
 -- Version: 6 (boards.completion_column_id replaced by the ordered
 -- board_completion_columns join table — see init.rs::migrate_v5_to_v6_completion_columns)
 -- Version: 3 (KAN-832: archived_cards.board_id + cards column_id FK dropped so
@@ -75,6 +77,7 @@ CREATE TABLE IF NOT EXISTS columns (
     name TEXT NOT NULL,
     position INTEGER NOT NULL,
     wip_limit INTEGER,
+    default_status TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -58,6 +58,7 @@ pub(crate) fn row_to_column(row: &SqliteRow) -> KanbanResult<Column> {
     let board_id_str: String = row.try_get("board_id").map_err(db_err)?;
     let created_at_str: String = row.try_get("created_at").map_err(db_err)?;
     let updated_at_str: String = row.try_get("updated_at").map_err(db_err)?;
+    let default_status_str: Option<String> = row.try_get("default_status").map_err(db_err)?;
 
     let record = ColumnRecord {
         id: p_uuid(&id_str)?,
@@ -65,7 +66,10 @@ pub(crate) fn row_to_column(row: &SqliteRow) -> KanbanResult<Column> {
         name: row.try_get("name").map_err(db_err)?,
         position: row.try_get("position").map_err(db_err)?,
         wip_limit: row.try_get("wip_limit").map_err(db_err)?,
-        default_status: None,
+        default_status: default_status_str
+            .as_deref()
+            .map(|s| p_enum(s, "column default_status"))
+            .transpose()?,
         created_at: p_dt(&created_at_str)?,
         updated_at: p_dt(&updated_at_str)?,
     };

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -81,7 +81,7 @@ impl DataStore for SqliteStore {
         run(self.db_conn(|conn| {
             Box::pin(async move {
                 let row = sqlx::query(
-                    "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
+                    "SELECT id, board_id, name, position, wip_limit, default_status, created_at, updated_at
                      FROM columns WHERE id = ?",
                 )
                 .bind(id.to_string())
@@ -97,7 +97,7 @@ impl DataStore for SqliteStore {
         run(self.db_conn(|conn| {
             Box::pin(async move {
                 let rows = sqlx::query(
-                    "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
+                    "SELECT id, board_id, name, position, wip_limit, default_status, created_at, updated_at
                      FROM columns WHERE board_id = ?
                      ORDER BY position ASC, created_at ASC, id ASC",
                 )

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/column.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/column.rs
@@ -10,11 +10,13 @@ impl SqliteStore {
     ) -> KanbanResult<()> {
         let rec = ColumnRecord::from(column);
         sqlx::query(
-            "INSERT INTO columns (id, board_id, name, position, wip_limit, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO columns (id, board_id, name, position, wip_limit, default_status,
+                created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
                 board_id=excluded.board_id, name=excluded.name,
                 position=excluded.position, wip_limit=excluded.wip_limit,
+                default_status=excluded.default_status,
                 updated_at=excluded.updated_at",
         )
         .bind(rec.id.to_string())
@@ -22,6 +24,7 @@ impl SqliteStore {
         .bind(required_str(&rec.name, "column.name")?)
         .bind(rec.position)
         .bind(rec.wip_limit)
+        .bind(rec.default_status.map(|s| format!("{s:?}")))
         .bind(fmt_dt(&rec.created_at))
         .bind(fmt_dt(&rec.updated_at))
         .execute(&mut *conn)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -143,6 +143,7 @@ impl SqliteStore {
             }
         }
         Self::migrate_v5_to_v6_completion_columns(pool).await?;
+        Self::migrate_v6_to_v7_column_default_status(pool).await?;
 
         // Once the ALTERs above have caught the schema up, normalise
         // schema_version. Doing it unconditionally is idempotent and
@@ -605,6 +606,33 @@ impl SqliteStore {
         .execute(pool)
         .await
         .map_err(db_err)?;
+        Ok(())
+    }
+
+    /// Schema 6 -> 7: add `columns.default_status`, nullable, backfilled `NULL`
+    /// for every existing column regardless of name. No table rebuild is
+    /// needed here (unlike the 5->6 migration): the column carries no FK and
+    /// `ALTER TABLE ADD COLUMN` is sufficient. Idempotence gate: presence of
+    /// the column, which only a pre-7 database lacks.
+    pub(crate) async fn migrate_v6_to_v7_column_default_status(
+        pool: &Pool<Sqlite>,
+    ) -> KanbanResult<()> {
+        let has_default_status: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('columns') WHERE name = 'default_status'",
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
+        if has_default_status {
+            return Ok(());
+        }
+
+        tracing::info!("migrating SQLite schema 6 -> 7: columns.default_status (backfilled NULL)");
+
+        sqlx::raw_sql("ALTER TABLE columns ADD COLUMN default_status TEXT")
+            .execute(pool)
+            .await
+            .map_err(db_err)?;
         Ok(())
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -81,7 +81,7 @@ impl SqliteStore {
         self.db_conn(|conn| {
             Box::pin(async move {
                 let rows = sqlx::query(
-                    "SELECT id, board_id, name, position, wip_limit, created_at, updated_at
+                    "SELECT id, board_id, name, position, wip_limit, default_status, created_at, updated_at
                      FROM columns ORDER BY position ASC, created_at ASC, id ASC",
                 )
                 .fetch_all(&mut *conn)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -33,7 +33,7 @@ const SCHEMA: &str = include_str!("../schema.sql");
 /// added to `init::migrate` or a sibling `migrate_*` function MUST be
 /// paired with bumping this constant, or it will run unbacked-up — the two
 /// are intentionally coupled but not enforced by the type system.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 6;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 7;
 
 /// sqlx-sqlite defaults `busy_timeout` to 5s; set to 10s to give a long
 /// command batch more headroom before a concurrently-flushing writer gives up.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -99,7 +99,7 @@ fn test_open_migrates_old_db_to_current_schema_with_board_archival_and_backup() 
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 6, "old DB migrates to current schema v6");
+        assert_eq!(version, 7, "old DB migrates to current schema v7");
 
         // board_archival table exists after the schema step.
         let has_table: bool = sqlx::query_scalar(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/columns.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/columns.rs
@@ -1,5 +1,5 @@
 use kanban_domain::data_store::DataStore;
-use kanban_domain::{Board, Column, ColumnRecord, NewColumn};
+use kanban_domain::{Board, CardStatus, Column, ColumnRecord, NewColumn};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -113,6 +113,60 @@ fn test_column_create_store_load_equal_sqlite() {
         store.upsert_column(column.clone()).unwrap();
 
         let loaded = store.get_column(id).unwrap().expect("column should load");
+        assert_eq!(loaded, column);
+    });
+}
+
+#[test]
+fn test_column_default_status_round_trips_through_sqlite() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let board = Board::new("B", None::<String>);
+        let board_id = board.id;
+        store.upsert_board(board).unwrap();
+
+        let mut record = record_for(board_id, Some(7));
+        record.default_status = Some(CardStatus::InProgress);
+        let column = Column::reconstitute(record).unwrap();
+        let id = column.id;
+        store.upsert_column(column.clone()).unwrap();
+        drop(store);
+
+        let reopened = SqliteStore::open(&path).await.unwrap();
+        let loaded = reopened
+            .get_column(id)
+            .unwrap()
+            .expect("column should load");
+        assert_eq!(loaded.default_status, Some(CardStatus::InProgress));
+        assert_eq!(loaded, column);
+    });
+}
+
+#[test]
+fn test_column_null_default_status_round_trips_as_none() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let board = Board::new("B", None::<String>);
+        let board_id = board.id;
+        store.upsert_board(board).unwrap();
+
+        let column = Column::reconstitute(record_for(board_id, Some(7))).unwrap();
+        let id = column.id;
+        store.upsert_column(column.clone()).unwrap();
+        drop(store);
+
+        let reopened = SqliteStore::open(&path).await.unwrap();
+        let loaded = reopened
+            .get_column(id)
+            .unwrap()
+            .expect("column should load");
+        assert_eq!(loaded.default_status, None);
         assert_eq!(loaded, column);
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
@@ -90,7 +90,7 @@ fn test_fresh_db_records_current_schema_version() {
             .await
             .unwrap();
         assert_eq!(version, SUPPORTED_SCHEMA_VERSION);
-        assert_eq!(version, 6, "fresh DB stamps schema_version 6");
+        assert_eq!(version, 7, "fresh DB stamps schema_version 7");
     });
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
@@ -81,8 +81,8 @@ fn test_migration_base_case_empty_db_backs_up_and_migrates_clean() {
 
         assert_eq!(
             store_schema_version(&store).await,
-            6,
-            "migrated to current v6"
+            7,
+            "migrated to current v7"
         );
         assert_eq!(
             backup_schema_version(&path).await,
@@ -130,7 +130,7 @@ fn test_migration_cards_case_preserves_live_and_archived_cards() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 6);
+        assert_eq!(store_schema_version(&store).await, 7);
         assert_eq!(backup_schema_version(&path).await, 2);
 
         // Board survived.
@@ -218,7 +218,7 @@ fn test_migration_boards_case_preserves_multiple_board_subtrees() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 6);
+        assert_eq!(store_schema_version(&store).await, 7);
         assert_eq!(backup_schema_version(&path).await, 2);
 
         // Both boards survived with their subtrees.
@@ -249,7 +249,7 @@ fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
         // First open: migrates + writes the v2 backup.
         {
             let store = SqliteStore::open(&path).await.unwrap();
-            assert_eq!(store_schema_version(&store).await, 6);
+            assert_eq!(store_schema_version(&store).await, 7);
         }
         let backup = SqliteStore::backup_path_for(&path, 2);
         assert!(backup.exists());
@@ -258,7 +258,7 @@ fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
         // Second open on the now-v3 DB: no migration, backup untouched.
         {
             let store = SqliteStore::open(&path).await.unwrap();
-            assert_eq!(store_schema_version(&store).await, 6);
+            assert_eq!(store_schema_version(&store).await, 7);
             assert_eq!(store.list_archived_cards().unwrap().len(), 1, "data intact");
         }
         assert_eq!(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
@@ -226,8 +226,8 @@ fn test_migrate_v2_db_adds_board_id_and_backfills() {
             .await
             .unwrap();
         assert_eq!(
-            version, 6,
-            "schema_version bumped to current (2->3 archived_cards, 4->5 cards.board_id, 5->6 completion columns)"
+            version, 7,
+            "schema_version bumped to current (2->3 archived_cards, 4->5 cards.board_id, 5->6 completion columns, 6->7 column default_status)"
         );
     });
 }
@@ -292,7 +292,7 @@ fn test_migrate_is_idempotent_on_v3_db() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 6);
+        assert_eq!(version, 7);
 
         let still_there: bool =
             sqlx::query_scalar("SELECT COUNT(*) > 0 FROM archived_cards WHERE card_id = ?")

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs
@@ -117,7 +117,7 @@ fn test_open_schema4_db_writes_durable_backup_before_board_id_migration() {
                 .fetch_one(store.pool())
                 .await
                 .unwrap();
-        assert_eq!(live_version, 6, "live store must be migrated to current");
+        assert_eq!(live_version, 7, "live store must be migrated to current");
 
         let live_board_id: String = sqlx::query_scalar("SELECT board_id FROM cards WHERE id = ?")
             .bind(card_id.to_string())

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v5_to_v6.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v5_to_v6.rs
@@ -61,7 +61,7 @@ fn test_sqlite_migration_v5_to_v6_creates_join_table() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 6, "schema_version must be bumped to 6");
+        assert_eq!(version, 7, "schema_version must be bumped to 7");
     });
 }
 
@@ -284,6 +284,6 @@ fn test_sqlite_migration_v5_to_v6_writes_v5_backup() {
                 .fetch_one(store.pool())
                 .await
                 .unwrap();
-        assert_eq!(live_version, 6, "live store must be migrated to current");
+        assert_eq!(live_version, 7, "live store must be migrated to current");
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v6_to_v7.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v6_to_v7.rs
@@ -1,0 +1,178 @@
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use std::path::Path;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+/// Seed a schema_version-6 shaped DB directly: `boards` already lacks the
+/// legacy `completion_column_id` column, `board_completion_columns` already
+/// exists, and `columns` has no `default_status` column yet. Returns
+/// (board_id, column_id).
+async fn seed_v6_db(path: &Path) -> (Uuid, Uuid) {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        "CREATE TABLE metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            instance_id TEXT NOT NULL,
+            saved_at TEXT NOT NULL,
+            schema_version INTEGER NOT NULL,
+            writer_version TEXT,
+            writer_commit TEXT
+        );
+        CREATE TABLE boards (
+            id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT,
+            sprint_prefix TEXT, card_prefix TEXT,
+            task_sort_field TEXT NOT NULL DEFAULT 'Default',
+            task_sort_order TEXT NOT NULL DEFAULT 'Ascending',
+            sprint_duration_days INTEGER,
+            sprint_name_used_count INTEGER NOT NULL DEFAULT 0,
+            next_sprint_number INTEGER NOT NULL DEFAULT 1,
+            active_sprint_id TEXT,
+            task_list_view TEXT NOT NULL DEFAULT 'Flat',
+            card_counter INTEGER NOT NULL DEFAULT 1,
+            position INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE columns (
+            id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
+            position INTEGER NOT NULL, wip_limit INTEGER,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+        );
+        CREATE TABLE board_completion_columns (
+            board_id TEXT NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+            column_id TEXT NOT NULL REFERENCES columns(id) ON DELETE CASCADE,
+            position INTEGER NOT NULL,
+            PRIMARY KEY (board_id, column_id)
+        );",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let board_id = Uuid::new_v4();
+    let column_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+         VALUES (1, ?, '2024-01-01T00:00:00Z', 6)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO boards (id, name, created_at, updated_at)
+         VALUES (?, 'B', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+         VALUES (?, ?, 'Doing', 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(column_id.to_string())
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    pool.close().await;
+    (board_id, column_id)
+}
+
+#[test]
+fn test_v6_database_upgrades_to_v7_with_null_default_status_for_existing_columns() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v6.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (_board_id, column_id) = seed_v6_db(&path).await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let default_status: Option<String> =
+            sqlx::query_scalar("SELECT default_status FROM columns WHERE id = ?")
+                .bind(column_id.to_string())
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            default_status, None,
+            "a column named 'Doing' must migrate to NULL, never an inferred status"
+        );
+    });
+}
+
+#[test]
+fn test_v6_to_v7_migration_leaves_a_v6_backup() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v6.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v6_db(&path).await;
+
+        SqliteStore::open(&path).await.unwrap();
+
+        let backup = SqliteStore::backup_path_for(&path, 6);
+        assert!(
+            backup.exists(),
+            "expected exactly one <path>.v6.backup file after opening a schema-6 DB"
+        );
+
+        let backup_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(SqliteConnectOptions::new().filename(&backup))
+            .await
+            .unwrap();
+        let backup_version: u32 =
+            sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                .fetch_one(&backup_pool)
+                .await
+                .unwrap();
+        assert_eq!(backup_version, 6, "backup must be a pre-migration snapshot");
+        let backup_has_default_status: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('columns') WHERE name = 'default_status'",
+        )
+        .fetch_one(&backup_pool)
+        .await
+        .unwrap();
+        assert!(
+            !backup_has_default_status,
+            "backup must predate the default_status migration"
+        );
+        backup_pool.close().await;
+    });
+}
+
+#[test]
+fn test_migrated_database_reports_schema_version_7() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v6.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v6_db(&path).await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let version: u32 = sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(version, 7, "schema_version must be bumped to 7");
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -14,6 +14,7 @@ mod migration_coverage;
 mod migration_v2_to_v3;
 mod migration_v4_to_v5;
 mod migration_v5_to_v6;
+mod migration_v6_to_v7;
 mod persistence_store;
 mod pre_migration_backup;
 mod snapshot_atomicity;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
@@ -127,7 +127,7 @@ fn test_existing_backup_not_clobbered() {
             .await
             .unwrap();
         assert_eq!(
-            version, 6,
+            version, 7,
             "main DB must still migrate to the current schema even when the backup is skipped"
         );
     });

--- a/crates/kanban-service/src/test_helpers/contract/column.rs
+++ b/crates/kanban-service/src/test_helpers/contract/column.rs
@@ -1,7 +1,7 @@
 use super::super::BackendFactory;
 use crate::KanbanContext;
 use kanban_core::AppConfig;
-use kanban_domain::{ColumnUpdate, FieldUpdate, KanbanOperations};
+use kanban_domain::{CardStatus, ColumnUpdate, FieldUpdate, KanbanOperations};
 use tempfile::TempDir;
 
 pub async fn test_column_all_fields_roundtrip(factory: &BackendFactory) {
@@ -52,6 +52,35 @@ pub async fn test_column_without_wip_limit_roundtrip(factory: &BackendFactory) {
     let c = ctx.get_column(col.id).unwrap().unwrap();
     assert_eq!(c.name, "Open");
     assert!(c.wip_limit.is_none());
+}
+
+pub async fn test_column_default_status_roundtrip(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Doing".into(), None).unwrap();
+    assert_eq!(col.default_status, None);
+
+    ctx.update_column(
+        col.id,
+        ColumnUpdate {
+            name: None,
+            position: None,
+            wip_limit: FieldUpdate::NoChange,
+            default_status: Some(Some(CardStatus::InProgress)),
+        },
+    )
+    .unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let c = ctx.get_column(col.id).unwrap().unwrap();
+    assert_eq!(c.default_status, Some(CardStatus::InProgress));
 }
 
 pub async fn test_multiple_columns_preserve_positions(factory: &BackendFactory) {

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -102,6 +102,10 @@ macro_rules! context_contract_tests {
         async fn test_multiple_columns_preserve_positions() {
             $crate::test_helpers::contract::column::test_multiple_columns_preserve_positions(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_column_default_status_roundtrip() {
+            $crate::test_helpers::contract::column::test_column_default_status_roundtrip(&$factory_fn()).await;
+        }
 
         // Sprint tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Third of six children implementing per-column default card status. Makes the field durable in the SQLite backend.

- Add `columns.default_status TEXT` to the schema
- Bump `SUPPORTED_SCHEMA_VERSION` to 7 with a backed-up in-place migration
- Carry the column through every read and write path
- Add a cross-backend contract test so JSON and SQLite are held to one spec

**What**: SQLite databases now store `default_status` per column. Existing databases upgrade in place on open, leaving a `.v6.backup`.

**Why**: KAN-1135 added the field to the domain and KAN-1136 made it durable for JSON. Until this lands, a value set on a SQLite-backed board is silently lost on reload, which is the failure mode the repo's testing rules single out as most dangerous.

**How**: `ALTER TABLE columns ADD COLUMN default_status TEXT`, so no table rebuild is needed, unlike the v5 to v6 migration which had to drop a column. The migration backfills NULL for every existing column with no inference from the column name; a column called "Doing" stays NULL, and a test pins that. The value is stored using the same representation `cards.status` already uses rather than a new spelling.

Three `SELECT` statements beyond the ones this card anticipated also needed the column added, in `data_store.rs` and `lists.rs`. Those surfaced as hard sqlx errors rather than silent nulls, caught by round-trip tests that genuinely reopen the store from disk.

**Testing**: Round-trips for both a set value and NULL, reopening from disk rather than reading back through a cache. Migration tests cover the v6 to v7 upgrade, the backfill, the no-name-inference rule, the backup filename, and the reported schema version. A new contract test in the shared cross-backend suite gives in-memory, JSON and SQLite parity coverage. Verified by hand against a real database file: v6 upgrades to v7 leaving exactly one `.v6.backup`, and a card moved into a column carrying `InProgress` comes back `in_progress`. All four gates green.

The pre-existing schema-version assertions bumped from 6 to 7 are the "current version" pins those tests exist to hold; no backward-compatibility test was altered.
