### PR TITLE
KAN-1254 refactor(domain): remove the superseded prefix ownership and collision API

### DIFF
--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -61,8 +61,7 @@ pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use operations::KanbanOperations;
 pub use prefix::{
-    allocate_card_number, allocate_sprint_number, effective_card_prefix, effective_prefixes,
-    find_prefix_collisions, EffectivePrefix, Prefix, PrefixCollision, PrefixOwner,
+    allocate_card_number, allocate_sprint_number, effective_card_prefix, effective_prefixes, Prefix,
 };
 pub use prefix_backfill::{
     plan_prefix_backfill, BackfillBoard, BackfillRow, BackfillSprint, DEFAULT_CARD_PREFIX,

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
-use crate::board::{Board, BoardId};
-use crate::sprint::{Sprint, SprintId};
+use crate::board::Board;
+use crate::sprint::Sprint;
 
 /// The namespace a NEW card belongs to, given its board's prefix and its
 /// sprint's override. Normalised.
@@ -129,35 +127,14 @@ impl Prefix {
     }
 }
 
-/// Which board or sprint a prefix is currently allocated to.
-///
-/// This is an ALLOCATION record, not a resolution mechanism: it says which
-/// entity a prefix currently belongs to for handing out the next number, not
-/// which prefix an existing card carries. Existing cards never look this up.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PrefixOwner {
-    Board(BoardId),
-    Sprint(SprintId),
-}
-
 impl Prefix {
     pub fn normalize(raw: &str) -> String {
         raw.to_lowercase()
     }
 }
 
-/// A prefix that would currently be handed out to a NEW card created under
-/// the given owner. Used for collision detection and for stamping a new
-/// card's prefix at creation time — never for resolving an existing card's
-/// already-stored prefix.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EffectivePrefix {
-    pub name: String,
-    pub owner: PrefixOwner,
-}
-
-/// Computes the set of prefixes a workspace would currently hand out to new
-/// cards: every board's effective prefix (falling back to
+/// Computes the set of normalised prefix names a workspace would currently
+/// hand out to new cards: every board's effective prefix (falling back to
 /// `default_card_prefix` when unset), plus every sprint's override. A board
 /// keeps its own entry even when one of its sprints overrides it — the two
 /// are independently effective for their respective new-card allocations.
