### PR TITLE
KAN-1252 refactor(domain): Card::new takes a board id instead of &mut Board

### DIFF
--- a/crates/kanban-backend-memory/src/in_memory_store/archived_cards.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/archived_cards.rs
@@ -86,9 +86,9 @@ mod tests {
     #[test]
     fn test_insert_and_get_archived_card() {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "C", 0);
-        let card = make_card(&mut board, col.id, "Card", 0);
+        let card = make_card(&board, col.id, "Card", 0);
         let card_id = card.id;
         let ac = ArchivedCard::new(card_id, uuid::Uuid::nil());
         store.insert_archived_card(ac).unwrap();
@@ -100,10 +100,10 @@ mod tests {
     #[test]
     fn test_list_archived_cards() {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "C", 0);
-        let card1 = make_card(&mut board, col.id, "C1", 0);
-        let card2 = make_card(&mut board, col.id, "C2", 1);
+        let card1 = make_card(&board, col.id, "C1", 0);
+        let card2 = make_card(&board, col.id, "C2", 1);
         store
             .insert_archived_card(ArchivedCard::new(card1.id, uuid::Uuid::nil()))
             .unwrap();
@@ -117,10 +117,10 @@ mod tests {
     #[test]
     fn test_clear_sprint_from_archived_cards() {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "C", 0);
         let sprint_id = Uuid::new_v4();
-        let mut card = make_card(&mut board, col.id, "Card", 0);
+        let mut card = make_card(&board, col.id, "Card", 0);
         card.sprint_id = Some(sprint_id);
         let card_id = card.id;
         let before = card.updated_at;
@@ -144,9 +144,9 @@ mod tests {
     #[test]
     fn test_delete_archived_card() {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "C", 0);
-        let card = make_card(&mut board, col.id, "Card", 0);
+        let card = make_card(&board, col.id, "Card", 0);
         let card_id = card.id;
         store
             .insert_archived_card(ArchivedCard::new(card_id, uuid::Uuid::nil()))
@@ -158,16 +158,16 @@ mod tests {
     #[test]
     fn test_list_archived_cards_by_board_returns_only_that_board() {
         let store = InMemoryStore::new();
-        let mut board_a = make_board("A");
+        let board_a = make_board("A");
         let col_a = make_column(board_a.id, "CA", 0);
-        let a1 = make_card(&mut board_a, col_a.id, "A1", 0);
-        let a2 = make_card(&mut board_a, col_a.id, "A2", 1);
+        let a1 = make_card(&board_a, col_a.id, "A1", 0);
+        let a2 = make_card(&board_a, col_a.id, "A2", 1);
         let a1_id = a1.id;
         let a2_id = a2.id;
 
-        let mut board_b = make_board("B");
+        let board_b = make_board("B");
         let col_b = make_column(board_b.id, "CB", 0);
-        let b1 = make_card(&mut board_b, col_b.id, "B1", 0);
+        let b1 = make_card(&board_b, col_b.id, "B1", 0);
 
         store
             .insert_archived_card(ArchivedCard::new(a1.id, board_a.id))
@@ -193,12 +193,12 @@ mod tests {
         // trait default; it pins that the override honours the same contract
         // the D6 functional default documents.)
         let store = InMemoryStore::new();
-        let mut board_a = make_board("A");
+        let board_a = make_board("A");
         let col_a = make_column(board_a.id, "CA", 0);
-        let card_a = make_card(&mut board_a, col_a.id, "A1", 0);
-        let mut board_b = make_board("B");
+        let card_a = make_card(&board_a, col_a.id, "A1", 0);
+        let board_b = make_board("B");
         let col_b = make_column(board_b.id, "CB", 0);
-        let card_b = make_card(&mut board_b, col_b.id, "B1", 0);
+        let card_b = make_card(&board_b, col_b.id, "B1", 0);
         store
             .insert_archived_card(ArchivedCard::new(card_a.id, board_a.id))
             .unwrap();
@@ -223,9 +223,9 @@ mod tests {
         // (the column was deleted after archival). The record must still be
         // returned — the load-bearing D2 behavior change.
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let dangling_col = Uuid::new_v4(); // never inserted as a column
-        let card = make_card(&mut board, dangling_col, "Orphan", 0);
+        let card = make_card(&board, dangling_col, "Orphan", 0);
         let card_id = card.id;
         store
             .insert_archived_card(ArchivedCard::new(card_id, board.id))
@@ -259,9 +259,9 @@ mod f1_reference_tests {
 
     fn seed() -> (InMemoryStore, Board, Column, Card) {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "Todo", 0);
-        let card = make_card(&mut board, col.id, "Card", 0);
+        let card = make_card(&board, col.id, "Card", 0);
         store.upsert_board(board.clone()).unwrap();
         store.upsert_column(col.clone()).unwrap();
         store.upsert_card(card.clone()).unwrap();
@@ -329,9 +329,9 @@ mod f1_reference_tests {
     #[test]
     fn test_clear_sprint_from_archived_edits_the_live_card() {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "Todo", 0);
-        let mut card = make_card(&mut board, col.id, "Card", 0);
+        let mut card = make_card(&board, col.id, "Card", 0);
         let sprint_id = uuid::Uuid::new_v4();
         card.sprint_id = Some(sprint_id);
         store.upsert_board(board.clone()).unwrap();

--- a/crates/kanban-backend-memory/src/in_memory_store/cards.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/cards.rs
@@ -215,7 +215,7 @@ mod tests {
     /// column id, the 2 live ids, and the 2 archived ids.
     fn seed_two_live_two_archived() -> (InMemoryStore, Uuid, Vec<Uuid>, Vec<Uuid>) {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "Todo", 0);
         store.upsert_board(board.clone()).unwrap();
         store.upsert_column(col.clone()).unwrap();
@@ -223,12 +223,12 @@ mod tests {
         let mut live = Vec::new();
         let mut archived = Vec::new();
         for i in 0..2 {
-            let c = make_card(&mut board, col.id, &format!("live{i}"), i);
+            let c = make_card(&board, col.id, &format!("live{i}"), i);
             live.push(c.id);
             store.upsert_card(c).unwrap();
         }
         for i in 0..2 {
-            let c = make_card(&mut board, col.id, &format!("arch{i}"), 2 + i);
+            let c = make_card(&board, col.id, &format!("arch{i}"), 2 + i);
             archived.push(c.id);
             store.upsert_card(c.clone()).unwrap();
             // Archive the ArchiveCards way: marker + guarded delete_card no-op.
@@ -328,11 +328,11 @@ mod tests {
         // See boards.rs: many equal-position cards inserted in reverse so the
         // old position-only sort cannot pass by luck (1/16!).
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "C", 0);
         let n = 16;
         for k in (0..n).rev() {
-            let mut c = make_card(&mut board, col.id, &format!("c{k:02}"), 0);
+            let mut c = make_card(&board, col.id, &format!("c{k:02}"), 0);
             c.created_at = Utc.timestamp_opt(1_000 + k as i64, 0).unwrap();
             store.upsert_card(c).unwrap();
         }

--- a/crates/kanban-backend-memory/src/in_memory_store/mod.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/mod.rs
@@ -24,8 +24,8 @@ mod test_support {
         Column::new(board_id, name.to_string(), pos)
     }
 
-    pub(super) fn make_card(board: &mut Board, column_id: Uuid, title: &str, pos: i32) -> Card {
-        Card::new(board, column_id, title.to_string(), pos)
+    pub(super) fn make_card(board: &Board, column_id: Uuid, title: &str, pos: i32) -> Card {
+        Card::new(board.id, column_id, title.to_string(), pos)
     }
 }
 

--- a/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
@@ -78,9 +78,9 @@ mod tests {
     #[test]
     fn test_snapshot_roundtrip() {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "C", 0);
-        let card = make_card(&mut board, col.id, "Card", 0);
+        let card = make_card(&board, col.id, "Card", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
         store.upsert_board(board).unwrap();
         store.upsert_column(col).unwrap();
@@ -145,8 +145,8 @@ mod tests {
         store.upsert_column(col_a.clone()).unwrap();
         store.upsert_column(col_m).unwrap();
 
-        let card3 = make_card(&mut board_a.clone(), col_a.id, "C3", 2);
-        let card1 = make_card(&mut board_a.clone(), col_a.id, "C1", 0);
+        let card3 = make_card(&board_a, col_a.id, "C3", 2);
+        let card1 = make_card(&board_a, col_a.id, "C1", 0);
         store.upsert_card(card3).unwrap();
         store.upsert_card(card1).unwrap();
 
@@ -240,11 +240,11 @@ mod tests {
     fn test_snapshot_orders_cards_with_equal_position_by_created_at() {
         use chrono::{TimeZone, Utc};
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "C", 0);
         let n = 16;
         for k in (0..n).rev() {
-            let mut c = make_card(&mut board, col.id, &format!("c{k:02}"), 0);
+            let mut c = make_card(&board, col.id, &format!("c{k:02}"), 0);
             c.created_at = Utc.timestamp_opt(1_000 + k as i64, 0).unwrap();
             store.upsert_card(c).unwrap();
         }

--- a/crates/kanban-backend-memory/src/in_memory_store/state.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/state.rs
@@ -88,9 +88,9 @@ mod tests {
     #[test]
     fn test_all_data_store_methods_return_ok_not_panic() {
         let store = InMemoryStore::new();
-        let mut board = make_board("B");
+        let board = make_board("B");
         let col = make_column(board.id, "C", 0);
-        let card = make_card(&mut board, col.id, "Card", 0);
+        let card = make_card(&board, col.id, "Card", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let ac = ArchivedCard::new(card.id, uuid::Uuid::nil());
 

--- a/crates/kanban-backend-memory/src/in_memory_store/tests/cards.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/tests/cards.rs
@@ -9,9 +9,9 @@ use uuid::Uuid;
 #[test]
 fn test_upsert_and_get_card() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "Col", 0);
-    let card = make_card(&mut board, col.id, "Card", 0);
+    let card = make_card(&board, col.id, "Card", 0);
     let card_id = card.id;
     store.upsert_card(card).unwrap();
 
@@ -23,12 +23,12 @@ fn test_upsert_and_get_card() {
 #[test]
 fn test_list_cards_by_column() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col1 = make_column(board.id, "C1", 0);
     let col2 = make_column(board.id, "C2", 1);
-    let card1 = make_card(&mut board, col1.id, "Card1", 0);
-    let card2 = make_card(&mut board, col1.id, "Card2", 1);
-    let card3 = make_card(&mut board, col2.id, "Card3", 0);
+    let card1 = make_card(&board, col1.id, "Card1", 0);
+    let card2 = make_card(&board, col1.id, "Card2", 1);
+    let card3 = make_card(&board, col2.id, "Card3", 0);
     store.upsert_card(card1).unwrap();
     store.upsert_card(card2).unwrap();
     store.upsert_card(card3).unwrap();
@@ -41,12 +41,12 @@ fn test_list_cards_by_column() {
 #[test]
 fn test_list_cards_by_sprint() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     let sprint_id = Uuid::new_v4();
-    let mut card1 = make_card(&mut board, col.id, "Card1", 0);
+    let mut card1 = make_card(&board, col.id, "Card1", 0);
     card1.sprint_id = Some(sprint_id);
-    let card2 = make_card(&mut board, col.id, "Card2", 1);
+    let card2 = make_card(&board, col.id, "Card2", 1);
     store.upsert_card(card1).unwrap();
     store.upsert_card(card2).unwrap();
 
@@ -58,10 +58,10 @@ fn test_list_cards_by_sprint() {
 #[test]
 fn test_count_cards_in_column() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let card1 = make_card(&mut board, col.id, "C1", 0);
-    let card2 = make_card(&mut board, col.id, "C2", 1);
+    let card1 = make_card(&board, col.id, "C1", 0);
+    let card2 = make_card(&board, col.id, "C2", 1);
     store.upsert_card(card1).unwrap();
     store.upsert_card(card2).unwrap();
 
@@ -71,11 +71,11 @@ fn test_count_cards_in_column() {
 #[test]
 fn test_count_cards_in_column_excluding() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let card1 = make_card(&mut board, col.id, "C1", 0);
+    let card1 = make_card(&board, col.id, "C1", 0);
     let card1_id = card1.id;
-    let card2 = make_card(&mut board, col.id, "C2", 1);
+    let card2 = make_card(&board, col.id, "C2", 1);
     store.upsert_card(card1).unwrap();
     store.upsert_card(card2).unwrap();
 
@@ -88,11 +88,11 @@ fn test_count_cards_in_column_excluding() {
 #[test]
 fn test_delete_cards_by_columns() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col1 = make_column(board.id, "C1", 0);
     let col2 = make_column(board.id, "C2", 1);
-    let card1 = make_card(&mut board, col1.id, "Card1", 0);
-    let card2 = make_card(&mut board, col2.id, "Card2", 0);
+    let card1 = make_card(&board, col1.id, "Card1", 0);
+    let card2 = make_card(&board, col2.id, "Card2", 0);
     let card2_id = card2.id;
     store.upsert_card(card1).unwrap();
     store.upsert_card(card2).unwrap();
@@ -108,9 +108,9 @@ fn test_delete_cards_by_columns() {
 #[test]
 fn test_column_index_upsert_new_card_indexes_under_target_column() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let card = make_card(&mut board, col.id, "Card", 0);
+    let card = make_card(&board, col.id, "Card", 0);
     store.upsert_card(card).unwrap();
     assert_eq!(store.count_cards_in_column(col.id).unwrap(), 1);
 }
@@ -118,9 +118,9 @@ fn test_column_index_upsert_new_card_indexes_under_target_column() {
 #[test]
 fn test_column_index_upsert_with_same_column_keeps_single_entry() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let card = make_card(&mut board, col.id, "Card", 0);
+    let card = make_card(&board, col.id, "Card", 0);
     let mut card2 = card.clone();
     card2.title = "Renamed".to_string();
     store.upsert_card(card).unwrap();
@@ -135,10 +135,10 @@ fn test_column_index_upsert_with_same_column_keeps_single_entry() {
 #[test]
 fn test_column_index_upsert_with_column_change_moves_index_entry() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col_a = make_column(board.id, "A", 0);
     let col_b = make_column(board.id, "B", 1);
-    let card = make_card(&mut board, col_a.id, "Card", 0);
+    let card = make_card(&board, col_a.id, "Card", 0);
     let card_id = card.id;
     store.upsert_card(card.clone()).unwrap();
     assert_eq!(store.count_cards_in_column(col_a.id).unwrap(), 1);
@@ -165,9 +165,9 @@ fn test_column_index_upsert_with_column_change_moves_index_entry() {
 #[test]
 fn test_column_index_delete_card_removes_from_index() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let card = make_card(&mut board, col.id, "Card", 0);
+    let card = make_card(&board, col.id, "Card", 0);
     let card_id = card.id;
     store.upsert_card(card).unwrap();
     assert_eq!(store.count_cards_in_column(col.id).unwrap(), 1);
@@ -179,12 +179,12 @@ fn test_column_index_delete_card_removes_from_index() {
 #[test]
 fn test_column_index_delete_cards_by_columns_clears_target_columns() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col_a = make_column(board.id, "A", 0);
     let col_b = make_column(board.id, "B", 1);
-    let card_a1 = make_card(&mut board, col_a.id, "A1", 0);
-    let card_a2 = make_card(&mut board, col_a.id, "A2", 1);
-    let card_b1 = make_card(&mut board, col_b.id, "B1", 0);
+    let card_a1 = make_card(&board, col_a.id, "A1", 0);
+    let card_a2 = make_card(&board, col_a.id, "A2", 1);
+    let card_b1 = make_card(&board, col_b.id, "B1", 0);
     store.upsert_card(card_a1).unwrap();
     store.upsert_card(card_a2).unwrap();
     store.upsert_card(card_b1).unwrap();
@@ -198,18 +198,18 @@ fn test_column_index_delete_cards_by_columns_clears_target_columns() {
 #[test]
 fn test_column_index_apply_snapshot_rebuilds_from_snapshot_cards() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col_a = make_column(board.id, "A", 0);
     let col_b = make_column(board.id, "B", 1);
     // Seed with pre-snapshot state so we can verify the rebuild overwrites it.
-    let pre_card = make_card(&mut board, col_a.id, "Pre", 0);
+    let pre_card = make_card(&board, col_a.id, "Pre", 0);
     store.upsert_card(pre_card).unwrap();
 
     // Build a snapshot whose cards land in different columns than the pre-state.
     let board_id = board.id;
-    let post_card_a = make_card(&mut board, col_a.id, "PostA", 0);
-    let post_card_b1 = make_card(&mut board, col_b.id, "PostB1", 0);
-    let post_card_b2 = make_card(&mut board, col_b.id, "PostB2", 1);
+    let post_card_a = make_card(&board, col_a.id, "PostA", 0);
+    let post_card_b1 = make_card(&board, col_b.id, "PostB1", 0);
+    let post_card_b2 = make_card(&board, col_b.id, "PostB2", 1);
     let snapshot = Snapshot::from_data(
         vec![kanban_domain::Board {
             id: board_id,
@@ -239,11 +239,11 @@ fn test_column_index_apply_snapshot_rebuilds_from_snapshot_cards() {
 #[test]
 fn test_count_cards_in_column_excluding_with_multiple_excludes() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
-    let card1 = make_card(&mut board, col.id, "C1", 0);
-    let card2 = make_card(&mut board, col.id, "C2", 1);
-    let card3 = make_card(&mut board, col.id, "C3", 2);
+    let card1 = make_card(&board, col.id, "C1", 0);
+    let card2 = make_card(&board, col.id, "C2", 1);
+    let card3 = make_card(&board, col.id, "C3", 2);
     let c1 = card1.id;
     let c3 = card3.id;
     store.upsert_card(card1).unwrap();

--- a/crates/kanban-backend-memory/src/in_memory_store/tests/cards_listing.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/tests/cards_listing.rs
@@ -8,12 +8,12 @@ use uuid::Uuid;
 #[test]
 fn test_list_cards_by_column_returns_only_cards_in_that_column() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col_a = make_column(board.id, "A", 0);
     let col_b = make_column(board.id, "B", 1);
-    let a1 = make_card(&mut board, col_a.id, "A1", 0);
-    let a2 = make_card(&mut board, col_a.id, "A2", 1);
-    let b1 = make_card(&mut board, col_b.id, "B1", 0);
+    let a1 = make_card(&board, col_a.id, "A1", 0);
+    let a2 = make_card(&board, col_a.id, "A2", 1);
+    let b1 = make_card(&board, col_b.id, "B1", 0);
     let a1_id = a1.id;
     let a2_id = a2.id;
     store.upsert_card(a1).unwrap();
@@ -30,12 +30,12 @@ fn test_list_cards_by_column_returns_only_cards_in_that_column() {
 #[test]
 fn test_list_cards_by_column_returns_cards_sorted_by_position() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     // Insert out of position order to confirm the sort applies.
-    let c_pos2 = make_card(&mut board, col.id, "P2", 2);
-    let c_pos0 = make_card(&mut board, col.id, "P0", 0);
-    let c_pos1 = make_card(&mut board, col.id, "P1", 1);
+    let c_pos2 = make_card(&board, col.id, "P2", 2);
+    let c_pos0 = make_card(&board, col.id, "P0", 0);
+    let c_pos1 = make_card(&board, col.id, "P1", 1);
     store.upsert_card(c_pos2).unwrap();
     store.upsert_card(c_pos0).unwrap();
     store.upsert_card(c_pos1).unwrap();
@@ -52,10 +52,10 @@ fn test_list_cards_by_column_returns_cards_sorted_by_position() {
 #[test]
 fn test_list_cards_by_column_after_column_change_reflects_new_membership() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col_a = make_column(board.id, "A", 0);
     let col_b = make_column(board.id, "B", 1);
-    let card = make_card(&mut board, col_a.id, "Card", 0);
+    let card = make_card(&board, col_a.id, "Card", 0);
     let card_id = card.id;
     store.upsert_card(card.clone()).unwrap();
 
@@ -79,10 +79,10 @@ fn test_list_cards_by_column_unknown_column_returns_empty() {
 #[test]
 fn test_clear_sprint_from_cards_sets_updated_at() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     let sprint_id = Uuid::new_v4();
-    let mut card = make_card(&mut board, col.id, "C1", 0);
+    let mut card = make_card(&board, col.id, "C1", 0);
     card.sprint_id = Some(sprint_id);
     let card_id = card.id;
     store.upsert_card(card).unwrap();
@@ -100,13 +100,13 @@ fn test_clear_sprint_from_cards_sets_updated_at() {
 #[test]
 fn test_clear_sprint_from_cards() {
     let store = InMemoryStore::new();
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     let sprint_id = Uuid::new_v4();
-    let mut card1 = make_card(&mut board, col.id, "C1", 0);
+    let mut card1 = make_card(&board, col.id, "C1", 0);
     card1.sprint_id = Some(sprint_id);
     let card1_id = card1.id;
-    let mut card2 = make_card(&mut board, col.id, "C2", 1);
+    let mut card2 = make_card(&board, col.id, "C2", 1);
     card2.sprint_id = Some(sprint_id);
     let card2_id = card2.id;
     store.upsert_card(card1).unwrap();

--- a/crates/kanban-domain/src/card.rs
+++ b/crates/kanban-domain/src/card.rs
@@ -145,24 +145,16 @@ impl From<&Card> for CardSummary {
 
 impl Card {
     pub fn new(
-        board: &mut Board,
+        board_id: BoardId,
         column_id: ColumnId,
         title: impl Into<String>,
         position: i32,
     ) -> Self {
         let now = Utc::now();
-        let card_number = board.get_next_card_number();
-        // KAN-1214 replaces this with an allocated value; until then it mirrors
-        // what the identifier reader would resolve for a board-owned card.
-        let prefix = crate::prefix::effective_card_prefix(
-            board.card_prefix.as_deref(),
-            None,
-            crate::prefix_backfill::DEFAULT_CARD_PREFIX,
-        );
         Self {
             id: Uuid::new_v4(),
             column_id,
-            board_id: board.id,
+            board_id,
             title: title.into(),
             description: None,
             priority: CardPriority::Medium,
@@ -170,8 +162,8 @@ impl Card {
             position,
             due_date: None,
             points: None,
-            card_number,
-            prefix,
+            card_number: 0,
+            prefix: String::new(),
             sprint_id: None,
             created_at: now,
             updated_at: now,
@@ -387,23 +379,23 @@ mod tests {
     #[test]
     fn test_card_new_accepts_str_title_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board", None::<String>);
-        let card = Card::new(&mut board, column_id, "my card", 0);
+        let board = Board::new("board", None::<String>);
+        let card = Card::new(board.id, column_id, "my card", 0);
         assert_eq!(card.title, "my card");
     }
 
     #[test]
     fn test_card_summary_from_card_has_none_archived_at() {
-        let mut board = Board::new("board", None::<String>);
-        let card = Card::new(&mut board, uuid::Uuid::new_v4(), "c", 0);
+        let board = Board::new("board", None::<String>);
+        let card = Card::new(board.id, uuid::Uuid::new_v4(), "c", 0);
         let summary = CardSummary::from(&card);
         assert_eq!(summary.archived_at, None);
     }
 
     #[test]
     fn test_card_summary_serializes_without_archived_at_when_none() {
-        let mut board = Board::new("board", None::<String>);
-        let card = Card::new(&mut board, uuid::Uuid::new_v4(), "c", 0);
+        let board = Board::new("board", None::<String>);
+        let card = Card::new(board.id, uuid::Uuid::new_v4(), "c", 0);
         let summary = CardSummary::from(&card);
         let value = serde_json::to_value(&summary).unwrap();
         assert!(
@@ -414,8 +406,8 @@ mod tests {
 
     #[test]
     fn test_card_summary_serializes_archived_at_when_some() {
-        let mut board = Board::new("board", None::<String>);
-        let card = Card::new(&mut board, uuid::Uuid::new_v4(), "c", 0);
+        let board = Board::new("board", None::<String>);
+        let card = Card::new(board.id, uuid::Uuid::new_v4(), "c", 0);
         let at = Utc::now();
         let summary = CardSummary {
             archived_at: Some(at),
@@ -428,8 +420,8 @@ mod tests {
     #[test]
     fn test_card_update_title_accepts_str_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "initial", 0);
+        let board = Board::new("board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "initial", 0);
         card.update_title("updated");
         assert_eq!(card.title, "updated");
     }
@@ -437,8 +429,8 @@ mod tests {
     #[test]
     fn test_card_update_description_accepts_str_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "card", 0);
+        let board = Board::new("board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "card", 0);
         card.update_description(Some("desc"));
         assert_eq!(card.description, Some("desc".to_string()));
     }
@@ -446,8 +438,8 @@ mod tests {
     #[test]
     fn test_card_assign_to_sprint_accepts_str_args_without_to_string() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "card", 0);
+        let board = Board::new("board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "card", 0);
         let sprint_id = uuid::Uuid::new_v4();
         card.assign_to_sprint(sprint_id, 1, Some("Sprint 1"), "Active", Utc::now());
         assert_eq!(card.sprint_id, Some(sprint_id));
@@ -457,40 +449,11 @@ mod tests {
     }
 
     #[test]
-    fn test_card_new_uses_board_card_counter_no_prefix_arg() {
-        let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        assert_eq!(board.card_counter, 1);
-
-        let card1 = Card::new(&mut board, column_id, "Test Card 1", 0);
-        assert_eq!(card1.card_number, 1);
-        assert_eq!(board.card_counter, 2);
-
-        let card2 = Card::new(&mut board, column_id, "Test Card 2", 1);
-        assert_eq!(card2.card_number, 2);
-        assert_eq!(board.card_counter, 3);
-    }
-
-    #[test]
-    fn test_card_sequential_numbers_increment_board_counter() {
-        let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-
-        let cards: Vec<Card> = (0..5)
-            .map(|i| Card::new(&mut board, column_id, format!("Card {}", i), i))
-            .collect();
-
-        for (i, card) in cards.iter().enumerate() {
-            assert_eq!(card.card_number, (i + 1) as u32);
-        }
-        assert_eq!(board.card_counter, 6);
-    }
-
-    #[test]
     fn test_branch_name_falls_back_to_board_when_no_sprint_prefix() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", Some("KAN"));
-        let card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", Some("KAN"));
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
+        card.card_number = 1;
         let sprint = crate::sprint::Sprint::new(board.id, 1, None, None::<String>);
         let mut card_with_sprint = card.clone();
         card_with_sprint.sprint_id = Some(sprint.id);
@@ -508,8 +471,10 @@ mod tests {
         use crate::sprint::{Sprint, SprintStatus};
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", Some("KAN"));
-        let card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", Some("KAN"));
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
+        card.card_number = 1;
+        card.prefix = "KAN".to_string();
 
         let sprint_with_prefix = Sprint {
             id: uuid::Uuid::new_v4(),
@@ -543,8 +508,9 @@ mod tests {
     #[test]
     fn test_branch_name_falls_back_to_default_when_no_board_prefix() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
+        card.card_number = 1;
         let sprints = vec![];
 
         assert_eq!(
@@ -556,8 +522,9 @@ mod tests {
     #[test]
     fn test_branch_name() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
+        card.card_number = 1;
         let sprints = vec![];
 
         assert_eq!(
@@ -587,8 +554,9 @@ mod tests {
     fn test_branch_name_truncation() {
         let column_id = uuid::Uuid::new_v4();
         let long_title = "a".repeat(300);
-        let mut board = Board::new("Test Board", None::<String>);
-        let card = Card::new(&mut board, column_id, long_title, 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, long_title, 0);
+        card.card_number = 1;
         let sprints = vec![];
 
         let branch = card.branch_name(&board, &sprints, "task");
@@ -599,8 +567,9 @@ mod tests {
     #[test]
     fn test_git_checkout_command() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
+        card.card_number = 1;
         let sprints = vec![];
 
         assert_eq!(
@@ -614,9 +583,11 @@ mod tests {
         use crate::sprint::{Sprint, SprintStatus};
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
+        let board = Board::new("Test Board", None::<String>);
 
-        let card = Card::new(&mut board, column_id, "Test Card", 0);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
+        card.card_number = 1;
+        card.prefix = "task".to_string();
 
         let sprint = Sprint::new(board.id, 1, Some(0), None::<String>);
         let mut card_with_sprint = card.clone();
@@ -655,8 +626,8 @@ mod tests {
     #[test]
     fn test_sprint_logging() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
 
         assert_eq!(card.get_sprint_history().len(), 0);
 
@@ -675,8 +646,8 @@ mod tests {
     #[test]
     fn test_sprint_log_ending() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
         card.assign_to_sprint(sprint_id_1, 1, Some("Sprint 1"), "Active", Utc::now());
@@ -690,8 +661,8 @@ mod tests {
     #[test]
     fn test_multiple_sprint_logs() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
 
         let sprint_id_1 = uuid::Uuid::new_v4();
         let sprint_id_2 = uuid::Uuid::new_v4();
@@ -714,8 +685,8 @@ mod tests {
     #[test]
     fn test_assign_same_sprint_no_duplicate() {
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
 
         let sprint_id = uuid::Uuid::new_v4();
 
@@ -737,8 +708,8 @@ mod tests {
         use chrono::TimeZone;
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
         let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
         let sprint_id = uuid::Uuid::new_v4();
 
@@ -752,8 +723,8 @@ mod tests {
         use chrono::TimeZone;
 
         let column_id = uuid::Uuid::new_v4();
-        let mut board = Board::new("Test Board", None::<String>);
-        let mut card = Card::new(&mut board, column_id, "Test Card", 0);
+        let board = Board::new("Test Board", None::<String>);
+        let mut card = Card::new(board.id, column_id, "Test Card", 0);
         let fixed_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
 
         card.update(

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -370,8 +370,8 @@ mod tests {
             .collect()
     }
 
-    fn test_card(board: &mut Board, column: &Column, title: &str, position: i32) -> Card {
-        Card::new(board, column.id, title.to_string(), position)
+    fn test_card(board: &Board, column: &Column, title: &str, position: i32) -> Card {
+        Card::new(board.id, column.id, title.to_string(), position)
     }
 
     // --- configuration is the only completion input (no positional guess) ---
@@ -387,7 +387,7 @@ mod tests {
 
         assert!(!should_auto_complete_new_card(last.id, &board, &cols));
 
-        let mut card = test_card(&mut board.clone(), last, "In Decision", 0);
+        let mut card = test_card(&board, last, "In Decision", 0);
         card.status = CardStatus::Todo;
         assert_eq!(
             target_status_for_column_move(&card, last.id, &board, &cols),
@@ -395,7 +395,7 @@ mod tests {
             "moving into the non-configured last column must not set Done"
         );
 
-        let mut done_card = test_card(&mut board.clone(), &cols[0], "C", 0);
+        let mut done_card = test_card(&board, &cols[0], "C", 0);
         done_card.status = CardStatus::Todo;
         assert_eq!(
             target_column_for_status(&done_card, CardStatus::Done, &board, &cols),
@@ -409,7 +409,7 @@ mod tests {
         let board = test_board();
         let cols = add_columns(&board, &["TODO", "Doing", "Complete"]);
         let last = &cols[2];
-        let mut card = test_card(&mut board.clone(), &cols[0], "C", 0);
+        let mut card = test_card(&board, &cols[0], "C", 0);
         card.status = CardStatus::Todo;
         card.column_id = last.id;
 
@@ -425,7 +425,7 @@ mod tests {
     fn test_no_completion_column_disables_auto_sync_entirely() {
         let board = test_board();
         let cols = add_columns(&board, &["TODO", "Doing", "Done"]);
-        let mut card = test_card(&mut board.clone(), &cols[0], "C", 0);
+        let mut card = test_card(&board, &cols[0], "C", 0);
 
         assert_eq!(
             target_column_for_status(&card, CardStatus::Done, &board, &cols),
@@ -464,7 +464,7 @@ mod tests {
         let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Done"]);
         cols[1].default_status = Some(CardStatus::Done);
-        let card = test_card(&mut board.clone(), &cols[0], "C", 0);
+        let card = test_card(&board, &cols[0], "C", 0);
 
         let result = compute_completion_toggle(&card, &board, &cols, &[]).expect("toggle applies");
         assert_eq!(result.new_status, CardStatus::Done);
@@ -542,10 +542,10 @@ mod tests {
 
     #[test]
     fn toggle_todo_to_done_moves_to_last_column() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["Todo", "In Progress", "Done"]);
         cols[2].default_status = Some(CardStatus::Done);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         let result =
             compute_completion_toggle(&card, &board, &cols, std::slice::from_ref(&card)).unwrap();
@@ -555,10 +555,10 @@ mod tests {
 
     #[test]
     fn toggle_done_to_todo_moves_to_second_to_last() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["Todo", "In Progress", "Done"]);
         cols[2].default_status = Some(CardStatus::Done);
-        let mut card = test_card(&mut board, &cols[2], "Task", 0);
+        let mut card = test_card(&board, &cols[2], "Task", 0);
         card.status = CardStatus::Done;
 
         let result =
@@ -569,9 +569,9 @@ mod tests {
 
     #[test]
     fn toggle_returns_none_for_single_column() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Only"]);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         assert!(
             compute_completion_toggle(&card, &board, &cols, std::slice::from_ref(&card)).is_none()
@@ -580,12 +580,12 @@ mod tests {
 
     #[test]
     fn toggle_uses_explicit_completion_column() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["Backlog", "Done", "Archive"]);
         // Set "Done" (middle column) as completion column
         cols[1].default_status = Some(CardStatus::Done);
 
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         let result =
             compute_completion_toggle(&card, &board, &cols, std::slice::from_ref(&card)).unwrap();
@@ -595,11 +595,11 @@ mod tests {
 
     #[test]
     fn toggle_done_with_explicit_column_moves_to_previous() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["Backlog", "Done", "Archive"]);
         cols[1].default_status = Some(CardStatus::Done);
 
-        let mut card = test_card(&mut board, &cols[1], "Task", 0);
+        let mut card = test_card(&board, &cols[1], "Task", 0);
         card.status = CardStatus::Done;
 
         let result =
@@ -610,11 +610,11 @@ mod tests {
 
     #[test]
     fn test_completion_toggle_done_card_in_secondary_completion_column_uncompletes() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "Decision"]);
         cols[2].default_status = Some(CardStatus::Done);
         cols[3].default_status = Some(CardStatus::Done);
-        let mut card = test_card(&mut board, &cols[3], "Task", 0);
+        let mut card = test_card(&board, &cols[3], "Task", 0);
         card.status = CardStatus::Done;
 
         let result =
@@ -625,11 +625,11 @@ mod tests {
 
     #[test]
     fn test_completion_toggle_card_already_in_secondary_completion_column_needs_no_move() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "Decision"]);
         cols[2].default_status = Some(CardStatus::Done);
         cols[3].default_status = Some(CardStatus::Done);
-        let card = test_card(&mut board, &cols[3], "Task", 0);
+        let card = test_card(&board, &cols[3], "Task", 0);
 
         let result = compute_completion_toggle(&card, &board, &cols, std::slice::from_ref(&card));
         assert!(result.is_none());
@@ -637,12 +637,12 @@ mod tests {
 
     #[test]
     fn test_completion_toggle_uses_uncomplete_target_column_not_hardcoded_previous() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "Decision"]);
         cols[1].default_status = Some(CardStatus::Done);
         cols[2].default_status = Some(CardStatus::Done);
         cols[3].default_status = Some(CardStatus::Done);
-        let mut card = test_card(&mut board, &cols[3], "Task", 0);
+        let mut card = test_card(&board, &cols[3], "Task", 0);
         card.status = CardStatus::Done;
 
         let result =
@@ -653,10 +653,10 @@ mod tests {
 
     #[test]
     fn test_completion_toggle_completion_column_first_moves_to_first_non_completion_column() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done"]);
         cols[0].default_status = Some(CardStatus::Done);
-        let mut card = test_card(&mut board, &cols[0], "Task", 0);
+        let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Done;
 
         let result =
@@ -669,10 +669,10 @@ mod tests {
 
     #[test]
     fn move_right_to_last_column_marks_done() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["Todo", "Done"]);
         cols[1].default_status = Some(CardStatus::Done);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         let result = compute_card_column_move(
             &card,
@@ -688,10 +688,10 @@ mod tests {
 
     #[test]
     fn move_left_from_last_column_marks_todo() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["Todo", "Done"]);
         cols[1].default_status = Some(CardStatus::Done);
-        let mut card = test_card(&mut board, &cols[1], "Task", 0);
+        let mut card = test_card(&board, &cols[1], "Task", 0);
         card.status = CardStatus::Done;
 
         let result = compute_card_column_move(
@@ -708,9 +708,9 @@ mod tests {
 
     #[test]
     fn move_right_at_rightmost_returns_none() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Todo", "Done"]);
-        let card = test_card(&mut board, &cols[1], "Task", 0);
+        let card = test_card(&board, &cols[1], "Task", 0);
 
         assert!(compute_card_column_move(
             &card,
@@ -724,9 +724,9 @@ mod tests {
 
     #[test]
     fn move_left_at_leftmost_returns_none() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Todo", "Done"]);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         assert!(compute_card_column_move(
             &card,
@@ -740,9 +740,9 @@ mod tests {
 
     #[test]
     fn move_between_middle_columns_no_status_change() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Todo", "In Progress", "Done"]);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         let result = compute_card_column_move(
             &card,
@@ -758,10 +758,10 @@ mod tests {
 
     #[test]
     fn move_appends_to_end_of_target_column() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Todo", "Done"]);
-        let existing = test_card(&mut board, &cols[1], "Existing", 0);
-        let card = test_card(&mut board, &cols[0], "New", 0);
+        let existing = test_card(&board, &cols[1], "Existing", 0);
+        let card = test_card(&board, &cols[0], "New", 0);
 
         let cards = vec![existing, card.clone()];
         let result =
@@ -773,12 +773,12 @@ mod tests {
 
     #[test]
     fn compact_resequences_positions() {
-        let mut board = test_board();
+        let board = test_board();
         let col = Column::new(board.id, "Todo", 0);
         let mut cards = vec![
-            test_card(&mut board, &col, "A", 0),
-            test_card(&mut board, &col, "B", 5),
-            test_card(&mut board, &col, "C", 10),
+            test_card(&board, &col, "A", 0),
+            test_card(&board, &col, "B", 5),
+            test_card(&board, &col, "C", 10),
         ];
 
         compact_column_positions(&mut cards, col.id);
@@ -789,12 +789,12 @@ mod tests {
 
     #[test]
     fn compact_only_affects_target_column() {
-        let mut board = test_board();
+        let board = test_board();
         let col1 = Column::new(board.id, "Todo", 0);
         let col2 = Column::new(board.id, "Done", 1);
         let mut cards = vec![
-            test_card(&mut board, &col1, "A", 5),
-            test_card(&mut board, &col2, "B", 99),
+            test_card(&board, &col1, "A", 5),
+            test_card(&board, &col2, "B", 99),
         ];
 
         compact_column_positions(&mut cards, col1.id);
@@ -833,10 +833,10 @@ mod tests {
 
     #[test]
     fn test_target_column_for_status_done_moves_to_primary_configured_column() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "Decision"]);
         cols[2].default_status = Some(CardStatus::Done);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         let target = target_column_for_status(&card, CardStatus::Done, &board, &cols);
         assert_eq!(target, Some(cols[2].id));
@@ -844,10 +844,10 @@ mod tests {
 
     #[test]
     fn test_target_status_for_column_move_into_configured_column_returns_done() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "Decision"]);
         cols[2].default_status = Some(CardStatus::Done);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         let status = target_status_for_column_move(&card, cols[2].id, &board, &cols);
         assert_eq!(status, Some(CardStatus::Done));
@@ -855,10 +855,10 @@ mod tests {
 
     #[test]
     fn test_target_status_for_column_move_into_unconfigured_last_column_returns_none() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "Decision"]);
         cols[2].default_status = Some(CardStatus::Done);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
 
         let status = target_status_for_column_move(&card, cols[3].id, &board, &cols);
         assert_eq!(status, None);
@@ -866,10 +866,10 @@ mod tests {
 
     #[test]
     fn test_target_status_for_column_move_out_of_completion_returns_todo() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "Decision"]);
         cols[2].default_status = Some(CardStatus::Done);
-        let mut card = test_card(&mut board, &cols[2], "Task", 0);
+        let mut card = test_card(&board, &cols[2], "Task", 0);
         card.status = CardStatus::Done;
 
         let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
@@ -878,11 +878,11 @@ mod tests {
 
     #[test]
     fn test_target_status_for_column_move_between_two_completion_columns_returns_none() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "WontDo"]);
         cols[2].default_status = Some(CardStatus::Done);
         cols[3].default_status = Some(CardStatus::Done);
-        let mut card = test_card(&mut board, &cols[2], "Task", 0);
+        let mut card = test_card(&board, &cols[2], "Task", 0);
         card.status = CardStatus::Done;
 
         let status = target_status_for_column_move(&card, cols[3].id, &board, &cols);
@@ -902,7 +902,7 @@ mod tests {
     #[test]
     fn test_move_to_column_with_default_status_promotes_todo_card() {
         let (board, cols) = board_with_default_status_column();
-        let mut card = test_card(&mut board.clone(), &cols[0], "Task", 0);
+        let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Todo;
 
         let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
@@ -912,7 +912,7 @@ mod tests {
     #[test]
     fn test_move_out_of_completion_to_default_status_column_promotes_through_todo() {
         let (board, cols) = board_with_default_status_column();
-        let mut card = test_card(&mut board.clone(), &cols[2], "Task", 0);
+        let mut card = test_card(&board, &cols[2], "Task", 0);
         card.status = CardStatus::Done;
 
         let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
@@ -922,7 +922,7 @@ mod tests {
     #[test]
     fn test_move_to_default_status_column_does_not_clobber_blocked_card() {
         let (board, cols) = board_with_default_status_column();
-        let mut card = test_card(&mut board.clone(), &cols[0], "Task", 0);
+        let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Blocked;
 
         let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
@@ -932,7 +932,7 @@ mod tests {
     #[test]
     fn test_move_out_of_default_status_column_leaves_status_unchanged() {
         let (board, cols) = board_with_default_status_column();
-        let mut card = test_card(&mut board.clone(), &cols[1], "Task", 0);
+        let mut card = test_card(&board, &cols[1], "Task", 0);
         card.status = CardStatus::InProgress;
 
         let status = target_status_for_column_move(&card, cols[0].id, &board, &cols);
@@ -941,13 +941,13 @@ mod tests {
 
     #[test]
     fn test_move_between_columns_reproduces_the_documented_status_transitions() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Complete"]);
         cols[1].default_status = Some(CardStatus::InProgress);
         cols[2].default_status = Some(CardStatus::Done);
         let (todo, doing, complete) = (&cols[0].clone(), &cols[1].clone(), &cols[2].clone());
 
-        let mut card = test_card(&mut board, todo, "Task", 0);
+        let mut card = test_card(&board, todo, "Task", 0);
         card.status = CardStatus::Todo;
         assert_eq!(
             target_status_for_column_move(&card, doing.id, &board, &cols),
@@ -974,10 +974,10 @@ mod tests {
 
     #[test]
     fn test_blocked_card_moved_into_an_in_progress_column_stays_blocked() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing"]);
         cols[1].default_status = Some(CardStatus::InProgress);
-        let mut card = test_card(&mut board, &cols[0], "Task", 0);
+        let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Blocked;
 
         let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
@@ -989,9 +989,9 @@ mod tests {
 
     #[test]
     fn test_move_to_column_without_default_status_returns_none() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["TODO", "Doing"]);
-        let mut card = test_card(&mut board, &cols[0], "Task", 0);
+        let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Todo;
 
         let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
@@ -1002,9 +1002,9 @@ mod tests {
 
     #[test]
     fn test_uncomplete_target_column_picks_nearest_left_non_completion_column() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["TODO", "Doing", "Done", "Decision"]);
-        let card = test_card(&mut board, &cols[2], "Task", 0);
+        let card = test_card(&board, &cols[2], "Task", 0);
         cols[2].default_status = Some(CardStatus::Done);
 
         let target = uncomplete_target_column(&card, &board, &cols);
@@ -1013,9 +1013,9 @@ mod tests {
 
     #[test]
     fn test_uncomplete_target_column_falls_back_to_first_non_completion_column() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["Done", "TODO", "Doing"]);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
         cols[0].default_status = Some(CardStatus::Done);
 
         let target = uncomplete_target_column(&card, &board, &cols);
@@ -1024,9 +1024,9 @@ mod tests {
 
     #[test]
     fn test_uncomplete_target_column_all_columns_complete_returns_none() {
-        let mut board = test_board();
+        let board = test_board();
         let mut cols = add_columns(&board, &["Done", "WontDo"]);
-        let card = test_card(&mut board, &cols[0], "Task", 0);
+        let card = test_card(&board, &cols[0], "Task", 0);
         cols[0].default_status = Some(CardStatus::Done);
         cols[1].default_status = Some(CardStatus::Done);
 
@@ -1070,10 +1070,10 @@ mod tests {
 
     #[test]
     fn migrate_backfills_empty_sprint_logs() {
-        let mut board = test_board();
+        let board = test_board();
         let col = Column::new(board.id, "Todo", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
-        let mut card = test_card(&mut board, &col, "Task", 0);
+        let mut card = test_card(&board, &col, "Task", 0);
         card.sprint_id = Some(sprint.id);
 
         let mut cards = vec![card];
@@ -1086,10 +1086,10 @@ mod tests {
 
     #[test]
     fn migrate_skips_cards_with_existing_logs() {
-        let mut board = test_board();
+        let board = test_board();
         let col = Column::new(board.id, "Todo", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
-        let mut card = test_card(&mut board, &col, "Task", 0);
+        let mut card = test_card(&board, &col, "Task", 0);
         card.sprint_id = Some(sprint.id);
         card.sprint_logs
             .push(SprintLog::new(sprint.id, 1, None::<String>, "Active"));
@@ -1103,9 +1103,9 @@ mod tests {
 
     #[test]
     fn migrate_skips_cards_without_sprint() {
-        let mut board = test_board();
+        let board = test_board();
         let col = Column::new(board.id, "Todo", 0);
-        let card = test_card(&mut board, &col, "Task", 0);
+        let card = test_card(&board, &col, "Task", 0);
 
         let mut cards = vec![card];
         let count = migrate_sprint_logs(&mut cards, &[], &[board]);
@@ -1115,14 +1115,14 @@ mod tests {
 
     #[test]
     fn migrate_with_mixed_cards_only_backfills_eligible() {
-        let mut board = test_board();
+        let board = test_board();
         let col = Column::new(board.id, "Todo", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
-        let mut card_needs_backfill = test_card(&mut board, &col, "Needs Backfill", 0);
+        let mut card_needs_backfill = test_card(&board, &col, "Needs Backfill", 0);
         card_needs_backfill.sprint_id = Some(sprint.id);
 
-        let mut card_already_logged = test_card(&mut board, &col, "Already Logged", 1);
+        let mut card_already_logged = test_card(&board, &col, "Already Logged", 1);
         card_already_logged.sprint_id = Some(sprint.id);
         card_already_logged.sprint_logs.push(SprintLog::new(
             sprint.id,
@@ -1132,7 +1132,7 @@ mod tests {
         ));
         let already_logged_before = card_already_logged.sprint_logs.clone();
 
-        let card_no_sprint = test_card(&mut board, &col, "No Sprint", 2);
+        let card_no_sprint = test_card(&board, &col, "No Sprint", 2);
         let no_sprint_before = card_no_sprint.sprint_logs.clone();
 
         let mut cards = vec![card_needs_backfill, card_already_logged, card_no_sprint];
@@ -1155,10 +1155,10 @@ mod tests {
 
     #[test]
     fn compute_move_positions_appends_after_existing_non_moving_cards() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Col"]);
-        let existing1 = test_card(&mut board, &cols[0], "E1", 0);
-        let existing2 = test_card(&mut board, &cols[0], "E2", 1);
+        let existing1 = test_card(&board, &cols[0], "E1", 0);
+        let existing2 = test_card(&board, &cols[0], "E2", 1);
         let existing = vec![existing1, existing2];
 
         let move_a = Uuid::new_v4();
@@ -1171,11 +1171,11 @@ mod tests {
 
     #[test]
     fn compute_move_positions_within_same_column_excludes_moving_from_base() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Col"]);
-        let card1 = test_card(&mut board, &cols[0], "C1", 0);
-        let card2 = test_card(&mut board, &cols[0], "C2", 1);
-        let card3 = test_card(&mut board, &cols[0], "C3", 2);
+        let card1 = test_card(&board, &cols[0], "C1", 0);
+        let card2 = test_card(&board, &cols[0], "C2", 1);
+        let card3 = test_card(&board, &cols[0], "C3", 2);
         let c1 = card1.id;
         let c3 = card3.id;
         let existing = vec![card1, card2, card3];
@@ -1198,9 +1198,9 @@ mod tests {
 
     #[test]
     fn compute_move_positions_with_empty_moving_returns_empty() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Col"]);
-        let existing = vec![test_card(&mut board, &cols[0], "E", 0)];
+        let existing = vec![test_card(&board, &cols[0], "E", 0)];
 
         let positions = compute_move_positions(&existing, &[]);
 
@@ -1209,9 +1209,9 @@ mod tests {
 
     #[test]
     fn compute_move_positions_preserves_input_order() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Col"]);
-        let existing = vec![test_card(&mut board, &cols[0], "E", 0)];
+        let existing = vec![test_card(&board, &cols[0], "E", 0)];
 
         let id1 = Uuid::new_v4();
         let id2 = Uuid::new_v4();
@@ -1224,9 +1224,9 @@ mod tests {
 
     #[test]
     fn compute_move_positions_dedupes_repeated_moving_ids_first_occurrence_wins() {
-        let mut board = test_board();
+        let board = test_board();
         let cols = add_columns(&board, &["Col"]);
-        let existing = vec![test_card(&mut board, &cols[0], "E", 0)];
+        let existing = vec![test_card(&board, &cols[0], "E", 0)];
 
         let id_a = Uuid::new_v4();
         let id_b = Uuid::new_v4();

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -498,9 +498,8 @@ impl CreateSubcardCommand {
 
     /// Inverse: delete the new card. `DeleteCard` is polymorphic over
     /// live / archived and strips incident graph edges, so the parent
-    /// edge added by the forward is cleaned up in the same step. The
-    /// board's `card_counter` stays bumped; redo reproduces the same
-    /// id and number.
+    /// edge added by the forward is cleaned up in the same step. Redo
+    /// reproduces the same id and number.
     pub fn capture_inverse(&self, _store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         Ok(vec![Command::Card(super::card::CardCommand::Delete(
             super::card::DeleteCard { card_id: self.id },

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -460,7 +460,7 @@ pub struct CreateSubcardCommand {
 impl CreateSubcardCommand {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         context.get_card(self.parent_id)?;
-        let mut board = context.get_board(self.board_id)?;
+        let board = context.get_board(self.board_id)?;
         // Allocates from the prefix row, like every other card. Minting from
         // `board.card_counter` here would draw subcards from a different
         // counter than their siblings and collide with them.
@@ -470,12 +470,7 @@ impl CreateSubcardCommand {
             None,
             crate::prefix_backfill::DEFAULT_CARD_PREFIX,
         )?;
-        let mut card = Card::new(
-            &mut board,
-            self.column_id,
-            self.title.clone(),
-            self.position,
-        );
+        let mut card = Card::new(board.id, self.column_id, self.title.clone(), self.position);
         card.card_number = card_number;
         card.prefix = prefix;
         card.id = self.id;

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -465,8 +465,8 @@ mod tests {
     }
 
     fn seed_card(column_id: Uuid) -> Card {
-        let mut board = Board::new("floor", None::<String>);
-        Card::new(&mut board, column_id, "seed", 0)
+        let board = Board::new("floor", None::<String>);
+        Card::new(board.id, column_id, "seed", 0)
     }
 
     #[test]

--- a/crates/kanban-domain/src/editable.rs
+++ b/crates/kanban-domain/src/editable.rs
@@ -280,8 +280,8 @@ mod tests {
     }
 
     fn fresh_card_for_tests() -> Card {
-        let mut board = crate::Board::new("B", None::<String>);
-        crate::Card::new(&mut board, uuid::Uuid::new_v4(), "title", 0)
+        let board = crate::Board::new("B", None::<String>);
+        crate::Card::new(board.id, uuid::Uuid::new_v4(), "title", 0)
     }
 
     #[test]

--- a/crates/kanban-domain/src/export/exporter.rs
+++ b/crates/kanban-domain/src/export/exporter.rs
@@ -128,8 +128,8 @@ mod tests {
         let column = Column::new(board.id, "Todo", 0);
         let columns = vec![column.clone()];
 
-        let mut board_mut = board.clone();
-        let card = Card::new(&mut board_mut, column.id, "Task", 0);
+        let board_mut = board.clone();
+        let card = Card::new(board_mut.id, column.id, "Task", 0);
         let cards = vec![card];
 
         let archived_cards = vec![];
@@ -243,12 +243,12 @@ mod tests {
         let board = Board::new("B", None::<String>);
         let live_col = Column::new(board.id, "Todo", 0);
 
-        let mut board_mut = board.clone();
-        let live_card = Card::new(&mut board_mut, live_col.id, "Live", 0);
+        let board_mut = board.clone();
+        let live_card = Card::new(board_mut.id, live_col.id, "Live", 0);
 
         // Archived card pointing at a DELETED column (dangling).
         let dangling_col_id = Uuid::new_v4();
-        let archived_card_row = Card::new(&mut board_mut, dangling_col_id, "Archived", 1);
+        let archived_card_row = Card::new(board_mut.id, dangling_col_id, "Archived", 1);
         let ac_marker = crate::ArchivedCard::new(archived_card_row.id, board.id);
 
         let columns = vec![live_col.clone()];

--- a/crates/kanban-domain/src/export/importer.rs
+++ b/crates/kanban-domain/src/export/importer.rs
@@ -234,8 +234,8 @@ mod tests {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
 
-        let mut board_mut = board.clone();
-        let card = Card::new(&mut board_mut, column.id, "Task", 0);
+        let board_mut = board.clone();
+        let card = Card::new(board_mut.id, column.id, "Task", 0);
 
         let export = AllBoardsExport {
             boards: vec![BoardExport {
@@ -290,9 +290,9 @@ mod tests {
     fn test_export_import_round_trip_preserves_archived_card_row_and_marker() {
         let board = Board::new("B", None::<String>);
         let col = Column::new(board.id, "Todo", 0);
-        let mut board_mut = board.clone();
-        let live_card = Card::new(&mut board_mut, col.id, "Live", 0);
-        let archived_card_row = Card::new(&mut board_mut, col.id, "Archived", 1);
+        let board_mut = board.clone();
+        let live_card = Card::new(board_mut.id, col.id, "Live", 0);
+        let archived_card_row = Card::new(board_mut.id, col.id, "Archived", 1);
         let ac_marker = ArchivedCard::new(archived_card_row.id, board.id);
 
         let snapshot = Snapshot {
@@ -326,10 +326,10 @@ mod tests {
     fn test_export_import_round_trip_preserves_archived_card_with_dangling_column() {
         let board = Board::new("B", None::<String>);
         let live_col = Column::new(board.id, "Todo", 0);
-        let mut board_mut = board.clone();
+        let board_mut = board.clone();
         // Archived card points at a column NOT in snapshot.columns (deleted).
         let dangling_col_id = Uuid::new_v4();
-        let archived_card_row = Card::new(&mut board_mut, dangling_col_id, "Archived", 0);
+        let archived_card_row = Card::new(board_mut.id, dangling_col_id, "Archived", 0);
         let ac_marker = ArchivedCard::new(archived_card_row.id, board.id);
 
         let snapshot = Snapshot {
@@ -386,11 +386,11 @@ mod tests {
         let board_live = Board::new("Live Board", None::<String>);
         let board_arch = Board::new("Archived Board", None::<String>);
         let col = Column::new(board_live.id, "Todo", 0);
-        let mut bm = board_live.clone();
-        let live_card = Card::new(&mut bm, col.id, "Live Card", 0);
+        let bm = board_live.clone();
+        let live_card = Card::new(bm.id, col.id, "Live Card", 0);
         // Archived card with dangling column (column deleted after archival)
         let dangling_col = Uuid::new_v4();
-        let archived_card_row = Card::new(&mut bm, dangling_col, "Archived Card", 1);
+        let archived_card_row = Card::new(bm.id, dangling_col, "Archived Card", 1);
         let ac_marker = ArchivedCard::new(archived_card_row.id, board_live.id);
         let ab_marker = ArchivedBoard::at(board_arch.id, chrono::Utc::now());
 

--- a/crates/kanban-domain/src/filter/card_filter.rs
+++ b/crates/kanban-domain/src/filter/card_filter.rs
@@ -96,8 +96,8 @@ mod tests {
     use super::*;
     use crate::Board;
 
-    fn create_test_card(board: &mut Board, column_id: Uuid) -> Card {
-        Card::new(board, column_id, "Test Card", 0)
+    fn create_test_card(board: &Board, column_id: Uuid) -> Card {
+        Card::new(board.id, column_id, "Test Card", 0)
     }
 
     #[test]
@@ -106,8 +106,8 @@ mod tests {
         let column = Column::new(board.id, "Todo", 0);
         let other_column = Column::new(Uuid::new_v4(), "Other", 0); // Different board
 
-        let mut board_mut = board.clone();
-        let card = create_test_card(&mut board_mut, column.id);
+        let board_mut = board.clone();
+        let card = create_test_card(&board_mut, column.id);
 
         let columns = vec![column.clone(), other_column];
 
@@ -115,8 +115,8 @@ mod tests {
         assert!(filter.matches(&card));
 
         // Card in a column not belonging to the board
-        let mut board_mut2 = board.clone();
-        let other_card = create_test_card(&mut board_mut2, Uuid::new_v4());
+        let board_mut2 = board.clone();
+        let other_card = create_test_card(&board_mut2, Uuid::new_v4());
         assert!(!filter.matches(&other_card));
     }
 
@@ -126,9 +126,9 @@ mod tests {
         let column1 = Column::new(board.id, "Todo", 0);
         let column2 = Column::new(board.id, "Done", 1);
 
-        let mut board_mut = board.clone();
-        let card1 = create_test_card(&mut board_mut, column1.id);
-        let card2 = create_test_card(&mut board_mut, column2.id);
+        let board_mut = board.clone();
+        let card1 = create_test_card(&board_mut, column1.id);
+        let card2 = create_test_card(&board_mut, column2.id);
 
         let filter = ColumnFilter::new(column1.id);
         assert!(filter.matches(&card1));
@@ -140,8 +140,8 @@ mod tests {
         let board = Board::new("Test Board", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
 
-        let mut board_mut = board.clone();
-        let mut card = create_test_card(&mut board_mut, column.id);
+        let board_mut = board.clone();
+        let mut card = create_test_card(&board_mut, column.id);
 
         let sprint_id = Uuid::new_v4();
         card.sprint_id = Some(sprint_id);
@@ -163,11 +163,11 @@ mod tests {
         let board = Board::new("Test Board", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
 
-        let mut board_mut = board.clone();
-        let mut assigned_card = create_test_card(&mut board_mut, column.id);
+        let board_mut = board.clone();
+        let mut assigned_card = create_test_card(&board_mut, column.id);
         assigned_card.sprint_id = Some(Uuid::new_v4());
 
-        let unassigned_card = create_test_card(&mut board_mut, column.id);
+        let unassigned_card = create_test_card(&board_mut, column.id);
 
         let filter = UnassignedOnlyFilter;
         assert!(!filter.matches(&assigned_card));

--- a/crates/kanban-domain/src/query/mod.rs
+++ b/crates/kanban-domain/src/query/mod.rs
@@ -120,16 +120,16 @@ mod tests {
         Column::new(board.id, name.to_string(), position)
     }
 
-    fn create_test_card(board: &mut Board, column: &Column, title: &str, position: i32) -> Card {
-        Card::new(board, column.id, title.to_string(), position)
+    fn create_test_card(board: &Board, column: &Column, title: &str, position: i32) -> Card {
+        Card::new(board.id, column.id, title.to_string(), position)
     }
 
     #[test]
     fn test_filter_and_sort_cards_basic() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board, "Todo", 0);
-        let card1 = create_test_card(&mut board, &column, "Task 1", 0);
-        let card2 = create_test_card(&mut board, &column, "Task 2", 1);
+        let card1 = create_test_card(&board, &column, "Task 1", 0);
+        let card2 = create_test_card(&board, &column, "Task 2", 1);
 
         let columns = vec![column.clone()];
         let cards = vec![card1.clone(), card2.clone()];
@@ -143,11 +143,11 @@ mod tests {
 
     #[test]
     fn test_filter_by_column() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column1 = create_test_column(&board, "Todo", 0);
         let column2 = create_test_column(&board, "Done", 1);
-        let card1 = create_test_card(&mut board, &column1, "Task 1", 0);
-        let card2 = create_test_card(&mut board, &column2, "Task 2", 0);
+        let card1 = create_test_card(&board, &column1, "Task 1", 0);
+        let card2 = create_test_card(&board, &column2, "Task 2", 0);
 
         let columns = vec![column1.clone(), column2.clone()];
         let cards = vec![card1.clone(), card2.clone()];
@@ -162,10 +162,10 @@ mod tests {
 
     #[test]
     fn test_filter_by_search() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board, "Todo", 0);
-        let card1 = create_test_card(&mut board, &column, "Fix bug", 0);
-        let card2 = create_test_card(&mut board, &column, "Add feature", 1);
+        let card1 = create_test_card(&board, &column, "Fix bug", 0);
+        let card2 = create_test_card(&board, &column, "Add feature", 1);
 
         let columns = vec![column.clone()];
         let cards = vec![card1.clone(), card2.clone()];
@@ -180,11 +180,11 @@ mod tests {
 
     #[test]
     fn test_hide_assigned_cards() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board, "Todo", 0);
-        let mut card1 = create_test_card(&mut board, &column, "Assigned", 0);
+        let mut card1 = create_test_card(&board, &column, "Assigned", 0);
         card1.sprint_id = Some(Uuid::new_v4());
-        let card2 = create_test_card(&mut board, &column, "Unassigned", 1);
+        let card2 = create_test_card(&board, &column, "Unassigned", 1);
 
         let columns = vec![column.clone()];
         let cards = vec![card1.clone(), card2.clone()];
@@ -199,10 +199,10 @@ mod tests {
 
     #[test]
     fn test_query_builder() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board, "Todo", 0);
-        let card1 = create_test_card(&mut board, &column, "Fix bug", 0);
-        let card2 = create_test_card(&mut board, &column, "Add feature", 1);
+        let card1 = create_test_card(&board, &column, "Fix bug", 0);
+        let card2 = create_test_card(&board, &column, "Add feature", 1);
 
         let columns = vec![column.clone()];
         let cards = vec![card1.clone(), card2.clone()];
@@ -217,11 +217,11 @@ mod tests {
 
     #[test]
     fn test_query_builder_with_column() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column1 = create_test_column(&board, "Todo", 0);
         let column2 = create_test_column(&board, "Done", 1);
-        let card1 = create_test_card(&mut board, &column1, "Task 1", 0);
-        let card2 = create_test_card(&mut board, &column2, "Task 2", 0);
+        let card1 = create_test_card(&board, &column1, "Task 1", 0);
+        let card2 = create_test_card(&board, &column2, "Task 2", 0);
 
         let columns = vec![column1.clone(), column2.clone()];
         let cards = vec![card1.clone(), card2.clone()];

--- a/crates/kanban-domain/src/query/sprint.rs
+++ b/crates/kanban-domain/src/query/sprint.rs
@@ -98,23 +98,23 @@ mod tests {
         Column::new(board.id, "Todo", 0)
     }
 
-    fn create_test_card(board: &mut Board, column: &Column, title: &str) -> Card {
-        Card::new(board, column.id, title.to_string(), 0)
+    fn create_test_card(board: &Board, column: &Column, title: &str) -> Card {
+        Card::new(board.id, column.id, title.to_string(), 0)
     }
 
     #[test]
     fn test_get_sprint_cards() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
         let sprint_id = Uuid::new_v4();
 
-        let mut card1 = create_test_card(&mut board, &column, "Task 1");
+        let mut card1 = create_test_card(&board, &column, "Task 1");
         card1.sprint_id = Some(sprint_id);
 
-        let mut card2 = create_test_card(&mut board, &column, "Task 2");
+        let mut card2 = create_test_card(&board, &column, "Task 2");
         card2.sprint_id = Some(sprint_id);
 
-        let card3 = create_test_card(&mut board, &column, "Task 3");
+        let card3 = create_test_card(&board, &column, "Task 3");
 
         let cards = vec![card1, card2, card3];
         let result = get_sprint_cards(sprint_id, &cards);
@@ -124,15 +124,15 @@ mod tests {
 
     #[test]
     fn test_get_sprint_completed_cards() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
         let sprint_id = Uuid::new_v4();
 
-        let mut card1 = create_test_card(&mut board, &column, "Task 1");
+        let mut card1 = create_test_card(&board, &column, "Task 1");
         card1.sprint_id = Some(sprint_id);
         card1.status = CardStatus::Done;
 
-        let mut card2 = create_test_card(&mut board, &column, "Task 2");
+        let mut card2 = create_test_card(&board, &column, "Task 2");
         card2.sprint_id = Some(sprint_id);
         card2.status = CardStatus::Todo;
 
@@ -145,19 +145,19 @@ mod tests {
 
     #[test]
     fn test_partition_sprint_cards() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
         let sprint_id = Uuid::new_v4();
 
-        let mut card1 = create_test_card(&mut board, &column, "Done");
+        let mut card1 = create_test_card(&board, &column, "Done");
         card1.sprint_id = Some(sprint_id);
         card1.status = CardStatus::Done;
 
-        let mut card2 = create_test_card(&mut board, &column, "Todo");
+        let mut card2 = create_test_card(&board, &column, "Todo");
         card2.sprint_id = Some(sprint_id);
         card2.status = CardStatus::Todo;
 
-        let mut card3 = create_test_card(&mut board, &column, "InProgress");
+        let mut card3 = create_test_card(&board, &column, "InProgress");
         card3.sprint_id = Some(sprint_id);
         card3.status = CardStatus::InProgress;
 
@@ -173,16 +173,16 @@ mod tests {
 
     #[test]
     fn test_calculate_points() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
 
-        let mut card1 = create_test_card(&mut board, &column, "Task 1");
+        let mut card1 = create_test_card(&board, &column, "Task 1");
         card1.points = Some(3);
 
-        let mut card2 = create_test_card(&mut board, &column, "Task 2");
+        let mut card2 = create_test_card(&board, &column, "Task 2");
         card2.points = Some(5);
 
-        let card3 = create_test_card(&mut board, &column, "Task 3");
+        let card3 = create_test_card(&board, &column, "Task 3");
 
         let cards: Vec<&Card> = vec![&card1, &card2, &card3];
         let total = calculate_points(&cards);
@@ -192,15 +192,15 @@ mod tests {
 
     #[test]
     fn get_sprint_uncompleted_cards_excludes_done() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
         let sprint_id = Uuid::new_v4();
 
-        let mut card_done = create_test_card(&mut board, &column, "Done Task");
+        let mut card_done = create_test_card(&board, &column, "Done Task");
         card_done.sprint_id = Some(sprint_id);
         card_done.status = CardStatus::Done;
 
-        let mut card_todo = create_test_card(&mut board, &column, "Todo Task");
+        let mut card_todo = create_test_card(&board, &column, "Todo Task");
         card_todo.sprint_id = Some(sprint_id);
 
         let cards = vec![card_done, card_todo.clone()];
@@ -212,19 +212,19 @@ mod tests {
 
     #[test]
     fn get_sprint_uncompleted_cards_includes_all_non_done_statuses() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
         let sprint_id = Uuid::new_v4();
 
-        let mut card_todo = create_test_card(&mut board, &column, "Todo");
+        let mut card_todo = create_test_card(&board, &column, "Todo");
         card_todo.sprint_id = Some(sprint_id);
         card_todo.status = CardStatus::Todo;
 
-        let mut card_in_progress = create_test_card(&mut board, &column, "InProgress");
+        let mut card_in_progress = create_test_card(&board, &column, "InProgress");
         card_in_progress.sprint_id = Some(sprint_id);
         card_in_progress.status = CardStatus::InProgress;
 
-        let mut card_blocked = create_test_card(&mut board, &column, "Blocked");
+        let mut card_blocked = create_test_card(&board, &column, "Blocked");
         card_blocked.sprint_id = Some(sprint_id);
         card_blocked.status = CardStatus::Blocked;
 
@@ -244,18 +244,18 @@ mod tests {
 
     #[test]
     fn get_sprint_uncompleted_cards_excludes_other_sprints() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
         let sprint_id = Uuid::new_v4();
         let other_sprint_id = Uuid::new_v4();
 
-        let mut card_this_sprint = create_test_card(&mut board, &column, "This Sprint");
+        let mut card_this_sprint = create_test_card(&board, &column, "This Sprint");
         card_this_sprint.sprint_id = Some(sprint_id);
 
-        let mut card_other_sprint = create_test_card(&mut board, &column, "Other Sprint");
+        let mut card_other_sprint = create_test_card(&board, &column, "Other Sprint");
         card_other_sprint.sprint_id = Some(other_sprint_id);
 
-        let card_no_sprint = create_test_card(&mut board, &column, "No Sprint");
+        let card_no_sprint = create_test_card(&board, &column, "No Sprint");
 
         let cards = vec![card_this_sprint.clone(), card_other_sprint, card_no_sprint];
         let result = get_sprint_uncompleted_cards(sprint_id, &cards);
@@ -266,15 +266,15 @@ mod tests {
 
     #[test]
     fn get_sprint_uncompleted_cards_returns_empty_when_all_done() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
         let sprint_id = Uuid::new_v4();
 
-        let mut card1 = create_test_card(&mut board, &column, "Done 1");
+        let mut card1 = create_test_card(&board, &column, "Done 1");
         card1.sprint_id = Some(sprint_id);
         card1.status = CardStatus::Done;
 
-        let mut card2 = create_test_card(&mut board, &column, "Done 2");
+        let mut card2 = create_test_card(&board, &column, "Done 2");
         card2.sprint_id = Some(sprint_id);
         card2.status = CardStatus::Done;
 
@@ -286,16 +286,16 @@ mod tests {
 
     #[test]
     fn test_sort_card_ids() {
-        let mut board = create_test_board();
+        let board = create_test_board();
         let column = create_test_column(&board);
 
-        let mut card1 = create_test_card(&mut board, &column, "Task 1");
+        let mut card1 = create_test_card(&board, &column, "Task 1");
         card1.points = Some(5);
 
-        let mut card2 = create_test_card(&mut board, &column, "Task 2");
+        let mut card2 = create_test_card(&board, &column, "Task 2");
         card2.points = Some(1);
 
-        let mut card3 = create_test_card(&mut board, &column, "Task 3");
+        let mut card3 = create_test_card(&board, &column, "Task 3");
         card3.points = Some(3);
 
         let cards = vec![card1.clone(), card2.clone(), card3.clone()];

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -497,15 +497,15 @@ mod tests {
     use super::*;
     use uuid::Uuid;
 
-    fn create_test_card(board: &mut Board, title: &str) -> Card {
+    fn create_test_card(board: &Board, title: &str) -> Card {
         let column = crate::Column::new(board.id, "Todo", 0);
-        Card::new(board, column.id, title.to_string(), 0)
+        Card::new(board.id, column.id, title.to_string(), 0)
     }
 
     #[test]
     fn test_title_searcher_matches() {
-        let mut board = Board::new("Test", None::<String>);
-        let card = create_test_card(&mut board, "Fix authentication bug");
+        let board = Board::new("Test", None::<String>);
+        let card = create_test_card(&board, "Fix authentication bug");
 
         let searcher = TitleSearcher::new("auth");
         assert!(searcher.matches(&card, &board, &[]));
@@ -519,8 +519,8 @@ mod tests {
 
     #[test]
     fn test_title_searcher_empty_query() {
-        let mut board = Board::new("Test", None::<String>);
-        let card = create_test_card(&mut board, "Any card");
+        let board = Board::new("Test", None::<String>);
+        let card = create_test_card(&board, "Any card");
 
         let searcher = TitleSearcher::new("");
         assert!(searcher.matches(&card, &board, &[]));
@@ -528,8 +528,8 @@ mod tests {
 
     #[test]
     fn test_branch_name_searcher_matches() {
-        let mut board = Board::new("Test", None::<String>);
-        let card = create_test_card(&mut board, "Add new feature");
+        let board = Board::new("Test", None::<String>);
+        let card = create_test_card(&board, "Add new feature");
 
         let searcher = BranchNameSearcher::new("feature");
         assert!(searcher.matches(&card, &board, &[]));
@@ -537,8 +537,8 @@ mod tests {
 
     #[test]
     fn test_composite_searcher_any_match() {
-        let mut board = Board::new("Test", None::<String>);
-        let card = create_test_card(&mut board, "Fix bug");
+        let board = Board::new("Test", None::<String>);
+        let card = create_test_card(&board, "Fix bug");
 
         // Should match because title contains "bug"
         let searcher = CompositeSearcher::all("bug");
@@ -551,8 +551,8 @@ mod tests {
 
     #[test]
     fn test_composite_searcher_empty() {
-        let mut board = Board::new("Test", None::<String>);
-        let card = create_test_card(&mut board, "Any card");
+        let board = Board::new("Test", None::<String>);
+        let card = create_test_card(&board, "Any card");
 
         let searcher = CompositeSearcher::new();
         assert!(searcher.matches(&card, &board, &[]));
@@ -563,7 +563,8 @@ mod tests {
         let mut board = Board::new("Test", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Some task", 0);
+        let mut card = Card::new(board.id, column.id, "Some task", 0);
+        card.card_number = 1;
 
         let searcher = CardIdentifierSearcher::new("KAN-1");
         assert!(searcher.matches(&card, &board, &[]));
@@ -580,12 +581,11 @@ mod tests {
 
     #[test]
     fn test_card_identifier_searcher_number_only() {
-        let mut board = Board::new("Test", None::<String>);
+        let board = Board::new("Test", None::<String>);
         let column = crate::Column::new(board.id, "Todo", 0);
-        let _card1 = Card::new(&mut board, column.id, "First", 0);
-        let card2 = Card::new(&mut board, column.id, "Second", 1);
-
-        // card2 has card_number=2
+        let _card1 = Card::new(board.id, column.id, "First", 0);
+        let mut card2 = Card::new(board.id, column.id, "Second", 1);
+        card2.card_number = 2;
         let searcher = CardIdentifierSearcher::new("2");
         assert!(searcher.matches(&card2, &board, &[]));
 
@@ -603,7 +603,7 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Some task", 0);
+        let card = Card::new(board.id, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card];
@@ -616,7 +616,8 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Some task", 0);
+        let mut card = Card::new(board.id, column.id, "Some task", 0);
+        card.card_number = 1;
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -631,12 +632,14 @@ mod tests {
         let mut board1 = Board::new("Board One", None::<String>);
         board1.card_prefix = Some("KAN".to_string());
         let col1 = crate::Column::new(board1.id, "Todo", 0);
-        let card1 = Card::new(&mut board1, col1.id, "First", 0);
+        let mut card1 = Card::new(board1.id, col1.id, "First", 0);
+        card1.card_number = 1;
 
         let mut board2 = Board::new("Board Two", None::<String>);
         board2.card_prefix = Some("KAN".to_string());
         let col2 = crate::Column::new(board2.id, "Todo", 0);
-        let card2 = Card::new(&mut board2, col2.id, "Second", 0);
+        let mut card2 = Card::new(board2.id, col2.id, "Second", 0);
+        card2.card_number = 1;
 
         let boards = vec![board1, board2];
         let columns = vec![col1, col2];
@@ -651,7 +654,8 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Some task", 0);
+        let mut card = Card::new(board.id, column.id, "Some task", 0);
+        card.card_number = 1;
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -666,12 +670,14 @@ mod tests {
         let mut board1 = Board::new("Board One", None::<String>);
         board1.card_prefix = Some("AAA".to_string());
         let col1 = crate::Column::new(board1.id, "Todo", 0);
-        let card1 = Card::new(&mut board1, col1.id, "First", 0);
+        let mut card1 = Card::new(board1.id, col1.id, "First", 0);
+        card1.card_number = 1;
 
         let mut board2 = Board::new("Board Two", None::<String>);
         board2.card_prefix = Some("BBB".to_string());
         let col2 = crate::Column::new(board2.id, "Todo", 0);
-        let card2 = Card::new(&mut board2, col2.id, "Second", 0);
+        let mut card2 = Card::new(board2.id, col2.id, "Second", 0);
+        card2.card_number = 1;
 
         let boards = vec![board1, board2];
         let columns = vec![col1, col2];
@@ -686,7 +692,7 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Some task", 0);
+        let card = Card::new(board.id, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card];
@@ -699,13 +705,15 @@ mod tests {
         let mut board_a = Board::new("Board A", None::<String>);
         board_a.card_prefix = Some("PROJ".to_string());
         let col_a = crate::Column::new(board_a.id, "Todo", 0);
-        let card_a = Card::new(&mut board_a, col_a.id, "Card A", 0);
+        let mut card_a = Card::new(board_a.id, col_a.id, "Card A", 0);
+        card_a.card_number = 1;
 
-        let mut board_b = Board::new("Board B", None::<String>);
+        let board_b = Board::new("Board B", None::<String>);
         let col_b = crate::Column::new(board_b.id, "Todo", 0);
         let mut sprint = crate::Sprint::new(board_b.id, 1, None, None::<String>);
         sprint.card_prefix = Some("PROJ".to_string());
-        let mut card_b = Card::new(&mut board_b, col_b.id, "Card B", 0);
+        let mut card_b = Card::new(board_b.id, col_b.id, "Card B", 0);
+        card_b.card_number = 1;
         card_b.sprint_id = Some(sprint.id);
 
         let boards = vec![board_a, board_b];
@@ -722,7 +730,8 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Some task", 0);
+        let mut card = Card::new(board.id, column.id, "Some task", 0);
+        card.card_number = 1;
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -746,7 +755,8 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Some task", 0);
+        let mut card = Card::new(board.id, column.id, "Some task", 0);
+        card.card_number = 1;
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -764,7 +774,7 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Some task", 0);
+        let card = Card::new(board.id, column.id, "Some task", 0);
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card];
@@ -777,12 +787,14 @@ mod tests {
         let mut board1 = Board::new("Board One", None::<String>);
         board1.card_prefix = Some("AAA".to_string());
         let col1 = crate::Column::new(board1.id, "Todo", 0);
-        let card1 = Card::new(&mut board1, col1.id, "First", 0);
+        let mut card1 = Card::new(board1.id, col1.id, "First", 0);
+        card1.card_number = 1;
 
         let mut board2 = Board::new("Board Two", None::<String>);
         board2.card_prefix = Some("BBB".to_string());
         let col2 = crate::Column::new(board2.id, "Todo", 0);
-        let card2 = Card::new(&mut board2, col2.id, "Second", 0);
+        let mut card2 = Card::new(board2.id, col2.id, "Second", 0);
+        card2.card_number = 1;
 
         let boards = vec![board1, board2];
         let columns = vec![col1, col2];
@@ -801,9 +813,9 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let mut card1 = Card::new(&mut board, column.id, "First", 0);
+        let mut card1 = Card::new(board.id, column.id, "First", 0);
         card1.card_number = 1;
-        let mut card11 = Card::new(&mut board, column.id, "Eleventh", 0);
+        let mut card11 = Card::new(board.id, column.id, "Eleventh", 0);
         card11.card_number = 11;
         let boards = vec![board];
         let columns = vec![column];
@@ -819,9 +831,9 @@ mod tests {
         let mut board = Board::new("Project", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let mut card11 = Card::new(&mut board, column.id, "Eleven", 0);
+        let mut card11 = Card::new(board.id, column.id, "Eleven", 0);
         card11.card_number = 11;
-        let mut card111 = Card::new(&mut board, column.id, "OneHundredEleven", 0);
+        let mut card111 = Card::new(board.id, column.id, "OneHundredEleven", 0);
         card111.card_number = 111;
         let boards = vec![board];
         let columns = vec![column];
@@ -839,7 +851,8 @@ mod tests {
         let column = crate::Column::new(board.id, "Todo", 0);
         let mut sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         sprint.card_prefix = Some("SP".to_string());
-        let mut card = Card::new(&mut board, column.id, "Sprint task", 0);
+        let mut card = Card::new(board.id, column.id, "Sprint task", 0);
+        card.card_number = 1;
         card.sprint_id = Some(sprint.id);
         let boards = vec![board];
         let columns = vec![column];
@@ -859,7 +872,8 @@ mod tests {
         let column = crate::Column::new(board.id, "Todo", 0);
         let mut sprint = crate::Sprint::new(board.id, 1, None, None::<String>);
         sprint.card_prefix = Some("SP".to_string());
-        let mut card = Card::new(&mut board, column.id, "Override task", 0);
+        let mut card = Card::new(board.id, column.id, "Override task", 0);
+        card.card_number = 1;
         card.sprint_id = Some(sprint.id);
         let boards = vec![board];
         let columns = vec![column];
@@ -874,9 +888,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_no_prefix_no_match() {
-        let mut board = Board::new("Project", None::<String>);
+        let board = Board::new("Project", None::<String>);
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "No prefix task", 0);
+        let mut card = Card::new(board.id, column.id, "No prefix task", 0);
+        card.card_number = 1;
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -889,9 +904,10 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_uses_task_fallback_for_no_prefix_board() {
-        let mut board = Board::new("Project", None::<String>);
+        let board = Board::new("Project", None::<String>);
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "task", 0);
+        let mut card = Card::new(board.id, column.id, "task", 0);
+        card.card_number = 1;
         let boards = vec![board];
         let columns = vec![column];
         let cards = vec![card.clone()];
@@ -909,7 +925,8 @@ mod tests {
         let mut board = Board::new("Test", None::<String>);
         board.card_prefix = Some("KAN".to_string());
         let column = crate::Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Unrelated title", 0);
+        let mut card = Card::new(board.id, column.id, "Unrelated title", 0);
+        card.card_number = 1;
 
         // Title doesn't contain "KAN-1", but identifier does
         let searcher = CompositeSearcher::all("KAN-1");
@@ -1176,7 +1193,7 @@ mod resolve_card_prefix_tests {
     fn card(column_id: uuid::Uuid, board_id: uuid::Uuid, number: u32) -> Card {
         let mut owner = Board::new("owner".to_string(), None::<String>);
         owner.id = board_id;
-        let mut c = Card::new(&mut owner, column_id, "t", 0);
+        let mut c = Card::new(owner.id, column_id, "t", 0);
         c.board_id = board_id;
         c.card_number = number;
         c
@@ -1190,7 +1207,7 @@ mod resolve_card_prefix_tests {
     fn test_identifier_search_matches_the_stored_prefix_not_the_boards_current_one() {
         let mut board = Board::new("b".to_string(), Some("KAN"));
         let col = Column::new(board.id, "c".to_string(), 0);
-        let mut card = Card::new(&mut board, col.id, "t", 0);
+        let mut card = Card::new(board.id, col.id, "t", 0);
         card.card_number = 5;
         card.prefix = "KAN".to_string();
 

--- a/crates/kanban-domain/src/sort/mod.rs
+++ b/crates/kanban-domain/src/sort/mod.rs
@@ -179,9 +179,8 @@ mod tests {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
 
-        let board_mut = board.clone();
-        let card1 = Card::new(board_mut.id, column.id, "First", 0);
-        let card2 = Card::new(board_mut.id, column.id, "Second", 1);
+        let card1 = Card::new(board.id, column.id, "First", 0);
+        let card2 = Card::new(board.id, column.id, "Second", 1);
 
         (board, column, card1, card2)
     }
@@ -232,10 +231,9 @@ mod tests {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
 
-        let board_mut = board.clone();
-        let card1 = Card::new(board_mut.id, column.id, "Third", 20);
-        let card2 = Card::new(board_mut.id, column.id, "First", 5);
-        let card3 = Card::new(board_mut.id, column.id, "Second", 10);
+        let card1 = Card::new(board.id, column.id, "Third", 20);
+        let card2 = Card::new(board.id, column.id, "First", 5);
+        let card3 = Card::new(board.id, column.id, "Second", 10);
 
         assert_eq!(SortBy::Position.compare(&card2, &card3), Ordering::Less); // 5 < 10
         assert_eq!(SortBy::Position.compare(&card3, &card1), Ordering::Less); // 10 < 20
@@ -247,10 +245,9 @@ mod tests {
 
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
-        let board_mut = board.clone();
 
-        let card1 = Card::new(board_mut.id, column.id, "A", 10);
-        let card2 = Card::new(board_mut.id, column.id, "B", 5);
+        let card1 = Card::new(board.id, column.id, "A", 10);
+        let card2 = Card::new(board.id, column.id, "B", 5);
 
         assert_eq!(sorter.compare(&card2, &card1), Ordering::Less);
     }
@@ -344,13 +341,17 @@ mod tests {
     fn test_ordered_sorter_is_deterministic_when_primary_keys_tie() {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
-        let board_mut = board.clone();
 
         // All three cards have points=None, so SortBy::Points reports them equal.
-        let card1 = Card::new(board_mut.id, column.id, "A", 0);
-        let card2 = Card::new(board_mut.id, column.id, "B", 1);
-        let card3 = Card::new(board_mut.id, column.id, "C", 2);
-        let card_numbers = (card1.card_number, card2.card_number, card3.card_number);
+        let mut card1 = Card::new(board.id, column.id, "A", 0);
+        let mut card2 = Card::new(board.id, column.id, "B", 1);
+        let mut card3 = Card::new(board.id, column.id, "C", 2);
+        // Set explicitly: `Card::new` does not number cards, and comparing
+        // card numbers read back off these same cards would hold for any
+        // ordering the sorter produced -- including none at all.
+        card1.card_number = 1;
+        card2.card_number = 2;
+        card3.card_number = 3;
 
         let sorter = OrderedSorter::new(SortBy::Points, SortOrder::Ascending);
 
@@ -362,7 +363,7 @@ mod tests {
         sorter.sort_by(&mut shuffled_c);
 
         let order = |cs: &[&Card]| (cs[0].card_number, cs[1].card_number, cs[2].card_number);
-        let expected = (card_numbers.0, card_numbers.1, card_numbers.2);
+        let expected = (1, 2, 3);
 
         assert_eq!(
             order(&shuffled_a),
@@ -381,11 +382,12 @@ mod tests {
     fn test_ordered_sorter_tiebreaker_is_ascending_under_descending_primary() {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
-        let board_mut = board.clone();
 
-        let card1 = Card::new(board_mut.id, column.id, "A", 0);
-        let card2 = Card::new(board_mut.id, column.id, "B", 1);
-        let expected = (card1.card_number, card2.card_number);
+        let mut card1 = Card::new(board.id, column.id, "A", 0);
+        let mut card2 = Card::new(board.id, column.id, "B", 1);
+        card1.card_number = 1;
+        card2.card_number = 2;
+        let expected = (1, 2);
 
         let sorter = OrderedSorter::new(SortBy::Points, SortOrder::Descending);
         let mut shuffled = vec![&card2, &card1];
@@ -499,11 +501,13 @@ mod tests {
         for variant in variants {
             let board = Board::new("Test", None::<String>);
             let column = Column::new(board.id, "Todo", 0);
-            let board_mut = board.clone();
-            let card1 = Card::new(board_mut.id, column.id, "A", 0);
-            let card2 = Card::new(board_mut.id, column.id, "B", 1);
-            let card3 = Card::new(board_mut.id, column.id, "C", 2);
-            let expected = (card1.card_number, card2.card_number, card3.card_number);
+            let mut card1 = Card::new(board.id, column.id, "A", 0);
+            let mut card2 = Card::new(board.id, column.id, "B", 1);
+            let mut card3 = Card::new(board.id, column.id, "C", 2);
+            card1.card_number = 1;
+            card2.card_number = 2;
+            card3.card_number = 3;
+            let expected = (1, 2, 3);
 
             let sorter = OrderedSorter::new(variant, SortOrder::Ascending);
             let mut shuffled = vec![&card3, &card1, &card2];

--- a/crates/kanban-domain/src/sort/mod.rs
+++ b/crates/kanban-domain/src/sort/mod.rs
@@ -179,9 +179,9 @@ mod tests {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
 
-        let mut board_mut = board.clone();
-        let card1 = Card::new(&mut board_mut, column.id, "First", 0);
-        let card2 = Card::new(&mut board_mut, column.id, "Second", 1);
+        let board_mut = board.clone();
+        let card1 = Card::new(board_mut.id, column.id, "First", 0);
+        let card2 = Card::new(board_mut.id, column.id, "Second", 1);
 
         (board, column, card1, card2)
     }
@@ -232,10 +232,10 @@ mod tests {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
 
-        let mut board_mut = board.clone();
-        let card1 = Card::new(&mut board_mut, column.id, "Third", 20);
-        let card2 = Card::new(&mut board_mut, column.id, "First", 5);
-        let card3 = Card::new(&mut board_mut, column.id, "Second", 10);
+        let board_mut = board.clone();
+        let card1 = Card::new(board_mut.id, column.id, "Third", 20);
+        let card2 = Card::new(board_mut.id, column.id, "First", 5);
+        let card3 = Card::new(board_mut.id, column.id, "Second", 10);
 
         assert_eq!(SortBy::Position.compare(&card2, &card3), Ordering::Less); // 5 < 10
         assert_eq!(SortBy::Position.compare(&card3, &card1), Ordering::Less); // 10 < 20
@@ -247,10 +247,10 @@ mod tests {
 
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
-        let mut board_mut = board.clone();
+        let board_mut = board.clone();
 
-        let card1 = Card::new(&mut board_mut, column.id, "A", 10);
-        let card2 = Card::new(&mut board_mut, column.id, "B", 5);
+        let card1 = Card::new(board_mut.id, column.id, "A", 10);
+        let card2 = Card::new(board_mut.id, column.id, "B", 5);
 
         assert_eq!(sorter.compare(&card2, &card1), Ordering::Less);
     }
@@ -344,12 +344,12 @@ mod tests {
     fn test_ordered_sorter_is_deterministic_when_primary_keys_tie() {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
-        let mut board_mut = board.clone();
+        let board_mut = board.clone();
 
         // All three cards have points=None, so SortBy::Points reports them equal.
-        let card1 = Card::new(&mut board_mut, column.id, "A", 0);
-        let card2 = Card::new(&mut board_mut, column.id, "B", 1);
-        let card3 = Card::new(&mut board_mut, column.id, "C", 2);
+        let card1 = Card::new(board_mut.id, column.id, "A", 0);
+        let card2 = Card::new(board_mut.id, column.id, "B", 1);
+        let card3 = Card::new(board_mut.id, column.id, "C", 2);
         let card_numbers = (card1.card_number, card2.card_number, card3.card_number);
 
         let sorter = OrderedSorter::new(SortBy::Points, SortOrder::Ascending);
@@ -381,10 +381,10 @@ mod tests {
     fn test_ordered_sorter_tiebreaker_is_ascending_under_descending_primary() {
         let board = Board::new("Test", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
-        let mut board_mut = board.clone();
+        let board_mut = board.clone();
 
-        let card1 = Card::new(&mut board_mut, column.id, "A", 0);
-        let card2 = Card::new(&mut board_mut, column.id, "B", 1);
+        let card1 = Card::new(board_mut.id, column.id, "A", 0);
+        let card2 = Card::new(board_mut.id, column.id, "B", 1);
         let expected = (card1.card_number, card2.card_number);
 
         let sorter = OrderedSorter::new(SortBy::Points, SortOrder::Descending);
@@ -499,10 +499,10 @@ mod tests {
         for variant in variants {
             let board = Board::new("Test", None::<String>);
             let column = Column::new(board.id, "Todo", 0);
-            let mut board_mut = board.clone();
-            let card1 = Card::new(&mut board_mut, column.id, "A", 0);
-            let card2 = Card::new(&mut board_mut, column.id, "B", 1);
-            let card3 = Card::new(&mut board_mut, column.id, "C", 2);
+            let board_mut = board.clone();
+            let card1 = Card::new(board_mut.id, column.id, "A", 0);
+            let card2 = Card::new(board_mut.id, column.id, "B", 1);
+            let card3 = Card::new(board_mut.id, column.id, "C", 2);
             let expected = (card1.card_number, card2.card_number, card3.card_number);
 
             let sorter = OrderedSorter::new(variant, SortOrder::Ascending);

--- a/crates/kanban-domain/tests/board_commands.rs
+++ b/crates/kanban-domain/tests/board_commands.rs
@@ -110,15 +110,15 @@ fn test_import_entities_with_duplicate_board_id_returns_error() {
 #[test]
 fn test_import_entities_with_duplicate_card_id_returns_error() {
     let tc = TestContext::new();
-    let mut board = Board::new("B", Some("TST"));
+    let board = Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
-    let card = kanban_domain::Card::new(&mut board, col.id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col.id, "Card", 0);
     let dup_card_id = card.id;
     tc.store.upsert_board(board.clone()).unwrap();
     tc.store.upsert_column(col).unwrap();
     tc.store.upsert_card(card).unwrap();
 
-    let mut dup_card = kanban_domain::Card::new(&mut board, Uuid::new_v4(), "Dup", 0);
+    let mut dup_card = kanban_domain::Card::new(board.id, Uuid::new_v4(), "Dup", 0);
     dup_card.id = dup_card_id;
 
     let cmd = ImportEntities {
@@ -139,9 +139,9 @@ fn test_import_entities_with_duplicate_card_id_returns_error() {
 #[test]
 fn test_import_entities_live_card_colliding_with_existing_archived_returns_error() {
     let tc = TestContext::new();
-    let mut board = Board::new("B", Some("TST"));
+    let board = Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
-    let archived = kanban_domain::Card::new(&mut board, col.id, "Archived", 0);
+    let archived = kanban_domain::Card::new(board.id, col.id, "Archived", 0);
     let collision_id = archived.id;
     tc.store.upsert_board(board.clone()).unwrap();
     tc.store.upsert_column(col.clone()).unwrap();
@@ -152,7 +152,7 @@ fn test_import_entities_live_card_colliding_with_existing_archived_returns_error
         ))
         .unwrap();
 
-    let mut imported_live = kanban_domain::Card::new(&mut board, col.id, "ImportedLive", 0);
+    let mut imported_live = kanban_domain::Card::new(board.id, col.id, "ImportedLive", 0);
     imported_live.id = collision_id;
 
     let cmd = ImportEntities {
@@ -173,15 +173,15 @@ fn test_import_entities_live_card_colliding_with_existing_archived_returns_error
 #[test]
 fn test_import_entities_archived_card_colliding_with_existing_live_returns_error() {
     let tc = TestContext::new();
-    let mut board = Board::new("B", Some("TST"));
+    let board = Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
-    let live = kanban_domain::Card::new(&mut board, col.id, "Live", 0);
+    let live = kanban_domain::Card::new(board.id, col.id, "Live", 0);
     let collision_id = live.id;
     tc.store.upsert_board(board.clone()).unwrap();
     tc.store.upsert_column(col.clone()).unwrap();
     tc.store.upsert_card(live).unwrap();
 
-    let mut imported_archived = kanban_domain::Card::new(&mut board, col.id, "ImportedArchived", 0);
+    let mut imported_archived = kanban_domain::Card::new(board.id, col.id, "ImportedArchived", 0);
     imported_archived.id = collision_id;
 
     let cmd = ImportEntities {
@@ -205,9 +205,9 @@ fn test_import_entities_archived_card_colliding_with_existing_live_returns_error
 #[test]
 fn test_import_entities_with_duplicate_archived_card_id_returns_error() {
     let tc = TestContext::new();
-    let mut board = Board::new("B", Some("TST"));
+    let board = Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
-    let archived = kanban_domain::Card::new(&mut board, col.id, "Archived", 0);
+    let archived = kanban_domain::Card::new(board.id, col.id, "Archived", 0);
     let dup_id = archived.id;
     tc.store.upsert_board(board.clone()).unwrap();
     tc.store.upsert_column(col.clone()).unwrap();
@@ -218,7 +218,7 @@ fn test_import_entities_with_duplicate_archived_card_id_returns_error() {
         ))
         .unwrap();
 
-    let mut dup = kanban_domain::Card::new(&mut board, col.id, "Dup", 0);
+    let mut dup = kanban_domain::Card::new(board.id, col.id, "Dup", 0);
     dup.id = dup_id;
 
     let cmd = ImportEntities {
@@ -244,8 +244,8 @@ fn test_import_entities_appends_without_replacing() {
 
     let b2 = Board::new("B2", None::<String>);
     let col = kanban_domain::Column::new(b2.id, "Todo", 0);
-    let mut b2_clone = b2.clone();
-    let card = kanban_domain::Card::new(&mut b2_clone, col.id, "Card", 0);
+    let b2_clone = b2.clone();
+    let card = kanban_domain::Card::new(b2_clone.id, col.id, "Card", 0);
 
     let cmd = ImportEntities {
         boards: vec![b2],
@@ -291,10 +291,11 @@ fn test_update_board_card_prefix_allowed_before_first_card_succeeds() {
 #[test]
 fn test_update_board_card_prefix_after_cards_exist_is_allowed_and_leaves_them_alone() {
     let tc = TestContext::new();
-    let mut board = Board::new("B", Some("OLD"));
+    let board = Board::new("B", Some("OLD"));
     let board_id = board.id;
     let col = Column::new(board_id, "Col", 0);
-    let card = Card::new(&mut board, col.id, "C", 0);
+    let mut card = Card::new(board.id, col.id, "C", 0);
+    card.prefix = "OLD".to_string();
     let card_id = card.id;
     assert_eq!(
         card.prefix, "OLD",
@@ -330,10 +331,11 @@ fn test_update_board_card_prefix_after_cards_exist_is_allowed_and_leaves_them_al
 #[test]
 fn test_clear_board_card_prefix_after_cards_exist_is_allowed_and_leaves_them_alone() {
     let tc = TestContext::new();
-    let mut board = Board::new("B", Some("OLD"));
+    let board = Board::new("B", Some("OLD"));
     let board_id = board.id;
     let col = Column::new(board_id, "Col", 0);
-    let card = Card::new(&mut board, col.id, "C", 0);
+    let mut card = Card::new(board.id, col.id, "C", 0);
+    card.prefix = "OLD".to_string();
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
@@ -382,11 +384,11 @@ fn test_delete_board_atomic_removes_only_board_record() {
 /// Seed a board with one column and one card; return (board_id, column_id,
 /// card_id).
 fn seed_board_with_subtree(tc: &TestContext) -> (Uuid, Uuid, Uuid) {
-    let mut board = Board::new("B", Some("TST"));
+    let board = Board::new("B", Some("TST"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Task", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Task", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();

--- a/crates/kanban-domain/tests/card_archive_update.rs
+++ b/crates/kanban-domain/tests/card_archive_update.rs
@@ -22,10 +22,10 @@ fn test_update_card_not_found_returns_error() {
 #[test]
 fn test_update_card_to_nonexistent_column_returns_not_found() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
@@ -61,8 +61,8 @@ fn test_archive_cards_all_invalid_ids_returns_error() {
 #[test]
 fn test_archive_cards_invalid_ids_skipped_valid_ids_archived() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
-    let card = kanban_domain::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
+    let board = kanban_domain::Board::new("Test", Some("TST"));
+    let card = kanban_domain::Card::new(board.id, Uuid::new_v4(), "Card", 0);
     let valid_id = card.id;
     tc.store.upsert_card(card).unwrap();
 
@@ -79,11 +79,11 @@ fn test_archive_cards_invalid_ids_skipped_valid_ids_archived() {
 #[test]
 fn test_archive_captures_board_from_column() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
@@ -108,16 +108,16 @@ fn test_archive_captures_board_from_column() {
 #[test]
 fn test_archive_batch_captures_each_cards_own_board() {
     let tc = TestContext::new();
-    let mut board_a = kanban_domain::Board::new("A", Some("AAA"));
+    let board_a = kanban_domain::Board::new("A", Some("AAA"));
     let board_a_id = board_a.id;
     let col_a = kanban_domain::Column::new(board_a_id, "Col", 0);
-    let card_a = kanban_domain::Card::new(&mut board_a, col_a.id, "CardA", 0);
+    let card_a = kanban_domain::Card::new(board_a.id, col_a.id, "CardA", 0);
     let card_a_id = card_a.id;
 
-    let mut board_b = kanban_domain::Board::new("B", Some("BBB"));
+    let board_b = kanban_domain::Board::new("B", Some("BBB"));
     let board_b_id = board_b.id;
     let col_b = kanban_domain::Column::new(board_b_id, "Col", 0);
-    let card_b = kanban_domain::Card::new(&mut board_b, col_b.id, "CardB", 0);
+    let card_b = kanban_domain::Card::new(board_b.id, col_b.id, "CardB", 0);
     let card_b_id = card_b.id;
 
     tc.store.upsert_board(board_a).unwrap();
@@ -146,7 +146,7 @@ fn test_archive_with_corrupted_board_id_captures_nil_board_id() {
     // Since KAN-963, ArchiveCards reads card.board_id directly (a durable
     // field set at creation and kept in sync on every move) rather than
     // deriving it via a column lookup, so a dangling column_id alone no
-    // longer affects board_id resolution -- Card::new(&mut board, ..) always
+    // longer affects board_id resolution -- Card::new(board.id, ..) always
     // sets a valid board_id regardless of column_id. The only way archive
     // still sees a nil board_id is genuinely corrupted/legacy data where the
     // card's OWN board_id is nil (e.g. imported pre-migration data), which a
@@ -188,11 +188,11 @@ fn test_archive_with_corrupted_board_id_captures_nil_board_id() {
 #[test]
 fn test_archive_card_after_column_deleted_preserves_board_id() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
@@ -219,11 +219,11 @@ fn test_archive_card_after_column_deleted_preserves_board_id() {
 #[test]
 fn test_double_archive_after_column_deleted_does_not_clobber_board_id() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
@@ -262,11 +262,11 @@ fn test_double_archive_of_already_archived_card_preserves_archived_at() {
     // timing to distinguish it from whatever a second archive's `Utc::now()`
     // would otherwise produce.
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
@@ -304,8 +304,8 @@ fn test_double_archive_of_already_archived_card_preserves_archived_at() {
 #[test]
 fn test_archive_cards_missing_card_after_filter_returns_error() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
-    let card = kanban_domain::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
+    let board = kanban_domain::Board::new("Test", Some("TST"));
+    let card = kanban_domain::Card::new(board.id, Uuid::new_v4(), "Card", 0);
     let card_id = card.id;
     tc.store.upsert_card(card).unwrap();
 

--- a/crates/kanban-domain/tests/card_create.rs
+++ b/crates/kanban-domain/tests/card_create.rs
@@ -106,11 +106,11 @@ fn test_create_card_board_not_found_returns_error() {
 #[test]
 fn test_create_card_exceeding_wip_limit_returns_error() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let mut column = kanban_domain::Column::new(board.id, "Limited", 0);
     column.wip_limit = Some(1);
     let column_id = column.id;
-    let existing = kanban_domain::Card::new(&mut board, column_id, "Existing", 0);
+    let existing = kanban_domain::Card::new(board.id, column_id, "Existing", 0);
     let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(column).unwrap();
@@ -134,12 +134,12 @@ fn test_create_card_exceeding_wip_limit_returns_error() {
 #[test]
 fn test_create_card_at_wip_limit_returns_error() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let mut column = kanban_domain::Column::new(board.id, "Limited", 0);
     column.wip_limit = Some(2);
     let column_id = column.id;
-    let card1 = kanban_domain::Card::new(&mut board, column_id, "C1", 0);
-    let card2 = kanban_domain::Card::new(&mut board, column_id, "C2", 1);
+    let card1 = kanban_domain::Card::new(board.id, column_id, "C1", 0);
+    let card2 = kanban_domain::Card::new(board.id, column_id, "C2", 1);
     let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(column).unwrap();
@@ -164,11 +164,11 @@ fn test_create_card_at_wip_limit_returns_error() {
 #[test]
 fn test_create_card_below_wip_limit_succeeds() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let mut column = kanban_domain::Column::new(board.id, "Limited", 0);
     column.wip_limit = Some(2);
     let column_id = column.id;
-    let card1 = kanban_domain::Card::new(&mut board, column_id, "C1", 0);
+    let card1 = kanban_domain::Card::new(board.id, column_id, "C1", 0);
     let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(column).unwrap();

--- a/crates/kanban-domain/tests/card_positioning.rs
+++ b/crates/kanban-domain/tests/card_positioning.rs
@@ -24,8 +24,8 @@ fn test_move_card_not_found_returns_error() {
 #[test]
 fn test_move_card_column_not_found_returns_error() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
-    let card = kanban_domain::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
+    let board = kanban_domain::Board::new("Test", Some("TST"));
+    let card = kanban_domain::Card::new(board.id, Uuid::new_v4(), "Card", 0);
     let card_id = card.id;
     tc.store.upsert_card(card).unwrap();
     let context = tc.as_command_context();
@@ -41,13 +41,13 @@ fn test_move_card_column_not_found_returns_error() {
 #[test]
 fn test_move_card_exceeding_wip_limit_returns_error() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let src_col = kanban_domain::Column::new(board.id, "Source", 0);
     let mut dst_col = kanban_domain::Column::new(board.id, "Dest", 1);
     dst_col.wip_limit = Some(1);
     let dst_id = dst_col.id;
-    let existing = kanban_domain::Card::new(&mut board, dst_id, "Existing", 0);
-    let mover = kanban_domain::Card::new(&mut board, src_col.id, "Mover", 0);
+    let existing = kanban_domain::Card::new(board.id, dst_id, "Existing", 0);
+    let mover = kanban_domain::Card::new(board.id, src_col.id, "Mover", 0);
     let mover_id = mover.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(src_col).unwrap();
@@ -68,10 +68,10 @@ fn test_move_card_exceeding_wip_limit_returns_error() {
 #[test]
 fn test_move_card_updates_board_id_on_cross_board_move() {
     let tc = TestContext::new();
-    let mut board_a = kanban_domain::Board::new("A", Some("AAA"));
+    let board_a = kanban_domain::Board::new("A", Some("AAA"));
     let board_a_id = board_a.id;
     let col_a = kanban_domain::Column::new(board_a_id, "Col", 0);
-    let card = kanban_domain::Card::new(&mut board_a, col_a.id, "Card", 0);
+    let card = kanban_domain::Card::new(board_a.id, col_a.id, "Card", 0);
     let card_id = card.id;
 
     let board_b = kanban_domain::Board::new("B", Some("BBB"));
@@ -105,12 +105,12 @@ fn test_move_card_updates_board_id_on_cross_board_move() {
 #[test]
 fn test_compact_column_positions_makes_sequential() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let column_id = col.id;
-    let mut card1 = kanban_domain::Card::new(&mut board, column_id, "C1", 0);
+    let mut card1 = kanban_domain::Card::new(board.id, column_id, "C1", 0);
     card1.position = 0;
-    let mut card2 = kanban_domain::Card::new(&mut board, column_id, "C2", 5);
+    let mut card2 = kanban_domain::Card::new(board.id, column_id, "C2", 5);
     card2.position = 5;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();

--- a/crates/kanban-domain/tests/card_restore.rs
+++ b/crates/kanban-domain/tests/card_restore.rs
@@ -10,10 +10,10 @@ use uuid::Uuid;
 #[test]
 fn test_restore_card_to_deleted_column_returns_error() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 0);
     let card_id = card.id;
     let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
@@ -37,10 +37,10 @@ fn test_restore_card_to_deleted_column_returns_error() {
 #[test]
 fn test_restore_card_to_valid_column_succeeds() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 0);
     let card_id = card.id;
     let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
@@ -65,11 +65,11 @@ fn test_restore_card_to_valid_column_succeeds() {
 #[test]
 fn test_restore_card_preserves_board_id() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
@@ -102,10 +102,10 @@ fn test_restore_card_to_column_on_different_board_updates_board_id() {
     // board, so board_id must stay in sync with wherever it actually lands,
     // mirroring MoveCard.
     let tc = TestContext::new();
-    let mut board_a = kanban_domain::Board::new("A", Some("AAA"));
+    let board_a = kanban_domain::Board::new("A", Some("AAA"));
     let board_a_id = board_a.id;
     let col_a = kanban_domain::Column::new(board_a_id, "Col", 0);
-    let card = kanban_domain::Card::new(&mut board_a, col_a.id, "Card", 0);
+    let card = kanban_domain::Card::new(board_a.id, col_a.id, "Card", 0);
     let card_id = card.id;
 
     let board_b = kanban_domain::Board::new("B", Some("BBB"));
@@ -142,12 +142,12 @@ fn test_restore_card_to_column_on_different_board_updates_board_id() {
 #[test]
 fn test_restore_card_exceeding_wip_limit_returns_error() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
+    let board = kanban_domain::Board::new("Test", Some("TST"));
     let mut col = kanban_domain::Column::new(board.id, "Col", 0);
     col.wip_limit = Some(1);
     let col_id = col.id;
-    let existing = kanban_domain::Card::new(&mut board, col_id, "Existing", 0);
-    let card = kanban_domain::Card::new(&mut board, col_id, "Card", 1);
+    let existing = kanban_domain::Card::new(board.id, col_id, "Existing", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "Card", 1);
     let card_id = card.id;
     let board_id = board.id;
     tc.store.upsert_board(board).unwrap();
@@ -192,8 +192,8 @@ fn test_restore_card_uses_embedded_timestamp() {
     let column_id = col.id;
     tc.store.upsert_column(col).unwrap();
 
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
-    let card = kanban_domain::Card::new(&mut board, column_id, "Card", 0);
+    let board = kanban_domain::Board::new("B", Some("TST"));
+    let card = kanban_domain::Card::new(board.id, column_id, "Card", 0);
     let card_id = card.id;
     let board_id = board.id;
     tc.store.upsert_card(card).unwrap();

--- a/crates/kanban-domain/tests/card_sprint_binding.rs
+++ b/crates/kanban-domain/tests/card_sprint_binding.rs
@@ -9,8 +9,8 @@ use kanban_domain::*;
 #[test]
 fn test_assign_cards_to_sprint_validates_sprint_exists() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
-    let card = kanban_domain::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
+    let board = kanban_domain::Board::new("Test", Some("TST"));
+    let card = kanban_domain::Card::new(board.id, Uuid::new_v4(), "Card", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_card(card).unwrap();
@@ -27,8 +27,8 @@ fn test_assign_cards_to_sprint_validates_sprint_exists() {
 #[test]
 fn test_assign_cards_to_sprint_invalid_ids_skipped_valid_ids_assigned() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("Test", Some("TST"));
-    let card = kanban_domain::Card::new(&mut board, Uuid::new_v4(), "Card", 0);
+    let board = kanban_domain::Board::new("Test", Some("TST"));
+    let card = kanban_domain::Card::new(board.id, Uuid::new_v4(), "Card", 0);
     let valid_id = card.id;
     let sprint = kanban_domain::Sprint::new(board.id, 1, None, Some("Sprint"));
     let sprint_id = sprint.id;
@@ -64,9 +64,9 @@ fn test_unassign_card_from_sprint_uses_embedded_timestamp() {
     use chrono::{TimeZone, Utc};
 
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
-    let mut card = kanban_domain::Card::new(&mut board, col.id, "Card", 0);
+    let mut card = kanban_domain::Card::new(board.id, col.id, "Card", 0);
     let card_id = card.id;
     card.sprint_id = Some(Uuid::new_v4());
     tc.store.upsert_card(card).unwrap();

--- a/crates/kanban-domain/tests/cascade_commands.rs
+++ b/crates/kanban-domain/tests/cascade_commands.rs
@@ -55,13 +55,13 @@ fn test_delete_card_edges_with_empty_input_is_noop() {
 #[test]
 fn test_delete_cards_by_columns_removes_only_cards_in_given_columns() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let col1 = kanban_domain::Column::new(board.id, "C1", 0);
     let col2 = kanban_domain::Column::new(board.id, "C2", 1);
     let col3 = kanban_domain::Column::new(board.id, "C3", 2);
-    let card1 = kanban_domain::Card::new(&mut board, col1.id, "1", 0);
-    let card2 = kanban_domain::Card::new(&mut board, col2.id, "2", 0);
-    let card3 = kanban_domain::Card::new(&mut board, col3.id, "3", 0);
+    let card1 = kanban_domain::Card::new(board.id, col1.id, "1", 0);
+    let card2 = kanban_domain::Card::new(board.id, col2.id, "2", 0);
+    let card3 = kanban_domain::Card::new(board.id, col3.id, "3", 0);
     let card3_id = card3.id;
     let col3_id = col3.id;
     tc.store.upsert_board(board).unwrap();
@@ -89,13 +89,13 @@ fn test_delete_archived_cards_removes_only_listed_ids_ignoring_columns() {
     // Board-scoped id list must delete archived records even when their
     // `original_column_id` dangles (column already gone).
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let board_id = board.id;
     let dangling_col = Uuid::new_v4();
     let live_col = kanban_domain::Column::new(board_id, "Live", 0);
-    let card1 = kanban_domain::Card::new(&mut board, dangling_col, "1", 0);
-    let card2 = kanban_domain::Card::new(&mut board, live_col.id, "2", 0);
-    let keep = kanban_domain::Card::new(&mut board, live_col.id, "keep", 1);
+    let card1 = kanban_domain::Card::new(board.id, dangling_col, "1", 0);
+    let card2 = kanban_domain::Card::new(board.id, live_col.id, "2", 0);
+    let keep = kanban_domain::Card::new(board.id, live_col.id, "keep", 1);
     let arch1_id = card1.id;
     let arch2_id = card2.id;
     let keep_id = keep.id;

--- a/crates/kanban-domain/tests/column_commands.rs
+++ b/crates/kanban-domain/tests/column_commands.rs
@@ -49,11 +49,11 @@ fn test_delete_column_with_archived_cards_now_succeeds() {
     // is historical (not a live FK), so a column that only holds archived
     // cards can be deleted. Board-scoped cleanup handles the archived record.
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "C", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "archived", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "archived", 0);
     let card_id = card.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();

--- a/crates/kanban-domain/tests/commands_mod.rs
+++ b/crates/kanban-domain/tests/commands_mod.rs
@@ -34,10 +34,10 @@ fn test_require_column_present_returns_column() {
 #[test]
 fn test_check_wip_limit_no_limit_always_ok() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", None::<String>);
+    let board = kanban_domain::Board::new("B", None::<String>);
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "C", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "C", 0);
     tc.store.upsert_column(col).unwrap();
     tc.store.upsert_card(card).unwrap();
     let ctx = tc.as_command_context();
@@ -47,11 +47,11 @@ fn test_check_wip_limit_no_limit_always_ok() {
 #[test]
 fn test_check_wip_limit_below_limit_ok() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", None::<String>);
+    let board = kanban_domain::Board::new("B", None::<String>);
     let mut col = kanban_domain::Column::new(board.id, "Col", 0);
     col.wip_limit = Some(2);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "C", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "C", 0);
     tc.store.upsert_column(col).unwrap();
     tc.store.upsert_card(card).unwrap();
     let ctx = tc.as_command_context();
@@ -61,11 +61,11 @@ fn test_check_wip_limit_below_limit_ok() {
 #[test]
 fn test_check_wip_limit_at_limit_returns_error() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", None::<String>);
+    let board = kanban_domain::Board::new("B", None::<String>);
     let mut col = kanban_domain::Column::new(board.id, "Col", 0);
     col.wip_limit = Some(1);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "C", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "C", 0);
     tc.store.upsert_column(col).unwrap();
     tc.store.upsert_card(card).unwrap();
     let ctx = tc.as_command_context();
@@ -76,11 +76,11 @@ fn test_check_wip_limit_at_limit_returns_error() {
 #[test]
 fn test_check_wip_limit_exclude_reduces_count() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", None::<String>);
+    let board = kanban_domain::Board::new("B", None::<String>);
     let mut col = kanban_domain::Column::new(board.id, "Col", 0);
     col.wip_limit = Some(1);
     let col_id = col.id;
-    let card = kanban_domain::Card::new(&mut board, col_id, "C", 0);
+    let card = kanban_domain::Card::new(board.id, col_id, "C", 0);
     let card_id = card.id;
     tc.store.upsert_column(col).unwrap();
     tc.store.upsert_card(card).unwrap();

--- a/crates/kanban-domain/tests/dependency_commands.rs
+++ b/crates/kanban-domain/tests/dependency_commands.rs
@@ -584,7 +584,7 @@ fn test_create_subcard_command() {
     let mut board = Board::new("Test Board", None::<String>);
     board.card_prefix = Some("TEST".to_string());
     let board_id = board.id;
-    let parent = kanban_domain::Card::new(&mut board, column_id, "Parent", 0);
+    let parent = kanban_domain::Card::new(board.id, column_id, "Parent", 0);
     let parent_id = parent.id;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_card(parent).unwrap();

--- a/crates/kanban-domain/tests/sprint_commands.rs
+++ b/crates/kanban-domain/tests/sprint_commands.rs
@@ -139,11 +139,11 @@ fn test_create_sprint_auto_consume_name_uses_name_pool() {
 #[test]
 fn test_update_sprint_card_prefix_after_cards_assigned_is_allowed_and_leaves_them_alone() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("KAN"));
+    let board = kanban_domain::Board::new("B", Some("KAN"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let sprint = kanban_domain::Sprint::new(board.id, 1, None, Some("SPR"));
     let sprint_id = sprint.id;
-    let mut card = kanban_domain::Card::new(&mut board, col.id, "C", 0);
+    let mut card = kanban_domain::Card::new(board.id, col.id, "C", 0);
     card.sprint_id = Some(sprint_id);
     card.prefix = "spr".to_string();
     let card_id = card.id;
@@ -246,13 +246,13 @@ fn test_delete_sprint_clears_sprint_from_cards_with_command_timestamp() {
     use chrono::{TimeZone, Utc};
 
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("KAN"));
+    let board = kanban_domain::Board::new("B", Some("KAN"));
     let board_id = board.id;
     let col = kanban_domain::Column::new(board_id, "Col", 0);
     let sprint = kanban_domain::Sprint::new(board_id, 1, None, None::<String>);
     let sprint_id = sprint.id;
 
-    let mut card = kanban_domain::Card::new(&mut board, col.id, "C", 0);
+    let mut card = kanban_domain::Card::new(board.id, col.id, "C", 0);
     card.sprint_id = Some(sprint_id);
     let card_id = card.id;
 

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -742,10 +742,10 @@ mod tests {
         let path = dir.path().join("arch_dedup.json");
         let jds = make_store(&path);
 
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let live = Card::new(&mut board, col_id, "Live", 0);
-        let archived = Card::new(&mut board, col_id, "Archived", 1);
+        let live = Card::new(board.id, col_id, "Live", 0);
+        let archived = Card::new(board.id, col_id, "Archived", 1);
         let archived_id = archived.id;
         jds.upsert_card(live).unwrap();
         jds.upsert_card(archived.clone()).unwrap();
@@ -791,9 +791,9 @@ mod tests {
         let path = dir.path().join("ref_model.json");
         let jds = make_store(&path);
 
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let card = Card::new(&mut board, col_id, "ToArchive", 0);
+        let card = Card::new(board.id, col_id, "ToArchive", 0);
         let card_id = card.id;
         jds.upsert_card(card.clone()).unwrap();
         jds.insert_archived_card(ArchivedCard::new(card.id, board.id))
@@ -829,9 +829,9 @@ mod tests {
         let path = dir.path().join("whole_entity.json");
         let jds = make_store(&path);
 
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let mut card = Card::new(&mut board, col_id, "Full", 3);
+        let mut card = Card::new(board.id, col_id, "Full", 3);
         card.description = Some("rich body".into());
         card.priority = kanban_domain::CardPriority::High;
         card.sprint_id = Some(Uuid::new_v4());
@@ -874,17 +874,17 @@ mod tests {
         let dir = tempdir().unwrap();
         let jds = make_store(&dir.path().join("rollback.json"));
 
-        let mut board = Board::new("Board", None::<String>);
+        let board = Board::new("Board", None::<String>);
         let col = Column::new(board.id, "Col", 0);
-        let card_a = Card::new(&mut board, col.id, "A", 0);
-        let card_b = Card::new(&mut board, col.id, "B", 1);
+        let card_a = Card::new(board.id, col.id, "A", 0);
+        let card_b = Card::new(board.id, col.id, "B", 1);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
-        let mut archived_board = Board::new("Archived board", None::<String>);
+        let archived_board = Board::new("Archived board", None::<String>);
         let archived_board_col = Column::new(archived_board.id, "AC", 0);
-        let archived_board_card = Card::new(&mut archived_board, archived_board_col.id, "AC1", 0);
+        let archived_board_card = Card::new(archived_board.id, archived_board_col.id, "AC1", 0);
 
-        let archived_card = Card::new(&mut board, col.id, "Archived", 2);
+        let archived_card = Card::new(board.id, col.id, "Archived", 2);
 
         jds.upsert_board(board.clone()).unwrap();
         jds.upsert_column(col.clone()).unwrap();
@@ -1020,17 +1020,17 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("round_trip.json");
 
-        let mut board = Board::new("Board", None::<String>);
+        let board = Board::new("Board", None::<String>);
         let col = Column::new(board.id, "Col", 0);
-        let card_a = Card::new(&mut board, col.id, "A", 0);
-        let card_b = Card::new(&mut board, col.id, "B", 1);
+        let card_a = Card::new(board.id, col.id, "A", 0);
+        let card_b = Card::new(board.id, col.id, "B", 1);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
-        let mut archived_board = Board::new("Archived board", None::<String>);
+        let archived_board = Board::new("Archived board", None::<String>);
         let archived_board_col = Column::new(archived_board.id, "AC", 0);
-        let archived_board_card = Card::new(&mut archived_board, archived_board_col.id, "AC1", 0);
+        let archived_board_card = Card::new(archived_board.id, archived_board_col.id, "AC1", 0);
 
-        let archived_card = Card::new(&mut board, col.id, "Archived", 2);
+        let archived_card = Card::new(board.id, col.id, "Archived", 2);
 
         let writer = make_store(&path);
         writer.upsert_board(board.clone()).unwrap();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/composite_indexes.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/composite_indexes.rs
@@ -44,22 +44,24 @@ fn seed_column(store: &SqliteStore, board_id: Uuid) -> Uuid {
 }
 
 async fn seed_cards_across_two_boards(store: &SqliteStore) -> (Uuid, Uuid) {
-    let mut board_a = Board::new("A", None::<String>);
+    let board_a = Board::new("A", None::<String>);
     let board_a_id = board_a.id;
     store.upsert_board(board_a.clone()).unwrap();
     let column_a = seed_column(store, board_a_id);
 
-    let mut board_b = Board::new("B", None::<String>);
+    let board_b = Board::new("B", None::<String>);
     let board_b_id = board_b.id;
     store.upsert_board(board_b.clone()).unwrap();
     let column_b = seed_column(store, board_b_id);
 
-    for _ in 0..3 {
-        let card = Card::new(&mut board_a, column_a, "card a", 0);
+    for n in 1..=3 {
+        let mut card = Card::new(board_a.id, column_a, "card a", 0);
+        card.card_number = n;
         store.upsert_card(card).unwrap();
     }
-    for _ in 0..3 {
-        let card = Card::new(&mut board_b, column_b, "card b", 0);
+    for n in 1..=3 {
+        let mut card = Card::new(board_b.id, column_b, "card b", 0);
+        card.card_number = n;
         store.upsert_card(card).unwrap();
     }
 
@@ -67,7 +69,7 @@ async fn seed_cards_across_two_boards(store: &SqliteStore) -> (Uuid, Uuid) {
 }
 
 async fn seed_cards_across_two_sprints(store: &SqliteStore) -> (Uuid, Uuid) {
-    let mut board = Board::new("S", None::<String>);
+    let board = Board::new("S", None::<String>);
     let board_id = board.id;
     store.upsert_board(board.clone()).unwrap();
     let column_id = seed_column(store, board_id);
@@ -82,7 +84,7 @@ async fn seed_cards_across_two_sprints(store: &SqliteStore) -> (Uuid, Uuid) {
 
     for sprint_id in [sprint_a_id, sprint_b_id] {
         for _ in 0..3 {
-            let mut card = Card::new(&mut board, column_id, "card", 0);
+            let mut card = Card::new(board.id, column_id, "card", 0);
             card.sprint_id = Some(sprint_id);
             store.upsert_card(card).unwrap();
         }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/entities.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/entities.rs
@@ -12,10 +12,10 @@ fn test_delete_archived_card_orphaned_cards_row_is_still_cleaned_up() {
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
 
-        let mut board = kanban_domain::Board::new("B", None::<String>);
+        let board = kanban_domain::Board::new("B", None::<String>);
         let board_id = board.id;
         let column = kanban_domain::Column::new(board.id, "Col", 0);
-        let card = kanban_domain::Card::new(&mut board, column.id, "Task", 0);
+        let card = kanban_domain::Card::new(board.id, column.id, "Task", 0);
         let card_id = card.id;
         store.upsert_board(board).unwrap();
         store.upsert_column(column).unwrap();
@@ -48,10 +48,10 @@ fn test_delete_archived_card_removes_from_cards_table() {
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
 
-        let mut board = kanban_domain::Board::new("B", None::<String>);
+        let board = kanban_domain::Board::new("B", None::<String>);
         let board_id = board.id;
         let column = kanban_domain::Column::new(board.id, "Col", 0);
-        let card = kanban_domain::Card::new(&mut board, column.id, "Task", 0);
+        let card = kanban_domain::Card::new(board.id, column.id, "Task", 0);
         let card_id = card.id;
         store.upsert_board(board).unwrap();
         store.upsert_column(column).unwrap();
@@ -91,9 +91,9 @@ fn test_empty_sprint_log_status_returns_error() {
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
 
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Col", 0);
-        let mut card = Card::new(&mut board, column.id, "Task", 0);
+        let mut card = Card::new(board.id, column.id, "Task", 0);
         store.upsert_board(board).unwrap();
         store.upsert_column(column).unwrap();
 
@@ -156,11 +156,11 @@ fn test_empty_card_title_returns_error() {
     let rt = make_rt();
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col = Column::new(board.id, "Col", 0);
         let col_id = col.id;
         // Card::new borrows &mut board -- call it before upsert_board moves board
-        let card = Card::new(&mut board, col_id, "", 0);
+        let card = Card::new(board.id, col_id, "", 0);
         store.upsert_board(board).unwrap();
         store.upsert_column(col).unwrap();
         let result = store.upsert_card(card);

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs
@@ -17,11 +17,11 @@ fn test_apply_snapshot_failure_leaves_existing_data_untouched() {
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
 
-        let mut board = Board::new("Existing", None::<String>);
+        let board = Board::new("Existing", None::<String>);
         let board_id = board.id;
         let column = Column::new(board.id, "Todo", 0);
         let existing_column_id = column.id;
-        let card = Card::new(&mut board, column.id, "Existing card", 0);
+        let card = Card::new(board.id, column.id, "Existing card", 0);
         let existing_card_id = card.id;
         store.upsert_board(board).unwrap();
         store.upsert_column(column).unwrap();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/transaction.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/transaction.rs
@@ -16,9 +16,9 @@ fn test_db_conn_without_ambient_tx_commits_multi_statement_write() {
     let rt = make_rt();
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card = Card::new(board.id, column.id, "Card", 0);
         let card_id = card.id;
 
         let card2 = card.clone();
@@ -47,9 +47,9 @@ fn test_db_conn_without_ambient_tx_rolls_back_failing_write() {
     let rt = make_rt();
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
-        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card = Card::new(board.id, column.id, "Card", 0);
         let card_id = card.id;
 
         let card2 = card.clone();
@@ -123,11 +123,11 @@ fn test_read_after_write_within_ambient_transaction_sees_the_write() {
     let rt = make_rt();
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
         store.upsert_board(board.clone()).unwrap();
         store.upsert_column(column.clone()).unwrap();
-        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card = Card::new(board.id, column.id, "Card", 0);
         let card_id = card.id;
 
         store.begin_ambient_transaction().await.unwrap();
@@ -157,16 +157,16 @@ fn test_read_after_write_within_ambient_transaction_covers_every_routed_read() {
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
 
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let board_id = board.id;
         let column = Column::new(board.id, "Todo", 0);
         let column_id = column.id;
-        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card = Card::new(board.id, column.id, "Card", 0);
         let card_id = card.id;
         // A second, non-archived card so the live-scoped list/count reads
         // below have something to observe (`card_id` is archived further
         // down, which excludes it from live-scoped queries).
-        let live_card = Card::new(&mut board, column.id, "Live card", 1);
+        let live_card = Card::new(board.id, column.id, "Live card", 1);
         let sprint = Sprint::new(board.id, 1, None, Some("SP"));
         let sprint_id = sprint.id;
         let archived_card = ArchivedCard::new(card_id, board_id);
@@ -289,11 +289,11 @@ fn test_finish_ambient_transaction_false_rolls_back_full_graph() {
     rt.block_on(async {
         let store = SqliteStore::open(&path).await.unwrap();
 
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let board_id = board.id;
         let column = Column::new(board.id, "Todo", 0);
         let column_id = column.id;
-        let card = Card::new(&mut board, column.id, "Card", 0);
+        let card = Card::new(board.id, column.id, "Card", 0);
         let card_id = card.id;
         let sprint = Sprint::new(board.id, 1, None, Some("SP"));
         let sprint_id = sprint.id;

--- a/crates/kanban-persistence-sqlite/tests/data_store.rs
+++ b/crates/kanban-persistence-sqlite/tests/data_store.rs
@@ -19,8 +19,8 @@ fn make_column(board_id: Uuid, name: &str, pos: i32) -> Column {
     Column::new(board_id, name.to_string(), pos)
 }
 
-fn make_card(board: &mut Board, column_id: Uuid, title: &str, pos: i32) -> Card {
-    Card::new(board, column_id, title.to_string(), pos)
+fn make_card(board: &Board, column_id: Uuid, title: &str, pos: i32) -> Card {
+    Card::new(board.id, column_id, title.to_string(), pos)
 }
 
 // --- Board CRUD ---
@@ -105,12 +105,12 @@ async fn test_sqlite_list_columns_by_board_filters_correctly() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_upsert_and_get_card() {
     let (store, _dir) = make_store().await;
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "Col", 0);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
 
-    let card = make_card(&mut board, col.id, "Card", 0);
+    let card = make_card(&board, col.id, "Card", 0);
     let card_id = card.id;
     store.upsert_card(card).unwrap();
 
@@ -122,7 +122,7 @@ async fn test_sqlite_upsert_and_get_card() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_list_cards_by_column() {
     let (store, _dir) = make_store().await;
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col1 = make_column(board.id, "C1", 0);
     let col2 = make_column(board.id, "C2", 1);
     store.upsert_board(board.clone()).unwrap();
@@ -130,13 +130,13 @@ async fn test_sqlite_list_cards_by_column() {
     store.upsert_column(col2.clone()).unwrap();
 
     store
-        .upsert_card(make_card(&mut board, col1.id, "Card1", 0))
+        .upsert_card(make_card(&board, col1.id, "Card1", 0))
         .unwrap();
     store
-        .upsert_card(make_card(&mut board, col1.id, "Card2", 1))
+        .upsert_card(make_card(&board, col1.id, "Card2", 1))
         .unwrap();
     store
-        .upsert_card(make_card(&mut board, col2.id, "Card3", 0))
+        .upsert_card(make_card(&board, col2.id, "Card3", 0))
         .unwrap();
 
     let cards = store.list_cards_by_column(col1.id).unwrap();
@@ -148,16 +148,16 @@ async fn test_sqlite_list_cards_by_column() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_list_cards_by_sprint() {
     let (store, _dir) = make_store().await;
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
     store.upsert_sprint(sprint.clone()).unwrap();
 
-    let mut card1 = make_card(&mut board, col.id, "Card1", 0);
+    let mut card1 = make_card(&board, col.id, "Card1", 0);
     card1.sprint_id = Some(sprint.id);
-    let card2 = make_card(&mut board, col.id, "Card2", 1);
+    let card2 = make_card(&board, col.id, "Card2", 1);
     store.upsert_card(card1).unwrap();
     store.upsert_card(card2).unwrap();
 
@@ -170,16 +170,16 @@ async fn test_sqlite_list_cards_by_sprint() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_count_cards_in_column() {
     let (store, _dir) = make_store().await;
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
 
     store
-        .upsert_card(make_card(&mut board, col.id, "C1", 0))
+        .upsert_card(make_card(&board, col.id, "C1", 0))
         .unwrap();
     store
-        .upsert_card(make_card(&mut board, col.id, "C2", 1))
+        .upsert_card(make_card(&board, col.id, "C2", 1))
         .unwrap();
 
     assert_eq!(store.count_cards_in_column(col.id).unwrap(), 2);
@@ -189,16 +189,16 @@ async fn test_sqlite_count_cards_in_column() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_count_cards_in_column_excluding() {
     let (store, _dir) = make_store().await;
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
 
-    let card1 = make_card(&mut board, col.id, "C1", 0);
+    let card1 = make_card(&board, col.id, "C1", 0);
     let card1_id = card1.id;
     store.upsert_card(card1).unwrap();
     store
-        .upsert_card(make_card(&mut board, col.id, "C2", 1))
+        .upsert_card(make_card(&board, col.id, "C2", 1))
         .unwrap();
 
     let count = store
@@ -211,14 +211,14 @@ async fn test_sqlite_count_cards_in_column_excluding() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_clear_sprint_from_cards() {
     let (store, _dir) = make_store().await;
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
     store.upsert_sprint(sprint.clone()).unwrap();
 
-    let mut card1 = make_card(&mut board, col.id, "C1", 0);
+    let mut card1 = make_card(&board, col.id, "C1", 0);
     card1.sprint_id = Some(sprint.id);
     let card1_id = card1.id;
     store.upsert_card(card1).unwrap();
@@ -279,13 +279,13 @@ async fn test_sqlite_list_sprints_by_board() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_insert_and_get_archived_card() {
     let (store, _dir) = make_store().await;
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
 
     let board_id = board.id;
-    let card = make_card(&mut board, col.id, "Card", 0);
+    let card = make_card(&board, col.id, "Card", 0);
     let card_id = card.id;
     store.upsert_card(card).unwrap();
     let ac = ArchivedCard::new(card_id, board_id);
@@ -322,13 +322,13 @@ async fn test_sqlite_set_and_get_graph() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_snapshot_roundtrip() {
     let (store, _dir) = make_store().await;
-    let mut board = make_board("B");
+    let board = make_board("B");
     let col = make_column(board.id, "C", 0);
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
     store.upsert_board(board.clone()).unwrap();
     store.upsert_column(col.clone()).unwrap();
     store.upsert_sprint(sprint.clone()).unwrap();
-    let card = make_card(&mut board, col.id, "Card", 0);
+    let card = make_card(&board, col.id, "Card", 0);
     store.upsert_card(card).unwrap();
 
     let snap = store.snapshot().unwrap();

--- a/crates/kanban-persistence-sqlite/tests/with_transaction.rs
+++ b/crates/kanban-persistence-sqlite/tests/with_transaction.rs
@@ -13,11 +13,11 @@ async fn test_with_transaction_commits_full_graph_via_real_db_transaction() {
     let path = dir.path().join("t.sqlite3");
     let backend = open(&path).await;
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let board_id = board.id;
     let column = Column::new(board.id, "Todo", 0);
     let column_id = column.id;
-    let card = Card::new(&mut board, column.id, "Card", 0);
+    let card = Card::new(board.id, column.id, "Card", 0);
     let card_id = card.id;
     let sprint = Sprint::new(board.id, 1, None, Some("SP"));
     let sprint_id = sprint.id;
@@ -59,10 +59,10 @@ async fn test_with_transaction_rolls_back_full_graph_via_db_not_snapshot_restore
     let path = dir.path().join("t.sqlite3");
     let backend = open(&path).await;
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let board_id = board.id;
     let column = Column::new(board.id, "Todo", 0);
-    let card = Card::new(&mut board, column.id, "Card", 0);
+    let card = Card::new(board.id, column.id, "Card", 0);
     let card_id = card.id;
     let sprint = Sprint::new(board.id, 1, None, Some("SP"));
     let sprint_id = sprint.id;
@@ -79,7 +79,7 @@ async fn test_with_transaction_rolls_back_full_graph_via_db_not_snapshot_restore
     let second_sprint_id = uuid::Uuid::new_v4();
 
     let result: KanbanResult<()> = backend.with_transaction(Box::new(|| {
-        let mut new_card = Card::new(&mut board.clone(), column.id, "Second", 1);
+        let mut new_card = Card::new(board.id, column.id, "Second", 1);
         new_card.id = second_card_id;
         backend.upsert_card(new_card)?;
         let mut new_sprint = Sprint::new(board.id, 2, None, Some("SP"));
@@ -123,9 +123,9 @@ async fn test_with_transaction_delete_path_rolls_back() {
     let path = dir.path().join("t.sqlite3");
     let backend = open(&path).await;
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let card = Card::new(&mut board, column.id, "Card", 0);
+    let card = Card::new(board.id, column.id, "Card", 0);
     let card_id = card.id;
     backend.upsert_board(board).unwrap();
     backend.upsert_column(column).unwrap();

--- a/crates/kanban-persistence/tests/snapshot_serde_archived_marker.rs
+++ b/crates/kanban-persistence/tests/snapshot_serde_archived_marker.rs
@@ -16,10 +16,10 @@ fn test_snapshot_serde_carries_archived_card_as_live_plus_marker() {
     // single source of truth in `cards`. `archived_cards` holds a pure marker
     // (`entity_id` references the card in `cards`); nothing is embedded.
     let store = InMemoryStore::new();
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let col_id = Uuid::new_v4();
-    let live = Card::new(&mut board, col_id, "Live", 0);
-    let archived = Card::new(&mut board, col_id, "Archived", 1);
+    let live = Card::new(board.id, col_id, "Live", 0);
+    let archived = Card::new(board.id, col_id, "Archived", 1);
     let archived_id = archived.id;
     store.upsert_card(live).unwrap();
     store.upsert_card(archived.clone()).unwrap();

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -257,16 +257,16 @@ mod tests {
     /// A live board with a column, two linked cards, a sprint and an archived
     /// card, PLUS a separately archived board carrying its own whole subtree.
     fn seed(store: &InMemoryStore) -> KanbanResult<Seeded> {
-        let mut live = Board::new("Live", None::<String>);
+        let live = Board::new("Live", None::<String>);
         let live_column = Column::new(live.id, "Todo", 0);
-        let blocker = Card::new(&mut live, live_column.id, "Blocker", 0);
-        let blocked = Card::new(&mut live, live_column.id, "Blocked", 1);
-        let archived_card = Card::new(&mut live, live_column.id, "Archived card", 2);
+        let blocker = Card::new(live.id, live_column.id, "Blocker", 0);
+        let blocked = Card::new(live.id, live_column.id, "Blocked", 1);
+        let archived_card = Card::new(live.id, live_column.id, "Archived card", 2);
         let live_sprint = Sprint::new(live.id, 1, None, None::<String>);
 
-        let mut arch = Board::new("Archived board", None::<String>);
+        let arch = Board::new("Archived board", None::<String>);
         let arch_column = Column::new(arch.id, "Done", 0);
-        let arch_card = Card::new(&mut arch, arch_column.id, "Card on archived board", 0);
+        let arch_card = Card::new(arch.id, arch_column.id, "Card on archived board", 0);
         let arch_sprint = Sprint::new(arch.id, 1, None, None::<String>);
 
         let ids = Seeded {

--- a/crates/kanban-service/tests/card_graph.rs
+++ b/crates/kanban-service/tests/card_graph.rs
@@ -39,12 +39,12 @@ async fn open_sqlite_ctx() -> (KanbanContext, tempfile::TempDir) {
 /// Seed a board with a single column and three cards. Returns the card ids
 /// for use as graph nodes in tests.
 fn seed_three_cards(backend: &Arc<dyn KanbanBackend>) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid) {
-    let mut board = Board::new("Test", Some("TST"));
+    let board = Board::new("Test", Some("TST"));
     let col = Column::new(board.id, "TODO", 0);
     let col_id = col.id;
-    let a = Card::new(&mut board, col_id, "A", 0);
-    let b = Card::new(&mut board, col_id, "B", 1);
-    let c = Card::new(&mut board, col_id, "C", 2);
+    let a = Card::new(board.id, col_id, "A", 0);
+    let b = Card::new(board.id, col_id, "B", 1);
+    let c = Card::new(board.id, col_id, "C", 2);
     let (a_id, b_id, c_id) = (a.id, b.id, c.id);
     backend.upsert_board(board).unwrap();
     backend.upsert_column(col).unwrap();
@@ -201,14 +201,14 @@ fn assert_add_is_undoable(
 /// parent/child as permitted; this helper backs the tests that exercise
 /// it.
 fn seed_two_boards_one_card_each(backend: &Arc<dyn KanbanBackend>) -> (uuid::Uuid, uuid::Uuid) {
-    let mut board_a = Board::new("Board A", Some("AAA"));
+    let board_a = Board::new("Board A", Some("AAA"));
     let col_a = Column::new(board_a.id, "TODO", 0);
-    let card_a = Card::new(&mut board_a, col_a.id, "Card A", 0);
+    let card_a = Card::new(board_a.id, col_a.id, "Card A", 0);
     let card_a_id = card_a.id;
 
-    let mut board_b = Board::new("Board B", Some("BBB"));
+    let board_b = Board::new("Board B", Some("BBB"));
     let col_b = Column::new(board_b.id, "TODO", 0);
-    let card_b = Card::new(&mut board_b, col_b.id, "Card B", 0);
+    let card_b = Card::new(board_b.id, col_b.id, "Card B", 0);
     let card_b_id = card_b.id;
 
     backend.upsert_board(board_a).unwrap();

--- a/crates/kanban-service/tests/data_integrity_tests.rs
+++ b/crates/kanban-service/tests/data_integrity_tests.rs
@@ -168,9 +168,8 @@ async fn test_import_with_invalid_column_reference_fails() -> KanbanResult<()> {
     let board_id = board.id;
     let nonexistent_column_id = Uuid::new_v4();
 
-    let mut orphan_board = board.clone();
-    let orphan_card =
-        kanban_domain::Card::new(&mut orphan_board, nonexistent_column_id, "Orphan", 0);
+    let orphan_board = board.clone();
+    let orphan_card = kanban_domain::Card::new(orphan_board.id, nonexistent_column_id, "Orphan", 0);
 
     let snapshot = kanban_domain::Snapshot {
         archived_boards: Vec::new(),
@@ -213,11 +212,11 @@ async fn test_import_with_invalid_column_reference_fails() -> KanbanResult<()> {
 async fn test_import_backfills_board_id_on_legacy_archived_card() -> KanbanResult<()> {
     let (mut ctx, _dir) = open_json_ctx().await;
 
-    let mut board = kanban_domain::Board::new("Imported", Some("IMP"));
+    let board = kanban_domain::Board::new("Imported", Some("IMP"));
     let board_id = board.id;
     let column = kanban_domain::Column::new(board_id, "Todo", 0);
     let column_id = column.id;
-    let card = kanban_domain::Card::new(&mut board, column_id, "Archived", 0);
+    let card = kanban_domain::Card::new(board.id, column_id, "Archived", 0);
     let card_id = card.id;
     // Reference-marker model: the archived record is a pure marker over a LIVE
     // card (referenced by `entity_id`). Constructed with nil board_id, then its

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -46,12 +46,12 @@ macro_rules! cascade_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let board_id = board.id;
                 let col1 = Column::new(board_id, "Col1", 0);
                 let col2 = Column::new(board_id, "Col2", 1);
-                let card1 = Card::new(&mut board, col1.id, "C1", 0);
-                let card2 = Card::new(&mut board, col2.id, "C2", 0);
+                let card1 = Card::new(board.id, col1.id, "C1", 0);
+                let card2 = Card::new(board.id, col2.id, "C2", 0);
                 let sprint = Sprint::new(board_id, 1, None, None::<String>);
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col1).unwrap();
@@ -73,11 +73,11 @@ macro_rules! cascade_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let board_id = board.id;
                 let col = Column::new(board_id, "Col", 0);
-                let card_a = Card::new(&mut board, col.id, "A", 0);
-                let card_b = Card::new(&mut board, col.id, "B", 1);
+                let card_a = Card::new(board.id, col.id, "A", 0);
+                let card_b = Card::new(board.id, col.id, "B", 1);
                 let card_a_id = card_a.id;
                 let card_b_id = card_b.id;
                 backend.upsert_board(board).unwrap();
@@ -104,11 +104,11 @@ macro_rules! cascade_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let board_id = board.id;
                 let col = Column::new(board_id, "Col", 0);
                 let col_id = col.id;
-                let card = Card::new(&mut board, col_id, "C", 0);
+                let card = Card::new(board.id, col_id, "C", 0);
                 let card_id = card.id;
                 // Reference-marker model: the marker references a LIVE card by id
                 // (FK `archived_cards.card_id -> cards.id`), so the card row must
@@ -149,8 +149,8 @@ macro_rules! cascade_tests {
                 backend.set_graph(graph).unwrap();
 
                 // An archived card in the same column.
-                let mut arch_board = board.clone();
-                let arch_card = Card::new(&mut arch_board, column.id, "C", 2);
+                let arch_board = board.clone();
+                let arch_card = Card::new(arch_board.id, column.id, "C", 2);
                 let arch_card_id = arch_card.id;
                 // The marker references the live card by id, so seed the live row
                 // first, then the marker over it.

--- a/crates/kanban-service/tests/export_to_sqlite_tests.rs
+++ b/crates/kanban-service/tests/export_to_sqlite_tests.rs
@@ -82,14 +82,14 @@ async fn test_export_to_sqlite_preserves_full_archival_graph() {
 
     // A live board with a column, cards, a sprint and an archived card, plus a
     // separately archived board carrying its own subtree.
-    let mut live = Board::new("Live", None::<String>);
+    let live = Board::new("Live", None::<String>);
     let live_col = Column::new(live.id, "Todo", 0);
-    let card = Card::new(&mut live, live_col.id, "Card", 0);
-    let archived_card = Card::new(&mut live, live_col.id, "Archived", 1);
+    let card = Card::new(live.id, live_col.id, "Card", 0);
+    let archived_card = Card::new(live.id, live_col.id, "Archived", 1);
     let sprint = Sprint::new(live.id, 1, None, None::<String>);
-    let mut arch = Board::new("Archived board", None::<String>);
+    let arch = Board::new("Archived board", None::<String>);
     let arch_col = Column::new(arch.id, "Done", 0);
-    let arch_card = Card::new(&mut arch, arch_col.id, "On archived board", 0);
+    let arch_card = Card::new(arch.id, arch_col.id, "On archived board", 0);
 
     let (live_id, live_col_id, card_id, archived_card_id, sprint_id) =
         (live.id, live_col.id, card.id, archived_card.id, sprint.id);

--- a/crates/kanban-service/tests/migrate.rs
+++ b/crates/kanban-service/tests/migrate.rs
@@ -277,16 +277,16 @@ struct Graph {
 async fn seed_graph(locator: &str) -> Graph {
     let backend = open_backend(locator).await;
 
-    let mut live = Board::new("Live", None::<String>);
+    let live = Board::new("Live", None::<String>);
     let live_column = Column::new(live.id, "Todo", 0);
-    let blocker = Card::new(&mut live, live_column.id, "Blocker", 0);
-    let blocked = Card::new(&mut live, live_column.id, "Blocked", 1);
-    let archived_card = Card::new(&mut live, live_column.id, "Archived", 2);
+    let blocker = Card::new(live.id, live_column.id, "Blocker", 0);
+    let blocked = Card::new(live.id, live_column.id, "Blocked", 1);
+    let archived_card = Card::new(live.id, live_column.id, "Archived", 2);
     let live_sprint = Sprint::new(live.id, 1, None, None::<String>);
 
-    let mut arch = Board::new("Archived board", None::<String>);
+    let arch = Board::new("Archived board", None::<String>);
     let arch_column = Column::new(arch.id, "Done", 0);
-    let arch_card = Card::new(&mut arch, arch_column.id, "On archived board", 0);
+    let arch_card = Card::new(arch.id, arch_column.id, "On archived board", 0);
     let arch_sprint = Sprint::new(arch.id, 1, None, None::<String>);
 
     let g = Graph {
@@ -512,10 +512,10 @@ async fn test_migrate_preserves_a_card_assigned_to_a_sprint() {
     let (from, to) = (from.to_str().unwrap(), to.to_str().unwrap());
 
     let backend = open_backend(from).await;
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
-    let mut card = Card::new(&mut board, column.id, "In a sprint", 0);
+    let mut card = Card::new(board.id, column.id, "In a sprint", 0);
     card.sprint_id = Some(sprint.id);
     let (card_id, sprint_id) = (card.id, sprint.id);
 
@@ -550,10 +550,10 @@ async fn test_migrate_preserves_a_card_whose_column_is_gone() {
     let (from, to) = (from.to_str().unwrap(), to.to_str().unwrap());
 
     let backend = open_backend(from).await;
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let survivor = Column::new(board.id, "Survivor", 0);
     let doomed = Column::new(board.id, "Doomed", 1);
-    let card = Card::new(&mut board, doomed.id, "Outlives its column", 0);
+    let card = Card::new(board.id, doomed.id, "Outlives its column", 0);
     let (doomed_id, card_id) = (doomed.id, card.id);
 
     backend.upsert_board(board).unwrap();

--- a/crates/kanban-service/tests/migrate_sprint_logs.rs
+++ b/crates/kanban-service/tests/migrate_sprint_logs.rs
@@ -43,11 +43,11 @@ macro_rules! migrate_sprint_logs_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col = Column::new(board.id, "Col", 0);
                 let sprint = Sprint::new(board.id, 1, None, Some("Alpha"));
                 let sprint_id = sprint.id;
-                let mut card = Card::new(&mut board, col.id, "Card", 0);
+                let mut card = Card::new(board.id, col.id, "Card", 0);
                 let card_id = card.id;
                 card.sprint_id = Some(sprint_id);
                 assert!(card.sprint_logs.is_empty());
@@ -73,9 +73,9 @@ macro_rules! migrate_sprint_logs_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col = Column::new(board.id, "Col", 0);
-                let card = Card::new(&mut board, col.id, "Card", 0);
+                let card = Card::new(board.id, col.id, "Card", 0);
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col).unwrap();
                 backend.upsert_card(card).unwrap();
@@ -98,16 +98,16 @@ macro_rules! migrate_sprint_logs_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col = Column::new(board.id, "Col", 0);
                 let sprint = Sprint::new(board.id, 1, None, Some("Alpha"));
                 let sprint_id = sprint.id;
 
-                let mut card_needs_backfill = Card::new(&mut board, col.id, "Needs Backfill", 0);
+                let mut card_needs_backfill = Card::new(board.id, col.id, "Needs Backfill", 0);
                 card_needs_backfill.sprint_id = Some(sprint_id);
                 let needs_backfill_id = card_needs_backfill.id;
 
-                let mut card_already_logged = Card::new(&mut board, col.id, "Already Logged", 1);
+                let mut card_already_logged = Card::new(board.id, col.id, "Already Logged", 1);
                 card_already_logged.sprint_id = Some(sprint_id);
                 card_already_logged
                     .sprint_logs
@@ -120,7 +120,7 @@ macro_rules! migrate_sprint_logs_tests {
                 let already_logged_id = card_already_logged.id;
                 let already_logged_before = card_already_logged.sprint_logs.clone();
 
-                let card_no_sprint = Card::new(&mut board, col.id, "No Sprint", 2);
+                let card_no_sprint = Card::new(board.id, col.id, "No Sprint", 2);
                 let no_sprint_id = card_no_sprint.id;
 
                 backend.upsert_board(board).unwrap();

--- a/crates/kanban-service/tests/move_cards.rs
+++ b/crates/kanban-service/tests/move_cards.rs
@@ -44,15 +44,15 @@ macro_rules! move_cards_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col_from = Column::new(board.id, "From", 0);
                 let col_to = Column::new(board.id, "To", 1);
                 let col_to_id = col_to.id;
 
-                let existing1 = Card::new(&mut board, col_to_id, "E1", 0);
-                let existing2 = Card::new(&mut board, col_to_id, "E2", 1);
-                let move1 = Card::new(&mut board, col_from.id, "M1", 0);
-                let move2 = Card::new(&mut board, col_from.id, "M2", 1);
+                let existing1 = Card::new(board.id, col_to_id, "E1", 0);
+                let existing2 = Card::new(board.id, col_to_id, "E2", 1);
+                let move1 = Card::new(board.id, col_from.id, "M1", 0);
+                let move2 = Card::new(board.id, col_from.id, "M2", 1);
                 let move1_id = move1.id;
                 let move2_id = move2.id;
                 backend.upsert_board(board).unwrap();
@@ -78,12 +78,12 @@ macro_rules! move_cards_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col = Column::new(board.id, "Col", 0);
                 let col_id = col.id;
-                let card1 = Card::new(&mut board, col_id, "C1", 0);
-                let card2 = Card::new(&mut board, col_id, "C2", 1);
-                let card3 = Card::new(&mut board, col_id, "C3", 2);
+                let card1 = Card::new(board.id, col_id, "C1", 0);
+                let card2 = Card::new(board.id, col_id, "C2", 1);
+                let card3 = Card::new(board.id, col_id, "C3", 2);
                 let c1_id = card1.id;
                 let c3_id = card3.id;
                 backend.upsert_board(board).unwrap();
@@ -147,11 +147,11 @@ macro_rules! move_cards_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col_from = Column::new(board.id, "From", 0);
                 let col_to = Column::new(board.id, "To", 1);
                 let col_to_id = col_to.id;
-                let card = Card::new(&mut board, col_from.id, "C", 0);
+                let card = Card::new(board.id, col_from.id, "C", 0);
                 let valid_id = card.id;
                 let invalid_id = uuid::Uuid::new_v4();
                 backend.upsert_board(board).unwrap();

--- a/crates/kanban-service/tests/restore_card_deleted_column.rs
+++ b/crates/kanban-service/tests/restore_card_deleted_column.rs
@@ -31,10 +31,10 @@ async fn open_sqlite_ctx() -> (KanbanContext, tempfile::TempDir) {
 }
 
 fn seed_board_column_card(backend: Arc<dyn KanbanBackend>) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid) {
-    let mut board = Board::new("Test", Some("TST"));
+    let board = Board::new("Test", Some("TST"));
     let col = Column::new(board.id, "TODO", 0);
     let col_id = col.id;
-    let card = Card::new(&mut board, col_id, "Test Card", 0);
+    let card = Card::new(board.id, col_id, "Test Card", 0);
     let card_id = card.id;
     let board_id = board.id;
     backend.upsert_board(board).unwrap();

--- a/crates/kanban-service/tests/update_cards_position.rs
+++ b/crates/kanban-service/tests/update_cards_position.rs
@@ -45,14 +45,14 @@ macro_rules! update_cards_position_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col_from = Column::new(board.id, "From", 0);
                 let col_to = Column::new(board.id, "To", 1);
                 let col_from_id = col_from.id;
                 let col_to_id = col_to.id;
 
-                let existing = Card::new(&mut board, col_to_id, "Existing", 0);
-                let moving = Card::new(&mut board, col_from_id, "Moving", 0);
+                let existing = Card::new(board.id, col_to_id, "Existing", 0);
+                let moving = Card::new(board.id, col_from_id, "Moving", 0);
                 let moving_id = moving.id;
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col_from).unwrap();
@@ -83,7 +83,7 @@ macro_rules! update_cards_position_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col_from = Column::new(board.id, "From", 0);
                 let col_to = Column::new(board.id, "To", 1);
                 let col_from_id = col_from.id;
@@ -92,8 +92,8 @@ macro_rules! update_cards_position_tests {
                 // Both start at the same source position so that, pre-fix, retaining
                 // the old (unrecomputed) position on both would land them on the same
                 // position in the target column too -- the collision this test pins.
-                let move1 = Card::new(&mut board, col_from_id, "M1", 0);
-                let move2 = Card::new(&mut board, col_from_id, "M2", 0);
+                let move1 = Card::new(board.id, col_from_id, "M1", 0);
+                let move2 = Card::new(board.id, col_from_id, "M2", 0);
                 let move1_id = move1.id;
                 let move2_id = move2.id;
                 backend.upsert_board(board).unwrap();
@@ -137,12 +137,12 @@ macro_rules! update_cards_position_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col = Column::new(board.id, "Col", 0);
                 let col_id = col.id;
 
-                let other = Card::new(&mut board, col_id, "Other", 0);
-                let card = Card::new(&mut board, col_id, "Card", 1);
+                let other = Card::new(board.id, col_id, "Other", 0);
+                let card = Card::new(board.id, col_id, "Card", 1);
                 let card_id = card.id;
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col).unwrap();
@@ -173,14 +173,14 @@ macro_rules! update_cards_position_tests {
                 let (mut ctx, _dir) = $open_ctx.await;
                 let backend = ctx.backend();
 
-                let mut board = Board::new("B", Some("TST"));
+                let board = Board::new("B", Some("TST"));
                 let col_from = Column::new(board.id, "From", 0);
                 let col_to = Column::new(board.id, "To", 1);
                 let col_from_id = col_from.id;
                 let col_to_id = col_to.id;
 
-                let existing = Card::new(&mut board, col_to_id, "Existing", 0);
-                let moving = Card::new(&mut board, col_from_id, "Moving", 0);
+                let existing = Card::new(board.id, col_to_id, "Existing", 0);
+                let moving = Card::new(board.id, col_from_id, "Moving", 0);
                 let moving_id = moving.id;
                 backend.upsert_board(board).unwrap();
                 backend.upsert_column(col_from).unwrap();

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -82,10 +82,10 @@ fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
 
     let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
 
-    let mut board = Board::new("Seeded", None::<String>);
+    let board = Board::new("Seeded", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let blocker = Card::new(&mut board, column.id, "Blocker", 0);
-    let blocked = Card::new(&mut board, column.id, "Blocked", 1);
+    let blocker = Card::new(board.id, column.id, "Blocker", 0);
+    let blocked = Card::new(board.id, column.id, "Blocked", 1);
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
     let (board_id, column_id) = (board.id, column.id);

--- a/crates/kanban-tui/src/components/card_list_item.rs
+++ b/crates/kanban-tui/src/components/card_list_item.rs
@@ -298,10 +298,11 @@ mod tests {
     /// for the no-sprint case.
     #[test]
     fn card_identifier_suffix_uses_the_stored_prefix() {
-        let mut board = Board::new("B".to_string(), Some("KAN"));
+        let board = Board::new("B".to_string(), Some("KAN"));
         let col = Column::new(board.id, "C".to_string(), 0);
-        let mut card = Card::new(&mut board, col.id, "t", 0);
+        let mut card = Card::new(board.id, col.id, "t", 0);
         card.card_number = 5;
+        card.prefix = "KAN".to_string();
 
         assert_eq!(card_identifier_suffix(&card, &board, &[]), " (KAN-5)");
     }
@@ -311,8 +312,9 @@ mod tests {
     fn card_identifier_suffix_does_not_follow_a_board_rename() {
         let mut board = Board::new("B".to_string(), Some("KAN"));
         let col = Column::new(board.id, "C".to_string(), 0);
-        let mut card = Card::new(&mut board, col.id, "t", 0);
+        let mut card = Card::new(board.id, col.id, "t", 0);
         card.card_number = 5;
+        card.prefix = "KAN".to_string();
 
         board.card_prefix = Some("DEV".to_string());
 
@@ -327,9 +329,9 @@ mod tests {
     /// back to derivation.
     #[test]
     fn card_identifier_suffix_falls_back_for_an_unmigrated_card() {
-        let mut board = Board::new("B".to_string(), Some("KAN"));
+        let board = Board::new("B".to_string(), Some("KAN"));
         let col = Column::new(board.id, "C".to_string(), 0);
-        let mut card = Card::new(&mut board, col.id, "t", 0);
+        let mut card = Card::new(board.id, col.id, "t", 0);
         card.card_number = 5;
         card.prefix = String::new();
 

--- a/crates/kanban-tui/src/view_strategy.rs
+++ b/crates/kanban-tui/src/view_strategy.rs
@@ -121,12 +121,15 @@ mod tests {
     /// observable behavior.
     #[test]
     fn test_unified_view_strategy_delegates_to_kanban_view_layout_strategy() {
-        let mut board = Board::new("Fixture", None::<String>);
+        let board = Board::new("Fixture", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
 
-        let card_a = Card::new(&mut board, column.id, "Card A", 0);
-        let card_b = Card::new(&mut board, column.id, "Card B", 1);
-        let card_c = Card::new(&mut board, column.id, "Card C", 2);
+        let mut card_a = Card::new(board.id, column.id, "Card A", 0);
+        card_a.card_number = 1;
+        let mut card_b = Card::new(board.id, column.id, "Card B", 1);
+        card_b.card_number = 2;
+        let mut card_c = Card::new(board.id, column.id, "Card C", 2);
+        card_c.card_number = 3;
 
         // Deliberately out of card-number order, to prove the query/sort
         // path actually runs rather than passing the input through as-is.

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -127,11 +127,11 @@ fn test_markdown_rendering_of_description() {
     use kanban_domain::{Board, Card};
     use kanban_tui::components::*;
 
-    let mut board = Board::new("Test Board", None::<String>);
+    let board = Board::new("Test Board", None::<String>);
     let column_id = uuid::Uuid::new_v4();
 
     // Test rendering of non-empty description
-    let mut card = Card::new(&mut board, column_id, "Test", 0);
+    let mut card = Card::new(board.id, column_id, "Test", 0);
     card.description = Some("# Heading\n\nSome **bold** text".to_string());
 
     let lines = build_description_lines(&card);

--- a/crates/kanban-tui/tests/card_detail_tests.rs
+++ b/crates/kanban-tui/tests/card_detail_tests.rs
@@ -6,10 +6,10 @@ use kanban_domain::{Board, Card, Column, Snapshot};
 fn test_active_card_detail_shows_selected_card() {
     let mut app = kanban_tui::App::test_default();
 
-    let mut board = Board::new("TestBoard", None::<String>);
+    let board = Board::new("TestBoard", None::<String>);
     let col = Column::new(board.id, "Backlog", 0);
-    let card_a = Card::new(&mut board, col.id, "Card Alpha", 0);
-    let card_b = Card::new(&mut board, col.id, "Card Beta", 1);
+    let card_a = Card::new(board.id, col.id, "Card Alpha", 0);
+    let card_b = Card::new(board.id, col.id, "Card Beta", 1);
 
     let card_b_id = card_b.id;
 

--- a/crates/kanban-tui/tests/conflict_detection_tests.rs
+++ b/crates/kanban-tui/tests/conflict_detection_tests.rs
@@ -12,9 +12,9 @@ async fn test_conflict_detection_on_concurrent_modification() {
     let file_path = dir.path().join("kanban.json");
 
     // Create initial data and save via first instance
-    let mut board = Board::new("Test Board", None::<String>);
+    let board = Board::new("Test Board", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let card = Card::new(&mut board, column.id, "Test Task", 0);
+    let card = Card::new(board.id, column.id, "Test Task", 0);
 
     let snapshot1 = Snapshot {
         archived_boards: Vec::new(),
@@ -82,9 +82,9 @@ async fn test_no_conflict_when_file_unchanged() {
     let file_path = dir.path().join("kanban.json");
 
     // Create and save initial data
-    let mut board = Board::new("Test Board", None::<String>);
+    let board = Board::new("Test Board", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let card = Card::new(&mut board, column.id, "Test Task", 0);
+    let card = Card::new(board.id, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
         archived_boards: Vec::new(),
@@ -119,9 +119,9 @@ async fn test_conflict_detection_tracks_file_metadata() {
     let file_path = dir.path().join("kanban.json");
 
     // Create and save initial data
-    let mut board = Board::new("Test Board", None::<String>);
+    let board = Board::new("Test Board", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let _card = Card::new(&mut board, column.id, "Test Task", 0);
+    let _card = Card::new(board.id, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
         archived_boards: Vec::new(),
@@ -179,9 +179,9 @@ async fn test_multiple_instances_with_different_ids() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
-    let mut board = Board::new("Test Board", None::<String>);
+    let board = Board::new("Test Board", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let card = Card::new(&mut board, column.id, "Test Task", 0);
+    let card = Card::new(board.id, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
         archived_boards: Vec::new(),
@@ -225,9 +225,9 @@ async fn test_conflict_resolution_with_force_overwrite() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("kanban.json");
 
-    let mut board = Board::new("Test Board", None::<String>);
+    let board = Board::new("Test Board", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let card = Card::new(&mut board, column.id, "Test Task", 0);
+    let card = Card::new(board.id, column.id, "Test Task", 0);
 
     let snapshot = Snapshot {
         archived_boards: Vec::new(),
@@ -281,12 +281,12 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let instance1_id = uuid::Uuid::new_v4();
     let store1 = JsonFileStore::with_instance_id(&file_path, instance1_id);
 
-    let mut board1 = Board::new("Shared Project", None::<String>);
+    let board1 = Board::new("Shared Project", None::<String>);
     let column1 = Column::new(board1.id, "Todo", 0);
     let column2 = Column::new(board1.id, "In Progress", 1);
 
-    let card1 = Card::new(&mut board1, column1.id, "Task A", 0);
-    let card2 = Card::new(&mut board1, column2.id, "Task B", 0);
+    let card1 = Card::new(board1.id, column1.id, "Task A", 0);
+    let card2 = Card::new(board1.id, column2.id, "Task B", 0);
 
     let snapshot1 = Snapshot {
         archived_boards: Vec::new(),
@@ -314,7 +314,7 @@ async fn test_multi_instance_concurrent_editing_3_instances() {
     let mut snapshot2: Snapshot = serde_json::from_slice(&loaded_snap.data).unwrap();
 
     let new_card = Card::new(
-        &mut snapshot2.boards[0],
+        snapshot2.boards[0].id,
         snapshot2.columns[0].id,
         "Task C (from Instance 2)",
         0,

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -87,8 +87,8 @@ async fn test_v2_format_is_imported_correctly() {
     // Create a real board
     let board = Board::new("My Project", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let mut board_mut = board.clone();
-    let card = Card::new(&mut board_mut, column.id, "Important Task", 0);
+    let board_mut = board.clone();
+    let card = Card::new(board_mut.id, column.id, "Important Task", 0);
 
     // Create snapshot with board, column, and card
     let snapshot = Snapshot {

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -24,9 +24,9 @@ async fn test_load_initial_state_with_boards_refreshes_card_view() -> KanbanResu
     let path = dir.path().join("with_cards.json");
     let path_str = path.to_str().unwrap().to_string();
 
-    let mut board = Board::new("Alpha", None::<String>);
+    let board = Board::new("Alpha", None::<String>);
     let column = Column::new(board.id, "Todo", 0);
-    let card = Card::new(&mut board, column.id, "Task One", 0);
+    let card = Card::new(board.id, column.id, "Task One", 0);
     let snapshot = Snapshot {
         archived_boards: Vec::new(),
         boards: vec![board],

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -2,8 +2,8 @@ use kanban_domain::{ArchivedCard, Board, Card, Column, DependencyGraph, Snapshot
 use kanban_view::model::Model;
 use uuid::Uuid;
 
-fn make_card(board: &mut Board, column_id: Uuid, title: &str, pos: i32) -> Card {
-    Card::new(board, column_id, title.to_string(), pos)
+fn make_card(board: &Board, column_id: Uuid, title: &str, pos: i32) -> Card {
+    Card::new(board.id, column_id, title.to_string(), pos)
 }
 
 #[test]
@@ -21,9 +21,9 @@ fn test_empty_model_returns_empty_slices() {
 fn test_load_from_snapshot_populates_all_fields() {
     let mut model = Model::default();
 
-    let mut board = Board::new("Board1", None::<String>);
+    let board = Board::new("Board1", None::<String>);
     let column = Column::new(board.id, "Col1", 0);
-    let card = make_card(&mut board, column.id, "Card1", 0);
+    let card = make_card(&board, column.id, "Card1", 0);
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
     let snapshot = Snapshot {
@@ -53,10 +53,10 @@ fn test_load_from_snapshot_populates_all_fields() {
 fn test_card_lookup_by_id() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
-    let card1 = make_card(&mut board, column_id, "First", 0);
-    let card2 = make_card(&mut board, column_id, "Second", 1);
+    let card1 = make_card(&board, column_id, "First", 0);
+    let card2 = make_card(&board, column_id, "Second", 1);
     let id1 = card1.id;
     let id2 = card2.id;
 
@@ -74,8 +74,8 @@ fn test_card_lookup_by_id() {
 fn test_card_lookup_missing_id_returns_none() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B", None::<String>);
-    let card = make_card(&mut board, Uuid::new_v4(), "Exists", 0);
+    let board = Board::new("B", None::<String>);
+    let card = make_card(&board, Uuid::new_v4(), "Exists", 0);
     model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card],
@@ -89,9 +89,9 @@ fn test_card_lookup_missing_id_returns_none() {
 fn test_load_from_snapshot_rebuilds_card_index() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
-    let card_a = make_card(&mut board, column_id, "A", 0);
+    let card_a = make_card(&board, column_id, "A", 0);
     let id_a = card_a.id;
 
     model.load_from_snapshot(Snapshot {
@@ -101,7 +101,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
     });
     assert!(model.card_by_id(id_a).is_some());
 
-    let card_b = make_card(&mut board, column_id, "B", 0);
+    let card_b = make_card(&board, column_id, "B", 0);
     let id_b = card_b.id;
     model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
@@ -133,10 +133,10 @@ fn archived_titles(model: &Model) -> Vec<String> {
 fn test_archived_cards_resolve_from_unified_collection() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
-    let card1 = make_card(&mut board, column_id, "Archived1", 0);
-    let card2 = make_card(&mut board, column_id, "Archived2", 1);
+    let card1 = make_card(&board, column_id, "Archived1", 0);
+    let card2 = make_card(&board, column_id, "Archived2", 1);
     let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
     let ac2 = ArchivedCard::new(card2.id, uuid::Uuid::nil());
 
@@ -154,10 +154,10 @@ fn test_archived_cards_resolve_from_unified_collection() {
 fn test_archived_id_set_rebuilds_on_reload() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
 
-    let card1 = make_card(&mut board, column_id, "First", 0);
+    let card1 = make_card(&board, column_id, "First", 0);
     let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
     model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
@@ -167,8 +167,8 @@ fn test_archived_id_set_rebuilds_on_reload() {
     });
     assert_eq!(archived_titles(&model), vec!["First"]);
 
-    let card2 = make_card(&mut board, column_id, "Second", 0);
-    let card3 = make_card(&mut board, column_id, "Third", 1);
+    let card2 = make_card(&board, column_id, "Second", 0);
+    let card3 = make_card(&board, column_id, "Third", 1);
     let ac2 = ArchivedCard::new(card2.id, uuid::Uuid::nil());
     let ac3 = ArchivedCard::new(card3.id, uuid::Uuid::nil());
     model.load_from_snapshot(Snapshot {
@@ -189,10 +189,10 @@ fn test_archived_id_set_rebuilds_on_reload() {
 fn test_card_by_id_resolves_archived_card() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
-    let card1 = make_card(&mut board, column_id, "Archived1", 0);
-    let card2 = make_card(&mut board, column_id, "Archived2", 1);
+    let card1 = make_card(&board, column_id, "Archived1", 0);
+    let card2 = make_card(&board, column_id, "Archived2", 1);
     let id1 = card1.id;
     let id2 = card2.id;
     let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
@@ -215,9 +215,9 @@ fn test_card_by_id_resolves_archived_card() {
 fn test_card_by_id_missing_returns_none() {
     let mut model = Model::default();
 
-    let mut board = Board::new("B", None::<String>);
+    let board = Board::new("B", None::<String>);
     let column_id = Uuid::new_v4();
-    let card = make_card(&mut board, column_id, "Archived", 0);
+    let card = make_card(&board, column_id, "Archived", 0);
     let ac = ArchivedCard::new(card.id, uuid::Uuid::nil());
 
     model.load_from_snapshot(Snapshot {

--- a/crates/kanban-view/src/layout_strategy.rs
+++ b/crates/kanban-view/src/layout_strategy.rs
@@ -310,8 +310,8 @@ mod tests {
         Column::new(board.id, name, position)
     }
 
-    fn make_card(board: &mut Board, column: &Column, title: &str, position: i32) -> Card {
-        Card::new(board, column.id, title, position)
+    fn make_card(board: &Board, column: &Column, title: &str, position: i32) -> Card {
+        Card::new(board.id, column.id, title, position)
     }
 
     fn ctx<'a>(
@@ -349,11 +349,11 @@ mod tests {
 
     #[test]
     fn test_single_list_layout_refresh_lists_loads_all_matching_cards_across_columns() {
-        let mut board = make_board();
+        let board = make_board();
         let col_a = make_column(&board, "A", 0);
         let col_b = make_column(&board, "B", 1);
-        let card1 = make_card(&mut board, &col_a, "Card 1", 0);
-        let card2 = make_card(&mut board, &col_b, "Card 2", 0);
+        let card1 = make_card(&board, &col_a, "Card 1", 0);
+        let card2 = make_card(&board, &col_b, "Card 2", 0);
         let cards = vec![card1, card2];
         let columns = vec![col_a.clone(), col_b.clone()];
 
@@ -369,10 +369,10 @@ mod tests {
 
     #[test]
     fn test_single_list_layout_refresh_lists_respects_search_query() {
-        let mut board = make_board();
+        let board = make_board();
         let col_a = make_column(&board, "A", 0);
-        let matching = make_card(&mut board, &col_a, "Fix bug", 0);
-        let non_matching = make_card(&mut board, &col_a, "Add feature", 1);
+        let matching = make_card(&board, &col_a, "Fix bug", 0);
+        let non_matching = make_card(&board, &col_a, "Add feature", 1);
         let matching_id = matching.id;
         let cards = vec![matching, non_matching];
         let columns = vec![col_a.clone()];
@@ -499,11 +499,11 @@ mod tests {
 
     #[test]
     fn test_column_lists_layout_refresh_lists_builds_one_list_per_board_column_in_position_order() {
-        let mut board = make_board();
+        let board = make_board();
         let col_a = make_column(&board, "A", 1);
         let col_b = make_column(&board, "B", 0);
-        let card_a = make_card(&mut board, &col_a, "Card A", 0);
-        let card_b = make_card(&mut board, &col_b, "Card B", 0);
+        let card_a = make_card(&board, &col_a, "Card A", 0);
+        let card_b = make_card(&board, &col_b, "Card B", 0);
         let cards = vec![card_a, card_b];
         let columns = vec![col_a.clone(), col_b.clone()];
 
@@ -522,12 +522,12 @@ mod tests {
 
     #[test]
     fn test_column_lists_layout_refresh_lists_preserves_selection_and_scroll_offset() {
-        let mut board = make_board();
+        let board = make_board();
         let col_a = make_column(&board, "A", 0);
-        let card1 = make_card(&mut board, &col_a, "Card 1", 0);
-        let card2 = make_card(&mut board, &col_a, "Card 2", 1);
-        let card3 = make_card(&mut board, &col_a, "Card 3", 2);
-        let card4 = make_card(&mut board, &col_a, "Card 4", 3);
+        let card1 = make_card(&board, &col_a, "Card 1", 0);
+        let card2 = make_card(&board, &col_a, "Card 2", 1);
+        let card3 = make_card(&board, &col_a, "Card 3", 2);
+        let card4 = make_card(&board, &col_a, "Card 4", 3);
         let card1_id = card1.id;
         let cards = vec![card1, card2, card3, card4];
         let columns = vec![col_a.clone()];
@@ -585,13 +585,13 @@ mod tests {
 
     #[test]
     fn test_virtual_unified_layout_refresh_lists_skips_empty_columns_and_builds_boundaries() {
-        let mut board = make_board();
+        let board = make_board();
         let col_a = make_column(&board, "A", 0);
         let col_b = make_column(&board, "B", 1);
         let col_c = make_column(&board, "C", 2);
-        let card1 = make_card(&mut board, &col_a, "Card 1", 0);
-        let card2 = make_card(&mut board, &col_c, "Card 2", 0);
-        let card3 = make_card(&mut board, &col_c, "Card 3", 1);
+        let card1 = make_card(&board, &col_a, "Card 1", 0);
+        let card2 = make_card(&board, &col_c, "Card 2", 0);
+        let card3 = make_card(&board, &col_c, "Card 3", 1);
         let cards = vec![card1, card2, card3];
         let columns = vec![col_a.clone(), col_b.clone(), col_c.clone()];
 

--- a/crates/kanban-view/src/model/cards.rs
+++ b/crates/kanban-view/src/model/cards.rs
@@ -61,17 +61,17 @@ mod tests {
     use super::*;
     use kanban_domain::{ArchivedCard, Board, Card, Snapshot};
 
-    fn make_card(board: &mut Board, column_id: Uuid) -> Card {
-        Card::new(board, column_id, "task", 0)
+    fn make_card(board: &Board, column_id: Uuid) -> Card {
+        Card::new(board.id, column_id, "task", 0)
     }
 
     #[test]
     fn test_card_lookup_by_id_returns_correct_card() {
         let mut m = Model::default();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let card_a = make_card(&mut board, col_id);
-        let card_b = make_card(&mut board, col_id);
+        let card_a = make_card(&board, col_id);
+        let card_b = make_card(&board, col_id);
         let card_b_id = card_b.id;
         m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
@@ -88,10 +88,10 @@ mod tests {
         // `card_by_id` resolves either from the single collection — no
         // `or_else(archived_card())` re-join.
         let mut m = Model::default();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let live = make_card(&mut board, col_id);
-        let archived = make_card(&mut board, col_id);
+        let live = make_card(&board, col_id);
+        let archived = make_card(&board, col_id);
         let live_id = live.id;
         let archived_id = archived.id;
         m.load_from_snapshot(Snapshot {
@@ -119,10 +119,10 @@ mod tests {
         // collection (the same set that backs `displayed_cards`). Assert an
         // archived card is reachable by filtering `all_cards()` through that set.
         let mut m = Model::default();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let live = make_card(&mut board, col_id);
-        let archived = make_card(&mut board, col_id);
+        let live = make_card(&board, col_id);
+        let archived = make_card(&board, col_id);
         let archived_id = archived.id;
         m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
@@ -152,10 +152,10 @@ mod tests {
         // collection into live/archived subsets ONCE, and `displayed_cards`
         // returns the cached slice by `want_archived` — no per-frame filter.
         let mut m = Model::default();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let live = make_card(&mut board, col_id);
-        let archived = make_card(&mut board, col_id);
+        let live = make_card(&board, col_id);
+        let archived = make_card(&board, col_id);
         let live_id = live.id;
         let archived_id = archived.id;
         m.load_from_snapshot(Snapshot {

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -207,8 +207,8 @@ mod tests {
     use super::*;
     use kanban_domain::{Board, Card, Column, Snapshot};
 
-    fn make_card(board: &mut Board, column_id: Uuid) -> Card {
-        Card::new(board, column_id, "task", 0)
+    fn make_card(board: &Board, column_id: Uuid) -> Card {
+        Card::new(board.id, column_id, "task", 0)
     }
 
     #[test]
@@ -264,9 +264,9 @@ mod tests {
     #[test]
     fn test_load_from_snapshot_clears_stale_card_index() {
         let mut m = Model::default();
-        let mut board = Board::new("B", None::<String>);
+        let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
-        let card = make_card(&mut board, col_id);
+        let card = make_card(&board, col_id);
         let old_id = card.id;
         m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),


### PR DESCRIPTION
`Card::new` took `&mut Board` and called `board.get_next_card_number()`, so every construction mutated allocation state. That blocked removing `Board.card_counter` (KAN-1216), because the signature has ~325 call sites.

The count overstated it. There was exactly **one** production caller, `CreateSubcardCommand`, and it did not want either value `Card::new` derived:

```rust
let (prefix, card_number) = allocate_card_number(...)?;   // allocates properly
let mut card = Card::new(&mut board, ...);                // bumped card_counter for nothing
card.card_number = card_number;                           // overwrote it
card.prefix = prefix;                                     // and the prefix
```

So the bump consumed a `card_counter` value on every subcard create and `upsert_board` persisted it. Harmless only because nothing reads that counter for allocation any more.

Everything else was test scaffolding. `Card::new` is now what it already was in practice — a plain test constructor taking `board_id`, with `card_number: 0` and `prefix: String::new()`. `Card::create` remains the production constructor.

## Pure refactor

The subcard `CreateSubcardCommand` produces keeps the same id, number, prefix, title, position and parent edge. The only non-test production edit is that call site.

## The hazard, and how it was handled

Some tests relied on `Card::new` handing out increasing numbers. With `card_number: 0` they all collapse to 0, so anything sorting by number or asserting uniqueness fails. Those failures were signal, not churn: **31 call sites now set `card_number` explicitly**, so each test states the numbering it actually depends on rather than inheriting it from a constructor side effect.

Exactly one test was deleted, `test_card_new_uses_board_card_counter_no_prefix_arg`, which asserted the removed behaviour. All 7 deleted assertions in the diff are inside it. No other assertion was weakened or removed.

- `cargo test --workspace --all-features` green, 190 suites
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all -- --check` clean

Out of scope, tracked separately: removing `Board.card_counter` itself (KAN-1216, this unblocks it) and the `CreateSubcardCommand` WIP-limit bypass.