### PR TITLE
KAN-1176 feat(domain): keep column default_status in step with completion columns

### DIFF
--- a/.changeset/kan-1176-config-writes-default-status.md
+++ b/.changeset/kan-1176-config-writes-default-status.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Keep column default_status in step with a board's completion-column configuration

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -512,18 +512,41 @@ impl ApplyBoardSettings {
     /// `Editable::from_entity` impl, then re-apply that DTO via another
     /// `ApplyBoardSettings`. The DTO covers exactly the fields this command
     /// writes, so the round-trip is symmetric.
+    ///
+    /// Re-dispatching `ApplyBoardSettings` alone is not enough for
+    /// `completion_column_ids`: its forward `execute` re-syncs every touched
+    /// column's `default_status` against the DTO's list, so a column that had
+    /// a deliberate non-`Done` status before the original change would land on
+    /// `Todo` (the sync's default for a removed column) instead of its prior
+    /// value. Snapshot every touched column here, before `execute` runs, and
+    /// append an explicit restore per column so it wins over the re-sync.
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let board = match store.get_board(self.board_id)? {
             Some(b) => b,
             None => return Err(KanbanError::not_found("Board", self.board_id)),
         };
         let prior_dto = crate::editable::BoardSettingsDto::from_entity(&board);
-        Ok(vec![Command::Board(BoardCommand::ApplySettings(
+        let mut commands = vec![Command::Board(BoardCommand::ApplySettings(
             ApplyBoardSettings {
                 board_id: self.board_id,
                 dto: prior_dto,
             },
-        ))])
+        ))];
+        let touched = super::completion_status_sync::snapshot_touched_columns(
+            store,
+            &board.completion_column_ids,
+            &self.dto.completion_column_ids,
+        )?;
+        commands.extend(touched.into_iter().map(|(column_id, prior_status)| {
+            Command::Column(super::ColumnCommand::Update(super::UpdateColumn {
+                column_id,
+                updates: crate::ColumnUpdate {
+                    default_status: Some(prior_status),
+                    ..Default::default()
+                },
+            }))
+        }));
+        Ok(commands)
     }
 }
 

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -177,7 +177,15 @@ impl UpdateBoard {
                 "board card_prefix cannot be changed after cards have been created",
             ));
         }
+        let prior_completion_column_ids = board.completion_column_ids.clone();
         board.update(self.updates.clone());
+        if let Some(next_ids) = self.updates.completion_column_ids.as_ref() {
+            super::completion_status_sync::sync_default_status(
+                context,
+                &prior_completion_column_ids,
+                next_ids,
+            )?;
+        }
         context.store.upsert_board(board)?;
         Ok(())
     }
@@ -240,10 +248,27 @@ impl UpdateBoard {
                 .map(|_| board.completion_column_ids.clone()),
             position: upd.position.map(|_| board.position),
         };
-        Ok(vec![Command::Board(BoardCommand::Update(UpdateBoard {
+        let mut commands = vec![Command::Board(BoardCommand::Update(UpdateBoard {
             board_id: self.board_id,
             updates: inverse,
-        }))])
+        }))];
+        if let Some(next_ids) = upd.completion_column_ids.as_ref() {
+            let touched = super::completion_status_sync::snapshot_touched_columns(
+                store,
+                &board.completion_column_ids,
+                next_ids,
+            )?;
+            commands.extend(touched.into_iter().map(|(column_id, prior_status)| {
+                Command::Column(super::ColumnCommand::Update(super::UpdateColumn {
+                    column_id,
+                    updates: crate::ColumnUpdate {
+                        default_status: Some(prior_status),
+                        ..Default::default()
+                    },
+                }))
+            }));
+        }
+        Ok(commands)
     }
 }
 
@@ -468,7 +493,13 @@ impl ApplyBoardSettings {
         let mut board = context.get_board(self.board_id)?;
         let columns = context.store.list_columns_by_board(self.board_id)?;
         board.validate_completion_columns(&self.dto.completion_column_ids, &columns)?;
+        let prior_completion_column_ids = board.completion_column_ids.clone();
         self.dto.clone().apply_to(&mut board);
+        super::completion_status_sync::sync_default_status(
+            context,
+            &prior_completion_column_ids,
+            &board.completion_column_ids,
+        )?;
         context.store.upsert_board(board)?;
         Ok(())
     }

