### PR TITLE
KAN-1205 perf(tui): reload the model once per animation tick

### DIFF
--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -105,12 +105,13 @@ impl App {
         // model that predates the previous iteration's restore. Each stays
         // its own `execute_command` call (its own undo entry, one user
         // action each), but none of them reloads on its own.
-        let mut restored_any = false;
+        let mut restored_ids = Vec::new();
         for card_id in restore_cards {
             if self.complete_restore_animation(card_id) {
-                restored_any = true;
+                restored_ids.push(card_id);
             }
         }
+        let restored_any = !restored_ids.is_empty();
 
         // One refresh for the tick, regardless of how many animation kinds
         // completed in it.
@@ -119,9 +120,15 @@ impl App {
         }
 
         // Selection reconciliation runs against the refreshed model.
+        // `select_card_by_id` resolves through the task lists, which are
+        // still stale until the next `prepare_frame`, so a card restored in
+        // this same tick would silently no-op the selection if it were
+        // picked as the candidate. Exclude it, so the fix-up only lands on
+        // cards the task lists already know about, exactly as it would have
+        // before restores shared this tick's reload.
         if archived_ok {
             if let Some((column_id, position)) = self.animation.archive_anchor.take() {
-                self.select_card_after_deletion(column_id, position);
+                self.select_card_after_deletion_excluding(column_id, position, &restored_ids);
             }
         }
     }

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -46,8 +46,11 @@ impl App {
         let had_deletes = !delete_cards.is_empty();
 
         // Execute archive + per-column compact as a single undo batch so that
-        // one user-perceived "delete" maps to one `u` press to undo.
-        if had_archives {
+        // one user-perceived "delete" maps to one `u` press to undo. Kept as
+        // its own `execute_commands_batch` call, separate from the delete
+        // batch below, so archiving and permanently deleting stay two
+        // distinct undo entries even when both complete in the same tick.
+        let archived_ok = if had_archives {
             let mut commands = vec![kanban_domain::commands::Command::Card(
                 kanban_domain::commands::CardCommand::Archive(
                     kanban_domain::commands::ArchiveCards { ids: archive_cards },
@@ -63,18 +66,19 @@ impl App {
                 ));
             }
 
-            if let Err(e) = self.execute_commands_batch(commands) {
-                tracing::error!("Failed to archive cards: {}", e);
-            } else {
-                self.reload_model();
-                if let Some((column_id, position)) = self.animation.archive_anchor.take() {
-                    self.select_card_after_deletion(column_id, position);
+            match self.execute_commands_batch(commands) {
+                Err(e) => {
+                    tracing::error!("Failed to archive cards: {}", e);
+                    false
                 }
+                Ok(_) => true,
             }
-        }
+        } else {
+            false
+        };
 
         // Execute batch delete commands
-        if had_deletes {
+        let deleted_ok = if had_deletes {
             let mut delete_commands: Vec<kanban_domain::commands::Command> = Vec::new();
             for card_id in delete_cards {
                 let cmd = kanban_domain::commands::Command::Card(
@@ -84,20 +88,45 @@ impl App {
                 );
                 delete_commands.push(cmd);
             }
-            if let Err(e) = self.execute_commands_batch(delete_commands) {
-                tracing::error!("Failed to delete cards: {}", e);
-            } else {
-                self.reload_model();
+            match self.execute_commands_batch(delete_commands) {
+                Err(e) => {
+                    tracing::error!("Failed to delete cards: {}", e);
+                    false
+                }
+                Ok(_) => true,
+            }
+        } else {
+            false
+        };
+
+        // Restores have no intra-loop dependency: `RestoreCard` only ever
+        // touches the card being restored (its own column/position/marker),
+        // never another card's, so each iteration is safe to run against a
+        // model that predates the previous iteration's restore. Each stays
+        // its own `execute_command` call (its own undo entry, one user
+        // action each), but none of them reloads on its own.
+        let mut restored_any = false;
+        for card_id in restore_cards {
+            if self.complete_restore_animation(card_id) {
+                restored_any = true;
             }
         }
 
-        // Handle restore animations individually (less common)
-        for card_id in restore_cards {
-            self.complete_restore_animation(card_id);
+        // One refresh for the tick, regardless of how many animation kinds
+        // completed in it.
+        if archived_ok || deleted_ok || restored_any {
+            self.reload_model();
+        }
+
+        // Selection reconciliation runs against the refreshed model.
+        if archived_ok {
+            if let Some((column_id, position)) = self.animation.archive_anchor.take() {
+                self.select_card_after_deletion(column_id, position);
+            }
         }
     }
 
-    fn complete_restore_animation(&mut self, card_id: uuid::Uuid) {
+    fn complete_restore_animation(&mut self, card_id: uuid::Uuid) -> bool {
         if let Some(archived_card) = self
             .model
             .archived_card_markers()
@@ -105,7 +134,9 @@ impl App {
             .find(|dc| dc.entity_id == card_id)
             .cloned()
         {
-            self.restore_card(archived_card);
+            self.restore_card_without_reload(archived_card)
+        } else {
+            false
         }
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -643,20 +643,36 @@ impl App {
         deleted_column_id: uuid::Uuid,
         deleted_position: i32,
     ) {
+        self.select_card_after_deletion_excluding(deleted_column_id, deleted_position, &[]);
+    }
+
+    /// Same as `select_card_after_deletion`, but skips cards whose id is in
+    /// `exclude`. `select_card_by_id` resolves against the task lists, which
+    /// are only rebuilt on the next `prepare_frame`; a card that entered
+    /// `live_cards()` this same tick (e.g. a restore completing alongside an
+    /// archive) is not in those lists yet, so landing on it would silently
+    /// no-op the selection. Callers that mutate the model and pick a
+    /// selection in the same tick pass those ids here to fall back to a
+    /// candidate the task lists already know about.
+    pub fn select_card_after_deletion_excluding(
+        &mut self,
+        deleted_column_id: uuid::Uuid,
+        deleted_position: i32,
+        exclude: &[uuid::Uuid],
+    ) {
         // Try to find a card in the same column at or after the deleted position
-        if let Some(next_card) = self
-            .model
-            .live_cards()
-            .iter()
-            .find(|c| c.column_id == deleted_column_id && c.position >= deleted_position)
-        {
+        if let Some(next_card) = self.model.live_cards().iter().find(|c| {
+            c.column_id == deleted_column_id
+                && c.position >= deleted_position
+                && !exclude.contains(&c.id)
+        }) {
             self.select_card_by_id(next_card.id);
         } else if let Some(prev_card) = self
             .model
             .live_cards()
             .iter()
             .rev()
-            .find(|c| c.column_id == deleted_column_id)
+            .find(|c| c.column_id == deleted_column_id && !exclude.contains(&c.id))
         {
             // Select the last remaining card in the column
             self.select_card_by_id(prev_card.id);

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -707,6 +707,12 @@ impl App {
     }
 
     pub fn restore_card(&mut self, archived_card: ArchivedCard) {
+        if self.restore_card_without_reload(archived_card) {
+            self.reload_model();
+        }
+    }
+
+    pub(crate) fn restore_card_without_reload(&mut self, archived_card: ArchivedCard) -> bool {
         let card_id = archived_card.entity_id;
         // Reference-marker model: the card stayed LIVE in place while archived, so
         // it keeps its current column/position on restore; there is no "original"
@@ -715,7 +721,7 @@ impl App {
         let (current_column_id, current_position, card_title) = match self.model.card_by_id(card_id)
         {
             Some(card) => (card.column_id, card.position, card.title.clone()),
-            None => return,
+            None => return false,
         };
 
         let board_id = self.active_board().map(|b| b.id);
@@ -741,11 +747,11 @@ impl App {
         if let Err(e) = self.execute_command(cmd) {
             tracing::error!("Failed to restore card: {}", e);
             self.set_error(format!("Failed to restore card: {}", e));
-            return;
+            return false;
         }
-        self.reload_model();
 
         tracing::info!("Card '{}' restored to original position", card_title);
+        true
     }
 
     pub fn handle_delete_card_permanent(&mut self) {

--- a/crates/kanban-tui/tests/animation_tick_reload_tests.rs
+++ b/crates/kanban-tui/tests/animation_tick_reload_tests.rs
@@ -397,3 +397,147 @@ fn test_animation_tick_archive_and_delete_are_separate_undo_entries() {
         "a single undo must revert exactly one of the two batched user actions"
     );
 }
+
+#[test]
+fn test_animation_tick_archive_selection_skips_a_card_restored_in_the_same_tick() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let _a = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "a".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let b = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "b".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let c = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "c".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let d = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "d".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    // c is archived and about to be restored in the same tick that archives d.
+    app.ctx.archive_card(c.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    app.animation.archive_anchor = Some((column.id, d.position));
+    insert_completed_animation(&mut app, c.id, AnimationType::Restoring);
+    insert_completed_animation(&mut app, d.id, AnimationType::Archiving);
+
+    app.handle_animation_tick();
+
+    // After archiving d and compacting, the live set (ignoring the
+    // just-restored c, which the stale task list does not know about yet)
+    // is a(0) b(1). Selection must land on b, exactly as it would if the
+    // restore had not shared this tick.
+    assert_eq!(
+        app.get_selected_card_id(),
+        Some(b.id),
+        "selection after an archive must skip a card restored in the same tick, \
+         because the task lists that select_card_by_id searches are stale until \
+         the next prepare_frame"
+    );
+}
+
+#[test]
+fn test_animation_tick_archive_succeeds_delete_fails_reloads_once_and_still_selects() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let to_archive = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "First".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let next = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Second".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let to_delete = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "ToDelete".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(to_delete.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    app.animation.archive_anchor = Some((column.id, to_archive.position));
+    insert_completed_animation(&mut app, to_archive.id, AnimationType::Archiving);
+    insert_completed_animation(&mut app, to_delete.id, AnimationType::Deleting);
+
+    // Purge the to-be-deleted card from both collections so DeleteCard's
+    // capture_inverse (which runs before the forward delete, per command,
+    // inside the batch transaction) fails with not-found, failing the whole
+    // delete batch while the archive batch remains untouched.
+    app.ctx.data_store().delete_card(to_delete.id).unwrap();
+    app.ctx
+        .data_store()
+        .delete_archived_card(to_delete.id)
+        .unwrap();
+
+    let reads = wrap_backend(&mut app);
+    app.handle_animation_tick();
+
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        1,
+        "the archive batch succeeding must still cost exactly one reload, even though the delete batch failed"
+    );
+    assert!(
+        app.model.live_cards().iter().all(|c| c.id != to_archive.id),
+        "the archive batch must still have taken effect"
+    );
+    assert_eq!(
+        app.get_selected_card_id(),
+        Some(next.id),
+        "the selection fix-up must still run when the archive batch succeeds, regardless of the delete batch's outcome"
+    );
+}

--- a/crates/kanban-tui/tests/animation_tick_reload_tests.rs
+++ b/crates/kanban-tui/tests/animation_tick_reload_tests.rs
@@ -1,0 +1,399 @@
+mod helpers;
+
+use helpers::SnapshotCountingBackend;
+use kanban_domain::{AnimationType, CreateCardOptions, KanbanOperations};
+use kanban_tui::app::animation::CardAnimation;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::App;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+fn wrap_backend(app: &mut App) -> std::sync::Arc<std::sync::atomic::AtomicUsize> {
+    let (backend, reads) = SnapshotCountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+    reads
+}
+
+fn insert_completed_animation(app: &mut App, card_id: uuid::Uuid, animation_type: AnimationType) {
+    app.animation.animating.insert(
+        card_id,
+        CardAnimation {
+            animation_type,
+            start_time: Instant::now() - Duration::from_millis(200),
+        },
+    );
+}
+
+#[test]
+fn test_animation_tick_completing_archive_and_delete_reads_the_store_once() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let live_card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived_card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Archived".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(archived_card.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, live_card.id, AnimationType::Archiving);
+    insert_completed_animation(&mut app, archived_card.id, AnimationType::Deleting);
+
+    let reads = wrap_backend(&mut app);
+    app.handle_animation_tick();
+
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        1,
+        "a tick completing both an archive and a delete must reload exactly once"
+    );
+}
+
+#[test]
+fn test_animation_tick_with_only_archives_still_reads_once() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, card.id, AnimationType::Archiving);
+
+    let reads = wrap_backend(&mut app);
+    app.handle_animation_tick();
+
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        1,
+        "a tick completing only archives must still reload exactly once"
+    );
+}
+
+#[test]
+fn test_animation_tick_with_a_failed_batch_does_not_reload() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, card.id, AnimationType::Archiving);
+    // Delete the card out from under the pending archive animation so its
+    // batch fails at execution time (card not found).
+    app.ctx.data_store().delete_card(card.id).unwrap();
+
+    let selected_before = app.get_selected_card_id();
+    let reads = wrap_backend(&mut app);
+    app.handle_animation_tick();
+
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        0,
+        "a failed batch must not reload the model"
+    );
+    assert_eq!(
+        app.get_selected_card_id(),
+        selected_before,
+        "a failed batch must not change the selection"
+    );
+}
+
+#[test]
+fn test_animation_tick_archive_selects_the_following_card() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let first = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "First".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let second = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Second".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    app.animation.archive_anchor = Some((column.id, first.position));
+    insert_completed_animation(&mut app, first.id, AnimationType::Archiving);
+
+    app.handle_animation_tick();
+
+    assert_eq!(
+        app.get_selected_card_id(),
+        Some(second.id),
+        "after archiving the first card, selection must land on the following card"
+    );
+}
+
+#[test]
+fn test_animation_tick_restoring_many_cards_reads_the_store_once() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let mut cards = Vec::new();
+    for i in 0..5 {
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                format!("Card {i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        app.ctx.archive_card(card.id).unwrap();
+        cards.push(card);
+    }
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    for card in &cards {
+        insert_completed_animation(&mut app, card.id, AnimationType::Restoring);
+    }
+
+    let reads = wrap_backend(&mut app);
+    app.handle_animation_tick();
+
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        1,
+        "restoring several cards in one tick must reload exactly once, not once per card"
+    );
+}
+
+#[test]
+fn test_animation_tick_restoring_many_cards_puts_each_in_the_right_column() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column_a = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let column_b = app
+        .ctx
+        .create_column(board.id, "Doing".to_string(), Some(1))
+        .unwrap();
+    let card_a = app
+        .ctx
+        .create_card(
+            board.id,
+            column_a.id,
+            "A".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_b = app
+        .ctx
+        .create_card(
+            board.id,
+            column_b.id,
+            "B".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card_a.id).unwrap();
+    app.ctx.archive_card(card_b.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, card_a.id, AnimationType::Restoring);
+    insert_completed_animation(&mut app, card_b.id, AnimationType::Restoring);
+
+    app.handle_animation_tick();
+
+    let restored_a = app.model.card_by_id(card_a.id).expect("card A restored");
+    let restored_b = app.model.card_by_id(card_b.id).expect("card B restored");
+    assert_eq!(
+        restored_a.column_id, column_a.id,
+        "card A must be restored to its own column"
+    );
+    assert_eq!(
+        restored_b.column_id, column_b.id,
+        "card B must be restored to its own column"
+    );
+    assert_eq!(restored_a.position, card_a.position);
+    assert_eq!(restored_b.position, card_b.position);
+}
+
+#[test]
+fn test_animation_tick_mixed_archive_delete_restore_reads_the_store_once() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let live_card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let to_delete = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "ToDelete".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(to_delete.id).unwrap();
+    let to_restore = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "ToRestore".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(to_restore.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, live_card.id, AnimationType::Archiving);
+    insert_completed_animation(&mut app, to_delete.id, AnimationType::Deleting);
+    insert_completed_animation(&mut app, to_restore.id, AnimationType::Restoring);
+
+    let reads = wrap_backend(&mut app);
+    app.handle_animation_tick();
+
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        1,
+        "a tick completing all three animation kinds must still reload exactly once"
+    );
+}
+
+#[test]
+fn test_animation_tick_archive_and_delete_are_separate_undo_entries() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let live_card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived_card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Archived".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(archived_card.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, live_card.id, AnimationType::Archiving);
+    insert_completed_animation(&mut app, archived_card.id, AnimationType::Deleting);
+
+    app.handle_animation_tick();
+
+    // Both completed in the same tick: the live card was archived, and the
+    // already-archived card was permanently deleted.
+    assert!(app.model.live_cards().iter().all(|c| c.id != live_card.id));
+    assert!(app.model.card_by_id(archived_card.id).is_none());
+
+    // One `u` press must revert exactly one of those two user actions, not
+    // both at once.
+    app.undo().unwrap();
+
+    // Exactly one of the two user actions must have been reverted by the
+    // single undo, never both and never neither.
+    let archive_reverted = app.model.live_cards().iter().any(|c| c.id == live_card.id);
+    let delete_reverted = app.model.card_by_id(archived_card.id).is_some();
+    assert!(
+        archive_reverted ^ delete_reverted,
+        "a single undo must revert exactly one of the two batched user actions"
+    );
+}

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -214,6 +214,183 @@ impl KanbanBackend for CountingBackend {
     }
 }
 
