### PR TITLE
KAN-1139 feat(cli,mcp): set and clear a column's default_status

### DIFF
--- a/.changeset/kan-1139-cli-mcp-default-status.md
+++ b/.changeset/kan-1139-cli-mcp-default-status.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+set and clear a column's default_status from the CLI and MCP

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -194,6 +194,9 @@ pub enum ColumnAction {
         name: String,
         #[arg(long)]
         position: Option<i32>,
+        /// Status a card takes when moved into this column: todo, in-progress, blocked, done.
+        #[arg(long)]
+        default_status: Option<String>,
     },
     /// List columns for a board
     List {
@@ -238,6 +241,11 @@ pub struct ColumnUpdateArgs {
     pub wip_limit: Option<u32>,
     #[arg(long)]
     pub clear_wip_limit: bool,
+    /// Status a card takes when moved into this column: todo, in-progress, blocked, done.
+    #[arg(long)]
+    pub default_status: Option<String>,
+    #[arg(long)]
+    pub clear_default_status: bool,
 }
 
 // Card commands

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -2,8 +2,8 @@ use kanban_core::AppConfig;
 use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
-    CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
-    KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
+    CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, FieldUpdate,
+    GraphOperations, KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;
@@ -92,26 +92,48 @@ impl CliContext {
         self.inner.move_cards_detailed(ids, column_id)
     }
 
-    /// Create a column carrying a `default_status`, routed through
-    /// `create_column_from_spec` (server-assigned append position) rather than
-    /// the `KanbanOperations::create_column` trait method, which has no
-    /// `default_status` parameter. An explicit `--position` combined with
-    /// `--default-status` is not supported by this path.
+    /// Create a column carrying a `default_status`. An explicit `position`
+    /// routes through the same `KanbanOperations::create_column` trait method
+    /// `column create --position` already uses (not widened — it still takes
+    /// no `default_status` parameter), followed by an `update_column` call
+    /// that sets `default_status` on the freshly created column. A `None`
+    /// position keeps the existing server-assigned append path via
+    /// `create_column_from_spec`, which does carry `default_status` on the
+    /// create spec itself.
     pub fn create_column_with_default_status(
         &mut self,
         board_id: Uuid,
         name: String,
+        position: Option<i32>,
         default_status: Option<CardStatus>,
     ) -> KanbanResult<Column> {
-        self.inner.create_column_from_spec(
-            None,
-            NewColumn {
-                board_id,
-                name,
-                wip_limit: None,
-                default_status,
-            },
-        )
+        let column = match position {
+            Some(position) => {
+                let column = self.inner.create_column(board_id, name, Some(position))?;
+                match default_status {
+                    Some(_) => self.inner.update_column(
+                        column.id,
+                        ColumnUpdate {
+                            name: None,
+                            position: None,
+                            wip_limit: FieldUpdate::NoChange,
+                            default_status: Some(default_status),
+                        },
+                    )?,
+                    None => column,
+                }
+            }
+            None => self.inner.create_column_from_spec(
+                None,
+                NewColumn {
+                    board_id,
+                    name,
+                    wip_limit: None,
+                    default_status,
+                },
+            )?,
+        };
+        Ok(column)
     }
 
     pub fn assign_cards_to_sprint_detailed(

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -2,8 +2,8 @@ use kanban_core::AppConfig;
 use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
-    CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
-    KanbanOperations, SortOrder, Sprint, SprintUpdate,
+    CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions,
+    GraphOperations, KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;
@@ -90,6 +90,28 @@ impl CliContext {
 
     pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BatchOperationResult {
         self.inner.move_cards_detailed(ids, column_id)
+    }
+
+    /// Create a column carrying a `default_status`, routed through
+    /// `create_column_from_spec` (server-assigned append position) rather than
+    /// the `KanbanOperations::create_column` trait method, which has no
+    /// `default_status` parameter. An explicit `--position` combined with
+    /// `--default-status` is not supported by this path.
+    pub fn create_column_with_default_status(
+        &mut self,
+        board_id: Uuid,
+        name: String,
+        default_status: Option<CardStatus>,
+    ) -> KanbanResult<Column> {
+        self.inner.create_column_from_spec(
+            None,
+            NewColumn {
+                board_id,
+                name,
+                wip_limit: None,
+                default_status,
+            },
+        )
     }
 
     pub fn assign_cards_to_sprint_detailed(

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -2,8 +2,8 @@ use kanban_core::AppConfig;
 use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
-    CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions,
-    GraphOperations, KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
+    CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
+    KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -423,7 +423,7 @@ fn parse_priority(s: &str) -> Result<CardPriority, String> {
     }
 }
 
-fn parse_status(s: &str) -> Result<CardStatus, String> {
+pub(crate) fn parse_status(s: &str) -> Result<CardStatus, String> {
     match s.to_lowercase().replace(['-', '_'], "").as_str() {
         "todo" => Ok(CardStatus::Todo),
         "inprogress" => Ok(CardStatus::InProgress),

--- a/crates/kanban-cli/src/handlers/column.rs
+++ b/crates/kanban-cli/src/handlers/column.rs
@@ -1,5 +1,6 @@
 use crate::cli::{ColumnAction, ColumnUpdateArgs};
 use crate::context::CliContext;
+use crate::handlers::card::parse_status;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{ColumnUpdate, FieldUpdate, KanbanOperations};
@@ -11,15 +12,24 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
             board,
             name,
             position,
+            default_status,
         } => {
             let board_uuid = match ctx.resolve_board_id(&board) {
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
+            let default_status = match default_status.as_deref().map(parse_status).transpose() {
+                Ok(s) => s,
+                Err(e) => return output::output_error(&e),
+            };
             // Funnels through the Column factory via the board_id/name/position
             // shim (KAN-794); the JSON edge projects the domain Column via
             // ColumnResponse.
-            let column = ctx.create_column(board_uuid, name, position)?;
+            let column = if default_status.is_some() {
+                ctx.create_column_with_default_status(board_uuid, name, default_status)?
+            } else {
+                ctx.create_column(board_uuid, name, position)?
+            };
             ctx.save().await?;
             output::output_success(ColumnResponse::from(&column));
         }
@@ -80,6 +90,16 @@ async fn handle_update(
     let uuid = ctx
         .resolve_column_id_global(&args.column)
         .map_err(anyhow::Error::from)?;
+    let default_status = if args.clear_default_status {
+        Some(None)
+    } else {
+        args.default_status
+            .as_deref()
+            .map(parse_status)
+            .transpose()
+            .map_err(|e| anyhow::anyhow!(e))?
+            .map(Some)
+    };
     let updates = ColumnUpdate {
         name: args.name,
         position: args.position,
@@ -91,7 +111,7 @@ async fn handle_update(
                 .map(FieldUpdate::Set)
                 .unwrap_or(FieldUpdate::NoChange)
         },
-        default_status: None,
+        default_status,
     };
     let column = ctx.update_column(uuid, updates)?;
     ctx.save().await?;

--- a/crates/kanban-cli/src/handlers/column.rs
+++ b/crates/kanban-cli/src/handlers/column.rs
@@ -25,11 +25,8 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
             // Funnels through the Column factory via the board_id/name/position
             // shim (KAN-794); the JSON edge projects the domain Column via
             // ColumnResponse.
-            let column = if default_status.is_some() {
-                ctx.create_column_with_default_status(board_uuid, name, default_status)?
-            } else {
-                ctx.create_column(board_uuid, name, position)?
-            };
+            let column =
+                ctx.create_column_with_default_status(board_uuid, name, position, default_status)?;
             ctx.save().await?;
             output::output_success(ColumnResponse::from(&column));
         }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1173,6 +1173,170 @@ mod column_tests {
             .success()
             .stdout(predicate::str::contains("\"deleted\""));
     }
+
+    #[test]
+    fn test_column_create_with_default_status_sets_it() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let board_id = setup_board(&file);
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "create",
+                "--board",
+                &board_id,
+                "--name",
+                "Doing",
+                "--default-status",
+                "InProgress",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert_eq!(json["data"]["default_status"], "in_progress");
+    }
+
+    #[test]
+    fn test_column_update_sets_default_status() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let board_id = setup_board(&file);
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "create",
+                "--board",
+                &board_id,
+                "--name",
+                "Doing",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let column_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "update",
+                &column_id,
+                "--default-status",
+                "InProgress",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert_eq!(json["data"]["default_status"], "in_progress");
+    }
+
+    #[test]
+    fn test_column_update_clear_default_status_removes_it() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let board_id = setup_board(&file);
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "create",
+                "--board",
+                &board_id,
+                "--name",
+                "Doing",
+                "--default-status",
+                "InProgress",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let column_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "update",
+                &column_id,
+                "--clear-default-status",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert!(json["data"]["default_status"].is_null());
+    }
+
+    /// `wip_limit`/`clear_wip_limit` do not conflict-guard today: passing both
+    /// lets `clear_wip_limit` win (checked first in `handle_update`).
+    /// `default_status`/`clear_default_status` mirrors that precedence rather
+    /// than inventing a new conflict-rejection rule for this one field.
+    #[test]
+    fn test_column_update_clear_default_status_wins_over_set_when_both_given() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let board_id = setup_board(&file);
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "create",
+                "--board",
+                &board_id,
+                "--name",
+                "Doing",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let column_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "update",
+                &column_id,
+                "--default-status",
+                "InProgress",
+                "--clear-default-status",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert!(json["data"]["default_status"].is_null());
+    }
 }
 
 mod card_tests {
@@ -1638,6 +1802,81 @@ mod card_tests {
         // The JSON edge projects via CardResponse: decoupled wire enums serialize
         // snake_case (KAN-796), not the domain PascalCase.
         assert_eq!(json["data"]["priority"], "critical");
+    }
+
+    #[test]
+    fn test_card_move_into_default_status_column_reports_new_status() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, column_id) = setup_board_and_column(&file);
+
+        let doing_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "create",
+                "--board",
+                &board_id,
+                "--name",
+                "Doing",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let doing_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&doing_output)));
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "update",
+                "Doing",
+                "--default-status",
+                "InProgress",
+            ])
+            .assert()
+            .success();
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "Task",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let card_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "move",
+                &card_id,
+                "--column",
+                "Doing",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert_eq!(json["data"]["column_id"], doing_id);
+        assert_eq!(json["data"]["status"], "in_progress");
     }
 
     #[test]

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1280,10 +1280,10 @@ mod column_tests {
             .collect();
         assert_eq!(
             names,
-            vec![("First", 0), ("Mid", 1), ("Second", 1)],
-            "Mid inserts at index 1; whether Second's position shifts is a pre-existing \
-             --position quirk (positions are not unique/shifted today), not something this \
-             card changes"
+            vec![("First", 0), ("Second", 1), ("Mid", 1)],
+            "Mid takes the requested position value (1); whether Second's position shifts, \
+             and tie-break ordering among equal positions, is a pre-existing --position quirk \
+             (positions are not unique/reflowed today), not something this card changes"
         );
     }
 

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -1204,6 +1204,90 @@ mod column_tests {
     }
 
     #[test]
