### PR TITLE
fix(service): name --column in the restore hint, not --column-id

### DIFF
--- a/.changeset/fix-restore-hint-column-flag.md
+++ b/.changeset/fix-restore-hint-column-flag.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: name `--column` in the restore hint when the original column is gone. The message pointed at `--column-id`, which `card restore` does not accept.

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -400,7 +400,7 @@ impl KanbanContext {
             // hint (restored pre-collapse behavior) rather than a bare not_found.
             if self.backend.get_column(card.column_id)?.is_none() {
                 return Err(KanbanError::validation(
-                    "Original column no longer exists. Specify --column-id to restore to a different column",
+                    "Original column no longer exists. Specify --column to restore to a different column",
                 ));
             }
             card.column_id

--- a/crates/kanban-service/tests/restore_card_deleted_column.rs
+++ b/crates/kanban-service/tests/restore_card_deleted_column.rs
@@ -66,8 +66,12 @@ macro_rules! restore_card_deleted_column_tests {
                     "error must mention 'Original column no longer exists', got: {msg}"
                 );
                 assert!(
-                    msg.contains("column-id"),
-                    "error must mention 'column-id' hint, got: {msg}"
+                    msg.contains("--column "),
+                    "error must name the real CLI flag '--column', got: {msg}"
+                );
+                assert!(
+                    !msg.contains("--column-id"),
+                    "error must not name '--column-id'; no such flag exists on `card restore`, got: {msg}"
                 );
             }
 

--- a/crates/kanban-service/tests/restore_card_deleted_column.rs
+++ b/crates/kanban-service/tests/restore_card_deleted_column.rs
@@ -66,7 +66,7 @@ macro_rules! restore_card_deleted_column_tests {
                     "error must mention 'Original column no longer exists', got: {msg}"
                 );
                 assert!(
-                    msg.contains("--column "),
+                    msg.contains("--column"),
                     "error must name the real CLI flag '--column', got: {msg}"
                 );
                 assert!(


### PR DESCRIPTION
## What

`restore_card` points the user at a flag that does not exist. When the original column has been deleted, it returns:

```
Original column no longer exists. Specify --column-id to restore to a different column
```

But `CardAction::Restore` declares `--column` (`crates/kanban-cli/src/cli.rs:287`), so following the hint gets you a clap error instead of a restored card. The MCP tool takes `column` as well (`crates/kanban-mcp/src/requests/card.rs:116`), so `--column` is the right name on both surfaces.

The message now reads:

```
Original column no longer exists. Specify --column to restore to a different column
```

## Why the test did not catch it

`test_restore_card_with_deleted_original_column_and_no_target_returns_actionable_hint` asserted `msg.contains("column-id")`, which pinned the wrong flag in place. It now asserts the message names `--column` and, separately, that it does not name `--column-id`, so the phantom flag cannot come back.

## Verification

Red first: with the assertions updated and the message untouched, both backend variants fail.

```
failures:
    json::test_restore_card_with_deleted_original_column_and_no_target_returns_actionable_hint
    sqlite::test_restore_card_with_deleted_original_column_and_no_target_returns_actionable_hint
test result: FAILED. 4 passed; 2 failed
```

Green after the one-line message fix:

```
test result: ok. 6 passed; 0 failed
```

Full crate suite passes, `cargo clippy -p kanban-service --all-targets -- -D warnings` is clean, and `cargo fmt --check` is clean.

## Context

Spotted while reviewing #548, which removes the same phantom `--column-id` from the demo tape.