+/// A `KanbanBackend` decorator that counts only `DataStore::snapshot` calls
+/// (what `App::reload_model` issues), delegating everything else verbatim to
+/// `inner`. Unlike `CountingBackend`, this does not count the incidental
+/// reads a command's own validation/execution performs, so it isolates "how
+/// many whole-model reloads happened" from "how many store reads happened".
+pub struct SnapshotCountingBackend {
+    inner: Arc<dyn KanbanBackend>,
+    snapshot_reads: Arc<AtomicUsize>,
+}
+
+impl SnapshotCountingBackend {
+    pub fn wrap(inner: Arc<dyn KanbanBackend>) -> (Arc<dyn KanbanBackend>, Arc<AtomicUsize>) {
+        let snapshot_reads = Arc::new(AtomicUsize::new(0));
+        let backend: Arc<dyn KanbanBackend> = Arc::new(Self {
+            inner,
+            snapshot_reads: snapshot_reads.clone(),
+        });
+        (backend, snapshot_reads)
+    }
+}
+
+impl DataStore for SnapshotCountingBackend {
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        self.inner.get_board(id)
+    }
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        self.inner.list_boards()
+    }
+    fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+        self.inner.upsert_board(board)
+    }
+    fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_board(id)
+    }
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        self.inner.get_column(id)
+    }
+    fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        self.inner.list_columns_by_board(board_id)
+    }
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.inner.list_all_columns()
+    }
+    fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+        self.inner.upsert_column(column)
+    }
+    fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_column(id)
+    }
+    fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_columns_by_board(board_id)
+    }
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        self.inner.get_card(id)
+    }
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+    fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_column(column_id)
+    }
+    fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_sprint(sprint_id)
+    }
+    fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+        self.inner.count_cards_in_column(column_id)
+    }
+    fn count_cards_in_column_excluding(
+        &self,
+        column_id: Uuid,
+        exclude_ids: &[Uuid],
+    ) -> KanbanResult<usize> {
+        self.inner
+            .count_cards_in_column_excluding(column_id, exclude_ids)
+    }
+    fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+        self.inner.upsert_card(card)
+    }
+    fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_card(id)
+    }
+    fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+        self.inner.delete_cards_by_columns(column_ids)
+    }
+    fn clear_sprint_from_cards(
+        &self,
+        sprint_id: Uuid,
+        cleared_at: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner.clear_sprint_from_cards(sprint_id, cleared_at)
+    }
+    fn get_archived_card(&self, id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        self.inner.get_archived_card(id)
+    }
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        self.inner.list_archived_cards()
+    }
+    fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+        self.inner.insert_archived_card(ac)
+    }
+    fn delete_archived_card(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_card(id)
+    }
+    fn get_archived_board(&self, id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        self.inner.get_archived_board(id)
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.inner.list_archived_boards()
+    }
+    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        self.inner.insert_archived_board(ab)
+    }
+    fn delete_archived_board(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_board(id)
+    }
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.unarchive_board(board_id)
+    }
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        self.inner.get_sprint(id)
+    }
+    fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        self.inner.list_sprints_by_board(board_id)
+    }
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.inner.list_all_sprints()
+    }
+    fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+        self.inner.upsert_sprint(sprint)
+    }
+    fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprint(id)
+    }
+    fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprints_by_board(board_id)
+    }
+    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+        self.inner.get_graph()
+    }
+    fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+        self.inner.set_graph(graph)
+    }
+    fn snapshot(&self) -> KanbanResult<Snapshot> {
+        self.snapshot_reads.fetch_add(1, Ordering::SeqCst);
+        self.inner.snapshot()
+    }
+    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+        self.inner.apply_snapshot(snapshot)
+    }
+}
+
+impl CommandStore for SnapshotCountingBackend {
+    fn append_batch(&self, batch: &CommandBatch) -> KanbanResult<u64> {
+        self.inner.append_batch(batch)
+    }
+    fn batch_count(&self) -> KanbanResult<u64> {
+        self.inner.batch_count()
+    }
+    fn load_batches(&self, offset: u64, limit: u64) -> KanbanResult<Vec<CommandBatch>> {
+        self.inner.load_batches(offset, limit)
+    }
+}
+
+impl KanbanBackend for SnapshotCountingBackend {
+    fn as_data_store(&self) -> &dyn DataStore {
+        self
+    }
+
+    fn remote_writes(&self) -> Option<&dyn RemoteWrites> {
+        self.inner.remote_writes()
+    }
+
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
+        self.inner.with_transaction(f)
+    }
+}
+
 pub fn render_widget_to_string<F>(width: u16, height: u16, draw_fn: F) -> String
 where
     F: FnOnce(&mut ratatui::Frame),

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -89,9 +89,31 @@ impl DataStore for CountingBackend {
         self.record();
         self.inner.list_cards_by_sprint(sprint_id)
     }