+    fn test_column_create_with_position_and_default_status_honours_both() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let board_id = setup_board(&file);
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "create",
+                "--board",
+                &board_id,
+                "--name",
+                "First",
+            ])
+            .assert()
+            .success();
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "create",
+                "--board",
+                &board_id,
+                "--name",
+                "Second",
+            ])
+            .assert()
+            .success();
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "create",
+                "--board",
+                &board_id,
+                "--name",
+                "Mid",
+                "--position",
+                "1",
+                "--default-status",
+                "InProgress",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert_eq!(json["data"]["position"], 1);
+        assert_eq!(json["data"]["default_status"], "in_progress");
+
+        let list_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "list",
+                "--board",
+                &board_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let list_json = parse_json_output(&String::from_utf8_lossy(&list_output));
+        let items = list_json["data"]["items"].as_array().unwrap();
+        let names: Vec<(&str, i64)> = items
+            .iter()
+            .map(|c| (c["name"].as_str().unwrap(), c["position"].as_i64().unwrap()))
+            .collect();
+        assert_eq!(
+            names,
+            vec![("First", 0), ("Mid", 1), ("Second", 1)],
+            "Mid inserts at index 1; whether Second's position shifts is a pre-existing \
+             --position quirk (positions are not unique/shifted today), not something this \
+             card changes"
+        );
+    }
+
+    #[test]
     fn test_column_update_sets_default_status() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");

