### PR TITLE
KAN-1215 perf(domain,service,persistence-sqlite): resolve card identifiers by (prefix, card_number)

### DIFF
--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -226,6 +226,14 @@ impl Card {
     /// Resolve the branch name prefix using two-level hierarchy:
     /// sprint.card_prefix → board.card_prefix → default_prefix
     pub fn branch_name(&self, board: &Board, sprints: &[Sprint], default_prefix: &str) -> String {
+        // Still DERIVED, deliberately. `self.prefix` is normalised to
+        // lowercase for matching, and a branch name is case-sensitive: reading
+        // it here would turn `KAN-668/...` into `kan-668/...` for every user.
+        //
+        // That makes this drift from the stored identifier after a board
+        // rename, which is a real defect -- see the card tracking it. Fixing it
+        // properly means storing the prefix as the user wrote it and comparing
+        // case-insensitively, not silently lowercasing everyone's branches.
         let prefix = if let Some(sprint_id) = self.sprint_id {
             sprints
                 .iter()

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -49,6 +49,44 @@ pub trait DataStore: Send + Sync {
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>>;
     fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize>;
 
+    /// Every live card in namespace `prefix` numbered `card_number`.
+    ///
+    /// Returns a Vec, not an Option: one namespace has one counter, so a
+    /// duplicate cannot be CREATED -- but migrated workspaces carry historical
+    /// duplicates deliberately, since renumbering them would change identifiers
+    /// users already reference. Collapsing to Option would silently drop one
+    /// and break the three-way none/one/many resolution contract.
+    ///
+    /// Default is an honest linear scan every backend can answer; SQL-backed
+    /// implementations override with an indexed query on
+    /// `cards(prefix, card_number)`.
+    fn list_cards_by_prefix_and_number(
+        &self,
+        prefix: &str,
+        card_number: u32,
+    ) -> KanbanResult<Vec<Card>> {
+        let wanted = crate::prefix::Prefix::normalize(prefix);
+        Ok(self
+            .list_all_cards()?
+            .into_iter()
+            .filter(|c| c.card_number == card_number && c.prefix == wanted)
+            .collect())
+    }
+
+    /// Every live card numbered `card_number`, in ANY namespace.
+    ///
+    /// A bare `"5"` deliberately matches across namespaces, so the
+    /// `(prefix, card_number)` index cannot serve it. Kept a first-class
+    /// method rather than a caller-side scan so SQL-backed implementations can
+    /// answer it from an index instead of loading every card.
+    fn list_cards_by_number(&self, card_number: u32) -> KanbanResult<Vec<Card>> {
+        Ok(self
+            .list_all_cards()?
+            .into_iter()
+            .filter(|c| c.card_number == card_number)
+            .collect())
+    }
+
     /// Find the card numbered `card_number` directly owned by `board_id`
     /// (via `Card.board_id`, not via column membership). Returns `None`
     /// when no live card matches. Default is an honest linear scan every

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -78,8 +78,8 @@ pub use query::{
 pub use search::{
     find_boards_by_name, find_cards_by_identifier, find_columns_by_name,
     find_sprints_by_query_global, find_sprints_by_query_on_board, format_ambiguous_matches,
-    resolve_card_prefix_by_ids, BranchNameSearcher, CardSearcher, CompositeSearcher, FieldSearcher,
-    SearchBy, Searcher, TitleSearcher,
+    parse_identifier, resolve_card_prefix_by_ids, BranchNameSearcher, CardSearcher,
+    CompositeSearcher, FieldSearcher, ParsedIdentifier, SearchBy, Searcher, TitleSearcher,
 };
 pub use snapshot::Snapshot;
 pub use sort::{

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -338,19 +338,26 @@ pub trait KanbanOperations {
         }
     }
 
-    /// Resolve a batch of card identifiers against a single snapshot. Pure
-    /// in-memory matching against `find_cards_by_identifier`; one set of
-    /// `list_all_*` calls regardless of batch size.
+    /// Resolve a batch of card identifiers.
+    ///
+    /// Matches on each card's STORED prefix, as single-identifier resolution
+    /// does. It previously re-derived the prefix through the card's board, so
+    /// after a board rename a batch operation and `card get` disagreed about
+    /// what `KAN-5` meant.
+    ///
+    /// Still one in-memory pass over the cards for the whole batch rather than
+    /// an indexed lookup per input: `KanbanOperations` is not bounded by
+    /// `DataStore`, so the indexed primitives are not reachable from here.
+    /// Correctness first; the batch path loads once for N inputs, so it never
+    /// had the per-lookup cost KAN-1215 removed. Reading the stored prefix does
+    /// drop the column, board and sprint loads, since there is nothing left to
+    /// derive.
     ///
     /// On failure, returns `KanbanError::BatchResolutionFailed` with per-input
     /// typed causes so callers can introspect (which raw inputs failed, and
     /// for what reason).
     fn resolve_card_ids(&self, raws: &[String]) -> KanbanResult<Vec<Uuid>> {
-        // Single snapshot for the whole batch — no per-element backend round-trips.
         let cards = self.list_all_cards()?;
-        let columns = self.list_all_columns()?;
-        let boards = self.list_boards()?;
-        let sprints = self.list_all_sprints()?;
 
         let mut resolved = Vec::with_capacity(raws.len());
         let mut failures = Vec::new();
@@ -359,8 +366,16 @@ pub trait KanbanOperations {
                 resolved.push(uuid);
                 continue;
             }
-            let matches =
-                crate::search::find_cards_by_identifier(raw, &cards, &columns, &boards, &sprints);
+            let matches: Vec<&Card> = match crate::parse_identifier(raw) {
+                Some(crate::ParsedIdentifier::PrefixAndNumber { prefix, number }) => cards
+                    .iter()
+                    .filter(|c| c.card_number == number && c.prefix == prefix)
+                    .collect(),
+                Some(crate::ParsedIdentifier::NumberOnly(number)) => {
+                    cards.iter().filter(|c| c.card_number == number).collect()
+                }
+                None => Vec::new(),
+            };
             match matches.as_slice() {
                 [] => failures.push(BatchResolutionFailure {
                     raw_input: raw.clone(),

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -201,12 +201,14 @@ impl Default for CompositeSearcher {
     }
 }
 
-enum ParsedIdentifier {
+/// A parsed card identifier: `"KAN-5"` or a bare `"5"`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedIdentifier {
     PrefixAndNumber { prefix: String, number: u32 },
     NumberOnly(u32),
 }
 
-fn parse_identifier(identifier: &str) -> Option<ParsedIdentifier> {
+pub fn parse_identifier(identifier: &str) -> Option<ParsedIdentifier> {
     let lower = identifier.to_lowercase();
     if let Some(dash_pos) = lower.rfind('-') {
         let prefix = &lower[..dash_pos];

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -220,6 +220,16 @@ impl DataStore for JsonDataStore {
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
         self.with_read(|s| s.list_cards_by_sprint(sprint_id))
     }
+    fn list_cards_by_number(&self, card_number: u32) -> KanbanResult<Vec<Card>> {
+        self.with_read(|s| s.list_cards_by_number(card_number))
+    }
+    fn list_cards_by_prefix_and_number(
+        &self,
+        prefix: &str,
+        card_number: u32,
+    ) -> KanbanResult<Vec<Card>> {
+        self.with_read(|s| s.list_cards_by_prefix_and_number(prefix, card_number))
+    }
     fn get_card_by_board_and_number(
         &self,
         board_id: Uuid,

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -246,6 +246,9 @@ CREATE INDEX IF NOT EXISTS idx_cards_sprint_number ON cards(sprint_id, card_numb
 -- Serves identifier resolution: one probe by (prefix, card_number), which is
 -- unique by construction because a namespace has exactly one counter.
 CREATE INDEX IF NOT EXISTS idx_cards_prefix_number ON cards(prefix, card_number);
+-- A bare `5` matches across namespaces, so the composite above cannot serve
+-- it and it would otherwise load every card.
+CREATE INDEX IF NOT EXISTS idx_cards_number ON cards(card_number);
 
 CREATE INDEX IF NOT EXISTS idx_archived_cards_board_id ON archived_cards(board_id);
 CREATE INDEX IF NOT EXISTS idx_archived_cards_archived_at ON archived_cards(archived_at);

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -104,6 +104,16 @@ impl DataStore for SqliteBackend {
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
         self.db.list_cards_by_sprint(sprint_id)
     }
+    fn list_cards_by_number(&self, card_number: u32) -> KanbanResult<Vec<kanban_domain::Card>> {
+        self.db.list_cards_by_number(card_number)
+    }
+    fn list_cards_by_prefix_and_number(
+        &self,
+        prefix: &str,
+        card_number: u32,
+    ) -> KanbanResult<Vec<kanban_domain::Card>> {
+        self.db.list_cards_by_prefix_and_number(prefix, card_number)
+    }
     fn get_card_by_board_and_number(
         &self,
         board_id: Uuid,

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -274,6 +274,26 @@ impl DataStore for SqliteStore {
         run(self.fetch_cards_with_filter("AND sprint_id = ?", vec![sprint_id.to_string()]))
     }
 
+    fn list_cards_by_prefix_and_number(
+        &self,
+        prefix: &str,
+        card_number: u32,
+    ) -> KanbanResult<Vec<Card>> {
+        // Indexed by idx_cards_prefix_number.
+        run(self.fetch_cards_with_filter(
+            "AND prefix = ? AND card_number = ?",
+            vec![
+                kanban_domain::Prefix::normalize(prefix),
+                card_number.to_string(),
+            ],
+        ))
+    }
+
+    fn list_cards_by_number(&self, card_number: u32) -> KanbanResult<Vec<Card>> {
+        // Indexed by idx_cards_number.
+        run(self.fetch_cards_with_filter("AND card_number = ?", vec![card_number.to_string()]))
+    }
+
     fn get_card_by_board_and_number(
         &self,
         board_id: Uuid,

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/composite_indexes.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/composite_indexes.rs
@@ -200,3 +200,62 @@ fn test_identifier_resolution_returns_identical_results_with_and_without_index()
         assert!(!with_index.is_empty());
     });
 }
+
+/// The lookup KAN-1215's resolver actually issues. Correctness is proven at
+/// the service tier; this proves it is INDEXED -- a correct lookup that scans
+/// the table would pass every behavioural test while delivering none of the
+/// speedup the epic exists for.
+#[test]
+fn test_prefix_number_lookup_uses_the_prefix_index() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        seed_cards_across_two_boards(&store).await;
+
+        let plan = explain_query_plan(
+            store.pool(),
+            "SELECT * FROM cards WHERE prefix = ?1 AND card_number = ?2",
+            "kan",
+            1,
+        )
+        .await;
+
+        assert!(
+            plan.contains("idx_cards_prefix_number"),
+            "expected the (prefix, card_number) index in the plan, got: {plan}"
+        );
+        assert!(
+            !plan.contains("SCAN cards"),
+            "the resolver's lookup must not scan the cards table: {plan}"
+        );
+    });
+}
+
+/// A bare `5` matches across namespaces, so the composite index cannot serve
+/// it. Without an index of its own it loads every card -- measured at 34ms
+/// against 3.8ms for the prefixed lookup on a 1216-card tracker.
+#[test]
+fn test_bare_number_lookup_uses_the_card_number_index() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        seed_cards_across_two_boards(&store).await;
+
+        let plan = explain_query_plan(
+            store.pool(),
+            "SELECT * FROM cards WHERE card_number = ?2",
+            "unused",
+            1,
+        )
+        .await;
+
+        assert!(
+            !plan.contains("SCAN cards"),
+            "a bare-number lookup must not scan the cards table: {plan}"
+        );
+    });
+}

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -223,15 +223,24 @@ impl KanbanContext {
         &self,
         identifier: &str,
     ) -> KanbanResult<Vec<Card>> {
-        use kanban_domain::search::find_cards_by_identifier as search;
-        let cards = self.list_live_cards_impl()?;
-        let columns = self.list_live_columns_impl()?;
-        let boards = self.backend.list_boards()?;
-        let sprints = self.list_live_sprints_impl()?;
-        Ok(search(identifier, &cards, &columns, &boards, &sprints)
-            .into_iter()
-            .cloned()
-            .collect())
+        use kanban_domain::{parse_identifier, ParsedIdentifier};
+
+        let Some(parsed) = parse_identifier(identifier) else {
+            return Ok(Vec::new());
+        };
+
+        match parsed {
+            // One indexed lookup. The prefix is stored on the card, so there
+            // is no board to walk back through and no collection to load.
+            ParsedIdentifier::PrefixAndNumber { prefix, number } => self
+                .backend
+                .list_cards_by_prefix_and_number(&prefix, number),
+            // A bare number deliberately matches ACROSS namespaces, so the
+            // composite index cannot serve it -- but it gets its own indexed
+            // lookup rather than loading every card. Measured at 34ms vs 3.8ms
+            // on a 1216-card tracker before this.
+            ParsedIdentifier::NumberOnly(number) => self.backend.list_cards_by_number(number),
+        }
     }
 
     /// LIVE-scoped (C3b): the user-facing "list all cards" excludes archived-

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -27,14 +27,6 @@ impl CountingBackend {
         self.list_archived_cards_calls.load(Ordering::SeqCst)
     }
 
-    /// The four whole-collection reads the identifier resolver used to make.
-    fn whole_store_scans(&self) -> usize {
-        self.cards_scans.load(Ordering::SeqCst)
-            + self.boards_scans.load(Ordering::SeqCst)
-            + self.columns_scans.load(Ordering::SeqCst)
-            + self.sprints_scans.load(Ordering::SeqCst)
-    }
-
     fn scan_breakdown(&self) -> String {
         format!(
             "cards={} boards={} columns={} sprints={}",
@@ -376,18 +368,34 @@ async fn test_identifier_resolution_makes_no_whole_store_reads() {
             .unwrap();
     }
 
-    let before = backend.whole_store_scans();
+    let boards_before = backend.boards_scans.load(Ordering::SeqCst);
+    let columns_before = backend.columns_scans.load(Ordering::SeqCst);
+    let sprints_before = backend.sprints_scans.load(Ordering::SeqCst);
+
     let found = ctx.find_cards_by_identifier("KAN-3").unwrap();
-    let during = backend.whole_store_scans() - before;
 
     assert_eq!(found.len(), 1, "KAN-3 resolves to exactly one card");
     assert_eq!(found[0].card_number, 3);
+
+    // The board indirection is what this card deletes: resolution no longer
+    // walks card -> column -> board, nor consults sprints, so none of those
+    // collections is read at all.
     assert_eq!(
-        during,
-        0,
-        "resolving one identifier must read no whole collection; got {}",
+        (
+            backend.boards_scans.load(Ordering::SeqCst) - boards_before,
+            backend.columns_scans.load(Ordering::SeqCst) - columns_before,
+            backend.sprints_scans.load(Ordering::SeqCst) - sprints_before,
+        ),
+        (0, 0, 0),
+        "no board, column or sprint collection may be read; got {}",
         backend.scan_breakdown()
     );
+
+    // Cards are deliberately NOT asserted at zero here. This backend is
+    // in-memory and inherits `list_cards_by_prefix_and_number`'s default, an
+    // honest scan -- a HashMap has no index to consult. The zero-scan claim
+    // belongs to SQLite, and is proven there by asserting the query plan uses
+    // idx_cards_prefix_number rather than scanning the table.
 }
 
 /// Historical duplicates still resolve to every match. Migrated workspaces

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -16,11 +16,33 @@ use uuid::Uuid;
 struct CountingBackend {
     inner: InMemoryStore,
     list_archived_cards_calls: AtomicUsize,
+    cards_scans: AtomicUsize,
+    boards_scans: AtomicUsize,
+    columns_scans: AtomicUsize,
+    sprints_scans: AtomicUsize,
 }
 
 impl CountingBackend {
     fn list_archived_cards_call_count(&self) -> usize {
         self.list_archived_cards_calls.load(Ordering::SeqCst)
+    }
+
+    /// The four whole-collection reads the identifier resolver used to make.
+    fn whole_store_scans(&self) -> usize {
+        self.cards_scans.load(Ordering::SeqCst)
+            + self.boards_scans.load(Ordering::SeqCst)
+            + self.columns_scans.load(Ordering::SeqCst)
+            + self.sprints_scans.load(Ordering::SeqCst)
+    }
+
+    fn scan_breakdown(&self) -> String {
+        format!(
+            "cards={} boards={} columns={} sprints={}",
+            self.cards_scans.load(Ordering::SeqCst),
+            self.boards_scans.load(Ordering::SeqCst),
+            self.columns_scans.load(Ordering::SeqCst),
+            self.sprints_scans.load(Ordering::SeqCst),
+        )
     }
 }
 
@@ -38,6 +60,7 @@ impl DataStore for CountingBackend {
         self.inner.get_board(id)
     }
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        self.boards_scans.fetch_add(1, Ordering::SeqCst);
         self.inner.list_boards()
     }
     fn upsert_board(&self, board: Board) -> KanbanResult<()> {
@@ -53,6 +76,7 @@ impl DataStore for CountingBackend {
         self.inner.list_columns_by_board(board_id)
     }
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.columns_scans.fetch_add(1, Ordering::SeqCst);
         self.inner.list_all_columns()
     }
     fn upsert_column(&self, column: Column) -> KanbanResult<()> {
@@ -68,6 +92,7 @@ impl DataStore for CountingBackend {
         self.inner.get_card(id)
     }
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.cards_scans.fetch_add(1, Ordering::SeqCst);
         self.inner.list_all_cards()
     }
     fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
@@ -172,6 +197,7 @@ impl DataStore for CountingBackend {
         self.inner.list_sprints_by_board(board_id)
     }
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.sprints_scans.fetch_add(1, Ordering::SeqCst);
         self.inner.list_all_sprints()
     }
     fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
@@ -325,4 +351,78 @@ fn test_filter_cards_still_uses_archived_card_index() {
         2,
         "list_cards's collection-shaped path keeps building the archived index the same way it did before this change"
     );
+}
+
+/// The epic's headline: resolving `PREFIX-N` must not read whole collections.
+///
+/// Before KAN-1215 this loaded every card, column, board and sprint to answer
+/// one lookup -- the 73ms-vs-9ms gap measured on a 1174-card tracker. With the
+/// prefix stored on the card it is one indexed lookup by
+/// `(prefix, card_number)`.
+///
+/// Counts calls rather than timing, so it holds on any machine and names which
+/// scan came back if one does.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_identifier_resolution_makes_no_whole_store_reads() {
+    let backend = Arc::new(CountingBackend::default());
+    let mut ctx = KanbanContext::open(backend.clone(), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    for i in 0..5 {
+        ctx.create_card(board.id, col.id, format!("card {i}"), Default::default())
+            .unwrap();
+    }
+
+    let before = backend.whole_store_scans();
+    let found = ctx.find_cards_by_identifier("KAN-3").unwrap();
+    let during = backend.whole_store_scans() - before;
+
+    assert_eq!(found.len(), 1, "KAN-3 resolves to exactly one card");
+    assert_eq!(found[0].card_number, 3);
+    assert_eq!(
+        during,
+        0,
+        "resolving one identifier must read no whole collection; got {}",
+        backend.scan_breakdown()
+    );
+}
+
+/// Historical duplicates still resolve to every match. Migrated workspaces
+/// carry them deliberately -- renumbering would change identifiers users
+/// already reference -- so the three-way none/one/many contract survives.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_identifier_resolution_still_returns_every_historical_duplicate() {
+    let backend = Arc::new(CountingBackend::default());
+    let mut ctx = KanbanContext::open(backend.clone(), AppConfig::default())
+        .await
+        .unwrap();
+
+    let a = ctx.create_board("A".into(), Some("DUP".into())).unwrap();
+    let col_a = ctx.create_column(a.id, "Todo".into(), None).unwrap();
+    let b = ctx.create_board("B".into(), Some("OTHER".into())).unwrap();
+    let col_b = ctx.create_column(b.id, "Todo".into(), None).unwrap();
+
+    let one = ctx
+        .create_card(a.id, col_a.id, "one".into(), Default::default())
+        .unwrap();
+    let two = ctx
+        .create_card(b.id, col_b.id, "two".into(), Default::default())
+        .unwrap();
+
+    // Force the collision a pre-prefix workspace can already contain: same
+    // namespace, same number. Creation can no longer produce this.
+    let mut two = ctx.get_card(two.id).unwrap().unwrap();
+    two.prefix = one.prefix.clone();
+    two.card_number = one.card_number;
+    backend.upsert_card(two.clone()).unwrap();
+
+    let found = ctx.find_cards_by_identifier("DUP-1").unwrap();
+    let mut ids: Vec<_> = found.iter().map(|c| c.id).collect();
+    ids.sort();
+    let mut expected = vec![one.id, two.id];
+    expected.sort();
+    assert_eq!(ids, expected, "both historical duplicates must come back");
 }

--- a/crates/kanban-service/tests/prefix_allocation.rs
+++ b/crates/kanban-service/tests/prefix_allocation.rs
@@ -214,3 +214,48 @@ async fn test_a_subcard_allocates_from_the_same_counter_as_its_siblings() {
         "both creates advanced ONE counter; a second counter would leave this at 1"
     );
 }
+
+/// Single-identifier and batch resolution must mean the same thing by
+/// `KAN-5`. They used different rules: `card get` reads the stored prefix
+/// while `resolve_card_ids` re-derived it through the card's board, so a board
+/// rename made them disagree -- one finding the card under its old identifier
+/// and the other under the new one.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_and_single_resolution_agree_after_a_board_rename() {
+    use kanban_domain::{BoardUpdate, FieldUpdate};
+
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("OLD".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = c
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+    let ident = format!("{}-{}", card.prefix, card.card_number);
+
+    c.update_board(
+        board.id,
+        BoardUpdate {
+            card_prefix: FieldUpdate::Set("NEW".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let single = c.find_cards_by_identifier(&ident).unwrap();
+    let batch = c.resolve_card_ids(std::slice::from_ref(&ident)).unwrap();
+
+    assert_eq!(single.len(), 1, "{ident} still resolves after the rename");
+    assert_eq!(
+        batch,
+        vec![card.id],
+        "batch resolution must agree with single resolution about {ident}"
+    );
+
+    // And neither answers to the board's NEW prefix, because the card was
+    // never minted under it.
+    let renamed = format!("new-{}", card.card_number);
+    assert!(c.find_cards_by_identifier(&renamed).unwrap().is_empty());
+    assert!(c.resolve_card_ids(&[renamed]).is_err());
+}


### PR DESCRIPTION
This is the card the epic exists for.

Resolving one identifier loaded every card, column, board and sprint and filtered in memory — four whole-collection reads to answer one lookup. With the prefix stored on the card (KAN-1246) there is no board to walk back through, so it becomes a single indexed lookup.

## Measured, not claimed

Real 1216-card tracker, migrated to SQLite, release builds, same machine, `develop` vs this branch:

| | before | after |
|---|---|---|
| empty-db process floor | 1.4 ms | 2.3 ms |
| `board list` | 4.0 ms | 4.0 ms |
| **`card get kan-668`** | **36.8 ms** | **3.3 ms** |
| **`card get 668`** | **38.6 ms** | **3.3 ms** |

Resolution now costs about a millisecond over the bare process floor, and less than listing boards — it reads one indexed row rather than a collection.

The two floors differ by ~0.9ms between builds and I have not chased why; it does not affect the conclusion, but it means the honest reading is "≈1ms over floor," not a precise 11.1x.

## Measuring changed the design

The first version left bare-number lookups (`card get 668`) as a scan, reasoning they were rare. Measuring made that untenable: **34ms against 3.8ms**, using precisely the whole-collection load this epic removes.

A bare `5` matches across namespaces, so the composite index cannot serve it — it gets its own. Now 3.3ms, identical to the prefixed path. I would not have found this by reasoning about the code.

## Vec, not Option

`list_cards_by_prefix_and_number` returns a Vec. One namespace has one counter, so a duplicate cannot be *created* — but migrated workspaces carry historical duplicates deliberately, since renumbering them would change identifiers users already reference. Collapsing to Option would silently drop one and break the three-way none/one/many contract, which is pinned by a test that forces the collision directly.

## Two things the tests pin that behaviour alone would not

**No whole-store reads.** The counting backend asserts that resolving an identifier reads no board, column or sprint collection. Card reads are deliberately *not* asserted at zero there: that backend is in-memory and inherits the default, an honest scan, because a HashMap has no index. Claiming zero there would be claiming something untrue of that backend.

**The lookup is indexed.** `EXPLAIN QUERY PLAN` asserts `idx_cards_prefix_number` and no `SCAN cards`. A correct lookup that scans the table passes every behavioural test while delivering none of the speedup — which is exactly the failure mode this card is about.

Both wrappers delegate explicitly. A defaulted method stops at `SqliteBackend` and never reaches `SqliteStore`'s indexed override, leaving the scan in place with everything green.

## Verification

3790 workspace tests, clippy `-D warnings`, fmt clean. Red and green are separate commits; red showed `cards=3 boards=4 columns=3 sprints=3`.

Also validated incidentally: the full migration chain ran on the real tracker, V12 → V16, backfilling 1216 card prefixes (`kan` ×1181, the sprint overrides, and 3 defaults).


## Post-review additions

Reviewing this branch before merge found a second resolution path that had not been updated.

**`resolve_card_ids` (batch operations) still re-derived each card's prefix through its board**, while `card get` reads the stored one. After a board rename the two disagreed — `card get kan-5` found the card, a batch operation with the same string did not, and `new-5` did the reverse. Two resolution semantics in one binary. Both now read the stored prefix, which also drops three of that path's four whole-collection loads.

**`branch_name` has the same defect and is deliberately NOT fixed here.** The stored prefix is normalised to lowercase, so reading it would emit `kan-668/...` where the tool has always emitted `KAN-668/...`. Git branch names are case-sensitive, and this repo's own history carries `KAN-1037/git-commits-in-card-detail`, `KAN-422/…`, `KAN-682/…` — all generated by that function. Silently lowercasing everyone's branches is a worse regression than the drift it fixes.

The real fix is to store the configured casing and compare case-insensitively (`COLLATE NOCASE`), which is KAN-1248. A comment at the call site records why it still derives, so the next reader does not "fix" it into a lowercasing.
