### PR TITLE
KAN-1207 KAN-1217 perf(service,cli): resolve archived-card markers by id instead of scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,6 +1458,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "kanban-backend",
+ "kanban-backend-memory",
  "kanban-core",
  "kanban-domain",
  "kanban-persistence",

--- a/crates/kanban-cli/Cargo.toml
+++ b/crates/kanban-cli/Cargo.toml
@@ -47,6 +47,7 @@ serde_json.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
+kanban-backend-memory = { path = "../kanban-backend-memory" }
 kanban-persistence-json = { path = "../kanban-persistence-json" }
 kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", features = ["test-helpers"] }
 tempfile.workspace = true

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -25,6 +25,10 @@ impl CliContext {
         self.inner.card_archived_at(id)
     }
 
+    pub fn get_archived_card(&self, id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        self.inner.get_archived_card(id)
+    }
+
     pub fn board_archived_at(
         &self,
         id: Uuid,

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -51,6 +51,11 @@ impl CliContext {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn from_context(inner: KanbanContext) -> Self {
+        Self { inner }
+    }
+
     pub async fn save(&self) -> KanbanResult<()> {
         self.inner.save().await
     }

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -435,3 +435,289 @@ pub(crate) fn parse_status(s: &str) -> Result<CardStatus, String> {
         )),
     }
 }
