### PR TITLE
KAN-1157 feat(persistence-sqlite): v8 derives columns.default_status from board_completion_columns

### DIFF
--- a/.changeset/kan-1157-sqlite-v8.md
+++ b/.changeset/kan-1157-sqlite-v8.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+SQLite v8 derives columns.default_status from board_completion_columns

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,7 @@ dependencies = [
  "kanban-core",
  "kanban-domain",
  "kanban-persistence",
+ "kanban-persistence-json",
  "kanban-service",
  "serde",
  "serde_json",

--- a/crates/kanban-persistence-sqlite/Cargo.toml
+++ b/crates/kanban-persistence-sqlite/Cargo.toml
@@ -36,6 +36,7 @@ tempfile.workspace = true
 
 [dev-dependencies]
 kanban-service = { path = "../kanban-service", features = ["test-helpers"] }
+kanban-persistence-json = { path = "../kanban-persistence-json" }
 tokio = { workspace = true, features = ["full"] }
 
 [[test]]

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -1,4 +1,7 @@
 -- SQLite schema for kanban persistence
+-- Version: 8 (columns.default_status derived from board_completion_columns
+-- for every column still NULL — see
+-- init.rs::migrate_v7_to_v8_default_status_derivation)
 -- Version: 7 (columns.default_status added — see
 -- init.rs::migrate_v6_to_v7_column_default_status)
 -- Version: 6 (boards.completion_column_id replaced by the ordered

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/card.rs
@@ -4,7 +4,7 @@ use kanban_domain::{Card, KanbanResult, SprintLog};
 use sqlx::Row;
 
 use crate::sqlite_store::conversions::{row_to_card, row_to_sprint_log};
-use crate::sqlite_store::helpers::{db_err, fmt_dt, opt_dt, required_str};
+use crate::sqlite_store::helpers::{db_err, fmt_dt, opt_dt, required_str, ser_enum};
 use crate::sqlite_store::SqliteStore;
 
 impl SqliteStore {
@@ -48,7 +48,7 @@ impl SqliteStore {
         .bind(required_str(&card.title, "card.title")?)
         .bind(&card.description)
         .bind(format!("{:?}", card.priority))
-        .bind(format!("{:?}", card.status))
+        .bind(ser_enum(&card.status, "card.status")?)
         .bind(card.position)
         .bind(opt_dt(&card.due_date))
         .bind(card.points.map(|v| v as i32))

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/column.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/column.rs
@@ -1,6 +1,6 @@
 use kanban_domain::{Column, ColumnRecord, KanbanResult};
 
-use crate::sqlite_store::helpers::{db_err, fmt_dt, required_str};
+use crate::sqlite_store::helpers::{db_err, fmt_dt, required_str, ser_enum};
 use crate::sqlite_store::SqliteStore;
 
 impl SqliteStore {
@@ -9,6 +9,11 @@ impl SqliteStore {
         column: &Column,
     ) -> KanbanResult<()> {
         let rec = ColumnRecord::from(column);
+        let default_status = rec
+            .default_status
+            .as_ref()
+            .map(|s| ser_enum(s, "column.default_status"))
+            .transpose()?;
         sqlx::query(
             "INSERT INTO columns (id, board_id, name, position, wip_limit, default_status,
                 created_at, updated_at)
@@ -24,7 +29,7 @@ impl SqliteStore {
         .bind(required_str(&rec.name, "column.name")?)
         .bind(rec.position)
         .bind(rec.wip_limit)
-        .bind(rec.default_status.map(|s| format!("{s:?}")))
+        .bind(default_status)
         .bind(fmt_dt(&rec.created_at))
         .bind(fmt_dt(&rec.updated_at))
         .execute(&mut *conn)

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -144,6 +144,7 @@ impl SqliteStore {
         }
         Self::migrate_v5_to_v6_completion_columns(pool).await?;
         Self::migrate_v6_to_v7_column_default_status(pool).await?;
+        Self::migrate_v7_to_v8_default_status_derivation(pool).await?;
 
         // Once the ALTERs above have caught the schema up, normalise
         // schema_version. Doing it unconditionally is idempotent and
@@ -633,6 +634,57 @@ impl SqliteStore {
             .execute(pool)
             .await
             .map_err(db_err)?;
+        Ok(())
+    }
+
+    /// Schema 7 -> 8: derive `columns.default_status` for every column still
+    /// carrying `NULL` at the time a pre-8 database is opened, using
+    /// `board_completion_columns` as the source of completion membership.
+    /// `board_completion_columns` is left in place. A column whose
+    /// `default_status` is already set (by an earlier write or a prior
+    /// partial run of this migration) keeps that value; only `NULL` rows
+    /// are touched.
+    ///
+    /// Idempotence gate: `metadata.schema_version` read directly (not the
+    /// `NULL`-presence check the shape-changing migrations above use) — a
+    /// column created after this migration has already run is allowed to
+    /// carry `default_status = NULL` deliberately (`NewColumn.default_status:
+    /// None`), and `migrate()` runs on every `open()`, so gating on "any NULL
+    /// row exists" would re-backfill those columns on the next open instead
+    /// of leaving the one-time migration's job done. A missing metadata row
+    /// means a brand-new database, which has no columns to backfill either
+    /// way.
+    pub(crate) async fn migrate_v7_to_v8_default_status_derivation(
+        pool: &Pool<Sqlite>,
+    ) -> KanbanResult<()> {
+        let schema_version: Option<u32> =
+            sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                .fetch_optional(pool)
+                .await
+                .map_err(db_err)?;
+        if !matches!(schema_version, Some(v) if v < 8) {
+            return Ok(());
+        }
+
+        tracing::info!(
+            "migrating SQLite schema 7 -> 8: columns.default_status derived from \
+             board_completion_columns"
+        );
+
+        sqlx::raw_sql(
+            "BEGIN;
+            UPDATE columns
+               SET default_status = 'Done'
+             WHERE default_status IS NULL
+               AND id IN (SELECT column_id FROM board_completion_columns);
+            UPDATE columns
+               SET default_status = 'Todo'
+             WHERE default_status IS NULL;
+            COMMIT;",
+        )
+        .execute(pool)
+        .await
+        .map_err(db_err)?;
         Ok(())
     }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -33,7 +33,7 @@ const SCHEMA: &str = include_str!("../schema.sql");
 /// added to `init::migrate` or a sibling `migrate_*` function MUST be
 /// paired with bumping this constant, or it will run unbacked-up — the two
 /// are intentionally coupled but not enforced by the type system.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 7;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 8;
 
 /// sqlx-sqlite defaults `busy_timeout` to 5s; set to 10s to give a long
 /// command batch more headroom before a concurrently-flushing writer gives up.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -99,7 +99,7 @@ fn test_open_migrates_old_db_to_current_schema_with_board_archival_and_backup() 
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 7, "old DB migrates to current schema v7");
+        assert_eq!(version, 8, "old DB migrates to current schema v8");
 
         // board_archival table exists after the schema step.
         let has_table: bool = sqlx::query_scalar(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
@@ -73,6 +73,31 @@ fn seed_column(store: &SqliteStore) -> Uuid {
 }
 
 #[test]
+fn test_card_status_is_stored_as_its_serde_wire_name_not_debug_output() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let column_id = seed_column(&store);
+
+        let card = fully_populated_card(column_id);
+        let id = card.id;
+        store.upsert_card(card).unwrap();
+
+        let raw: String = sqlx::query_scalar("SELECT status FROM cards WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            raw, "Done",
+            "the raw stored text must be the serde wire name, never Debug output"
+        );
+    });
+}
+
+#[test]
 fn test_list_cards_by_column_ties_break_by_id_when_position_and_created_at_equal() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.sqlite3");

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/columns.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/columns.rs
@@ -172,6 +172,35 @@ fn test_column_null_default_status_round_trips_as_none() {
 }
 
 #[test]
+fn test_column_default_status_is_stored_as_its_serde_wire_name_not_debug_output() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let board = Board::new("B", None::<String>);
+        let board_id = board.id;
+        store.upsert_board(board).unwrap();
+
+        let mut record = record_for(board_id, None);
+        record.default_status = Some(CardStatus::Done);
+        let column = Column::reconstitute(record).unwrap();
+        let id = column.id;
+        store.upsert_column(column).unwrap();
+
+        let raw: String = sqlx::query_scalar("SELECT default_status FROM columns WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            raw, "Done",
+            "the raw stored text must be the serde wire name, never Debug output"
+        );
+    });
+}
+
+#[test]
 fn test_list_columns_by_board_ties_break_by_created_at_then_id() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.sqlite3");

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/init.rs
@@ -90,7 +90,7 @@ fn test_fresh_db_records_current_schema_version() {
             .await
             .unwrap();
         assert_eq!(version, SUPPORTED_SCHEMA_VERSION);
-        assert_eq!(version, 7, "fresh DB stamps schema_version 7");
+        assert_eq!(version, 8, "fresh DB stamps schema_version 8");
     });
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_coverage.rs
@@ -81,8 +81,8 @@ fn test_migration_base_case_empty_db_backs_up_and_migrates_clean() {
 
         assert_eq!(
             store_schema_version(&store).await,
-            7,
-            "migrated to current v7"
+            8,
+            "migrated to current v8"
         );
         assert_eq!(
             backup_schema_version(&path).await,
@@ -130,7 +130,7 @@ fn test_migration_cards_case_preserves_live_and_archived_cards() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 7);
+        assert_eq!(store_schema_version(&store).await, 8);
         assert_eq!(backup_schema_version(&path).await, 2);
 
         // Board survived.
@@ -218,7 +218,7 @@ fn test_migration_boards_case_preserves_multiple_board_subtrees() {
 
         let store = SqliteStore::open(&path).await.unwrap();
 
-        assert_eq!(store_schema_version(&store).await, 7);
+        assert_eq!(store_schema_version(&store).await, 8);
         assert_eq!(backup_schema_version(&path).await, 2);
 
         // Both boards survived with their subtrees.
@@ -249,7 +249,7 @@ fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
         // First open: migrates + writes the v2 backup.
         {
             let store = SqliteStore::open(&path).await.unwrap();
-            assert_eq!(store_schema_version(&store).await, 7);
+            assert_eq!(store_schema_version(&store).await, 8);
         }
         let backup = SqliteStore::backup_path_for(&path, 2);
         assert!(backup.exists());
@@ -258,7 +258,7 @@ fn test_migration_reopen_is_idempotent_and_writes_no_new_backup() {
         // Second open on the now-v3 DB: no migration, backup untouched.
         {
             let store = SqliteStore::open(&path).await.unwrap();
-            assert_eq!(store_schema_version(&store).await, 7);
+            assert_eq!(store_schema_version(&store).await, 8);
             assert_eq!(store.list_archived_cards().unwrap().len(), 1, "data intact");
         }
         assert_eq!(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v2_to_v3.rs
@@ -226,8 +226,8 @@ fn test_migrate_v2_db_adds_board_id_and_backfills() {
             .await
             .unwrap();
         assert_eq!(
-            version, 7,
-            "schema_version bumped to current (2->3 archived_cards, 4->5 cards.board_id, 5->6 completion columns, 6->7 column default_status)"
+            version, 8,
+            "schema_version bumped to current (2->3 archived_cards, 4->5 cards.board_id, 5->6 completion columns, 6->7 column default_status, 7->8 default_status derivation)"
         );
     });
 }
@@ -292,7 +292,7 @@ fn test_migrate_is_idempotent_on_v3_db() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, 8);
 
         let still_there: bool =
             sqlx::query_scalar("SELECT COUNT(*) > 0 FROM archived_cards WHERE card_id = ?")

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v4_to_v5.rs
@@ -117,7 +117,7 @@ fn test_open_schema4_db_writes_durable_backup_before_board_id_migration() {
                 .fetch_one(store.pool())
                 .await
                 .unwrap();
-        assert_eq!(live_version, 7, "live store must be migrated to current");
+        assert_eq!(live_version, 8, "live store must be migrated to current");
 
         let live_board_id: String = sqlx::query_scalar("SELECT board_id FROM cards WHERE id = ?")
             .bind(card_id.to_string())

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v5_to_v6.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v5_to_v6.rs
@@ -61,7 +61,7 @@ fn test_sqlite_migration_v5_to_v6_creates_join_table() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 7, "schema_version must be bumped to 7");
+        assert_eq!(version, 8, "schema_version must be bumped to 8");
     });
 }
 
