### PR TITLE
fix(domain,backend-memory,persistence-json): stop the first save erasing the V15 prefixes backfill

### DIFF
--- a/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
@@ -38,6 +38,7 @@ impl InMemoryStore {
             state.graph.clone(),
         );
         snap.archived_boards = archived_boards;
+        snap.prefixes = state.prefixes.clone();
         Ok(snap)
     }
 
@@ -62,6 +63,7 @@ impl InMemoryStore {
             .collect();
         state.sprints = snapshot.sprints.into_iter().map(|s| (s.id, s)).collect();
         state.graph = snapshot.graph;
+        state.prefixes = snapshot.prefixes;
         Ok(())
     }
 }

--- a/crates/kanban-backend-memory/src/in_memory_store/state.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/state.rs
@@ -22,6 +22,10 @@ pub(super) struct StoreState {
     /// (columns/cards/sprints) stays in place in the flat collections.
     pub(super) archived_boards: HashMap<Uuid, ArchivedBoard>,
     pub(super) graph: DependencyGraph,
+    /// Prefix namespaces carried verbatim between load and flush. Not yet
+    /// read or allocated from -- the mirror holds them so a save cannot drop
+    /// what the V15 backfill wrote.
+    pub(super) prefixes: Vec<kanban_domain::Prefix>,
 }
 
 impl StoreState {
@@ -35,6 +39,7 @@ impl StoreState {
             archived_cards: HashMap::new(),
             archived_boards: HashMap::new(),
             graph: DependencyGraph::new(),
+            prefixes: Vec::new(),
         }
     }
 

--- a/crates/kanban-domain/src/export/importer.rs
+++ b/crates/kanban-domain/src/export/importer.rs
@@ -277,6 +277,7 @@ mod tests {
             archived_cards: vec![],
             sprints: vec![],
             graph: crate::DependencyGraph::new(),
+            prefixes: Vec::new(),
         };
 
         let export = BoardImporter::convert_snapshot_to_export(snapshot);
@@ -302,6 +303,7 @@ mod tests {
             archived_cards: vec![ac_marker],
             sprints: vec![],
             graph: crate::DependencyGraph::new(),
+            prefixes: Vec::new(),
         };
 
         let export = BoardImporter::convert_snapshot_to_export(snapshot);
@@ -338,6 +340,7 @@ mod tests {
             archived_cards: vec![ac_marker],
             sprints: vec![],
             graph: crate::DependencyGraph::new(),
+            prefixes: Vec::new(),
         };
 
         let export = BoardImporter::convert_snapshot_to_export(snapshot);
@@ -364,6 +367,7 @@ mod tests {
             archived_cards: vec![],
             sprints: vec![],
             graph: crate::DependencyGraph::new(),
+            prefixes: Vec::new(),
         };
 
         let export = BoardImporter::convert_snapshot_to_export(snapshot);
@@ -398,6 +402,7 @@ mod tests {
             archived_cards: vec![ac_marker],
             sprints: vec![],
             graph: crate::DependencyGraph::new(),
+            prefixes: Vec::new(),
         };
 
         let export = BoardImporter::convert_snapshot_to_export(snapshot);

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::board::{Board, BoardId};
 use crate::sprint::{Sprint, SprintId};
 
@@ -13,12 +15,14 @@ use crate::sprint::{Sprint, SprintId};
 /// `Prefix` is not consulted to resolve an EXISTING
 /// card's identifier; it exists to allocate NEW cards and to detect
 /// collisions among the effective prefixes a workspace could hand out next.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Prefix {
     /// Always normalised. Construct through [`Prefix::new`] rather than a
     /// struct literal, or the normalisation contract is silently violated.
     pub name: String,
+    #[serde(default)]
     pub card_counter: u32,
+    #[serde(default)]
     pub sprint_counter: u32,
 }
 

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -9,7 +9,7 @@
 //! This type is pure data with no UI dependencies, making it suitable for
 //! use by both TUI and future API server implementations.
 
-use crate::{ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, Sprint};
+use crate::{ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, Prefix, Sprint};
 use serde::{Deserialize, Serialize};
 
 /// Point-in-time capture of all kanban data.
