### PR TITLE
KAN-1247 feat(domain,service): allocate card numbers from the prefix row, not from the board

### DIFF
--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -2680,36 +2680,66 @@ mod card_tests {
         )
     }
 
+    /// Two boards deliberately given the same prefix now SHARE one namespace
+    /// and one counter, so they cannot both hold KAN-1. This is the defect the
+    /// prefix row removes: previously each board minted from its own counter
+    /// and `KAN-1` named two different cards.
+    ///
+    /// The ambiguous-resolution path is not dead -- historical duplicates
+    /// survive in migrated data, deliberately, because renumbering them would
+    /// change identifiers users already reference. It simply can no longer be
+    /// reached by creating cards.
     #[test]
-    fn test_card_get_ambiguous_identifier_returns_all_matches() {
+    fn test_two_boards_sharing_a_prefix_get_distinct_identifiers() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
-        let (_, _, _, _, _, _) = setup_two_boards_same_prefix(&file);
+        let (_, _, _, _, card_a_id, card_b_id) = setup_two_boards_same_prefix(&file);
 
-        let output = kanban()
-            .args([file.to_str().unwrap(), "card", "get", "KAN-1"])
-            .assert()
-            .success()
-            .get_output()
-            .stdout
-            .clone();
+        let get = |ident: &str| {
+            let out = kanban()
+                .args([file.to_str().unwrap(), "card", "get", ident])
+                .assert()
+                .success()
+                .get_output()
+                .stdout
+                .clone();
+            parse_json_output(&String::from_utf8_lossy(&out))
+        };
 
-        let json = parse_json_output(&String::from_utf8_lossy(&output));
-        assert!(json["success"].as_bool().unwrap());
-        let items = json["data"]
-            .as_array()
-            .expect("data should be an array when multiple cards match");
-        assert_eq!(items.len(), 2);
-        let titles: Vec<&str> = items.iter().map(|c| c["title"].as_str().unwrap()).collect();
-        assert!(titles.contains(&"Card on A"));
-        assert!(titles.contains(&"Card on B"));
+        let first = get("KAN-1");
+        assert!(
+            first["data"].as_array().is_none(),
+            "KAN-1 must resolve to exactly one card, not a set: {}",
+            first["data"]
+        );
+        assert_eq!(first["data"]["id"].as_str().unwrap(), card_a_id);
+
+        let second = get("KAN-2");
+        assert_eq!(
+            second["data"]["id"].as_str().unwrap(),
+            card_b_id,
+            "the second board drew the next number from the shared counter"
+        );
     }
 
+    /// The ambiguous-identifier error still fires -- for data that already
+    /// contains duplicates. Those cannot be produced by creating cards any
+    /// more, so the file is seeded directly, which is exactly the shape a
+    /// migrated pre-prefix workspace has.
     #[test]
     fn test_card_mutate_ambiguous_identifier_error_lists_candidates() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("test.json");
         let (_, _, _, _, card_a_id, card_b_id) = setup_two_boards_same_prefix(&file);
