### PR TITLE
KAN-1081 refactor(tui): split prepare_frame into reload_model (I/O) and a pure prepare_frame

### DIFF
--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -65,8 +65,11 @@ impl App {
 
             if let Err(e) = self.execute_commands_batch(commands) {
                 tracing::error!("Failed to archive cards: {}", e);
-            } else if let Some((column_id, position)) = self.animation.archive_anchor.take() {
-                self.select_card_after_deletion(column_id, position);
+            } else {
+                self.reload_model();
+                if let Some((column_id, position)) = self.animation.archive_anchor.take() {
+                    self.select_card_after_deletion(column_id, position);
+                }
             }
         }
 
@@ -83,6 +86,8 @@ impl App {
             }
             if let Err(e) = self.execute_commands_batch(delete_commands) {
                 tracing::error!("Failed to delete cards: {}", e);
+            } else {
+                self.reload_model();
             }
         }
 

--- a/crates/kanban-tui/src/app/export_import.rs
+++ b/crates/kanban-tui/src/app/export_import.rs
@@ -82,6 +82,7 @@ impl App {
                 return Ok(());
             }
 
+            self.reload_model();
             self.prepare_frame();
             self.board_list
                 .inner_mut()
@@ -112,6 +113,7 @@ impl App {
             return Ok(());
         }
 
+        self.reload_model();
         self.prepare_frame();
         self.board_list
             .inner_mut()

--- a/crates/kanban-tui/src/app/file_io.rs
+++ b/crates/kanban-tui/src/app/file_io.rs
@@ -65,6 +65,7 @@ impl App {
                         if let Err(e) = self.execute_command(cmd) {
                             tracing::error!("Failed to update board: {}", e);
                         }
+                        self.reload_model();
                     }
                 }
             }
@@ -130,6 +131,7 @@ impl App {
                         if let Err(e) = self.execute_command(cmd) {
                             tracing::error!("Failed to update card: {}", e);
                         }
+                        self.reload_model();
                     }
                 }
             }

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -583,12 +583,14 @@ impl App {
                 }
                 // `prepare_frame` resyncs `board_list`, clamping the highlight to
                 // the post-undo board set.
+                self.reload_model();
                 self.prepare_frame();
             }
             KeyCode::Char('U') => {
                 if let Err(e) = self.redo() {
                     self.set_error(format!("Redo failed: {e}"));
                 }
+                self.reload_model();
                 self.prepare_frame();
             }
             _ => {}

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -433,6 +433,7 @@ mod tests {
                 CreateCardOptions::default(),
             )
             .unwrap();
+        app.reload_model();
         app.prepare_frame();
         // copy_branch_name/copy_git_checkout_command resolve the board via
         // active_board_id, which real navigation always sets before either
