### PR TITLE
KAN-1142 fix(cli,tui): seed template columns with their default card status

### DIFF
--- a/.changeset/kan-1142-seed-default-status.md
+++ b/.changeset/kan-1142-seed-default-status.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Seed board-creation template columns with their default card status

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -178,15 +178,18 @@ fn resolve_archived_board(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, Str
     }
 }
 
-const DEFAULT_TEMPLATE_COLUMNS: [&str; 3] = ["TODO", "Doing", "Complete"];
-
 fn seed_default_columns(
     ctx: &mut CliContext,
     board_id: uuid::Uuid,
 ) -> anyhow::Result<kanban_domain::Board> {
     let mut complete_column_id = None;
-    for name in DEFAULT_TEMPLATE_COLUMNS {
-        let column = ctx.create_column(board_id, name.to_string(), None)?;
+    for (name, default_status) in kanban_domain::DEFAULT_TEMPLATE_COLUMNS {
+        let column = ctx.create_column_with_default_status(
+            board_id,
+            name.to_string(),
+            None,
+            default_status,
+        )?;
         if name == "Complete" {
             complete_column_id = Some(column.id);
         }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -6130,6 +6130,62 @@ mod default_columns_tests {
     }
 
     #[test]
+    fn test_cli_board_init_seeds_default_statuses_on_template_columns() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "create",
+                "--name",
+                "Board",
+                "--with-default-columns",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
+
+        let list_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "list",
+                "--board",
+                &board_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&list_output));
+        let items = json["data"]["items"].as_array().unwrap();
+        let names_and_statuses: Vec<(String, Option<String>)> = items
+            .iter()
+            .map(|c| {
+                (
+                    c["name"].as_str().unwrap().to_string(),
+                    c["default_status"].as_str().map(str::to_string),
+                )
+            })
+            .collect();
+        assert_eq!(
+            names_and_statuses,
+            vec![
+                ("TODO".to_string(), Some("todo".to_string())),
+                ("Doing".to_string(), Some("in_progress".to_string())),
+                ("Complete".to_string(), Some("done".to_string())),
+            ]
+        );
+    }
+
+    #[test]
     fn test_board_create_without_flag_leaves_board_with_no_columns() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");

--- a/crates/kanban-domain/src/column.rs
+++ b/crates/kanban-domain/src/column.rs
@@ -8,6 +8,14 @@ use crate::field_update::FieldUpdate;
 
 pub type ColumnId = Uuid;
 