--- a/crates/kanban-domain/src/commands/completion_status_sync.rs
+++ b/crates/kanban-domain/src/commands/completion_status_sync.rs
@@ -1,0 +1,66 @@
+use super::CommandContext;
+use crate::data_store::DataStore;
+use crate::{CardStatus, KanbanResult};
+use uuid::Uuid;
+
+fn added_and_removed(prior: &[Uuid], next: &[Uuid]) -> (Vec<Uuid>, Vec<Uuid>) {
+    let added = next
+        .iter()
+        .copied()
+        .filter(|id| !prior.contains(id))
+        .collect();
+    let removed = prior
+        .iter()
+        .copied()
+        .filter(|id| !next.contains(id))
+        .collect();
+    (added, removed)
+}
+
+/// Keep `column.default_status` in step with a board's completion-column
+/// configuration: a newly-added completion column gets `Done`; a removed
+/// column is reset to `Todo` only when it was `Done` (any other value is a
+/// deliberate choice and is left alone).
+pub(super) fn sync_default_status(
+    context: &CommandContext,
+    prior: &[Uuid],
+    next: &[Uuid],
+) -> KanbanResult<()> {
+    let (added, removed) = added_and_removed(prior, next);
+    for id in added {
+        if let Some(mut column) = context.store.get_column(id)? {
+            column.default_status = Some(CardStatus::Done);
+            context.store.upsert_column(column)?;
+        }
+    }
+    for id in removed {
+        if let Some(mut column) = context.store.get_column(id)? {
+            if column.default_status == Some(CardStatus::Done) {
+                column.default_status = Some(CardStatus::Todo);
+                context.store.upsert_column(column)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Snapshot `default_status` for every column a completion-column change will
+/// touch (added or removed), read BEFORE the change executes, so undo can
+/// restore each column's prior value exactly.
+pub(super) fn snapshot_touched_columns(
+    store: &dyn DataStore,
+    prior: &[Uuid],
+    next: &[Uuid],
+) -> KanbanResult<Vec<(Uuid, Option<CardStatus>)>> {
+    let (added, removed) = added_and_removed(prior, next);
+    added
+        .into_iter()
+        .chain(removed)
+        .filter_map(|id| {
+            store
+                .get_column(id)
+                .map(|found| found.map(|column| (column.id, column.default_status)))
+                .transpose()
+        })
+        .collect()
+}

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod board_commands;
 pub mod card;
 pub mod cascade_commands;
 pub mod column_commands;
+mod completion_status_sync;
 pub mod dependency_commands;
 pub mod sprint_commands;
 

--- a/crates/kanban-domain/tests/board_commands.rs
+++ b/crates/kanban-domain/tests/board_commands.rs
@@ -873,3 +873,42 @@ fn test_apply_board_settings_sets_done_default_status_on_added_completion_column
     let col_a = tc.store.get_column(col_a_id).unwrap().unwrap();
     assert_eq!(col_a.default_status, Some(CardStatus::Done));
 }
+
+#[test]
+fn test_undo_of_apply_board_settings_restores_prior_column_default_statuses() {
+    let tc = TestContext::new();
+    let (board_id, col_a_id, col_b_id) = seed_board_with_two_columns(&tc);
+    let ctx = tc.as_command_context();
+
+    // col_b starts with a deliberate non-Done status.
+    let mut col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    col_b.default_status = Some(CardStatus::InProgress);
+    tc.store.upsert_column(col_b).unwrap();
+
+    let cmd = ApplyBoardSettings {
+        board_id,
+        dto: kanban_domain::editable::BoardSettingsDto {
+            sprint_prefix: None,
+            card_prefix: None,
+            sprint_duration_days: None,
+            sprint_names: Vec::new(),
+            completion_column_ids: vec![col_a_id, col_b_id],
+        },
+    };
+    let inverse = cmd.capture_inverse(&tc.store).unwrap();
+    cmd.execute(&ctx).unwrap();
+
+    let col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    assert_eq!(col_b.default_status, Some(CardStatus::Done));
+
+    for cmd in inverse {
+        cmd.execute(&ctx).unwrap();
+    }
+
+    let col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    assert_eq!(
+        col_b.default_status,
+        Some(CardStatus::InProgress),
+        "undo must restore the deliberate InProgress, not overwrite it with Todo"
+    );
+}

--- a/crates/kanban-domain/tests/board_commands.rs
+++ b/crates/kanban-domain/tests/board_commands.rs
@@ -655,3 +655,221 @@ fn test_delete_missing_board_inverse_errors() {
     .capture_inverse(&tc.store);
     assert!(result.is_err());
 }
+
+fn seed_board_with_two_columns(tc: &TestContext) -> (Uuid, Uuid, Uuid) {
+    let board = Board::new("B", Some("TST"));
+    let board_id = board.id;
+    let col_a = Column::new(board_id, "A", 0);
+    let col_b = Column::new(board_id, "B", 1);
+    let col_a_id = col_a.id;
+    let col_b_id = col_b.id;
+    tc.store.upsert_board(board).unwrap();
+    tc.store.upsert_column(col_a).unwrap();
+    tc.store.upsert_column(col_b).unwrap();
+    (board_id, col_a_id, col_b_id)
+}
+
+#[test]
+fn test_setting_completion_columns_sets_done_default_status_on_those_columns() {
+    let tc = TestContext::new();
+    let (board_id, col_a_id, col_b_id) = seed_board_with_two_columns(&tc);
+    let ctx = tc.as_command_context();
+    let cmd = UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(vec![col_a_id, col_b_id]),
+            ..Default::default()
+        },
+    };
+    cmd.execute(&ctx).unwrap();
+
+    let col_a = tc.store.get_column(col_a_id).unwrap().unwrap();
+    let col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    assert_eq!(col_a.default_status, Some(CardStatus::Done));
+    assert_eq!(col_b.default_status, Some(CardStatus::Done));
+}
+
+#[test]
+fn test_removing_a_completion_column_resets_its_default_status_to_todo() {
+    let tc = TestContext::new();
+    let (board_id, col_a_id, col_b_id) = seed_board_with_two_columns(&tc);
+    let ctx = tc.as_command_context();
+    UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(vec![col_a_id, col_b_id]),
+            ..Default::default()
+        },
+    }
+    .execute(&ctx)
+    .unwrap();
+
+    UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(vec![col_a_id]),
+            ..Default::default()
+        },
+    }
+    .execute(&ctx)
+    .unwrap();
+
+    let col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    assert_eq!(col_b.default_status, Some(CardStatus::Todo));
+}
+
+#[test]
+fn test_removing_a_completion_column_leaves_a_non_done_default_status_alone() {
+    let tc = TestContext::new();
+    let (board_id, col_a_id, col_b_id) = seed_board_with_two_columns(&tc);
+    let ctx = tc.as_command_context();
+    UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(vec![col_a_id, col_b_id]),
+            ..Default::default()
+        },
+    }
+    .execute(&ctx)
+    .unwrap();
+
+    // User deliberately overrides the completion column's default status to
+    // something other than Done before it is removed from the list.
+    let mut col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    col_b.default_status = Some(CardStatus::InProgress);
+    tc.store.upsert_column(col_b).unwrap();
+
+    UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(vec![col_a_id]),
+            ..Default::default()
+        },
+    }
+    .execute(&ctx)
+    .unwrap();
+
+    let col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    assert_eq!(col_b.default_status, Some(CardStatus::InProgress));
+}
+
+#[test]
+fn test_undo_of_a_completion_column_change_restores_prior_column_default_statuses() {
+    let tc = TestContext::new();
+    let (board_id, col_a_id, col_b_id) = seed_board_with_two_columns(&tc);
+    let ctx = tc.as_command_context();
+
+    // col_b starts with a deliberate non-Done status.
+    let mut col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    col_b.default_status = Some(CardStatus::InProgress);
+    tc.store.upsert_column(col_b).unwrap();
+
+    let cmd = UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(vec![col_a_id, col_b_id]),
+            ..Default::default()
+        },
+    };
+    let inverse = cmd.capture_inverse(&tc.store).unwrap();
+    cmd.execute(&ctx).unwrap();
+
+    let col_a = tc.store.get_column(col_a_id).unwrap().unwrap();
+    let col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    assert_eq!(col_a.default_status, Some(CardStatus::Done));
+    assert_eq!(col_b.default_status, Some(CardStatus::Done));
+
+    for cmd in inverse {
+        cmd.execute(&ctx).unwrap();
+    }
+
+    let board = tc.store.get_board(board_id).unwrap().unwrap();
+    assert!(board.completion_column_ids.is_empty());
+    let col_a = tc.store.get_column(col_a_id).unwrap().unwrap();
+    let col_b = tc.store.get_column(col_b_id).unwrap().unwrap();
+    assert_eq!(
+        col_a.default_status, None,
+        "col_a had no default_status before the change"
+    );
+    assert_eq!(
+        col_b.default_status,
+        Some(CardStatus::InProgress),
+        "col_b's deliberate non-Done status must survive the round trip"
+    );
+}
+
+#[test]
+fn test_board_update_and_column_default_status_never_disagree() {
+    let tc = TestContext::new();
+    let (board_id, col_a_id, col_b_id) = seed_board_with_two_columns(&tc);
+    let ctx = tc.as_command_context();
+
+    let assert_agrees = || {
+        let board = tc.store.get_board(board_id).unwrap().unwrap();
+        for col_id in [col_a_id, col_b_id] {
+            let column = tc.store.get_column(col_id).unwrap().unwrap();
+            let is_completion = board.completion_column_ids.contains(&col_id);
+            if is_completion {
+                assert_eq!(
+                    column.default_status,
+                    Some(CardStatus::Done),
+                    "column {col_id} is a completion column but its default_status disagrees"
+                );
+            }
+        }
+    };
+
+    UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(vec![col_a_id]),
+            ..Default::default()
+        },
+    }
+    .execute(&ctx)
+    .unwrap();
+    assert_agrees();
+
+    UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(vec![col_a_id, col_b_id]),
+            ..Default::default()
+        },
+    }
+    .execute(&ctx)
+    .unwrap();
+    assert_agrees();
+
+    UpdateBoard {
+        board_id,
+        updates: BoardUpdate {
+            completion_column_ids: Some(Vec::new()),
+            ..Default::default()
+        },
+    }
+    .execute(&ctx)
+    .unwrap();
+    assert_agrees();
+}
+
+#[test]
+fn test_apply_board_settings_sets_done_default_status_on_added_completion_columns() {
+    let tc = TestContext::new();
+    let (board_id, col_a_id, _col_b_id) = seed_board_with_two_columns(&tc);
+    let ctx = tc.as_command_context();
+    let cmd = ApplyBoardSettings {
+        board_id,
+        dto: kanban_domain::editable::BoardSettingsDto {
+            sprint_prefix: None,
+            card_prefix: None,
+            sprint_duration_days: None,
+            sprint_names: Vec::new(),
+            completion_column_ids: vec![col_a_id],
+        },
+    };
+    cmd.execute(&ctx).unwrap();
+
+    let col_a = tc.store.get_column(col_a_id).unwrap().unwrap();
+    assert_eq!(col_a.default_status, Some(CardStatus::Done));
+}


