### PR TITLE
KAN-1210 feat(domain,persistence-sqlite,persistence-json): defaulted DataStore primitives for owner-scoped card lookup

### DIFF
--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -25,6 +25,37 @@ pub trait DataStore: Send + Sync {
     fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>>;
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>>;
     fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize>;
+
+    /// Find the card numbered `card_number` directly owned by `board_id`
+    /// (via `Card.board_id`, not via column membership). Returns `None`
+    /// when no live card matches. Default is an honest linear scan every
+    /// backend can answer; SQL-backed implementations should override with
+    /// an indexed single-row query.
+    fn get_card_by_board_and_number(
+        &self,
+        board_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        Ok(self
+            .list_all_cards()?
+            .into_iter()
+            .find(|c| c.board_id == board_id && c.card_number == card_number))
+    }
+
+    /// Find the card numbered `card_number` directly owned by `sprint_id`.
+    /// Returns `None` when no live card matches. Default delegates to
+    /// [`list_cards_by_sprint`](Self::list_cards_by_sprint); SQL-backed
+    /// implementations should override with an indexed single-row query.
+    fn get_card_by_sprint_and_number(
+        &self,
+        sprint_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        Ok(self
+            .list_cards_by_sprint(sprint_id)?
+            .into_iter()
+            .find(|c| c.card_number == card_number))
+    }
     fn count_cards_in_column_excluding(
         &self,
         column_id: Uuid,

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -209,6 +209,20 @@ impl DataStore for JsonDataStore {
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
         self.with_read(|s| s.list_cards_by_sprint(sprint_id))
     }
+    fn get_card_by_board_and_number(
+        &self,
+        board_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        self.with_read(|s| s.get_card_by_board_and_number(board_id, card_number))
+    }
+    fn get_card_by_sprint_and_number(
+        &self,
+        sprint_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        self.with_read(|s| s.get_card_by_sprint_and_number(sprint_id, card_number))
+    }
     fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
         self.with_read(|s| s.count_cards_in_column(column_id))
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -94,6 +94,21 @@ impl DataStore for SqliteBackend {
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
         self.db.list_cards_by_sprint(sprint_id)
     }
+    fn get_card_by_board_and_number(
+        &self,
+        board_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        self.db.get_card_by_board_and_number(board_id, card_number)
+    }
+    fn get_card_by_sprint_and_number(
+        &self,
+        sprint_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        self.db
+            .get_card_by_sprint_and_number(sprint_id, card_number)
+    }
     fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
         self.db.count_cards_in_column(column_id)
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -199,6 +199,30 @@ impl DataStore for SqliteStore {
         run(self.fetch_cards_with_filter("AND sprint_id = ?", vec![sprint_id.to_string()]))
     }
 
+    fn get_card_by_board_and_number(
+        &self,
+        board_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        let cards = run(self.fetch_cards_with_filter(
+            "AND board_id = ? AND card_number = ?",
+            vec![board_id.to_string(), card_number.to_string()],
+        ))?;
+        Ok(cards.into_iter().next())
+    }
+
+    fn get_card_by_sprint_and_number(
+        &self,
+        sprint_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        let cards = run(self.fetch_cards_with_filter(
+            "AND sprint_id = ? AND card_number = ?",
+            vec![sprint_id.to_string(), card_number.to_string()],
+        ))?;
+        Ok(cards.into_iter().next())
+    }
+
     /// 3-state archived-aware column read. Overrides the loud-floor default so
     /// SQLite honours `ArchivedOnly`/`Include`; `LiveOnly` stays byte-identical
     /// to `list_cards_by_column` (same `NOT EXISTS` base clause).

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
@@ -320,6 +320,12 @@ fn test_get_card_by_sprint_and_number_returns_matching_card() {
 /// `EXPLAIN QUERY PLAN` on the override's exact query must report an indexed
 /// `SEARCH`, not an unindexed full-table `SCAN`.
 #[test]
+// Matches any board-leading index name, not one specific index. The planner
+// picks `idx_cards_board_id` or the composite `idx_cards_board_number`
+// depending on which exist, and pinning either name makes this test fail the
+// moment the other lands. The load-bearing half is the `SCAN cards` exclusion
+// below: the trait default has no WHERE clause, so a full scan is the only
+// plan it can produce, and its absence is what proves the override ran.
 fn test_get_card_by_board_and_number_uses_indexed_search_not_full_scan() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.sqlite3");
@@ -346,8 +352,8 @@ fn test_get_card_by_board_and_number_uses_indexed_search_not_full_scan() {
         let plan_text = plan.join(" | ");
 
         assert!(
-            plan_text.contains("SEARCH cards USING INDEX idx_cards_board_id"),
-            "expected an indexed search on idx_cards_board_id, got: {plan_text}"
+            plan_text.contains("SEARCH cards USING INDEX idx_cards_board"),
+            "expected an indexed search on a board-leading index, got: {plan_text}"
         );
         assert!(
             !plan_text.contains("SCAN cards"),

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cards.rs
@@ -2,6 +2,7 @@ use kanban_domain::data_store::DataStore;
 use kanban_domain::{
     Board, Card, CardPriority, CardRecord, CardStatus, Column, ColumnRecord, SprintLog,
 };
+use sqlx::Row;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -212,5 +213,145 @@ fn test_sqlite_card_reconstitute_rejects_malformed_row() {
 
         let result = store.get_card(id);
         assert!(result.is_err());
+    });
+}
+
+#[test]
+fn test_get_card_by_board_and_number_returns_matching_card() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let column_id = seed_column(&store);
+
+        let mut a = fully_populated_card(column_id);
+        a.card_number = 1;
+        let mut b = fully_populated_card(column_id);
+        b.board_id = a.board_id;
+        b.card_number = 2;
+        let mut other_board = fully_populated_card(column_id);
+        other_board.card_number = 1;
+
+        store.upsert_card(a.clone()).unwrap();
+        store.upsert_card(b.clone()).unwrap();
+        store.upsert_card(other_board.clone()).unwrap();
+
+        let found = store
+            .get_card_by_board_and_number(a.board_id, 1)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.id, a.id);
+
+        let found = store
+            .get_card_by_board_and_number(a.board_id, 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.id, b.id);
+
+        assert!(store
+            .get_card_by_board_and_number(a.board_id, 999)
+            .unwrap()
+            .is_none());
+    });
+}
+
+#[test]
+fn test_get_card_by_sprint_and_number_returns_matching_card() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let board = Board::new("B", None::<String>);
+        let board_id = board.id;
+        store.upsert_board(board).unwrap();
+        let column = Column::reconstitute(ColumnRecord {
+            id: Uuid::new_v4(),
+            board_id,
+            name: "In Progress".to_string(),
+            position: 0,
+            wip_limit: None,
+            default_status: None,
+            created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+            updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+        })
+        .unwrap();
+        let column_id = column.id;
+        store.upsert_column(column).unwrap();
+        let sprint = kanban_domain::Sprint::new(board_id, 1, None, Some("SP"));
+        let sprint_id = sprint.id;
+        store.upsert_sprint(sprint).unwrap();
+
+        let mut a = fully_populated_card(column_id);
+        a.sprint_id = Some(sprint_id);
+        a.card_number = 1;
+        let mut b = fully_populated_card(column_id);
+        b.sprint_id = Some(sprint_id);
+        b.card_number = 2;
+        let unsprinted = fully_populated_card(column_id);
+
+        store.upsert_card(a.clone()).unwrap();
+        store.upsert_card(b.clone()).unwrap();
+        store.upsert_card(unsprinted.clone()).unwrap();
+
+        let found = store
+            .get_card_by_sprint_and_number(sprint_id, 1)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.id, a.id);
+
+        let found = store
+            .get_card_by_sprint_and_number(sprint_id, 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.id, b.id);
+
+        assert!(store
+            .get_card_by_sprint_and_number(sprint_id, 999)
+            .unwrap()
+            .is_none());
+    });
+}
+
+/// Structural proof that the SQLite override issues a targeted, indexed
+/// single-row query rather than silently falling back to the trait's
+/// `list_all_cards`-based default (which has no `WHERE` clause at all).
+/// `EXPLAIN QUERY PLAN` on the override's exact query must report an indexed
+/// `SEARCH`, not an unindexed full-table `SCAN`.
+#[test]
+fn test_get_card_by_board_and_number_uses_indexed_search_not_full_scan() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        let plan_rows = sqlx::query(
+            "EXPLAIN QUERY PLAN
+             SELECT id FROM cards
+             WHERE NOT EXISTS (SELECT 1 FROM archived_cards a WHERE a.card_id = cards.id)
+               AND board_id = ? AND card_number = ?",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(1_i64)
+        .fetch_all(store.pool())
+        .await
+        .unwrap();
+
+        let plan: Vec<String> = plan_rows
+            .iter()
+            .map(|row| row.try_get::<String, _>("detail").unwrap())
+            .collect();
+        let plan_text = plan.join(" | ");
+
+        assert!(
+            plan_text.contains("SEARCH cards USING INDEX idx_cards_board_id"),
+            "expected an indexed search on idx_cards_board_id, got: {plan_text}"
+        );
+        assert!(
+            !plan_text.contains("SCAN cards"),
+            "override must not fall back to a full table scan, got: {plan_text}"
+        );
     });
 }

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -2,7 +2,7 @@ use super::super::BackendFactory;
 use crate::KanbanContext;
 use kanban_core::AppConfig;
 use kanban_domain::card::{CardPriority, CardStatus};