@@ -50,6 +50,15 @@ pub struct Snapshot {
     /// Card dependency graph (blocks, relates-to, parent-child).
     #[serde(default)]
     pub graph: DependencyGraph,
+
+    /// Prefix namespaces and their allocation counters.
+    ///
+    /// Carried here because the JSON backend flushes by re-serialising this
+    /// struct: a field absent from it is silently dropped on every save, so
+    /// the V15 backfill would be erased by the first ordinary write after
+    /// upgrading.
+    #[serde(default)]
+    pub prefixes: Vec<Prefix>,
 }
 
 impl Snapshot {
@@ -75,6 +84,7 @@ impl Snapshot {
             sprints,
             graph,
             archived_boards: Vec::new(),
+            prefixes: Vec::new(),
         }
     }
 

--- a/crates/kanban-persistence-json/tests/v15_migration.rs
+++ b/crates/kanban-persistence-json/tests/v15_migration.rs
@@ -179,3 +179,123 @@ fn test_migrate_v14_to_v15_on_a_real_binary_fixture() {
         "prefix names must be unique: {names:?}"
     );
 }
+
+/// The migration writes `data.prefixes`, but every later save re-serialises
+/// the envelope from whatever type the store deserialises into. If that type
+/// has no `prefixes` field, serde drops the array silently and the first
+/// ordinary save after upgrading erases the backfill.
+#[tokio::test]
+async fn test_v15_prefixes_survive_a_load_and_save_round_trip() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("store.json");
+    write_fixture(&path);
+
+    Migrator::migrate(FormatVersion::V14, FormatVersion::MAX, &path)
+        .await
+        .expect("V14 -> V15 must succeed");
+
+    let before = read_json(&path);
+    let before_prefixes = before["data"]["prefixes"].clone();
+    assert!(
+        before_prefixes.as_array().is_some_and(|a| !a.is_empty()),
+        "migration must have written prefixes to begin with"
+    );
+
+    let store = JsonFileStore::new(&path);
+    let (snapshot, _meta) = store.load().await.unwrap();
+    store.save(snapshot).await.unwrap();
+
+    let after = read_json(&path);
+    assert_eq!(
+        after["data"]["prefixes"], before_prefixes,
+        "an ordinary save after the migration must not erase the backfilled prefixes"
+    );
+}
+
+/// The store-level round trip above moves `data` as opaque bytes, so it
+/// cannot see this: the JSON BACKEND flushes by re-serialising a domain
+/// `Snapshot`, which has no `prefixes` field. Serde ignores unknown fields
+/// on read and does not re-emit them, so the first ordinary save after
+/// upgrading would erase everything the migration just backfilled.
+///
+/// Nothing reads `prefixes` yet, so this would have stayed invisible until
+/// the allocation card started depending on it -- against stores where it
+/// had already been wiped.
+#[tokio::test]
+async fn test_v15_prefixes_survive_a_backend_flush() {
+    use kanban_persistence::{snapshot_from_json_bytes, snapshot_to_json_bytes, PersistenceStore};
+
+    // The real-binary fixture, not the hand-authored one: this path decodes
+    // into full domain types, so every field the software really writes has
+    // to be present.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("store.json");
+    std::fs::write(&path, include_str!("fixtures/v14_real_binary.json")).unwrap();
+
+    Migrator::migrate(FormatVersion::V14, FormatVersion::MAX, &path)
+        .await
+        .expect("V14 -> V15 must succeed");
+
+    let before = read_json(&path);
+    let before_prefixes = before["data"]["prefixes"].clone();
+    assert!(
+        before_prefixes.as_array().is_some_and(|a| !a.is_empty()),
+        "migration must have written prefixes to begin with"
+    );
+
+    // Exactly what JsonDataStore::flush does: load, decode to a domain
+    // Snapshot, re-encode, save.
+    let store = JsonFileStore::new(&path);
+    let (loaded, metadata) = store.load().await.unwrap();
+    let snapshot = snapshot_from_json_bytes(&loaded.data).unwrap();
+    let data = snapshot_to_json_bytes(&snapshot).unwrap();
+    store
+        .save(kanban_persistence::StoreSnapshot { data, metadata })
+        .await
+        .unwrap();
+
+    let after = read_json(&path);
+    assert_eq!(
+        after["data"]["prefixes"], before_prefixes,
+        "a backend flush must not erase the backfilled prefixes"
+    );
+}
+
+/// The real flush path, end to end. `JsonDataStore::flush` does not
+/// re-serialise the snapshot it loaded -- it serialises
+/// `InMemoryStore::snapshot_impl()`, built from the mirror's entity maps.
+/// Adding a field to `Snapshot` is therefore not sufficient on its own: the
+/// mirror has to carry prefixes too, or every flush still writes an empty
+/// array over the backfill.
+#[tokio::test]
+async fn test_v15_prefixes_survive_a_real_json_backend_flush() {
+    use kanban_backend::KanbanBackend;
+    use kanban_domain::DataStore;
+    use kanban_persistence_json::JsonDataStore;
+    use std::sync::Arc;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("store.json");
+    std::fs::write(&path, include_str!("fixtures/v14_real_binary.json")).unwrap();
+
+    Migrator::migrate(FormatVersion::V14, FormatVersion::MAX, &path)
+        .await
+        .expect("V14 -> V15 must succeed");
+    let before_prefixes = read_json(&path)["data"]["prefixes"].clone();
+    assert!(
+        before_prefixes.as_array().is_some_and(|a| !a.is_empty()),
+        "migration must have written prefixes to begin with"
+    );
+
+    let backend = JsonDataStore::new(Arc::new(JsonFileStore::new(&path)));
+    // An ordinary mutation followed by the ordinary write path.
+    let board = backend.list_boards().unwrap().into_iter().next().unwrap();
+    backend.upsert_board(board).unwrap();
+    backend.flush().await.expect("flush");
+
+    assert_eq!(
+        read_json(&path)["data"]["prefixes"],
+        before_prefixes,
+        "a real backend flush must not erase the backfilled prefixes"
+    );
+}

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -148,5 +148,6 @@ pub fn fully_populated_snapshot() -> Snapshot {
         archived_cards: vec![archived_card],
         sprints: vec![sprint],
         graph,
+        prefixes: Vec::new(),
     }
 }

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -278,6 +278,7 @@ impl KanbanContext {
                 archived_cards,
                 sprints,
                 graph,
+                prefixes: Vec::new(),
             }
         } else {
             self.backend.snapshot()?

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -51,6 +51,9 @@ pub(crate) fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot
         archived_boards,
         sprints: store.list_all_sprints()?,
         graph: store.get_graph()?,
+        // Prefixes are not a `DataStore` entity yet; the store that owns them
+        // round-trips them itself. Populated when the prefix store lands.
+        prefixes: Vec::new(),
     })
 }
 

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -230,6 +230,7 @@ impl StoreManager {
                 archived_cards: entities.archived_cards,
                 sprints: entities.sprints,
                 graph: DependencyGraph::default(),
+                prefixes: Vec::new(),
             };
             self.write_sqlite_destination(filename, snapshot).await
         }

