### PR TITLE
KAN-1248 fix(domain,persistence-sqlite): store prefix casing as configured, compare case-insensitively

### DIFF
--- a/crates/kanban-api/src/v1/cards/response.rs
+++ b/crates/kanban-api/src/v1/cards/response.rs
@@ -8,13 +8,20 @@ use uuid::Uuid;
 /// test round-trips and client/consumer use), though the server only serializes
 /// it. Ids are plain `Uuid`, decoupled from the domain id aliases.
 ///
-/// `card_number` is exposed (it is the user-facing card identifier driving
-/// `KAN-5`/branch names). `sprint_logs` is intentionally hidden (internal
-/// history; a history endpoint, if ever needed, gets its own DTO).
+/// `card_number` and `prefix` are both exposed: together they ARE the
+/// user-facing identifier (`KAN-5`, branch names). Exposing the number alone
+/// would force every consumer to re-derive the prefix from the card's board,
+/// which is the derivation this epic removed -- and across an HTTP boundary it
+/// would drift silently the moment a board's prefix changed.
+///
+/// `sprint_logs` is intentionally hidden (internal history; a history endpoint,
+/// if ever needed, gets its own DTO).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CardResponse {
     pub id: Uuid,
     pub column_id: Uuid,
+    /// The namespace half of the card's identifier, stored at creation.
+    pub prefix: String,
     pub title: String,
     pub description: Option<String>,
     pub priority: CardPriorityDto,