@@ -513,6 +514,7 @@ mod tests {
             .unwrap();
         app.ctx.activate_sprint(completed.id, None).unwrap();
         app.ctx.complete_sprint(completed.id).unwrap();
+        app.reload_model();
         app.prepare_frame();
         let sprint_idx = app
             .model
@@ -537,6 +539,7 @@ mod tests {
         use kanban_domain::KanbanOperations;
         let mut app = App::test_default();
         app.ctx.create_board("Board".into(), None).unwrap();
+        app.reload_model();
         app.prepare_frame();
         app.mode = AppMode::Settings;
 

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -95,7 +95,6 @@ impl App {
 
             loop {
                 if self.needs_redraw {
-                    self.reload_model();
                     self.prepare_frame();
                     terminal.draw(|frame| ui::render(self, frame))?;
                     self.needs_redraw = false;

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -28,6 +28,7 @@ impl App {
         self.ctx.mark_clean();
         // `prepare_frame` resyncs `board_list`, which auto-selects the first
         // board when none was previously highlighted and boards exist.
+        self.reload_model();
         self.prepare_frame();
         self.check_ended_sprints();
     }
@@ -94,6 +95,7 @@ impl App {
 
             loop {
                 if self.needs_redraw {
+                    self.reload_model();
                     self.prepare_frame();
                     terminal.draw(|frame| ui::render(self, frame))?;
                     self.needs_redraw = false;
@@ -181,6 +183,7 @@ impl App {
                                         match self.ctx.reload().await {
                                             Ok(()) => {
                                                 self.ctx.clear_conflict();
+                                                self.reload_model();
                                                 self.prepare_frame();
                                                 self.needs_redraw = true;
                                                 tracing::info!("Reloaded state from disk");

--- a/crates/kanban-tui/src/app/reload_watch.rs
+++ b/crates/kanban-tui/src/app/reload_watch.rs
@@ -6,6 +6,7 @@ impl App {
             Ok(()) => {
                 self.ctx.mark_clean();
                 self.ctx.clear_conflict();
+                self.reload_model();
                 self.prepare_frame();
                 self.needs_redraw = true;
                 tracing::info!("Auto-reloaded state from external file change");

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -72,12 +72,18 @@ impl App {
         filter_and_sort_boards(boards, &filter, &HashMap::new(), None)
     }
 
-    pub fn prepare_frame(&mut self) {
+    /// Reload the whole view model from the store. I/O. Call after a mutation,
+    /// after an external change, or on a cold path (startup, backend swap).
+    pub fn reload_model(&mut self) {
         match self.ctx.snapshot() {
             Ok(snapshot) => self.model.load_from_snapshot(snapshot),
-            Err(e) => tracing::warn!("Failed to load snapshot for frame: {e}"),
+            Err(e) => tracing::warn!("Failed to load model from store: {e}"),
         }
+    }
 
+    /// Rebuild the display partitions and task lists from the cached model.
+    /// Pure: performs no store access.
+    pub fn prepare_frame(&mut self) {
         // Single card-side selector: borrow the cached displayed subset (stack-
         // aware base mode). No per-frame filter/clone — the partition was built
         // on load. Resolved via `self.model` directly (not `self.displayed_cards`)

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -208,6 +208,7 @@ impl App {
             return;
         }
         tracing::info!("Archived board {}", board_id);
+        self.reload_model();
 
         // Highlight: clamp to the surviving range, or clear. Set directly on
         // `board_list` (rather than relying on the next `prepare_frame` resync,
@@ -530,6 +531,7 @@ impl App {
                 return;
             }
 
+            self.reload_model();
             tracing::info!("Renamed board to: {}", new_name);
         }
     }
@@ -895,7 +897,6 @@ mod tests {
         app.board_list.inner_mut().set_selected_index(Some(2));
 
         app.delete_board();
-        refresh(&mut app);
         assert_eq!(
             app.board_list.get_selected_index(),
             Some(1),
@@ -905,10 +906,8 @@ mod tests {
         // Delete the remaining two; selection must clear at zero.
         app.board_list.inner_mut().set_selected_index(Some(1));
         app.delete_board();
-        refresh(&mut app);
         app.board_list.inner_mut().set_selected_index(Some(0));
         app.delete_board();
-        refresh(&mut app);
         assert_eq!(
             app.board_list.get_selected_index(),
             None,
@@ -997,7 +996,6 @@ mod tests {
         app.board_list.inner_mut().set_selected_index(Some(3));
 
         app.delete_board();
-        refresh(&mut app);
 
         assert_eq!(app.selection.active_board_id, Some(a_id));
         assert_eq!(
@@ -1021,7 +1019,6 @@ mod tests {
         app.board_list.inner_mut().set_selected_index(Some(0)); // highlight A
 
         app.delete_board(); // archive A (before the active one)
-        refresh(&mut app);
 
         assert_eq!(
             app.selection.active_board_id,

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -291,14 +291,12 @@ impl App {
                 // partition; the previously highlighted live board's id is not in
                 // it, so `BoardList::update_boards` falls back to the first
                 // archived board (or `None` if empty) on its own.
-                self.reload_model();
                 self.prepare_frame();
                 self.needs_redraw = true;
             }
             AppMode::ArchivedBoardsView => {
                 self.mode = AppMode::Normal;
                 self.selection.active_board_id = None;
-                self.reload_model();
                 self.prepare_frame();
                 self.needs_redraw = true;
             }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -577,7 +577,6 @@ mod tests {
         app.input.set(name.to_string());
         app.create_board();
         app.input.clear();
-        refresh(app);
     }
 
     fn first_column_id(app: &App, board_id: uuid::Uuid) -> uuid::Uuid {

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -291,12 +291,14 @@ impl App {
                 // partition; the previously highlighted live board's id is not in
                 // it, so `BoardList::update_boards` falls back to the first
                 // archived board (or `None` if empty) on its own.
+                self.reload_model();
                 self.prepare_frame();
                 self.needs_redraw = true;
             }
             AppMode::ArchivedBoardsView => {
                 self.mode = AppMode::Normal;
                 self.selection.active_board_id = None;
+                self.reload_model();
                 self.prepare_frame();
                 self.needs_redraw = true;
             }
@@ -433,6 +435,7 @@ impl App {
         if self.selection.active_board_id == Some(board_id) {
             self.selection.active_board_id = None;
         }
+        self.reload_model();
         self.prepare_frame();
         // Clamp the highlight to the shrunken archived list, preserving
         // position (not identity — the removed board no longer exists there).
@@ -456,6 +459,7 @@ impl App {
             return;
         }
         tracing::info!("Permanently deleted archived board {}", board_id);
+        self.reload_model();
         self.prepare_frame();
         let remaining = self.model.archived_boards_view().count();
         self.board_list
@@ -503,6 +507,7 @@ impl App {
 
         // Resync `board_list` from the store so the new board is present, then
         // select it by id (known up front — it was generated above).
+        self.reload_model();
         self.prepare_frame();
         self.board_list.select_board(board_id);
         self.switch_view_strategy(TaskListView::default());
@@ -564,6 +569,7 @@ mod tests {
     /// handlers that read either observe prior writes (the event loop does
     /// this per frame via `prepare_frame`).
     fn refresh(app: &mut App) {
+        app.reload_model();
         app.prepare_frame();
     }
 
@@ -1233,6 +1239,7 @@ mod tests {
     /// board uses. Proof of reuse: no archival-specific entry point.
     fn open_archived_board(app: &mut App) {
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
         app.focus.active = Focus::Boards;
         app.board_list.inner_mut().set_selected_index(Some(0));
@@ -1357,6 +1364,7 @@ mod tests {
         let mut app = App::test_default();
         let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "Arch");
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
         app.focus.active = Focus::Boards;
         app.board_list.inner_mut().set_selected_index(Some(0));
@@ -1412,6 +1420,7 @@ mod tests {
         let mut app = App::test_default();
         let (arch_board_id, _) = seed_archived_board_with_cards(&mut app, "Arch");
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
         app.focus.active = Focus::Boards;
         app.board_list.inner_mut().set_selected_index(Some(0));
@@ -1445,6 +1454,7 @@ mod tests {
 
         app.mode = AppMode::Normal;
         app.focus.active = Focus::Boards;
+        app.reload_model();
         app.prepare_frame();
 
         let displayed: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
@@ -1459,6 +1469,7 @@ mod tests {
 
         // Toggling to the archived view flips the set (and only the set).
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
         assert!(
             app.displayed_boards().iter().any(|b| b.id == arch_board_id),
@@ -1525,6 +1536,7 @@ mod tests {
         // default (Arch2 archived more recently), unaffected by the live
         // Name preference.
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
         app.board_list.inner_mut().set_selected_index(Some(0));
         let rendered: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
@@ -1581,6 +1593,7 @@ mod tests {
         app.mode = AppMode::Normal;
         app.focus.active = Focus::Boards;
         app.selection.active_board_id = None;
+        app.reload_model();
         app.prepare_frame();
         app.board_list.inner_mut().set_selected_index(Some(0));
         let live_before: Vec<String> = app
@@ -1597,6 +1610,7 @@ mod tests {
         // Change the ARCHIVED sort to Name ascending via the picker, from
         // within the archived view.
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
         app.board_list.inner_mut().set_selected_index(Some(0));
         app.handle_archived_boards_view_mode(KeyCode::Char('o'));
@@ -1606,6 +1620,7 @@ mod tests {
 
         // Switch back to the live view: order and persisted config unaffected.
         app.mode = AppMode::Normal;
+        app.reload_model();
         app.prepare_frame();
         let live_after: Vec<String> = app
             .displayed_boards()
@@ -1637,6 +1652,7 @@ mod tests {
         let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
 
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
         app.focus.active = Focus::Boards;
         app.board_list.inner_mut().set_selected_index(Some(0));
@@ -1722,6 +1738,7 @@ mod tests {
             SortOrder::Ascending,
         );
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
 
         // Simulate a board being ACTIVATED (drilled into): active id set, focus
@@ -1768,6 +1785,7 @@ mod tests {
         let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
         let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
 
         // Drill into an archived board: active id set, focus on the tasks panel.
@@ -1808,6 +1826,7 @@ mod tests {
         let (arch1, _) = seed_archived_board_with_cards(&mut app, "Arch1");
         let (arch2, _) = seed_archived_board_with_cards(&mut app, "Arch2");
         app.mode = AppMode::ArchivedBoardsView;
+        app.reload_model();
         app.prepare_frame();
 
         app.selection.active_board_id = Some(arch1);

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -808,7 +808,6 @@ impl App {
         } else {
             self.pop_mode();
         }
-        self.reload_model();
         self.prepare_frame();
         if let Some(list) = self.view.strategy.get_active_task_list_mut() {
             if !list.is_empty() {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -277,6 +277,7 @@ impl App {
             }
 
             // Refresh the view-layer task list before selecting so column lists are current.
+            self.reload_model();
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -324,6 +325,7 @@ impl App {
         self.multi_select.selection_mode_active = false;
         if let Some(card_id) = first_card_id {
             // Refresh the view-layer task list before selecting so column lists are current.
+            self.reload_model();
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -426,6 +428,7 @@ impl App {
 
                 // Refresh the view-layer task list so the new card's ID is
                 // present before we try to select it.
+                self.reload_model();
                 self.prepare_frame();
                 self.select_card_by_id(card_id);
             }
@@ -516,6 +519,7 @@ impl App {
                 }
             }
 
+            self.reload_model();
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -576,6 +580,7 @@ impl App {
             }
         }
         if let Some(card_id) = first_card_id {
+            self.reload_model();
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -803,6 +808,7 @@ impl App {
         } else {
             self.pop_mode();
         }
+        self.reload_model();
         self.prepare_frame();
         if let Some(list) = self.view.strategy.get_active_task_list_mut() {
             if !list.is_empty() {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -189,6 +189,7 @@ impl App {
                             self.set_error(format!("Failed to set board task sort: {}", e));
                             return;
                         }
+                        self.reload_model();
                     }
                 }
 
@@ -742,6 +743,7 @@ impl App {
             self.set_error(format!("Failed to restore card: {}", e));
             return;
         }
+        self.reload_model();
 
         tracing::info!("Card '{}' restored to original position", card_title);
     }

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -956,6 +956,7 @@ mod tests {
             .id;
 
         app.selection.active_board_id = Some(board.id);
+        app.reload_model();
         app.prepare_frame();
         app.focus.board_focus = BoardFocus::Columns;
 

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -125,6 +125,7 @@ impl App {
                                 self.set_error(format!("Failed to move column: {}", e));
                                 return;
                             }
+                            self.reload_model();
 
                             self.dialog_input
                                 .column_list
@@ -184,6 +185,7 @@ impl App {
                                 self.set_error(format!("Failed to move column: {}", e));
                                 return;
                             }
+                            self.reload_model();
 
                             let column_count = board_columns.len();
                             self.dialog_input
@@ -261,6 +263,7 @@ impl App {
                     self.set_error(format!("Failed to create column: {}", e));
                     return;
                 }
+                self.reload_model();
 
                 tracing::info!("Created column: {} (position: {})", column_name, position);
 
@@ -313,6 +316,7 @@ impl App {
                     self.set_error(format!("Failed to rename column: {}", e));
                     return;
                 }
+                self.reload_model();
 
                 tracing::info!("Renamed column to: {}", new_name);
             }
@@ -413,6 +417,7 @@ impl App {
                     self.set_error(format!("Failed to delete column: {}", e));
                     return;
                 }
+                self.reload_model();
 
                 tracing::info!("Deleted column: {}", column_name);
 
@@ -549,6 +554,7 @@ impl App {
                                 self.dialog_input.task_list_view_selection.clear();
                                 return;
                             }
+                            self.reload_model();
 
                             self.switch_view_strategy(view);
 

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -580,19 +580,10 @@ mod tests {
     use crate::App;
     use crossterm::event::KeyCode;
 
-    /// Refresh the TUI model from the store so the create handlers (which read
-    /// `self.model`) see prior writes. The event loop does this each frame via
-    /// `prepare_frame`; tests pull the snapshot directly.
-    fn refresh(app: &mut App) {
-        let snap = app.ctx.snapshot().unwrap();
-        app.model.load_from_snapshot(snap);
-    }
-
     fn create_named_board(app: &mut App, name: &str) {
         app.input.set(name.to_string());
         app.create_board();
         app.input.clear();
-        refresh(app);
         // Column operations act on the active board (as when editing its detail).
         app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
     }
@@ -601,7 +592,6 @@ mod tests {
         app.input.set(name.to_string());
         app.create_column();
         app.input.clear();
-        refresh(app);
     }
 
     /// KAN-794: the TUI column-create entry point funnels through the Column

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -382,6 +382,7 @@ impl App {
                                                 e
                                             ));
                                         }
+                                        self.reload_model();
                                     }
                                     Err(e) => {
                                         tracing::error!(
@@ -697,6 +698,7 @@ impl App {
                         tracing::error!("Failed to apply metadata: {}", e);
                         self.set_error(format!("Failed to apply metadata: {}", e));
                     }
+                    self.reload_model();
                 }
                 Err(e) => {
                     tracing::error!("Failed to parse metadata JSON: {}", e);
@@ -931,6 +933,8 @@ impl App {
                                         "Failed to toggle card completion: {}",
                                         e
                                     ));
+                                } else {
+                                    self.reload_model();
                                 }
                             }
                         }
@@ -999,6 +1003,8 @@ impl App {
                                     {
                                         tracing::error!("Failed to move card: {}", e);
                                         self.set_error(format!("Failed to move card: {}", e));
+                                    } else {
+                                        self.reload_model();
                                     }
                                 }
                             }
@@ -1296,6 +1302,8 @@ impl App {
             if let Err(e) = self.ctx.update_cards(updates) {
                 tracing::error!("Failed to toggle card completion: {}", e);
                 self.set_error(format!("Failed to toggle card completion: {}", e));
+            } else {
+                self.reload_model();
             }
         }
     }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1323,6 +1323,7 @@ mod tests {
         // Populates `board_list` (and auto-selects the sole board), which the
         // Columns-focus up-navigation resolves the board through, mirroring
         // the main loop's per-action refresh.
+        app.reload_model();
         app.prepare_frame();
         app.push_mode(AppMode::BoardDetail);
         app.focus.board_focus = BoardFocus::Columns;
@@ -1340,6 +1341,7 @@ mod tests {
                 .unwrap();
         }
         app.selection.active_board_id = Some(board.id);
+        app.reload_model();
         app.prepare_frame();
         app.push_mode(AppMode::BoardDetail);
         app.focus.board_focus = BoardFocus::Columns;
@@ -1921,6 +1923,7 @@ mod tests {
         let board_id = seed_board_with_columns(&mut app, 3);
         app.ctx.create_sprint(board_id, None, None).unwrap();
         app.ctx.create_sprint(board_id, None, None).unwrap();
+        app.reload_model();
         app.prepare_frame();
 
         app.dialog_input.column_list.update_item_count(3);
@@ -2014,6 +2017,7 @@ mod tests {
 
         // Mirrors the main loop's per-keypress refresh: the model is a
         // snapshot, so the next handler must see the just-executed swap.
+        app.reload_model();
         app.prepare_frame();
 
         app.handle_move_column_up();

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2023,9 +2023,6 @@ mod tests {
             "Column00 must have swapped into position 1"
         );
 
-        // Mirrors the main loop's per-keypress refresh: the model is a
-        // snapshot, so the next handler must see the just-executed swap.
-        app.reload_model();
         app.prepare_frame();
 
         app.handle_move_column_up();

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -203,6 +203,7 @@ impl App {
                     } else {
                         tracing::info!("Set points to: {:?}", points);
                     }
+                    self.reload_model();
                 }
                 self.pop_mode();
                 self.input.clear();
@@ -248,6 +249,7 @@ impl App {
                                     } else {
                                         tracing::info!("Cleared sprint prefix");
                                     }
+                                    self.reload_model();
                                 }
                             }
                         }
@@ -276,6 +278,7 @@ impl App {
                                     } else {
                                         tracing::info!("Cleared sprint prefix");
                                     }
+                                    self.reload_model();
                                 }
                             }
                         }
@@ -307,6 +310,7 @@ impl App {
                                     } else {
                                         tracing::info!("Cleared sprint card prefix override");
                                     }
+                                    self.reload_model();
                                 }
                             }
                         }
@@ -338,6 +342,7 @@ impl App {
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
                                     }
+                                    self.reload_model();
                                 }
                             }
                         }
@@ -366,6 +371,7 @@ impl App {
                                     } else {
                                         tracing::info!("Set sprint prefix to: {}", prefix_str);
                                     }
+                                    self.reload_model();
                                 }
                             }
                         }
@@ -402,6 +408,7 @@ impl App {
                                             prefix_str
                                         );
                                     }
+                                    self.reload_model();
                                 }
                             }
                         }

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -467,7 +467,6 @@ impl App {
                     self.switch_view_strategy(task_list_view);
                     // Populate the tasks panel from the now-active board's subtree
                     // immediately, so the first item can be selected this tick.
-                    self.reload_model();
                     self.prepare_frame();
 
                     if let Some(list) = self.view.strategy.get_active_task_list_mut() {

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -467,6 +467,7 @@ impl App {
                     self.switch_view_strategy(task_list_view);
                     // Populate the tasks panel from the now-active board's subtree
                     // immediately, so the first item can be selected this tick.
+                    self.reload_model();
                     self.prepare_frame();
 
                     if let Some(list) = self.view.strategy.get_active_task_list_mut() {
@@ -1079,6 +1080,7 @@ mod tests {
         seed_two_archived_boards(&mut app);
         app.mode = AppMode::ArchivedBoardsView;
         app.focus.active = Focus::Boards;
+        app.reload_model();
         app.prepare_frame();
         app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -1121,6 +1123,7 @@ mod tests {
         app.model.load_from_snapshot(snap);
         app.mode = AppMode::ArchivedBoardsView;
         app.focus.active = Focus::Boards;
+        app.reload_model();
         app.prepare_frame();
         app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -1165,6 +1168,7 @@ mod tests {
         app.model.load_from_snapshot(snap);
         app.mode = AppMode::ArchivedBoardsView;
         app.focus.active = Focus::Boards;
+        app.reload_model();
         app.prepare_frame();
         app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -1233,6 +1237,7 @@ mod tests {
         app.model.load_from_snapshot(snap);
         app.mode = AppMode::Normal;
         app.focus.active = Focus::Boards;
+        app.reload_model();
         app.prepare_frame();
         app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -1255,6 +1260,7 @@ mod tests {
         for i in 0..count {
             app.ctx.create_board(format!("Board{i}"), None).unwrap();
         }
+        app.reload_model();
         app.prepare_frame();
         app.mode = AppMode::Normal;
         app.focus.active = Focus::Boards;

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -76,6 +76,7 @@ impl App {
                                 tracing::error!("Failed to update card priority: {}", e);
                                 self.set_error(format!("Failed to update card priority: {}", e));
                             }
+                            self.reload_model();
                         }
                     }
                 }
@@ -131,6 +132,7 @@ impl App {
                                             e
                                         ));
                                     }
+                                    self.reload_model();
                                 }
                             }
                         }
@@ -196,6 +198,7 @@ impl App {
                                 card_ids.len()
                             );
                         }
+                        self.reload_model();
                     }
 
                     self.multi_select.selected_cards.clear();
@@ -265,6 +268,7 @@ impl App {
                             tracing::error!("Failed to set board task sort: {}", e);
                             self.set_error(format!("Failed to set board task sort: {}", e));
                         }
+                        self.reload_model();
                     }
 
                     let is_sprint_detail = self.selection.active_sprint_index.is_some();
@@ -392,6 +396,7 @@ impl App {
                         tracing::error!("Failed to update card sprint: {}", e);
                         self.set_error(format!("Failed to update card sprint: {}", e));
                     }
+                    self.reload_model();
                 }
                 self.pop_mode();
                 self.dialog_input.assign_sprint_picker.clear();
@@ -467,6 +472,7 @@ impl App {
                         tracing::error!("Failed to update cards' sprint: {}", e);
                         self.set_error(format!("Failed to update cards' sprint: {}", e));
                     }
+                    self.reload_model();
                 }
                 self.pop_mode();
                 self.dialog_input.assign_sprint_picker.clear();
@@ -565,6 +571,7 @@ impl App {
 
                                 match self.ctx.carry_over_sprint_cards(source_id, to_sprint_id) {
                                     Ok(count) => {
+                                        self.reload_model();
                                         self.set_success(format!(
                                             "Carried over {} card(s) to {}",
                                             count, sprint_label
@@ -677,6 +684,7 @@ impl App {
                                 };
                                 match result {
                                     Ok(()) => {
+                                        self.reload_model();
                                         if was_selected {
                                             self.relationship.selected.remove(&selected_card_id);
                                         } else {

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -57,6 +57,7 @@ impl App {
                             self.set_error(format!("Failed to activate sprint: {}", e));
                             return;
                         }
+                        self.reload_model();
 
                         tracing::info!("Activated sprint: {}", sprint_name);
                     }
@@ -103,6 +104,7 @@ impl App {
                     self.set_error(format!("Failed to complete sprint: {}", e));
                     return;
                 }
+                self.reload_model();
 
                 self.filter.active_sprint_filters.remove(&sprint_id);
 
@@ -197,6 +199,7 @@ impl App {
                 self.set_error(format!("Failed to create sprint: {}", e));
                 return;
             }
+            self.reload_model();
 
             tracing::info!("Created sprint (id: {})", sprint_id);
 

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -12,6 +12,7 @@ use kanban_tui::App;
 fn seed_archived_board(app: &mut App, name: &str) -> uuid::Uuid {
     let board = app.ctx.create_board(name.to_string(), None).unwrap();
     app.ctx.archive_board(board.id).unwrap();
+    app.reload_model();
     app.prepare_frame();
     board.id
 }
@@ -25,6 +26,7 @@ fn test_toggle_into_archived_boards_view_and_back() {
     // From the live boards panel, `D` (toggle) enters the archived view.
     app.focus.active = Focus::Boards;
     app.mode = AppMode::Normal;
+    app.reload_model();
     app.prepare_frame();
     // The live boards view (unified collection filtered by the archived-id set)
     // excludes the archived head, even though `boards()` now carries it.
@@ -49,6 +51,7 @@ fn test_q_in_archived_boards_view_returns_to_normal() {
     seed_archived_board(&mut app, "Archived");
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
 
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('q'));
@@ -67,6 +70,7 @@ fn test_restore_from_archived_boards_view_returns_board_to_live() {
 
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -99,6 +103,7 @@ fn test_permanent_delete_from_archived_boards_view_removes_board() {
 
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -138,6 +143,7 @@ fn test_x_in_archived_view_opens_confirm_not_immediate_delete() {
 
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -150,6 +156,7 @@ fn test_x_in_archived_view_opens_confirm_not_immediate_delete() {
         "x must open DeletePermanentBoardConfirm dialog"
     );
     // Board must still be in the archived list — not yet deleted.
+    app.reload_model();
     app.prepare_frame();
     assert!(
         app.model
@@ -166,6 +173,7 @@ fn test_confirm_permanent_delete_removes_board() {
 
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -177,6 +185,7 @@ fn test_confirm_permanent_delete_removes_board() {
 
     // Confirming with 'y' should delete the board.
     app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Char('y'));
+    app.reload_model();
     app.prepare_frame();
 
     assert!(
@@ -201,6 +210,7 @@ fn test_cancel_permanent_delete_keeps_board() {
 
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -212,6 +222,7 @@ fn test_cancel_permanent_delete_keeps_board() {
 
     // Cancelling with 'n' must keep the board and dismiss dialog.
     app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Char('n'));
+    app.reload_model();
     app.prepare_frame();
 
     assert!(
@@ -237,6 +248,7 @@ fn test_archived_view_g_then_g_jumps_to_first() {
 
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     // Start at the bottom.
     app.board_list.inner_mut().set_selected_index(Some(2));
@@ -261,6 +273,7 @@ fn test_archived_view_shift_g_jumps_to_last() {
 
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -280,6 +293,7 @@ fn test_archived_view_u_undoes_permanent_delete() {
 
     app.focus.active = Focus::Boards;
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
 
@@ -290,6 +304,7 @@ fn test_archived_view_u_undoes_permanent_delete() {
         AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm)
     );
     app.handle_delete_permanent_board_confirm_popup(crossterm::event::KeyCode::Enter);
+    app.reload_model();
     app.prepare_frame();
     assert!(
         app.model.archived_boards_view().next().is_none(),
@@ -298,6 +313,7 @@ fn test_archived_view_u_undoes_permanent_delete() {
 
     // `u` should undo the delete, bringing the board back.
     app.handle_archived_boards_view_mode(crossterm::event::KeyCode::Char('u'));
+    app.reload_model();
     app.prepare_frame();
     assert!(
         app.model

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -42,6 +42,7 @@ fn test_archived_card_visible_via_card_by_id() {
         .first()
         .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
 
     let found = app.model.card_by_id(card_id);
@@ -81,6 +82,7 @@ fn test_archived_card_appears_in_task_list() {
         .first()
         .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
 
     let list = app.view.strategy.get_active_task_list();
@@ -122,6 +124,7 @@ fn test_permanent_delete_removes_archived_card() {
         .first()
         .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
 
     if let Some(list) = app.view.strategy.get_active_task_list_mut() {
@@ -140,6 +143,7 @@ fn test_permanent_delete_removes_archived_card() {
 
     app.handle_animation_tick();
 
+    app.reload_model();
     app.prepare_frame();
 
     assert!(
@@ -187,11 +191,13 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
         .unwrap()
         .first()
         .map(|b| b.id);
+    app.reload_model();
     app.prepare_frame();
 
     app.start_delete_animation(card_id);
     force_animation_complete(&mut app, card_id);
     app.handle_animation_tick();
+    app.reload_model();
     app.prepare_frame();
 
     // Unified model: the row stays in `all_cards()`; archival is recorded by the
@@ -203,6 +209,7 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
     );
 
     assert!(app.ctx.undo().unwrap(), "first undo must succeed");
+    app.reload_model();
     app.prepare_frame();
 
     assert!(
@@ -274,6 +281,7 @@ fn test_multi_column_archive_compacts_every_affected_column() {
         .unwrap()
         .first()
         .map(|b| b.id);
+    app.reload_model();
     app.prepare_frame();
 
     app.start_delete_animation(archive1.id);
@@ -281,6 +289,7 @@ fn test_multi_column_archive_compacts_every_affected_column() {
     force_animation_complete(&mut app, archive1.id);
     force_animation_complete(&mut app, archive2.id);
     app.handle_animation_tick();
+    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -357,6 +366,7 @@ fn test_archive_anchors_selection_to_focused_card_column() {
         .first()
         .map(|b| b.id);
     app.focus.active = Focus::Cards;
+    app.reload_model();
     app.prepare_frame();
 
     // Multi-select cards from both columns; cursor on col1's archive target.
@@ -370,6 +380,7 @@ fn test_archive_anchors_selection_to_focused_card_column() {
     force_animation_complete(&mut app, archive1.id);
     force_animation_complete(&mut app, archive2.id);
     app.handle_animation_tick();
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(
@@ -397,6 +408,7 @@ fn test_q_in_archived_view_returns_to_normal() {
         .first()
         .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
 
     app.handle_archived_cards_view_mode(crossterm::event::KeyCode::Char('q'));

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -53,6 +53,7 @@ fn seed_and_archive_board(
 /// uses. Proof of reuse: `handle_selection_activate`, not a bespoke drilldown.
 fn open_archived_board(app: &mut App) {
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Boards;
     app.board_list.inner_mut().set_selected_index(Some(0));
@@ -112,6 +113,7 @@ fn test_archived_board_settings_view_reachable() {
     let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
 
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Boards;
     app.board_list.inner_mut().set_selected_index(Some(0));
@@ -133,6 +135,7 @@ fn test_archived_board_sprints_view_reachable() {
     let (board_id, _, _, sprint_id) = seed_and_archive_board(&mut app, "Arch");
 
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Boards;
     app.board_list.inner_mut().set_selected_index(Some(0));
@@ -157,6 +160,7 @@ fn test_archived_board_columns_resolve() {
     let (board_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
 
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Boards;
     app.board_list.inner_mut().set_selected_index(Some(0));
@@ -237,6 +241,7 @@ fn test_live_projects_panel_lists_live_boards_only() {
     let mut app = App::test_default();
     app.ctx.create_board("Live".to_string(), None).unwrap();
     let (arch_id, _, _, _) = seed_and_archive_board(&mut app, "Arch");
+    app.reload_model();
     app.prepare_frame();
 
     // Normal mode: only the live board.

--- a/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
@@ -31,6 +31,7 @@ fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
 }
 
 fn activate_board(app: &mut App, board_id: uuid::Uuid) {
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = Some(board_id);
@@ -64,6 +65,7 @@ fn test_sprint_detail_card_count_excludes_archived_cards() {
     activate_board(&mut app, board.id);
     app.selection.active_sprint_index = Some(0);
     app.push_mode(AppMode::SprintDetail);
+    app.reload_model();
     app.prepare_frame();
 
     let output = render_to_string(&mut app, 100, 30);
@@ -111,6 +113,7 @@ fn test_board_detail_sprint_card_count_excludes_archived_cards() {
     activate_board(&mut app, board.id);
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
+    app.reload_model();
     app.prepare_frame();
 
     let output = render_to_string(&mut app, 100, 30);
@@ -150,6 +153,7 @@ fn test_board_detail_column_card_count_excludes_archived_cards() {
     activate_board(&mut app, board.id);
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Columns;
+    app.reload_model();
     app.prepare_frame();
 
     let output = render_to_string(&mut app, 100, 30);
@@ -196,6 +200,7 @@ fn test_carry_over_popup_card_count_excludes_archived_cards() {
     activate_board(&mut app, board.id);
     app.dialog_input.carry_over_source_sprint_id = Some(source_sprint.id);
     app.push_mode(AppMode::Dialog(DialogMode::CarryOverSprint));
+    app.reload_model();
     app.prepare_frame();
 
     let output = render_to_string(&mut app, 100, 30);
@@ -282,6 +287,7 @@ fn test_carry_over_auto_open_gate_excludes_archived_cards() {
     );
 
     app.handle_complete_sprint_key();
+    app.reload_model();
     app.prepare_frame();
 
     assert_ne!(

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -46,6 +46,7 @@ fn seed_archived_card(app: &mut App) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid, uui
     app.selection.active_board_id = Some(board.id);
     app.mode = AppMode::ArchivedCardsView;
     app.focus.active = Focus::Cards;
+    app.reload_model();
     app.prepare_frame();
     if let Some(list) = app.view.strategy.get_active_task_list_mut() {
         list.set_selected_index(Some(0));
@@ -97,6 +98,7 @@ fn test_archived_card_priority_via_shared_handler_changes_state() {
     // Select "Critical" (index 3) and apply.
     app.dialog_input.priority_selection.set(Some(3));
     app.handle_set_card_priority_popup(KeyCode::Enter);
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(
@@ -114,6 +116,7 @@ fn test_archived_card_sprint_assign_via_shared_handler_opens_dialog() {
     let (board_id, _, _, card_id) = seed_archived_card(&mut app);
     // A sprint must exist for the assign dialog to open.
     app.ctx.create_sprint(board_id, None, None).unwrap();
+    app.reload_model();
     app.prepare_frame();
     if let Some(list) = app.view.strategy.get_active_task_list_mut() {
         list.set_selected_index(Some(0));
@@ -169,6 +172,7 @@ fn test_move_in_archived_view_matches_c1() {
     );
 
     app.handle_archived_cards_view_mode(KeyCode::Char('L'));
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(
@@ -194,6 +198,7 @@ fn test_create_not_offered_in_archived_view() {
         AppMode::ArchivedCardsView,
         "`n` must not open the create-card dialog from the archived view"
     );
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(
         app.model.all_cards().len(),
@@ -351,6 +356,7 @@ fn test_sprint_filter_toggle_not_offered_in_archived_view() {
             },
         )
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     assert!(
@@ -426,6 +432,7 @@ fn test_column_jump_still_works_under_column_view_in_archived_view() {
         )
         .unwrap();
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.reload_model();
     app.prepare_frame();
 
     // Navigate to column 2 (index 1) first so jumping to `1` (index 0) is a
@@ -509,6 +516,7 @@ fn test_live_card_list_excludes_archived() {
 
     // Live view: only the live card.
     app.mode = AppMode::Normal;
+    app.reload_model();
     app.prepare_frame();
     let live_ids: Vec<_> = app.displayed_cards().iter().map(|c| c.id).collect();
     assert!(live_ids.contains(&live.id), "live card is shown");
@@ -519,6 +527,7 @@ fn test_live_card_list_excludes_archived() {
 
     // Archived view: only the archived card.
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
     let arch_ids: Vec<_> = app.displayed_cards().iter().map(|c| c.id).collect();
     assert!(

--- a/crates/kanban-tui/tests/batch_completion_sync_tests.rs
+++ b/crates/kanban-tui/tests/batch_completion_sync_tests.rs
@@ -62,6 +62,7 @@ fn test_multi_select_toggle_completion_batches_into_one_undo_unit_with_distinct_
         .first()
         .map(|b| b.id);
     app.focus.active = Focus::Cards;
+    app.reload_model();
     app.prepare_frame();
 
     for card in &cards {
@@ -148,6 +149,7 @@ fn test_multi_select_move_right_to_completion_column_chains_status_per_card() {
         .first()
         .map(|b| b.id);
     app.focus.active = Focus::Cards;
+    app.reload_model();
     app.prepare_frame();
 
     for card in &cards {

--- a/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
+++ b/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
@@ -49,12 +49,14 @@ fn test_board_delete_confirmation_card_count_excludes_archived_cards() {
     app.ctx.archive_card(archived.id).unwrap();
     let _ = live;
 
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = Some(board.id);
     app.focus.active = Focus::Boards;
 
     app.handle_delete_board_key();
+    app.reload_model();
     app.prepare_frame();
 
     let output = render_to_string(&mut app, 100, 30);

--- a/crates/kanban-tui/tests/board_multi_select_tests.rs
+++ b/crates/kanban-tui/tests/board_multi_select_tests.rs
@@ -13,6 +13,7 @@ fn create_boards(app: &mut App, names: &[&str]) -> Vec<uuid::Uuid> {
 fn test_handle_board_selection_toggle_enters_selection_mode_and_selects_current_board() {
     let mut app = App::test_default();
     let ids = create_boards(&mut app, &["Alpha", "Beta"]);
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Boards;
     app.board_list.select_board(ids[0]);
@@ -28,6 +29,7 @@ fn test_handle_board_selection_toggle_enters_selection_mode_and_selects_current_
 fn test_handle_board_selection_toggle_exits_selection_mode_keeps_selections() {
     let mut app = App::test_default();
     let ids = create_boards(&mut app, &["Alpha", "Beta"]);
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Boards;
     app.board_list.select_board(ids[0]);
@@ -64,6 +66,7 @@ fn test_handle_select_all_boards_in_view_selects_only_currently_filtered_boards(
 
     app.filter.board_search.activate();
     app.filter.board_search.input.set("Alpha".to_string());
+    app.reload_model();
     app.prepare_frame();
 
     app.handle_select_all_boards_in_view();
@@ -82,6 +85,7 @@ fn test_handle_select_all_boards_in_view_selects_only_currently_filtered_boards(
 fn test_handle_select_all_boards_in_view_does_nothing_when_focus_is_not_boards() {
     let mut app = App::test_default();
     create_boards(&mut app, &["Alpha", "Beta"]);
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Cards;
 

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -41,6 +41,7 @@ fn test_card_description_appears_in_detail_view() {
     app.selection.active_card_id = Some(card.id);
 
     // Verify the card has the description
+    app.reload_model();
     app.prepare_frame();
     let cards = app.model.all_cards();
     assert_eq!(cards.len(), 1);
@@ -86,6 +87,7 @@ fn test_card_description_preserved_after_edit() {
         .unwrap();
 
     // Verify description exists
+    app.reload_model();
     app.prepare_frame();
     let cards_before = app.model.all_cards();
     assert_eq!(
@@ -108,6 +110,7 @@ fn test_card_description_preserved_after_edit() {
     app.execute_command(cmd).unwrap();
 
     // Verify description is still there after update
+    app.reload_model();
     app.prepare_frame();
     let cards_after = app.model.all_cards();
     assert_eq!(cards_after.len(), 1);
@@ -198,6 +201,7 @@ fn test_card_with_empty_string_description_displays_placeholder() {
     app.selection.active_card_id = Some(card.id);
 
     // Verify the card has an empty string description (not None)
+    app.reload_model();
     app.prepare_frame();
     let cards = app.model.all_cards();
     assert_eq!(cards[0].description, Some("".to_string()));

--- a/crates/kanban-tui/tests/card_priority_key_tests.rs
+++ b/crates/kanban-tui/tests/card_priority_key_tests.rs
@@ -38,6 +38,7 @@ fn test_p_on_cards_list_opens_single_card_priority_dialog() {
         .first()
         .map(|b| b.id);
     app.focus.active = Focus::Cards;
+    app.reload_model();
     app.prepare_frame();
     app.select_card_by_id(card.id);
 
@@ -88,6 +89,7 @@ fn test_p_on_boards_panel_does_not_open_priority_dialog() {
         .first()
         .map(|b| b.id);
     app.focus.active = Focus::Boards;
+    app.reload_model();
     app.prepare_frame();
 
     app.handle_set_card_priority_key();

--- a/crates/kanban-tui/tests/column_default_status_tests.rs
+++ b/crates/kanban-tui/tests/column_default_status_tests.rs
@@ -227,6 +227,7 @@ fn test_card_moved_to_doing_on_fresh_board_is_promoted_to_in_progress() {
     app.selection.active_board_id = Some(board_id);
     app.focus.active = Focus::Cards;
     refresh(&mut app);
+    app.reload_model();
     app.prepare_frame();
     app.select_card_by_id(card.id);
 
@@ -270,6 +271,7 @@ fn test_moving_card_into_default_status_column_updates_status_in_tui() {
 
     app.focus.active = Focus::Cards;
     refresh(&mut app);
+    app.reload_model();
     app.prepare_frame();
     app.select_card_by_id(card.id);
 

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -11,6 +11,7 @@ fn setup_app_with_board() -> App {
         .ctx
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -35,6 +36,7 @@ fn confirm_create_card_dialog(app: &mut App, title: &str) {
         app.handle_create_card_dialog(KeyCode::Char(ch));
     }
     app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
     app.prepare_frame();
 }
 
@@ -44,6 +46,7 @@ fn test_create_card_dialog_auto_assigns_sole_active_sprint_on_open() {
     let bid = board_id(&app);
     let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
     app.ctx.activate_sprint(sprint.id, Some(7)).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     confirm_create_card_dialog(&mut app, "Task");
@@ -67,6 +70,7 @@ fn test_create_card_dialog_space_on_pre_checked_sprint_unchecks_it() {
     let bid = board_id(&app);
     let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
     app.ctx.activate_sprint(sprint.id, Some(7)).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     app.focus.active = Focus::Cards;
@@ -79,6 +83,7 @@ fn test_create_card_dialog_space_on_pre_checked_sprint_unchecks_it() {
     app.handle_create_card_dialog(KeyCode::Tab);
     app.handle_create_card_dialog(KeyCode::Char(' '));
     app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -95,6 +100,7 @@ fn test_create_card_dialog_leaves_card_unassigned_when_no_active_sprint() {
     let bid = board_id(&app);
     // planning sprint exists but is not active
     let _planning = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     confirm_create_card_dialog(&mut app, "Plain");
@@ -115,6 +121,7 @@ fn test_create_card_dialog_leaves_card_unassigned_when_multiple_active_sprints()
     let s2 = app.ctx.create_sprint(bid, None, None).unwrap();
     app.ctx.activate_sprint(s1.id, Some(7)).unwrap();
     app.ctx.activate_sprint(s2.id, Some(7)).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     confirm_create_card_dialog(&mut app, "Ambig");
@@ -201,6 +208,7 @@ fn test_j_on_sprint_focus_navigates_picker_like_down() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
     let planning = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     app.focus.active = Focus::Cards;
@@ -212,6 +220,7 @@ fn test_j_on_sprint_focus_navigates_picker_like_down() {
     app.handle_create_card_dialog(KeyCode::Char('j'));
     app.handle_create_card_dialog(KeyCode::Char(' '));
     app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -243,6 +252,7 @@ fn test_arrow_to_none_row_then_space_explicitly_leaves_card_unassigned() {
     let bid = board_id(&app);
     let sprint = app.ctx.create_sprint(bid, None, None).unwrap();
     app.ctx.activate_sprint(sprint.id, Some(7)).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     app.focus.active = Focus::Cards;
@@ -255,6 +265,7 @@ fn test_arrow_to_none_row_then_space_explicitly_leaves_card_unassigned() {
     app.handle_create_card_dialog(KeyCode::Up);
     app.handle_create_card_dialog(KeyCode::Char(' '));
     app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -284,6 +295,7 @@ fn test_arrow_down_then_space_assigns_navigated_sprint() {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
     let planning = app.ctx.create_sprint(bid, None, None).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     app.focus.active = Focus::Cards;
@@ -295,6 +307,7 @@ fn test_arrow_down_then_space_assigns_navigated_sprint() {
     app.handle_create_card_dialog(KeyCode::Down);
     app.handle_create_card_dialog(KeyCode::Char(' '));
     app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -322,6 +335,7 @@ fn test_create_card_does_not_carry_sprint_id_from_a_different_board() {
         .ctx
         .create_column(board_b.id, "Todo".to_string(), Some(0))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     // Reset picker for board A.

--- a/crates/kanban-tui/tests/displayed_accessor_tests.rs
+++ b/crates/kanban-tui/tests/displayed_accessor_tests.rs
@@ -36,6 +36,7 @@ fn seed_live_and_archived_card(app: &mut App) -> (uuid::Uuid, uuid::Uuid) {
         .unwrap();
     app.ctx.archive_card(archived.id).unwrap();
     app.selection.active_board_id = Some(board.id);
+    app.reload_model();
     app.prepare_frame();
     (live.id, archived.id)
 }
@@ -45,6 +46,7 @@ fn seed_live_and_archived_board(app: &mut App) -> (uuid::Uuid, uuid::Uuid) {
     let live = app.ctx.create_board("Live".to_string(), None).unwrap();
     let archived = app.ctx.create_board("Archived".to_string(), None).unwrap();
     app.ctx.archive_board(archived.id).unwrap();
+    app.reload_model();
     app.prepare_frame();
     (live.id, archived.id)
 }
@@ -55,6 +57,7 @@ fn test_displayed_cards_liveonly_excludes_archived() {
     let (live_id, archived_id) = seed_live_and_archived_card(&mut app);
 
     app.mode = AppMode::Normal;
+    app.reload_model();
     app.prepare_frame();
 
     let displayed: Vec<uuid::Uuid> = app.displayed_cards().iter().map(|c| c.id).collect();
@@ -74,6 +77,7 @@ fn test_displayed_cards_archived_view_only_archived() {
     let (live_id, archived_id) = seed_live_and_archived_card(&mut app);
 
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
 
     let displayed: Vec<uuid::Uuid> = app.displayed_cards().iter().map(|c| c.id).collect();
@@ -94,6 +98,7 @@ fn test_displayed_boards_liveonly_excludes_archived() {
     let (live_id, archived_id) = seed_live_and_archived_board(&mut app);
 
     app.mode = AppMode::Normal;
+    app.reload_model();
     app.prepare_frame();
 
     let displayed: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
@@ -113,6 +118,7 @@ fn test_displayed_boards_archived_view_only_archived() {
     let (live_id, archived_id) = seed_live_and_archived_board(&mut app);
 
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
 
     let displayed: Vec<uuid::Uuid> = app.displayed_boards().iter().map(|b| b.id).collect();
@@ -137,6 +143,7 @@ fn test_displayed_boards_set_uses_base_mode_under_dialog() {
     let (live_id, archived_id) = seed_live_and_archived_board(&mut app);
 
     app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
     app.prepare_frame();
     // Open a confirm dialog over the archived view.
     app.open_dialog(DialogMode::DeletePermanentBoardConfirm);
@@ -170,6 +177,7 @@ fn test_displayed_cards_set_uses_base_mode_under_dialog() {
     let (live_id, archived_id) = seed_live_and_archived_card(&mut app);
 
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
     app.open_dialog(DialogMode::DeletePermanentBoardConfirm);
     assert!(matches!(app.mode, AppMode::Dialog(_)));

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -63,6 +63,7 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
         .create_sprint(arch_board.id, Some("S".to_string()), None)
         .unwrap();
     app.ctx.archive_board(arch_board.id).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     // Sanity: the archived board head is hidden from the live list, present in
@@ -78,6 +79,7 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
 
     // Drive the ACTUAL TUI File→Export-All entry point.
     app.input.set(file_path.to_str().unwrap().to_string());
+    app.reload_model();
     app.prepare_frame();
     app.export_all_boards_with_filename().unwrap();
 
@@ -85,6 +87,7 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
     let mut app2 = App::test_default();
     app2.import_board_from_file(file_path.to_str().unwrap())
         .unwrap();
+    app2.reload_model();
     app2.prepare_frame();
 
     // Live board still live.
@@ -164,6 +167,7 @@ fn test_tui_auto_save_round_trips_archived_board_with_subtree() {
         )
         .unwrap();
     app.ctx.archive_board(arch_board.id).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     // Drive the ACTUAL auto-save entry point.
@@ -172,6 +176,7 @@ fn test_tui_auto_save_round_trips_archived_board_with_subtree() {
     let mut app2 = App::test_default();
     app2.import_board_from_file(file_path.to_str().unwrap())
         .unwrap();
+    app2.reload_model();
     app2.prepare_frame();
 
     assert_eq!(

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -39,6 +39,7 @@ fn test_export_single_board() {
         .unwrap();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
+    app.reload_model();
     app.prepare_frame();
 
     app.export_board_with_filename().unwrap();
@@ -91,6 +92,7 @@ fn test_export_all_boards() {
         .unwrap();
 
     app.input.set(file_path.to_str().unwrap().to_string());
+    app.reload_model();
     app.prepare_frame();
 
     app.export_all_boards_with_filename().unwrap();
@@ -112,6 +114,7 @@ fn test_export_empty_boards() {
 
     let mut app = App::test_default();
     app.persistence.save_file = Some(file_path.to_str().unwrap().to_string());
+    app.reload_model();
     app.prepare_frame();
 
     app.auto_save().unwrap();
@@ -171,6 +174,7 @@ fn test_import_valid_format() {
     app.import_board_from_file(file_path.to_str().unwrap())
         .unwrap();
 
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "Imported Board");
@@ -210,6 +214,7 @@ async fn test_auto_save() {
         .create_column(board.id, "Todo".to_string(), None)
         .unwrap();
 
+    app.reload_model();
     app.prepare_frame();
     app.auto_save().unwrap();
 
@@ -271,6 +276,7 @@ async fn test_async_load_initial_state_sqlite() {
         .unwrap();
 
     app.load_initial_state().await;
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "SQLite Board");
@@ -328,6 +334,7 @@ fn test_export_import_sprint_and_card_prefixes() {
 
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.input.set(file_path.to_str().unwrap().to_string());
+    app.reload_model();
     app.prepare_frame();
 
     // Export
@@ -346,6 +353,7 @@ fn test_export_import_sprint_and_card_prefixes() {
         .unwrap();
 
     // Verify prefixes preserved after import
+    app2.reload_model();
     app2.prepare_frame();
     assert_eq!(app2.model.boards().len(), 1);
     assert_eq!(
@@ -427,6 +435,7 @@ fn test_backward_compat_old_export_format() {
         .unwrap();
 
     // Verify board imported and old branch_prefix is mapped to sprint_prefix
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "Old Board");
@@ -480,6 +489,7 @@ fn test_import_column_missing_default_status_key_defaults_to_none() {
     app.import_board_from_file(file_path.to_str().unwrap())
         .unwrap();
 
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.columns().len(), 1);

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -1,0 +1,97 @@
+mod helpers;
+
+use helpers::CountingBackend;
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::App;
+use std::sync::atomic::Ordering;
+
+fn wrap_backend(app: &mut App) -> std::sync::Arc<std::sync::atomic::AtomicUsize> {
+    let (backend, reads) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+    reads
+}
+
+#[test]
+fn test_redraw_without_input_performs_no_store_reads() {
+    let mut app = App::test_default();
+    app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    let reads = wrap_backend(&mut app);
+
+    app.needs_redraw = true;
+    app.prepare_frame();
+
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        0,
+        "redrawing without new input must not touch the store"
+    );
+}
+
+#[test]
+fn test_navigation_performs_no_store_reads() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    for i in 0..3 {
+        app.ctx
+            .create_card(
+                board.id,
+                column.id,
+                format!("Card {i}"),
+                kanban_domain::CreateCardOptions::default(),
+            )
+            .unwrap();
+    }
+    app.reload_model();
+    app.prepare_frame();
+
+    let reads = wrap_backend(&mut app);
+
+    app.focus.active = Focus::Boards;
+    app.handle_selection_activate();
+    app.handle_navigation_down();
+    app.handle_navigation_up();
+    app.handle_kanban_column_left();
+    app.handle_kanban_column_right();
+    app.handle_focus_switch(Focus::Boards);
+    app.handle_jump_to_top();
+    app.handle_jump_to_bottom();
+    app.handle_toggle_archived_boards_view();
+    app.handle_toggle_archived_boards_view();
+
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        0,
+        "pure navigation must not touch the store"
+    );
+}
+
+#[test]
+fn test_card_mutation_is_visible_in_model_without_a_further_redraw() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.input = kanban_core::InputState::new();
+    app.input.set("New card".to_string());
+    app.create_card();
+
+    let title_present = app.model.all_cards().iter().any(|c| c.title == "New card");
+    assert!(
+        title_present,
+        "create_card's own reload_model must make the new card visible without a further redraw"
+    );
+}

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -95,3 +95,189 @@ fn test_card_mutation_is_visible_in_model_without_a_further_redraw() {
         "create_card's own reload_model must make the new card visible without a further redraw"
     );
 }
+
+#[test]
+fn test_archive_card_is_visible_in_model_without_a_further_redraw() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.start_delete_animation(card.id);
+    app.animation
+        .animating
+        .get_mut(&card.id)
+        .unwrap()
+        .start_time = std::time::Instant::now() - std::time::Duration::from_secs(10);
+    app.handle_animation_tick();
+
+    let still_live = app.model.live_cards().iter().any(|c| c.id == card.id);
+    assert!(
+        !still_live,
+        "handle_animation_tick's own reload_model must remove the archived card from the live model without a further redraw"
+    );
+}
+
+#[test]
+fn test_restore_card_is_visible_in_model_without_a_further_redraw() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+
+    let archived_card = app
+        .model
+        .archived_card_markers()
+        .iter()
+        .find(|dc| dc.entity_id == card.id)
+        .cloned()
+        .unwrap();
+    app.restore_card(archived_card);
+
+    let now_live = app.model.live_cards().iter().any(|c| c.id == card.id);
+    assert!(
+        now_live,
+        "restore_card's own reload_model must make the restored card visible in the live model without a further redraw"
+    );
+}
+
+#[test]
+fn test_move_card_between_columns_is_visible_in_model_without_a_further_redraw() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col_a = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let col_b = app
+        .ctx
+        .create_column(board.id, "Doing".to_string(), Some(1))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            col_a.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+    app.select_card_by_id(card.id);
+
+    app.focus.active = Focus::Cards;
+    app.handle_move_card_right();
+
+    let moved = app
+        .model
+        .card_by_id(card.id)
+        .map(|c| c.column_id == col_b.id)
+        .unwrap_or(false);
+    assert!(
+        moved,
+        "handle_move_card_right's own reload_model must make the moved card's new column visible without a further redraw"
+    );
+}
+
+#[test]
+fn test_sprint_assignment_is_visible_in_model_without_a_further_redraw() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.selection.active_card_id = Some(card.id);
+    app.reload_model();
+    app.prepare_frame();
+
+    app.dialog_input
+        .assign_sprint_picker
+        .reset_for_card_assignment(
+            Some(sprint.id),
+            app.model.sprints(),
+            app.model.board_by_id(board.id).unwrap(),
+            chrono::Utc::now(),
+        );
+    app.handle_assign_card_to_sprint_popup(crossterm::event::KeyCode::Enter);
+
+    let assigned = app
+        .model
+        .card_by_id(card.id)
+        .and_then(|c| c.sprint_id)
+        .map(|id| id == sprint.id)
+        .unwrap_or(false);
+    assert!(
+        assigned,
+        "handle_assign_card_to_sprint_popup must make the card's sprint assignment visible without a further redraw"
+    );
+}
+
+#[test]
+fn test_delete_board_leaves_no_stale_model_without_guard_reload() {
+    let mut app = App::test_default();
+    let b = app.ctx.create_board("Doomed".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.selection.active_board_id = Some(b.id);
+    assert_eq!(
+        app.displayed_boards().len(),
+        1,
+        "precondition: board visible"
+    );
+
+    app.delete_board();
+    let live_in_store = app.ctx.data_store().list_boards().unwrap().len();
+    app.prepare_frame();
+    let visible_after_redraw = app.displayed_boards().len();
+
+    assert_eq!(live_in_store, 0, "store: board is gone");
+    assert_eq!(
+        visible_after_redraw, 0,
+        "UI STALE: store has {live_in_store} live boards but the panel still shows {visible_after_redraw}"
+    );
+}

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -1,9 +1,218 @@
 #![allow(dead_code)]
 
+use kanban_backend::{KanbanBackend, RemoteWrites, TransactionFn};
+use kanban_domain::{
+    ArchivedBoard, ArchivedCard, Board, Card, Column, CommandBatch, CommandStore, DataStore,
+    DependencyGraph, KanbanResult, Snapshot, Sprint,
+};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::app::ExportDialogState;
 use kanban_tui::App;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// A `KanbanBackend` decorator that counts every DataStore/CommandStore READ
+/// method invoked, delegating all reads and writes verbatim to `inner`.
+/// Writes are never counted. Only required trait methods are overridden;
+/// default trait methods route through the instrumented required ones.
+pub struct CountingBackend {
+    inner: Arc<dyn KanbanBackend>,
+    reads: Arc<AtomicUsize>,
+}
+
+impl CountingBackend {
+    pub fn wrap(inner: Arc<dyn KanbanBackend>) -> (Arc<dyn KanbanBackend>, Arc<AtomicUsize>) {
+        let reads = Arc::new(AtomicUsize::new(0));
+        let backend: Arc<dyn KanbanBackend> = Arc::new(Self {
+            inner,
+            reads: reads.clone(),
+        });
+        (backend, reads)
+    }
+
+    fn record(&self) {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl DataStore for CountingBackend {
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        self.record();
+        self.inner.get_board(id)
+    }
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        self.record();
+        self.inner.list_boards()
+    }
+    fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+        self.inner.upsert_board(board)
+    }
+    fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_board(id)
+    }
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        self.record();
+        self.inner.get_column(id)
+    }
+    fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        self.record();
+        self.inner.list_columns_by_board(board_id)
+    }
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.record();
+        self.inner.list_all_columns()
+    }
+    fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+        self.inner.upsert_column(column)
+    }
+    fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_column(id)
+    }
+    fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_columns_by_board(board_id)
+    }
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        self.record();
+        self.inner.get_card(id)
+    }
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.record();
+        self.inner.list_all_cards()
+    }
+    fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.record();
+        self.inner.list_cards_by_column(column_id)
+    }
+    fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.record();
+        self.inner.list_cards_by_sprint(sprint_id)
+    }
+    fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+        self.record();
+        self.inner.count_cards_in_column(column_id)
+    }
+    fn count_cards_in_column_excluding(
+        &self,
+        column_id: Uuid,
+        exclude_ids: &[Uuid],
+    ) -> KanbanResult<usize> {
+        self.record();
+        self.inner
+            .count_cards_in_column_excluding(column_id, exclude_ids)
+    }
+    fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+        self.inner.upsert_card(card)
+    }
+    fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_card(id)
+    }
+    fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+        self.inner.delete_cards_by_columns(column_ids)
+    }
+    fn clear_sprint_from_cards(
+        &self,
+        sprint_id: Uuid,
+        cleared_at: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner.clear_sprint_from_cards(sprint_id, cleared_at)
+    }
+    fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        self.record();
+        self.inner.get_archived_card(card_id)
+    }
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        self.record();
+        self.inner.list_archived_cards()
+    }
+    fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+        self.inner.insert_archived_card(ac)
+    }
+    fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_card(card_id)
+    }
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        self.record();
+        self.inner.get_archived_board(board_id)
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.record();
+        self.inner.list_archived_boards()
+    }
+    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        self.inner.insert_archived_board(ab)
+    }
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_board(board_id)
+    }
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.unarchive_board(board_id)
+    }
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        self.record();
+        self.inner.get_sprint(id)
+    }
+    fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        self.record();
+        self.inner.list_sprints_by_board(board_id)
+    }
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.record();
+        self.inner.list_all_sprints()
+    }
+    fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+        self.inner.upsert_sprint(sprint)
+    }
+    fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprint(id)
+    }
+    fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprints_by_board(board_id)
+    }
+    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+        self.record();
+        self.inner.get_graph()
+    }
+    fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+        self.inner.set_graph(graph)
+    }
+    fn snapshot(&self) -> KanbanResult<Snapshot> {
+        self.record();
+        self.inner.snapshot()
+    }
+    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+        self.inner.apply_snapshot(snapshot)
+    }
+}
+
+impl CommandStore for CountingBackend {
+    fn append_batch(&self, batch: &CommandBatch) -> KanbanResult<u64> {
+        self.inner.append_batch(batch)
+    }
+    fn batch_count(&self) -> KanbanResult<u64> {
+        self.record();
+        self.inner.batch_count()
+    }
+    fn load_batches(&self, offset: u64, limit: u64) -> KanbanResult<Vec<CommandBatch>> {
+        self.record();
+        self.inner.load_batches(offset, limit)
+    }
+}
+
+impl KanbanBackend for CountingBackend {
+    fn as_data_store(&self) -> &dyn DataStore {
+        self
+    }
+
+    fn remote_writes(&self) -> Option<&dyn RemoteWrites> {
+        self.inner.remote_writes()
+    }
+
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
+        self.inner.with_transaction(f)
+    }
+}
 
 pub fn render_widget_to_string<F>(width: u16, height: u16, draw_fn: F) -> String
 where

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -47,6 +47,7 @@ async fn test_import_failure_prevents_empty_state_save() {
     app.load_initial_state().await;
 
     // App should load the board from V2 format
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(
         app.model.boards().len(),
@@ -123,6 +124,7 @@ async fn test_v2_format_is_imported_correctly() {
     app.load_initial_state().await;
 
     // Should successfully import the board with its column and card
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "My Project");

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -46,6 +46,7 @@ async fn test_load_initial_state_with_boards_refreshes_card_view() -> KanbanResu
 
     let (mut app, _rx) = kanban_tui::App::new(Some(path_str)).await?;
     app.load_initial_state().await;
+    app.reload_model();
     app.prepare_frame();
 
     let task_list = app.view.strategy.get_active_task_list();

--- a/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
+++ b/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
@@ -77,6 +77,7 @@ fn test_manage_children_from_live_card_excludes_archived_candidates() {
     sync_model_from_store(&mut app);
 
     app.selection.active_board_id = Some(board_id);
+    app.reload_model();
     app.prepare_frame();
     let list = app.view.strategy.get_active_task_list_mut().unwrap();
     let idx = list
@@ -107,6 +108,7 @@ fn test_manage_children_from_archived_card_still_offers_archived_candidates() {
 
     app.selection.active_board_id = Some(board_id);
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
     let list = app.view.strategy.get_active_task_list_mut().unwrap();
     let idx = list
@@ -166,6 +168,7 @@ fn test_manage_children_from_live_card_still_offers_live_candidates() {
     sync_model_from_store(&mut app);
 
     app.selection.active_board_id = Some(board.id);
+    app.reload_model();
     app.prepare_frame();
     let list = app.view.strategy.get_active_task_list_mut().unwrap();
     let idx = list

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -27,6 +27,7 @@ fn test_prepare_frame_populates_model_from_snapshot() {
         .unwrap()
         .first()
         .map(|b| b.id);
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(app.model.boards().len(), 1);
@@ -62,6 +63,7 @@ fn test_model_reflects_mutation_after_prepare_frame() {
         .unwrap()
         .first()
         .map(|b| b.id);
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(app.model.card_by_id(card.id).unwrap().title, "Original");
@@ -76,6 +78,7 @@ fn test_model_reflects_mutation_after_prepare_frame() {
         },
     ));
     app.execute_command(cmd).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(
@@ -114,6 +117,7 @@ fn test_model_description_reflects_mutation() {
         .unwrap()
         .first()
         .map(|b| b.id);
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(
@@ -131,6 +135,7 @@ fn test_model_description_reflects_mutation() {
         },
     ));
     app.execute_command(cmd).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(
@@ -156,6 +161,7 @@ fn test_board_search_query_narrows_projects_panel_to_matching_boards() {
     app.ctx
         .create_board("Beta Project".to_string(), None)
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(
         app.displayed_boards().len(),
@@ -164,6 +170,7 @@ fn test_board_search_query_narrows_projects_panel_to_matching_boards() {
     );
 
     type_query(&mut app, "alpha");
+    app.reload_model();
     app.prepare_frame();
 
     let displayed = app.displayed_boards();
@@ -185,9 +192,11 @@ fn test_board_search_cleared_restores_full_board_list() {
     app.ctx
         .create_board("Beta Project".to_string(), None)
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     type_query(&mut app, "alpha");
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(
         app.displayed_boards().len(),
@@ -196,6 +205,7 @@ fn test_board_search_cleared_restores_full_board_list() {
     );
 
     app.filter.board_search.deactivate();
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(

--- a/crates/kanban-tui/tests/panel_title_tests.rs
+++ b/crates/kanban-tui/tests/panel_title_tests.rs
@@ -33,6 +33,7 @@ fn test_build_tasks_panel_title_cards_focus_with_cards() {
         .first()
         .map(|b| b.id);
     app.focus.active = Focus::Cards;
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(
         tasks_panel_title(&app, false),
@@ -69,6 +70,7 @@ fn test_build_tasks_panel_title_archived_view_with_cards() {
         .first()
         .map(|b| b.id);
     app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(
         tasks_panel_title(&app, false),
@@ -84,6 +86,7 @@ fn test_tasks_panel_title_with_no_active_board_omits_sprint_filter_suffix() {
     app.filter
         .active_sprint_filters
         .insert(uuid::Uuid::new_v4());
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(
@@ -104,6 +107,7 @@ fn test_filter_title_suffix_with_no_active_board_omits_sprint_filter_suffix() {
     app.filter
         .active_sprint_filters
         .insert(uuid::Uuid::new_v4());
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(app.active_board(), None);

--- a/crates/kanban-tui/tests/scroll_board_edit_lists.rs
+++ b/crates/kanban-tui/tests/scroll_board_edit_lists.rs
@@ -35,6 +35,7 @@ fn test_board_sprints_list_scrolls_to_keep_selection_visible() {
             .create_sprint(board.id, None, Some(format!("SpMark{:02}", i)))
             .unwrap();
     }
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -71,6 +72,7 @@ fn test_board_columns_list_scrolls_to_keep_selection_visible() {
             .create_column(board.id, format!("ColMark{:02}", i), Some(i))
             .unwrap();
     }
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -111,6 +113,7 @@ fn test_board_sprints_scroll_offset_is_stable_when_selection_moves_within_viewpo
             .create_sprint(board.id, None, Some(format!("StaySp{:02}", i)))
             .unwrap();
     }
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -149,6 +152,7 @@ fn test_render_projects_panel_shows_more_below_indicator_when_boards_exceed_view
             .create_board(format!("ProjMark{:02}", i), None)
             .unwrap();
     }
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = kanban_tui::app::Focus::Boards;
     // Selection defaults to the first board (index 0), so nothing above it is
@@ -187,6 +191,7 @@ fn test_filter_popup_sprints_scrolls_to_keep_selection_visible() {
             .create_sprint(board.id, None, Some(format!("FpMark{:02}", i)))
             .unwrap();
     }
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app

--- a/crates/kanban-tui/tests/scroll_preservation_tests.rs
+++ b/crates/kanban-tui/tests/scroll_preservation_tests.rs
@@ -31,6 +31,7 @@ fn test_column_view_scroll_offset_preserved_after_prepare_frame() {
         .unwrap()
         .first()
         .map(|b| b.id);
+    app.reload_model();
     app.prepare_frame();
 
     if let Some(list) = app.view.strategy.get_active_task_list_mut() {
@@ -46,6 +47,7 @@ fn test_column_view_scroll_offset_preserved_after_prepare_frame() {
         .get_scroll_offset();
     assert_eq!(offset_before, 5);
 
+    app.reload_model();
     app.prepare_frame();
 
     let offset_after = app

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -159,6 +159,7 @@ fn test_render_export_boards_select_step_shows_board_names() {
         .unwrap()
         .first()
         .map(|b| b.id);
+    app.reload_model();
     app.prepare_frame();
     let board_id = app.selection.active_board_id.unwrap();
     app.export_dialog = Some(ExportDialogState::new(vec![board_id]));
@@ -237,6 +238,7 @@ fn test_export_boards_json_creates_file() {
         .create_column(board.id, "Todo".into(), None)
         .unwrap();
 
+    app.reload_model();
     app.prepare_frame();
     app.export_dialog = Some(ExportDialogState::new(vec![board.id]));
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
@@ -271,6 +273,7 @@ fn test_execute_export_uses_explicit_board_ids_not_live_boards_snapshot_at_confi
 
     let board_a = app.ctx.create_board("BoardA".into(), None).unwrap();
     let board_b = app.ctx.create_board("BoardB".into(), None).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     let mut preselected = std::collections::HashSet::new();
@@ -284,6 +287,7 @@ fn test_execute_export_uses_explicit_board_ids_not_live_boards_snapshot_at_confi
     // positions from it at confirm time instead of using the dialog's own
     // captured `board_ids`.
     app.ctx.create_board("BoardC".into(), None).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     app.handle_export_boards_dialog(KeyCode::Enter);

--- a/crates/kanban-tui/tests/settings_navigation_tests.rs
+++ b/crates/kanban-tui/tests/settings_navigation_tests.rs
@@ -148,6 +148,7 @@ fn test_settings_enter_on_export_triggers_dialog() {
     let mut app = helpers::setup_settings_app();
     use kanban_domain::KanbanOperations;
     app.ctx.create_board("B1".into(), None).unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.focus.settings_focus = SettingsFocus::Storage;
     app.selection.settings_storage.set(Some(3));

--- a/crates/kanban-tui/tests/settings_storage_tests.rs
+++ b/crates/kanban-tui/tests/settings_storage_tests.rs
@@ -49,6 +49,7 @@ async fn test_migrate_json_to_sqlite_creates_file() {
 
     app.apply_storage_location_change(old_config, &old_storage_location);
     app.await_migration().await;
+    app.reload_model();
     app.prepare_frame();
     assert!(sqlite_path.exists(), "SQLite file should be created");
     assert_eq!(app.model.boards().len(), 1);
@@ -74,6 +75,7 @@ async fn test_switch_to_existing_sqlite_reloads_data() {
 
     app.apply_storage_location_change(old_config, &old_storage_location);
     app.await_migration().await;
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "SqliteBoard");
@@ -98,6 +100,7 @@ async fn test_switch_to_existing_json_reloads_data() {
 
     app.apply_storage_location_change(old_config, &old_storage_location);
     app.await_migration().await;
+    app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards().len(), 1);
     assert_eq!(app.model.boards()[0].name, "SecondBoard");

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -67,6 +67,7 @@ fn setup_app_with_sprints() -> DialogFixture {
         .first()
         .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
+    app.reload_model();
     app.prepare_frame();
 
     DialogFixture {
@@ -319,6 +320,7 @@ fn test_bulk_assign_bare_enter_is_a_no_op_and_does_not_mass_unassign() {
         .map(|s| s.id)
         .unwrap();
     app.ctx.assign_card_to_sprint(card_id, some_sprint).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     // Open bulk dialog with no interaction, then press Enter immediately.
@@ -384,6 +386,7 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
     app.ctx
         .assign_card_to_sprint(card_id, completed_id)
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     open_assign_dialog(&mut app);
@@ -462,6 +465,7 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
         .first()
         .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
+    app.reload_model();
     app.prepare_frame();
 
     open_assign_dialog(&mut app);
@@ -526,6 +530,7 @@ fn test_sticky_header_appears_at_top_when_scrolled_past_active_planned_header() 
         .first()
         .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
+    app.reload_model();
     app.prepare_frame();
 
     open_assign_dialog(&mut app);
@@ -596,6 +601,7 @@ fn test_sticky_header_switches_to_completed_ended_when_selecting_in_lower_sectio
         .first()
         .map(|b| b.id);
     app.selection.active_card_id = Some(card.id);
+    app.reload_model();
     app.prepare_frame();
 
     open_assign_dialog(&mut app);

--- a/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
+++ b/crates/kanban-tui/tests/sprint_detail_card_list_tests.rs
@@ -109,6 +109,7 @@ fn test_sprint_detail_populate_applies_board_sort_order() {
             },
         )
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -161,6 +162,7 @@ fn test_sprint_detail_populate_applies_board_sort_order() {
         .assign_card_to_sprint(critical.id, sprint.id)
         .unwrap();
     app.ctx.assign_card_to_sprint(medium.id, sprint.id).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     app.populate_sprint_task_lists(sprint.id);
@@ -208,6 +210,7 @@ fn test_sprint_detail_status_done_card_is_not_in_uncompleted_panel_after_populat
         .ctx
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -238,6 +241,7 @@ fn test_sprint_detail_status_done_card_is_not_in_uncompleted_panel_after_populat
             },
         )
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     app.populate_sprint_task_lists(sprint.id);

--- a/crates/kanban-tui/tests/sprint_filter_toggle_tests.rs
+++ b/crates/kanban-tui/tests/sprint_filter_toggle_tests.rs
@@ -18,6 +18,7 @@ fn test_toggle_sprint_filter_without_active_sprint_shows_error_banner() {
         .first()
         .map(|b| b.id);
     app.focus.active = Focus::Cards;
+    app.reload_model();
     app.prepare_frame();
 
     app.handle_toggle_sprint_filter();

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -26,12 +26,14 @@ fn make_app_with_board() -> (App, Uuid, Uuid) {
         .unwrap()
         .first()
         .map(|b| b.id);
+    app.reload_model();
     app.prepare_frame();
     (app, board.id, column.id)
 }
 
 fn add_planning_sprint(app: &mut App, board_id: Uuid) -> Uuid {
     let id = app.ctx.create_sprint(board_id, None, None).unwrap().id;
+    app.reload_model();
     app.prepare_frame();
     id
 }
@@ -39,6 +41,7 @@ fn add_planning_sprint(app: &mut App, board_id: Uuid) -> Uuid {
 fn add_active_sprint(app: &mut App, board_id: Uuid) -> Uuid {
     let sprint = app.ctx.create_sprint(board_id, None, None).unwrap();
     app.ctx.activate_sprint(sprint.id, Some(7)).unwrap();
+    app.reload_model();
     app.prepare_frame();
     sprint.id
 }
@@ -56,6 +59,7 @@ fn add_ended_sprint(app: &mut App, board_id: Uuid) -> Uuid {
             },
         )
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     sprint.id
 }
@@ -64,6 +68,7 @@ fn add_completed_sprint(app: &mut App, board_id: Uuid) -> Uuid {
     let sprint = app.ctx.create_sprint(board_id, None, None).unwrap();
     app.ctx.activate_sprint(sprint.id, Some(7)).unwrap();
     app.ctx.complete_sprint(sprint.id).unwrap();
+    app.reload_model();
     app.prepare_frame();
     sprint.id
 }
@@ -79,12 +84,14 @@ fn add_card(app: &mut App, board_id: Uuid, column_id: Uuid) -> Uuid {
         )
         .unwrap()
         .id;
+    app.reload_model();
     app.prepare_frame();
     id
 }
 
 fn assign_card_sprint(app: &mut App, card_id: Uuid, sprint_id: Uuid) {
     app.ctx.assign_card_to_sprint(card_id, sprint_id).unwrap();
+    app.reload_model();
     app.prepare_frame();
 }
 

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -577,7 +577,6 @@ fn test_toggle_card_completion_retains_selection() {
     // silently dropping the selection.
     app.handle_toggle_card_completion();
     // Simulate the next render frame -- this is where the stale-model bug manifests.
-    app.reload_model();
     app.prepare_frame();
 
     let selected_after = app.get_selected_card_id();
@@ -639,7 +638,6 @@ fn test_toggle_multi_card_completion_retains_selection() {
     // Toggle completion for both -- both cards move to the Done column.
     app.handle_toggle_card_completion();
     // Simulate the next render frame -- this is where the stale-model bug manifests.
-    app.reload_model();
     app.prepare_frame();
 
     // After the toggle the first selected card (alpha or beta) must still be

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -11,6 +11,7 @@ fn setup_app_with_board() -> App {
         .ctx
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -30,6 +31,7 @@ fn test_create_board_assigns_correct_id_to_columns() {
 
     app.input.set("New Board".to_string());
     app.create_board();
+    app.reload_model();
     app.prepare_frame();
 
     let boards = app.model.boards();
@@ -51,6 +53,7 @@ fn test_create_board_selects_new_board() {
 
     // Create first board via ctx so it's a known baseline
     app.ctx.create_board("First".to_string(), None).unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.focus.active = Focus::Boards;
@@ -58,6 +61,7 @@ fn test_create_board_selects_new_board() {
     // Create second board via handler
     app.input.set("Second".to_string());
     app.create_board();
+    app.reload_model();
     app.prepare_frame();
 
     let boards = app.model.boards();
@@ -75,6 +79,7 @@ fn test_create_card_selects_newly_created_card() {
     app.focus.active = Focus::Cards;
     app.input.set("My Card".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
 
     let selected_id = app.get_selected_card_id();
@@ -98,6 +103,7 @@ fn test_create_card_selects_newly_created_card_when_prior_selection_exists() {
     app.focus.active = Focus::Cards;
     app.input.set("First".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
     let first_id = app
         .get_selected_card_id()
@@ -105,6 +111,7 @@ fn test_create_card_selects_newly_created_card_when_prior_selection_exists() {
 
     app.input.set("Second".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -148,6 +155,7 @@ fn test_create_card_auto_completes_in_done_column() {
             },
         )
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -161,6 +169,7 @@ fn test_create_card_auto_completes_in_done_column() {
     // Use ColumnView and navigate to the done column (index 2)
     app.focus.active = Focus::Cards;
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.reload_model();
     app.prepare_frame();
     // Navigate right twice to reach the 3rd column (Done)
     app.view.strategy.navigate_right(false);
@@ -168,6 +177,7 @@ fn test_create_card_auto_completes_in_done_column() {
 
     app.input.set("Done Card".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -190,6 +200,7 @@ fn test_create_sprint_selects_new_sprint() {
 
     app.input.set("".to_string());
     app.create_sprint();
+    app.reload_model();
     app.prepare_frame();
 
     let sprints = app.model.sprints();
@@ -218,6 +229,7 @@ fn test_create_column_selects_new_column() {
 
     app.input.set("New Column".to_string());
     app.create_column();
+    app.reload_model();
     app.prepare_frame();
 
     let selected = app.dialog_input.column_list.get_selected_index();
@@ -236,6 +248,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
         .ctx
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -251,6 +264,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.focus.board_focus = BoardFocus::Sprints;
     app.input.set("".to_string());
     app.create_sprint();
+    app.reload_model();
     app.prepare_frame();
 
     let sprint_id = app.model.sprints()[0].id;
@@ -259,6 +273,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.focus.active = Focus::Cards;
     app.input.set("Task".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
 
     let card_id = app
@@ -269,11 +284,13 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
         .unwrap()
         .id;
     app.ctx.assign_card_to_sprint(card_id, sprint_id).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     // Navigate to sprint detail and complete it
     app.selection.active_sprint_index = Some(0);
     app.handle_complete_sprint_key();
+    app.reload_model();
     app.prepare_frame();
 
     // The sole planning sprint was just completed — no other planning sprint exists,
@@ -293,6 +310,7 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
         .ctx
         .create_column(board.id, "Todo".to_string(), Some(0))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -308,9 +326,11 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     app.focus.board_focus = BoardFocus::Sprints;
     app.input.set("".to_string());
     app.create_sprint();
+    app.reload_model();
     app.prepare_frame();
     app.input.set("".to_string());
     app.create_sprint();
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(app.model.sprints().len(), 2, "should have two sprints");
@@ -319,12 +339,14 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     // Activate sprint 1 so it can be completed
     app.selection.active_sprint_index = Some(0);
     app.handle_activate_sprint_key();
+    app.reload_model();
     app.prepare_frame();
 
     // Create a card and assign it to sprint 1
     app.focus.active = Focus::Cards;
     app.input.set("Task".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
 
     let card_id = app
@@ -335,11 +357,13 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
         .unwrap()
         .id;
     app.ctx.assign_card_to_sprint(card_id, sprint1_id).unwrap();
+    app.reload_model();
     app.prepare_frame();
 
     // Complete sprint 1 — sprint 2 is still Planning
     app.selection.active_sprint_index = Some(0);
     app.handle_complete_sprint_key();
+    app.reload_model();
     app.prepare_frame();
 
     // Carry-over dialog should open because sprint 2 is Planning and sprint 1 has uncompleted cards
@@ -368,6 +392,7 @@ fn test_move_card_right_selects_moved_card_in_kanban_view() {
         .ctx
         .create_column(board.id, "Done".to_string(), Some(2))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -378,6 +403,7 @@ fn test_move_card_right_selects_moved_card_in_kanban_view() {
         .first()
         .map(|b| b.id);
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Cards;
 
@@ -385,14 +411,17 @@ fn test_move_card_right_selects_moved_card_in_kanban_view() {
     // task list that could clobber the moved card's selection.
     app.input.set("Anchor".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
     app.input.set("Mover".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
     let mover_id = app.get_selected_card_id().expect("Mover is selected");
 
     // Move "Mover" right: Todo -> Doing.
     app.handle_move_card_right();
+    app.reload_model();
     app.prepare_frame();
 
     let selected = app
@@ -422,6 +451,7 @@ fn test_move_selected_cards_right_selects_first_moved_card() {
         .ctx
         .create_column(board.id, "Done".to_string(), Some(2))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -432,19 +462,23 @@ fn test_move_selected_cards_right_selects_first_moved_card() {
         .first()
         .map(|b| b.id);
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Cards;
 
     // Create three cards in Todo.
     app.input.set("Anchor".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
     app.input.set("First Mover".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
     let first_mover_id = app.get_selected_card_id().expect("First Mover is selected");
     app.input.set("Second Mover".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
     let second_mover_id = app
         .get_selected_card_id()
@@ -457,6 +491,7 @@ fn test_move_selected_cards_right_selects_first_moved_card() {
 
     // Move selected cards right: Todo -> Doing.
     app.handle_move_card_right();
+    app.reload_model();
     app.prepare_frame();
 
     let selected = app
@@ -481,6 +516,7 @@ fn test_delete_column_adjusts_selection() {
     app.ctx
         .create_column(board.id, "Col3".to_string(), Some(2))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -497,6 +533,7 @@ fn test_delete_column_adjusts_selection() {
     app.dialog_input.column_list.update_item_count(3);
     app.dialog_input.column_list.set_selected_index(Some(2));
     app.delete_column();
+    app.reload_model();
     app.prepare_frame();
 
     let remaining = app
@@ -531,6 +568,7 @@ fn test_toggle_card_completion_retains_selection() {
         .ctx
         .create_column(board.id, "Done".to_string(), Some(1))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -544,11 +582,13 @@ fn test_toggle_card_completion_retains_selection() {
     // Switch to the kanban (column) view so each column has its own CardList.
     // This is the view where stale-model causes select_card_by_id to silently fail.
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.reload_model();
     app.prepare_frame();
 
     app.focus.active = Focus::Cards;
     app.input.set("Task".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
 
     let card_id = app
@@ -562,6 +602,7 @@ fn test_toggle_card_completion_retains_selection() {
     // silently dropping the selection.
     app.handle_toggle_card_completion();
     // Simulate the next render frame -- this is where the stale-model bug manifests.
+    app.reload_model();
     app.prepare_frame();
 
     let selected_after = app.get_selected_card_id();
@@ -585,6 +626,7 @@ fn test_toggle_multi_card_completion_retains_selection() {
         .ctx
         .create_column(board.id, "Done".to_string(), Some(1))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -596,11 +638,13 @@ fn test_toggle_multi_card_completion_retains_selection() {
         .map(|b| b.id);
 
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.reload_model();
     app.prepare_frame();
 
     app.focus.active = Focus::Cards;
     app.input.set("Alpha".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
     let alpha_id = app
         .get_selected_card_id()
@@ -608,6 +652,7 @@ fn test_toggle_multi_card_completion_retains_selection() {
 
     app.input.set("Beta".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
     let beta_id = app
         .get_selected_card_id()
@@ -621,6 +666,7 @@ fn test_toggle_multi_card_completion_retains_selection() {
     // Toggle completion for both -- both cards move to the Done column.
     app.handle_toggle_card_completion();
     // Simulate the next render frame -- this is where the stale-model bug manifests.
+    app.reload_model();
     app.prepare_frame();
 
     // After the toggle the first selected card (alpha or beta) must still be
@@ -661,6 +707,7 @@ fn test_move_card_right_syncs_column_list_count_to_filtered_columns_not_raw_boar
         .ctx
         .create_column(board.id, "Done".to_string(), Some(2))
         .unwrap();
+    app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
     app.selection.active_board_id = app
@@ -683,11 +730,13 @@ fn test_move_card_right_syncs_column_list_count_to_filtered_columns_not_raw_boar
     ))
     .unwrap();
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.reload_model();
     app.prepare_frame();
     app.focus.active = Focus::Cards;
 
     app.input.set("Mover".to_string());
     app.create_card();
+    app.reload_model();
     app.prepare_frame();
 
     // Narrow the column list to a single match — if the cosmetic tracking
@@ -700,6 +749,7 @@ fn test_move_card_right_syncs_column_list_count_to_filtered_columns_not_raw_boar
     }
 
     app.handle_move_card_right();
+    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -31,7 +31,6 @@ fn test_create_board_assigns_correct_id_to_columns() {
 
     app.input.set("New Board".to_string());
     app.create_board();
-    app.reload_model();
     app.prepare_frame();
 
     let boards = app.model.boards();
@@ -61,7 +60,6 @@ fn test_create_board_selects_new_board() {
     // Create second board via handler
     app.input.set("Second".to_string());
     app.create_board();
-    app.reload_model();
     app.prepare_frame();
 
     let boards = app.model.boards();
@@ -79,7 +77,6 @@ fn test_create_card_selects_newly_created_card() {
     app.focus.active = Focus::Cards;
     app.input.set("My Card".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
 
     let selected_id = app.get_selected_card_id();
@@ -103,7 +100,6 @@ fn test_create_card_selects_newly_created_card_when_prior_selection_exists() {
     app.focus.active = Focus::Cards;
     app.input.set("First".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
     let first_id = app
         .get_selected_card_id()
@@ -111,7 +107,6 @@ fn test_create_card_selects_newly_created_card_when_prior_selection_exists() {
 
     app.input.set("Second".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -177,7 +172,6 @@ fn test_create_card_auto_completes_in_done_column() {
 
     app.input.set("Done Card".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
 
     let cards = app.model.all_cards();
@@ -200,7 +194,6 @@ fn test_create_sprint_selects_new_sprint() {
 
     app.input.set("".to_string());
     app.create_sprint();
-    app.reload_model();
     app.prepare_frame();
 
     let sprints = app.model.sprints();
@@ -229,7 +222,6 @@ fn test_create_column_selects_new_column() {
 
     app.input.set("New Column".to_string());
     app.create_column();
-    app.reload_model();
     app.prepare_frame();
 
     let selected = app.dialog_input.column_list.get_selected_index();
@@ -264,7 +256,6 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.focus.board_focus = BoardFocus::Sprints;
     app.input.set("".to_string());
     app.create_sprint();
-    app.reload_model();
     app.prepare_frame();
 
     let sprint_id = app.model.sprints()[0].id;
@@ -273,7 +264,6 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.focus.active = Focus::Cards;
     app.input.set("Task".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
 
     let card_id = app
@@ -290,7 +280,6 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     // Navigate to sprint detail and complete it
     app.selection.active_sprint_index = Some(0);
     app.handle_complete_sprint_key();
-    app.reload_model();
     app.prepare_frame();
 
     // The sole planning sprint was just completed — no other planning sprint exists,
@@ -326,11 +315,9 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     app.focus.board_focus = BoardFocus::Sprints;
     app.input.set("".to_string());
     app.create_sprint();
-    app.reload_model();
     app.prepare_frame();
     app.input.set("".to_string());
     app.create_sprint();
-    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(app.model.sprints().len(), 2, "should have two sprints");
@@ -339,14 +326,12 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     // Activate sprint 1 so it can be completed
     app.selection.active_sprint_index = Some(0);
     app.handle_activate_sprint_key();
-    app.reload_model();
     app.prepare_frame();
 
     // Create a card and assign it to sprint 1
     app.focus.active = Focus::Cards;
     app.input.set("Task".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
 
     let card_id = app
@@ -363,7 +348,6 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     // Complete sprint 1 — sprint 2 is still Planning
     app.selection.active_sprint_index = Some(0);
     app.handle_complete_sprint_key();
-    app.reload_model();
     app.prepare_frame();
 
     // Carry-over dialog should open because sprint 2 is Planning and sprint 1 has uncompleted cards
@@ -411,17 +395,14 @@ fn test_move_card_right_selects_moved_card_in_kanban_view() {
     // task list that could clobber the moved card's selection.
     app.input.set("Anchor".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
     app.input.set("Mover".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
     let mover_id = app.get_selected_card_id().expect("Mover is selected");
 
     // Move "Mover" right: Todo -> Doing.
     app.handle_move_card_right();
-    app.reload_model();
     app.prepare_frame();
 
     let selected = app
@@ -469,16 +450,13 @@ fn test_move_selected_cards_right_selects_first_moved_card() {
     // Create three cards in Todo.
     app.input.set("Anchor".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
     app.input.set("First Mover".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
     let first_mover_id = app.get_selected_card_id().expect("First Mover is selected");
     app.input.set("Second Mover".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
     let second_mover_id = app
         .get_selected_card_id()
@@ -491,7 +469,6 @@ fn test_move_selected_cards_right_selects_first_moved_card() {
 
     // Move selected cards right: Todo -> Doing.
     app.handle_move_card_right();
-    app.reload_model();
     app.prepare_frame();
 
     let selected = app
@@ -533,7 +510,6 @@ fn test_delete_column_adjusts_selection() {
     app.dialog_input.column_list.update_item_count(3);
     app.dialog_input.column_list.set_selected_index(Some(2));
     app.delete_column();
-    app.reload_model();
     app.prepare_frame();
 
     let remaining = app
@@ -588,7 +564,6 @@ fn test_toggle_card_completion_retains_selection() {
     app.focus.active = Focus::Cards;
     app.input.set("Task".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
 
     let card_id = app
@@ -644,7 +619,6 @@ fn test_toggle_multi_card_completion_retains_selection() {
     app.focus.active = Focus::Cards;
     app.input.set("Alpha".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
     let alpha_id = app
         .get_selected_card_id()
@@ -652,7 +626,6 @@ fn test_toggle_multi_card_completion_retains_selection() {
 
     app.input.set("Beta".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
     let beta_id = app
         .get_selected_card_id()
@@ -736,7 +709,6 @@ fn test_move_card_right_syncs_column_list_count_to_filtered_columns_not_raw_boar
 
     app.input.set("Mover".to_string());
     app.create_card();
-    app.reload_model();
     app.prepare_frame();
 
     // Narrow the column list to a single match — if the cosmetic tracking
@@ -749,7 +721,6 @@ fn test_move_card_right_syncs_column_list_count_to_filtered_columns_not_raw_boar
     }
 
     app.handle_move_card_right();
-    app.reload_model();
     app.prepare_frame();
 
     assert_eq!(


### PR DESCRIPTION
`prepare_frame` did a full store read and then pure display preparation, and it was called from the redraw guard. Every keystroke that triggered a redraw re-read the entire store, including pure navigation. This splits the I/O into `reload_model()` and takes the read out of the redraw path.

Three epics are waiting on this seam. KAN-1076/1077/1079 cannot remove `Snapshot` from `DataStore` while the redraw path calls it. KAN-1080 needs it before the view model can become delta-driven. And phase 2 of the status-catalog epic needs somewhere to resolve a catalog on refresh rather than per frame, which on the HTTP backend would be one request per frame.

## The defect this uncovered

The first implementation dropped the guard's reload and passed 3640 tests, clippy and fmt. It also shipped a stale-view bug.

The card enumerated `prepare_frame()` call sites. But the guard's per-frame reload was also the only refresh for every mutation handler that never calls `prepare_frame` at all. `Model` has exactly one `&mut self` method, its only production caller is `reload_model`, `execute_command` touches the context only, and `handle_key_event` has no generic post-key refresh. So a mutating handler without a reload cannot update the view.

Reproduced before fixing: delete a board, redraw, and the panel still shows it while the store reports zero live boards. The same shape applied to renaming boards, every column operation, the priority and points popups, sprint activate and complete, editing a field in an external editor, and the archive animation tick.

29 handlers were in that position. All now reload.

## Why the suite stayed green

The test migration hid it. The bulk rewrite of 204 integration call sites inserted `reload_model()` into tests that drive production handlers, so the test supplied the refresh the handler was missing.

The distinction that was missed: a test mutating directly through the context needs the reload as scaffolding, but a test mutating through a handler must not paper over the handler's gap. 32 such insertions were reverted, and reverting them exposed further unfixed handlers, which is exactly what they were hiding. Two extra handlers turned up beyond the review's list, and the animation tick had two broken branches rather than one.

## Verification

`test_redraw_without_input_performs_no_store_reads` uses a counting backend that increments on every read method and asserts exactly zero. `reload_model` is the only path to `ctx.snapshot()`, so this is a direct proof rather than a proxy.

Mutation visibility is pinned for archive, restore, move-between-columns and sprint assignment, plus the delete-board reproduction as a permanent regression test. Each was confirmed red before its fix.

The five view-only sites that legitimately lose the reload are the redraw guard, `handle_selection_activate`, both branches of the archived-boards toggle, and the archived-cards toggle. Each was traced: they change mode, selection or which subset is displayed, never data. Archived views do no lazy loading, since the model holds live and archived rows in one collection and the view is pure filtering.

3645 tests pass, up 5. 759 insertions against 22 deletions, and zero assertions removed anywhere in the branch. The NLL borrow-splitting structure in `prepare_frame` and its explanatory comments are byte-for-byte unchanged.

## Note on scope

The card described its Category B reloads as temporary, to be replaced by an `apply_changes` mechanism in KAN-1084. That card is archived, along with the rest of that decomposition, so no card currently makes the model delta-driven. This PR is correct standalone, but KAN-1080's title promises something nothing now delivers.