### PR TITLE
KAN-1211 feat(domain): the Prefix entity and pure effective-prefix resolution

### DIFF
--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -22,6 +22,7 @@ pub mod field_update;
 pub mod filter;
 pub mod graph_operations;
 pub mod operations;
+pub mod prefix;
 pub mod query;
 pub mod search;
 pub mod snapshot;
@@ -57,6 +58,7 @@ pub use field_update::FieldUpdate;
 pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use operations::KanbanOperations;
+pub use prefix::{effective_prefixes, find_prefix_collisions, EffectivePrefix, Prefix, PrefixCollision, PrefixOwner};
 pub use query::{
     count_filtered_cards, filter_and_sort_boards, filter_and_sort_cards, resolve_board_sort,
     sprint::{

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -58,7 +58,10 @@ pub use field_update::FieldUpdate;
 pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use operations::KanbanOperations;
-pub use prefix::{effective_prefixes, find_prefix_collisions, EffectivePrefix, Prefix, PrefixCollision, PrefixOwner};
+pub use prefix::{
+    effective_prefixes, find_prefix_collisions, EffectivePrefix, Prefix, PrefixCollision,
+    PrefixOwner,
+};
 pub use query::{
     count_filtered_cards, filter_and_sort_boards, filter_and_sort_cards, resolve_board_sort,
     sprint::{

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -5,16 +5,32 @@ use crate::sprint::{Sprint, SprintId};
 
 /// A prefix that has been (or will be) allocated to a board or sprint.
 ///
-/// A card's prefix is fixed at creation and stored on the card itself — see
-/// [`Card`](crate::Card). `Prefix` is not consulted to resolve an EXISTING
+/// A card's prefix is fixed at creation and WILL be stored on the card itself.
+/// `Card` does not carry that field yet; it arrives with the allocation card.
+/// `Prefix` is not consulted to resolve an EXISTING
 /// card's identifier; it exists to allocate NEW cards and to detect
 /// collisions among the effective prefixes a workspace could hand out next.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Prefix {
+    /// Always normalised. Construct through [`Prefix::new`] rather than a
+    /// struct literal, or the normalisation contract is silently violated.
     pub name: String,
     pub owner: PrefixOwner,
     pub card_counter: u32,
     pub sprint_counter: u32,
+}
+
+impl Prefix {
+    /// Normalises `raw` so the stored name always satisfies the type's
+    /// contract. A struct literal bypasses this; prefer this constructor.
+    pub fn new(raw: &str, owner: PrefixOwner) -> Self {
+        Self {
+            name: Self::normalize(raw),
+            owner,
+            card_counter: 0,
+            sprint_counter: 0,
+        }
+    }
 }
 
 /// Which board or sprint a prefix is currently allocated to.
@@ -90,14 +106,19 @@ pub fn find_prefix_collisions(effective: &[EffectivePrefix]) -> Vec<PrefixCollis
             .push(entry.owner);
     }
 
-    by_name
+    // Sorted so a migration dry-run reports collisions in a stable order.
+    // `HashMap::into_iter` alone would reorder between runs and flake any
+    // test asserting on more than one collision.
+    let mut collisions: Vec<PrefixCollision> = by_name
         .into_iter()
         .filter(|(_, owners)| owners.len() > 1)
         .map(|(name, owners)| PrefixCollision {
             name: name.to_string(),
             owners,
         })
-        .collect()
+        .collect();
+    collisions.sort_by(|a, b| a.name.cmp(&b.name));
+    collisions
 }
 
 #[cfg(test)]
@@ -139,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn test_effective_prefixes_sprint_override_wins_over_board() {
+    fn test_effective_prefixes_sprint_override_yields_an_independent_entry() {
         let board = board_with_prefix(Some("KAN"));
         let board_id = board.id;
         let sprint = sprint_with_prefix(board_id, Some("AUTH"));
@@ -196,5 +217,20 @@ mod tests {
         let collisions = find_prefix_collisions(&effective);
 
         assert!(collisions.is_empty());
+    }
+
+    #[test]
+    fn test_sprint_without_an_override_emits_no_entry() {
+        // The `None` arm is what stops every sprint echoing its board's
+        // prefix into the set as a duplicate. Every other test uses `Some`.
+        let board = board_with_prefix(Some("kan"));
+        let sprint = sprint_with_prefix(board.id, None);
+        let effective = effective_prefixes(&[board], &[sprint], "task");
+        assert_eq!(
+            effective.len(),
+            1,
+            "a sprint with no override must contribute nothing"
+        );
+        assert_eq!(effective[0].name, "kan");
     }
 }

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -29,8 +29,8 @@ pub enum PrefixOwner {
 }
 
 impl Prefix {
-    pub fn normalize(_raw: &str) -> String {
-        unimplemented!()
+    pub fn normalize(raw: &str) -> String {
+        raw.to_lowercase()
     }
 }
 
@@ -50,11 +50,26 @@ pub struct EffectivePrefix {
 /// keeps its own entry even when one of its sprints overrides it — the two
 /// are independently effective for their respective new-card allocations.
 pub fn effective_prefixes(
-    _boards: &[Board],
-    _sprints: &[Sprint],
-    _default_card_prefix: &str,
+    boards: &[Board],
+    sprints: &[Sprint],
+    default_card_prefix: &str,
 ) -> Vec<EffectivePrefix> {
-    unimplemented!()
+    let mut result: Vec<EffectivePrefix> = boards
+        .iter()
+        .map(|board| EffectivePrefix {
+            name: Prefix::normalize(board.card_prefix.as_deref().unwrap_or(default_card_prefix)),
+            owner: PrefixOwner::Board(board.id),
+        })
+        .collect();
+
+    result.extend(sprints.iter().filter_map(|sprint| {
+        sprint.card_prefix.as_deref().map(|prefix| EffectivePrefix {
+            name: Prefix::normalize(prefix),
+            owner: PrefixOwner::Sprint(sprint.id),
+        })
+    }));
+
+    result
 }
 
 /// A normalised prefix that more than one owner would currently hand out.
@@ -66,8 +81,23 @@ pub struct PrefixCollision {
 
 /// Groups effective prefixes by their normalised name and reports every
 /// group with more than one owner.
-pub fn find_prefix_collisions(_effective: &[EffectivePrefix]) -> Vec<PrefixCollision> {
-    unimplemented!()
+pub fn find_prefix_collisions(effective: &[EffectivePrefix]) -> Vec<PrefixCollision> {
+    let mut by_name: HashMap<&str, Vec<PrefixOwner>> = HashMap::new();
+    for entry in effective {
+        by_name
+            .entry(entry.name.as_str())
+            .or_default()
+            .push(entry.owner);
+    }
+
+    by_name
+        .into_iter()
+        .filter(|(_, owners)| owners.len() > 1)
+        .map(|(name, owners)| PrefixCollision {
+            name: name.to_string(),
+            owners,
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -115,8 +145,11 @@ mod tests {
         let sprint = sprint_with_prefix(board_id, Some("AUTH"));
         let sprint_id = sprint.id;
 
-        let mut effective =
-            effective_prefixes(std::slice::from_ref(&board), std::slice::from_ref(&sprint), "task");
+        let mut effective = effective_prefixes(
+            std::slice::from_ref(&board),
+            std::slice::from_ref(&sprint),
+            "task",
+        );
         effective.sort_by(|a, b| a.name.cmp(&b.name));
 
         assert_eq!(
@@ -139,8 +172,7 @@ mod tests {
         let board_a = board_with_prefix(Some("KAN"));
         let board_b = board_with_prefix(Some("kan"));
 
-        let effective =
-            effective_prefixes(&[board_a.clone(), board_b.clone()], &[], "task");
+        let effective = effective_prefixes(&[board_a.clone(), board_b.clone()], &[], "task");
         let collisions = find_prefix_collisions(&effective);
 
         assert_eq!(collisions.len(), 1);
@@ -153,9 +185,7 @@ mod tests {
 
     #[test]
     fn test_find_prefix_collisions_empty_on_real_tracker_shape() {
-        let prefixes = [
-            "kan", "dev", "ops", "web", "doc", "sec",
-        ];
+        let prefixes = ["kan", "dev", "ops", "web", "doc", "sec"];
         let boards: Vec<Board> = prefixes
             .iter()
             .map(|p| board_with_prefix(Some(p)))

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -1,0 +1,170 @@
+use std::collections::HashMap;
+
+use crate::board::{Board, BoardId};
+use crate::sprint::{Sprint, SprintId};
+
+/// A prefix that has been (or will be) allocated to a board or sprint.
+///
+/// A card's prefix is fixed at creation and stored on the card itself — see
+/// [`Card`](crate::Card). `Prefix` is not consulted to resolve an EXISTING
+/// card's identifier; it exists to allocate NEW cards and to detect
+/// collisions among the effective prefixes a workspace could hand out next.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Prefix {
+    pub name: String,
+    pub owner: PrefixOwner,
+    pub card_counter: u32,
+    pub sprint_counter: u32,
+}
+
+/// Which board or sprint a prefix is currently allocated to.
+///
+/// This is an ALLOCATION record, not a resolution mechanism: it says which
+/// entity a prefix currently belongs to for handing out the next number, not
+/// which prefix an existing card carries. Existing cards never look this up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PrefixOwner {
+    Board(BoardId),
+    Sprint(SprintId),
+}
+
+impl Prefix {
+    pub fn normalize(_raw: &str) -> String {
+        unimplemented!()
+    }
+}
+
+/// A prefix that would currently be handed out to a NEW card created under
+/// the given owner. Used for collision detection and for stamping a new
+/// card's prefix at creation time — never for resolving an existing card's
+/// already-stored prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectivePrefix {
+    pub name: String,
+    pub owner: PrefixOwner,
+}
+
+/// Computes the set of prefixes a workspace would currently hand out to new
+/// cards: every board's effective prefix (falling back to
+/// `default_card_prefix` when unset), plus every sprint's override. A board
+/// keeps its own entry even when one of its sprints overrides it — the two
+/// are independently effective for their respective new-card allocations.
+pub fn effective_prefixes(
+    _boards: &[Board],
+    _sprints: &[Sprint],
+    _default_card_prefix: &str,
+) -> Vec<EffectivePrefix> {
+    unimplemented!()
+}
+
+/// A normalised prefix that more than one owner would currently hand out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrefixCollision {
+    pub name: String,
+    pub owners: Vec<PrefixOwner>,
+}
+
+/// Groups effective prefixes by their normalised name and reports every
+/// group with more than one owner.
+pub fn find_prefix_collisions(_effective: &[EffectivePrefix]) -> Vec<PrefixCollision> {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::board::Board;
+    use crate::sprint::Sprint;
+    use uuid::Uuid;
+
+    fn board_with_prefix(prefix: Option<&str>) -> Board {
+        Board::new("board".to_string(), prefix)
+    }
+
+    fn sprint_with_prefix(board_id: Uuid, prefix: Option<&str>) -> Sprint {
+        let mut sprint = Sprint::new(board_id, 1, None, None::<String>);
+        sprint.card_prefix = prefix.map(str::to_string);
+        sprint
+    }
+
+    #[test]
+    fn test_normalize_lowercases_prefix() {
+        assert_eq!(Prefix::normalize("KAN"), Prefix::normalize("kan"));
+        assert_eq!(Prefix::normalize("KAN"), "kan");
+    }
+
+    #[test]
+    fn test_effective_prefixes_defaults_none_board_prefix_to_config_default() {
+        let board = board_with_prefix(None);
+        let board_id = board.id;
+        let effective = effective_prefixes(std::slice::from_ref(&board), &[], "task");
+
+        assert_eq!(
+            effective,
+            vec![EffectivePrefix {
+                name: "task".to_string(),
+                owner: PrefixOwner::Board(board_id),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_effective_prefixes_sprint_override_wins_over_board() {
+        let board = board_with_prefix(Some("KAN"));
+        let board_id = board.id;
+        let sprint = sprint_with_prefix(board_id, Some("AUTH"));
+        let sprint_id = sprint.id;
+
+        let mut effective =
+            effective_prefixes(std::slice::from_ref(&board), std::slice::from_ref(&sprint), "task");
+        effective.sort_by(|a, b| a.name.cmp(&b.name));
+
+        assert_eq!(
+            effective,
+            vec![
+                EffectivePrefix {
+                    name: "auth".to_string(),
+                    owner: PrefixOwner::Sprint(sprint_id),
+                },
+                EffectivePrefix {
+                    name: "kan".to_string(),
+                    owner: PrefixOwner::Board(board_id),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_prefix_collisions_detects_case_insensitive_duplicate() {
+        let board_a = board_with_prefix(Some("KAN"));
+        let board_b = board_with_prefix(Some("kan"));
+
+        let effective =
+            effective_prefixes(&[board_a.clone(), board_b.clone()], &[], "task");
+        let collisions = find_prefix_collisions(&effective);
+
+        assert_eq!(collisions.len(), 1);
+        let collision = &collisions[0];
+        assert_eq!(collision.name, "kan");
+        assert_eq!(collision.owners.len(), 2);
+        assert!(collision.owners.contains(&PrefixOwner::Board(board_a.id)));
+        assert!(collision.owners.contains(&PrefixOwner::Board(board_b.id)));
+    }
+
+    #[test]
+    fn test_find_prefix_collisions_empty_on_real_tracker_shape() {
+        let prefixes = [
+            "kan", "dev", "ops", "web", "doc", "sec",
+        ];
+        let boards: Vec<Board> = prefixes
+            .iter()
+            .map(|p| board_with_prefix(Some(p)))
+            .collect();
+        let sprint = sprint_with_prefix(boards[0].id, Some("auth-sprint"));
+
+        let effective = effective_prefixes(&boards, std::slice::from_ref(&sprint), "task");
+        let collisions = find_prefix_collisions(&effective);
+
+        assert!(collisions.is_empty());
+    }
+}


### PR DESCRIPTION
First card of the O(1) identifier-resolution epic. Adds the `Prefix` domain entity and the pure helpers that detect prefix collisions, with no I/O and no storage work — the SQLite table, the JSON envelope, service wiring and the resolver rewrite all land in later cards.

## Why this exists

Card identifiers collide today. Two boards created without an explicit `--card-prefix` both inherit the configured default, so a card on each ends up as `KAN-1`. Reproduced against the real binary:

```
kanban f.json board create --name B --with-default-columns
kanban f.json board create --name C --with-default-columns
# a card on each board -> both are KAN-1
```

That is why `find_cards_by_identifier` returns a `Vec` and why an `Ambiguous` error code exists. Making the prefix a first-class entity with a unique key makes an identifier globally unique, which is what lets a later card resolve one in a single indexed lookup instead of loading every card in the workspace.

## What is in this card

`Prefix`, `PrefixOwner`, `EffectivePrefix`, and the pure `effective_prefixes` / `find_prefix_collisions` / `normalize` helpers, in a new `crates/kanban-domain/src/prefix.rs`.

Case-insensitivity is load-bearing rather than cosmetic. `search/mod.rs:260` already compares lowercased, so `KAN` and `kan` resolve identically today; a case-sensitive key would hold both as distinct rows while the resolver treated them as one, and the constraint would look enforced without being so. The JSON backend has no collation, so normalisation happens on the domain side.

## The distinction the doc comments carry

A card's prefix is **stored** on the card, fixed at creation. This entity is never consulted to resolve an existing card's identifier — it records which prefix an owner currently allocates from, for stamping *new* cards and for detecting collisions.

That matters because changing a board's prefix must not retroactively rename its existing cards. `PrefixOwner`'s doc states it is an allocation record, not a resolution mechanism, so the next card in the chain does not re-derive the model this replaces.

## Not in this card

`Board::effective_card_prefix` and `Sprint::effective_card_prefix` are deliberately untouched — `Board.card_prefix` stays `Option<String>` until the storage cards land. Nothing consumes the new type yet.

## Verification

3662 workspace tests pass. Clippy `-D warnings` and fmt clean. Red and green are separate commits; the red run confirmed all five tests failing on `unimplemented!()` bodies before the implementation existed.

Collision detection is proven for both shapes that matter: a board prefix colliding with a sprint override, and two case-variant spellings grouping into a single collision carrying both owners.