+    fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
+        self.record();
+        self.inner.list_cards_by_columns(column_ids)
+    }
+    fn list_cards_by_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        self.record();
+        self.inner
+            .list_cards_by_column_filtered(column_id, archived)
+    }
     fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
         self.record();
         self.inner.count_cards_in_column(column_id)
+    }
+    fn count_cards_in_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        self.record();
+        self.inner
+            .count_cards_in_column_filtered(column_id, archived)
     }
     fn count_cards_in_column_excluding(
         &self,
@@ -126,11 +148,23 @@ impl DataStore for CountingBackend {
         self.record();
         self.inner.list_archived_cards()
     }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.record();
+        self.inner.list_archived_cards_by_board(board_id)
+    }
     fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
         self.inner.insert_archived_card(ac)
     }
     fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
         self.inner.delete_archived_card(card_id)
+    }
+    fn clear_sprint_from_archived_cards(
+        &self,
+        sprint_id: Uuid,
+        cleared_at: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner
+            .clear_sprint_from_archived_cards(sprint_id, cleared_at)
     }
     fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
         self.record();
@@ -176,6 +210,10 @@ impl DataStore for CountingBackend {
     }
     fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
         self.inner.set_graph(graph)
+    }
+    fn modify_graph(&self, f: kanban_domain::GraphMutFn) -> KanbanResult<()> {
+        self.record();
+        self.inner.modify_graph(f)
     }
     fn snapshot(&self) -> KanbanResult<Snapshot> {
         self.record();
@@ -278,8 +316,27 @@ impl DataStore for SnapshotCountingBackend {
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
         self.inner.list_cards_by_sprint(sprint_id)
     }
+    fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_columns(column_ids)
+    }
+    fn list_cards_by_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        self.inner
+            .list_cards_by_column_filtered(column_id, archived)
+    }
     fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
         self.inner.count_cards_in_column(column_id)
