### PR TITLE
KAN-1168 refactor(cli,mcp,tui): remove direct completion-column configuration surfaces

### DIFF
--- a/.changeset/kan-1168-remove-completion-surfaces.md
+++ b/.changeset/kan-1168-remove-completion-surfaces.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+cli,mcp,tui: remove direct completion-column configuration surfaces (--completion-columns CLI flag, MCP completion_column_ids field, and the TUI board-creation seeding call). Completion is now configured only by giving a column a default_status of done: use 'column update <name> --default-status done' in place of 'board update <board> --completion-columns <name>'. A legacy completion_column_ids key sent to the MCP update_board tool is now silently ignored rather than rejected, so older agent scripts do not hard-fail.

--- a/.changeset/kan-1168-remove-completion-surfaces.md
+++ b/.changeset/kan-1168-remove-completion-surfaces.md
@@ -2,4 +2,4 @@
 bump: minor
 ---
 
-cli,mcp,tui: remove direct completion-column configuration surfaces (--completion-columns CLI flag, MCP completion_column_ids field, and the TUI board-creation seeding call). Completion is now configured only by giving a column a default_status of done: use 'column update <name> --default-status done' in place of 'board update <board> --completion-columns <name>'. A legacy completion_column_ids key sent to the MCP update_board tool is now silently ignored rather than rejected, so older agent scripts do not hard-fail.
+Remove direct completion-column configuration from the CLI, MCP and TUI

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -169,11 +169,6 @@ pub struct BoardUpdateArgs {
     /// Default sort direction for the task list view.
     #[arg(long, value_enum)]
     pub sort_order: Option<SortDir>,
-    /// Columns that mean "complete", most-primary first. Accepts names or
-    /// UUIDs, comma-separated. Pass an empty string to disable status/column
-    /// auto-sync for this board.
-    #[arg(long, value_delimiter = ',')]
-    pub completion_columns: Option<Vec<String>>,
 }
 
 // Column commands

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -182,24 +182,11 @@ fn seed_default_columns(
     ctx: &mut CliContext,
     board_id: uuid::Uuid,
 ) -> anyhow::Result<kanban_domain::Board> {
-    let mut complete_column_id = None;
     for (name, default_status) in kanban_domain::DEFAULT_TEMPLATE_COLUMNS {
-        let column = ctx.create_column_with_default_status(
-            board_id,
-            name.to_string(),
-            None,
-            default_status,
-        )?;
-        if name == "Complete" {
-            complete_column_id = Some(column.id);
-        }
+        ctx.create_column_with_default_status(board_id, name.to_string(), None, default_status)?;
     }
-    let updates = BoardUpdate {
-        completion_column_ids: complete_column_id.map(|id| vec![id]),
-        ..Default::default()
-    };
-    ctx.update_board(board_id, updates)
-        .map_err(anyhow::Error::from)
+    ctx.get_board(board_id)?
+        .ok_or_else(|| anyhow::anyhow!("board not found after seeding default columns"))
 }
 
 async fn handle_update(
@@ -209,20 +196,6 @@ async fn handle_update(
     let uuid = ctx
         .resolve_board_id(&args.board)
         .map_err(anyhow::Error::from)?;
-    // `--completion-columns ''` becomes `Some(vec![])` (the explicit disable):
-    // the empty entry is filtered out rather than treated as a column name.
-    let completion_column_ids = match args.completion_columns {
-        None => None,
-        Some(raw) => Some(
-            raw.iter()
-                .filter(|s| !s.trim().is_empty())
-                .map(|s| {
-                    ctx.resolve_column_id(s, uuid)
-                        .map_err(|e| anyhow::anyhow!("{e}"))
-                })
-                .collect::<anyhow::Result<Vec<_>>>()?,
-        ),
-    };
     let updates = BoardUpdate {
         name: args.name,
         description: args
@@ -239,7 +212,6 @@ async fn handle_update(
             .unwrap_or(FieldUpdate::NoChange),
         task_sort_field: args.sort_field.map(|s| s.to_sort_field()),
         task_sort_order: args.sort_order.map(|o| o.to_sort_order()),
-        completion_column_ids,
         ..Default::default()
     };
     let board = ctx.update_board(uuid, updates)?;

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5776,199 +5776,32 @@ mod completion_columns_tests {
         (board_id, column_ids)
     }
 
-    fn update_completion_columns(
-        file: &std::path::Path,
-        board: &str,
-        value: &str,
-    ) -> assert_cmd::assert::Assert {
+    /// The replacement for the removed `--completion-columns` flag: give a
+    /// column a `default_status` of `done` directly.
+    fn set_column_done(file: &std::path::Path, column: &str) -> assert_cmd::assert::Assert {
         kanban()
             .args([
                 file.to_str().unwrap(),
-                "board",
-                "update",
-                board,
-                "--completion-columns",
-                value,
-            ])
-            .assert()
-    }
-
-    /// The current default_status of every column on the board, keyed by
-    /// column id, in creation/position order.
-    fn column_default_statuses(file: &std::path::Path, board_id: &str) -> Vec<(String, Value)> {
-        let output = kanban()
-            .args([
-                file.to_str().unwrap(),
                 "column",
-                "list",
-                "--board",
-                board_id,
-            ])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        let json = parse_json_output(&String::from_utf8_lossy(&output));
-        json["data"]["items"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|c| {
-                (
-                    c["id"].as_str().unwrap().to_string(),
-                    c["default_status"].clone(),
-                )
-            })
-            .collect()
-    }
-
-    fn default_status_of(statuses: &[(String, Value)], column_id: &str) -> Value {
-        statuses
-            .iter()
-            .find(|(id, _)| id == column_id)
-            .unwrap_or_else(|| panic!("column {column_id} not found in {statuses:?}"))
-            .1
-            .clone()
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_by_name_sets_default_status_done() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, "Done").success();
-
-        let statuses = column_default_statuses(&file, &board_id);
-        assert_eq!(
-            default_status_of(&statuses, &cols[2]),
-            serde_json::json!("done"),
-            "the named completion column must carry default_status = done"
-        );
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_by_uuid_sets_default_status_done() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, &cols[2]).success();
-
-        let statuses = column_default_statuses(&file, &board_id);
-        assert_eq!(
-            default_status_of(&statuses, &cols[2]),
-            serde_json::json!("done"),
-            "the completion column addressed by uuid must carry default_status = done"
-        );
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_empty_string_resets_previous_column_to_todo() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, "Done").success();
-        update_completion_columns(&file, &board_id, "").success();
-
-        let statuses = column_default_statuses(&file, &board_id);
-        assert_eq!(
-            default_status_of(&statuses, &cols[2]),
-            serde_json::json!("todo"),
-            "clearing the completion configuration must reset the previously-completion column"
-        );
-    }
-
-    #[test]
-    fn test_board_update_without_completion_flag_leaves_default_statuses_unchanged() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, "Done").success();
-        let before = column_default_statuses(&file, &board_id);
-
-        kanban()
-            .args([
-                file.to_str().unwrap(),
-                "board",
                 "update",
-                &board_id,
-                "--name",
-                "Renamed",
+                column,
+                "--default-status",
+                "done",
             ])
             .assert()