@@ -165,168 +142,28 @@ pub fn effective_prefixes(
     boards: &[Board],
     sprints: &[Sprint],
     default_card_prefix: &str,
-) -> Vec<EffectivePrefix> {
-    let mut result: Vec<EffectivePrefix> = boards
+) -> Vec<String> {
+    let mut result: Vec<String> = boards
         .iter()
-        .map(|board| EffectivePrefix {
-            name: Prefix::normalize(board.card_prefix.as_deref().unwrap_or(default_card_prefix)),
-            owner: PrefixOwner::Board(board.id),
-        })
+        .map(|board| Prefix::normalize(board.card_prefix.as_deref().unwrap_or(default_card_prefix)))
         .collect();
 
-    result.extend(sprints.iter().filter_map(|sprint| {
-        sprint.card_prefix.as_deref().map(|prefix| EffectivePrefix {
-            name: Prefix::normalize(prefix),
-            owner: PrefixOwner::Sprint(sprint.id),
-        })
-    }));
+    result.extend(
+        sprints
+            .iter()
+            .filter_map(|sprint| sprint.card_prefix.as_deref().map(Prefix::normalize)),
+    );
 
     result
-}
-
-/// A normalised prefix that more than one owner would currently hand out.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PrefixCollision {
-    pub name: String,
-    pub owners: Vec<PrefixOwner>,
-}
-
-/// Groups effective prefixes by their normalised name and reports every
-/// group with more than one owner.
-pub fn find_prefix_collisions(effective: &[EffectivePrefix]) -> Vec<PrefixCollision> {
-    let mut by_name: HashMap<&str, Vec<PrefixOwner>> = HashMap::new();
-    for entry in effective {
-        by_name
-            .entry(entry.name.as_str())
-            .or_default()
-            .push(entry.owner);
-    }
-
-    // Sorted so a migration dry-run reports collisions in a stable order.
-    // `HashMap::into_iter` alone would reorder between runs and flake any
-    // test asserting on more than one collision.
-    let mut collisions: Vec<PrefixCollision> = by_name
-        .into_iter()
-        .filter(|(_, owners)| owners.len() > 1)
-        .map(|(name, owners)| PrefixCollision {
-            name: name.to_string(),
-            owners,
-        })
-        .collect();
-    collisions.sort_by(|a, b| a.name.cmp(&b.name));
-    collisions
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::board::Board;
-    use crate::sprint::Sprint;
-    use uuid::Uuid;
-
-    fn board_with_prefix(prefix: Option<&str>) -> Board {
-        Board::new("board".to_string(), prefix)
-    }
-
-    fn sprint_with_prefix(board_id: Uuid, prefix: Option<&str>) -> Sprint {
-        let mut sprint = Sprint::new(board_id, 1, None, None::<String>);
-        sprint.card_prefix = prefix.map(str::to_string);
-        sprint
-    }
 
     #[test]
     fn test_normalize_lowercases_prefix() {
         assert_eq!(Prefix::normalize("KAN"), Prefix::normalize("kan"));
         assert_eq!(Prefix::normalize("KAN"), "kan");
-    }
-
-    #[test]
-    fn test_effective_prefixes_defaults_none_board_prefix_to_config_default() {
-        let board = board_with_prefix(None);
-        let board_id = board.id;
-        let effective = effective_prefixes(std::slice::from_ref(&board), &[], "task");
-
-        assert_eq!(
-            effective,
-            vec![EffectivePrefix {
-                name: "task".to_string(),
-                owner: PrefixOwner::Board(board_id),
-            }]
-        );
-    }
-
-    #[test]
-    fn test_effective_prefixes_sprint_override_yields_an_independent_entry() {
-        let board = board_with_prefix(Some("KAN"));
-        let board_id = board.id;
-        let sprint = sprint_with_prefix(board_id, Some("AUTH"));
-        let sprint_id = sprint.id;
-
-        let mut effective = effective_prefixes(
-            std::slice::from_ref(&board),
-            std::slice::from_ref(&sprint),
-            "task",
-        );
-        effective.sort_by(|a, b| a.name.cmp(&b.name));
-
-        assert_eq!(
-            effective,
-            vec![
-                EffectivePrefix {
-                    name: "auth".to_string(),
-                    owner: PrefixOwner::Sprint(sprint_id),
-                },
-                EffectivePrefix {
-                    name: "kan".to_string(),
-                    owner: PrefixOwner::Board(board_id),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn test_find_prefix_collisions_detects_case_insensitive_duplicate() {
-        let board_a = board_with_prefix(Some("KAN"));
-        let board_b = board_with_prefix(Some("kan"));
-
-        let effective = effective_prefixes(&[board_a.clone(), board_b.clone()], &[], "task");
-        let collisions = find_prefix_collisions(&effective);
-
-        assert_eq!(collisions.len(), 1);
-        let collision = &collisions[0];
-        assert_eq!(collision.name, "kan");
-        assert_eq!(collision.owners.len(), 2);
-        assert!(collision.owners.contains(&PrefixOwner::Board(board_a.id)));
-        assert!(collision.owners.contains(&PrefixOwner::Board(board_b.id)));
-    }
-
-    #[test]
-    fn test_find_prefix_collisions_empty_on_real_tracker_shape() {
-        let prefixes = ["kan", "dev", "ops", "web", "doc", "sec"];
-        let boards: Vec<Board> = prefixes
-            .iter()
-            .map(|p| board_with_prefix(Some(p)))
-            .collect();
-        let sprint = sprint_with_prefix(boards[0].id, Some("auth-sprint"));
-
-        let effective = effective_prefixes(&boards, std::slice::from_ref(&sprint), "task");
-        let collisions = find_prefix_collisions(&effective);
-
-        assert!(collisions.is_empty());
-    }
-
-    #[test]
-    fn test_sprint_without_an_override_emits_no_entry() {
-        // The `None` arm is what stops every sprint echoing its board's
-        // prefix into the set as a duplicate. Every other test uses `Some`.
-        let board = board_with_prefix(Some("kan"));
-        let sprint = sprint_with_prefix(board.id, None);
-        let effective = effective_prefixes(&[board], &[sprint], "task");
-        assert_eq!(
-            effective.len(),
-            1,
-            "a sprint with no override must contribute nothing"
-        );
-        assert_eq!(effective[0].name, "kan");
     }
 }

--- a/crates/kanban-persistence-json/tests/v15_migration.rs
+++ b/crates/kanban-persistence-json/tests/v15_migration.rs
@@ -4,7 +4,7 @@
 //! for the same board/sprint graph.
 
 use kanban_domain::board::Board;
-use kanban_domain::prefix::{effective_prefixes, find_prefix_collisions};
+use kanban_domain::prefix::effective_prefixes;
 use kanban_domain::sprint::Sprint;
 use kanban_persistence::{FormatVersion, PersistenceStore};
 use kanban_persistence_json::migration::Migrator;
@@ -100,11 +100,6 @@ fn test_migrate_v14_to_v15_identifier_preservation() {
     let sprints = vec![sprint_auth.clone()];
 
     let before = effective_prefixes(&boards, &sprints, "task");
-    let before_collisions = find_prefix_collisions(&before);
-    assert!(
-        before_collisions.is_empty(),
-        "fixture must be collision-free before migration"
-    );
 
     let mut env = v14_fixture();
     kanban_persistence_json::migration_test_support::transform_v14_to_v15(&mut env);
@@ -121,11 +116,10 @@ fn test_migrate_v14_to_v15_identifier_preservation() {
     // whole of what identifier preservation means: no board or sprint may
     // find its prefix renamed out from under the cards already stamped with
     // it.
-    for entry in &before {
+    for name in &before {
         assert!(
-            names.contains(&entry.name.as_str()),
-            "the dynamically-resolved prefix {} vanished from the backfill: {names:?}",
-            entry.name
+            names.contains(&name.as_str()),
+            "the dynamically-resolved prefix {name} vanished from the backfill: {names:?}"
         );
     }
 }


### PR DESCRIPTION
`PrefixOwner`, `EffectivePrefix`, `PrefixCollision` and `find_prefix_collisions` implemented the original prefix design: a prefix had an **owner**, and two owners wanting one prefix was a **collision** to reject.

That design was overruled. A prefix row is a shared namespace with no owner, and two boards holding `KAN` is legal — it is what makes `(prefix, card_number)` unique from a single counter. `Prefix` itself carries no owner field, and its doc says so.

So this was not merely unused code. `PrefixOwner` asserted an ownership relation the model does not have, and `find_prefix_collisions` detected a condition that is now correct behaviour. `prefix.rs` documented two contradictory models side by side, and the superseded one looked authoritative because it was exported and had passing tests.

## What survives, and a correction

`effective_prefixes` **stays** — it has a real consumer, `test_migrate_v14_to_v15_identifier_preservation`, which proves every prefix a workspace resolved to before the V15 migration still exists as a namespace after it. It now returns `Vec<String>` instead of `Vec<EffectivePrefix>`, because that type existed only to carry an `owner` the sole caller never read.

Worth recording: the card originally claimed all five symbols had zero callers. That was wrong. The verification grep was scoped to `crates/*/src`, which never searches `crates/*/tests/` where integration tests live, so the consuming test was invisible to it. Caught before any code was deleted.

## The one removed assertion

The test also checked its fixture was "collision-free before migration". Under shared namespaces a collision is legal and expected, so that no longer describes an invariant — and the loop it preceded, which is what the test actually proves, holds whether or not the fixture had colliding prefixes. Removed with its import; the loop and its explanatory comment are untouched.

## Not leftovers

`ConfirmSprintPrefixCollision` in `kanban-tui` matches on substring but is a distinct live rule: a sprint's card-prefix override must differ from its own board's prefix, validated by `validate_card_prefix_unique`. Untouched.

- `cargo test --workspace --all-features` green, 191 suites
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all` applied
- `grep -rn "PrefixOwner\|EffectivePrefix\|PrefixCollision\|find_prefix_collisions" crates/` returns only the unrelated TUI dialog names above