### PR TITLE
KAN-1138 feat(api,service): expose column default_status through DTOs and the service layer

### DIFF
--- a/.changeset/kan-1138-api-service-default-status.md
+++ b/.changeset/kan-1138-api-service-default-status.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+column default_status through the API and service layer

--- a/crates/kanban-api/src/v1/columns/conversions.rs
+++ b/crates/kanban-api/src/v1/columns/conversions.rs
@@ -18,6 +18,7 @@ impl TryFrom<UpdateColumnRequest> for ColumnUpdate {
             name,
             position,
             wip_limit,
+            default_status,
         } = req;
         validate_position(position)?;
         if let Patch::Set(limit) = &wip_limit {
@@ -27,7 +28,11 @@ impl TryFrom<UpdateColumnRequest> for ColumnUpdate {
             name,
             position,
             wip_limit: wip_limit.into(),
-            default_status: None,
+            default_status: match default_status {
+                Patch::NoChange => None,
+                Patch::Clear => Some(None),
+                Patch::Set(status) => Some(Some(status.into())),
+            },
         })
     }
 }
@@ -45,6 +50,7 @@ impl CreateColumnRequest {
             id,
             name,
             wip_limit,
+            default_status,
         } = self;
         if let Some(limit) = wip_limit {
             validate_wip_limit(limit)?;
@@ -53,7 +59,7 @@ impl CreateColumnRequest {
             board_id,
             name,
             wip_limit,
-            default_status: None,
+            default_status: default_status.map(Into::into),
         };
         Ok((id, spec))
     }
@@ -73,6 +79,7 @@ impl ReplaceColumnRequest {
             name,
             position,
             wip_limit,
+            default_status,
         } = self;
         validate_position(Some(position))?;
         if let Some(limit) = wip_limit {
@@ -82,7 +89,7 @@ impl ReplaceColumnRequest {
             board_id,
             name,
             wip_limit,
-            default_status: None,
+            default_status: default_status.map(Into::into),
         };
         Ok((spec, position))
     }
@@ -120,6 +127,7 @@ fn validate_wip_limit(limit: i32) -> KanbanResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::v1::enums::CardStatusDto;
     use kanban_domain::FieldUpdate;
 
     #[test]
@@ -128,6 +136,7 @@ mod tests {
             name: Some("Done".to_string()),
             position: Some(4),
             wip_limit: Patch::Clear,
+            default_status: Patch::NoChange,
         };
         let update = ColumnUpdate::try_from(req).unwrap();
         assert_eq!(update.name, Some("Done".to_string()));
@@ -141,8 +150,48 @@ mod tests {
             name: None,
             position: None,
             wip_limit: Patch::Set(-1),
+            default_status: Patch::NoChange,
         };
         assert!(ColumnUpdate::try_from(req).is_err());
+    }
+
+    #[test]
+    fn test_update_column_request_default_status_set_maps_to_some_some() {
+        let req = UpdateColumnRequest {
+            name: None,
+            position: None,
+            wip_limit: Patch::NoChange,
+            default_status: Patch::Set(CardStatusDto::InProgress),
+        };
+        let update = ColumnUpdate::try_from(req).unwrap();
+        assert_eq!(
+            update.default_status,
+            Some(Some(kanban_domain::CardStatus::InProgress))
+        );
+    }
+
+    #[test]
+    fn test_update_column_request_default_status_clear_maps_to_some_none() {
+        let req = UpdateColumnRequest {
+            name: None,
+            position: None,
+            wip_limit: Patch::NoChange,
+            default_status: Patch::Clear,
+        };
+        let update = ColumnUpdate::try_from(req).unwrap();
+        assert_eq!(update.default_status, Some(None));
+    }
+
+    #[test]
+    fn test_update_column_request_default_status_no_change_maps_to_none() {
+        let req = UpdateColumnRequest {
+            name: None,
+            position: None,
+            wip_limit: Patch::NoChange,
+            default_status: Patch::NoChange,
+        };
+        let update = ColumnUpdate::try_from(req).unwrap();
+        assert_eq!(update.default_status, None);
     }
 
     #[test]
@@ -152,6 +201,7 @@ mod tests {
             id: None,
             name: "Doing".to_string(),
             wip_limit: Some(3),
+            default_status: None,
         };
         let (id, spec) = req.into_new_column(board_id).unwrap();
         assert_eq!(id, None);