--- a/crates/kanban-service/tests/data_integrity_tests.rs
+++ b/crates/kanban-service/tests/data_integrity_tests.rs
@@ -180,6 +180,7 @@ async fn test_import_with_invalid_column_reference_fails() -> KanbanResult<()> {
         archived_cards: vec![],
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::default(),
+        prefixes: Vec::new(),
     };
 
     let json = serde_json::to_string(&snapshot).unwrap();
@@ -232,6 +233,7 @@ async fn test_import_backfills_board_id_on_legacy_archived_card() -> KanbanResul
         archived_cards: vec![archived],
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::default(),
+        prefixes: Vec::new(),
     };
 
     let mut value = serde_json::to_value(&snapshot).unwrap();

--- a/crates/kanban-service/tests/export_import_archived_roundtrip.rs
+++ b/crates/kanban-service/tests/export_import_archived_roundtrip.rs
@@ -184,6 +184,7 @@ fn import_into_context(ctx: &KanbanContext, export_path: &str) -> KanbanResult<(
         archived_cards: entities.archived_cards,
         sprints: entities.sprints,
         graph: DependencyGraph::default(),
+        prefixes: Vec::new(),
     };
     ctx.apply_snapshot(snapshot)
 }

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -42,6 +42,7 @@ async fn test_import_board_checkpoints_wal_on_sqlite_path() {
         archived_cards: vec![],
         sprints: vec![],
         graph: Default::default(),
+        prefixes: Vec::new(),
     };
     let json = serde_json::to_string(&snapshot).unwrap();
     ctx.import_board(&json).unwrap();

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -216,6 +216,7 @@ mod active_card_helpers {
             archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
             sprints: app.ctx.data_store().list_all_sprints().unwrap(),
             graph: app.ctx.data_store().get_graph().unwrap(),
+            prefixes: Vec::new(),
         };
         app.model.load_from_snapshot(snap);
         (app, card.id)

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1365,6 +1365,7 @@ mod tests {
             archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
             sprints: app.ctx.data_store().list_all_sprints().unwrap(),
             graph: app.ctx.data_store().get_graph().unwrap(),
+            prefixes: Vec::new(),
         };
         app.model.load_from_snapshot(snap);
     }

