### PR TITLE
KAN-1214 feat(domain,persistence-sqlite,persistence-json): allocate sprint numbers from the shared prefix row

### DIFF
--- a/crates/kanban-backend-memory/src/in_memory_store/prefixes.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/prefixes.rs
@@ -18,14 +18,20 @@ impl InMemoryStore {
 
     pub(crate) fn upsert_prefix_impl(&self, prefix: Prefix) -> KanbanResult<()> {
         let mut state = self.write_state()?;
-        let normalized = Prefix::normalize(&prefix.name);
+        // Normalised on the way in rather than trusted from the caller, so the
+        // stored name satisfies `Prefix`'s invariant however it was built.
+        // SQLite gets this for free: its ON CONFLICT never updates the name.
+        let prefix = Prefix {
+            name: Prefix::normalize(&prefix.name),
+            ..prefix
+        };
         // Replace in place rather than push-and-dedup: two spellings of one
         // name are one namespace, and a second row would let two owners
         // allocate the same number.
         match state
             .prefixes
             .iter_mut()
-            .find(|p| Prefix::normalize(&p.name) == normalized)
+            .find(|p| Prefix::normalize(&p.name) == prefix.name)
         {
             Some(existing) => *existing = prefix,
             None => state.prefixes.push(prefix),

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -1,5 +1,5 @@
 use crate::data_store::DataStore;
-use crate::{DomainError, KanbanError, KanbanResult};
+use crate::{KanbanError, KanbanResult};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -130,18 +130,6 @@ impl<'a> CommandContext<'a> {
         adding: usize,
         exclude: &[Uuid],
     ) -> KanbanResult<()> {
-        let column = self.get_column(column_id)?;
-        if let Some(limit) = column.wip_limit {
-            let current = self
-                .store
-                .count_cards_in_column_excluding(column_id, exclude)?;
-            if current + adding > limit as usize {
-                return Err(KanbanError::Domain(DomainError::wip_limit_exceeded(
-                    column_id,
-                    limit as u32,
-                )));
-            }
-        }
-        Ok(())
+        crate::wip::check_wip_limit(self.store, column_id, adding, exclude)
     }
 }

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -263,8 +263,6 @@ pub struct CreateSprint {
 
 impl CreateSprint {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
-        let sprints_snapshot = context.store.list_sprints_by_board(self.board_id)?;
-
         let mut board = context.get_board(self.board_id)?;
         let effective_prefix = self
             .explicit_prefix
@@ -272,8 +270,23 @@ impl CreateSprint {
             .or_else(|| board.sprint_prefix.clone())
             .unwrap_or_else(|| self.default_sprint_prefix.clone());
 
-        board.ensure_sprint_counter_initialized(&effective_prefix, &sprints_snapshot);
-        let sprint_number = board.get_next_sprint_number(&effective_prefix);
+        // The prefix row is the source of truth; the board's map is written
+        // behind it only until KAN-1216 removes it. The old
+        // `ensure_sprint_counter_initialized` scan is deliberately gone: it
+        // seeded a counter from MAX(sprint_number) FOR THIS BOARD, which is
+        // exactly what lets two boards sharing a namespace both hand out 1.
+        let (effective_prefix, sprint_number) =
+            crate::prefix::allocate_sprint_number(context.store, &effective_prefix)?;
+        // The legacy map holds the NEXT number, the row holds the last used.
+        // Clamped upward only, matching how `CreateCard` maintains
+        // `board.card_counter`: the row steers allocation now, so dragging
+        // this back down would discard a value nothing re-derives.
+        if board
+            .get_sprint_counter(&effective_prefix)
+            .is_none_or(|next| next <= sprint_number)
+        {
+            board.initialize_sprint_counter(&effective_prefix, sprint_number + 1);
+        }
         let name_index = match &self.name {
             Some(name) if !name.trim().is_empty() => {
                 Some(board.add_sprint_name_at_used_index(name.clone()))

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -275,7 +275,7 @@ impl CreateSprint {
         // `ensure_sprint_counter_initialized` scan is deliberately gone: it
         // seeded a counter from MAX(sprint_number) FOR THIS BOARD, which is
         // exactly what lets two boards sharing a namespace both hand out 1.
-        let (effective_prefix, sprint_number) =
+        let sprint_number =
             crate::prefix::allocate_sprint_number(context.store, &effective_prefix)?;
         // The legacy map holds the NEXT number, the row holds the last used.
         // Clamped upward only, matching how `CreateCard` maintains

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -33,6 +33,7 @@ pub mod sprint_factory;
 pub mod sprint_log;
 pub mod tag;
 pub mod task_list_view;
+pub mod wip;
 
 pub use archival::{ArchiveMetadata, Archived, ArchivedEntity, NoContext};
 pub use archived_board::{ArchivedBoard, ArchivedBoardSummary};
@@ -60,8 +61,8 @@ pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use operations::KanbanOperations;
 pub use prefix::{
-    allocate_card_number, effective_card_prefix, effective_prefixes, find_prefix_collisions,
-    EffectivePrefix, Prefix, PrefixCollision, PrefixOwner,
+    allocate_card_number, allocate_sprint_number, effective_card_prefix, effective_prefixes,
+    find_prefix_collisions, EffectivePrefix, Prefix, PrefixCollision, PrefixOwner,
 };
 pub use prefix_backfill::{
     plan_prefix_backfill, BackfillBoard, BackfillRow, BackfillSprint, DEFAULT_CARD_PREFIX,
@@ -91,6 +92,7 @@ pub use sprint_factory::{NewSprint, SprintRecord};
 pub use sprint_log::SprintLog;
 pub use tag::{Tag, TagId};
 pub use task_list_view::TaskListView;
+pub use wip::check_wip_limit;
 
 pub use command_batch::CommandBatch;
 pub use command_store::CommandStore;

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -64,7 +64,37 @@ pub fn allocate_card_number(
     Ok((display, card_number))
 }
 
+/// Reserves the next sprint number in the namespace a new sprint belongs to,
+/// and returns the `(prefix, sprint_number)` it is stamped with.
+///
+/// The sprint-axis twin of [`allocate_card_number`], and it exists for the
+/// same reason: `board.sprint_counters` is private to one board, so two
+/// boards sharing a sprint prefix each hand out number 1.
+///
+/// Takes the already-resolved effective prefix rather than the board/sprint
+/// pair, because the caller has a `Board` in hand and `Sprint::create` needs
+/// the same value for its own field. Returns it in its configured casing;
+/// only the row name is normalised.
+pub fn allocate_sprint_number(
+    store: &dyn crate::DataStore,
+    effective_sprint_prefix: &str,
+) -> crate::KanbanResult<(String, u32)> {
+    let name = Prefix::normalize(effective_sprint_prefix);
+    let mut row = store
+        .get_prefix(&name)?
+        .unwrap_or_else(|| Prefix::new(&name));
+    let sprint_number = row.sprint_counter + 1;
+    row.sprint_counter = sprint_number;
+    store.upsert_prefix(row)?;
+    Ok((effective_sprint_prefix.to_string(), sprint_number))
+}
+
 /// A namespace that allocates card and sprint numbers for one name.
+///
+/// Both counters are HIGH-WATER MARKS: the last number handed out, so the
+/// next is `counter + 1`. This differs from the legacy `board.sprint_counters`
+/// map, which stores the next number instead; anything projecting that map
+/// into this field must convert.
 ///
 /// Several boards may share a prefix, so this deliberately records no owner:
 /// the reference runs board -> prefix, not the other way round.

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -64,21 +64,23 @@ pub fn allocate_card_number(
     Ok((display, card_number))
 }
 
-/// Reserves the next sprint number in the namespace a new sprint belongs to,
-/// and returns the `(prefix, sprint_number)` it is stamped with.
+/// Reserves and returns the next sprint number in the namespace a new sprint
+/// belongs to.
 ///
 /// The sprint-axis twin of [`allocate_card_number`], and it exists for the
 /// same reason: `board.sprint_counters` is private to one board, so two
 /// boards sharing a sprint prefix each hand out number 1.
 ///
 /// Takes the already-resolved effective prefix rather than the board/sprint
-/// pair, because the caller has a `Board` in hand and `Sprint::create` needs
-/// the same value for its own field. Returns it in its configured casing;
-/// only the row name is normalised.
+/// pair the card version takes, because the caller has a `Board` in hand and
+/// `Sprint::create` needs the same value for its own field. It returns only
+/// the number for that reason: unlike [`allocate_card_number`], which derives
+/// the prefix it returns, this one would only hand back its own argument.
+/// Only the row name is normalised; the caller keeps its configured casing.
 pub fn allocate_sprint_number(
     store: &dyn crate::DataStore,
     effective_sprint_prefix: &str,
-) -> crate::KanbanResult<(String, u32)> {
+) -> crate::KanbanResult<u32> {
     let name = Prefix::normalize(effective_sprint_prefix);
     let mut row = store
         .get_prefix(&name)?
@@ -86,7 +88,7 @@ pub fn allocate_sprint_number(
     let sprint_number = row.sprint_counter + 1;
     row.sprint_counter = sprint_number;
     store.upsert_prefix(row)?;
-    Ok((effective_sprint_prefix.to_string(), sprint_number))
+    Ok(sprint_number)
 }
 
 /// A namespace that allocates card and sprint numbers for one name.

--- a/crates/kanban-domain/src/prefix_backfill.rs
+++ b/crates/kanban-domain/src/prefix_backfill.rs
@@ -195,9 +195,10 @@ mod tests {
         let sprint = rows.iter().find(|r| r.name == "sprint").unwrap();
 
         assert_eq!(
-            sprint.sprint_counter, 9,
-            "the shared sprint namespace must start at the highest counter any \
-             contributing board reached, or the next sprint re-uses a number"
+            sprint.sprint_counter, 8,
+            "the shared sprint namespace must start at the highest number any \
+             contributing board has USED (9 was next, so 8 was last), or the \
+             next sprint re-uses a number"
         );
     }
 
@@ -227,7 +228,7 @@ mod tests {
         let sprint = forward.iter().find(|r| r.name == "sprint").unwrap();
         assert_eq!(
             (task.card_counter, sprint.sprint_counter),
-            (9, 7),
+            (9, 6),
             "each counter takes its own maximum, from whichever board held it"
         );
     }
@@ -268,6 +269,51 @@ mod tests {
         );
     }
 
+    /// `board.sprint_counters` stores the NEXT number to hand out, while
+    /// `Prefix.card_counter` -- the field sitting beside `sprint_counter` in
+    /// the same struct -- stores the LAST one used. Copying the legacy value
+    /// across verbatim gives one struct two opposite meanings, and the first
+    /// sprint allocated after migrating would skip a number forever.
+    ///
+    /// One struct, one meaning: both counters are high-water marks.
+    #[test]
+    fn test_plan_records_the_sprint_counter_as_the_last_number_used() {
+        let mut b = board(None, None, 0);
+        // Sprints 1 and 2 exist, so the legacy counter says "3 is next".
+        b.sprint_counters = vec![("sprint".to_string(), 3)];
+
+        let rows = plan(&[b], &[]);
+        let sprint = rows.iter().find(|r| r.name == "sprint").unwrap();
+
+        assert_eq!(
+            sprint.sprint_counter, 2,
+            "the row records the highest number USED, matching card_counter; \
+             storing the legacy next-to-hand-out here makes the first sprint \
+             after migration number 4 and 3 is never issued"
+        );
+    }
+
+    /// A board that has never allocated a sprint has no legacy entry at all,
+    /// and `initialize_sprint_counter` writes 1 for its first. Both mean
+    /// "nothing used yet", which is 0 -- and 0 must not underflow.
+    #[test]
+    fn test_plan_records_zero_for_a_board_that_has_allocated_no_sprint() {
+        let mut never = board(None, None, 0);
+        never.sprint_counters = vec![];
+        let mut initialized = board(Some("dev"), Some("dev"), 0);
+        initialized.sprint_counters = vec![("dev".to_string(), 1)];
+
+        let rows = plan(&[never, initialized], &[]);
+
+        for name in ["sprint", "dev"] {
+            let row = rows.iter().find(|r| r.name == name).unwrap();
+            assert_eq!(
+                row.sprint_counter, 0,
+                "{name}: nothing allocated yet, so the next sprint must be 1"
+            );
+        }
+    }
+
     #[test]
     fn test_plan_matches_sprint_counter_key_case_insensitively() {
         let mut b = board(Some("KAN"), Some("KAN"), 12);
@@ -276,7 +322,7 @@ mod tests {
         let rows = plan(&[b], &[]);
 
         assert_eq!(
-            rows[0].sprint_counter, 7,
+            rows[0].sprint_counter, 6,
             "the recorded key's casing need not match the board's current prefix"
         );
         assert_eq!(rows[0].card_counter, 12);

--- a/crates/kanban-domain/src/prefix_backfill.rs
+++ b/crates/kanban-domain/src/prefix_backfill.rs
@@ -40,9 +40,15 @@ pub struct BackfillBoard {
     pub id: Uuid,
     pub card_prefix: Option<String>,
     pub sprint_prefix: Option<String>,
+    /// The NEXT card number to hand out, seeded to 1 on a new board. The row
+    /// it feeds is a high-water mark, so [`plan_prefix_backfill`] converts.
     pub card_counter: i64,
     /// Sprint counters keyed by the prefix they were recorded under, in
     /// whatever casing was current at the time. Matched normalised.
+    ///
+    /// These hold the NEXT number to hand out, not the last used. The row
+    /// they feed is a high-water mark like [`BackfillBoard::card_counter`],
+    /// so [`plan_prefix_backfill`] converts.
     pub sprint_counters: Vec<(String, i64)>,
 }
 
@@ -91,17 +97,22 @@ pub fn plan_prefix_backfill(
         let sprint_name =
             Prefix::normalize(b.sprint_prefix.as_deref().unwrap_or(default_sprint_prefix));
 
+        // Legacy counters are next-to-hand-out; rows are last-used. A board
+        // with no entry, and one initialized to 1 without ever allocating,
+        // both mean zero.
         let sprint_counter = b
             .sprint_counters
             .iter()
             .find(|(prefix, _)| Prefix::normalize(prefix) == sprint_name)
-            .map(|(_, counter)| *counter)
+            .map(|(_, counter)| (*counter - 1).max(0))
             .unwrap_or(0);
 
+        let card_counter = (b.card_counter - 1).max(0);
+
         if card_name == sprint_name {
-            raise(card_name, b.card_counter, sprint_counter);
+            raise(card_name, card_counter, sprint_counter);
         } else {
-            raise(card_name, b.card_counter, 0);
+            raise(card_name, card_counter, 0);
             raise(sprint_name, 0, sprint_counter);
         }
     }
@@ -174,9 +185,10 @@ mod tests {
         let task = rows.iter().find(|r| r.name == "task").unwrap();
 
         assert_eq!(
-            task.card_counter, 9,
+            task.card_counter, 8,
             "the counter is a high-water mark; starting below the highest would \
-             re-mint a number an existing card already carries"
+             re-mint a number an existing card already carries. Legacy 9 was \
+             the next to hand out, so 8 was the last used"
         );
     }
 
@@ -228,7 +240,7 @@ mod tests {
         let sprint = forward.iter().find(|r| r.name == "sprint").unwrap();
         assert_eq!(
             (task.card_counter, sprint.sprint_counter),
-            (9, 6),
+            (8, 6),
             "each counter takes its own maximum, from whichever board held it"
         );
     }
@@ -241,7 +253,10 @@ mod tests {
         );
         let alpha = rows.iter().find(|r| r.name == "alpha").unwrap();
 
-        assert_eq!(alpha.card_counter, 7);
+        assert_eq!(
+            alpha.card_counter, 6,
+            "legacy 7 next-to-hand-out is 6 last-used"
+        );
         assert_eq!(
             names(&rows),
             vec!["alpha", "sprint"],
@@ -266,6 +281,33 @@ mod tests {
             vec!["sprint", "task", "task2"],
             "colliding boards share a row, so no suffixed name is ever generated \
              and none can collide with a name a board explicitly holds"
+        );
+    }
+
+    /// `board.card_counter` has the same next-to-hand-out meaning as
+    /// `sprint_counters`, and starts at 1 on a brand-new board rather than 0.
+    /// Copying it across verbatim makes the first card allocated after
+    /// migrating skip a number: a board with cards 1..3 records a legacy 4,
+    /// and a row reading 4 as last-used issues 5.
+    #[test]
+    fn test_plan_records_the_card_counter_as_the_last_number_used() {
+        let rows = plan(&[board(Some("kan"), Some("kan"), 4)], &[]);
+
+        assert_eq!(
+            rows[0].card_counter, 3,
+            "legacy 4 means 'next is 4', so 3 was the last used and 4 must \
+             still be issued"
+        );
+    }
+
+    #[test]
+    fn test_plan_records_zero_for_a_board_that_has_allocated_no_card() {
+        // `Board::new` seeds card_counter to 1, not 0.
+        let rows = plan(&[board(Some("kan"), Some("kan"), 1)], &[]);
+
+        assert_eq!(
+            rows[0].card_counter, 0,
+            "nothing allocated yet, so the first card must be number 1"
         );
     }
 
@@ -325,7 +367,7 @@ mod tests {
             rows[0].sprint_counter, 6,
             "the recorded key's casing need not match the board's current prefix"
         );
-        assert_eq!(rows[0].card_counter, 12);
+        assert_eq!(rows[0].card_counter, 11);
     }
 
     #[test]

--- a/crates/kanban-domain/src/wip.rs
+++ b/crates/kanban-domain/src/wip.rs
@@ -1,0 +1,42 @@
+//! The WIP-limit rule, in one place.
+//!
+//! Lives here rather than on `CommandContext` because two callers need it and
+//! they sit on opposite sides of the command boundary: `CreateCard::execute`,
+//! which must keep checking so a replayed command log cannot exceed a limit,
+//! and the service's create path, which must check BEFORE it allocates a card
+//! number. Allocation cannot move back inside the command -- `CreateCard`'s
+//! serialized shape is frozen around `card_number` -- so a create rejected
+//! inside the command would otherwise consume a number no card ever carries.
+//!
+//! Same shape as [`crate::prefix::allocate_card_number`], for the same reason:
+//! one rule, two tiers, and a second copy is how they drift.
+
+use uuid::Uuid;
+
+use crate::{DataStore, DomainError, KanbanError, KanbanResult};
+
+/// Returns `WipLimitExceeded` if adding `adding` cards to `column_id` would
+/// exceed its WIP limit. Cards whose ids appear in `exclude` are not counted
+/// toward the current occupancy. Returns `not_found` if the column does not
+/// exist.
+pub fn check_wip_limit(
+    store: &dyn DataStore,
+    column_id: Uuid,
+    adding: usize,
+    exclude: &[Uuid],
+) -> KanbanResult<()> {
+    let column = store
+        .get_column(column_id)?
+        .ok_or_else(|| KanbanError::not_found("Column", column_id))?;
+    let Some(limit) = column.wip_limit else {
+        return Ok(());
+    };
+    let current = store.count_cards_in_column_excluding(column_id, exclude)?;
+    if current + adding > limit as usize {
+        return Err(KanbanError::Domain(DomainError::wip_limit_exceeded(
+            column_id,
+            limit as u32,
+        )));
+    }
+    Ok(())
+}

--- a/crates/kanban-persistence-json/src/migration/v15_prefixes.rs
+++ b/crates/kanban-persistence-json/src/migration/v15_prefixes.rs
@@ -240,7 +240,11 @@ mod tests {
         transform_v14_to_v15_value(&mut env).unwrap();
 
         let prefixes = env["data"]["prefixes"].as_array().unwrap();
-        assert_eq!(prefixes[0]["card_counter"], 7);
+        assert_eq!(
+            prefixes[0]["card_counter"], 6,
+            "the board's counter holds the NEXT number to hand out; the row \
+             holds the last used, so 7 is still issued after migrating"
+        );
     }
 
     #[test]

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cross_backend_prefix_agreement.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cross_backend_prefix_agreement.rs
@@ -338,8 +338,11 @@ fn test_both_backfills_agree_on_counter_preservation() {
     let rows = rt.block_on(sqlite_rows(&scenario)).unwrap();
     assert_eq!(
         rows,
-        vec![("kan".to_string(), 12, 7)],
-        "the migrated row must carry BOTH counters forward, not just match the other backend"
+        vec![("kan".to_string(), 11, 6)],
+        "the migrated row must carry BOTH counters forward, not just match the \
+         other backend. Both convert: the legacy 12 and 7 are the NEXT numbers \
+         to hand out, and the row records the last ones used, so 12 and 7 are \
+         still issued after migrating"
     );
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v9_to_v10.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/migration_v9_to_v10.rs
@@ -126,12 +126,15 @@ fn test_migrate_v9_to_v10_merges_equal_card_and_sprint_prefix_into_one_row() {
         );
         let (_, card_counter, sprint_counter) = kan_rows[0];
         assert_eq!(
-            *card_counter, 4,
-            "BoardA created 3 cards off card_counter starting at 1"
+            *card_counter, 3,
+            "BoardA created 3 cards, so 3 is the highest used; the legacy \
+             counter reads 4 because it holds the NEXT number"
         );
         assert_eq!(
-            *sprint_counter, 2,
-            "BoardA created 1 sprint off a counter starting at 1"
+            *sprint_counter, 1,
+            "BoardA created 1 sprint, so 1 is the highest number used. The \
+             legacy counter says 2 because it holds the NEXT number; the row \
+             holds the last used, matching card_counter"
         );
     });
 }
@@ -145,10 +148,7 @@ fn test_migrate_v9_to_v10_creates_two_rows_when_card_and_sprint_prefix_differ() 
         let rows = prefix_rows(store.pool()).await;
 
         let dev = rows.iter().find(|(n, ..)| n == "dev").unwrap();
-        assert_eq!(
-            dev.1, 3,
-            "BoardC created 2 cards off card_counter starting at 1"
-        );
+        assert_eq!(dev.1, 2, "BoardC created 2 cards, so 2 is the highest used");
         assert_eq!(dev.2, 0, "the card-prefix row carries no sprint counter");
 
         let rel = rows.iter().find(|(n, ..)| n == "rel").unwrap();
@@ -188,12 +188,15 @@ fn test_migrate_v9_to_v10_preserves_card_counter_value() {
                 .unwrap_or_else(|| "task".to_string())
                 .to_lowercase();
             let row = rows.iter().find(|(n, ..)| n == &name).unwrap();
+            // Compared as NEXT-to-issue on both sides: the row records the
+            // last number used, the board's legacy counter records the next.
             assert!(
-                row.1 >= counter,
-                "board {board_id} allocates from `{name}`, whose counter ({}) must be at \
-                 least its own ({counter}) -- a shared counter is a high-water mark, and \
-                 starting below one would re-mint a number an existing card carries",
-                row.1
+                row.1 + 1 >= counter,
+                "board {board_id} allocates from `{name}`, which would next issue {} -- \
+                 not below the {counter} the board itself would have. A shared counter \
+                 is a high-water mark, and starting below one would re-mint a number an \
+                 existing card carries",
+                row.1 + 1
             );
         }
     });
@@ -221,10 +224,10 @@ fn test_migrate_v9_to_v10_preserves_sprint_counter_value() {
                 .find(|(n, ..)| n == &name)
                 .unwrap_or_else(|| panic!("no row for sprint namespace {name}"));
             assert!(
-                row.2 >= counter,
-                "board {board_id}'s sprint namespace `{name}` must carry a counter ({}) \
-                 at least as high as the board's own ({counter})",
-                row.2
+                row.2 + 1 >= counter,
+                "board {board_id}'s sprint namespace `{name}` would next issue {}, which \
+                 must not be below the board's own next ({counter})",
+                row.2 + 1
             );
         }
     });
@@ -263,8 +266,10 @@ fn test_migrate_v9_to_v10_shares_one_row_between_boards_without_a_prefix() {
         let highest = board_counters.iter().map(|(c,)| *c).max().unwrap();
         let task = rows.iter().find(|(n, ..)| n == "task").unwrap();
         assert_eq!(
-            task.1, highest,
-            "the shared counter is the high-water mark across both boards"
+            task.1,
+            highest - 1,
+            "the shared counter is the high-water mark across both boards, \
+             recorded as the last number used rather than the next"
         );
     });
 }
@@ -607,9 +612,9 @@ fn test_migrate_v9_to_v10_accepts_existing_cross_board_duplicates_without_renumb
         let rows = prefix_rows(store.pool()).await;
         let task = rows.iter().find(|(n, ..)| n == "task").unwrap();
         assert_eq!(
-            task.1, 6,
-            "the shared counter is the high-water mark across both boards (6, not 4 and not \
-             10), so the next card minted from either board is task-6 -- a number neither \
+            task.1, 5,
+            "the shared counter is the high-water mark across both boards (5, not 3 and not \
+             9), so the next card minted from either board is task-6 -- a number neither \
              board has used"
         );
     });

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -105,6 +105,12 @@ impl KanbanContext {
             .backend
             .get_board(board_id)?
             .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
+        // Checked here, before allocating, as well as inside `CreateCard`.
+        // Allocation cannot move into the command -- its serialized shape is
+        // frozen around `card_number` -- so a create rejected inside the
+        // command consumes a number no card ever carries. The command keeps
+        // its own check so a replayed log cannot exceed a limit either.
+        kanban_domain::check_wip_limit(self.backend.as_data_store(), spec.column_id, 1, &[])?;
         // The prefix is deliberately dropped here: `CreateCard` is replayed from
         // serialized command logs, so its shape is frozen and cannot carry one.
         // It re-derives through the same `effective_card_prefix`, so the two

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -332,7 +332,9 @@ pub async fn test_full_populated_context_roundtrip(factory: &BackendFactory) -> 
     // longer steers allocation -- for a real workspace the migration seeds the
     // prefix row FROM this field, so the two agree from the start.
     assert_eq!(b.card_counter, 10);
-    assert_eq!(b.sprint_counters.get("SP"), Some(&6));
+    // Same story on the sprint axis: seeded to 5 above and left there by the
+    // sprint created since, which drew number 1 from the "sp" prefix row.
+    assert_eq!(b.sprint_counters.get("SP"), Some(&5));
 
     let cols = loaded.list_columns(board.id).unwrap();
     assert_eq!(cols.len(), 2);

--- a/crates/kanban-service/src/test_helpers/contract/prefix.rs
+++ b/crates/kanban-service/src/test_helpers/contract/prefix.rs
@@ -112,6 +112,14 @@ pub async fn test_prefix_upsert_replaces_the_row_for_an_existing_name(factory: &
     );
     assert_eq!(all[0].card_counter, 9, "the later write wins");
     assert_eq!(all[0].sprint_counter, 2);
+    assert_eq!(
+        all[0].name, "kan",
+        "`Prefix::name` is documented as always normalised, so the stored name \
+         must not take the caller's casing. Backends disagreed here: SQLite's \
+         ON CONFLICT leaves the name alone while the in-memory path replaced \
+         the whole row, so the same two writes produced `kan` on one and `KAN` \
+         on the other"
+    );
 }
 
 pub async fn test_prefix_list_returns_every_namespace(factory: &BackendFactory) {

--- a/crates/kanban-service/tests/prefix_allocation.rs
+++ b/crates/kanban-service/tests/prefix_allocation.rs
@@ -163,6 +163,61 @@ async fn test_legacy_board_counter_still_moves_in_lockstep() {
     );
 }
 