@@ -174,6 +224,7 @@ mod tests {
             id: Some(client_id),
             name: "Doing".to_string(),
             wip_limit: None,
+            default_status: None,
         };
         let (id, _) = req.into_new_column(board_id).unwrap();
         assert_eq!(id, Some(client_id));
@@ -194,6 +245,7 @@ mod tests {
             id: None,
             name: "X".to_string(),
             wip_limit: Some(-5),
+            default_status: None,
         };
         assert!(req.into_new_column(board_id).is_err());
     }
@@ -207,6 +259,7 @@ mod tests {
             id: None,
             name: "Backlog".to_string(),
             wip_limit: None,
+            default_status: None,
         };
         let (_, spec) = req.into_new_column(board_id).unwrap();
         let NewColumn {
@@ -224,6 +277,7 @@ mod tests {
             name: "Doing".to_string(),
             position: 3,
             wip_limit: Some(2),
+            default_status: None,
         };
         let (spec, position) = req.into_new_column(board_id).unwrap();
         assert_eq!(
@@ -245,6 +299,7 @@ mod tests {
             name: "X".to_string(),
             position: -1,
             wip_limit: None,
+            default_status: None,
         };
         assert!(req.into_new_column(board_id).is_err());
     }
@@ -256,6 +311,7 @@ mod tests {
             name: "X".to_string(),
             position: 0,
             wip_limit: Some(-1),
+            default_status: None,
         };
         assert!(req.into_new_column(board_id).is_err());
     }

--- a/crates/kanban-api/src/v1/columns/requests.rs
+++ b/crates/kanban-api/src/v1/columns/requests.rs
@@ -1,3 +1,4 @@
+use super::super::enums::CardStatusDto;
 use super::super::Patch;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -18,6 +19,8 @@ pub struct CreateColumnRequest {
     pub name: String,
     #[serde(default)]
     pub wip_limit: Option<i32>,
+    #[serde(default)]
+    pub default_status: Option<CardStatusDto>,
 }
 
 /// Request body for `PATCH /v1/columns/:id` — JSON Merge Patch (RFC 7386):
@@ -30,6 +33,8 @@ pub struct UpdateColumnRequest {
     pub position: Option<i32>,
     #[serde(default, skip_serializing_if = "Patch::is_no_change")]
     pub wip_limit: Patch<i32>,
+    #[serde(default, skip_serializing_if = "Patch::is_no_change")]
+    pub default_status: Patch<CardStatusDto>,
 }
 
 /// Request body for `PUT /v1/columns/:id` — full replace of client-editable
@@ -40,6 +45,8 @@ pub struct ReplaceColumnRequest {
     pub position: i32,
     #[serde(default)]
     pub wip_limit: Option<i32>,
+    #[serde(default)]
+    pub default_status: Option<CardStatusDto>,
 }
 
 /// Request body for `POST /v1/columns/:id/reorder`.