-use kanban_domain::{CardUpdate, CreateCardOptions, KanbanOperations};
+use kanban_domain::{CardUpdate, CreateCardOptions, DataStore, KanbanOperations};
 use tempfile::TempDir;
 
 pub async fn test_card_all_fields_roundtrip(factory: &BackendFactory) {
@@ -310,4 +310,163 @@ pub async fn test_card_completed_at_set_on_done_status(factory: &BackendFactory)
     let c = ctx.get_card(card.id).unwrap().unwrap();
     assert_eq!(c.status, CardStatus::Done);
     assert!(c.completed_at.is_some());
+}
+
+pub async fn test_get_card_by_board_and_number_returns_matching_card(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board_a = ctx.create_board("Board A".into(), None).unwrap();
+    let col_a = ctx.create_column(board_a.id, "Col".into(), None).unwrap();
+    let board_b = ctx.create_board("Board B".into(), None).unwrap();
+    let col_b = ctx.create_column(board_b.id, "Col".into(), None).unwrap();
+
+    let card_a1 = ctx
+        .create_card(
+            board_a.id,
+            col_a.id,
+            "A1".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_a2 = ctx
+        .create_card(
+            board_a.id,
+            col_a.id,
+            "A2".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_b1 = ctx
+        .create_card(
+            board_b.id,
+            col_b.id,
+            "B1".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let found = ctx
+        .data_store()
+        .get_card_by_board_and_number(board_a.id, card_a1.card_number)
+        .unwrap();
+    assert_eq!(found.map(|c| c.id), Some(card_a1.id));
+
+    let found = ctx
+        .data_store()
+        .get_card_by_board_and_number(board_a.id, card_a2.card_number)
+        .unwrap();
+    assert_eq!(found.map(|c| c.id), Some(card_a2.id));
+
+    let found = ctx
+        .data_store()
+        .get_card_by_board_and_number(board_b.id, card_b1.card_number)
+        .unwrap();
+    assert_eq!(found.map(|c| c.id), Some(card_b1.id));
+}
+
+pub async fn test_get_card_by_board_and_number_returns_none_for_missing_number(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    ctx.create_card(
+        board.id,
+        col.id,
+        "Card".into(),
+        CreateCardOptions::default(),
+    )
+    .unwrap();
+
+    let found = ctx
+        .data_store()
+        .get_card_by_board_and_number(board.id, 9999)
+        .unwrap();
+    assert!(found.is_none());
+}
+
+pub async fn test_get_card_by_sprint_and_number_returns_matching_card(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    let card1 = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card 1".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card2 = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card 2".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    ctx.assign_card_to_sprint(card1.id, sprint.id).unwrap();
+    ctx.assign_card_to_sprint(card2.id, sprint.id).unwrap();
+
+    let card1 = ctx.get_card(card1.id).unwrap().unwrap();
+    let card2 = ctx.get_card(card2.id).unwrap().unwrap();
+
+    let found = ctx
+        .data_store()
+        .get_card_by_sprint_and_number(sprint.id, card1.card_number)
+        .unwrap();
+    assert_eq!(found.map(|c| c.id), Some(card1.id));
+
+    let found = ctx
+        .data_store()
+        .get_card_by_sprint_and_number(sprint.id, card2.card_number)
+        .unwrap();
+    assert_eq!(found.map(|c| c.id), Some(card2.id));
+}
+
+pub async fn test_get_card_by_sprint_and_number_returns_none_for_missing_number(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+    let card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.assign_card_to_sprint(card.id, sprint.id).unwrap();
+
+    let found = ctx
+        .data_store()
+        .get_card_by_sprint_and_number(sprint.id, 9999)
+        .unwrap();
+    assert!(found.is_none());
 }

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -2,7 +2,7 @@ use super::super::BackendFactory;
 use crate::KanbanContext;
 use kanban_core::AppConfig;
 use kanban_domain::card::{CardPriority, CardStatus};
-use kanban_domain::{CardUpdate, CreateCardOptions, DataStore, KanbanOperations};
+use kanban_domain::{CardUpdate, CreateCardOptions, KanbanOperations};
 use tempfile::TempDir;
 
 pub async fn test_card_all_fields_roundtrip(factory: &BackendFactory) {

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -439,6 +439,45 @@ pub async fn test_get_card_by_sprint_and_number_returns_matching_card(factory: &
         .get_card_by_sprint_and_number(sprint.id, card2.card_number)
         .unwrap();
     assert_eq!(found.map(|c| c.id), Some(card2.id));
+
+    // A second sprint on a second board, holding a card whose number COLLIDES
+    // with card1's. Card numbers are per-board, so this is the only way to
+    // produce a duplicate. Without this foil an implementation that ignored
+    // sprint_id entirely and matched on card_number alone would still pass
+    // every assertion above.
+    let board_b = ctx.create_board("Board B".into(), None).unwrap();
+    let col_b = ctx.create_column(board_b.id, "Col".into(), None).unwrap();
+    let sprint_b = ctx.create_sprint(board_b.id, None, None).unwrap();
+    let card_b = ctx
+        .create_card(
+            board_b.id,
+            col_b.id,
+            "Colliding number".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.assign_card_to_sprint(card_b.id, sprint_b.id).unwrap();
+    let card_b = ctx.get_card(card_b.id).unwrap().unwrap();
+    assert_eq!(
+        card_b.card_number, card1.card_number,
+        "the foil only works if the numbers actually collide"
+    );
+
+    let found = ctx
+        .data_store()
+        .get_card_by_sprint_and_number(sprint.id, card1.card_number)
+        .unwrap();
+    assert_eq!(
+        found.map(|c| c.id),
+        Some(card1.id),
+        "must return the card in the requested sprint, not the colliding number in another"
+    );
+
+    let found = ctx
+        .data_store()
+        .get_card_by_sprint_and_number(sprint_b.id, card_b.card_number)
+        .unwrap();
+    assert_eq!(found.map(|c| c.id), Some(card_b.id));
 }
 
 pub async fn test_get_card_by_sprint_and_number_returns_none_for_missing_number(

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -121,6 +121,22 @@ macro_rules! context_contract_tests {
         async fn test_column_filtered_reads_three_state() {
             $crate::test_helpers::contract::card::test_column_filtered_reads_three_state(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_get_card_by_board_and_number_returns_matching_card() {
+            $crate::test_helpers::contract::card::test_get_card_by_board_and_number_returns_matching_card(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_get_card_by_board_and_number_returns_none_for_missing_number() {
+            $crate::test_helpers::contract::card::test_get_card_by_board_and_number_returns_none_for_missing_number(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_get_card_by_sprint_and_number_returns_matching_card() {
+            $crate::test_helpers::contract::card::test_get_card_by_sprint_and_number_returns_matching_card(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_get_card_by_sprint_and_number_returns_none_for_missing_number() {
+            $crate::test_helpers::contract::card::test_get_card_by_sprint_and_number_returns_none_for_missing_number(&$factory_fn()).await;
+        }
 
         // Sprint log tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Adds `get_card_by_board_and_number` and `get_card_by_sprint_and_number` to `DataStore`, so a card can be fetched by its owner and number without loading the collection. The resolver rewrite that consumes them is a later card; this is the primitive.

## Defaulted, then explicitly delegated — both are necessary

The methods are defaulted so a stale implementor count cannot break the build. `impl DataStore for` is at **13 blocks across 12 files** today, up from the 11/10 recorded when the card was written and 9 before that. It has moved three times during this epic.

But a default protects the build and endangers the behaviour, and the rule is structural rather than a list of crates:

```
SqliteBackend { db: SqliteStore, ... }          wraps an inner store -> a default SHADOWS its override
JsonDataStore { inner: InMemoryStore }          wraps an inner store -> a default SHADOWS its override
InMemoryStore, SqliteStore                      base stores -> a default IS the implementation
```

Both wrappers now forward explicitly. This is not hypothetical: an earlier spike in this epic added a defaulted method, `SqliteBackend` never forwarded it, the fast path was silently never taken, and the benchmark measured 40 ms before and 40 ms after with nothing failing anywhere. It took debug prints to find.

## Proving the override actually runs

A passing test does not prove the real implementation executed rather than the default. `test_get_card_by_board_and_number_uses_indexed_search_not_full_scan` asserts on `EXPLAIN QUERY PLAN`:

```
plan contains  "SEARCH cards USING INDEX idx_cards_board_id"
plan excludes  "SCAN cards"
```

That is structural rather than a proxy. The trait default calls `list_all_cards()` with no `WHERE` clause, so a full scan is the only plan it can produce — an indexed `SEARCH` is possible only if the SQLite override ran.

## Contract tests, not per-backend one-offs

Four new test functions in the shared contract suite (`kanban-service/src/test_helpers/contract/card.rs`), covering matching and missing cases for both lookups, expanded per backend by the existing macro. Every backend is held to one spec rather than each getting its own interpretation.

## Scope

Trait primitives only. No SQLite table, no JSON envelope, no service wiring, no resolver.

The SQLite override rides the existing single-column `idx_cards_board_id` / `idx_cards_sprint_id`. The composite indexes land separately in #588; these methods get faster when that merges, with no change here.

On the identifier-integrity decision: `Card` does not yet carry a stored prefix, so these are keyed on `board_id`/`sprint_id`, which remain the correct join keys. A later `PREFIX-N` lookup resolves the prefix to an owner id first and then calls these same two methods — no signature change anticipated.

## Verification

3690 workspace tests pass. Clippy `-D warnings` and fmt clean. Red and green are separate commits; the red run showed 7 `E0599: method not found` before the implementation existed.