### PR TITLE
KAN-1159 refactor(api): drop completion_column_ids from the board DTOs

### DIFF
--- a/.changeset/kan-1159-drop-board-dto-field.md
+++ b/.changeset/kan-1159-drop-board-dto-field.md
@@ -1,0 +1,5 @@
+---
+bump: major
+---
+
+Remove completion_column_ids from the REST board DTOs (BoardResponse, UpdateBoardRequest, ReplaceBoardRequest); clients configuring board completion via the wire must migrate to per-column default_status. Legacy request bodies that still send the key are ignored, not rejected.

--- a/crates/kanban-api/src/v1/boards/conversions.rs
+++ b/crates/kanban-api/src/v1/boards/conversions.rs
@@ -4,21 +4,9 @@
 //! different reasons. Each conversion destructures and constructs exhaustively
 //! (no `..`) so a new field is a compile error.
 
-use super::super::Patch;
 use super::requests::{CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
 use kanban_domain::{BoardUpdate, FieldUpdate, NewBoard};
 use uuid::Uuid;
-
-/// The one place the wire's three PATCH states meet the domain's two: with a
-/// `Vec` payload, `Clear` (null) and `Set(vec![])` collapse to the same
-/// cleared configuration.
-fn patch_ids_to_update(p: Patch<Vec<Uuid>>) -> Option<Vec<Uuid>> {
-    match p {
-        Patch::NoChange => None,
-        Patch::Clear => Some(Vec::new()),
-        Patch::Set(ids) => Some(ids),
-    }
-}
 
 impl From<UpdateBoardRequest> for BoardUpdate {
     fn from(req: UpdateBoardRequest) -> Self {
@@ -31,7 +19,6 @@ impl From<UpdateBoardRequest> for BoardUpdate {
             task_sort_order,
             sprint_duration_days,
             task_list_view,
-            completion_column_ids,
         } = req;
         BoardUpdate {
             name,
@@ -42,7 +29,7 @@ impl From<UpdateBoardRequest> for BoardUpdate {
             task_sort_order: task_sort_order.map(Into::into),
             sprint_duration_days: sprint_duration_days.into(),
             task_list_view: task_list_view.map(Into::into),
-            completion_column_ids: patch_ids_to_update(completion_column_ids),
+            completion_column_ids: None,
             // Server-managed — never accepted from a PATCH body:
             active_sprint_id: FieldUpdate::NoChange,
             position: None,
@@ -66,10 +53,7 @@ struct BoardContentFields {
     task_list_view: Option<super::super::TaskListViewDto>,
 }
 
-fn new_board_from_content(
-    content: BoardContentFields,
-    completion_column_ids: Vec<Uuid>,
-) -> NewBoard {
+fn new_board_from_content(content: BoardContentFields) -> NewBoard {
     let BoardContentFields {
         name,
         description,
@@ -89,7 +73,7 @@ fn new_board_from_content(
         task_sort_order: task_sort_order.map(Into::into),
         sprint_duration_days,
         task_list_view: task_list_view.map(Into::into),
-        completion_column_ids,
+        completion_column_ids: Vec::new(),
     }
 }
 
@@ -111,30 +95,23 @@ impl CreateBoardRequest {
             sprint_duration_days,
             task_list_view,
         } = self;
-        let spec = new_board_from_content(
-            BoardContentFields {
-                name,
-                description,
-                sprint_prefix,
-                card_prefix,
-                task_sort_field,
-                task_sort_order,
-                sprint_duration_days,
-                task_list_view,
-            },
-            Vec::new(),
-        );
+        let spec = new_board_from_content(BoardContentFields {
+            name,
+            description,
+            sprint_prefix,
+            card_prefix,
+            task_sort_field,
+            task_sort_order,
+            sprint_duration_days,
+            task_list_view,
+        });
         (id, spec)
     }
 }
 
 impl ReplaceBoardRequest {
     /// Full-replace content spec for the `PUT /v1/boards/:id` create-or-replace
-    /// seam. `completion_column_ids` carries straight through — legitimate on
-    /// the replace arm (an existing board may already have columns); the
-    /// service still rejects it at the specific call site where this same
-    /// spec ends up creating a brand-new board (zero columns regardless of
-    /// which request type supplied it).
+    /// seam.
     pub fn into_new_board(self) -> NewBoard {
         let ReplaceBoardRequest {
             name,
@@ -145,21 +122,17 @@ impl ReplaceBoardRequest {
             task_sort_order,
             sprint_duration_days,
             task_list_view,
-            completion_column_ids,
         } = self;
-        new_board_from_content(
-            BoardContentFields {
-                name,
-                description,
-                sprint_prefix,
-                card_prefix,
-                task_sort_field: Some(task_sort_field),
-                task_sort_order: Some(task_sort_order),
-                sprint_duration_days,
-                task_list_view: Some(task_list_view),
-            },
-            completion_column_ids,
-        )
+        new_board_from_content(BoardContentFields {
+            name,
+            description,
+            sprint_prefix,
+            card_prefix,
+            task_sort_field: Some(task_sort_field),
+            task_sort_order: Some(task_sort_order),
+            sprint_duration_days,
+            task_list_view: Some(task_list_view),
+        })
     }
 }
 
@@ -180,7 +153,6 @@ mod tests {
             task_sort_order: Some(SortOrderDto::Ascending),
             sprint_duration_days: Patch::Set(7),
             task_list_view: Some(TaskListViewDto::Flat),
-            completion_column_ids: Patch::NoChange,
         };
         let update: BoardUpdate = req.into();
         assert_eq!(update.name, Some("N".to_string()));
@@ -284,8 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replace_board_request_into_new_board_carries_completion_column_ids() {
-        let col = Uuid::new_v4();
+    fn test_replace_board_request_into_new_board_maps_all_content_fields() {
         let req = ReplaceBoardRequest {
             name: "Roadmap".to_string(),
             description: None,
@@ -295,38 +266,11 @@ mod tests {
             task_sort_order: SortOrderDto::Ascending,
             sprint_duration_days: None,
             task_list_view: TaskListViewDto::GroupedByColumn,
-            completion_column_ids: vec![col],
         };
         let spec = req.into_new_board();
         assert_eq!(spec.name, "Roadmap");
         assert_eq!(spec.task_sort_field, Some(SortField::Priority));
         assert_eq!(spec.task_sort_order, Some(SortOrder::Ascending));
         assert_eq!(spec.task_list_view, Some(TaskListView::GroupedByColumn));
-        assert_eq!(spec.completion_column_ids, vec![col]);
-    }
-
-    #[test]
-    fn test_patch_clear_and_set_empty_both_map_to_cleared_domain_update() {
-        for patch in [Patch::Clear, Patch::Set(Vec::new())] {
-            let update: BoardUpdate = UpdateBoardRequest {
-                name: None,
-                description: Patch::NoChange,
-                sprint_prefix: Patch::NoChange,
-                card_prefix: Patch::NoChange,
-                task_sort_field: None,
-                task_sort_order: None,
-                sprint_duration_days: Patch::NoChange,
-                task_list_view: None,
-                completion_column_ids: patch,
-            }
-            .into();
-            assert_eq!(update.completion_column_ids, Some(Vec::new()));
-        }
-    }
-
-    #[test]
-    fn test_update_board_request_absent_completion_column_ids_is_no_change() {
-        let update: BoardUpdate = UpdateBoardRequest::default().into();
-        assert_eq!(update.completion_column_ids, None);
     }
 }

--- a/crates/kanban-api/src/v1/boards/requests.rs
+++ b/crates/kanban-api/src/v1/boards/requests.rs
@@ -57,10 +57,6 @@ pub struct UpdateBoardRequest {
     pub sprint_duration_days: Patch<u32>,
     #[serde(default)]
     pub task_list_view: Option<TaskListViewDto>,
-    /// Ordered; element 0 is the primary completion column. `[]` disables
-    /// status/column auto-sync for the board (`null` means the same).
-    #[serde(default, skip_serializing_if = "Patch::is_no_change")]
-    pub completion_column_ids: Patch<Vec<Uuid>>,
 }
 
 /// Request body for `PUT /v1/boards/:id` — a true full replace per
@@ -84,8 +80,6 @@ pub struct ReplaceBoardRequest {
     #[serde(default)]
     pub sprint_duration_days: Option<u32>,
     pub task_list_view: TaskListViewDto,
-    #[serde(default)]
-    pub completion_column_ids: Vec<Uuid>,
 }
 
 #[cfg(test)]
@@ -152,7 +146,6 @@ mod tests {
             task_sort_order: None,
             sprint_duration_days: Patch::Set(14),
             task_list_view: Some(TaskListViewDto::GroupedByColumn),
-            completion_column_ids: Patch::Set(vec![Uuid::nil()]),
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: UpdateBoardRequest = serde_json::from_str(&json).unwrap();
@@ -160,7 +153,6 @@ mod tests {
         assert_eq!(back.sprint_prefix, Patch::Clear);
         assert_eq!(back.task_sort_field, Some(SortFieldDto::CreatedAt));
         assert_eq!(back.task_list_view, Some(TaskListViewDto::GroupedByColumn));
-        assert_eq!(back.completion_column_ids, Patch::Set(vec![Uuid::nil()]));
     }
 
     #[test]
@@ -169,7 +161,6 @@ mod tests {
         assert_eq!(back.name, None);
         assert_eq!(back.description, Patch::Clear); // explicit null → clear
         assert_eq!(back.sprint_prefix, Patch::NoChange); // absent → no change
-        assert_eq!(back.completion_column_ids, Patch::NoChange);
     }
 
     #[test]
@@ -183,7 +174,6 @@ mod tests {
             "sprint_prefix",
             "card_prefix",
             "sprint_duration_days",
-            "completion_column_ids",
         ] {
             assert!(
                 v.get(field).is_none(),
@@ -193,38 +183,54 @@ mod tests {
     }
 
     #[test]
-    fn test_update_board_request_completion_column_ids_null_is_clear() {
-        let back: UpdateBoardRequest =
-            serde_json::from_str(r#"{"completion_column_ids":null}"#).unwrap();
-        assert_eq!(back.completion_column_ids, Patch::Clear);
+    fn test_update_board_request_ignores_a_legacy_completion_column_ids_key() {
+        let json = r#"{"name":"Renamed","completion_column_ids":["00000000-0000-0000-0000-000000000000"]}"#;
+        let back: UpdateBoardRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(back.name, Some("Renamed".to_string()));
+        let round_tripped = serde_json::to_value(&back).unwrap();
+        assert!(
+            round_tripped.get("completion_column_ids").is_none(),
+            "a legacy completion_column_ids key must be ignored, not carried through: {round_tripped}"
+        );
     }
 
     #[test]
-    fn test_update_board_request_completion_column_ids_empty_array_is_set_empty() {
-        let back: UpdateBoardRequest =
-            serde_json::from_str(r#"{"completion_column_ids":[]}"#).unwrap();
-        assert_eq!(back.completion_column_ids, Patch::Set(Vec::new()));
-    }
-
-    #[test]
-    fn test_update_board_request_completion_column_ids_round_trips_order() {
-        let a = Uuid::new_v4();
-        let b = Uuid::new_v4();
-        let req = UpdateBoardRequest {
-            completion_column_ids: Patch::Set(vec![b, a]),
-            ..Default::default()
-        };
-        let json = serde_json::to_string(&req).unwrap();
-        let back: UpdateBoardRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.completion_column_ids, Patch::Set(vec![b, a]));
-    }
-
-    #[test]
-    fn test_replace_board_request_completion_column_ids_defaults_empty() {
+    fn test_replace_board_request_ignores_a_legacy_completion_column_ids_key() {
         let json = r#"{"name":"Fresh","task_sort_field":"priority",
-            "task_sort_order":"ascending","task_list_view":"flat"}"#;
+            "task_sort_order":"ascending","task_list_view":"flat",
+            "completion_column_ids":["00000000-0000-0000-0000-000000000000"]}"#;
         let back: ReplaceBoardRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(back.completion_column_ids, Vec::<Uuid>::new());
+        assert_eq!(back.name, "Fresh");
+        let round_tripped = serde_json::to_value(&back).unwrap();
+        assert!(
+            round_tripped.get("completion_column_ids").is_none(),
+            "a legacy completion_column_ids key must be ignored, not carried through: {round_tripped}"
+        );
+    }
+
+    #[test]
+    fn test_board_dto_round_trips_without_the_field() {
+        let board = kanban_domain::Board::new("B", Some("KAN"));
+        let response = super::super::response::BoardResponse::from(&board);
+        let response_json = serde_json::to_value(&response).unwrap();
+        assert!(response_json.get("completion_column_ids").is_none());
+
+        let update = UpdateBoardRequest::default();
+        let update_json = serde_json::to_value(&update).unwrap();
+        assert!(update_json.get("completion_column_ids").is_none());
+
+        let replace = ReplaceBoardRequest {
+            name: "Fresh".to_string(),
+            description: None,
+            sprint_prefix: None,
+            card_prefix: None,
+            task_sort_field: SortFieldDto::Priority,
+            task_sort_order: SortOrderDto::Ascending,
+            sprint_duration_days: None,
+            task_list_view: TaskListViewDto::Flat,
+        };
+        let replace_json = serde_json::to_value(&replace).unwrap();
+        assert!(replace_json.get("completion_column_ids").is_none());
     }
 
     #[test]

--- a/crates/kanban-api/src/v1/boards/response.rs
+++ b/crates/kanban-api/src/v1/boards/response.rs
@@ -22,9 +22,6 @@ pub struct BoardResponse {
     pub sprint_duration_days: Option<u32>,
     pub task_list_view: TaskListViewDto,
     pub active_sprint_id: Option<Uuid>,
-    /// Ordered; element 0 is the primary completion column. Empty means
-    /// status/column auto-sync is disabled for the board.
-    pub completion_column_ids: Vec<Uuid>,
     pub position: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -61,7 +58,6 @@ impl From<&Board> for BoardResponse {
             sprint_duration_days: b.sprint_duration_days,
             task_list_view: b.task_list_view.into(),
             active_sprint_id: b.active_sprint_id,
-            completion_column_ids: b.completion_column_ids.clone(),
             position: b.position,
             created_at: b.created_at,
             updated_at: b.updated_at,
@@ -73,6 +69,17 @@ impl From<&Board> for BoardResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_board_response_no_longer_serializes_completion_column_ids() {
+        let board = Board::new("Test", Some("KAN"));
+        let resp = BoardResponse::from(&board);
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(
+            !json.contains("completion_column_ids"),
+            "BoardResponse must no longer serialize completion_column_ids: {json}"
+        );
+    }
 
     #[test]
     fn test_board_response_from_ref_omits_internal_state_and_uses_snake_case_enums() {

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5793,76 +5793,6 @@ mod completion_columns_tests {
             .assert()
     }
 
-    fn board_completion_ids(file: &std::path::Path, board_id: &str) -> Value {
-        let output = kanban()
-            .args([file.to_str().unwrap(), "board", "get", board_id])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        parse_json_output(&String::from_utf8_lossy(&output))["data"]["completion_column_ids"]
-            .clone()
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_by_name_sets_field() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, "Done").success();
-
-        assert_eq!(
-            board_completion_ids(&file, &board_id),
-            serde_json::json!([cols[2]])
-        );
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_by_uuid_sets_field() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, &cols[2]).success();
-
-        assert_eq!(
-            board_completion_ids(&file, &board_id),
-            serde_json::json!([cols[2]])
-        );
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_comma_separated_preserves_order() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, "Decision,Done").success();
-
-        assert_eq!(
-            board_completion_ids(&file, &board_id),
-            serde_json::json!([cols[3], cols[2]]),
-            "element 0 is the primary completion column; order must be as typed"
-        );
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_empty_string_clears_configuration() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, _cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, "Done").success();
-        update_completion_columns(&file, &board_id, "").success();
-
-        assert_eq!(
-            board_completion_ids(&file, &board_id),
-            serde_json::json!([])
-        );
-    }
-
     #[test]
     fn test_board_update_completion_columns_unknown_name_errors_with_raw_identifier() {
         let dir = tempdir().unwrap();
@@ -5906,38 +5836,6 @@ mod completion_columns_tests {
         let other_col = extract_id(&parse_json_output(&String::from_utf8_lossy(&output)));
 
         update_completion_columns(&file, &board_id, &other_col).failure();
-
-        assert_eq!(
-            board_completion_ids(&file, &board_id),
-            serde_json::json!([]),
-            "a rejected update must not be partially applied"
-        );
-    }
-
-    #[test]
-    fn test_board_update_without_completion_flag_leaves_field_unchanged() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, "Done").success();
-        kanban()
-            .args([
-                file.to_str().unwrap(),
-                "board",
-                "update",
-                &board_id,
-                "--name",
-                "Renamed",
-            ])
-            .assert()
-            .success();
-
-        assert_eq!(
-            board_completion_ids(&file, &board_id),
-            serde_json::json!([cols[2]]),
-            "an unrelated update must not wipe the completion configuration"
-        );
     }
 
     #[test]
@@ -6074,62 +5972,6 @@ mod default_columns_tests {
     }
 
     #[test]
-    fn test_board_create_with_default_columns_sets_completion_to_complete_column() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        kanban().args([file.to_str().unwrap()]).assert().success();
-
-        let create_output = kanban()
-            .args([
-                file.to_str().unwrap(),
-                "board",
-                "create",
-                "--name",
-                "Board",
-                "--with-default-columns",
-            ])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
-
-        let list_output = kanban()
-            .args([
-                file.to_str().unwrap(),
-                "column",
-                "list",
-                "--board",
-                &board_id,
-            ])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        let json = parse_json_output(&String::from_utf8_lossy(&list_output));
-        let items = json["data"]["items"].as_array().unwrap();
-        let complete_id = items.iter().find(|c| c["name"] == "Complete").unwrap()["id"]
-            .as_str()
-            .unwrap()
-            .to_string();
-
-        let get_output = kanban()
-            .args([file.to_str().unwrap(), "board", "get", &board_id])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        let board_json = parse_json_output(&String::from_utf8_lossy(&get_output));
-        assert_eq!(
-            board_json["data"]["completion_column_ids"],
-            serde_json::json!([complete_id])
-        );
-    }
-
-    #[test]
     fn test_cli_board_init_seeds_default_statuses_on_template_columns() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
@@ -6215,18 +6057,5 @@ mod default_columns_tests {
             .clone();
         let json = parse_json_output(&String::from_utf8_lossy(&list_output));
         assert_eq!(json["data"]["total"], 0);
-
-        let get_output = kanban()
-            .args([file.to_str().unwrap(), "board", "get", &board_id])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        let board_json = parse_json_output(&String::from_utf8_lossy(&get_output));
-        assert_eq!(
-            board_json["data"]["completion_column_ids"],
-            serde_json::json!([])
-        );
     }
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5793,6 +5793,127 @@ mod completion_columns_tests {
             .assert()
     }
 
+    /// The current default_status of every column on the board, keyed by
+    /// column id, in creation/position order.
+    fn column_default_statuses(file: &std::path::Path, board_id: &str) -> Vec<(String, Value)> {
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "list",
+                "--board",
+                board_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        json["data"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| {
+                (
+                    c["id"].as_str().unwrap().to_string(),
+                    c["default_status"].clone(),
+                )
+            })
+            .collect()
+    }
+
+    fn default_status_of(statuses: &[(String, Value)], column_id: &str) -> Value {
+        statuses
+            .iter()
+            .find(|(id, _)| id == column_id)
+            .unwrap_or_else(|| panic!("column {column_id} not found in {statuses:?}"))
+            .1
+            .clone()
+    }
+
+    #[test]
+    fn test_board_update_completion_columns_by_name_sets_default_status_done() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, cols) = setup_board_with_columns(&file);
+
+        update_completion_columns(&file, &board_id, "Done").success();
+
+        let statuses = column_default_statuses(&file, &board_id);
+        assert_eq!(
+            default_status_of(&statuses, &cols[2]),
+            serde_json::json!("done"),
+            "the named completion column must carry default_status = done"
+        );
+    }
+
+    #[test]
+    fn test_board_update_completion_columns_by_uuid_sets_default_status_done() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, cols) = setup_board_with_columns(&file);
+
+        update_completion_columns(&file, &board_id, &cols[2]).success();
+
+        let statuses = column_default_statuses(&file, &board_id);
+        assert_eq!(
+            default_status_of(&statuses, &cols[2]),
+            serde_json::json!("done"),
+            "the completion column addressed by uuid must carry default_status = done"
+        );
+    }
+
+    #[test]
+    fn test_board_update_completion_columns_empty_string_resets_previous_column_to_todo() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, cols) = setup_board_with_columns(&file);
+
+        update_completion_columns(&file, &board_id, "Done").success();
+        update_completion_columns(&file, &board_id, "").success();
+
+        let statuses = column_default_statuses(&file, &board_id);
+        assert_eq!(
+            default_status_of(&statuses, &cols[2]),
+            serde_json::json!("todo"),
+            "clearing the completion configuration must reset the previously-completion column"
+        );
+    }
+
+    #[test]
+    fn test_board_update_without_completion_flag_leaves_default_statuses_unchanged() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, cols) = setup_board_with_columns(&file);
+
+        update_completion_columns(&file, &board_id, "Done").success();
+        let before = column_default_statuses(&file, &board_id);
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "update",
+                &board_id,
+                "--name",
+                "Renamed",
+            ])
+            .assert()
+            .success();
+
+        let after = column_default_statuses(&file, &board_id);
+        assert_eq!(
+            after, before,
+            "an unrelated board update must not touch any column's default_status"
+        );
+        assert_eq!(
+            default_status_of(&after, &cols[2]),
+            serde_json::json!("done"),
+            "the configured completion column must still be done"
+        );
+    }
+
     #[test]
     fn test_board_update_completion_columns_unknown_name_errors_with_raw_identifier() {
         let dir = tempdir().unwrap();
@@ -5969,6 +6090,47 @@ mod default_columns_tests {
                 ("Complete".to_string(), 2),
             ]
         );