+/// Allocation moved ahead of `CreateCard::execute`, but the WIP check lives
+/// inside it, so a rejected create used to bump the counter and then fail.
+///
+/// The counter is the discriminating assertion, not the error: the create
+/// correctly fails either way. What must not happen is a number being reserved
+/// for a card that was never created.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_wip_rejected_create_does_not_burn_a_card_number() {
+    use kanban_domain::{ColumnUpdate, FieldUpdate};
+
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    c.update_column(
+        col.id,
+        ColumnUpdate {
+            wip_limit: FieldUpdate::Set(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let first = c
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+    let before = counter(&c, "kan");
+
+    let rejected = c.create_card(board.id, col.id, "two".into(), CreateCardOptions::default());
+    assert!(rejected.is_err(), "the column is full, so this must fail");
+
+    assert_eq!(
+        counter(&c, "kan"),
+        before,
+        "a create that never produced a card must not consume a number"
+    );
+
+    // And numbering stays contiguous once the column has room again.
+    c.delete_card(first.id).unwrap();
+    let next = c
+        .create_card(
+            board.id,
+            col.id,
+            "three".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(
+        next.card_number,
+        first.card_number + 1,
+        "the rejected create must leave no gap"
+    );
+}
+
 /// A subcard is created by a different command on a different layer
 /// (`CreateSubcardCommand`, inside the domain). Before this card it minted from
 /// `board.card_counter` while ordinary cards minted from the prefix row, so the

--- a/crates/kanban-service/tests/resolve.rs
+++ b/crates/kanban-service/tests/resolve.rs
@@ -183,8 +183,15 @@ async fn test_resolve_sprint_id_global_ambiguous_number_lists_boards() {
     let (mut ctx, _dir) = open_ctx().await;
     let board_a = ctx.create_board("A".into(), None).unwrap();
     let board_b = ctx.create_board("B".into(), None).unwrap();
-    let _ = ctx.create_sprint(board_a.id, None, None).unwrap();
-    let _ = ctx.create_sprint(board_b.id, None, None).unwrap();
+    // Distinct sprint prefixes, so the two boards allocate from separate
+    // namespaces and both reach number 1. Sharing a prefix would hand out 1
+    // and 2 instead, which is the point of the shared counter.
+    let _ = ctx
+        .create_sprint(board_a.id, Some("ALPHA".into()), None)
+        .unwrap();
+    let _ = ctx
+        .create_sprint(board_b.id, Some("BETA".into()), None)
+        .unwrap();
     let err = ctx.resolve_sprint_id_global("1").unwrap_err().to_string();
     assert!(err.contains("ambiguous"), "got: {err}");
     assert!(err.contains("'A'"), "got: {err}");
@@ -401,8 +408,13 @@ async fn test_resolve_sprint_id_on_board_does_not_bleed_other_board_numbers() {
     let (mut ctx, _dir) = open_ctx().await;
     let board_a = ctx.create_board("A".into(), None).unwrap();
     let board_b = ctx.create_board("B".into(), None).unwrap();
-    let _s_a = ctx.create_sprint(board_a.id, None, None).unwrap();
-    let s_b = ctx.create_sprint(board_b.id, None, None).unwrap();
+    // Separate namespaces so both sprints really are #1.
+    let _s_a = ctx
+        .create_sprint(board_a.id, Some("ALPHA".into()), None)
+        .unwrap();
+    let s_b = ctx
+        .create_sprint(board_b.id, Some("BETA".into()), None)
+        .unwrap();
     assert_eq!(s_b.sprint_number, 1, "both sprints are #1 by construction");
     // Resolving "1" on board B returns the B sprint, not A's.
     let resolved = ctx.resolve_sprint_id("1", board_b.id).unwrap();

--- a/crates/kanban-service/tests/sprint_allocation.rs
+++ b/crates/kanban-service/tests/sprint_allocation.rs
@@ -1,0 +1,185 @@
+//! Sprint numbers are allocated from the shared prefix row, not from the
+//! board's private `sprint_counters` map.
+//!
+//! The mirror of `prefix_allocation.rs` on the sprint axis. Same defect, same
+//! shape: per-board counters let two boards sharing a prefix each hand out
+//! "sprint 1", and a card's sibling concept must not be governed by a
+//! different rule than the card.
+//!
+//! Assertions are on the ROW VALUE wherever the returned number alone would
+//! pass identically against the legacy map.
+
+use kanban_core::AppConfig;
+use kanban_domain::KanbanOperations;
+use kanban_service::KanbanContext;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+async fn ctx(path: &std::path::Path) -> KanbanContext {
+    let backend = kanban_persistence_sqlite::SqliteBackend::open(path.to_str().unwrap())
+        .await
+        .expect("open sqlite backend");
+    KanbanContext::open(Arc::new(backend), AppConfig::default())
+        .await
+        .expect("open context")
+}
+
+/// An absent row and a row at zero both mean "nothing allocated from this
+/// namespace yet".
+fn sprint_counter(ctx: &KanbanContext, name: &str) -> u32 {
+    ctx.backend()
+        .get_prefix(name)
+        .unwrap()
+        .map_or(0, |p| p.sprint_counter)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_numbers_are_drawn_from_the_prefix_row_counter() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), None).unwrap();
+    let before = sprint_counter(&c, "sprint");
+
+    c.create_sprint(board.id, None, None).unwrap();
+    let after_one = sprint_counter(&c, "sprint");
+    c.create_sprint(board.id, None, None).unwrap();
+    let after_two = sprint_counter(&c, "sprint");
+
+    assert_eq!(
+        (after_one, after_two),
+        (before + 1, before + 2),
+        "each create must advance the PREFIX ROW's sprint counter; advancing \
+         only board.sprint_counters would leave this at zero"
+    );
+}
+
+/// The invariant this card exists for, on the sprint axis.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_two_boards_sharing_a_sprint_prefix_never_mint_the_same_number() {
+    use kanban_domain::{BoardUpdate, FieldUpdate};
+
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let a = c.create_board("A".into(), None).unwrap();
+    let b = c.create_board("B".into(), None).unwrap();
+    for id in [a.id, b.id] {
+        c.update_board(
+            id,
+            BoardUpdate {
+                sprint_prefix: FieldUpdate::Set("REL".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let first = c.create_sprint(a.id, None, None).unwrap();
+    let second = c.create_sprint(b.id, None, None).unwrap();
+
+    assert_ne!(
+        first.sprint_number, second.sprint_number,
+        "one namespace, one counter; per-board counters give both number 1"
+    );
+    assert_eq!(sprint_counter(&c, "rel"), 2, "both advanced the one row");
+}
+
+/// Casing separates display from matching here exactly as it does for cards.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_differently_cased_sprint_prefixes_share_one_namespace() {
+    use kanban_domain::{BoardUpdate, FieldUpdate};
+
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let a = c.create_board("A".into(), None).unwrap();
+    let b = c.create_board("B".into(), None).unwrap();
+    for (id, spelling) in [(a.id, "REL"), (b.id, "rel")] {
+        c.update_board(
+            id,
+            BoardUpdate {
+                sprint_prefix: FieldUpdate::Set(spelling.into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let first = c.create_sprint(a.id, None, None).unwrap();
+    let second = c.create_sprint(b.id, None, None).unwrap();
+
+    assert_ne!(first.sprint_number, second.sprint_number);
+    assert_eq!(
+        first.prefix.as_deref(),
+        Some("REL"),
+        "each sprint keeps ITS board's configured casing"
+    );
+    assert_eq!(second.prefix.as_deref(), Some("rel"));
+    assert_eq!(sprint_counter(&c, "rel"), 2);
+}
+
+/// A sprint whose own prefix overrides its board's allocates from THAT
+/// namespace, leaving the board's counter untouched.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_sprint_prefix_override_allocates_from_its_own_namespace() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), None).unwrap();
+    let board_before = sprint_counter(&c, "sprint");
+
+    let sprint = c
+        .create_sprint(board.id, Some("REL".to_string()), None)
+        .unwrap();
+
+    assert_eq!(sprint.prefix.as_deref(), Some("REL"));
+    assert_eq!(
+        sprint_counter(&c, "sprint"),
+        board_before,
+        "the board's namespace must not advance, or it permanently skips a number"
+    );
+    assert_eq!(sprint_counter(&c, "rel"), 1);
+}
+
+/// KAN-1216 removes `board.sprint_counters` only once this read path has
+/// proven itself. Until then both move together, and deleting this test is
+/// what that card does.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_legacy_board_sprint_counter_still_moves_in_lockstep() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), None).unwrap();
+    c.create_sprint(board.id, None, None).unwrap();
+
+    assert_eq!(
+        c.get_board(board.id)
+            .unwrap()
+            .unwrap()
+            .get_sprint_counter("sprint"),
+        Some(2),
+        "the legacy map stores the NEXT number and stays in sync until KAN-1216 \
+         removes it"
+    );
+}
+
+/// Numbers must be contiguous across the point where allocation moved onto the
+/// prefix row. A row seeded with the legacy next-to-hand-out instead of the
+/// last-used would make this skip.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_numbering_is_contiguous_across_the_allocation_switch() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), None).unwrap();
+    let numbers: Vec<u32> = (0..3)
+        .map(|_| c.create_sprint(board.id, None, None).unwrap().sprint_number)
+        .collect();
+
+    assert_eq!(
+        numbers,
+        vec![1, 2, 3],
+        "sprint numbering starts at 1 and never skips"
+    );
+}


### PR DESCRIPTION
Sprint numbering moves onto `prefixes.sprint_counter`, the same shared namespace the card axis already allocates from. Two boards sharing a sprint prefix now draw from one counter instead of each handing out number 1.

The old `ensure_sprint_counter_initialized` scan is deleted rather than ported. It seeded a counter from `MAX(sprint_number)` for one board, which is precisely what lets a shared namespace issue the same number twice. `board.sprint_counters` is still written behind the row, clamped upward only, matching how `CreateCard` maintains `board.card_counter`. KAN-1216 removes both.

## A counter-semantics defect this exposed

Both legacy counters hold the NEXT number to hand out, and `card_counter` starts at 1 on a brand-new board. A prefix row holds the LAST number used, so its next allocation is `counter + 1`. The V15 backfill copied both across verbatim, giving one struct two opposite meanings and making the first card and the first sprint allocated after migrating each skip a number.

Nothing read `Prefix.sprint_counter` yet, which is why no test caught it. The card half had already shipped in KAN-1247.

The projection now converts, clamped at zero. Verified against the real 1216-card tracker migrating V12 to V16:

| | highest existing | prefix row | first allocation after migrating |
|---|---|---|---|
| cards | KAN-1248 | 1248 | KAN-1249 |
| sprints | 22 | 22 | 23 |

Contiguous on both axes. Before this change the row read 1249 and 23, and the next allocations were KAN-1250 and sprint 24.

V15 is unreleased and no store has been migrated by it, so correcting the projection in place is sufficient. No corrective migration is needed.

## Test changes worth reading

Two tests in `resolve.rs` constructed cross-board sprint-number ambiguity by creating a sprint on each of two default-prefix boards. Those boards now share a namespace and get 1 and 2, so the tests give them distinct prefixes instead. The ambiguity they guard is still reachable, just not through the default prefix.

The remaining updated expectations are the semantic shift itself. The two invariant tests in `migration_v9_to_v10.rs` now compare next-to-issue on both sides rather than raw values, which is what they meant all along.

- `cargo test --workspace --all-features` green
- `cargo clippy --all-targets --all-features -- -D warnings` green
- `cargo fmt --all` applied