### PR TITLE
KAN-1251 refactor(service,domain): allocate card numbers inside the command transaction

### DIFF
--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -219,13 +219,6 @@ impl Board {
         self.updated_at = Utc::now();
     }
 
-    pub fn allocate_sprint_number(&mut self) -> u32 {
-        let number = self.next_sprint_number;
-        self.next_sprint_number += 1;
-        self.updated_at = Utc::now();
-        number
-    }
-
     pub fn consume_sprint_name(&mut self) -> Option<usize> {
         if self.sprint_name_used_count < self.sprint_names.len() {
             let index = self.sprint_name_used_count;

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -35,19 +35,6 @@ impl KanbanContext {
         self.backend.get_archived_card(id)
     }
 
-    /// Create a card from a full `NewCard` spec plus an optional client-supplied
-    /// id (idempotent PUT-create). The owning board is DERIVED from
-    /// `column.board_id` (no `board_id` param). Validates the dual FK: the
-    /// `column_id` must exist (missing → `NotFound`), and an optional `sprint_id`
-    /// must exist and belong to the derived board (cross-board →
-    /// `SprintBoardMismatch`). Resolves the id (client value or a fresh mint) and
-    /// enforces uniqueness across BOTH live and archived cards (duplicate →
-    /// `AlreadyExists`/409). All validation runs BEFORE the board counter is
-    /// minted/bumped, so a rejected create leaves no side effect. `card_number`
-    /// minting + board bump stay a service/command-tier responsibility (the
-    /// domain `create` is Board-free). Inherent on `KanbanContext` (not a
-    /// `KanbanOperations` trait method) — the trait is dual-impl by TUI+CLI and
-    /// would force churn there.
     /// Thin wrapper over the domain allocator: resolves the sprint override,
     /// then defers. The rule lives in `kanban_domain::allocate_card_number` so
     /// this and `CreateSubcardCommand` cannot draw from different counters.
@@ -71,6 +58,25 @@ impl KanbanContext {
         )
     }
 
+    /// Create a card from a full `NewCard` spec plus an optional client-supplied
+    /// id (idempotent PUT-create). The owning board is DERIVED from
+    /// `column.board_id` (no `board_id` param). Validates the dual FK: the
+    /// `column_id` must exist (missing → `NotFound`), and an optional `sprint_id`
+    /// must exist and belong to the derived board (cross-board →
+    /// `SprintBoardMismatch`). Resolves the id (client value or a fresh mint) and
+    /// enforces uniqueness across BOTH live and archived cards (duplicate →
+    /// `AlreadyExists`/409).
+    ///
+    /// A rejected create leaves no side effect, including no consumed
+    /// `card_number`: the number is minted inside the batch's transaction, so
+    /// a command that rejects rolls the allocation back with it. That holds
+    /// regardless of which validation rejects, so no validation ordering here
+    /// is load-bearing.
+    ///
+    /// `card_number` minting stays a service/command-tier responsibility (the
+    /// domain `create` is Board-free). Inherent on `KanbanContext` (not a
+    /// `KanbanOperations` trait method) — the trait is dual-impl by TUI+CLI and
+    /// would force churn there.
     pub fn create_card_from_spec(
         &mut self,
         client_id: Option<Uuid>,

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -51,20 +51,20 @@ impl KanbanContext {
     /// Thin wrapper over the domain allocator: resolves the sprint override,
     /// then defers. The rule lives in `kanban_domain::allocate_card_number` so
     /// this and `CreateSubcardCommand` cannot draw from different counters.
+    /// Takes the store explicitly so the caller can hand it the TRANSACTION's
+    /// store: the counter bump this performs must roll back with the create it
+    /// is minting for.
     fn allocate_card_number(
-        &self,
+        store: &dyn kanban_domain::DataStore,
         board: &kanban_domain::Board,
         sprint_id: Option<Uuid>,
     ) -> KanbanResult<(String, u32)> {
         let sprint_override = match sprint_id {
-            Some(id) => self
-                .backend
-                .get_sprint(id)?
-                .and_then(|s| s.card_prefix.clone()),
+            Some(id) => store.get_sprint(id)?.and_then(|s| s.card_prefix.clone()),
             None => None,
         };
         kanban_domain::allocate_card_number(
-            self.backend.as_data_store(),
+            store,
             board.card_prefix.as_deref(),
             sprint_override.as_deref(),
             kanban_domain::DEFAULT_CARD_PREFIX,
@@ -105,18 +105,6 @@ impl KanbanContext {
             .backend
             .get_board(board_id)?
             .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
-        // Checked here, before allocating, as well as inside `CreateCard`.
-        // Allocation cannot move into the command -- its serialized shape is
-        // frozen around `card_number` -- so a create rejected inside the
-        // command consumes a number no card ever carries. The command keeps
-        // its own check so a replayed log cannot exceed a limit either.
-        kanban_domain::check_wip_limit(self.backend.as_data_store(), spec.column_id, 1, &[])?;
-        // The prefix is deliberately dropped here: `CreateCard` is replayed from
-        // serialized command logs, so its shape is frozen and cannot carry one.
-        // It re-derives through the same `effective_card_prefix`, so the two
-        // cannot disagree -- and the allocation tests assert the stamped prefix
-        // against the namespace whose counter moved.
-        let (_prefix, card_number) = self.allocate_card_number(&board, spec.sprint_id)?;
         // Append past the FULL (live + archived) set so a new card shares one
         // coherent ordinal space with any archived siblings (KAN-916 / O1-A).
         let position = self.backend.count_cards_in_column_filtered(
@@ -127,24 +115,36 @@ impl KanbanContext {
         // Keep construction inside the frozen `CreateCard` command (it owns the
         // WIP check, board-counter bump, sprint-log seeding and upserts); the
         // service supplies the minted id/number/position and the rich options.
+        //
+        // Built INSIDE the transaction so the number is minted there too. The
+        // command's own validations (WIP above all) can then reject without
+        // leaving a number reserved for a card that was never created -- the
+        // rollback takes the counter with it. The prefix is deliberately
+        // dropped: `CreateCard` is replayed from serialized command logs, so
+        // its shape is frozen and cannot carry one. It re-derives through the
+        // same `effective_card_prefix`, so the two cannot disagree.
         let column_id = spec.column_id;
-        let cmd = Command::Card(CardCommand::Create(kanban_domain::commands::CreateCard {
-            id,
-            card_number,
-            board_id,
-            column_id,
-            title: spec.title,
-            position,
-            options: CreateCardOptions {
-                description: spec.description,
-                priority: Some(spec.priority),
-                points: spec.points,
-                due_date: spec.due_date,
-                sprint_id: spec.sprint_id,
-            },
-            timestamp: chrono::Utc::now(),
-        }));
-        self.execute(vec![cmd])?;
+        self.execute_with(|store| {
+            let (_prefix, card_number) = Self::allocate_card_number(store, &board, spec.sprint_id)?;
+            Ok(vec![Command::Card(CardCommand::Create(
+                kanban_domain::commands::CreateCard {
+                    id,
+                    card_number,
+                    board_id,
+                    column_id,
+                    title: spec.title,
+                    position,
+                    options: CreateCardOptions {
+                        description: spec.description,
+                        priority: Some(spec.priority),
+                        points: spec.points,
+                        due_date: spec.due_date,
+                        sprint_id: spec.sprint_id,
+                    },
+                    timestamp: chrono::Utc::now(),
+                },
+            ))])
+        })?;
         self.get_card_impl(id)?.ok_or_else(|| {
             KanbanError::Internal("Card creation succeeded but card not found".into())
         })

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -15,23 +15,49 @@ impl KanbanContext {
     /// per-command inverses in reverse order, so undoing each `Fk_inv`
     /// runs against the state `Fk` itself saw at capture time.
     pub fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<()> {
+        self.execute_with(|_| Ok(commands))
+    }
+
+    /// Like [`execute`](Self::execute), but the batch is BUILT inside the
+    /// transaction, so anything the builder writes rolls back with it.
+    ///
+    /// This exists because a value a command needs may itself be a write.
+    /// Minting a card number is the case: `CreateCard`'s serialized shape is
+    /// frozen around `card_number`, so the number must exist before the
+    /// command is constructed — but constructing the command early does not
+    /// require reserving the number early. Allocating from the builder keeps
+    /// the reservation and the create in one atomic unit, so a command that
+    /// rejects cannot leave a number reserved for a card that was never made.
+    ///
+    /// Without this, correctness depends on every failure inside a command
+    /// also being pre-checked by the caller, which is an invariant nothing
+    /// enforces.
+    pub fn execute_with(
+        &mut self,
+        build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>,
+    ) -> KanbanResult<()> {
         if self.backend.remote_writes().is_some() {
             return Err(KanbanError::unsupported(
                 "this operation is not supported over the HTTP backend in v1 (only board/column/card create/update/delete are)",
             ));
         }
         let backend = Arc::clone(&self.backend);
-        let cmds = &commands;
         let mut per_cmd_inverses: Vec<Vec<Command>> = Vec::new();
+        // The builder's output has to outlive the closure: the undo entry is
+        // pushed after the transaction commits, and it must carry the commands
+        // that actually ran.
+        let mut commands: Vec<Command> = Vec::new();
+        let built = &mut commands;
         self.backend.with_transaction(Box::new(|| {
             let store: &dyn DataStore = backend.as_data_store();
+            *built = build(store)?;
             let ctx = CommandContext { store };
-            for cmd in cmds.iter() {
+            for cmd in built.iter() {
                 per_cmd_inverses.push(cmd.capture_inverse(store)?);
                 cmd.execute(&ctx)?;
             }
             let batch = kanban_domain::CommandBatch {
-                commands: cmds.clone(),
+                commands: built.clone(),
                 correlation_id: Uuid::new_v4(),
                 // nil locally; the HTTP layer assigns the real client identity (KAN-751)
                 issued_by: ClientId::nil(),

--- a/crates/kanban-service/src/test_helpers/contract/prefix.rs
+++ b/crates/kanban-service/src/test_helpers/contract/prefix.rs
@@ -200,3 +200,70 @@ pub async fn test_prefix_counters_survive_repeated_save_cycles(factory: &Backend
         "counters must survive a second save/reload cycle unchanged"
     );
 }
+
+/// A rejected create must not consume a card number, on EVERY backend.
+///
+/// This is a rollback-semantics test, and rollback is implemented per backend:
+/// SQLite uses a real write transaction, while the JSON and in-memory backends
+/// snapshot and restore. A snapshot that did not carry `prefixes` would restore
+/// everything except the counter, so the number would be burned on those two
+/// and not on SQLite -- passing a SQLite-only test while silently diverging.
+pub async fn test_a_rejected_create_does_not_consume_a_card_number(factory: &BackendFactory) {
+    use kanban_domain::{ColumnUpdate, CreateCardOptions, FieldUpdate, KanbanOperations};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = crate::KanbanContext::open(factory(&path), kanban_core::AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    ctx.update_column(
+        col.id,
+        ColumnUpdate {
+            wip_limit: FieldUpdate::Set(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let first = ctx
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+    let before = ctx
+        .backend()
+        .get_prefix("kan")
+        .unwrap()
+        .unwrap()
+        .card_counter;
+
+    let rejected = ctx.create_card(board.id, col.id, "two".into(), CreateCardOptions::default());
+    assert!(rejected.is_err(), "the column is full, so this must fail");
+
+    assert_eq!(
+        ctx.backend()
+            .get_prefix("kan")
+            .unwrap()
+            .unwrap()
+            .card_counter,
+        before,
+        "the allocation is made inside the batch's transaction, so a command \
+         that rejects must roll it back on this backend too"
+    );
+
+    ctx.delete_card(first.id).unwrap();
+    let next = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "three".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(
+        next.card_number,
+        first.card_number + 1,
+        "and numbering stays contiguous"
+    );
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -42,6 +42,10 @@ macro_rules! context_contract_tests {
         async fn test_prefix_counters_survive_repeated_save_cycles() {
             $crate::test_helpers::contract::prefix::test_prefix_counters_survive_repeated_save_cycles(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_rejected_create_does_not_consume_a_card_number() {
+            $crate::test_helpers::contract::prefix::test_a_rejected_create_does_not_consume_a_card_number(&$factory_fn()).await;
+        }
 
         // Board tests
         #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/execute_with.rs
+++ b/crates/kanban-service/tests/execute_with.rs
@@ -6,8 +6,8 @@
 //! writes must roll back with the batch.
 
 use kanban_core::AppConfig;
-use kanban_domain::commands::{Command, CardCommand, CreateCard};
-use kanban_domain::{CreateCardOptions, DataStore, KanbanOperations, Prefix};
+use kanban_domain::commands::{CardCommand, Command, CreateCard};
+use kanban_domain::{CreateCardOptions, KanbanOperations, Prefix};
 use kanban_service::KanbanContext;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -64,7 +64,12 @@ async fn test_execute_with_rolls_back_a_builder_write_when_a_command_fails() {
 
     // The column is untouched, so a normal create still works afterwards.
     let ok = c
-        .create_card(board.id, col.id, "fine".into(), CreateCardOptions::default())
+        .create_card(
+            board.id,
+            col.id,
+            "fine".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
     assert_eq!(ok.card_number, 1);
 }
@@ -116,9 +121,8 @@ async fn test_execute_with_propagates_a_builder_error_and_records_nothing() {
         .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
         .unwrap();
 
-    let result = c.execute_with(|_store| {
-        Err(kanban_domain::KanbanError::validation("builder said no"))
-    });
+    let result =
+        c.execute_with(|_store| Err(kanban_domain::KanbanError::validation("builder said no")));
     assert!(result.is_err(), "a builder error must surface");
 
     // Undo now reverses the earlier create, proving the failed builder pushed

--- a/crates/kanban-service/tests/execute_with.rs
+++ b/crates/kanban-service/tests/execute_with.rs
@@ -1,0 +1,131 @@
+//! `execute_with` builds its batch INSIDE the transaction.
+//!
+//! The point is the rollback boundary, not the builder. A card number minted
+//! outside the transaction survives a failed batch, which is how a rejected
+//! create came to reserve a number no card ever carried. Anything the builder
+//! writes must roll back with the batch.
+
+use kanban_core::AppConfig;
+use kanban_domain::commands::{Command, CardCommand, CreateCard};
+use kanban_domain::{CreateCardOptions, DataStore, KanbanOperations, Prefix};
+use kanban_service::KanbanContext;
+use std::sync::Arc;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn ctx(path: &std::path::Path) -> KanbanContext {
+    let backend = kanban_persistence_sqlite::SqliteBackend::open(path.to_str().unwrap())
+        .await
+        .expect("open sqlite backend");
+    KanbanContext::open(Arc::new(backend), AppConfig::default())
+        .await
+        .expect("open context")
+}
+
+/// The seam itself: a builder write must not outlive a failed batch.
+///
+/// Uses the prefix row because that is the write the whole card exists for,
+/// but the assertion is about the transaction boundary, not about prefixes.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_with_rolls_back_a_builder_write_when_a_command_fails() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+
+    let result = c.execute_with(|store| {
+        store.upsert_prefix(Prefix {
+            name: "builder".into(),
+            card_counter: 42,
+            sprint_counter: 0,
+        })?;
+        // A card into a column that does not exist: the command fails, so the
+        // batch rolls back and the write above must go with it.
+        Ok(vec![Command::Card(CardCommand::Create(CreateCard {
+            id: Uuid::new_v4(),
+            card_number: 1,
+            board_id: board.id,
+            column_id: Uuid::new_v4(),
+            title: "doomed".into(),
+            position: 0,
+            options: CreateCardOptions::default(),
+            timestamp: chrono::Utc::now(),
+        }))])
+    });
+
+    assert!(result.is_err(), "the batch must fail");
+    assert!(
+        c.backend().get_prefix("builder").unwrap().is_none(),
+        "the builder's write must roll back with the batch it belongs to; \
+         surviving it is exactly how an allocation outlives the create it was \
+         minted for"
+    );
+
+    // The column is untouched, so a normal create still works afterwards.
+    let ok = c
+        .create_card(board.id, col.id, "fine".into(), CreateCardOptions::default())
+        .unwrap();
+    assert_eq!(ok.card_number, 1);
+}
+
+/// The batch the builder produced is what gets recorded, so undo has something
+/// to reverse. A builder whose commands never escaped the closure would leave
+/// an empty undo entry and the create would be unundoable.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_with_records_the_built_batch_for_undo() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let id = Uuid::new_v4();
+
+    c.execute_with(|_store| {
+        Ok(vec![Command::Card(CardCommand::Create(CreateCard {
+            id,
+            card_number: 7,
+            board_id: board.id,
+            column_id: col.id,
+            title: "built".into(),
+            position: 0,
+            options: CreateCardOptions::default(),
+            timestamp: chrono::Utc::now(),
+        }))])
+    })
+    .unwrap();
+
+    assert!(c.get_card(id).unwrap().is_some(), "the card was created");
+    assert!(c.undo().unwrap(), "the built batch must be undoable");
+    assert!(
+        c.get_card(id).unwrap().is_none(),
+        "undo must reverse the commands the BUILDER produced, not an empty batch"
+    );
+}
+
+/// A builder that fails must abort the whole thing, leaving no partial batch
+/// and nothing on the undo stack.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_with_propagates_a_builder_error_and_records_nothing() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+
+    let before = c
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+
+    let result = c.execute_with(|_store| {
+        Err(kanban_domain::KanbanError::validation("builder said no"))
+    });
+    assert!(result.is_err(), "a builder error must surface");
+
+    // Undo now reverses the earlier create, proving the failed builder pushed
+    // nothing onto the stack.
+    assert!(c.undo().unwrap());
+    assert!(
+        c.get_card(before.id).unwrap().is_none(),
+        "the undo stack must be untouched by a failed builder"
+    );
+}


### PR DESCRIPTION
Card numbers were minted before `execute`'s transaction opened, so a command that rejected left the counter advanced for a card that was never created.

KAN-1249 patched the one reachable case by checking the WIP limit in the service ahead of allocation. That worked, but it made a policy check load-bearing for numbering correctness. It enumerated a failure rather than establishing an invariant: any validation added to `CreateCard::execute` later silently re-opens the hole, and nothing fails if the author does not also mirror it into the service. WIP limits and card numbers have no business knowing about each other.

## The fix

`execute_with` builds its batch inside the transaction, so anything the builder writes rolls back with it:

```rust
self.execute_with(|store| {
    let (_prefix, card_number) = Self::allocate_card_number(store, &board, spec.sprint_id)?;
    Ok(vec![Command::Card(CardCommand::Create(CreateCard { card_number, .. }))])
})?;
```

`execute` delegates to it (`self.execute_with(|_| Ok(commands))`), so all 27 existing call sites are untouched.

The reason this was not the original shape: `CreateCard`'s serialized form is frozen around `card_number`, so the number must exist before the command is constructed. That forced minting *earlier*, and minting earlier got read as minting *outside*. Those are separable — the command can be constructed late, inside the transaction.

The service-side WIP pre-check is **deleted**, not kept. A dormant coupling is still a coupling. `CreateCard::execute` keeps its own check, which is the only place that needs one.

`CreateSprint` already worked this way, allocating from inside the command, which is why the sprint axis never had this defect. The two create paths now have the same shape, and the comment explaining why they differed is gone.

## Why this is structural rather than another patch

`test_a_wip_rejected_create_does_not_burn_a_card_number`, added in #600, still passes with the pre-check removed. It now passes because of the rollback boundary rather than because that particular failure was anticipated.

Verified on a copy of the real tracker, three consecutive rejections:

```
created KAN-1252
Error: column 591afb61... has reached its WIP limit of 1   (x3)
after 3 rejections: KAN-1253
```

## Also

Drops `Board::allocate_sprint_number`, which had no callers and incremented a third counter (`next_sprint_number`) unrelated to both the prefix row and `sprint_counters`. Sharing a name with the real allocator made it a trap for the next reader. The field itself stays, since it is still serialized.

Filed as a deferred follow-up on the card rather than fixed here: `CreateSubcardCommand` allocates a card number but never calls `check_wip_limit`, so subcard creation bypasses the target column's limit. Pre-existing, and a missing policy check rather than a numbering problem.

- `cargo test --workspace --all-features` green, 190 suites
- `cargo clippy --all-targets --all-features -- -D warnings` green
- `cargo fmt --all` applied