+    }
+
+    #[test]
+    fn test_board_create_with_default_columns_sets_complete_default_status_done() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        kanban().args([file.to_str().unwrap()]).assert().success();
+
+        let create_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "create",
+                "--name",
+                "Board",
+                "--with-default-columns",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let board_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&create_output)));
+
+        let list_output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "column",
+                "list",
+                "--board",
+                &board_id,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&list_output));
+        let items = json["data"]["items"].as_array().unwrap();
+        let complete = items.iter().find(|c| c["name"] == "Complete").unwrap();
+        assert_eq!(complete["default_status"], serde_json::json!("done"));
     }
 
     #[test]

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -3262,6 +3262,125 @@ fn board_update_req(completion: Option<Vec<String>>) -> kanban_mcp::UpdateBoardR
     }
 }
 
+/// The current default_status of every column on board "B", keyed by column
+/// id, in creation/position order.
+async fn column_default_statuses(server: &KanbanMcpServer, board: &str) -> Vec<(String, Value)> {
+    let cols = text_payload(
+        &server
+            .tool_list_columns(Parameters(ListColumnsRequest {
+                board: board.into(),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap(),
+    );
+    cols["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| {
+            (
+                c["id"].as_str().unwrap().to_string(),
+                c["default_status"].clone(),
+            )
+        })
+        .collect()
+}
+
+fn default_status_of(statuses: &[(String, Value)], column_id: &str) -> Value {
+    statuses
+        .iter()
+        .find(|(id, _)| id == column_id)
+        .unwrap_or_else(|| panic!("column {column_id} not found in {statuses:?}"))
+        .1
+        .clone()
+}
+
+#[tokio::test]
+async fn test_update_board_sets_completion_column_ids_by_name() {
+    let (server, _tmp, cols) = setup_server_with_completion_board().await;
+
+    server
+        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
+        .await
+        .unwrap();
+
+    let statuses = column_default_statuses(&server, "B").await;
+    assert_eq!(
+        default_status_of(&statuses, &cols[2]),
+        serde_json::json!("done"),
+        "the named completion column must carry default_status = done"
+    );
+}
+
+#[tokio::test]
+async fn test_update_board_sets_completion_column_ids_by_uuid() {
+    let (server, _tmp, cols) = setup_server_with_completion_board().await;
+
+    server
+        .tool_update_board(Parameters(board_update_req(Some(vec![cols[2].clone()]))))
+        .await
+        .unwrap();
+
+    let statuses = column_default_statuses(&server, "B").await;
+    assert_eq!(
+        default_status_of(&statuses, &cols[2]),
+        serde_json::json!("done"),
+        "the completion column addressed by uuid must carry default_status = done"
+    );
+}
+
+#[tokio::test]
+async fn test_update_board_empty_completion_column_ids_resets_previous_column_to_todo() {
+    let (server, _tmp, cols) = setup_server_with_completion_board().await;
+
+    server
+        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
+        .await
+        .unwrap();
+    server
+        .tool_update_board(Parameters(board_update_req(Some(vec![]))))
+        .await
+        .unwrap();
+
+    let statuses = column_default_statuses(&server, "B").await;
+    assert_eq!(
+        default_status_of(&statuses, &cols[2]),
+        serde_json::json!("todo"),
+        "clearing the completion configuration must reset the previously-completion column"
+    );
+}
+
+#[tokio::test]
+async fn test_update_board_omitting_completion_column_ids_leaves_default_statuses_unchanged() {
+    let (server, _tmp, cols) = setup_server_with_completion_board().await;
+
+    server
+        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
+        .await
+        .unwrap();
+    let before = column_default_statuses(&server, "B").await;
+
+    let mut rename_only = board_update_req(None);
+    rename_only.name = Some("Renamed".into());
+    server
+        .tool_update_board(Parameters(rename_only))
+        .await
+        .unwrap();
+
+    let after = column_default_statuses(&server, "Renamed").await;
+    assert_eq!(
+        after, before,
+        "an unrelated board update must not touch any column's default_status"
+    );
+    assert_eq!(
+        default_status_of(&after, &cols[2]),
+        serde_json::json!("done"),
+        "the configured completion column must still be done"
+    );
+}
+
 #[tokio::test]
 async fn test_update_board_completion_column_of_other_board_returns_error() {
     let (server, _tmp, _cols) = setup_server_with_completion_board().await;

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -3262,107 +3262,6 @@ fn board_update_req(completion: Option<Vec<String>>) -> kanban_mcp::UpdateBoardR
     }
 }
 
-async fn board_completion_ids(server: &KanbanMcpServer) -> Value {
-    let result = server
-        .tool_get_board(Parameters(GetBoardRequest { board: "B".into() }))
-        .await
-        .unwrap();
-    text_payload(&result)["completion_column_ids"].clone()
-}
-
-#[tokio::test]
-async fn test_update_board_sets_completion_column_ids_by_name() {
-    let (server, _tmp, cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
-        .await
-        .unwrap();
-
-    assert_eq!(
-        board_completion_ids(&server).await,
-        serde_json::json!([cols[2]])
-    );
-}
-
-#[tokio::test]
-async fn test_update_board_sets_completion_column_ids_by_uuid() {
-    let (server, _tmp, cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec![cols[2].clone()]))))
-        .await
-        .unwrap();
-
-    assert_eq!(
-        board_completion_ids(&server).await,
-        serde_json::json!([cols[2]])
-    );
-}
-
-#[tokio::test]
-async fn test_update_board_completion_column_ids_preserves_order() {
-    let (server, _tmp, cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec![
-            "Decision".into(),
-            "Done".into(),
-        ]))))
-        .await
-        .unwrap();
-
-    assert_eq!(
-        board_completion_ids(&server).await,
-        serde_json::json!([cols[3], cols[2]]),
-        "element 0 is the primary completion column; order must be as supplied"
-    );
-}
-
-#[tokio::test]
-async fn test_update_board_empty_completion_column_ids_clears_configuration() {
-    let (server, _tmp, _cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
-        .await
-        .unwrap();
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec![]))))
-        .await
-        .unwrap();
-
-    assert_eq!(board_completion_ids(&server).await, serde_json::json!([]));
-}
-
-#[tokio::test]
-async fn test_update_board_omitting_completion_column_ids_leaves_field_unchanged() {
-    let (server, _tmp, cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
-        .await
-        .unwrap();
-    let mut rename_only = board_update_req(None);
-    rename_only.name = Some("Renamed".into());
-    server
-        .tool_update_board(Parameters(rename_only))
-        .await
-        .unwrap();
-
-    let result = server
-        .tool_get_board(Parameters(GetBoardRequest {
-            board: "Renamed".into(),
-        }))
-        .await
-        .unwrap();
-    assert_eq!(
-        text_payload(&result)["completion_column_ids"],
-        serde_json::json!([cols[2]]),
-        "an unrelated update must not wipe the completion configuration"
-    );
-}
-
 #[tokio::test]
 async fn test_update_board_completion_column_of_other_board_returns_error() {
     let (server, _tmp, _cols) = setup_server_with_completion_board().await;
@@ -3383,7 +3282,6 @@ async fn test_update_board_completion_column_of_other_board_returns_error() {
 
     let msg = format!("{err:?}");
     assert!(msg.contains("column"), "err: {msg}");
-    assert_eq!(board_completion_ids(&server).await, serde_json::json!([]));
 }
 
 #[tokio::test]

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -86,7 +86,6 @@ curl -s http://127.0.0.1:58548/v1/boards | jq
     "sprint_duration_days": 7,
     "task_list_view": "grouped_by_column",
     "active_sprint_id": "2ab2a4d3-80d0-4bd6-881c-88bed5fd7670",
-    "completion_column_ids": [],
     "position": 0,
     "created_at": "2025-10-10T08:47:44.779097Z",
     "updated_at": "2026-07-04T10:55:00.488151029Z"

--- a/crates/kanban-server/tests/board_create_seam.rs
+++ b/crates/kanban-server/tests/board_create_seam.rs
@@ -6,7 +6,7 @@ use kanban_server::handlers::boards::{create_board, create_or_replace_board};
 use kanban_service::api::{
     CreateBoardRequest, ReplaceBoardRequest, SortFieldDto, SortOrderDto, TaskListViewDto,
 };
-use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -41,7 +41,6 @@ fn replace_req(name: &str) -> ReplaceBoardRequest {
         task_sort_order: SortOrderDto::Ascending,
         sprint_duration_days: None,
         task_list_view: TaskListViewDto::GroupedByColumn,
-        completion_column_ids: Vec::new(),
     }
 }
 
@@ -119,24 +118,6 @@ async fn test_create_or_replace_board_seam_replaces_when_present() {
     assert!(!created, "present id must report replace (200)");
     assert_eq!(resp.id, id, "id stable across replace");
     assert_eq!(resp.name, "Replaced");
-}
-
-/// `PUT /v1/boards/:id` with a non-empty completion_column_ids on a fresh id rejects.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_create_or_replace_board_seam_with_completion_column_ids_on_fresh_id_rejects() {
-    let dir = tempdir().unwrap();
-    let mut ctx = make_ctx(&dir.path().join("s.json"));
-    let id = Uuid::new_v4();
-
-    let req = ReplaceBoardRequest {
-        completion_column_ids: vec![Uuid::new_v4()],
-        ..replace_req("Fresh")
-    };
-
-    let err = create_or_replace_board(&mut ctx, id, req).unwrap_err();
-
-    assert_eq!(err.code, kanban_service::api::ErrorCode::ValidationFailed);
-    assert_eq!(ctx.list_boards().unwrap().len(), 0);
 }
 
 /// Both seams project via BoardResponse, omitting internal allocation state.

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -365,47 +365,7 @@ async fn test_post_board_persists_to_disk() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_patch_board_sets_completion_column_ids_and_echoes_order() {
-    let dir = tempdir().unwrap();
-    let state = make_state(&dir.path().join("s.json"));
-
-    let board =
-        json_of(send(&state, "POST", "/v1/boards", Some(&json!({"name": "B"}))).await).await;
-    let board_id = board["id"].as_str().unwrap().to_string();
-
-    let mut col_ids = Vec::new();
-    for (i, name) in ["TODO", "Done", "Decision"].iter().enumerate() {
-        let col = json_of(
-            send(
-                &state,
-                "POST",
-                &format!("/v1/boards/{board_id}/columns"),
-                Some(&json!({"name": name, "position": i})),
-            )
-            .await,
-        )
-        .await;
-        col_ids.push(col["id"].as_str().unwrap().to_string());
-    }
-
-    let response = send(
-        &state,
-        "PATCH",
-        &format!("/v1/boards/{board_id}"),
-        Some(&json!({"completion_column_ids": [col_ids[2], col_ids[1]]})),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = json_of(response).await;
-    assert_eq!(
-        body["completion_column_ids"],
-        json!([col_ids[2], col_ids[1]]),
-        "response must echo the configured list in order"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_patch_board_with_invalid_completion_column_returns_422() {
+async fn test_patch_board_ignores_a_legacy_completion_column_ids_key() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -417,14 +377,19 @@ async fn test_patch_board_with_invalid_completion_column_returns_422() {
         &state,
         "PATCH",
         &format!("/v1/boards/{board_id}"),
-        Some(&json!({"completion_column_ids": [Uuid::new_v4()]})),
+        Some(&json!({
+            "name": "Renamed",
+            "completion_column_ids": [Uuid::new_v4()],
+        })),
     )
     .await;
 
     assert_eq!(
         response.status(),
-        StatusCode::UNPROCESSABLE_ENTITY,
-        "a column that is not a live column of the board is a validation error, not a 500"
+        StatusCode::OK,
+        "a legacy completion_column_ids key must be ignored, not rejected"
     );
-    assert_eq!(json_of(response).await["code"], "VALIDATION_FAILED");
+    let body = json_of(response).await;
+    assert_eq!(body["name"], "Renamed");
+    assert!(body.get("completion_column_ids").is_none());
 }


### PR DESCRIPTION
Removes board-level completion configuration from the REST wire. Completion is now expressed by a column's `default_status`.

Removed: `BoardResponse.completion_column_ids` and its mapping, `UpdateBoardRequest.completion_column_ids` (a `Patch<Vec<Uuid>>`), `ReplaceBoardRequest.completion_column_ids`, and the conversion arms and Patch-behaviour tests that went with them.

`CreateBoardRequest` is untouched. It has no such field by design, since a board created that way has zero columns and there is nothing to point at. That special case is real and stays.

Legacy request bodies carrying `completion_column_ids` are ignored, not rejected. Older clients and scripts will keep sending it. Proven at both layers: deserialization tests for both request types, and a real PATCH over HTTP that returns 200, applies the unrelated field, and omits the stale key from the response.

Breaking wire change, so the changeset is a major bump.

Coverage worth calling out, since deletions are easy to hide. Tests whose subject was the wire field itself are deleted: the kanban-api Patch-behaviour tests and two kanban-server tests. Two more are deleted because their subject genuinely no longer exists — list ORDER is unobservable now, since every completion column simply becomes `done` and the primary is derived as first-by-position.

But `--completion-columns` and the MCP `completion_column_ids` field both still exist and still work, so their tests were kept, re-pointed at the observable effect rather than deleted. KAN-1176 made that configuration path write `column.default_status`, so the behaviour is still fully assertable:

    board create --with-default-columns        TODO=todo  Doing=in_progress  Complete=done
    board update --completion-columns "Doing"  TODO=todo  Doing=done         Complete=todo

Setting completion to "Doing" makes it `done` and resets the previous completion column to `todo`. Five CLI tests and four MCP tests now assert against that instead of the removed response field, so a live feature keeps its coverage until the slice that removes it.