@@ -58,6 +65,7 @@ mod tests {
             id: None,
             name: "In Review".to_string(),
             wip_limit: Some(3),
+            default_status: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: CreateColumnRequest = serde_json::from_str(&json).unwrap();
@@ -72,6 +80,7 @@ mod tests {
             id: Some(Uuid::new_v4()),
             name: "In Review".to_string(),
             wip_limit: Some(3),
+            default_status: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: CreateColumnRequest = serde_json::from_str(&json).unwrap();
@@ -112,6 +121,7 @@ mod tests {
             name: Some("Done".to_string()),
             position: Some(4),
             wip_limit: Patch::Clear,
+            default_status: Patch::NoChange,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: UpdateColumnRequest = serde_json::from_str(&json).unwrap();

--- a/crates/kanban-api/src/v1/columns/response.rs
+++ b/crates/kanban-api/src/v1/columns/response.rs
@@ -1,3 +1,4 @@
+use super::super::enums::CardStatusDto;
 use chrono::{DateTime, Utc};
 use kanban_domain::Column;
 use serde::{Deserialize, Serialize};
@@ -13,6 +14,7 @@ pub struct ColumnResponse {
     pub name: String,
     pub position: i32,
     pub wip_limit: Option<i32>,
+    pub default_status: Option<CardStatusDto>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -25,6 +27,7 @@ impl From<&Column> for ColumnResponse {
             name: c.name.clone(),
             position: c.position,
             wip_limit: c.wip_limit,
+            default_status: c.default_status.map(Into::into),
             created_at: c.created_at,
             updated_at: c.updated_at,
         }
@@ -57,10 +60,7 @@ mod tests {
 
         let resp = ColumnResponse::from(&column);
 
-        assert_eq!(
-            resp.default_status,
-            Some(super::super::super::enums::CardStatusDto::InProgress)
-        );
+        assert_eq!(resp.default_status, Some(CardStatusDto::InProgress));
         let back: ColumnResponse =
             serde_json::from_str(&serde_json::to_string(&resp).unwrap()).unwrap();
         assert_eq!(back, resp);

--- a/crates/kanban-api/src/v1/columns/response.rs
+++ b/crates/kanban-api/src/v1/columns/response.rs
@@ -48,4 +48,21 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&resp).unwrap()).unwrap();
         assert_eq!(back, resp);
     }
+
+    #[test]
+    fn test_column_response_dto_round_trips_default_status() {
+        let board_id = Uuid::new_v4();
+        let mut column = Column::new(board_id, "Doing", 1);
+        column.default_status = Some(kanban_domain::CardStatus::InProgress);
+
+        let resp = ColumnResponse::from(&column);
+
+        assert_eq!(
+            resp.default_status,
+            Some(super::super::super::enums::CardStatusDto::InProgress)
+        );
+        let back: ColumnResponse =
+            serde_json::from_str(&serde_json::to_string(&resp).unwrap()).unwrap();
+        assert_eq!(back, resp);
+    }
 }

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -815,6 +815,7 @@ fn column_req(board: &str, name: &str) -> CreateColumnParams {
             id: None,
             name: name.to_string(),
             wip_limit: None,
+            default_status: None,
         },
     }
 }
@@ -1603,6 +1604,7 @@ async fn test_mcp_create_column_uses_shared_factory() {
             id: None,
             name: "In Review".into(),
             wip_limit: Some(4),
+            default_status: None,
         },
     };
     let result = server
@@ -1638,6 +1640,7 @@ fn test_mcp_create_column_content_is_the_shared_service_type() {
             id: None,
             name: "x".into(),
             wip_limit: None,
+            default_status: None,
         },
     };
     assert_same(&req.content);