-            .success();
-
-        let after = column_default_statuses(&file, &board_id);
-        assert_eq!(
-            after, before,
-            "an unrelated board update must not touch any column's default_status"
-        );
-        assert_eq!(
-            default_status_of(&after, &cols[2]),
-            serde_json::json!("done"),
-            "the configured completion column must still be done"
-        );
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_unknown_name_errors_with_raw_identifier() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, _cols) = setup_board_with_columns(&file);
-
-        update_completion_columns(&file, &board_id, "Nonexistent")
-            .failure()
-            .stderr(predicate::str::contains("Nonexistent"));
-    }
-
-    #[test]
-    fn test_board_update_completion_columns_column_of_other_board_errors() {
-        let dir = tempdir().unwrap();
-        let file = dir.path().join("test.json");
-        let (board_id, _cols) = setup_board_with_columns(&file);
-
-        let output = kanban()
-            .args([file.to_str().unwrap(), "board", "create", "--name", "Other"])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        let other_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&output)));
-        let output = kanban()
-            .args([
-                file.to_str().unwrap(),
-                "column",
-                "create",
-                "--board",
-                &other_id,
-                "--name",
-                "Elsewhere",
-            ])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
-        let other_col = extract_id(&parse_json_output(&String::from_utf8_lossy(&output)));
-
-        update_completion_columns(&file, &board_id, &other_col).failure();
     }
 
     #[test]
     fn test_card_update_status_done_lands_in_configured_column() {
-        // The root reproduction: board TODO, Doing, Done, Decision configured
-        // [Done]. status=done must land in Done (not the last column,
-        // Decision), and a subsequent move into Done must keep status=done.
+        // The root reproduction: board TODO, Doing, Done, Decision, with Done
+        // given default_status = done. status=done must land in Done (not the
+        // last column, Decision), and a subsequent move into Done must keep
+        // status=done.
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
         let (board_id, cols) = setup_board_with_columns(&file);
 
-        update_completion_columns(&file, &board_id, "Done").success();
+        set_column_done(&file, "Done").success();
 
         let output = kanban()
             .args([
@@ -6029,6 +5862,81 @@ mod completion_columns_tests {
         assert_eq!(
             json["data"]["status"], "done",
             "moving into the configured completion column must not reset the status"
+        );
+    }
+
+    #[test]
+    fn test_cli_no_longer_accepts_completion_columns_flag() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, _cols) = setup_board_with_columns(&file);
+
+        kanban()
+            .args([
+                file.to_str().unwrap(),
+                "board",
+                "update",
+                &board_id,
+                "--completion-columns",
+                "Done",
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--completion-columns"));
+    }
+
+    #[test]
+    fn test_cli_column_update_default_status_done_makes_it_a_completion_column() {
+        // The replacement path, end to end: `column update --default-status
+        // done` (not `--completion-columns`) must produce the same completion
+        // behavior — moving a card into that column marks it done.
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.json");
+        let (board_id, cols) = setup_board_with_columns(&file);
+
+        set_column_done(&file, "Done").success();
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &cols[0],
+                "--title",
+                "Card",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let card_id = extract_id(&parse_json_output(&String::from_utf8_lossy(&output)));
+
+        let output = kanban()
+            .args([
+                file.to_str().unwrap(),
+                "card",
+                "move",
+                &card_id,
+                "--column",
+                "Done",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert_eq!(
+            json["data"]["status"], "done",
+            "moving a card into a column with default_status=done must set status=done"
+        );
+        assert!(
+            json["data"]["completed_at"].is_string(),
+            "the completion timestamp must be stamped"
         );
     }
 }

--- a/crates/kanban-mcp/src/requests/board.rs
+++ b/crates/kanban-mcp/src/requests/board.rs
@@ -31,13 +31,6 @@ pub struct UpdateBoardRequest {
     pub task_sort_field: Option<String>,
     #[schemars(description = "Default sort direction. Valid: asc, desc")]
     pub task_sort_order: Option<String>,
-    #[schemars(
-        description = "Columns that mean 'complete', as names or UUIDs, most-primary first. \
-        The first entry is where a card goes when its status is set to done; membership in \
-        the whole list is what marks a card complete. Pass an empty array to disable \
-        status/column auto-sync for this board. Omit to leave unchanged."
-    )]
-    pub completion_column_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -112,7 +112,7 @@ impl KanbanMcpServer {
     }
 
     #[tool(
-        description = "Update a board's properties (name, description, sprint_prefix, card_prefix, task_sort_field, task_sort_order, completion_column_ids)"
+        description = "Update a board's properties (name, description, sprint_prefix, card_prefix, task_sort_field, task_sort_order)"
     )]
     pub async fn tool_update_board(
         &self,
@@ -130,15 +130,6 @@ impl KanbanMcpServer {
             .transpose()?;
         let board = locked_write(&self.ctx, |ctx| {
             let id = ctx.mcp_resolve_board(&req.board)?;
-            let completion_column_ids = req
-                .completion_column_ids
-                .as_ref()
-                .map(|raw| {
-                    raw.iter()
-                        .map(|s| ctx.mcp_resolve_column_in_board(s, id))
-                        .collect::<Result<Vec<_>, _>>()
-                })
-                .transpose()?;
             let updates = BoardUpdate {
                 name: req.name,
                 description: req
@@ -155,7 +146,6 @@ impl KanbanMcpServer {
                     .unwrap_or(FieldUpdate::NoChange),
                 task_sort_field,
                 task_sort_order,
-                completion_column_ids,
                 ..Default::default()
             };
             ctx.update_board(id, updates).map_err(kanban_err_to_mcp)

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -3249,17 +3249,21 @@ async fn setup_server_with_completion_board() -> (KanbanMcpServer, TempDir, Vec<
     (server, tmp, col_ids)
 }
 
-fn board_update_req(completion: Option<Vec<String>>) -> kanban_mcp::UpdateBoardRequest {
-    kanban_mcp::UpdateBoardRequest {
-        board: "B".to_string(),
-        name: None,
-        description: None,
-        sprint_prefix: None,
-        card_prefix: None,
-        task_sort_field: None,
-        task_sort_order: None,
-        completion_column_ids: completion,
-    }
+/// The replacement for the removed `completion_column_ids` field: give a
+/// column a `default_status` of `done` directly via the column-update tool.
+async fn set_column_done_via_mcp(server: &KanbanMcpServer, column: &str) {
+    server
+        .tool_update_column(Parameters(kanban_mcp::UpdateColumnRequest {
+            column: column.to_string(),
+            name: None,
+            position: None,
+            wip_limit: None,
+            clear_wip_limit: None,
+            default_status: Some(kanban_service::api::CardStatusDto::Done),
+            clear_default_status: None,
+        }))
+        .await
+        .unwrap();
 }
 
 /// The current default_status of every column on board "B", keyed by column
@@ -3298,130 +3302,39 @@ fn default_status_of(statuses: &[(String, Value)], column_id: &str) -> Value {
 }
 
 #[tokio::test]
-async fn test_update_board_sets_completion_column_ids_by_name() {
-    let (server, _tmp, cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
-        .await
-        .unwrap();
-
-    let statuses = column_default_statuses(&server, "B").await;
-    assert_eq!(
-        default_status_of(&statuses, &cols[2]),
-        serde_json::json!("done"),
-        "the named completion column must carry default_status = done"
-    );
-}
-
-#[tokio::test]
-async fn test_update_board_sets_completion_column_ids_by_uuid() {
-    let (server, _tmp, cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec![cols[2].clone()]))))
-        .await
-        .unwrap();
-
-    let statuses = column_default_statuses(&server, "B").await;
-    assert_eq!(
-        default_status_of(&statuses, &cols[2]),
-        serde_json::json!("done"),
-        "the completion column addressed by uuid must carry default_status = done"
-    );
-}
-
-#[tokio::test]
-async fn test_update_board_empty_completion_column_ids_resets_previous_column_to_todo() {
-    let (server, _tmp, cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
-        .await
-        .unwrap();
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec![]))))
-        .await
-        .unwrap();
-
-    let statuses = column_default_statuses(&server, "B").await;
-    assert_eq!(
-        default_status_of(&statuses, &cols[2]),
-        serde_json::json!("todo"),
-        "clearing the completion configuration must reset the previously-completion column"
-    );
-}
-
-#[tokio::test]
-async fn test_update_board_omitting_completion_column_ids_leaves_default_statuses_unchanged() {
-    let (server, _tmp, cols) = setup_server_with_completion_board().await;
-
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
-        .await
-        .unwrap();
-    let before = column_default_statuses(&server, "B").await;
-
-    let mut rename_only = board_update_req(None);
-    rename_only.name = Some("Renamed".into());
-    server
-        .tool_update_board(Parameters(rename_only))
-        .await
-        .unwrap();
-
-    let after = column_default_statuses(&server, "Renamed").await;
-    assert_eq!(
-        after, before,
-        "an unrelated board update must not touch any column's default_status"
-    );
-    assert_eq!(
-        default_status_of(&after, &cols[2]),
-        serde_json::json!("done"),
-        "the configured completion column must still be done"
-    );
-}
-
-#[tokio::test]
-async fn test_update_board_completion_column_of_other_board_returns_error() {
+async fn test_mcp_board_update_ignores_a_legacy_completion_column_ids_field() {
+    // An older agent script that still sends `completion_column_ids` on
+    // `update_board` must not hard-fail: the field is gone from
+    // `UpdateBoardRequest`, so serde silently ignores the unknown key rather
+    // than rejecting the request.
     let (server, _tmp, _cols) = setup_server_with_completion_board().await;
-    server
-        .tool_create_board(Parameters(board_req("Other", None)))
-        .await
-        .unwrap();
-    let result = server
-        .tool_create_column(Parameters(column_req("Other", "Elsewhere")))
-        .await
-        .unwrap();
-    let other_col = text_payload(&result)["id"].as_str().unwrap().to_string();
+    let json = serde_json::json!({
+        "board": "B",
+        "name": "Renamed",
+        "completion_column_ids": ["00000000-0000-0000-0000-000000000000"],
+    });
+    let req: kanban_mcp::UpdateBoardRequest = serde_json::from_value(json).unwrap();
 
-    let err = server
-        .tool_update_board(Parameters(board_update_req(Some(vec![other_col]))))
+    let board = server
+        .tool_update_board(Parameters(req))
         .await
-        .unwrap_err();
-
-    let msg = format!("{err:?}");
-    assert!(msg.contains("column"), "err: {msg}");
+        .expect("a legacy completion_column_ids field must be ignored, not rejected");
+    assert_eq!(text_payload(&board)["name"], "Renamed");
 }
 
 #[tokio::test]
-async fn test_update_board_schema_advertises_completion_column_ids() {
-    // An undiscoverable field is not shipped: the advertised JSON schema must
-    // carry the field with a description covering ordering and the disable.
-    let schema =
-        serde_json::to_value(rmcp::schemars::schema_for!(kanban_mcp::UpdateBoardRequest)).unwrap();
-    let prop = &schema["properties"]["completion_column_ids"];
-    assert!(
-        !prop.is_null(),
-        "schema must advertise completion_column_ids: {schema}"
-    );
-    let description = prop["description"].as_str().unwrap_or_default();
-    assert!(
-        description.contains("first") || description.contains("primary"),
-        "description must explain ordering: {description}"
-    );
-    assert!(
-        description.contains("empty"),
-        "description must explain the empty-array disable: {description}"
+async fn test_mcp_column_update_default_status_done_makes_it_a_completion_column() {
+    // The replacement path, end to end through the MCP tools: `update_column`
+    // with `default_status: done` (not `completion_column_ids`) must produce
+    // the same completion behavior.
+    let (server, _tmp, cols) = setup_server_with_completion_board().await;
+    set_column_done_via_mcp(&server, "Done").await;
+
+    let statuses = column_default_statuses(&server, "B").await;
+    assert_eq!(
+        default_status_of(&statuses, &cols[2]),
+        serde_json::json!("done"),
+        "the column must carry default_status = done"
     );
 }
 
@@ -3431,10 +3344,7 @@ async fn test_update_card_status_done_lands_in_configured_column_via_mcp() {
     // agent sets status=done and the card must land in the CONFIGURED Done
     // column (not the last column), then a move into Done keeps status=done.
     let (server, _tmp, cols) = setup_server_with_completion_board().await;
-    server
-        .tool_update_board(Parameters(board_update_req(Some(vec!["Done".into()]))))
-        .await
-        .unwrap();
+    set_column_done_via_mcp(&server, "Done").await;
     let result = server
         .tool_create_card(Parameters(card_req("B", "TODO", "Card")))
         .await

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -477,15 +477,11 @@ impl App {
             position,
         }))];
 
-        let mut complete_column_id = None;
         for (position, (name, default_status)) in kanban_domain::DEFAULT_TEMPLATE_COLUMNS
             .into_iter()
             .enumerate()
         {
             let column_id = uuid::Uuid::new_v4();
-            if name == "Complete" {
-                complete_column_id = Some(column_id);
-            }
             commands.push(Command::Column(ColumnCommand::Create(CreateColumn {
                 id: column_id,
                 board_id,
@@ -493,20 +489,6 @@ impl App {
                 position: position as i32,
                 default_status,
             })));
-        }
-        // Configure the template's Complete column as the completion column in
-        // the same batch: an explicit, creation-time choice (frozen, undoable
-        // with the rest), so a fresh board needs no manual setup step.
-        if let Some(complete_id) = complete_column_id {
-            commands.push(Command::Board(BoardCommand::Update(
-                kanban_domain::commands::UpdateBoard {
-                    board_id,
-                    updates: kanban_domain::BoardUpdate {
-                        completion_column_ids: Some(vec![complete_id]),
-                        ..Default::default()
-                    },
-                },
-            )));
         }
 
         // Single batch so undo reverses the whole "create a board"
@@ -604,27 +586,32 @@ mod tests {
     }
 
     #[test]
-    fn test_create_board_configures_complete_as_completion_column() {
-        // The default template seeds TODO/Doing/Complete; the creation batch
-        // must also configure Complete as the completion column, so a fresh
-        // board's status/column sync works without a manual setup step.
+    fn test_create_board_seeds_default_statuses_and_sets_no_completion_ids() {
+        // The default template seeds TODO/Doing/Complete, each carrying its own
+        // `default_status`; the creation batch no longer sets
+        // `completion_column_ids` at all, since the lifecycle sync is driven by
+        // `default_status` alone.
+        use kanban_domain::CardStatus;
+
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
 
         let board = app.ctx.data_store().list_boards().unwrap().remove(0);
-        let complete_id = app
-            .ctx
-            .data_store()
-            .list_all_columns()
-            .unwrap()
-            .into_iter()
-            .find(|c| c.board_id == board.id && c.name == "Complete")
-            .expect("template Complete column")
-            .id;
+        let cols = app.ctx.data_store().list_all_columns().unwrap();
+        let by_name = |name: &str| {
+            cols.iter()
+                .find(|c| c.board_id == board.id && c.name == name)
+                .unwrap_or_else(|| panic!("template column {name}"))
+        };
+        assert_eq!(by_name("TODO").default_status, Some(CardStatus::Todo));
         assert_eq!(
-            board.completion_column_ids,
-            vec![complete_id],
-            "a template-created board must come configured, not require manual setup"
+            by_name("Doing").default_status,
+            Some(CardStatus::InProgress)
+        );
+        assert_eq!(by_name("Complete").default_status, Some(CardStatus::Done));
+        assert!(
+            board.completion_column_ids.is_empty(),
+            "board creation must no longer set completion_column_ids directly"
         );
     }
 
@@ -681,7 +668,11 @@ mod tests {
     }
 
     #[test]
-    fn test_undo_board_creation_reverses_completion_configuration_too() {
+    fn test_undo_board_creation_still_reverses_the_full_seed() {
+        // Board creation remains one undoable batch: the board and every
+        // template column (each carrying its own seeded `default_status`)
+        // must vanish together on undo, even though no separate
+        // `completion_column_ids` update is issued anymore.
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
 
@@ -689,6 +680,10 @@ mod tests {
         assert!(
             app.ctx.data_store().list_boards().unwrap().is_empty(),
             "the whole creation batch reverses in one step"
+        );
+        assert!(
+            app.ctx.data_store().list_all_columns().unwrap().is_empty(),
+            "the seeded default-status columns reverse with the board"
         );
     }
 


### PR DESCRIPTION
Removes the user-facing ways to configure completion columns directly. Completion is now configured only by giving a column a `default_status` of `done`.

Removed:

- CLI `--completion-columns` and its name resolution
- the MCP `completion_column_ids` request field, its resolution, and the mention of it in the tool description that advertised it to agents
- the `completion_column_ids` batch entry in board creation, in both the TUI and the CLI `--with-default-columns` path

Migration for users: `--completion-columns Complete` becomes `column update Complete --default-status done`.

The domain field and its helpers still exist; the next slice removes them.

Verified end to end on both backends. A freshly created board now has an EMPTY `completion_column_ids` and still behaves correctly, which is the point of the whole phase:

    completion_column_ids = 0
    TODO -> Doing = in_progress
    Doing -> Complete = done
    Complete -> Doing = in_progress

And the replacement path produces real completion behaviour on a new column: `column update Shipped --default-status done`, then moving a card into Shipped marks it `done`. Confirmed on JSON and SQLite.

On deletions, since they are easy to hide. The CLI and MCP tests that exercised the removed flag are deleted, because their subject genuinely disappears with it. KAN-1159 had deliberately kept and re-pointed those same tests while the flag still worked; that is no longer true here.

Tests exercising lifecycle behaviour are kept, with their setup migrated from the removed flag to `column update --default-status done`, so completion behaviour stays covered. The board-creation undo test is kept and strengthened rather than weakened: it now also asserts the seeded columns disappear on undo.

Two things were missing from the card's enumeration and were found by re-running it: the CLI's own `seed_default_columns` also wrote `completion_column_ids`, and two tests were filed under the wrong list. Both handled per the card's stated principle: subject gone means delete, lifecycle survives means migrate.