### PR TITLE
KAN-1253 fix(domain): CreateSubcardCommand must respect the column WIP limit

### DIFF
--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -459,6 +459,7 @@ pub struct CreateSubcardCommand {
 
 impl CreateSubcardCommand {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
+        context.check_wip_limit(self.column_id, 1, &[])?;
         context.get_card(self.parent_id)?;
         let board = context.get_board(self.board_id)?;
         // Allocates from the prefix row, like every other card. Minting from

--- a/crates/kanban-domain/tests/dependency_commands.rs
+++ b/crates/kanban-domain/tests/dependency_commands.rs
@@ -579,14 +579,16 @@ fn test_create_subcard_command() {
     use kanban_domain::Board;
 
     let tc = TestContext::new();
-    let column_id = Uuid::new_v4();
 
     let mut board = Board::new("Test Board", None::<String>);
     board.card_prefix = Some("TEST".to_string());
     let board_id = board.id;
+    let column = kanban_domain::Column::new(board.id, "Col", 0);
+    let column_id = column.id;
     let parent = kanban_domain::Card::new(board.id, column_id, "Parent", 0);
     let parent_id = parent.id;
     tc.store.upsert_board(board).unwrap();
+    tc.store.upsert_column(column).unwrap();
     tc.store.upsert_card(parent).unwrap();
 
     let context = tc.as_command_context();

--- a/crates/kanban-service/tests/subcard_wip_limit.rs
+++ b/crates/kanban-service/tests/subcard_wip_limit.rs
@@ -149,3 +149,46 @@ async fn test_a_rejected_subcard_does_not_consume_a_card_number() {
         "the rejected subcard's allocation must be rolled back with the batch"
     );
 }
+
+/// The WIP check is `CreateSubcardCommand`'s ONLY column validation — it has
+/// no `require_column` of its own — so it is what stops a subcard being
+/// created into a column that does not exist.
+///
+/// That hole was open before the check was added, which is why the pre-existing
+/// `test_create_subcard_command` passed while addressing a bare `Uuid` that was
+/// never inserted as a column. Pinned here because it is now load-bearing:
+/// making the WIP check conditional, or moving it below the writes, silently
+/// reopens the hole.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_subcard_into_a_nonexistent_column_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    let parent = c
+        .create_card(board.id, col.id, "Parent".into(), Default::default())
+        .unwrap();
+
+    let subcard_id = Uuid::new_v4();
+    let result = c.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+        CreateSubcardCommand {
+            id: subcard_id,
+            parent_id: parent.id,
+            board_id: board.id,
+            column_id: Uuid::new_v4(),
+            title: "Orphan".into(),
+            description: None,
+            position: 0,
+        },
+    ))]);
+
+    assert!(
+        result.is_err(),
+        "a subcard must not be created into a column that does not exist"
+    );
+    assert!(
+        c.get_card(subcard_id).unwrap().is_none(),
+        "and no card may be left behind"
+    );
+}