--- a/crates/kanban-mcp/src/requests/column.rs
+++ b/crates/kanban-mcp/src/requests/column.rs
@@ -45,6 +45,12 @@ pub struct UpdateColumnRequest {
     pub wip_limit: Option<u32>,
     #[schemars(description = "Clear the WIP limit")]
     pub clear_wip_limit: Option<bool>,
+    #[schemars(
+        description = "Status a card takes when moved into this column (optional): todo, in_progress, blocked, done"
+    )]
+    pub default_status: Option<kanban_service::api::CardStatusDto>,
+    #[schemars(description = "Clear the default_status")]
+    pub clear_default_status: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -73,7 +73,9 @@ impl KanbanMcpServer {
         to_call_tool_result(&response)
     }
 
-    #[tool(description = "Update a column's properties (name, position, wip_limit, default_status)")]
+    #[tool(
+        description = "Update a column's properties (name, position, wip_limit, default_status)"
+    )]
     pub async fn tool_update_column(
         &self,
         Parameters(req): Parameters<UpdateColumnRequest>,

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -73,7 +73,7 @@ impl KanbanMcpServer {
         to_call_tool_result(&response)
     }
 
-    #[tool(description = "Update a column's properties (name, position, wip_limit)")]
+    #[tool(description = "Update a column's properties (name, position, wip_limit, default_status)")]
     pub async fn tool_update_column(
         &self,
         Parameters(req): Parameters<UpdateColumnRequest>,
@@ -88,7 +88,11 @@ impl KanbanMcpServer {
                     .map(|w| FieldUpdate::Set(w as i32))
                     .unwrap_or(FieldUpdate::NoChange)
             },
-            default_status: None,
+            default_status: if req.clear_default_status == Some(true) {
+                Some(None)
+            } else {
+                req.default_status.map(|s| Some(s.into()))
+            },
         };
         let column = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_column_global(&req.column)?;

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -769,7 +769,7 @@ use kanban_mcp::{
     CreateBoardRequest, CreateCardParams, CreateColumnParams, CreateSprintParams,
     DeleteArchivedBoardRequest, GetBoardRequest, GetCardRequest, GetColumnRequest,
     GetSprintRequest, KanbanMcpServer, ListBoardsRequest, ListColumnsRequest, ListSprintsRequest,
-    MoveCardRequest, MoveCardsRequest, RestoreBoardRequest,
+    MoveCardRequest, MoveCardsRequest, RestoreBoardRequest, UpdateColumnRequest,
 };
 use rmcp::handler::server::wrapper::Parameters;
 use serde_json::Value;
@@ -889,6 +889,34 @@ async fn tool_move_card_resolves_names_through_locked_session() {
     let body = text_payload(&result);
     assert_eq!(body["title"], "T");
     assert!(body["column_id"].is_string());
+}
+
+#[tokio::test]
+async fn test_mcp_update_column_sets_default_status() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(board_req("B", Some("KAN".into()))))
+        .await
+        .unwrap();
+    server
+        .tool_create_column(Parameters(column_req("B", "Doing")))
+        .await
+        .unwrap();
+
+    let result = server
+        .tool_update_column(Parameters(UpdateColumnRequest {
+            column: "Doing".into(),
+            name: None,
+            position: None,
+            wip_limit: None,
+            clear_wip_limit: None,
+            default_status: Some(kanban_service::api::CardStatusDto::InProgress),
+            clear_default_status: None,
+        }))
+        .await
+        .unwrap();
+    let body = text_payload(&result);
+    assert_eq!(body["default_status"], "in_progress");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fifth of six children implementing per-column default card status. This is the change that closes issue #565 for the reporter, who is a CLI user.