@@ -284,6 +284,6 @@ fn test_sqlite_migration_v5_to_v6_writes_v5_backup() {
                 .fetch_one(store.pool())
                 .await
                 .unwrap();
-        assert_eq!(live_version, 7, "live store must be migrated to current");
+        assert_eq!(live_version, 8, "live store must be migrated to current");
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v6_to_v7.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v6_to_v7.rs
@@ -96,7 +96,11 @@ async fn seed_v6_db(path: &Path) -> (Uuid, Uuid) {
 }
 
 #[test]
-fn test_v6_database_upgrades_to_v7_with_null_default_status_for_existing_columns() {
+fn test_v6_database_upgrades_to_v8_with_todo_default_status_for_non_completion_columns() {
+    // v7's terminal NULL is superseded by v8, which runs in the same
+    // open() chain and derives a non-null value for every column; a column
+    // named "Doing" that is not in board_completion_columns must never be
+    // inferred as Done from its name, only from completion membership.
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("v6.db");
     let rt = make_rt();
@@ -112,8 +116,9 @@ fn test_v6_database_upgrades_to_v7_with_null_default_status_for_existing_columns
                 .await
                 .unwrap();
         assert_eq!(
-            default_status, None,
-            "a column named 'Doing' must migrate to NULL, never an inferred status"
+            default_status,
+            Some("Todo".to_string()),
+            "a column named 'Doing' that is not a completion column must derive Todo, never an inferred status from its name"
         );
     });
 }