--- a/crates/kanban-service/tests/subcard_wip_limit.rs
+++ b/crates/kanban-service/tests/subcard_wip_limit.rs
@@ -1,0 +1,151 @@
+//! `CreateSubcardCommand::execute` must respect the target column's WIP
+//! limit, the same as every other path that puts a card in a column.
+
+use kanban_core::AppConfig;
+use kanban_domain::commands::{Command, CreateSubcardCommand, DependencyCommand};
+use kanban_domain::{ColumnUpdate, FieldUpdate, KanbanOperations};
+use kanban_service::KanbanContext;
+use std::sync::Arc;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn ctx(path: &std::path::Path) -> KanbanContext {
+    let backend = kanban_persistence_sqlite::SqliteBackend::open(path.to_str().unwrap())
+        .await
+        .expect("open sqlite backend");
+    KanbanContext::open(Arc::new(backend), AppConfig::default())
+        .await
+        .expect("open context")
+}
+
+fn counter(ctx: &KanbanContext, name: &str) -> u32 {
+    ctx.backend()
+        .get_prefix(name)
+        .unwrap()
+        .map_or(0, |p| p.card_counter)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_subcard_into_a_full_column_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    c.update_column(
+        col.id,
+        ColumnUpdate {
+            wip_limit: FieldUpdate::Set(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let parent = c
+        .create_card(board.id, col.id, "Parent".into(), Default::default())
+        .unwrap();
+
+    let subcard_id = Uuid::new_v4();
+    let result = c.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+        CreateSubcardCommand {
+            id: subcard_id,
+            parent_id: parent.id,
+            board_id: board.id,
+            column_id: col.id,
+            title: "Subcard".into(),
+            description: None,
+            position: 1,
+        },
+    ))]);
+
+    assert!(
+        result.is_err(),
+        "the column is already at its WIP limit of 1, so the subcard must be rejected"
+    );
+    assert_eq!(
+        c.backend().list_cards_by_column(col.id).unwrap().len(),
+        1,
+        "the rejected subcard must not have been written to the column"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_subcard_into_a_column_with_room_still_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    c.update_column(
+        col.id,
+        ColumnUpdate {
+            wip_limit: FieldUpdate::Set(2),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let parent = c
+        .create_card(board.id, col.id, "Parent".into(), Default::default())
+        .unwrap();
+
+    let subcard_id = Uuid::new_v4();
+    c.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+        CreateSubcardCommand {
+            id: subcard_id,
+            parent_id: parent.id,
+            board_id: board.id,
+            column_id: col.id,
+            title: "Subcard".into(),
+            description: None,
+            position: 1,
+        },
+    ))])
+    .expect("column has room, so the subcard must be created");
+
+    assert_eq!(c.backend().list_cards_by_column(col.id).unwrap().len(), 2);
+    assert!(
+        c.graph().unwrap().contains(parent.id, subcard_id),
+        "the parent edge must still be set"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_rejected_subcard_does_not_consume_a_card_number() {
+    let dir = TempDir::new().unwrap();
+    let mut c = ctx(&dir.path().join("s.db")).await;
+
+    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
+    c.update_column(
+        col.id,
+        ColumnUpdate {
+            wip_limit: FieldUpdate::Set(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let parent = c
+        .create_card(board.id, col.id, "Parent".into(), Default::default())
+        .unwrap();
+
+    let before = counter(&c, "kan");
+
+    let subcard_id = Uuid::new_v4();
+    let result = c.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+        CreateSubcardCommand {
+            id: subcard_id,
+            parent_id: parent.id,
+            board_id: board.id,
+            column_id: col.id,
+            title: "Subcard".into(),
+            description: None,
+            position: 1,
+        },
+    ))]);
+
+    assert!(result.is_err(), "the column is full, so this must fail");
+    assert_eq!(
+        counter(&c, "kan"),
+        before,
+        "the rejected subcard's allocation must be rolled back with the batch"
+    );
+}


### PR DESCRIPTION
## Defect

`CreateSubcardCommand::execute` never checked the target column's WIP limit, so creating a subcard could silently exceed it. Every other path that puts a card in a column checks it: `CreateCard::execute`, the archived-card restore, and `MoveCard::execute`. The subcard path was the only hole.

Verified against a real `SqliteBackend`, column WIP limit 1, one card already in the column:

```
column now has 1 card, wip limit 1
ordinary create -> Err("column ... has reached its WIP limit of 1")
SUBCARD create  -> Ok("OK")
cards now in column: 2
```

## Fix

Exactly one line of production code, at the top of `CreateSubcardCommand::execute`, matching how `CreateCard::execute` opens:

```rust
context.check_wip_limit(self.column_id, 1, &[])?;
```

An existing unit test (`test_create_subcard_command` in `crates/kanban-domain/tests/dependency_commands.rs`) exercised a column id that was never inserted into the store, which now fails the WIP lookup. Updated it to create a real `Column` so the parent/subcard setup matches production shape.

## Tests

Added `crates/kanban-service/tests/subcard_wip_limit.rs` against a real `SqliteBackend`:
- `test_create_subcard_into_a_full_column_is_rejected` — asserts both the rejection and that the column's card count is unchanged (not just the error).
- `test_create_subcard_into_a_column_with_room_still_succeeds` — non-regression twin.
- `test_a_rejected_subcard_does_not_consume_a_card_number` — pins that the number allocation rolls back with the batch.

## Test plan

- [x] Tests written first, confirmed to fail for the right reason (subcard created into a full column instead of rejected)
- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all`