+
+        // Force the historical collision the shared counter now prevents.
+        let mut env: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&file).unwrap()).unwrap();
+        for card in env["data"]["cards"].as_array_mut().unwrap() {
+            card["card_number"] = serde_json::json!(1);
+            card["prefix"] = serde_json::json!("kan");
+        }
+        std::fs::write(&file, serde_json::to_string_pretty(&env).unwrap()).unwrap();
 
         kanban()
             .args([file.to_str().unwrap(), "card", "archive", "KAN-1"])

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -125,11 +125,10 @@ impl CreateCard {
         // replayed from serialized command logs, so its shape is frozen. The
         // value must match what the identifier reader resolves, so a sprint
         // override is applied below once the sprint is known.
-        let board_prefix = crate::prefix::Prefix::normalize(
-            board
-                .card_prefix
-                .as_deref()
-                .unwrap_or(crate::prefix_backfill::DEFAULT_CARD_PREFIX),
+        let board_prefix = crate::prefix::effective_card_prefix(
+            board.card_prefix.as_deref(),
+            None,
+            crate::prefix_backfill::DEFAULT_CARD_PREFIX,
         );
         let mut card = crate::Card::create(
             spec,
@@ -160,9 +159,11 @@ impl CreateCard {
             // The reader resolves `sprint.card_prefix -> board.card_prefix`, so
             // a card created into an overriding sprint is addressed under the
             // sprint's prefix and must be stored under it.
-            if let Some(override_prefix) = sprint.card_prefix.as_deref() {
-                card.prefix = crate::prefix::Prefix::normalize(override_prefix);
-            }
+            card.prefix = crate::prefix::effective_card_prefix(
+                board.card_prefix.as_deref(),
+                sprint.card_prefix.as_deref(),
+                crate::prefix_backfill::DEFAULT_CARD_PREFIX,
+            );
             card.assign_to_sprint(sprint_id, sprint_number, sprint_name, sprint_status, now);
         }
 

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -461,12 +461,23 @@ impl CreateSubcardCommand {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         context.get_card(self.parent_id)?;
         let mut board = context.get_board(self.board_id)?;
+        // Allocates from the prefix row, like every other card. Minting from
+        // `board.card_counter` here would draw subcards from a different
+        // counter than their siblings and collide with them.
+        let (prefix, card_number) = crate::prefix::allocate_card_number(
+            context.store,
+            board.card_prefix.as_deref(),
+            None,
+            crate::prefix_backfill::DEFAULT_CARD_PREFIX,
+        )?;
         let mut card = Card::new(
             &mut board,
             self.column_id,
             self.title.clone(),
             self.position,
         );
+        card.card_number = card_number;
+        card.prefix = prefix;
         card.id = self.id;
 
         if let Some(desc) = &self.description {

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -60,8 +60,8 @@ pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use operations::KanbanOperations;
 pub use prefix::{
-    effective_prefixes, find_prefix_collisions, EffectivePrefix, Prefix, PrefixCollision,
-    PrefixOwner,
+    allocate_card_number, effective_card_prefix, effective_prefixes, find_prefix_collisions,
+    EffectivePrefix, Prefix, PrefixCollision, PrefixOwner,
 };
 pub use prefix_backfill::{
     plan_prefix_backfill, BackfillBoard, BackfillRow, BackfillSprint, DEFAULT_CARD_PREFIX,

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -5,6 +5,57 @@ use serde::{Deserialize, Serialize};
 use crate::board::{Board, BoardId};
 use crate::sprint::{Sprint, SprintId};
 
+/// The namespace a NEW card belongs to, given its board's prefix and its
+/// sprint's override. Normalised.
+///
+/// A sprint override beats its board's prefix, and the configured default
+/// applies when neither is set. Shared so the service's allocator and
+/// `CreateCard::execute` cannot derive different prefixes for one card -- they
+/// run at different layers and the command's serialized shape is frozen, so
+/// the number is passed to it but the prefix is re-derived.
+pub fn effective_card_prefix(
+    board_card_prefix: Option<&str>,
+    sprint_card_prefix: Option<&str>,
+    default_card_prefix: &str,
+) -> String {
+    Prefix::normalize(
+        sprint_card_prefix
+            .or(board_card_prefix)
+            .unwrap_or(default_card_prefix),
+    )
+}
+
+/// Reserves the next card number in the namespace a new card belongs to, and
+/// returns the `(prefix, card_number)` it is stamped with.
+///
+/// Numbering belongs to the prefix row, not to the card and not to the board.
+/// One counter per namespace is what makes `(prefix, card_number)` unique: with
+/// per-board counters, two boards sharing a prefix each mint number 1 and the
+/// same identifier names two cards.
+///
+/// Lives here rather than in the service tier because two callers need it and
+/// they sit on opposite sides of that boundary -- the service's create path and
+/// `CreateSubcardCommand`, which runs inside the domain. A subcard allocating
+/// from a different counter than a card is the collision this prevents.
+///
+/// Creates the row on demand: a board can predate the prefixes table, and an
+/// absent row means nothing has been allocated from that namespace yet.
+pub fn allocate_card_number(
+    store: &dyn crate::DataStore,
+    board_card_prefix: Option<&str>,
+    sprint_card_prefix: Option<&str>,
+    default_card_prefix: &str,
+) -> crate::KanbanResult<(String, u32)> {
+    let name = effective_card_prefix(board_card_prefix, sprint_card_prefix, default_card_prefix);
+    let mut row = store
+        .get_prefix(&name)?
+        .unwrap_or_else(|| Prefix::new(&name));
+    let card_number = row.card_counter + 1;
+    row.card_counter = card_number;
+    store.upsert_prefix(row)?;
+    Ok((name, card_number))
+}
+
 /// A namespace that allocates card and sprint numbers for one name.
 ///
 /// Several boards may share a prefix, so this deliberately records no owner:

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -580,8 +580,15 @@ async fn find_cards_by_identifier_single_match() {
     assert_eq!(results[0].id, card.id);
 }
 
+/// Two boards given the same prefix share one namespace and one counter, so
+/// they draw DIFFERENT numbers and each identifier resolves to exactly one
+/// card. Previously each board counted independently and `KAN-1` named two
+/// cards -- the defect the prefix row removes.
+///
+/// The multi-match path itself is still live for historical duplicates in
+/// migrated data; it just cannot be reached by creating cards.
 #[tokio::test]
-async fn find_cards_by_identifier_multiple_matches() {
+async fn find_cards_by_identifier_resolves_one_card_per_shared_namespace_number() {
     let (mut ctx, _tmp) = setup().await;
 
     let board_a = ctx
@@ -600,11 +607,18 @@ async fn find_cards_by_identifier_multiple_matches() {
         .create_card(board_b.id, col_b.id, "Card on B".into(), Default::default())
         .unwrap();
 
-    let results = ctx.find_cards_by_identifier("KAN-1").unwrap();
-    assert_eq!(results.len(), 2);
-    let ids: Vec<_> = results.iter().map(|c| c.id).collect();
-    assert!(ids.contains(&card_a.id));
-    assert!(ids.contains(&card_b.id));
+    assert_ne!(
+        card_a.card_number, card_b.card_number,
+        "one counter serves both boards"
+    );
+
+    let first = ctx.find_cards_by_identifier("KAN-1").unwrap();
+    assert_eq!(first.len(), 1, "no longer ambiguous");
+    assert_eq!(first[0].id, card_a.id);
+
+    let second = ctx.find_cards_by_identifier("KAN-2").unwrap();
+    assert_eq!(second.len(), 1);
+    assert_eq!(second[0].id, card_b.id);
 }
 
 #[tokio::test]

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -48,6 +48,29 @@ impl KanbanContext {
     /// domain `create` is Board-free). Inherent on `KanbanContext` (not a
     /// `KanbanOperations` trait method) — the trait is dual-impl by TUI+CLI and
     /// would force churn there.
+    /// Thin wrapper over the domain allocator: resolves the sprint override,
+    /// then defers. The rule lives in `kanban_domain::allocate_card_number` so
+    /// this and `CreateSubcardCommand` cannot draw from different counters.
+    fn allocate_card_number(
+        &self,
+        board: &kanban_domain::Board,
+        sprint_id: Option<Uuid>,
+    ) -> KanbanResult<(String, u32)> {
+        let sprint_override = match sprint_id {
+            Some(id) => self
+                .backend
+                .get_sprint(id)?
+                .and_then(|s| s.card_prefix.clone()),
+            None => None,
+        };
+        kanban_domain::allocate_card_number(
+            self.backend.as_data_store(),
+            board.card_prefix.as_deref(),
+            sprint_override.as_deref(),
+            kanban_domain::DEFAULT_CARD_PREFIX,
+        )
+    }
+
     pub fn create_card_from_spec(
         &mut self,
         client_id: Option<Uuid>,
@@ -82,7 +105,12 @@ impl KanbanContext {
             .backend
             .get_board(board_id)?
             .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
-        let card_number = board.card_counter;
+        // The prefix is deliberately dropped here: `CreateCard` is replayed from
+        // serialized command logs, so its shape is frozen and cannot carry one.
+        // It re-derives through the same `effective_card_prefix`, so the two
+        // cannot disagree -- and the allocation tests assert the stamped prefix
+        // against the namespace whose counter moved.
+        let (_prefix, card_number) = self.allocate_card_number(&board, spec.sprint_id)?;
         // Append past the FULL (live + archived) set so a new card shares one
         // coherent ordinal space with any archived siblings (KAN-916 / O1-A).
         let position = self.backend.count_cards_in_column_filtered(

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -441,11 +441,16 @@ pub async fn test_get_card_by_sprint_and_number_returns_matching_card(factory: &
     assert_eq!(found.map(|c| c.id), Some(card2.id));
 
     // A second sprint on a second board, holding a card whose number COLLIDES
-    // with card1's. Card numbers are per-board, so this is the only way to
-    // produce a duplicate. Without this foil an implementation that ignored
-    // sprint_id entirely and matched on card_number alone would still pass
-    // every assertion above.
-    let board_b = ctx.create_board("Board B".into(), None).unwrap();
+    // with card1's. Without this foil an implementation that ignored sprint_id
+    // entirely and matched on card_number alone would still pass every
+    // assertion above.
+    //
+    // The second board needs its OWN prefix. Boards sharing a namespace share
+    // one counter and so cannot produce a duplicate number at all -- which is
+    // the point of the prefix row, and which would silently disarm this foil.
+    let board_b = ctx
+        .create_board("Board B".into(), Some("FOIL".into()))
+        .unwrap();
     let col_b = ctx.create_column(board_b.id, "Col".into(), None).unwrap();
     let sprint_b = ctx.create_sprint(board_b.id, None, None).unwrap();
     let card_b = ctx

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -326,7 +326,12 @@ pub async fn test_full_populated_context_roundtrip(factory: &BackendFactory) -> 
     assert_eq!(b.active_sprint_id, Some(sprint.id));
     assert_eq!(b.sprint_names, vec!["Alpha", "Beta"]);
     assert_eq!(b.sprint_name_used_count, 1);
-    assert_eq!(b.card_counter, 14);
+    // Seeded to 10 above and unchanged by the four cards created since:
+    // numbers now come from the prefix row, and the legacy counter is only
+    // clamped UPWARD past a number actually issued. Seeding it directly no
+    // longer steers allocation -- for a real workspace the migration seeds the
+    // prefix row FROM this field, so the two agree from the start.
+    assert_eq!(b.card_counter, 10);
     assert_eq!(b.sprint_counters.get("SP"), Some(&6));
 
     let cols = loaded.list_columns(board.id).unwrap();

--- a/crates/kanban-service/tests/prefix_allocation.rs
+++ b/crates/kanban-service/tests/prefix_allocation.rs
@@ -6,7 +6,7 @@
 //! `MAX(card_number)` scan -- the two implementations this card replaces.
 
 use kanban_core::AppConfig;
-use kanban_domain::{CreateCardOptions, DataStore, KanbanOperations};
+use kanban_domain::{CreateCardOptions, KanbanOperations};
 use kanban_service::KanbanContext;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -20,12 +20,14 @@ async fn ctx(path: &std::path::Path) -> KanbanContext {
         .expect("open context")
 }
 
+/// An absent row and a row at zero mean the same thing: nothing has been
+/// allocated from that namespace yet. The row is created on first allocation,
+/// so reading before any card exists must not be an error.
 fn counter(ctx: &KanbanContext, name: &str) -> u32 {
     ctx.backend()
         .get_prefix(name)
         .unwrap()
-        .unwrap_or_else(|| panic!("no prefix row named {name}"))
-        .card_counter
+        .map_or(0, |p| p.card_counter)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -154,5 +156,61 @@ async fn test_legacy_board_counter_still_moves_in_lockstep() {
         c.get_board(board.id).unwrap().unwrap().card_counter,
         before + 1,
         "the legacy counter stays in sync until KAN-1216 removes it"
+    );
+}
+
+/// A subcard is created by a different command on a different layer
+/// (`CreateSubcardCommand`, inside the domain). Before this card it minted from
+/// `board.card_counter` while ordinary cards minted from the prefix row, so the
+/// two drew from INDEPENDENT counters. They do not necessarily collide on the
+/// next create -- they drift, and drift is what lets them collide later. The
+/// discriminating assertion below is the counter, not the identifiers.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_subcard_allocates_from_the_same_counter_as_its_siblings() {
+    use kanban_domain::commands::{Command, CreateSubcardCommand, DependencyCommand};
+    use uuid::Uuid;
+
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let parent = c
+        .create_card(
+            board.id,
+            col.id,
+            "parent".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let subcard_id = Uuid::new_v4();
+    c.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+        CreateSubcardCommand {
+            id: subcard_id,
+            parent_id: parent.id,
+            board_id: board.id,
+            column_id: col.id,
+            title: "sub".into(),
+            description: None,
+            position: 1,
+        },
+    ))])
+    .unwrap();
+
+    let sub = c.get_card(subcard_id).unwrap().unwrap();
+    assert_eq!(
+        sub.prefix, "kan",
+        "a subcard belongs to its board's namespace"
+    );
+    assert_ne!(
+        (sub.prefix.as_str(), sub.card_number),
+        (parent.prefix.as_str(), parent.card_number),
+        "a subcard must not collide with its own parent"
+    );
+    assert_eq!(
+        counter(&c, "kan"),
+        2,
+        "both creates advanced ONE counter; a second counter would leave this at 1"
     );
 }

--- a/crates/kanban-service/tests/prefix_allocation.rs
+++ b/crates/kanban-service/tests/prefix_allocation.rs
@@ -1,0 +1,158 @@
+//! Card numbers are allocated from the prefix row, not from the board.
+//!
+//! Every assertion here is on the `prefixes` ROW VALUE rather than on the
+//! returned `card_number`. Asserting the returned number only proves it went
+//! up, which passes identically against `boards.card_counter` or a
+//! `MAX(card_number)` scan -- the two implementations this card replaces.
+
+use kanban_core::AppConfig;
+use kanban_domain::{CreateCardOptions, DataStore, KanbanOperations};
+use kanban_service::KanbanContext;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+async fn ctx(path: &std::path::Path) -> KanbanContext {
+    let backend = kanban_persistence_sqlite::SqliteBackend::open(path.to_str().unwrap())
+        .await
+        .expect("open sqlite backend");
+    KanbanContext::open(Arc::new(backend), AppConfig::default())
+        .await
+        .expect("open context")
+}
+
+fn counter(ctx: &KanbanContext, name: &str) -> u32 {
+    ctx.backend()
+        .get_prefix(name)
+        .unwrap()
+        .unwrap_or_else(|| panic!("no prefix row named {name}"))
+        .card_counter
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_card_numbers_are_drawn_from_the_prefix_row_counter() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+
+    let before = counter(&c, "kan");
+    let one = c
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+    let after_one = counter(&c, "kan");
+    let two = c
+        .create_card(board.id, col.id, "two".into(), CreateCardOptions::default())
+        .unwrap();
+    let after_two = counter(&c, "kan");
+
+    assert_eq!(
+        (after_one, after_two),
+        (before + 1, before + 2),
+        "each create must advance the PREFIX ROW's counter; advancing only \
+         boards.card_counter would leave this unchanged"
+    );
+    assert_eq!(one.prefix, "kan");
+    assert_eq!(two.prefix, "kan");
+    assert_ne!(one.card_number, two.card_number);
+}
+
+/// The invariant the whole epic exists for. Two boards sharing a namespace
+/// draw from ONE counter, so they cannot mint the same identifier -- which is
+/// exactly what per-board counters allow today.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_two_boards_sharing_a_prefix_never_mint_the_same_identifier() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let a = c.create_board("A".into(), Some("SHARED".into())).unwrap();
+    let b = c.create_board("B".into(), Some("shared".into())).unwrap();
+    let col_a = c.create_column(a.id, "Todo".into(), None).unwrap();
+    let col_b = c.create_column(b.id, "Todo".into(), None).unwrap();
+
+    let card_a = c
+        .create_card(a.id, col_a.id, "a".into(), CreateCardOptions::default())
+        .unwrap();
+    let card_b = c
+        .create_card(b.id, col_b.id, "b".into(), CreateCardOptions::default())
+        .unwrap();
+
+    assert_eq!(
+        card_a.prefix, card_b.prefix,
+        "one namespace, spelled two ways"
+    );
+    assert_ne!(
+        (card_a.prefix.as_str(), card_a.card_number),
+        (card_b.prefix.as_str(), card_b.card_number),
+        "cards on different boards sharing a namespace must not collide; this \
+         is the defect that let KAN-1 name two different cards"
+    );
+}
+
+/// A card created into a sprint that overrides its board's prefix must draw
+/// from THAT namespace's counter, not the board's.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_sprint_override_allocates_from_the_sprints_namespace() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let sprint = c.create_sprint(board.id, None, None).unwrap();
+    c.update_sprint(
+        sprint.id,
+        kanban_domain::SprintUpdate {
+            card_prefix: kanban_domain::FieldUpdate::Set("AUTH".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let board_before = counter(&c, "kan");
+    let card = c
+        .create_card(
+            board.id,
+            col.id,
+            "in sprint".into(),
+            CreateCardOptions {
+                sprint_id: Some(sprint.id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(card.prefix, "auth", "stamped with the sprint's namespace");
+    assert_eq!(
+        counter(&c, "kan"),
+        board_before,
+        "allocating from the sprint's namespace must NOT advance the board's \
+         counter, or the board permanently skips numbers"
+    );
+    assert_eq!(
+        counter(&c, "auth"),
+        1,
+        "the sprint's namespace is what advanced"
+    );
+}
+
+/// KAN-1216 removes `boards.card_counter` only once KAN-1215 reads through the
+/// prefix row. Until then both move together, and deleting this test is what
+/// that card does.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_legacy_board_counter_still_moves_in_lockstep() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let before = c.get_board(board.id).unwrap().unwrap().card_counter;
+
+    c.create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+
+    assert_eq!(
+        c.get_board(board.id).unwrap().unwrap().card_counter,
+        before + 1,
+        "the legacy counter stays in sync until KAN-1216 removes it"
+    );
+}


### PR DESCRIPTION
A card no longer mints its own number by mutating a board. The prefix row owns the counter; the card is handed the `(prefix, card_number)` it stores.

## The red test is the defect

```
left:  ("shared", 1)
right: ("shared", 1)
```

Two boards configured with the same prefix each minted card number 1, so `shared-1` named two different cards. That is how `KAN-1` came to name two cards on the real tracker. One counter per namespace is what makes the pair unique.

Every assertion is on the `prefixes` **row value**, not the returned `card_number`. Asserting the returned number only proves it went up, which passes identically against `boards.card_counter` or a `MAX(card_number)` scan — the two implementations this replaces.

## A live defect found on the way

`allocate_card_number` lives in `kanban-domain`, not the service tier, because two callers need it from opposite sides of that boundary: the service's create path, and `CreateSubcardCommand`, which runs inside the domain.

That second caller was **not** a cleanup. It minted via `Card::new(&mut board, …)`, so subcards drew from `boards.card_counter` while their siblings drew from the prefix row. Two independent counters for one namespace drift, and drift is what lets them collide. Both now allocate through one function, pinned by a test whose discriminating assertion is the counter — the identifiers alone don't diverge on the very next create.

A sprint override allocates from the sprint's namespace and does **not** advance the board's counter; doing so would make the board permanently skip numbers it never issued.

`boards.card_counter` is still written, clamped upward past any number issued, so KAN-1215 and any unmigrated reader stay correct until KAN-1216 removes it. That dual-write has its own test, and deleting it is what KAN-1216 does.

## Three tests encoded the defect as expected behaviour

Two CLI tests and one MCP test built two boards with the same prefix and expected `KAN-1` to match both. They now assert the fix.

**The ambiguous-resolution path is untouched and still tested.** Historical duplicates survive in migrated data deliberately — renumbering them would change identifiers users already reference — so the mutate test seeds that collision directly, which is the shape a migrated pre-prefix workspace actually has. What changed is that ambiguity can no longer be *created*.

## Two expectations moved, both for real reasons

- A sprint-scoped foil needed its own prefix. Boards sharing a namespace can no longer produce a duplicate number, so the foil would have silently disarmed while still passing.
- A roundtrip test seeded `board.card_counter = 10` directly and expected allocation to continue from it. Seeding that field no longer steers allocation. For a real workspace the migration seeds the prefix row *from* it, so the two agree from the start — this test bypassed the migration.

## Deferred, deliberately

`Board::get_next_card_number` now has callers in test fixtures only. Removing its `&mut Board` parameter touches **243 call sites across 63 files**; that is mechanical and should not ride along with the logic change. It is the last step before KAN-1216 can remove the field.

## Verification

3786 workspace tests, clippy `-D warnings`, fmt clean. Red and green are separate commits.