+/// Name/default_status pairs for the board-creation template, shared by every
+/// seeder so the set cannot drift between them.
+pub const DEFAULT_TEMPLATE_COLUMNS: [(&str, Option<CardStatus>); 3] = [
+    ("TODO", Some(CardStatus::Todo)),
+    ("Doing", Some(CardStatus::InProgress)),
+    ("Complete", Some(CardStatus::Done)),
+];
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Column {
     pub id: ColumnId,

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -106,20 +106,23 @@ pub struct CreateColumn {
     pub board_id: Uuid,
     pub name: String,
     pub position: i32,
+    #[serde(default)]
+    pub default_status: Option<crate::card::CardStatus>,
 }
 
 impl CreateColumn {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         // Funnel construction through the factory (no `Column::new` + post-patch).
-        // The frozen command shape carries only id/board_id/name/position, so
-        // `wip_limit` defaults to `None`; the rich-spec create path (which honours
-        // a client `wip_limit`) lives in the service tier via `Column::create`
-        // dispatched through the import command.
+        // The frozen command shape carries only id/board_id/name/position/
+        // default_status, so `wip_limit` defaults to `None`; the rich-spec
+        // create path (which honours a client `wip_limit`) lives in the
+        // service tier via `Column::create` dispatched through the import
+        // command.
         let spec = crate::NewColumn {
             board_id: self.board_id,
             name: self.name.clone(),
             wip_limit: None,
-            default_status: None,
+            default_status: self.default_status,
         };
         let column = crate::Column::create(spec, self.id, self.position, Utc::now())?;
         context.store.upsert_column(column)?;
@@ -161,6 +164,7 @@ impl DeleteColumn {
             board_id: column.board_id,
             name: column.name.clone(),
             position: column.position,
+            default_status: column.default_status,
         }))];
         if let Some(wip) = column.wip_limit {
             commands.push(Command::Column(ColumnCommand::Update(UpdateColumn {

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -45,7 +45,7 @@ pub use card::{
     CreateCardOptions,
 };
 pub use card_factory::{CardRecord, NewCard};
-pub use column::{Column, ColumnId, ColumnUpdate};
+pub use column::{Column, ColumnId, ColumnUpdate, DEFAULT_TEMPLATE_COLUMNS};
 pub use column_factory::{ColumnRecord, NewColumn};
 pub use dependencies::{
     BlocksEdge, CardEdgeType, DependencyGraph, RelatesEdge, RelatesKind, Severity, SpawnsEdge,

--- a/crates/kanban-domain/tests/column_commands.rs
+++ b/crates/kanban-domain/tests/column_commands.rs
@@ -28,6 +28,7 @@ fn test_create_column_command_funnels_through_factory_with_injected_id() {
         board_id,
         name: "Factory Funnel".to_string(),
         position: 3,
+        default_status: None,
     };
     cmd.execute(&context).unwrap();
 
@@ -84,6 +85,7 @@ fn test_create_column_command_rejects_negative_position_via_factory_validation()
         board_id: Uuid::new_v4(),
         name: "Bad".to_string(),
         position: -1,
+        default_status: None,
     };
     // The legacy `Column::new` + id-overwrite path silently accepts a
     // negative position; routing through `Column::create` enforces the

--- a/crates/kanban-domain/tests/commands_mod.rs
+++ b/crates/kanban-domain/tests/commands_mod.rs
@@ -183,6 +183,7 @@ fn test_command_serde_roundtrip_all_domains() {
             board_id: Uuid::new_v4(),
             name: "Col".into(),
             position: 0,
+            default_status: None,
         })),
         Command::Card(CardCommand::Delete(DeleteCard {
             card_id: Uuid::new_v4(),

--- a/crates/kanban-service/src/context/columns.rs
+++ b/crates/kanban-service/src/context/columns.rs
@@ -102,6 +102,7 @@ impl KanbanContext {
                     board_id,
                     name,
                     position,
+                    default_status: None,
                 }));
                 self.execute(vec![cmd])?;
                 self.get_column_impl(id)?.ok_or_else(|| {

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -13,7 +13,7 @@ use kanban_domain::commands::{
     UpdateCard, UpdateColumn, UpdateSprint,
 };
 use kanban_domain::{
-    BoardUpdate, CardPriority, CardUpdate, ColumnUpdate, FieldUpdate, KanbanOperations,
+    BoardUpdate, CardPriority, CardStatus, CardUpdate, ColumnUpdate, FieldUpdate, KanbanOperations,
     KanbanResult, SortField, SortOrder, SprintStatus, SprintUpdate, TaskListView,
 };
 use kanban_service::KanbanContext;
@@ -432,6 +432,36 @@ async fn test_inverse_delete_column_recreates_with_fields() -> KanbanResult<()> 
     assert_eq!(restored.name, "Reborn", "name restored");
     assert_eq!(restored.position, original_pos, "position restored");
     assert_eq!(restored.wip_limit, Some(7), "wip_limit restored");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undo_column_delete_restores_its_default_status() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "Doing".into(), None)?;
+    ctx.execute(vec![Command::Column(ColumnCommand::Update(UpdateColumn {
+        column_id: col.id,
+        updates: ColumnUpdate {
+            default_status: Some(Some(CardStatus::InProgress)),
+            ..Default::default()
+        },
+    }))])?;
+    ctx.clear_history()?;
+
+    ctx.execute(vec![Command::Column(ColumnCommand::Delete(DeleteColumn {
+        column_id: col.id,
+    }))])?;
+    assert_eq!(ctx.columns()?.len(), 0, "column deleted by forward");
+
+    assert!(ctx.undo()?);
+    let restored = &ctx.columns()?[0];
+    assert_eq!(restored.id, col.id, "id restored");
+    assert_eq!(
+        restored.default_status,
+        Some(CardStatus::InProgress),
+        "default_status restored"
+    );
     Ok(())
 }
 

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -71,6 +71,7 @@ async fn test_inverse_create_column_restores_state() -> KanbanResult<()> {
         board_id,
         name: "TODO".into(),
         position: 0,
+        default_status: None,
     }))])?;
     assert_eq!(ctx.columns()?.len(), 1, "forward execute creates column");
 
@@ -101,6 +102,7 @@ async fn test_inverse_update_column_restores_prior_fields() -> KanbanResult<()> 
         board_id,
         name: "Original".into(),
         position: 5,
+        default_status: None,
     }))])?;
 
     // Update both name and position; leave wip_limit unchanged.

--- a/crates/kanban-service/tests/list_cards_filters.rs
+++ b/crates/kanban-service/tests/list_cards_filters.rs
@@ -42,6 +42,7 @@ async fn setup(ctx: &mut KanbanContext) -> KanbanResult<Setup> {
         board_id,
         name: "Todo".into(),
         position: 0,
+        default_status: None,
     }))])?;
 
     let sprint_a = Uuid::new_v4();

--- a/crates/kanban-service/tests/list_cards_sort.rs
+++ b/crates/kanban-service/tests/list_cards_sort.rs
@@ -49,6 +49,7 @@ async fn seed_three_cards_with_due_dates(
         board_id,
         name: "Todo".into(),
         position: 0,
+        default_status: None,
     }))])?;
 
     let mut ids = Vec::new();

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -478,7 +478,10 @@ impl App {
         }))];
 
         let mut complete_column_id = None;