@@ -160,7 +165,7 @@ fn test_v6_to_v7_migration_leaves_a_v6_backup() {
 }
 
 #[test]
-fn test_migrated_database_reports_schema_version_7() {
+fn test_migrated_database_reports_schema_version_8() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("v6.db");
     let rt = make_rt();
@@ -173,6 +178,6 @@ fn test_migrated_database_reports_schema_version_7() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-        assert_eq!(version, 7, "schema_version must be bumped to 7");
+        assert_eq!(version, 8, "schema_version must be bumped to 8");
     });
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v7_to_v8.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v7_to_v8.rs
@@ -1,0 +1,360 @@
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::Pool;
+use sqlx::Sqlite;
+use std::path::Path;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+/// Seed a schema_version-7 shaped DB directly: `columns.default_status`
+/// already exists (nullable), `board_completion_columns` already exists.
+/// Returns (pool, board_id, done_column_id, other_column_id).
+async fn seed_v7_db(path: &Path) -> (Pool<Sqlite>, Uuid, Uuid, Uuid) {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        "CREATE TABLE metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            instance_id TEXT NOT NULL,
+            saved_at TEXT NOT NULL,
+            schema_version INTEGER NOT NULL,
+            writer_version TEXT,
+            writer_commit TEXT
+        );
+        CREATE TABLE boards (
+            id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT,
+            sprint_prefix TEXT, card_prefix TEXT,
+            task_sort_field TEXT NOT NULL DEFAULT 'Default',
+            task_sort_order TEXT NOT NULL DEFAULT 'Ascending',
+            sprint_duration_days INTEGER,
+            sprint_name_used_count INTEGER NOT NULL DEFAULT 0,
+            next_sprint_number INTEGER NOT NULL DEFAULT 1,
+            active_sprint_id TEXT,
+            task_list_view TEXT NOT NULL DEFAULT 'Flat',
+            card_counter INTEGER NOT NULL DEFAULT 1,
+            position INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE columns (
+            id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
+            position INTEGER NOT NULL, wip_limit INTEGER, default_status TEXT,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+        );
+        CREATE TABLE board_completion_columns (
+            board_id TEXT NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+            column_id TEXT NOT NULL REFERENCES columns(id) ON DELETE CASCADE,
+            position INTEGER NOT NULL,
+            PRIMARY KEY (board_id, column_id)
+        );
+        CREATE TABLE cards (
+            id TEXT PRIMARY KEY, column_id TEXT NOT NULL, board_id TEXT NOT NULL,
+            title TEXT NOT NULL, description TEXT,
+            priority TEXT NOT NULL DEFAULT 'Medium', status TEXT NOT NULL DEFAULT 'Todo',
+            position INTEGER NOT NULL, due_date TEXT,
+            points INTEGER CHECK (points >= 0 AND points <= 255),
+            card_number INTEGER NOT NULL DEFAULT 0, sprint_id TEXT,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL, completed_at TEXT
+        );
+        CREATE TABLE sprints (
+            id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
+            number INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'Planned',
+            start_date TEXT, end_date TEXT,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE spawns_edges (
+            source_id TEXT NOT NULL, target_id TEXT NOT NULL,
+            PRIMARY KEY (source_id, target_id)
+        );",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let board_id = Uuid::new_v4();
+    let done_column_id = Uuid::new_v4();
+    let other_column_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+         VALUES (1, ?, '2024-01-01T00:00:00Z', 7)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO boards (id, name, created_at, updated_at)
+         VALUES (?, 'B', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    for (cid, name, pos) in [
+        (done_column_id, "Complete", 1),
+        (other_column_id, "Doing", 0),
+    ] {
+        sqlx::query(
+            "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+             VALUES (?, ?, ?, ?, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+        )
+        .bind(cid.to_string())
+        .bind(board_id.to_string())
+        .bind(name)
+        .bind(pos)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    sqlx::query(
+        "INSERT INTO board_completion_columns (board_id, column_id, position)
+         VALUES (?, ?, 0)",
+    )
+    .bind(board_id.to_string())
+    .bind(done_column_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    (pool, board_id, done_column_id, other_column_id)
+}
+
+async fn default_status_of(pool: &Pool<Sqlite>, column_id: Uuid) -> Option<String> {
+    sqlx::query_scalar("SELECT default_status FROM columns WHERE id = ?")
+        .bind(column_id.to_string())
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+#[test]
+fn test_v7_to_v8_sets_done_for_columns_in_board_completion_columns() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v7.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (seed_pool, _board_id, done_column_id, _other) = seed_v7_db(&path).await;
+        seed_pool.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let status = default_status_of(store.pool(), done_column_id).await;
+        assert_eq!(status, Some("Done".to_string()));
+    });
+}
+
+#[test]
+fn test_v7_to_v8_sets_todo_for_other_columns() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v7.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (seed_pool, _board_id, _done, other_column_id) = seed_v7_db(&path).await;
+        seed_pool.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let status = default_status_of(store.pool(), other_column_id).await;
+        assert_eq!(status, Some("Todo".to_string()));
+    });
+}
+
+#[test]
+fn test_v7_to_v8_existing_default_status_wins_over_derivation() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v7.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (seed_pool, _board_id, done_column_id, _other) = seed_v7_db(&path).await;
+        sqlx::query("UPDATE columns SET default_status = 'InProgress' WHERE id = ?")
+            .bind(done_column_id.to_string())
+            .execute(&seed_pool)
+            .await
+            .unwrap();
+        seed_pool.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let status = default_status_of(store.pool(), done_column_id).await;
+        assert_eq!(
+            status,
+            Some("InProgress".to_string()),
+            "a completion column carrying an explicit non-Done default_status must keep it"
+        );
+    });
+}
+
+#[test]
+fn test_v7_to_v8_leaves_board_completion_columns_in_place() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v7.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (seed_pool, board_id, done_column_id, _other) = seed_v7_db(&path).await;
+        seed_pool.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let rows = super::completion_rows(&store, board_id).await;
+        assert_eq!(rows, vec![done_column_id.to_string()]);
+    });
+}
+
+#[test]
+fn test_v7_to_v8_writes_a_v7_backup_before_migrating() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v7.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (seed_pool, _board_id, _done, _other) = seed_v7_db(&path).await;
+        seed_pool.close().await;
+
+        SqliteStore::open(&path).await.unwrap();
+
+        let backup = SqliteStore::backup_path_for(&path, 7);
+        assert!(
+            backup.exists(),
+            "expected a <path>.v7.backup file after opening a schema-7 DB"
+        );
+
+        let backup_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(SqliteConnectOptions::new().filename(&backup))
+            .await
+            .unwrap();
+        let backup_version: u32 =
+            sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                .fetch_one(&backup_pool)
+                .await
+                .unwrap();
+        assert_eq!(backup_version, 7, "backup must be a pre-migration snapshot");
+        backup_pool.close().await;
+    });
+}
+
+#[test]
+fn test_v7_to_v8_preserves_cards_columns_sprints_and_edges() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v7.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (seed_pool, board_id, done_column_id, other_column_id) = seed_v7_db(&path).await;
+
+        let card_a = Uuid::new_v4();
+        let card_b = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO cards (id, column_id, board_id, title, position, card_number,
+                created_at, updated_at)
+             VALUES (?, ?, ?, 'Card A', 0, 1, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+        )
+        .bind(card_a.to_string())
+        .bind(other_column_id.to_string())
+        .bind(board_id.to_string())
+        .execute(&seed_pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO cards (id, column_id, board_id, title, position, card_number,
+                created_at, updated_at)
+             VALUES (?, ?, ?, 'Card B', 1, 2, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+        )
+        .bind(card_b.to_string())
+        .bind(done_column_id.to_string())
+        .bind(board_id.to_string())
+        .execute(&seed_pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO sprints (id, board_id, name, number, created_at, updated_at)
+             VALUES (?, ?, 'Sprint 1', 1, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(board_id.to_string())
+        .execute(&seed_pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO spawns_edges (source_id, target_id) VALUES (?, ?)")
+            .bind(card_a.to_string())
+            .bind(card_b.to_string())
+            .execute(&seed_pool)
+            .await
+            .unwrap();
+        seed_pool.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let boards: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM boards")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(boards, 1, "board survived");
+
+        let columns: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM columns")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(columns, 2, "both columns survived");
+
+        let cards: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cards")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(cards, 2, "both cards survived");
+
+        let sprints: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sprints")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(sprints, 1, "sprint survived");
+
+        let edges: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM spawns_edges")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(edges, 1, "spawns edge survived");
+
+        let completion_rows_after = super::completion_rows(&store, board_id).await;
+        assert_eq!(completion_rows_after, vec![done_column_id.to_string()]);
+    });
+}
+
+#[test]
+fn test_v8_migration_is_idempotent() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v7.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let (seed_pool, _board_id, done_column_id, other_column_id) = seed_v7_db(&path).await;
+        seed_pool.close().await;
+
+        {
+            let store = SqliteStore::open(&path).await.unwrap();
+            assert_eq!(
+                default_status_of(store.pool(), done_column_id).await,
+                Some("Done".to_string())
+            );
+        }
+
+        let store = SqliteStore::open(&path).await.unwrap();
+        assert_eq!(
+            default_status_of(store.pool(), done_column_id).await,
+            Some("Done".to_string())
+        );
+        assert_eq!(
+            default_status_of(store.pool(), other_column_id).await,
+            Some("Todo".to_string())
+        );
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -15,6 +15,7 @@ mod migration_v2_to_v3;
 mod migration_v4_to_v5;
 mod migration_v5_to_v6;
 mod migration_v6_to_v7;
+mod migration_v7_to_v8;
 mod persistence_store;
 mod pre_migration_backup;
 mod snapshot_atomicity;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/pre_migration_backup.rs
@@ -127,7 +127,7 @@ fn test_existing_backup_not_clobbered() {
             .await
             .unwrap();
         assert_eq!(
-            version, 7,
+            version, 8,
             "main DB must still migrate to the current schema even when the backup is skipped"
         );
     });