+    }
+    fn count_cards_in_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        self.inner
+            .count_cards_in_column_filtered(column_id, archived)
     }
     fn count_cards_in_column_excluding(
         &self,
@@ -311,11 +368,22 @@ impl DataStore for SnapshotCountingBackend {
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         self.inner.list_archived_cards()
     }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.inner.list_archived_cards_by_board(board_id)
+    }
     fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
         self.inner.insert_archived_card(ac)
     }
     fn delete_archived_card(&self, id: Uuid) -> KanbanResult<()> {
         self.inner.delete_archived_card(id)
+    }
+    fn clear_sprint_from_archived_cards(
+        &self,
+        sprint_id: Uuid,
+        cleared_at: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner
+            .clear_sprint_from_archived_cards(sprint_id, cleared_at)
     }
     fn get_archived_board(&self, id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
         self.inner.get_archived_board(id)
@@ -355,6 +423,9 @@ impl DataStore for SnapshotCountingBackend {
     }
     fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
         self.inner.set_graph(graph)
+    }
+    fn modify_graph(&self, f: kanban_domain::GraphMutFn) -> KanbanResult<()> {
+        self.inner.modify_graph(f)
     }
     fn snapshot(&self) -> KanbanResult<Snapshot> {
         self.snapshot_reads.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
`handle_animation_tick` reloaded the whole view model once per branch: once for the archive batch, once for the delete batch, and once per card inside the restore loop. A tick completing five restore animations did five whole-store snapshots. This makes it one reload per tick regardless of how many animations of how many kinds complete.

Measured, counting `DataStore::snapshot` calls:

| scenario | before | after |
|---|---|---|
| archive + delete together | 2 | 1 |
| archive only | 1 | 1 |
| restoring 5 cards | 5 | 1 |
| archive + delete + restore | 3 | 1 |
| failed batch | 0 | 0 |

## What was deliberately not done

An earlier draft of the card suggested merging the archive and delete batches into a single `execute_commands_batch`. That is wrong and is not done here. Archiving a live card and permanently deleting an already-archived one are two distinct user actions from two different views; merging them would make one `u` press undo both. The batches stay separate, each restore stays its own command, and `test_animation_tick_archive_and_delete_are_separate_undo_entries` pins it with an XOR assertion that exactly one of the two reverts.

## Hoisting the reload out of the restore loop

This needed proving rather than assuming, since a wrong answer silently restores cards to wrong positions.

`RestoreCard::execute` writes one card, deletes one marker, and unarchives one graph node — never a sibling's position. The real hazard was the archive branch's `CompactColumnPositions`, which does renumber siblings: if it renumbered a card awaiting restore, the hoisted stale position would be written back wrong. It cannot, because both backends exclude archived rows from `list_cards_by_column` (in-memory filters on `is_card_archived`, SQLite uses the archived `NOT EXISTS` clause). Same-column double restores and deleted-column fallbacks were both checked and produce identical positions before and after.

## The regression this introduced, and the fix

Moving the restore loop ahead of the selection fix-up broke it. `select_card_after_deletion` picks a candidate from the model but resolves it through `select_card_by_id`, which searches the task lists — stale until the next `prepare_frame`. A card restored in the same tick is a valid model candidate but invisible to those lists, so the selection silently no-opped and the cursor kept a stale index.

Reproduced with column `a b c d`, `c` archived with a restore in flight, cursor on `d`, both animations completing together: develop selects `b`, the intermediate code selected `a`.

Fixed by having the restore loop collect the ids it restored and pass them as an exclusion set, so the candidate search sees exactly the set it saw before. `select_card_after_deletion` keeps its old signature and delegates with an empty exclusion list.

## Also

Both test decorators, `CountingBackend` and `SnapshotCountingBackend`, were hand-delegating a fixed method list and letting six defaulted `DataStore` methods fall through to trait defaults rather than to the inner backend — one of which errors for any non-`LiveOnly` filter. Both now delegate them.

Added a partial-failure test: archive succeeds, delete fails, exactly one reload, selection fix-up still runs. The behaviour was already correct but untested.

3657 tests pass, 10 in the animation-tick suite. Guard tests were verified to pass against the pre-change code, so they prove behaviour was preserved rather than merely describing the new behaviour.