--- a/crates/kanban-tui/src/state/snapshot.rs
+++ b/crates/kanban-tui/src/state/snapshot.rs
@@ -57,6 +57,7 @@ mod tests {
             archived_cards: vec![],
             sprints: vec![],
             graph: DependencyGraph::new(),
+            prefixes: Vec::new(),
         };
 
         let bytes = snapshot_to_json_bytes(&snapshot).unwrap();
@@ -80,6 +81,7 @@ mod tests {
             archived_cards: vec![],
             sprints: vec![],
             graph: DependencyGraph::new(),
+            prefixes: Vec::new(),
         };
 
         // Create a minimal app with the active board set by id.

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -29,6 +29,7 @@ pub fn load_with_card_order(app: &mut App, order: &[uuid::Uuid]) {
         archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
         sprints: app.ctx.data_store().list_all_sprints().unwrap(),
         graph: app.ctx.data_store().get_graph().unwrap(),
+        prefixes: Vec::new(),
     };
     app.model.load_from_snapshot(snap);
 }

--- a/crates/kanban-tui/tests/conflict_detection_tests.rs
+++ b/crates/kanban-tui/tests/conflict_detection_tests.rs
@@ -24,6 +24,7 @@ async fn test_conflict_detection_on_concurrent_modification() {
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::new(),
         archived_cards: vec![],
+        prefixes: Vec::new(),
     };
 
     let store_id = uuid::Uuid::new_v4();
@@ -93,6 +94,7 @@ async fn test_no_conflict_when_file_unchanged() {
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::new(),
         archived_cards: vec![],
+        prefixes: Vec::new(),
     };
 
     let store = JsonFileStore::new(&file_path);
@@ -129,6 +131,7 @@ async fn test_conflict_detection_tracks_file_metadata() {
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::new(),
         archived_cards: vec![],
+        prefixes: Vec::new(),
     };
 
     let store = JsonFileStore::new(&file_path);
@@ -188,6 +191,7 @@ async fn test_multiple_instances_with_different_ids() {
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::new(),
         archived_cards: vec![],
+        prefixes: Vec::new(),
     };
 
     // First instance saves
@@ -233,6 +237,7 @@ async fn test_conflict_resolution_with_force_overwrite() {
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::new(),
         archived_cards: vec![],
+        prefixes: Vec::new(),
     };
 
     let store = JsonFileStore::new(&file_path);
@@ -291,6 +296,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::new(),
         archived_cards: vec![],