+
+#[cfg(test)]
+mod card_board_id_tests {
+    use super::card_board_id;
+    use crate::context::CliContext;
+    use async_trait::async_trait;
+    use kanban_backend::{KanbanBackend, TransactionFn};
+    use kanban_backend_memory::InMemoryStore;
+    use kanban_domain::command_store::CommandStore;
+    use kanban_domain::data_store::DataStore;
+    use kanban_domain::{
+        ArchivedBoard, ArchivedCard, Board, Card, Column, CommandBatch, DependencyGraph,
+        KanbanOperations, KanbanResult, Snapshot, Sprint,
+    };
+    use kanban_service::{AppConfig, KanbanContext};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    #[derive(Default)]
+    struct CountingBackend {
+        inner: InMemoryStore,
+        list_archived_cards_calls: AtomicUsize,
+    }
+
+    impl CountingBackend {
+        fn list_archived_cards_call_count(&self) -> usize {
+            self.list_archived_cards_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl DataStore for CountingBackend {
+        fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+            self.inner.get_board(id)
+        }
+        fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+            self.inner.list_boards()
+        }
+        fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+            self.inner.upsert_board(board)
+        }
+        fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_board(id)
+        }
+        fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+            self.inner.get_column(id)
+        }
+        fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+            self.inner.list_columns_by_board(board_id)
+        }
+        fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+            self.inner.list_all_columns()
+        }
+        fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+            self.inner.upsert_column(column)
+        }
+        fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_column(id)
+        }
+        fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_columns_by_board(board_id)
+        }
+        fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+            self.inner.get_card(id)
+        }
+        fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+            self.inner.list_all_cards()
+        }
+        fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+            self.inner.list_cards_by_column(column_id)
+        }
+        fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+            self.inner.list_cards_by_sprint(sprint_id)
+        }
+        fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+            self.inner.count_cards_in_column(column_id)
+        }
+        fn count_cards_in_column_excluding(
+            &self,
+            column_id: Uuid,
+            exclude: &[Uuid],
+        ) -> KanbanResult<usize> {
+            self.inner
+                .count_cards_in_column_excluding(column_id, exclude)
+        }
+        fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+            self.inner.upsert_card(card)
+        }
+        fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_card(id)
+        }
+        fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+            self.inner.delete_cards_by_columns(column_ids)
+        }
+        fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
+            self.inner.list_cards_by_columns(column_ids)
+        }
+        fn list_cards_by_column_filtered(
+            &self,
+            column_id: Uuid,
+            archived: kanban_domain::ArchivedFilter,
+        ) -> KanbanResult<Vec<Card>> {
+            self.inner
+                .list_cards_by_column_filtered(column_id, archived)
+        }
+        fn count_cards_in_column_filtered(
+            &self,
+            column_id: Uuid,
+            archived: kanban_domain::ArchivedFilter,
+        ) -> KanbanResult<usize> {
+            self.inner
+                .count_cards_in_column_filtered(column_id, archived)
+        }
+        fn clear_sprint_from_cards(
+            &self,
+            sprint_id: Uuid,
+            timestamp: chrono::DateTime<chrono::Utc>,
+        ) -> KanbanResult<()> {
+            self.inner.clear_sprint_from_cards(sprint_id, timestamp)
+        }
+        fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+            self.inner.get_archived_card(card_id)
+        }
+        fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+            self.list_archived_cards_calls
+                .fetch_add(1, Ordering::SeqCst);
+            self.inner.list_archived_cards()
+        }
+        fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+            self.inner.insert_archived_card(ac)
+        }
+        fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_archived_card(card_id)
+        }
+        fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+            self.inner.list_archived_cards_by_board(board_id)
+        }
+        fn clear_sprint_from_archived_cards(
+            &self,
+            sprint_id: Uuid,
+            timestamp: chrono::DateTime<chrono::Utc>,
+        ) -> KanbanResult<()> {
+            self.inner
+                .clear_sprint_from_archived_cards(sprint_id, timestamp)
+        }
+        fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+            self.inner.get_archived_board(board_id)
+        }
+        fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+            self.inner.list_archived_boards()
+        }
+        fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+            self.inner.insert_archived_board(ab)
+        }
+        fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_archived_board(board_id)
+        }
+        fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.inner.unarchive_board(board_id)
+        }
+        fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+            self.inner.get_sprint(id)
+        }
+        fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+            self.inner.list_sprints_by_board(board_id)
+        }
+        fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+            self.inner.list_all_sprints()
+        }
+        fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+            self.inner.upsert_sprint(sprint)
+        }
+        fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_sprint(id)
+        }
+        fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_sprints_by_board(board_id)
+        }
+        fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+            self.inner.get_graph()
+        }
+        fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+            self.inner.set_graph(graph)
+        }
+        fn snapshot(&self) -> KanbanResult<Snapshot> {
+            self.inner.snapshot()
+        }
+        fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+            self.inner.apply_snapshot(snapshot)
+        }
+    }
+
+    impl CommandStore for CountingBackend {
+        fn append_batch(&self, batch: &CommandBatch) -> KanbanResult<u64> {
+            self.inner.append_batch(batch)
+        }
+        fn batch_count(&self) -> KanbanResult<u64> {
+            self.inner.batch_count()
+        }
+        fn load_batches(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
+            self.inner.load_batches(from, to)
+        }
+    }
+
+    #[async_trait]
+    impl KanbanBackend for CountingBackend {
+        fn as_data_store(&self) -> &dyn DataStore {
+            self
+        }
+        fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
+            self.inner.with_transaction(f)
+        }
+    }
+
+    fn counting_cli_context() -> (Arc<CountingBackend>, CliContext) {
+        let backend = Arc::new(CountingBackend::default());
+        let ctx = KanbanContext::open_deferred(backend.clone(), AppConfig::default());
+        (backend, CliContext::from_context(ctx))
+    }
+
+    fn make_card(ctx: &mut CliContext, board_id: Uuid, column_id: Uuid, title: &str) -> Card {
+        ctx.create_card(
+            board_id,
+            column_id,
+            title.to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_card_board_id_zero_list_archived_cards_calls_for_archived_card() {
+        let (backend, mut ctx) = counting_cli_context();
+        let board = ctx.create_board("Board".into(), None).unwrap();
+        let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+        let card = make_card(&mut ctx, board.id, col.id, "Card");
+        ctx.archive_card(card.id).unwrap();
+
+        backend
+            .list_archived_cards_calls
+            .store(0, Ordering::SeqCst);
+
+        let resolved = card_board_id(&ctx, card.id).unwrap();
+
+        assert_eq!(resolved, board.id);
+        assert_eq!(
+            backend.list_archived_cards_call_count(),
+            0,
+            "card_board_id should perform a by-id lookup, not a full scan"
+        );
+    }
+
+    #[test]
+    fn test_card_board_id_returns_correct_board_for_live_card() {
+        let (_backend, mut ctx) = counting_cli_context();
+        let board = ctx.create_board("Board".into(), None).unwrap();
+        let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+        let card = make_card(&mut ctx, board.id, col.id, "Card");
+
+        let resolved = card_board_id(&ctx, card.id).unwrap();
+
+        assert_eq!(resolved, board.id);
+    }
+
+    #[test]
+    fn test_card_board_id_returns_correct_board_for_archived_card() {
+        let (_backend, mut ctx) = counting_cli_context();
+        let board = ctx.create_board("Board".into(), None).unwrap();
+        let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+        let card = make_card(&mut ctx, board.id, col.id, "Card");
+        ctx.archive_card(card.id).unwrap();
+
+        let resolved = card_board_id(&ctx, card.id).unwrap();
+
+        assert_eq!(resolved, board.id);
+    }
+
+    #[test]
+    fn test_card_board_id_returns_error_for_missing_card() {
+        let (_backend, ctx) = counting_cli_context();
+
+        let resolved = card_board_id(&ctx, Uuid::new_v4());
+
+        assert!(resolved.is_err());
+    }
+}

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -668,9 +668,7 @@ mod card_board_id_tests {
         let card = make_card(&mut ctx, board.id, col.id, "Card");
         ctx.archive_card(card.id).unwrap();
 
-        backend
-            .list_archived_cards_calls
-            .store(0, Ordering::SeqCst);
+        backend.list_archived_cards_calls.store(0, Ordering::SeqCst);
 
         let resolved = card_board_id(&ctx, card.id).unwrap();
 

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -260,12 +260,7 @@ fn card_board_id(ctx: &CliContext, card_id: Uuid) -> Result<Uuid, String> {
     // Reference-marker model: an archived card carries its board on the marker
     // (first-class `board_id`), which survives a deleted column. Prefer it; else
     // resolve the LIVE card's column -> board (`get_card` is unfiltered).
-    if let Some(marker) = ctx
-        .list_archived_cards()
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .find(|a| a.entity_id == card_id)
-    {
+    if let Some(marker) = ctx.get_archived_card(card_id).map_err(|e| e.to_string())? {
         return Ok(marker.context.board_id);
     }
     let card = ctx

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -1,8 +1,8 @@
 use super::KanbanContext;
 use kanban_domain::commands::{CardCommand, Command};
 use kanban_domain::{
-    ArchivedCard, Card, CardListFilter, CardSummary, CardUpdate, Column, CreateCardOptions,
-    DomainError, FieldUpdate, KanbanError, KanbanResult, NewCard, Sprint,
+    ArchivedCard, ArchivedEntity, Card, CardListFilter, CardSummary, CardUpdate, Column,
+    CreateCardOptions, DomainError, FieldUpdate, KanbanError, KanbanResult, NewCard, Sprint,
 };
 use uuid::Uuid;
 
@@ -25,8 +25,10 @@ impl KanbanContext {
         &self,
         id: Uuid,
     ) -> KanbanResult<Option<chrono::DateTime<chrono::Utc>>> {
-        let (_ids, at_by_id) = self.archived_card_index()?;
-        Ok(at_by_id.get(&id).copied())
+        Ok(self
+            .backend
+            .get_archived_card(id)?
+            .map(|ac| ac.archived_at()))
     }
 
     /// Create a card from a full `NewCard` spec plus an optional client-supplied

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -31,6 +31,10 @@ impl KanbanContext {
             .map(|ac| ac.archived_at()))
     }
 
+    pub fn get_archived_card(&self, id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        self.backend.get_archived_card(id)
+    }
+
     /// Create a card from a full `NewCard` spec plus an optional client-supplied
     /// id (idempotent PUT-create). The owning board is DERIVED from
     /// `column.board_id` (no `board_id` param). Validates the dual FK: the

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -75,7 +75,8 @@ impl DataStore for CountingBackend {
         column_id: Uuid,
         exclude: &[Uuid],
     ) -> KanbanResult<usize> {
-        self.inner.count_cards_in_column_excluding(column_id, exclude)
+        self.inner
+            .count_cards_in_column_excluding(column_id, exclude)
     }
     fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
         self.inner.list_cards_by_columns(column_ids)
@@ -85,14 +86,16 @@ impl DataStore for CountingBackend {
         column_id: Uuid,
         archived: kanban_domain::ArchivedFilter,
     ) -> KanbanResult<Vec<Card>> {
-        self.inner.list_cards_by_column_filtered(column_id, archived)
+        self.inner
+            .list_cards_by_column_filtered(column_id, archived)
     }
     fn count_cards_in_column_filtered(
         &self,
         column_id: Uuid,
         archived: kanban_domain::ArchivedFilter,
     ) -> KanbanResult<usize> {
-        self.inner.count_cards_in_column_filtered(column_id, archived)
+        self.inner
+            .count_cards_in_column_filtered(column_id, archived)
     }
     fn upsert_card(&self, card: Card) -> KanbanResult<()> {
         self.inner.upsert_card(card)
@@ -114,7 +117,8 @@ impl DataStore for CountingBackend {
         self.inner.get_archived_card(card_id)
     }
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
-        self.list_archived_cards_calls.fetch_add(1, Ordering::SeqCst);
+        self.list_archived_cards_calls
+            .fetch_add(1, Ordering::SeqCst);
         self.inner.list_archived_cards()
     }
     fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
@@ -134,7 +138,10 @@ impl DataStore for CountingBackend {
         self.inner
             .clear_sprint_from_archived_cards(sprint_id, timestamp)
     }
-    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<kanban_domain::ArchivedBoard>> {
+    fn get_archived_board(
+        &self,
+        board_id: Uuid,
+    ) -> KanbanResult<Option<kanban_domain::ArchivedBoard>> {
         self.inner.get_archived_board(board_id)
     }
     fn list_archived_boards(&self) -> KanbanResult<Vec<kanban_domain::ArchivedBoard>> {
@@ -230,9 +237,7 @@ fn test_card_get_by_id_zero_list_archived_cards_calls() {
         .unwrap();
     ctx.archive_card(card.id).unwrap();
 
-    backend
-        .list_archived_cards_calls
-        .store(0, Ordering::SeqCst);
+    backend.list_archived_cards_calls.store(0, Ordering::SeqCst);
 
     let archived_at = ctx.card_archived_at(card.id).unwrap();
 
@@ -295,9 +300,7 @@ fn test_filter_cards_still_uses_archived_card_index() {
     ctx.archive_card(card_a.id).unwrap();
     ctx.archive_card(card_b.id).unwrap();
 
-    backend
-        .list_archived_cards_calls
-        .store(0, Ordering::SeqCst);
+    backend.list_archived_cards_calls.store(0, Ordering::SeqCst);
 
     let cards = ctx
         .list_cards(kanban_domain::CardListFilter {

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -1,0 +1,316 @@
+use async_trait::async_trait;
+use kanban_backend::{KanbanBackend, TransactionFn};
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::command_store::CommandStore;
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{
+    ArchivedCard, Board, Card, Column, CommandBatch, DependencyGraph, KanbanOperations,
+    KanbanResult, Snapshot, Sprint,
+};
+use kanban_service::{AppConfig, KanbanContext};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Default)]
+struct CountingBackend {
+    inner: InMemoryStore,
+    list_archived_cards_calls: AtomicUsize,
+}
+
+impl CountingBackend {
+    fn list_archived_cards_call_count(&self) -> usize {
+        self.list_archived_cards_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl DataStore for CountingBackend {
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        self.inner.get_board(id)
+    }
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        self.inner.list_boards()
+    }
+    fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+        self.inner.upsert_board(board)
+    }
+    fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_board(id)
+    }
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        self.inner.get_column(id)
+    }
+    fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        self.inner.list_columns_by_board(board_id)
+    }
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.inner.list_all_columns()
+    }
+    fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+        self.inner.upsert_column(column)
+    }
+    fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_column(id)
+    }
+    fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_columns_by_board(board_id)
+    }
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        self.inner.get_card(id)
+    }
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+    fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_column(column_id)
+    }
+    fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_sprint(sprint_id)
+    }
+    fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+        self.inner.count_cards_in_column(column_id)
+    }
+    fn count_cards_in_column_excluding(
+        &self,
+        column_id: Uuid,
+        exclude: &[Uuid],
+    ) -> KanbanResult<usize> {
+        self.inner.count_cards_in_column_excluding(column_id, exclude)
+    }
+    fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_columns(column_ids)
+    }
+    fn list_cards_by_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_column_filtered(column_id, archived)
+    }
+    fn count_cards_in_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        self.inner.count_cards_in_column_filtered(column_id, archived)
+    }
+    fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+        self.inner.upsert_card(card)
+    }
+    fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_card(id)
+    }
+    fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+        self.inner.delete_cards_by_columns(column_ids)
+    }
+    fn clear_sprint_from_cards(
+        &self,
+        sprint_id: Uuid,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner.clear_sprint_from_cards(sprint_id, timestamp)
+    }
+    fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        self.inner.get_archived_card(card_id)
+    }
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        self.list_archived_cards_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.list_archived_cards()
+    }
+    fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+        self.inner.insert_archived_card(ac)
+    }
+    fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_card(card_id)
+    }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.inner.list_archived_cards_by_board(board_id)
+    }
+    fn clear_sprint_from_archived_cards(
+        &self,
+        sprint_id: Uuid,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner
+            .clear_sprint_from_archived_cards(sprint_id, timestamp)
+    }
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<kanban_domain::ArchivedBoard>> {
+        self.inner.get_archived_board(board_id)
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<kanban_domain::ArchivedBoard>> {
+        self.inner.list_archived_boards()
+    }
+    fn insert_archived_board(&self, ab: kanban_domain::ArchivedBoard) -> KanbanResult<()> {
+        self.inner.insert_archived_board(ab)
+    }
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_board(board_id)
+    }
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.unarchive_board(board_id)
+    }
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        self.inner.get_sprint(id)
+    }
+    fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        self.inner.list_sprints_by_board(board_id)
+    }
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.inner.list_all_sprints()
+    }
+    fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+        self.inner.upsert_sprint(sprint)
+    }
+    fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprint(id)
+    }
+    fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprints_by_board(board_id)
+    }
+    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+        self.inner.get_graph()
+    }
+    fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+        self.inner.set_graph(graph)
+    }
+    fn snapshot(&self) -> KanbanResult<Snapshot> {
+        self.inner.snapshot()
+    }
+    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+        self.inner.apply_snapshot(snapshot)
+    }
+}
+
+impl CommandStore for CountingBackend {
+    fn append_batch(&self, batch: &CommandBatch) -> KanbanResult<u64> {
+        self.inner.append_batch(batch)
+    }
+    fn batch_count(&self) -> KanbanResult<u64> {
+        self.inner.batch_count()
+    }
+    fn load_batches(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
+        self.inner.load_batches(from, to)
+    }
+}
+
+#[async_trait]
+impl KanbanBackend for CountingBackend {
+    fn as_data_store(&self) -> &dyn DataStore {
+        self
+    }
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
+        self.inner.with_transaction(f)
+    }
+}
+
+fn counting_context() -> (Arc<CountingBackend>, KanbanContext) {
+    let backend = Arc::new(CountingBackend::default());
+    let ctx = KanbanContext::open_deferred(backend.clone(), AppConfig::default());
+    (backend, ctx)
+}
+
+#[test]
+fn test_card_get_by_id_zero_list_archived_cards_calls() {
+    let (backend, mut ctx) = counting_context();
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = ctx
+        .create_card_from_spec(
+            None,
+            kanban_domain::NewCard {
+                column_id: col.id,
+                title: "Card".into(),
+                description: None,
+                priority: kanban_domain::CardPriority::Medium,
+                due_date: None,
+                points: None,
+                sprint_id: None,
+            },
+        )
+        .unwrap();
+    ctx.archive_card(card.id).unwrap();
+
+    backend
+        .list_archived_cards_calls
+        .store(0, Ordering::SeqCst);
+
+    let archived_at = ctx.card_archived_at(card.id).unwrap();
+
+    assert!(archived_at.is_some());
+    assert_eq!(
+        backend.list_archived_cards_call_count(),
+        0,
+        "card_archived_at should perform a by-id lookup, not a full scan"
+    );
+}
+
+fn make_card(ctx: &mut KanbanContext, col_id: Uuid, title: &str) -> Card {
+    ctx.create_card_from_spec(
+        None,
+        kanban_domain::NewCard {
+            column_id: col_id,
+            title: title.to_string(),
+            description: None,
+            priority: kanban_domain::CardPriority::Medium,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_card_get_by_id_still_stamps_archived_at_for_archived_card() {
+    let (_backend, mut ctx) = counting_context();
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = make_card(&mut ctx, col.id, "Card");
+    ctx.archive_card(card.id).unwrap();
+
+    let archived_at = ctx.card_archived_at(card.id).unwrap();
+
+    assert!(archived_at.is_some());
+}
+
+#[test]
+fn test_card_get_by_id_leaves_live_card_archived_at_none() {
+    let (_backend, mut ctx) = counting_context();
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = make_card(&mut ctx, col.id, "Card");
+
+    let archived_at = ctx.card_archived_at(card.id).unwrap();
+
+    assert_eq!(archived_at, None);
+}
+
+#[test]
+fn test_filter_cards_still_uses_archived_card_index() {
+    let (backend, mut ctx) = counting_context();
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card_a = make_card(&mut ctx, col.id, "A");
+    let card_b = make_card(&mut ctx, col.id, "B");
+    ctx.archive_card(card_a.id).unwrap();
+    ctx.archive_card(card_b.id).unwrap();
+
+    backend
+        .list_archived_cards_calls
+        .store(0, Ordering::SeqCst);
+
+    let cards = ctx
+        .list_cards(kanban_domain::CardListFilter {
+            board_id: Some(board.id),
+            archived: kanban_domain::ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(cards.len(), 2);
+    assert_eq!(
+        backend.list_archived_cards_call_count(),
+        2,
+        "list_cards's collection-shaped path keeps building the archived index the same way it did before this change"
+    );
+}


### PR DESCRIPTION
Two small cards from the O(1) identifier-resolution epic, shipped together because they are the same defect at two layers and review better side by side.

Both replace a full archived-cards scan with a single by-id lookup.

## The defect

`card_archived_at` in `kanban-service` and `card_board_id` in `kanban-cli` each loaded every archived card in the workspace to answer a question about one card. On a tracker with a few hundred archived rows that is the cheapest possible operation done the most expensive possible way, and it runs on the common `card get` path.

## What changed

**`kanban-service`** — `card_archived_at` now calls `backend.get_archived_card(id)` instead of building the whole `archived_card_index()`. `filter_cards`'s collection-shaped path is deliberately untouched; it genuinely needs the collection.

**`kanban-cli`** — `card_board_id` now calls `ctx.get_archived_card(card_id)` instead of `list_archived_cards().into_iter().find(...)`, via a new `CliContext::get_archived_card` pass-through.

The CLI's marker-preference order — prefer the archived marker's `board_id`, else fall back to the live card's column — is preserved verbatim. That logic looks redundant next to the MCP equivalent, but MCP does no archived-marker resolution at all, so copying it would have silently dropped archived-card handling from the CLI.

## Verification

Both changes are proven by counting backends that record read calls, not by inspection. Each card's test asserts the `list_archived_cards` count drops to zero for a by-id lookup, and each was confirmed red before the fix.

One assertion was corrected during implementation: the pre-existing `filter_cards`/`list_cards_impl` path calls `list_archived_cards` twice, not once as first assumed. The test was written against observed behaviour rather than the guess.

The CLI test needed a `#[cfg(test)]` constructor (`CliContext::from_context`) to inject a counting backend, because the `assert_cmd` integration tier cannot observe internal call counts — an integration test would have passed whether or not the scan was removed.

3665 workspace tests pass. Clippy `-D warnings` and fmt clean. Red and green are separate commits per card.

## Scope

These two are independent of the epic's prefix work, which is why they ship first. Nothing here touches prefix resolution, card numbering, or any storage schema.