--- a/crates/kanban-persistence-sqlite/tests/default_status_migration_parity.rs
+++ b/crates/kanban-persistence-sqlite/tests/default_status_migration_parity.rs
@@ -1,0 +1,229 @@
+use kanban_domain::data_store::DataStore;
+use kanban_persistence::PersistenceStore;
+use kanban_persistence_json::JsonFileStore;
+use kanban_persistence_sqlite::SqliteStore;
+use serde_json::{json, Value};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+/// Write a V13 JSON envelope (pre-derivation: every column carries a `null`
+/// `default_status`) with one board whose `completion_column_ids` names
+/// `done_column_id`, and two columns.
+async fn write_v13_json(
+    path: &std::path::Path,
+    board_id: Uuid,
+    done_column_id: Uuid,
+    other_column_id: Uuid,
+) {
+    let envelope = json!({
+        "version": 13,
+        "metadata": {
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "saved_at": "2024-01-01T00:00:00Z"
+        },
+        "data": {
+            "boards": [{
+                "id": board_id,
+                "name": "B",
+                "completion_column_ids": [done_column_id],
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z"
+            }],
+            "columns": [
+                {
+                    "id": done_column_id, "board_id": board_id, "name": "Complete",
+                    "position": 1, "default_status": Value::Null,
+                    "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+                },
+                {
+                    "id": other_column_id, "board_id": board_id, "name": "Doing",
+                    "position": 0, "default_status": Value::Null,
+                    "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+                }
+            ],
+            "cards": [],
+            "archived_cards": [],
+            "sprints": [],
+            "graph": {
+                "spawns": { "edges": [] },
+                "blocks": { "edges": [] },
+                "relates": { "edges": [] }
+            }
+        }
+    });
+    tokio::fs::write(path, serde_json::to_string_pretty(&envelope).unwrap())
+        .await
+        .unwrap();
+}
+
+/// Read back a column's `default_status` from a JSON store's loaded data.
+async fn json_default_status(path: &std::path::Path, column_id: Uuid) -> Option<String> {
+    let store = JsonFileStore::new(path);
+    let (snapshot, _) = store.load().await.unwrap();
+    let data: Value = serde_json::from_slice(&snapshot.data).unwrap();
+    data["columns"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["id"] == column_id.to_string())
+        .and_then(|c| c["default_status"].as_str())
+        .map(str::to_string)
+}
+
+/// Seed a schema_version-7 shaped SQLite DB directly: `columns.default_status`
+/// already exists (nullable), `board_completion_columns` already exists.
+async fn write_v7_sqlite(
+    path: &std::path::Path,
+    board_id: Uuid,
+    done_column_id: Uuid,
+    other_column_id: Uuid,
+) {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        "CREATE TABLE metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            instance_id TEXT NOT NULL,
+            saved_at TEXT NOT NULL,
+            schema_version INTEGER NOT NULL,
+            writer_version TEXT,
+            writer_commit TEXT
+        );
+        CREATE TABLE boards (
+            id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT,
+            sprint_prefix TEXT, card_prefix TEXT,
+            task_sort_field TEXT NOT NULL DEFAULT 'Default',
+            task_sort_order TEXT NOT NULL DEFAULT 'Ascending',
+            sprint_duration_days INTEGER,
+            sprint_name_used_count INTEGER NOT NULL DEFAULT 0,
+            next_sprint_number INTEGER NOT NULL DEFAULT 1,
+            active_sprint_id TEXT,
+            task_list_view TEXT NOT NULL DEFAULT 'Flat',
+            card_counter INTEGER NOT NULL DEFAULT 1,
+            position INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE columns (
+            id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
+            position INTEGER NOT NULL, wip_limit INTEGER, default_status TEXT,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+        );
+        CREATE TABLE board_completion_columns (
+            board_id TEXT NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+            column_id TEXT NOT NULL REFERENCES columns(id) ON DELETE CASCADE,
+            position INTEGER NOT NULL,
+            PRIMARY KEY (board_id, column_id)
+        );",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+         VALUES (1, ?, '2024-01-01T00:00:00Z', 7)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO boards (id, name, created_at, updated_at)
+         VALUES (?, 'B', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+    )
+    .bind(board_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+    for (cid, name, pos) in [
+        (done_column_id, "Complete", 1),
+        (other_column_id, "Doing", 0),
+    ] {
+        sqlx::query(
+            "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+             VALUES (?, ?, ?, ?, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+        )
+        .bind(cid.to_string())
+        .bind(board_id.to_string())
+        .bind(name)
+        .bind(pos)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    sqlx::query(
+        "INSERT INTO board_completion_columns (board_id, column_id, position)
+         VALUES (?, ?, 0)",
+    )
+    .bind(board_id.to_string())
+    .bind(done_column_id.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    pool.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_and_sqlite_derive_identical_default_status_for_the_same_graph() {
+    let dir = TempDir::new().unwrap();
+    let board_id = Uuid::new_v4();
+    let done_column_id = Uuid::new_v4();
+    let other_column_id = Uuid::new_v4();
+
+    let json_path = dir.path().join("board.json");
+    write_v13_json(&json_path, board_id, done_column_id, other_column_id).await;
+
+    let sqlite_path = dir.path().join("board.sqlite3");
+    write_v7_sqlite(&sqlite_path, board_id, done_column_id, other_column_id).await;
+
+    let json_done_status = json_default_status(&json_path, done_column_id).await;
+    let json_other_status = json_default_status(&json_path, other_column_id).await;
+
+    let store = SqliteStore::open(&sqlite_path).await.unwrap();
+    let sqlite_columns = store.list_columns_by_board(board_id).unwrap();
+    let sqlite_done_status = sqlite_columns
+        .iter()
+        .find(|c| c.id == done_column_id)
+        .and_then(|c| c.default_status)
+        .map(|s| {
+            serde_json::to_value(s)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string()
+        });
+    let sqlite_other_status = sqlite_columns
+        .iter()
+        .find(|c| c.id == other_column_id)
+        .and_then(|c| c.default_status)
+        .map(|s| {
+            serde_json::to_value(s)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string()
+        });
+
+    assert_eq!(
+        json_done_status, sqlite_done_status,
+        "the completion column must derive the same default_status on both backends"
+    );
+    assert_eq!(
+        json_other_status, sqlite_other_status,
+        "the non-completion column must derive the same default_status on both backends"
+    );
+    assert_eq!(json_done_status, Some("Done".to_string()));
+    assert_eq!(json_other_status, Some("Todo".to_string()));
+}


### PR DESCRIPTION
SQLite counterpart of the JSON V14 migration. Aligns stored data with the derivation helpers from KAN-1174, matching the JSON semantics exactly.

Rules, in priority order:

1. a column already carrying a non-null `default_status` keeps it
2. else `Done` if the column id appears in `board_completion_columns` for its board
3. else `Todo`

`board_completion_columns` is deliberately left in place, so no boards-table rebuild is needed here. A later slice removes it. No column-name heuristic: a board whose completion column was bound by the earlier last-column backfill keeps that binding, and re-pointing stays a user action.

A cross-backend test asserts JSON and SQLite derive identical results for the same seed graph.

Two things worth a reviewer's attention.

**The write path was corrupting-by-luck.** `cards.status` and `columns.default_status` were written with `format!("{:?}")` (Debug) but read back through serde via `p_enum`. Those agree today only because `CardStatus` has no `rename_all`. The crate already has `ser_enum` for exactly this, with a comment warning that coupling the on-disk format to `Debug` "would break the read/write round-trip silently". Both writes now go through it, with tests asserting the raw stored TEXT rather than the deserialized value.

**The migration gates on `schema_version < 8`, not on the presence of NULLs.** `migrate()` runs on every `open()`, and a column created after this migration is allowed to carry `default_status = NULL` deliberately. A presence-based gate would re-backfill those on the next open, turning a one-time migration into permanent behaviour. Verified by hand: a column created with no default status stays NULL across three reopens.

One pre-existing test changed subject rather than mechanically. `test_v6_database_upgrades_to_v7_with_null_default_status_for_existing_columns` asserted a column named "Doing" migrates to NULL. Since `open()` runs the whole chain, a v6 database now lands on v8 and derives `Todo` for it. The test's actual guarantee, that a status is never inferred from a column's name, is preserved and now stated more explicitly.

Verified end to end on a downgraded v7 database: a column named "Doing" that was in `board_completion_columns` became `Done`, while one named "Complete" carrying an explicit `InProgress` kept it.