+        prefixes: Vec::new(),
     };
 
     let data = kanban_persistence::snapshot_to_json_bytes(&snapshot1).unwrap();

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -266,6 +266,7 @@ async fn test_async_load_initial_state_sqlite() {
         archived_cards: vec![],
         sprints: vec![],
         graph: Default::default(),
+        prefixes: Vec::new(),
     };
     store.apply_snapshot(snapshot).unwrap();
     drop(store);

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -569,6 +569,7 @@ pub async fn create_test_json_file(dir: &std::path::Path, name: &str, boards: &[
         archived_cards: vec![],
         sprints: vec![],
         graph: Default::default(),
+        prefixes: Vec::new(),
     };
 
     let store_snapshot = StoreSnapshot {
@@ -601,6 +602,7 @@ pub async fn create_test_sqlite_file(dir: &std::path::Path, name: &str, boards: 
         archived_cards: vec![],
         sprints: vec![],
         graph: Default::default(),
+        prefixes: Vec::new(),
     };
     store.apply_snapshot(snapshot).unwrap();
 

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -21,6 +21,7 @@ async fn test_import_failure_prevents_empty_state_save() {
         archived_cards: vec![],
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::new(),
+        prefixes: Vec::new(),
     };
 
     // Manually create V2 format JSON
@@ -98,6 +99,7 @@ async fn test_v2_format_is_imported_correctly() {
         archived_cards: vec![],
         sprints: vec![],
         graph: kanban_domain::DependencyGraph::new(),
+        prefixes: Vec::new(),
     };
 
     // Manually create V2 format JSON

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -35,6 +35,7 @@ async fn test_load_initial_state_with_boards_refreshes_card_view() -> KanbanResu
         archived_cards: vec![],
         sprints: vec![],
         graph: Default::default(),
+        prefixes: Vec::new(),
     };
     let store = kanban_persistence_json::JsonFileStore::new(&path_str);
     let store_snapshot = StoreSnapshot {

--- a/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
+++ b/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
@@ -19,6 +19,7 @@ fn sync_model_from_store(app: &mut App) {
         archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
         sprints: app.ctx.data_store().list_all_sprints().unwrap(),
         graph: app.ctx.data_store().get_graph().unwrap(),
+        prefixes: Vec::new(),
     };
     app.model.load_from_snapshot(snapshot);
 }

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -34,6 +34,7 @@ fn test_load_from_snapshot_populates_all_fields() {
         archived_cards: vec![],
         sprints: vec![sprint],
         graph: DependencyGraph::default(),
+        prefixes: Vec::new(),
     };
 
     model.load_from_snapshot(snapshot);

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -102,6 +102,7 @@ fn test_manage_parents_popup_enter_creates_parent_edge() {
         archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
         sprints: app.ctx.data_store().list_all_sprints().unwrap(),
         graph: app.ctx.data_store().get_graph().unwrap(),
+        prefixes: Vec::new(),
     };
     app.model.load_from_snapshot(snapshot);
     app.selection.active_card_id = Some(child.id);
@@ -190,6 +191,7 @@ fn test_manage_parents_popup_cycle_surfaces_error_banner_to_user() {
         archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
         sprints: app.ctx.data_store().list_all_sprints().unwrap(),
         graph: app.ctx.data_store().get_graph().unwrap(),
+        prefixes: Vec::new(),
     };
     app.model.load_from_snapshot(snapshot);
     // active card is `a`; the popup will offer `c` as a candidate parent


### PR DESCRIPTION
Post-merge review of #592 found a defect in it. The prefixes table is effectively write-only on the JSON backend: the migration writes the backfill and the next ordinary save deletes it.

## Cause

`JsonDataStore::flush` serialises a domain `Snapshot`, which had no `prefixes` field. Serde ignores unknown fields on read and does not re-emit them, so the array is dropped on every write.

Nothing reads `prefixes` yet, which is exactly why this was invisible: every test asserted on the file immediately after migrating, never after a write. It would have surfaced later as KAN-1214/1215 reading empty prefixes from any store that had been used even once since upgrading.

The damage is permanent on JSON, and the two backends differ in a way worth stating precisely:

- **SQLite** calls `migrate_v9_to_v10_prefixes` on every `open()`, guarded only by `COUNT(*) > 0`, so an emptied table refills on the next open. It self-heals — and it never had the erasure to begin with, since its prefixes live in a real table.
- **JSON** gates the transform on `version >= 15` and returns early. Once the file is V15 carrying `prefixes: []`, the migration never runs again. Nothing refills it.

So without this fix, a JSON user who upgrades and then does any ordinary write is left permanently with an empty table and no path back short of a new migration.

## Fix

Two changes. The first looks sufficient and is not:

- `Snapshot` carries `prefixes`, so encode/decode round-trips it.
- `InMemoryStore`'s state carries them too. `flush` does not re-serialise the snapshot it loaded; it serialises `snapshot_impl()`, built from the mirror's entity maps. With only the `Snapshot` field, a flush wrote an empty array instead of omitting the key — still erasure, just quieter.

The mirror carries prefixes verbatim. It does not read or allocate from them; the `DataStore` surface remains KAN-1244.

## Tests

Three, each of which the previous one would have passed:

1. store-level load/save round trip — **passes even unfixed**, because `StoreSnapshot` moves `data` as opaque bytes and cannot observe the defect
2. decode/re-encode through `Snapshot` — catches the missing field
3. real `JsonDataStore` mutate-and-flush — catches the mirror

Only the third proves the property. I kept all three because the first two document why the obvious test is insufficient; a future reader who deletes the third has to notice the other two are weaker.

The third uses the real-binary fixture rather than the hand-authored one: this path decodes into full domain types, and the hand-authored fixture omits `created_at`, which the software always writes. That is the third time on this epic a hand-authored fixture has passed while proving nothing.

## Scope note

Adding a field to `Snapshot` broke every exhaustive struct literal across the workspace. Those are mechanical `prefixes: Vec::new()` additions; the load-bearing changes are `snapshot.rs`, `state.rs`, `in_memory_store/snapshot.rs`, and the tests.

## Verification

3737 workspace tests, clippy `-D warnings`, fmt clean.

## Not covered

SQLite is unaffected — its prefixes live in a real table that `apply_snapshot` does not touch. I did not add an equivalent SQLite flush test, because there is no analogous erasure path; if that reasoning is wrong the gap is real, so it is stated rather than assumed.