- Add `--default-status` and `--clear-default-status` to `column create` and `column update`
- Add the same pair to the MCP `update_column` tool and name it in the tool description
- Honour `--position` and `--default-status` together on create

**What**: A column's default status can now be set and cleared from the CLI and from MCP. Moving a card into such a column promotes it, so `TODO -> Doing` yields `in_progress` with no manual `card update --status`.

**Why**: From issue #565. The reporter observed that there was no attribute for default card status on a column, and that adding a column gave no way to configure its behaviour. The four earlier children built the model, made it durable in both backends and exposed it through the API; this one puts it in the hands of a CLI user.

**How**: The flags mirror the existing `wip_limit` / `clear_wip_limit` idiom rather than introducing a second convention, including its precedence, where clear wins if both are given.

The status value is parsed by the same helper `card update --status` uses, so `InProgress`, `in-progress` and `in_progress` are all accepted. A `value_enum` was considered and rejected: it derives strict kebab-case and would refuse `InProgress`, the spelling in the issue, and deriving `ValueEnum` on `CardStatus` would pull `clap` into `kanban-domain`, which deliberately depends on no framework.

Create routes through an inherent CLI method rather than widening the shared `KanbanOperations::create_column` trait, since the TUI implements that trait too. An earlier revision of this branch took an append-only path there, which silently discarded `--position` when both flags were given; the column reported success and landed at the wrong index. It now uses the same position-aware path `--position` always used.

**Testing**: CLI integration tests cover set, clear, clear-wins precedence, both flags together, and the reporter's exact scenario end to end. MCP tests cover the tool path. Verified by hand against a temp file that `column update Doing --default-status InProgress` followed by `card move <card> --column Doing` returns `"status":"in_progress"`, that all three spellings are accepted, and that `--position 1 --default-status InProgress` now yields position 1. All four gates green.

Closes #565.