--- a/crates/kanban-service/tests/create_column_from_spec.rs
+++ b/crates/kanban-service/tests/create_column_from_spec.rs
@@ -8,7 +8,8 @@
 //! smoke test guards the relational backend.
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_service::{
-    AppConfig, ColumnCreateOutcome, KanbanBackend, KanbanContext, KanbanOperations, NewColumn,
+    AppConfig, CardStatus, ColumnCreateOutcome, KanbanBackend, KanbanContext, KanbanOperations,
+    NewColumn,
 };
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -278,5 +279,29 @@ async fn test_create_or_replace_column_is_idempotent() {
         ctx.list_columns(bid).unwrap().len(),
         1,
         "PUT twice must not duplicate"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_column_with_default_status_persists_it() {
+    let (_dir, mut ctx) = ctx_for("default_status");
+    let bid = board_id(&mut ctx);
+
+    let column = ctx
+        .create_column_from_spec(
+            None,
+            NewColumn {
+                board_id: bid,
+                name: "Doing".to_string(),
+                wip_limit: None,
+                default_status: Some(CardStatus::InProgress),
+            },
+        )
+        .unwrap();
+
+    assert_eq!(column.default_status, Some(CardStatus::InProgress));
+    assert_eq!(
+        ctx.get_column(column.id).unwrap().unwrap().default_status,
+        Some(CardStatus::InProgress)
     );
 }

--- a/crates/kanban-service/tests/update_column_default_status.rs
+++ b/crates/kanban-service/tests/update_column_default_status.rs
@@ -1,0 +1,116 @@
+//! Service-tier integration tests for `KanbanContext::update_column`'s
+//! `default_status` field: `ColumnUpdate.default_status` is
+//! `Option<Option<CardStatus>>`, so set, clear, and leave-unchanged must be
+//! three distinguishable outcomes.
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_service::{
+    AppConfig, CardStatus, ColumnUpdate, FieldUpdate, KanbanBackend, KanbanContext,
+    KanbanOperations, NewColumn,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+fn make_json_backend(path: &std::path::Path) -> Arc<dyn KanbanBackend> {
+    Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))))
+}
+
+fn ctx_for(name: &str) -> (tempfile::TempDir, KanbanContext) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(format!("{name}.json"));
+    let ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
+    (dir, ctx)
+}
+
+fn board_with_column(ctx: &mut KanbanContext, default_status: Option<CardStatus>) -> Uuid {
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    ctx.create_column_from_spec(
+        None,
+        NewColumn {
+            board_id,
+            name: "Doing".to_string(),
+            wip_limit: None,
+            default_status,
+        },
+    )
+    .unwrap()
+    .id
+}
+
+fn no_op_update() -> ColumnUpdate {
+    ColumnUpdate {
+        name: None,
+        position: None,
+        wip_limit: FieldUpdate::NoChange,
+        default_status: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_column_sets_default_status() {
+    let (_dir, mut ctx) = ctx_for("set");
+    let column_id = board_with_column(&mut ctx, None);
+
+    let updated = ctx
+        .update_column(
+            column_id,
+            ColumnUpdate {
+                default_status: Some(Some(CardStatus::InProgress)),
+                ..no_op_update()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(updated.default_status, Some(CardStatus::InProgress));
+    assert_eq!(
+        ctx.get_column(column_id).unwrap().unwrap().default_status,
+        Some(CardStatus::InProgress)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_column_clears_default_status() {
+    let (_dir, mut ctx) = ctx_for("clear");
+    let column_id = board_with_column(&mut ctx, Some(CardStatus::InProgress));
+
+    let updated = ctx
+        .update_column(
+            column_id,
+            ColumnUpdate {
+                default_status: Some(None),
+                ..no_op_update()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(updated.default_status, None);
+    assert_eq!(
+        ctx.get_column(column_id).unwrap().unwrap().default_status,
+        None
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_column_without_default_status_field_leaves_it_unchanged() {
+    let (_dir, mut ctx) = ctx_for("unchanged");
+    let column_id = board_with_column(&mut ctx, Some(CardStatus::InProgress));
+
+    let updated = ctx
+        .update_column(
+            column_id,
+            ColumnUpdate {
+                name: Some("Renamed".to_string()),
+                ..no_op_update()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(updated.default_status, Some(CardStatus::InProgress));
+    assert_eq!(
+        ctx.get_column(column_id).unwrap().unwrap().default_status,
+        Some(CardStatus::InProgress)
+    );
+}


### PR DESCRIPTION
Fourth of six children implementing per-column default card status. Exposes the field through the wire DTOs and the service layer.

- Add `default_status` to `ColumnResponse` and its `From<&Column>` impl
- Accept it on create, replace and update requests
- Give update three-state set / clear / no-change semantics via the existing `Patch<T>`

**What**: `default_status` is now readable and writable through the API. `column list` reports the value instead of omitting the field.

**Why**: The three prerequisite children made the field durable in the domain and both backends, but the API projection dropped it. The symptom was a value that demonstrably worked while being invisible: with `default_status` set on a SQLite column, moving a card into it correctly yielded `in_progress`, yet nothing in any read surface showed why. That is the worst kind of gap, since the behaviour is real but unexplainable to the user.

**How**: `ColumnResponse` gains the field, mapped from the domain `Column`. On the request side, `UpdateColumnRequest` uses the `Patch<T>` JSON-Merge-Patch type already used for `wip_limit`, converting to the domain's `Option<Option<CardStatus>>` so that setting a value, clearing it, and leaving it alone stay three distinguishable outcomes. `ReplaceColumnRequest` follows PUT semantics, where an absent field clears, matching how `wip_limit` already behaves on that path.

The conversion structs destructure exhaustively with no `..`, so the compiler enumerated every call site that needed a decision rather than letting one silently keep a placeholder.

**Testing**: Service-level tests cover create-with-value and the three update outcomes against a real backend. A DTO round-trip test covers the projection, and three conversion tests pin the wire-to-domain mapping of each `Patch` state at the layer that owns it. Verified by hand that `column list` against a real SQLite database now reports `"default_status":"in_progress"` for a column carrying a value and `null` for those without. All four gates green.

The struct literals updated in `kanban-mcp` tests are mechanical field additions from widening the request type, with no assertion changes.
