### PR TITLE
KAN-1244 feat(domain,backend-memory,persistence-sqlite,persistence-json): the prefix DataStore surface across all backends

### DIFF
--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -1,11 +1,23 @@
 use crate::HttpBackend;
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
-    KanbanResult, Snapshot, Sprint,
+    KanbanResult, Prefix, Snapshot, Sprint,
 };
 use uuid::Uuid;
 
 impl DataStore for HttpBackend {
+    fn get_prefix(&self, _name: &str) -> KanbanResult<Option<Prefix>> {
+        Err(KanbanError::unsupported("get_prefix"))
+    }
+
+    fn list_prefixes(&self) -> KanbanResult<Vec<Prefix>> {
+        Err(KanbanError::unsupported("list_prefixes"))
+    }
+
+    fn upsert_prefix(&self, _prefix: Prefix) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("upsert_prefix"))
+    }
+
     fn get_board(&self, _id: Uuid) -> KanbanResult<Option<Board>> {
         Err(KanbanError::unsupported("get_board"))
     }

--- a/crates/kanban-backend-memory/src/in_memory_store/mod.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/mod.rs
@@ -6,6 +6,7 @@ mod columns;
 mod command_log;
 mod graph;
 mod ordering;
+mod prefixes;
 mod snapshot;
 mod sprints;
 mod state;
@@ -88,6 +89,20 @@ impl Default for InMemoryStore {
 }
 
 impl DataStore for InMemoryStore {
+    // Prefix
+
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+        self.get_prefix_impl(name)
+    }
+
+    fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+        self.list_prefixes_impl()
+    }
+
+    fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+        self.upsert_prefix_impl(prefix)
+    }
+
     // Board
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {

--- a/crates/kanban-backend-memory/src/in_memory_store/prefixes.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/prefixes.rs
@@ -1,0 +1,35 @@
+use super::InMemoryStore;
+use kanban_domain::{KanbanResult, Prefix};
+
+impl InMemoryStore {
+    pub(crate) fn get_prefix_impl(&self, name: &str) -> KanbanResult<Option<Prefix>> {
+        let wanted = Prefix::normalize(name);
+        Ok(self
+            .read_state()?
+            .prefixes
+            .iter()
+            .find(|p| Prefix::normalize(&p.name) == wanted)
+            .cloned())
+    }
+
+    pub(crate) fn list_prefixes_impl(&self) -> KanbanResult<Vec<Prefix>> {
+        Ok(self.read_state()?.prefixes.clone())
+    }
+
+    pub(crate) fn upsert_prefix_impl(&self, prefix: Prefix) -> KanbanResult<()> {
+        let mut state = self.write_state()?;
+        let normalized = Prefix::normalize(&prefix.name);
+        // Replace in place rather than push-and-dedup: two spellings of one
+        // name are one namespace, and a second row would let two owners
+        // allocate the same number.
+        match state
+            .prefixes
+            .iter_mut()
+            .find(|p| Prefix::normalize(&p.name) == normalized)
+        {
+            Some(existing) => *existing = prefix,
+            None => state.prefixes.push(prefix),
+        }
+        Ok(())
+    }
+}

--- a/crates/kanban-backend-memory/src/in_memory_store/state.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/state.rs
@@ -25,7 +25,7 @@ pub(super) struct StoreState {
     /// Prefix namespaces carried verbatim between load and flush. Not yet
     /// read or allocated from -- the mirror holds them so a save cannot drop
     /// what the V15 backfill wrote.
-    pub(super) prefixes: Vec<kanban_domain::Prefix>,
+    pub(crate) prefixes: Vec<kanban_domain::Prefix>,
 }
 
 impl StoreState {

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -160,6 +160,15 @@ mod tests {
     struct StubBackend;
 
     impl DataStore for StubBackend {
+        fn get_prefix(&self, _name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+            unimplemented!()
+        }
+        fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+            unimplemented!()
+        }
+        fn upsert_prefix(&self, _prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+            unimplemented!()
+        }
         fn get_board(&self, _id: Uuid) -> KanbanResult<Option<Board>> {
             unimplemented!()
         }

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -462,6 +462,15 @@ mod card_board_id_tests {
     }
 
     impl DataStore for CountingBackend {
+        fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+            self.inner.get_prefix(name)
+        }
+        fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+            self.inner.list_prefixes()
+        }
+        fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+            self.inner.upsert_prefix(prefix)
+        }
         fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
             self.inner.get_board(id)
         }

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -1,6 +1,8 @@
 use uuid::Uuid;
 