-        for (name, position) in [("TODO", 0i32), ("Doing", 1i32), ("Complete", 2i32)] {
+        for (position, (name, default_status)) in kanban_domain::DEFAULT_TEMPLATE_COLUMNS
+            .into_iter()
+            .enumerate()
+        {
             let column_id = uuid::Uuid::new_v4();
             if name == "Complete" {
                 complete_column_id = Some(column_id);
@@ -487,7 +490,8 @@ impl App {
                 id: column_id,
                 board_id,
                 name: name.to_string(),
-                position,
+                position: position as i32,
+                default_status,
             })));
         }
         // Configure the template's Complete column as the completion column in

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -689,6 +689,18 @@ mod tests {
     }
 
     #[test]
+    fn test_undo_board_creation_reverses_seeded_default_statuses() {
+        let mut app = App::test_default();
+        create_named_board(&mut app, "Roadmap");
+
+        assert!(app.ctx.undo().unwrap(), "undo applies");
+        assert!(
+            app.ctx.data_store().list_all_columns().unwrap().is_empty(),
+            "the whole creation batch, including the seeded columns, reverses in one step"
+        );
+    }
+
+    #[test]
     fn test_delete_board_key_on_boards_opens_delete_board_confirm() {
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -246,6 +246,7 @@ impl App {
                     board_id,
                     name: column_name.clone(),
                     position,
+                    default_status: None,
                 }));
 
                 let prior_column_count = self

--- a/crates/kanban-tui/tests/column_default_status_tests.rs
+++ b/crates/kanban-tui/tests/column_default_status_tests.rs
@@ -176,6 +176,72 @@ fn test_column_default_status_change_is_undoable() {
 }
 
 #[test]
+fn test_tui_board_creation_seeds_default_statuses_on_template_columns() {
+    let mut app = App::test_default();
+    app.input.set("Board".to_string());
+    app.create_board();
+    app.input.clear();
+    refresh(&mut app);
+
+    let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
+    let columns = board_columns(&app, board_id);
+    let names_and_statuses: Vec<(String, Option<CardStatus>)> = columns
+        .iter()
+        .map(|c| (c.name.clone(), c.default_status))
+        .collect();
+
+    assert_eq!(
+        names_and_statuses,
+        vec![
+            ("TODO".to_string(), Some(CardStatus::Todo)),
+            ("Doing".to_string(), Some(CardStatus::InProgress)),
+            ("Complete".to_string(), Some(CardStatus::Done)),
+        ]
+    );
+}
+
+#[test]
+fn test_card_moved_to_doing_on_fresh_board_is_promoted_to_in_progress() {
+    let mut app = App::test_default();
+    app.input.set("Board".to_string());
+    app.create_board();
+    app.input.clear();
+    refresh(&mut app);
+
+    let board_id = app.ctx.data_store().list_boards().unwrap()[0].id;
+    let columns = board_columns(&app, board_id);
+    let todo_id = columns.iter().find(|c| c.name == "TODO").unwrap().id;
+    let doing_id = columns.iter().find(|c| c.name == "Doing").unwrap().id;
+
+    let card = app
+        .ctx
+        .create_card(
+            board_id,
+            todo_id,
+            "Mover".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(card.status, CardStatus::Todo);
+
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    refresh(&mut app);
+    app.prepare_frame();
+    app.select_card_by_id(card.id);
+
+    app.handle_move_card_right();
+
+    let moved = app.ctx.get_card(card.id).unwrap().unwrap();
+    assert_eq!(moved.column_id, doing_id, "card must land in Doing");
+    assert_eq!(
+        moved.status,
+        CardStatus::InProgress,
+        "a fresh board's seeded default_status must promote the card with zero setup"
+    );
+}
+
+#[test]
 fn test_moving_card_into_default_status_column_updates_status_in_tui() {
     let mut app = App::test_default();
     let (todo, doing, _done) = setup_board_with_columns(&mut app);


### PR DESCRIPTION
The KAN-1133 tree added per-column `default_status` and the promotion rule that consumes it, but neither board-creation seeder ever set the field. `Column::new` hardcodes `default_status: None`, so the promotion feature shipped switched off on every newly created board: a card moved from TODO into Doing kept `Todo` instead of being promoted.

Changes:

- Add `DEFAULT_TEMPLATE_COLUMNS` to `kanban-domain`, pairing each template column name with its default status (TODO/todo, Doing/in_progress, Complete/done). Both seeders read this one table so they cannot drift.
- CLI `seed_default_columns` routes through `create_column_with_default_status`.
- TUI board creation carries `default_status` on the `CreateColumn` payloads, keeping the whole seed in one undoable batch.
- Add `default_status` to the `CreateColumn` command, with `#[serde(default)]` so existing command-log entries stay deserializable.
- Carry `default_status` through `DeleteColumn::capture_inverse`. Undoing a column deletion previously resurrected the column with its default status lost.

Verified end to end on both backends, with no setup step: a card created in TODO reports `todo`, moving it to Doing reports `in_progress`, and moving it to Complete reports `done`. A card explicitly set to `blocked` still stays `blocked` when moved into Doing, so a deliberate status is never clobbered.

Existing boards are untouched. Their columns keep `default_status: None`, which remains valid.