### PR TITLE
KAN-1081 fix(tui): reload the model after undo, redo and a storage swap

### DIFF
--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -582,15 +582,13 @@ impl App {
                     self.set_error(format!("Undo failed: {e}"));
                 }
                 // `prepare_frame` resyncs `board_list`, clamping the highlight to
-                // the post-undo board set.
-                self.reload_model();
+                // the post-undo board set. `undo` has already reloaded the model.
                 self.prepare_frame();
             }
             KeyCode::Char('U') => {
                 if let Err(e) = self.redo() {
                     self.set_error(format!("Redo failed: {e}"));
                 }
-                self.reload_model();
                 self.prepare_frame();
             }
             _ => {}

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -130,6 +130,7 @@ impl App {
     /// Undo the last action
     pub fn undo(&mut self) -> KanbanResult<()> {
         if self.ctx.undo()? {
+            self.reload_model();
             self.needs_redraw = true;
         } else {
             self.set_error("Nothing to undo".to_string());
@@ -140,6 +141,7 @@ impl App {
     /// Redo the last undone action
     pub fn redo(&mut self) -> KanbanResult<()> {
         if self.ctx.redo()? {
+            self.reload_model();
             self.needs_redraw = true;
         } else {
             self.set_error("Nothing to redo".to_string());

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -271,6 +271,10 @@ impl App {
             tracing::error!("Failed to clear history: {}", e);
         }
 
+        // The backend now serves a different file, so the selection below must be
+        // computed from that file's boards rather than the outgoing one's.
+        self.reload_model();
+
         self.selection.active_board_id = self.model.live_boards().next().map(|b| b.id);
         let live_ids: Vec<uuid::Uuid> = self.model.live_boards().map(|b| b.id).collect();
         self.board_list.update_boards(live_ids);

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -281,3 +281,49 @@ fn test_delete_board_leaves_no_stale_model_without_guard_reload() {
         "UI STALE: store has {live_in_store} live boards but the panel still shows {visible_after_redraw}"
     );
 }
+
+#[test]
+fn test_undo_is_visible_in_model_without_a_further_redraw() {
+    let mut app = App::test_default();
+    app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+    assert_eq!(app.displayed_boards().len(), 1);
+
+    app.undo().expect("undo must succeed");
+    app.prepare_frame();
+
+    let live = app.ctx.data_store().list_boards().unwrap().len();
+    assert_eq!(
+        app.displayed_boards().len(),
+        live,
+        "the model must match the store after an undo, without a further reload"
+    );
+}
+
+#[test]
+fn test_redo_is_visible_in_model_without_a_further_redraw() {
+    let mut app = App::test_default();
+    app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.undo().expect("undo must succeed");
+    // Reload explicitly so the model is accurate BEFORE the redo; otherwise a
+    // stale model left by the undo cancels out a stale model left by the redo
+    // and the assertion passes without proving anything.
+    app.reload_model();
+    app.prepare_frame();
+    assert_eq!(
+        app.displayed_boards().len(),
+        0,
+        "precondition: undo applied"
+    );
+
+    app.redo().expect("redo must succeed");
+    app.prepare_frame();
+
+    let live = app.ctx.data_store().list_boards().unwrap().len();
+    assert_eq!(
+        app.displayed_boards().len(),
+        live,
+        "the model must match the store after a redo, without a further reload"
+    );
+}


### PR DESCRIPTION
Follow-up to #583. A post-merge review found that the handler audit in that PR missed three mutation paths, two of which are live stale-view bugs on develop right now.

## undo and redo

`App::undo` and `App::redo` call into `KanbanContext` and set `needs_redraw`, but never reload the view model. They were not in the 29-handler list. Of their three call sites only one had a compensating reload, and it was not the main one:

- `input_router.rs` archived-views path had a reload
- `input_router.rs` `u`/`U` in Normal mode, the primary undo path in the app, did not
- `keybindings.rs` `execute_action`, reachable by firing Undo from the Help menu, did not

Reproduced before fixing: create a board, press `u`, and the store reports zero live boards while the panel still shows one. The board stays on screen until some unrelated mutation happens to reload. Redo has the mirror bug.

Fixed by reloading inside `undo` and `redo` themselves, which covers all three call sites at once. That makes the compensating reload at the archived-views site redundant, so it is removed rather than left as a double read.

## The storage swap

`handle_migration_complete` calls `replace_backend`, then computes `selection.active_board_id` and the board list from `self.model`, which still holds the outgoing file's boards. Pointing storage at an existing different kanban file leaves the old project on screen and can select a board id that does not exist in the new store. Before #583 the per-frame reload repaired this on the next frame.

`adopt_storage_file` is not affected: it seeds the new backend from the current in-memory snapshot, so model and store already agree.

## Tests

`test_undo_is_visible_in_model_without_a_further_redraw` and `test_redo_is_visible_in_model_without_a_further_redraw`, both confirmed red before the fix.

The redo test reloads explicitly between the undo and the redo. Without that step it passes for the wrong reason: the stale model left by the undo cancels out the stale model left by the redo, and the assertion holds while proving nothing. It was written that way first and caught during review, so the guard against it is commented in place.

3647 tests pass. Clippy and fmt clean.

## Not fixed here

Two findings from the same review are deliberately out of scope for a hotfix and are worth follow-ups:

- `handle_animation_tick` reloads once per branch, so a tick completing both an archive and a delete animation pays two full store reads. Correct, wasteful.
- `CountingBackend` in the test helpers does not delegate seven defaulted `KanbanBackend` methods. Harmless today because it only ever wraps the in-memory backend, but the first test that wraps JSON or SQLite silently loses persistence and own-write detection.