-use crate::{ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult, Snapshot, Sprint};
+use crate::{
+    ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult, Prefix, Snapshot, Sprint,
+};
 
 pub type GraphMutFn = Box<dyn FnOnce(&mut DependencyGraph) -> KanbanResult<()>>;
 
@@ -10,6 +12,27 @@ pub trait DataStore: Send + Sync {
     fn list_boards(&self) -> KanbanResult<Vec<Board>>;
     fn upsert_board(&self, board: Board) -> KanbanResult<()>;
     fn delete_board(&self, id: Uuid) -> KanbanResult<()>;
+
+    // Prefix
+    //
+    // A prefix is a shared namespace holding the counters that allocate card
+    // and sprint numbers for one name; it records no owner, and several boards
+    // may point at the same one.
+    //
+    // Deliberately NOT defaulted. `SqliteBackend` and `JsonDataStore` wrap
+    // another store and hand-delegate every method, so a default would not
+    // reach the wrapped store -- SQLite would report no prefixes while its
+    // table was populated. Without a default the compiler enumerates the
+    // sites instead of a reviewer having to.
+
+    /// Look a namespace up by name. Matching is case-insensitive, because the
+    /// identifier resolver lowercases before comparing; a case-sensitive
+    /// lookup would fork one namespace into two that each allocate from zero.
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<Prefix>>;
+    fn list_prefixes(&self) -> KanbanResult<Vec<Prefix>>;
+    /// Insert or replace by normalised name. Two spellings of one name are one
+    /// row.
+    fn upsert_prefix(&self, prefix: Prefix) -> KanbanResult<()>;
 
     // Column
     fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>>;
@@ -268,6 +291,17 @@ mod tests {
     }
 
     impl DataStore for FloorStore {
+        // The floor stub exists to prove the FILTER-AWARE defaults, so the
+        // prefix surface is out of its scope and stays unimplemented.
+        fn get_prefix(&self, _name: &str) -> KanbanResult<Option<Prefix>> {
+            unimplemented!("FloorStore does not model prefixes")
+        }
+        fn list_prefixes(&self) -> KanbanResult<Vec<Prefix>> {
+            unimplemented!("FloorStore does not model prefixes")
+        }
+        fn upsert_prefix(&self, _prefix: Prefix) -> KanbanResult<()> {
+            unimplemented!("FloorStore does not model prefixes")
+        }
         fn get_board(&self, _id: Uuid) -> KanbanResult<Option<Board>> {
             unimplemented!()
         }

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -162,6 +162,17 @@ impl JsonDataStore {
 // ─── DataStore ────────────────────────────────────────────────────────────────
 
 impl DataStore for JsonDataStore {
+    // Prefix
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+        self.with_read(|s| s.get_prefix(name))
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+        self.with_read(|s| s.list_prefixes())
+    }
+    fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+        self.with_mutate(|s| s.upsert_prefix(prefix))
+    }
+
     // Board
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         self.with_read(|s| s.get_board(id))

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -47,6 +47,16 @@ impl SqliteBackend {
 // ─── DataStore ───────────────────────────────────────────────────────────────
 
 impl DataStore for SqliteBackend {
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+        self.db.get_prefix(name)
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+        self.db.list_prefixes()
+    }
+    fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+        self.db.upsert_prefix(prefix)
+    }
+
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         self.db.get_board(id)
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -14,6 +14,81 @@ use super::helpers::{db_err, fmt_dt, p_dt, run};
 use super::SqliteStore;
 
 impl DataStore for SqliteStore {
+    // Prefix
+
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+        // `prefixes.name` is `COLLATE NOCASE`, so `=` already matches
+        // case-insensitively at the schema level. Normalising the probe as
+        // well keeps this agreeing with the in-memory store, whose comparison
+        // is the only one on the JSON path.
+        let wanted = kanban_domain::Prefix::normalize(name);
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let row: Option<(String, i64, i64)> = sqlx::query_as(
+                    "SELECT name, card_counter, sprint_counter FROM prefixes WHERE name = ?",
+                )
+                .bind(wanted)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                Ok(row.map(
+                    |(name, card_counter, sprint_counter)| kanban_domain::Prefix {
+                        name,
+                        card_counter: card_counter as u32,
+                        sprint_counter: sprint_counter as u32,
+                    },
+                ))
+            })
+        }))
+    }
+
+    fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+        run(self.db_conn(|conn| {
+            Box::pin(async move {
+                let rows: Vec<(String, i64, i64)> = sqlx::query_as(
+                    "SELECT name, card_counter, sprint_counter FROM prefixes ORDER BY name ASC",
+                )
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                Ok(rows
+                    .into_iter()
+                    .map(
+                        |(name, card_counter, sprint_counter)| kanban_domain::Prefix {
+                            name,
+                            card_counter: card_counter as u32,
+                            sprint_counter: sprint_counter as u32,
+                        },
+                    )
+                    .collect())
+            })
+        }))
+    }
+
+    fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+        let name = kanban_domain::Prefix::normalize(&prefix.name);
+        let card_counter = prefix.card_counter as i64;
+        let sprint_counter = prefix.sprint_counter as i64;
+        run(self.db_conn(move |conn| {
+            Box::pin(async move {
+                sqlx::query(
+                    "INSERT INTO prefixes (name, card_counter, sprint_counter)
+                     VALUES (?, ?, ?)
+                     ON CONFLICT(name) DO UPDATE SET
+                         card_counter = excluded.card_counter,
+                         sprint_counter = excluded.sprint_counter",
+                )
+                .bind(name)
+                .bind(card_counter)
+                .bind(sprint_counter)
+                .execute(&mut *conn)
+                .await
+                .map_err(db_err)?;
+                Ok(())
+            })
+        }))
+    }
+
     // Board
 
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {

--- a/crates/kanban-service/src/backend_test_support.rs
+++ b/crates/kanban-service/src/backend_test_support.rs
@@ -59,6 +59,15 @@ impl Default for MockBackend {
 }
 
 impl DataStore for MockBackend {
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+        self.inner.get_prefix(name)
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+        self.inner.list_prefixes()
+    }
+    fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+        self.inner.upsert_prefix(prefix)
+    }
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         self.inner.get_board(id)
     }

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -100,6 +100,16 @@ mod tests {
     struct NoWholeStoreReads(InMemoryStore);
 
     impl DataStore for NoWholeStoreReads {
+        fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+            self.0.get_prefix(name)
+        }
+        fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+            self.0.list_prefixes()
+        }
+        fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+            self.0.upsert_prefix(prefix)
+        }
+
         fn snapshot(&self) -> KanbanResult<Snapshot> {
             panic!("read_full_snapshot must compose per-entity reads, not call snapshot()")
         }