### PR DESCRIPTION
Found by executing a later slice and hitting a failure, not by review.

The V14 and v8 migrations made every column's `default_status` agree with its board's `completion_column_ids`. That fixed data at rest. It did not fix the write path: `Board::update` sets the board's list and never touches any column, so the two sources diverge again the moment anyone configures completion columns at runtime.

That is not a legacy-data edge case. It is the only way boards are configured today. Repointing the lifecycle rules onto the derived helpers without closing this gap broke ~24 tests across 8 binaries.

Rules now applied whenever a board's completion columns change:

- a column added to the list gets `default_status = Done`
- a column removed from the list is reset to `Todo` only if it was `Done`
- a removed column carrying anything else is left alone, so this never silently overwrites a deliberate choice

Undo is handled by snapshotting each touched column's prior `default_status` before the change executes, and appending one column update per touched column to the inverse batch. Restoring the board's list without restoring the columns would leave the two sources diverged after an undo, which is the bug this closes.

`ApplyBoardSettings` also writes `completion_column_ids` directly and needed the same treatment. The card only named `UpdateBoard`; the second path came from re-running the enumeration rather than trusting it.

Nothing is removed here. `--completion-columns` and `completion_column_ids` both stay; later slices remove them. This card only makes the two sources agree.

Verified by applying the saved repoint patch on top of this branch and re-running every previously-failing binary: `completion_sync` 17/17 (was 11 failed), `archival_contract` 247/247, `move_cards` 26/26, `cli_integration` 162/162, `mcp integration` 96/96, `batch_completion_sync` 2/2, `stale_model_regression` 15/15.