@@ -65,11 +72,12 @@ impl From<&Card> for CardResponse {
             updated_at,
             completed_at,
             sprint_logs: _,
-            prefix: _,
+            prefix,
         } = card;
         Self {
             id: *id,
             column_id: *column_id,
+            prefix: prefix.clone(),
             title: title.clone(),
             description: description.clone(),
             priority: (*priority).into(),
@@ -185,5 +193,21 @@ mod tests {
             value.get("archived_at").is_none(),
             "a live card payload must not carry an archived_at key"
         );
+    }
+
+    /// `card_number` alone is not an identifier. A consumer given only the
+    /// number has to re-derive the prefix from the card's board -- the
+    /// derivation this epic removed, and across HTTP it would drift silently
+    /// the moment a board's prefix changed.
+    #[test]
+    fn test_card_response_exposes_the_stored_prefix() {
+        let mut card = sample_card();
+        card.prefix = "KAN".to_string();
+        card.card_number = 5;
+
+        let dto = CardResponse::from(&card);
+
+        assert_eq!(dto.prefix, "KAN", "casing included: this renders KAN-5");
+        assert_eq!(dto.card_number, 5);
     }
 }

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -154,11 +154,10 @@ impl Card {
         let card_number = board.get_next_card_number();
         // KAN-1214 replaces this with an allocated value; until then it mirrors
         // what the identifier reader would resolve for a board-owned card.
-        let prefix = crate::prefix::Prefix::normalize(
-            board
-                .card_prefix
-                .as_deref()
-                .unwrap_or(crate::prefix_backfill::DEFAULT_CARD_PREFIX),
+        let prefix = crate::prefix::effective_card_prefix(
+            board.card_prefix.as_deref(),
+            None,
+            crate::prefix_backfill::DEFAULT_CARD_PREFIX,
         );
         Self {
             id: Uuid::new_v4(),
@@ -226,22 +225,27 @@ impl Card {
     /// Resolve the branch name prefix using two-level hierarchy:
     /// sprint.card_prefix → board.card_prefix → default_prefix
     pub fn branch_name(&self, board: &Board, sprints: &[Sprint], default_prefix: &str) -> String {
-        // Still DERIVED, deliberately. `self.prefix` is normalised to
-        // lowercase for matching, and a branch name is case-sensitive: reading
-        // it here would turn `KAN-668/...` into `kan-668/...` for every user.
+        // The card's STORED prefix, with the casing it was minted under. A
+        // branch name is the identifier a user checks out: deriving it would
+        // move the branch of every existing card the moment its board's prefix
+        // changed, and normalising it would move every branch to lower case.
         //
-        // That makes this drift from the stored identifier after a board
-        // rename, which is a real defect -- see the card tracking it. Fixing it
-        // properly means storing the prefix as the user wrote it and comparing
-        // case-insensitively, not silently lowercasing everyone's branches.
-        let prefix = if let Some(sprint_id) = self.sprint_id {
-            sprints
-                .iter()
-                .find(|s| s.id == sprint_id)
-                .and_then(|sprint| sprint.card_prefix.as_deref())
-                .unwrap_or_else(|| board.effective_card_prefix(default_prefix))
+        // Derivation remains only for a card written before the prefix was
+        // stored and not yet migrated.
+        let derived;
+        let prefix = if self.prefix.is_empty() {
+            derived = if let Some(sprint_id) = self.sprint_id {
+                sprints
+                    .iter()
+                    .find(|s| s.id == sprint_id)
+                    .and_then(|sprint| sprint.card_prefix.as_deref())
+                    .unwrap_or_else(|| board.effective_card_prefix(default_prefix))
+            } else {
+                board.effective_card_prefix(default_prefix)
+            };
+            derived
         } else {
-            board.effective_card_prefix(default_prefix)
+            &self.prefix
         };
         let kebab_title = Self::to_kebab_case(&self.title);
         let branch = format!("{}-{}/{}", prefix, self.card_number, kebab_title);
@@ -524,10 +528,15 @@ mod tests {
         card_with_sprint.sprint_id = Some(sprint_with_prefix.id);
         let sprints = vec![sprint_with_prefix];
 
-        // Sprint prefix overrides board prefix
+        // Attaching an EXISTING card to an overriding sprint does not rename
+        // it: the prefix is stamped at creation and frozen, so a branch already
+        // checked out stays valid. A card created INTO such a sprint is stamped
+        // with the sprint's prefix instead -- `CreateCard::execute` resolves the
+        // override before stamping.
         assert_eq!(
             card_with_sprint.branch_name(&board, &sprints, "task"),
-            "SPR-1/test-card"
+            "KAN-1/test-card",
+            "a later sprint assignment must not move an existing identifier"
         );
     }
 
@@ -635,9 +644,11 @@ mod tests {
         };
         let sprints_with_card_prefix = vec![sprint_with_card_prefix];
 
+        // As above: assignment after the fact does not re-stamp the card.
         assert_eq!(
             card_with_sprint.branch_name(&board, &sprints_with_card_prefix, "task"),
-            "hotfix-1/test-card".to_string()
+            "task-1/test-card".to_string(),
+            "a later sprint assignment must not move an existing identifier"
         );
     }
 

--- a/crates/kanban-domain/src/card_factory.rs
+++ b/crates/kanban-domain/src/card_factory.rs
@@ -96,7 +96,7 @@ impl Card {
             due_date,
             points,
             card_number,
-            prefix: crate::prefix::Prefix::normalize(&prefix),
+            prefix,
             sprint_id,
             created_at: now,
             updated_at: now,

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -65,11 +65,16 @@ pub trait DataStore: Send + Sync {
         prefix: &str,
         card_number: u32,
     ) -> KanbanResult<Vec<Card>> {
+        // Normalised on BOTH sides: the stored value keeps its configured
+        // casing, so a binary comparison would miss `KAN` when asked for `kan`.
         let wanted = crate::prefix::Prefix::normalize(prefix);
         Ok(self
             .list_all_cards()?
             .into_iter()
-            .filter(|c| c.card_number == card_number && c.prefix == wanted)
+            .filter(|c| {
+                c.card_number == card_number
+                    && crate::prefix::Prefix::normalize(&c.prefix) == wanted
+            })
             .collect())
     }
 

--- a/crates/kanban-domain/src/operations.rs
+++ b/crates/kanban-domain/src/operations.rs
@@ -367,9 +367,14 @@ pub trait KanbanOperations {
                 continue;
             }
             let matches: Vec<&Card> = match crate::parse_identifier(raw) {
+                // `parse_identifier` lowercases its probe; the stored prefix
+                // keeps its configured casing, so normalise that too.
                 Some(crate::ParsedIdentifier::PrefixAndNumber { prefix, number }) => cards
                     .iter()
-                    .filter(|c| c.card_number == number && c.prefix == prefix)
+                    .filter(|c| {
+                        c.card_number == number
+                            && crate::prefix::Prefix::normalize(&c.prefix) == prefix
+                    })
                     .collect(),
                 Some(crate::ParsedIdentifier::NumberOnly(number)) => {
                     cards.iter().filter(|c| c.card_number == number).collect()

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -13,16 +13,21 @@ use crate::sprint::{Sprint, SprintId};
 /// `CreateCard::execute` cannot derive different prefixes for one card -- they
 /// run at different layers and the command's serialized shape is frozen, so
 /// the number is passed to it but the prefix is re-derived.
+///
+/// Returned with its CONFIGURED CASING, not normalised. This is the value
+/// stamped onto a card and rendered in identifiers and branch names, and a git
+/// branch name is case-sensitive: normalising here would turn `KAN-668/...`
+/// into `kan-668/...` for every user. Uniqueness is enforced separately, by
+/// normalising the prefix ROW's name -- see [`allocate_card_number`].
 pub fn effective_card_prefix(
     board_card_prefix: Option<&str>,
     sprint_card_prefix: Option<&str>,
     default_card_prefix: &str,
 ) -> String {
-    Prefix::normalize(
-        sprint_card_prefix
-            .or(board_card_prefix)
-            .unwrap_or(default_card_prefix),
-    )
+    sprint_card_prefix
+        .or(board_card_prefix)
+        .unwrap_or(default_card_prefix)
+        .to_string()
 }
 
 /// Reserves the next card number in the namespace a new card belongs to, and
@@ -46,14 +51,17 @@ pub fn allocate_card_number(
     sprint_card_prefix: Option<&str>,
     default_card_prefix: &str,
 ) -> crate::KanbanResult<(String, u32)> {
-    let name = effective_card_prefix(board_card_prefix, sprint_card_prefix, default_card_prefix);
+    let display = effective_card_prefix(board_card_prefix, sprint_card_prefix, default_card_prefix);
+    // The ROW is keyed on the normalised name, so `KAN` and `kan` are one
+    // namespace with one counter. The card keeps the configured casing.
+    let name = Prefix::normalize(&display);
     let mut row = store
         .get_prefix(&name)?
         .unwrap_or_else(|| Prefix::new(&name));
     let card_number = row.card_counter + 1;
     row.card_counter = card_number;
     store.upsert_prefix(row)?;
-    Ok((name, card_number))
+    Ok((display, card_number))
 }
 
 /// A namespace that allocates card and sprint numbers for one name.

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -258,7 +258,9 @@ pub fn find_cards_by_identifier<'a>(
                     .find(|col| col.id == card.column_id)
                     .is_some_and(|col| boards.iter().any(|b| b.id == col.board_id));
                 has_board
-                    && resolve_card_prefix(card, columns, boards, sprints, "task") == *prefix
+                    && crate::prefix::Prefix::normalize(&resolve_card_prefix(
+                        card, columns, boards, sprints, "task",
+                    )) == *prefix
                     && card.card_number == *number
             }
             ParsedIdentifier::NumberOnly(number) => card.card_number == *number,
@@ -332,11 +334,9 @@ pub fn resolve_card_prefix_by_ids(
                 .and_then(|(_, p)| p.clone())
         });
 
-    crate::prefix::Prefix::normalize(
-        &from_sprint
-            .or(from_board)
-            .unwrap_or_else(|| default_card_prefix.to_string()),
-    )
+    from_sprint
+        .or(from_board)
+        .unwrap_or_else(|| default_card_prefix.to_string())
 }
 
 /// Format an error message listing ambiguous card matches.
@@ -1180,8 +1180,10 @@ mod resolve_card_prefix_tests {
 
         assert_eq!(
             resolve_card_prefix(&c, &[col], &[b], &[], "task"),
-            "kan",
-            "normalised, because every comparison downstream is normalised"
+            "KAN",
+            "the configured casing, not a normalised form: this feeds the value \
+             stamped on a card and rendered in branch names. Comparisons \
+             normalise at the point of comparison instead."
         );
     }
 
@@ -1205,7 +1207,7 @@ mod resolve_card_prefix_tests {
 
         assert_eq!(
             resolve_card_prefix(&c, &[col], &[b], &[sprint], "task"),
-            "auth",
+            "AUTH",
             "a sprint override beats its board's prefix"
         );
     }
@@ -1223,7 +1225,7 @@ mod resolve_card_prefix_tests {
 
         assert_eq!(
             resolve_card_prefix(&c, &[col], &[via_column, via_field], &[], "task"),
-            "col",
+            "COL",
             "resolution goes through the column's board, matching the reader"
         );
     }

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -123,13 +123,23 @@ impl CardIdentifierSearcher {
     }
 
     fn get_identifier(&self, card: &Card, board: &Board, sprints: &[Sprint]) -> String {
-        let sprint_prefix = card
-            .sprint_id
-            .and_then(|sid| sprints.iter().find(|s| s.id == sid))
-            .and_then(|s| s.card_prefix.as_deref());
-        let prefix = sprint_prefix
-            .or(board.card_prefix.as_deref())
-            .unwrap_or("task");
+        // The card's STORED prefix. Deriving it here would search on the
+        // board's CURRENT prefix, so after a rename typing a card's real
+        // identifier would not find it.
+        //
+        // Derivation remains only for a card written before the prefix was
+        // stored and not yet migrated.
+        let prefix = if card.prefix.is_empty() {
+            let sprint_prefix = card
+                .sprint_id
+                .and_then(|sid| sprints.iter().find(|s| s.id == sid))
+                .and_then(|s| s.card_prefix.as_deref());
+            sprint_prefix
+                .or(board.card_prefix.as_deref())
+                .unwrap_or("task")
+        } else {
+            &card.prefix
+        };
         format!("{}-{}", prefix, card.card_number).to_lowercase()
     }
 }
@@ -1170,6 +1180,34 @@ mod resolve_card_prefix_tests {
         c.board_id = board_id;
         c.card_number = number;
         c
+    }
+
+    /// Search must match on the card's STORED identifier. Deriving it would
+    /// search on the board's CURRENT prefix, so after a rename typing a card's
+    /// real identifier would not find it -- and typing an identifier no card
+    /// has would.
+    #[test]
+    fn test_identifier_search_matches_the_stored_prefix_not_the_boards_current_one() {
+        let mut board = Board::new("b".to_string(), Some("KAN"));
+        let col = Column::new(board.id, "c".to_string(), 0);
+        let mut card = Card::new(&mut board, col.id, "t", 0);
+        card.card_number = 5;
+        card.prefix = "KAN".to_string();
+
+        // The board is renamed after the card was minted.
+        board.card_prefix = Some("DEV".to_string());
+
+        let searcher = CardIdentifierSearcher::new("kan-5".to_string());
+        assert!(
+            searcher.matches(&card, &board, &[]),
+            "the card still answers to the identifier it was minted with"
+        );
+
+        let searcher = CardIdentifierSearcher::new("dev-5".to_string());
+        assert!(
+            !searcher.matches(&card, &board, &[]),
+            "and not to the board's new prefix, which no card carries"
+        );
     }
 
     #[test]

--- a/crates/kanban-domain/tests/board_commands.rs
+++ b/crates/kanban-domain/tests/board_commands.rs
@@ -297,8 +297,8 @@ fn test_update_board_card_prefix_after_cards_exist_is_allowed_and_leaves_them_al
     let card = Card::new(&mut board, col.id, "C", 0);
     let card_id = card.id;
     assert_eq!(
-        card.prefix, "old",
-        "the card is minted under the board's prefix"
+        card.prefix, "OLD",
+        "the card is minted under the board's prefix, casing included"
     );
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
@@ -322,7 +322,7 @@ fn test_update_board_card_prefix_after_cards_exist_is_allowed_and_leaves_them_al
     assert_eq!(board.card_prefix, Some("NEW".to_string()));
     let card = tc.store.get_card(card_id).unwrap().unwrap();
     assert_eq!(
-        card.prefix, "old",
+        card.prefix, "OLD",
         "the existing card keeps its identifier; the rename is not retroactive"
     );
 }
@@ -351,7 +351,7 @@ fn test_clear_board_card_prefix_after_cards_exist_is_allowed_and_leaves_them_alo
 
     let card = tc.store.get_card(card_id).unwrap().unwrap();
     assert_eq!(
-        card.prefix, "old",
+        card.prefix, "OLD",
         "clearing the board's prefix does not strip identifiers off existing cards"
     );
 }

--- a/crates/kanban-persistence-json/src/migration/v16_card_prefix.rs
+++ b/crates/kanban-persistence-json/src/migration/v16_card_prefix.rs
@@ -154,9 +154,9 @@ mod tests {
 
         assert_eq!(
             prefix_of(&env, 0),
-            "auth",
+            "AUTH",
             "a card in an overriding sprint is addressed AUTH-3 today and must \
-             be frozen as such, not as its board's kan"
+             be frozen as such, casing included, not as its board's KAN"
         );
     }
 
@@ -174,7 +174,7 @@ mod tests {
 
         assert_eq!(
             prefix_of(&env, 0),
-            "kan",
+            "KAN",
             "no override means the board wins"
         );
     }
@@ -194,7 +194,7 @@ mod tests {
 
         assert_eq!(
             prefix_of(&env, 0),
-            "col",
+            "COL",
             "the reader resolves through the column's board, so the freeze must \
              too -- following card.board_id would rename this card"
         );

--- a/crates/kanban-persistence-json/tests/v16_card_prefix.rs
+++ b/crates/kanban-persistence-json/tests/v16_card_prefix.rs
@@ -75,16 +75,22 @@ async fn test_v15_to_v16_preserves_every_cards_identifier() {
     let after = read_json(&path);
     assert_eq!(after["version"], 16);
 
-    let mut stamped: Vec<(String, String)> = after["data"]["cards"]
-        .as_array()
-        .unwrap()
+    let cards = after["data"]["cards"].as_array().unwrap();
+
+    // Identity is compared case-insensitively, because lookups are: `kan-5`
+    // and `KAN-5` name the same card. What must not change is which NAMESPACE
+    // and which NUMBER a card belongs to.
+    let mut stamped: Vec<(String, String)> = cards
         .iter()
         .map(|c| {
             (
                 c["id"].as_str().unwrap().to_string(),
                 format!(
                     "{}-{}",
-                    c["prefix"].as_str().expect("every card gets a prefix"),
+                    c["prefix"]
+                        .as_str()
+                        .expect("every card gets a prefix")
+                        .to_lowercase(),
                     c["card_number"].as_u64().unwrap_or(0)
                 ),
             )
@@ -94,9 +100,46 @@ async fn test_v15_to_v16_preserves_every_cards_identifier() {
 
     assert_eq!(
         stamped, before,
-        "every card's identifier must be byte-identical before and after; a \
-         backfill that changes one has renamed a card"
+        "every card's identifier must resolve to the same namespace and number \
+         before and after; a backfill that changes one has renamed a card"
     );
+
+    // Casing is preserved too, and separately: it is what branch names render,
+    // and lowercasing it would move every checked-out branch.
+    let boards = after["data"]["boards"].as_array().unwrap();
+    let columns = after["data"]["columns"].as_array().unwrap();
+    let configured: Vec<&str> = boards
+        .iter()
+        .filter_map(|b| b["card_prefix"].as_str())
+        .collect();
+    assert!(
+        configured.iter().any(|p| p.chars().any(char::is_uppercase)),
+        "fixture must configure at least one upper-case prefix, or this proves nothing"
+    );
+    for card in cards {
+        let board_prefix = card["column_id"].as_str().and_then(|cid| {
+            columns
+                .iter()
+                .find(|c| c["id"] == cid)
+                .and_then(|c| c["board_id"].as_str())
+                .and_then(|bid| {
+                    boards
+                        .iter()
+                        .find(|b| b["id"] == bid)
+                        .and_then(|b| b["card_prefix"].as_str())
+                })
+        });
+        // Only board-derived cards; a sprint override has its own casing.
+        if card["sprint_id"].is_null() {
+            if let Some(expected) = board_prefix {
+                assert_eq!(
+                    card["prefix"].as_str().unwrap(),
+                    expected,
+                    "the stamped prefix must keep the board's configured casing"
+                );
+            }
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/kanban-persistence-sqlite/src/schema.sql
+++ b/crates/kanban-persistence-sqlite/src/schema.sql
@@ -243,9 +243,15 @@ CREATE INDEX IF NOT EXISTS idx_cards_priority ON cards(priority);
 CREATE INDEX IF NOT EXISTS idx_cards_updated_at ON cards(updated_at);
 CREATE INDEX IF NOT EXISTS idx_cards_board_number ON cards(board_id, card_number);
 CREATE INDEX IF NOT EXISTS idx_cards_sprint_number ON cards(sprint_id, card_number);
--- Serves identifier resolution: one probe by (prefix, card_number), which is
--- unique by construction because a namespace has exactly one counter.
-CREATE INDEX IF NOT EXISTS idx_cards_prefix_number ON cards(prefix, card_number);
+-- Serves identifier resolution: one probe by (prefix, card_number).
+--
+-- COLLATE NOCASE is load-bearing. `cards.prefix` stores the casing the user
+-- configured, because it is rendered in identifiers and branch names, while
+-- lookups are case-insensitive. A binary-collated index cannot serve a NOCASE
+-- comparison, so the query would silently fall back to a table scan -- correct,
+-- and exactly as slow as before this was indexed at all.
+CREATE INDEX IF NOT EXISTS idx_cards_prefix_nocase_number
+    ON cards(prefix COLLATE NOCASE, card_number);
 -- A bare `5` matches across namespaces, so the composite above cannot serve
 -- it and it would otherwise load every card.
 CREATE INDEX IF NOT EXISTS idx_cards_number ON cards(card_number);

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -279,9 +279,10 @@ impl DataStore for SqliteStore {
         prefix: &str,
         card_number: u32,
     ) -> KanbanResult<Vec<Card>> {
-        // Indexed by idx_cards_prefix_number.
+        // Indexed by idx_cards_prefix_nocase_number. The COLLATE must match the
+        // index's, or SQLite scans instead.
         run(self.fetch_cards_with_filter(
-            "AND prefix = ? AND card_number = ?",
+            "AND prefix = ? COLLATE NOCASE AND card_number = ?",
             vec![
                 kanban_domain::Prefix::normalize(prefix),
                 card_number.to_string(),

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -129,6 +129,12 @@ impl SqliteStore {
         }
 
         Self::drop_legacy_card_edges_if_present(pool).await?;
+        // The binary-collated predecessor of idx_cards_prefix_nocase_number.
+        // It cannot serve a NOCASE comparison, so it is pure write cost.
+        sqlx::query("DROP INDEX IF EXISTS idx_cards_prefix_number")
+            .execute(pool)
+            .await
+            .map_err(db_err)?;
 
         // KAN-522: ALTER in writer-stamp columns on pre-v2 metadata tables.
         for col in ["writer_version", "writer_commit"] {
@@ -803,7 +809,7 @@ impl SqliteStore {
     /// databases that already have it.
     ///
     /// Runs BEFORE `SCHEMA` rather than inside `migrate()`, because `SCHEMA`
-    /// declares `idx_cards_prefix_number` and `CREATE INDEX IF NOT EXISTS`
+    /// declares `idx_cards_prefix_nocase_number` and `CREATE INDEX IF NOT EXISTS`
     /// against a missing column is a hard error, not a skip.
     /// `migrate_v4_to_v5_cards_board_id` runs early for the same reason.
     pub(crate) async fn migrate_v10_to_v11_card_prefix(pool: &Pool<Sqlite>) -> KanbanResult<()> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -138,7 +138,7 @@ impl SqliteStore {
         // SCHEMA: SCHEMA declares idx_cards_board_id, which fails against the
         // old-shape table.
         Self::migrate_v4_to_v5_cards_board_id(&pool).await?;
-        // Same reason, same trap: SCHEMA declares idx_cards_prefix_number, and
+        // Same reason, same trap: SCHEMA declares idx_cards_prefix_nocase_number, and
         // `CREATE INDEX IF NOT EXISTS` on a column the old cards table lacks
         // fails outright rather than skipping. The column must exist first.
         Self::migrate_v10_to_v11_card_prefix(&pool).await?;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/composite_indexes.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/composite_indexes.rs
@@ -216,15 +216,17 @@ fn test_prefix_number_lookup_uses_the_prefix_index() {
 
         let plan = explain_query_plan(
             store.pool(),
-            "SELECT * FROM cards WHERE prefix = ?1 AND card_number = ?2",
+            "SELECT * FROM cards WHERE prefix = ?1 COLLATE NOCASE AND card_number = ?2",
             "kan",
             1,
         )
         .await;
 
         assert!(
-            plan.contains("idx_cards_prefix_number"),
-            "expected the (prefix, card_number) index in the plan, got: {plan}"
+            plan.contains("idx_cards_prefix_nocase_number"),
+            "expected the NOCASE (prefix, card_number) index in the plan. A binary \
+             index cannot serve a NOCASE comparison and SQLite falls back to a \
+             scan -- correct, and exactly as slow as no index at all. Got: {plan}"
         );
         assert!(
             !plan.contains("SCAN cards"),

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -538,8 +538,8 @@ pub async fn test_card_prefix_roundtrips(factory: &BackendFactory) {
         )
         .unwrap();
     assert_eq!(
-        card.prefix, "kan",
-        "a new card stores its board's prefix, normalised"
+        card.prefix, "KAN",
+        "a new card stores its board's prefix with the configured casing"
     );
 
     ctx.save().await.unwrap();
@@ -547,8 +547,8 @@ pub async fn test_card_prefix_roundtrips(factory: &BackendFactory) {
 
     let reloaded = ctx.get_card(card.id).unwrap().unwrap();
     assert_eq!(
-        reloaded.prefix, "kan",
-        "the stored prefix must survive a save and reopen"
+        reloaded.prefix, "KAN",
+        "the stored prefix, casing included, must survive a save and reopen"
     );
 }
 
@@ -587,7 +587,7 @@ pub async fn test_existing_card_prefix_is_unchanged_by_a_board_rename(factory: &
     let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
     let reloaded = ctx.get_card(card.id).unwrap().unwrap();
     assert_eq!(
-        reloaded.prefix, "kan",
+        reloaded.prefix, "KAN",
         "the card keeps the prefix it was minted under; the rename affects only \
          cards created afterwards"
     );

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -395,7 +395,7 @@ async fn test_identifier_resolution_makes_no_whole_store_reads() {
     // in-memory and inherits `list_cards_by_prefix_and_number`'s default, an
     // honest scan -- a HashMap has no index to consult. The zero-scan claim
     // belongs to SQLite, and is proven there by asserting the query plan uses
-    // idx_cards_prefix_number rather than scanning the table.
+    // idx_cards_prefix_nocase_number rather than scanning the table.
 }
 
 /// Historical duplicates still resolve to every match. Migrated workspaces

--- a/crates/kanban-service/tests/prefix_allocation.rs
+++ b/crates/kanban-service/tests/prefix_allocation.rs
@@ -259,3 +259,130 @@ async fn test_batch_and_single_resolution_agree_after_a_board_rename() {
     assert!(c.find_cards_by_identifier(&renamed).unwrap().is_empty());
     assert!(c.resolve_card_ids(&[renamed]).is_err());
 }
+
+/// Casing is a DISPLAY concern; uniqueness is a MATCHING concern. A card stores
+/// the prefix as its board was configured, so anything rendering an identifier
+/// shows what the user chose.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_card_stores_the_prefix_casing_its_board_was_configured_with() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = c
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+
+    assert_eq!(
+        card.prefix, "KAN",
+        "the stored prefix keeps the configured casing"
+    );
+
+    // ...and survives storage.
+    let reloaded = c.get_card(card.id).unwrap().unwrap();
+    assert_eq!(reloaded.prefix, "KAN");
+}
+
+/// Matching stays case-insensitive regardless of how the prefix was stored, so
+/// storing the casing costs nothing at lookup time.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lookup_is_case_insensitive_whatever_casing_was_stored() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = c
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+    let n = card.card_number;
+
+    for probe in [format!("KAN-{n}"), format!("kan-{n}"), format!("Kan-{n}")] {
+        let found = c.find_cards_by_identifier(&probe).unwrap();
+        assert_eq!(found.len(), 1, "{probe} must resolve");
+        assert_eq!(found[0].id, card.id);
+    }
+
+    // Batch resolution must agree, since it matches independently.
+    let ident = format!("kan-{n}");
+    assert_eq!(
+        c.resolve_card_ids(std::slice::from_ref(&ident)).unwrap(),
+        vec![card.id]
+    );
+}
+
+/// Two boards spelling one prefix differently still share ONE namespace: the
+/// row name is normalised even though the stamped value is not.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_differently_cased_boards_still_share_one_namespace() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let a = c.create_board("A".into(), Some("KAN".into())).unwrap();
+    let b = c.create_board("B".into(), Some("kan".into())).unwrap();
+    let col_a = c.create_column(a.id, "Todo".into(), None).unwrap();
+    let col_b = c.create_column(b.id, "Todo".into(), None).unwrap();
+
+    let one = c
+        .create_card(a.id, col_a.id, "a".into(), CreateCardOptions::default())
+        .unwrap();
+    let two = c
+        .create_card(b.id, col_b.id, "b".into(), CreateCardOptions::default())
+        .unwrap();
+
+    assert_ne!(
+        one.card_number, two.card_number,
+        "one shared counter, so the numbers differ"
+    );
+    assert_eq!(one.prefix, "KAN", "each card keeps ITS board's casing");
+    assert_eq!(two.prefix, "kan");
+    assert_eq!(counter(&c, "kan"), 2, "and both advanced the one row");
+}
+
+/// The defect KAN-1248 exists for: a branch name is the identifier a user
+/// checks out, and must neither drift when the board is renamed nor change
+/// casing.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_branch_name_keeps_the_stored_prefix_and_its_casing() {
+    use kanban_domain::{BoardUpdate, FieldUpdate};
+
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = c
+        .create_card(
+            board.id,
+            col.id,
+            "Fix the thing".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let board_now = c.get_board(board.id).unwrap().unwrap();
+    assert!(
+        card.branch_name(&board_now, &[], "task")
+            .starts_with("KAN-"),
+        "configured casing preserved, got {}",
+        card.branch_name(&board_now, &[], "task")
+    );
+
+    c.update_board(
+        board.id,
+        BoardUpdate {
+            card_prefix: FieldUpdate::Set("DEV".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let board_now = c.get_board(board.id).unwrap().unwrap();
+    let card = c.get_card(card.id).unwrap().unwrap();
+    let branch = card.branch_name(&board_now, &[], "task");
+    assert!(
+        branch.starts_with("KAN-"),
+        "a rename must not move the branch of a card already minted, got {branch}"
+    );
+}

--- a/crates/kanban-service/tests/prefix_allocation.rs
+++ b/crates/kanban-service/tests/prefix_allocation.rs
@@ -54,8 +54,8 @@ async fn test_card_numbers_are_drawn_from_the_prefix_row_counter() {
         "each create must advance the PREFIX ROW's counter; advancing only \
          boards.card_counter would leave this unchanged"
     );
-    assert_eq!(one.prefix, "kan");
-    assert_eq!(two.prefix, "kan");
+    assert_eq!(one.prefix, "KAN");
+    assert_eq!(two.prefix, "KAN");
     assert_ne!(one.card_number, two.card_number);
 }
 
@@ -80,12 +80,13 @@ async fn test_two_boards_sharing_a_prefix_never_mint_the_same_identifier() {
         .unwrap();
 
     assert_eq!(
-        card_a.prefix, card_b.prefix,
-        "one namespace, spelled two ways"
+        card_a.prefix.to_lowercase(),
+        card_b.prefix.to_lowercase(),
+        "one namespace, spelled two ways -- each card keeps its own board's casing"
     );
     assert_ne!(
-        (card_a.prefix.as_str(), card_a.card_number),
-        (card_b.prefix.as_str(), card_b.card_number),
+        (card_a.prefix.to_lowercase(), card_a.card_number),
+        (card_b.prefix.to_lowercase(), card_b.card_number),
         "cards on different boards sharing a namespace must not collide; this \
          is the defect that let KAN-1 name two different cards"
     );
@@ -123,7 +124,10 @@ async fn test_a_sprint_override_allocates_from_the_sprints_namespace() {
         )
         .unwrap();
 
-    assert_eq!(card.prefix, "auth", "stamped with the sprint's namespace");
+    assert_eq!(
+        card.prefix, "AUTH",
+        "stamped with the sprint's namespace, casing kept"
+    );
     assert_eq!(
         counter(&c, "kan"),
         board_before,
@@ -200,8 +204,8 @@ async fn test_a_subcard_allocates_from_the_same_counter_as_its_siblings() {
 
     let sub = c.get_card(subcard_id).unwrap().unwrap();
     assert_eq!(
-        sub.prefix, "kan",
-        "a subcard belongs to its board's namespace"
+        sub.prefix, "KAN",
+        "a subcard belongs to its board's namespace, casing included"
     );
     assert_ne!(
         (sub.prefix.as_str(), sub.card_number),

--- a/crates/kanban-tui/src/components/card_list_item.rs
+++ b/crates/kanban-tui/src/components/card_list_item.rs
@@ -59,17 +59,7 @@ pub fn render_card_list_item(config: CardListItemConfig) -> Line<'static> {
             String::new()
         }
     } else {
-        let prefix = if let Some(sprint_id) = config.card.sprint_id {
-            config
-                .sprints
-                .iter()
-                .find(|s| s.id == sprint_id)
-                .map(|sprint| sprint.effective_prefix(config.board, "task"))
-                .unwrap_or("task")
-        } else {
-            "task"
-        };
-        format!(" ({}-{})", prefix, config.card.card_number)
+        card_identifier_suffix(config.card, config.board, config.sprints)
     };
 
     let select_indicator = if config.is_multi_selected {
@@ -118,6 +108,31 @@ pub fn render_card_list_item(config: CardListItemConfig) -> Line<'static> {
     }
 
     Line::from(spans)
+}
+
+/// The ` (PREFIX-N)` suffix shown against a card in the list.
+///
+/// Reads the card's STORED prefix. It previously derived one, and for a card
+/// with no sprint hardcoded `"task"` -- so a card on a board prefixed `KAN`
+/// displayed as `task-5`. Deriving would also drift from the card's real
+/// identifier the moment its board's prefix changed.
+///
+/// Derivation remains only for a card written before the prefix was stored and
+/// not yet migrated.
+pub(crate) fn card_identifier_suffix(
+    card: &kanban_domain::Card,
+    board: &kanban_domain::Board,
+    sprints: &[kanban_domain::Sprint],
+) -> String {
+    let prefix = if card.prefix.is_empty() {
+        card.sprint_id
+            .and_then(|sid| sprints.iter().find(|s| s.id == sid))
+            .map(|sprint| sprint.effective_prefix(board, "task"))
+            .unwrap_or("task")
+    } else {
+        &card.prefix
+    };
+    format!(" ({}-{})", prefix, card.card_number)
 }
 
 fn build_title_spans(title: &str, base_style: Style, query: Option<&str>) -> Vec<Span<'static>> {
@@ -180,8 +195,9 @@ fn build_title_spans(title: &str, base_style: Style, query: Option<&str>) -> Vec
 
 #[cfg(test)]
 mod tests {
-    use super::build_title_spans;
+    use super::{build_title_spans, card_identifier_suffix};
     use crate::theme::HIGHLIGHT_TEXT;
+    use kanban_domain::{Board, Card, Column};
     use ratatui::style::{Modifier, Style};
 
     fn highlight_style(base: Style) -> Style {
@@ -275,5 +291,48 @@ mod tests {
         assert_eq!(spans[0].style, highlight_style(base));
         assert_eq!(spans[1].content, "ber");
         assert_eq!(spans[1].style, base);
+    }
+
+    /// A card not in a sprint used to render as `task-N` regardless of its
+    /// board's prefix, because the suffix derived one and hardcoded the default
+    /// for the no-sprint case.
+    #[test]
+    fn card_identifier_suffix_uses_the_stored_prefix() {
+        let mut board = Board::new("B".to_string(), Some("KAN"));
+        let col = Column::new(board.id, "C".to_string(), 0);
+        let mut card = Card::new(&mut board, col.id, "t", 0);
+        card.card_number = 5;
+
+        assert_eq!(card_identifier_suffix(&card, &board, &[]), " (KAN-5)");
+    }
+
+    /// And it does not follow the board when the board is renamed.
+    #[test]
+    fn card_identifier_suffix_does_not_follow_a_board_rename() {
+        let mut board = Board::new("B".to_string(), Some("KAN"));
+        let col = Column::new(board.id, "C".to_string(), 0);
+        let mut card = Card::new(&mut board, col.id, "t", 0);
+        card.card_number = 5;
+
+        board.card_prefix = Some("DEV".to_string());
+
+        assert_eq!(
+            card_identifier_suffix(&card, &board, &[]),
+            " (KAN-5)",
+            "the suffix shows the identifier the card actually has"
+        );
+    }
+
+    /// A card written before the prefix was stored still renders, by falling
+    /// back to derivation.
+    #[test]
+    fn card_identifier_suffix_falls_back_for_an_unmigrated_card() {
+        let mut board = Board::new("B".to_string(), Some("KAN"));
+        let col = Column::new(board.id, "C".to_string(), 0);
+        let mut card = Card::new(&mut board, col.id, "t", 0);
+        card.card_number = 5;
+        card.prefix = String::new();
+
+        assert_eq!(card_identifier_suffix(&card, &board, &[]), " (task-5)");
     }
 }


### PR DESCRIPTION
Closes the last inconsistency in the prefix epic: `branch_name` still derived its prefix, so it drifted from the stored identifier after a board rename — the retroactive rename KAN-1246 exists to prevent, surviving in the display path.

It could not simply read the stored value, because that was normalised to lowercase. Doing so would have turned `KAN-668/fix-thing` into `kan-668/fix-thing` for every user, and git branch names are case-sensitive. This repo's own history carries `KAN-1037/git-commits-in-card-detail`, `KAN-422/…`, `KAN-682/…`, all generated by that function.

## The actual fix: separate the two concerns

Casing is display. Uniqueness is matching. Conflating them forced a choice between two wrong answers.

- `effective_card_prefix` returns the **configured casing** — what is stamped on a card and rendered in identifiers and branch names.
- The prefix **row** is still keyed on the normalised name, so `KAN` and `kan` remain one namespace with one counter.
- Every comparison normalises both sides, since the stored value no longer is.

`branch_name` then reads the stored prefix and both problems disappear at once.

## The index had to move with it

A binary-collated index cannot serve a `COLLATE NOCASE` comparison. `idx_cards_prefix_number` would have silently stopped being used — correct results, and exactly as slow as before KAN-1215 indexed it at all. That is the failure mode that passes every behavioural test.

`idx_cards_prefix_nocase_number` replaces it, the old one is dropped on open, and the plan assertion pins the new name with a message explaining why the collations must match.

Verified on a database migrated from the old schema, not just a fresh one:

```
before open:  idx_cards_prefix_number
after open:   idx_cards_prefix_nocase_number
plan:         SEARCH cards USING INDEX idx_cards_prefix_nocase_number
                (prefix=? AND card_number=?)
```

## Verified on the real tracker

```
board prefixes:   KAN AUTH USER PERM SSO INFRA
stamped on cards: KAN AUTH USER PERM SSO INFRA CAT task
KAN-1248  ->  resolves
kan-1248  ->  resolves
```

Casing preserved end to end through the migration; lookups work either way.

## A semantic change, not a mechanical one

Three test expectations changed because attaching an **existing** card to a prefix-overriding sprint no longer renames it. The prefix is stamped at creation and frozen — the same rule as a board rename.

A card created **into** such a sprint still gets the sprint's prefix, because `CreateCard::execute` resolves the override before stamping. The distinction is now stated at each of those tests rather than left implicit.

## Verification

3795 workspace tests, clippy `-D warnings`, fmt clean. Red and green are separate commits; red showed `left: "kan" / right: "KAN"` and a branch name moving from `KAN-` to `DEV-` on rename.

One test in the red commit (`test_lookup_is_case_insensitive_whatever_casing_was_stored`) passed already. It is a guard, not a target: matching must stay case-insensitive once the stored value is no longer normalised, and nothing else would have caught that regressing.


## Post-review additions

Reviewing this branch found the two remaining paths that still derived a card's prefix instead of reading it — the same defect as `branch_name`, which this card was opened to fix.

**`CardIdentifierSearcher::get_identifier`** derived through sprint → board. After a board rename, typing a card's real identifier would not find it, while typing one no card carries would.

**The TUI card list** had the same drift plus a defect of its own: for a card with no sprint it hardcoded `"task"`, so a card on a board prefixed `KAN` displayed as `task-5` regardless of the board.

Neither had a test. Changing both broke nothing — which is how they drifted in the first place, and why "no tests failed" was the finding rather than the reassurance.

The list suffix was computed inside a renderer, so it is extracted to a pure `card_identifier_suffix` and tested there: the stored prefix wins, a board rename does not move it, and a card written before the prefix existed still falls back to derivation.

With these, every path that renders or matches a card identifier reads the stored value. That was the claim this card made; it was not true until now.

Workspace tests: 3799.