--- a/crates/kanban-service/src/test_helpers/contract/mod.rs
+++ b/crates/kanban-service/src/test_helpers/contract/mod.rs
@@ -5,6 +5,7 @@ pub mod column;
 pub mod edge;
 pub mod lifecycle;
 pub mod movement;
+pub mod prefix;
 pub mod sprint;
 pub mod sprint_log;
 

--- a/crates/kanban-service/src/test_helpers/contract/prefix.rs
+++ b/crates/kanban-service/src/test_helpers/contract/prefix.rs
@@ -1,0 +1,194 @@
+//! One spec for the prefix surface, run against every backend.
+//!
+//! A prefix row is a shared namespace holding the counters that allocate card
+//! and sprint numbers for one name. Several boards may point at the same row,
+//! so these tests never assume a prefix belongs to anyone.
+//!
+//! Every case round-trips through durable storage, because the failure mode
+//! this surface exists to prevent is a counter that silently resets: an
+//! allocator reading a zeroed counter re-mints numbers that existing cards
+//! already carry.
+
+use super::super::BackendFactory;
+use kanban_domain::{DataStore, Prefix};
+use tempfile::TempDir;
+
+/// Writes through one backend instance, then reads through a fresh one over
+/// the same path, so nothing can pass on cached state alone.
+async fn reopened(
+    factory: &BackendFactory,
+    path: &std::path::Path,
+    write: impl FnOnce(&dyn DataStore),
+) -> std::sync::Arc<dyn crate::KanbanBackend> {
+    let backend = factory(path);
+    backend.reload().await.unwrap();
+    write(backend.as_data_store());
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = factory(path);
+    reopened.reload().await.unwrap();
+    reopened
+}
+
+pub async fn test_prefix_upsert_and_get_roundtrip(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = reopened(factory, &path, |store| {
+        store
+            .upsert_prefix(Prefix {
+                name: "kan".to_string(),
+                card_counter: 12,
+                sprint_counter: 7,
+            })
+            .unwrap();
+    })
+    .await;
+
+    let prefix = backend
+        .get_prefix("kan")
+        .unwrap()
+        .expect("the prefix must survive a save and reopen");
+    assert_eq!(prefix.name, "kan");
+    assert_eq!(prefix.card_counter, 12, "card counter must persist");
+    assert_eq!(prefix.sprint_counter, 7, "sprint counter must persist");
+}
+
+pub async fn test_prefix_get_is_case_insensitive(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = reopened(factory, &path, |store| {
+        store
+            .upsert_prefix(Prefix {
+                name: "kan".to_string(),
+                card_counter: 3,
+                sprint_counter: 0,
+            })
+            .unwrap();
+    })
+    .await;
+
+    // The identifier resolver lowercases before matching, so a case-sensitive
+    // lookup here would fork one namespace into two and let both allocate the
+    // same number.
+    for probe in ["kan", "KAN", "Kan"] {
+        assert!(
+            backend.get_prefix(probe).unwrap().is_some(),
+            "get_prefix({probe:?}) must find the `kan` namespace"
+        );
+    }
+}
+
+pub async fn test_prefix_upsert_replaces_the_row_for_an_existing_name(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = reopened(factory, &path, |store| {
+        store
+            .upsert_prefix(Prefix {
+                name: "kan".to_string(),
+                card_counter: 1,
+                sprint_counter: 0,
+            })
+            .unwrap();
+        store
+            .upsert_prefix(Prefix {
+                name: "KAN".to_string(),
+                card_counter: 9,
+                sprint_counter: 2,
+            })
+            .unwrap();
+    })
+    .await;
+
+    let all = backend.list_prefixes().unwrap();
+    assert_eq!(
+        all.len(),
+        1,
+        "`kan` and `KAN` are one namespace; a second row would let two owners \
+         allocate the same number: {all:?}"
+    );
+    assert_eq!(all[0].card_counter, 9, "the later write wins");
+    assert_eq!(all[0].sprint_counter, 2);
+}
+
+pub async fn test_prefix_list_returns_every_namespace(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = reopened(factory, &path, |store| {
+        for (name, card_counter) in [("kan", 1), ("dev", 2), ("task", 3)] {
+            store
+                .upsert_prefix(Prefix {
+                    name: name.to_string(),
+                    card_counter,
+                    sprint_counter: 0,
+                })
+                .unwrap();
+        }
+    })
+    .await;
+
+    let mut names: Vec<String> = backend
+        .list_prefixes()
+        .unwrap()
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["dev", "kan", "task"]);
+}
+
+pub async fn test_prefix_get_returns_none_for_an_unknown_name(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = reopened(factory, &path, |store| {
+        store
+            .upsert_prefix(Prefix {
+                name: "kan".to_string(),
+                card_counter: 1,
+                sprint_counter: 0,
+            })
+            .unwrap();
+    })
+    .await;
+
+    assert!(
+        backend.get_prefix("nope").unwrap().is_none(),
+        "an absent namespace must read as None, never as a zeroed row -- an \
+         allocator cannot tell those apart and would start numbering from 1"
+    );
+}
+
+/// The counters are what the whole prefix entity exists for. A backend that
+/// stored the name but reset the counters would pass every test above that
+/// only checks presence, and would then re-mint numbers existing cards carry.
+pub async fn test_prefix_counters_survive_repeated_save_cycles(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = reopened(factory, &path, |store| {
+        store
+            .upsert_prefix(Prefix {
+                name: "kan".to_string(),
+                card_counter: 41,
+                sprint_counter: 5,
+            })
+            .unwrap();
+    })
+    .await;
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+    let prefix = backend.get_prefix("kan").unwrap().expect("still present");
+    assert_eq!(
+        (prefix.card_counter, prefix.sprint_counter),
+        (41, 5),
+        "counters must survive a second save/reload cycle unchanged"
+    );
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -7,6 +7,32 @@ pub type BackendFactory =
 #[macro_export]
 macro_rules! context_contract_tests {
     ($factory_fn:expr) => {
+        // Prefix tests
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_prefix_upsert_and_get_roundtrip() {
+            $crate::test_helpers::contract::prefix::test_prefix_upsert_and_get_roundtrip(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_prefix_get_is_case_insensitive() {
+            $crate::test_helpers::contract::prefix::test_prefix_get_is_case_insensitive(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_prefix_upsert_replaces_the_row_for_an_existing_name() {
+            $crate::test_helpers::contract::prefix::test_prefix_upsert_replaces_the_row_for_an_existing_name(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_prefix_list_returns_every_namespace() {
+            $crate::test_helpers::contract::prefix::test_prefix_list_returns_every_namespace(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_prefix_get_returns_none_for_an_unknown_name() {
+            $crate::test_helpers::contract::prefix::test_prefix_get_returns_none_for_an_unknown_name(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_prefix_counters_survive_repeated_save_cycles() {
+            $crate::test_helpers::contract::prefix::test_prefix_counters_survive_repeated_save_cycles(&$factory_fn()).await;
+        }
+
         // Board tests
         #[tokio::test(flavor = "multi_thread")]
         async fn test_board_basic_fields_roundtrip() {

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -25,6 +25,15 @@ impl CountingBackend {
 }
 
 impl DataStore for CountingBackend {
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+        self.inner.get_prefix(name)
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+        self.inner.list_prefixes()
+    }
+    fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+        self.inner.upsert_prefix(prefix)
+    }
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         self.inner.get_board(id)
     }

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -38,6 +38,17 @@ impl CountingBackend {
 }
 
 impl DataStore for CountingBackend {
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+        self.record();
+        self.inner.get_prefix(name)
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+        self.record();
+        self.inner.list_prefixes()
+    }
+    fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+        self.inner.upsert_prefix(prefix)
+    }
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         self.record();
         self.inner.get_board(id)
@@ -274,6 +285,16 @@ impl SnapshotCountingBackend {
 }
 
 impl DataStore for SnapshotCountingBackend {
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+        self.inner.get_prefix(name)
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+        self.inner.list_prefixes()
+    }
+    fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+        self.inner.upsert_prefix(prefix)
+    }
+
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         self.inner.get_board(id)
     }


### PR DESCRIPTION
`get_prefix` / `list_prefixes` / `upsert_prefix` on `DataStore`, implemented on every backend. KAN-1214 and KAN-1215 both read through this; without it the table KAN-1212/1213 backfilled has no reader.

## The card's premise was false

It said `get_prefix` "defaults to `Ok(None)` and `upsert_prefix` to a no-op". **`DataStore` had no prefix methods at all** — `grep -n 'prefix' crates/kanban-domain/src/data_store.rs` returned nothing. The spike it was written from ran in a throwaway worktree and never landed. So this card adds the surface rather than replacing a default, which makes it a prerequisite for both backends rather than a JSON-only gap-filler. The card has been corrected in place, along with several warnings that no longer apply (the `missing field 'owner'` trap is dead — `Prefix` has no owner now; the equivalence gap was closed by #592's live cross-backend test).

## No defaults, on purpose

`SqliteBackend` and `JsonDataStore` each wrap another store and hand-delegate every method. A defaulted method stops at the wrapper and never reaches the wrapped store, so SQLite would have reported no prefixes while its table was populated — and that failure reads as a migration bug, not a missing delegation.

Leaving the methods undefaulted makes the compiler enumerate the sites instead of a reviewer. It found **nine**: three production layers, six test stubs. The card predicted three.

Each was handled on its merits rather than blanket-stubbed: delegating wrappers delegate, counting backends count, and `FloorStore` stays `unimplemented!` because it exists to prove the filter-aware defaults and does not model prefixes.

## Implementations

- **InMemoryStore** reads the `prefixes` state the snapshot round trip already carries (#593), matching normalised so two spellings are one namespace.
- **SqliteStore** queries the table. `name` is `COLLATE NOCASE`, so `=` already matches case-insensitively at the schema level; the probe is normalised anyway so this agrees with the in-memory comparison, which is the only one on the JSON path.
- **SqliteBackend / JsonDataStore** delegate to the wrapped store. The JSON upsert goes through `with_mutate`, so it marks the store dirty and gets flushed.
- **HttpBackend** returns its standard unsupported error; KAN-1241 owns it.

## Tests

Six contract cases wired into `context_contract_tests!`, so in-memory, JSON and SQLite are held to one spec — 24 tests rather than three parallel one-offs.

Every case writes through one backend instance and reads through a **fresh one over the same path**. The failure this surface exists to prevent is a counter that silently resets, and a test that only checked presence would pass against a backend that stored the name and dropped the counters. So the counters are asserted by value, and across two save/reload cycles.

Also pinned: case-insensitive lookup (a case-sensitive one forks a namespace in two, each allocating from zero), and absence reading as `None` rather than a zeroed row (an allocator cannot tell those apart and would start numbering from 1).

Red was compile-level — the test commit does not build, because the methods did not exist.

## Verification

3761 workspace tests, clippy `-D warnings`, fmt clean.

## Not in scope

Allocation itself. Nothing yet *reads* a counter to mint a number; that is KAN-1214, and KAN-1216 must not remove the legacy counters until it lands.